### PR TITLE
[cicd] reduce parallelism to cut down on costs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run: cargo xclippy --workspace --all-targets
       - run: cargo fmt
       - run: cargo xfmt --check
-  e2e-test-0:
+  e2e-test:
     machine:
       image: ubuntu-2004:current
     resource_class: xlarge
@@ -40,25 +40,7 @@ jobs:
       - build-and-split
       - run: mv /tmp/tests.0 /tmp/tests_to_run
       - run-e2e-tests
-  e2e-test-1:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: xlarge
-    steps:
-      - dev-setup
-      - build-and-split
-      - run: mv /tmp/tests.1 /tmp/tests_to_run
-      - run-e2e-tests
-  e2e-test-2:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: xlarge
-    steps:
-      - dev-setup
-      - build-and-split
-      - run: mv /tmp/tests.2 /tmp/tests_to_run
-      - run-e2e-tests
-  unit-test-0:
+  unit-test:
     machine:
       image: ubuntu-2004:current
     resource_class: xlarge
@@ -66,27 +48,16 @@ jobs:
       - dev-setup
       - run: cargo xtest --package jsonrpc-integration-tests --changed-since "origin/main"
       - run: cargo xtest --doc --jobs 8 --unit --changed-since "origin/main"
-      - run: cargo nextest --nextest-profile ci --partition hash:1/2 --jobs 6 --test-threads 8 --unit --exclude backup-cli --changed-since "origin/main"
-  unit-test-1:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: xlarge
-    steps:
-      - dev-setup
-      - run: cargo nextest --nextest-profile ci --partition hash:2/2 --jobs 6 --test-threads 8 --unit --exclude backup-cli --changed-since "origin/main"
+      - run: cargo nextest --nextest-profile ci --partition hash:1/1 --jobs 6 --test-threads 8 --unit --exclude backup-cli --changed-since "origin/main"
 
 workflows:
   build-test-deploy:
     jobs:
-      - build-benchmarks
+#      - build-benchmarks
       - crypto
-      - e2e-test-0
-      - e2e-test-1
-      - e2e-test-2
+      - e2e-test
       - lint
-      - unit-test-0
-      - unit-test-1
-
+      - unit-test
 commands:
   dev-setup:
     steps:
@@ -100,7 +71,7 @@ commands:
       - run: |
           cargo x test --package smoke-test --jobs 8 -- --list | grep "::" | sed 's/: .*$//' > e2e_tests
           echo -e "Found $(wc -l e2e_tests) tests."
-          split -n r/3 -d -a 1 e2e_tests /tmp/tests.
+          split -n r/1 -d -a 1 e2e_tests /tmp/tests.
   run-e2e-tests:
     steps:
       - run: |


### PR DESCRIPTION
e2e tests take about 40 minutes total and about 15 minutes to setup:
1 runner -- 55 minutes
2 runners -- 35 minutes
3 runners -- 28 minutes

the better approach is to figure out how to clean up the shell script to
run two jobs at a time...

while the unit tests  can take up to an hour, they normally run really
quickly thanks to nextest

benchmarks take forever to compile and shouldn't be using non-standard
interfaces, so disabling just because

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
