### PR TITLE
Fix CORS for unsuccessful responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,7 +2396,6 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "either",
- "futures",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -3087,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3097,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
 name = "futures-executor"
@@ -3133,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
 
 [[package]]
 name = "futures-task"
@@ -3787,15 +3786,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5a75aeaaef0ce18b58056d306c27b07436fbb34b8816c53094b76dd81803136"
 dependencies = [
  "unindent",
-]
-
-[[package]]
-name = "input_buffer"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
-dependencies = [
- "bytes",
 ]
 
 [[package]]
@@ -4954,9 +4944,9 @@ dependencies = [
 
 [[package]]
 name = "multipart"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050aeedc89243f5347c3e237e3e13dc76fbe4ae3742a57b94dc14f69acf76d4"
+checksum = "00dec633863867f29cb39df64a397cdf4a6354708ddd7759f70c7fb51c5f9182"
 dependencies = [
  "buf_redux",
  "httparse",
@@ -4964,7 +4954,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "quick-error 1.2.3",
- "rand 0.7.3",
+ "rand 0.8.4",
  "safemem",
  "tempfile",
  "twoway",
@@ -7815,9 +7805,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a5f475f1b9d077ea1017ecbc60890fda8e54942d680ca0b1d2b47cfa2d861b"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
 dependencies = [
  "futures-util",
  "log",
@@ -7925,16 +7915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8038,19 +8018,19 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
 dependencies = [
  "base64",
  "byteorder",
  "bytes",
  "http",
  "httparse",
- "input_buffer",
  "log",
  "rand 0.8.4",
  "sha-1 0.9.4",
+ "thiserror",
  "url",
  "utf-8",
 ]
@@ -8070,7 +8050,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -8398,12 +8378,13 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dafd0aac2818a94a34df0df1100a7356c493d8ede4393875fd0b5c51bb6bc80"
+checksum = "3cef4e1e9114a4b7f1ac799f16ce71c14de5778500c5450ec6b7b920c55b587e"
 dependencies = [
  "bytes",
- "futures",
+ "futures-channel",
+ "futures-util",
  "headers",
  "http",
  "hyper",
@@ -8424,7 +8405,6 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -22,7 +22,7 @@ percent-encoding = "2.1.0"
 serde = { version = "1.0.124", features = ["derive"], default-features = false }
 serde_json = "1.0.64"
 tokio = { version = "1.8.1", features = ["full"] }
-warp = { version = "0.3.0", features = ["default", "tls"] }
+warp = { version = "0.3.2", features = ["default", "tls"] }
 
 diem-config = { path = "../config" }
 diem-crypto = { path = "../crates/diem-crypto" }

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -15,7 +15,7 @@ bcs = "0.1.2"
 hex = "0.4.3"
 serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
-warp = { version = "0.3.0", features = ["default"] }
+warp = { version = "0.3.2", features = ["default"] }
 
 diem-crypto = { path = "../../crates/diem-crypto" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }

--- a/crates/debug-interface/Cargo.toml
+++ b/crates/debug-interface/Cargo.toml
@@ -16,7 +16,7 @@ reqwest = { version = "0.11.2", features = ["blocking", "json"], default_feature
 serde = { version = "1.0.124", features = ["derive"], default-features = false }
 serde_json = "1.0.64"
 tokio = { version = "1.8.1", features = ["full"] }
-warp = "0.3.0"
+warp = "0.3.2"
 
 diem-config = { path = "../../config" }
 diem-logger = { path = "../../crates/diem-logger" }

--- a/crates/diem-faucet/Cargo.toml
+++ b/crates/diem-faucet/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 structopt = "0.3.21"
 tokio = { version = "1.8.1", features = ["full"] }
 url = "2.2.2"
-warp = "0.3.0"
+warp = "0.3.2"
 
 generate-key = { path = "../../config/generate-key" }
 diem-crypto = { path = "../diem-crypto" }

--- a/crates/diem-workspace-hack/Cargo.toml
+++ b/crates/diem-workspace-hack/Cargo.toml
@@ -24,11 +24,10 @@ crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam
 crossbeam-queue = { version = "0.3.1", features = ["alloc", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["lazy_static", "std"] }
 either = { version = "1.6.1", features = ["use_std"] }
-futures = { version = "0.3.12", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
-futures-channel = { version = "0.3.16", features = ["alloc", "futures-sink", "sink", "std"] }
-futures-core = { version = "0.3.16", features = ["alloc", "std"] }
+futures-channel = { version = "0.3.21", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-io = { version = "0.3.16", features = ["std"] }
-futures-sink = { version = "0.3.16", features = ["alloc", "std"] }
+futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.16", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 hyper = { version = "0.14.11", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 indexmap = { version = "1.7.0", default-features = false, features = ["std"] }
@@ -54,7 +53,7 @@ tokio = { version = "1.9.0", features = ["bytes", "fs", "full", "io-std", "io-ut
 tokio-util = { version = "0.6.7", features = ["codec", "compat", "futures-io", "io"] }
 toml = { version = "0.5.8" }
 tracing = { version = "0.1.26", features = ["attributes", "log", "std", "tracing-attributes"] }
-warp = { version = "0.3.0", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
+warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "zeroize_derive"] }
 
 [build-dependencies]
@@ -72,11 +71,10 @@ crossbeam-deque = { version = "0.8.1", features = ["crossbeam-epoch", "crossbeam
 crossbeam-queue = { version = "0.3.1", features = ["alloc", "std"] }
 crossbeam-utils = { version = "0.8.3", features = ["lazy_static", "std"] }
 either = { version = "1.6.1", features = ["use_std"] }
-futures = { version = "0.3.12", features = ["alloc", "async-await", "executor", "futures-executor", "std"] }
-futures-channel = { version = "0.3.16", features = ["alloc", "futures-sink", "sink", "std"] }
-futures-core = { version = "0.3.16", features = ["alloc", "std"] }
+futures-channel = { version = "0.3.21", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-io = { version = "0.3.16", features = ["std"] }
-futures-sink = { version = "0.3.16", features = ["alloc", "std"] }
+futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.16", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 hyper = { version = "0.14.11", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 indexmap = { version = "1.7.0", default-features = false, features = ["std"] }
@@ -103,7 +101,7 @@ tokio = { version = "1.9.0", features = ["bytes", "fs", "full", "io-std", "io-ut
 tokio-util = { version = "0.6.7", features = ["codec", "compat", "futures-io", "io"] }
 toml = { version = "0.5.8" }
 tracing = { version = "0.1.26", features = ["attributes", "log", "std", "tracing-attributes"] }
-warp = { version = "0.3.0", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
+warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.2.0", features = ["alloc", "zeroize_derive"] }
 
 ### END HAKARI SECTION

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -49,7 +49,7 @@ storage-interface = { path = "../../storage-interface" }
 
 [dev-dependencies]
 proptest = "1.0.0"
-warp = "0.3.0"
+warp = "0.3.2"
 
 backup-service = { path = "../backup-service" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers" }

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -16,7 +16,7 @@ hyper = "0.14.4"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", default-features = false }
 tokio = { version = "1.8.1", features = ["full"] }
-warp = "0.3.0"
+warp = "0.3.2"
 
 bcs = "0.1.2"
 diem-crypto = { path = "../../../crates/diem-crypto" }


### PR DESCRIPTION
## Motivation
CORS not being set on non-200 responses (i.e 404s) makes it impossible to distinguish between anything other than a 200 from the front end. This fixes that so FE applications can make a successful preflight + cross-origin request even if the request is not a 'success'