### PR TITLE
[docker] remove writeset tool

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -45,7 +45,6 @@ COPY --from=builder /diem/target/release/db-backup /usr/local/bin
 COPY --from=builder /diem/target/release/db-backup-verify /usr/local/bin
 COPY --from=builder /diem/target/release/db-restore /usr/local/bin
 COPY --from=builder /diem/target/release/diem-transaction-replay /usr/local/bin
-COPY --from=builder /diem/target/release/diem-writeset-generator /usr/local/bin
 
 ### Get DPN Move modules bytecodes for genesis ceremony
 RUN mkdir -p /diem/move


### PR DESCRIPTION
Docker image build keeps failing on building tool, remote writeset-generator for now since we don't actually use it in tool image