### PR TITLE
[forge][fgi] only support forge-0

### DIFF
--- a/scripts/fgi/kube.py
+++ b/scripts/fgi/kube.py
@@ -3,7 +3,7 @@
 
 import json, os, random, subprocess, time
 
-FORGE_K8S_CLUSTERS = ["forge-0", "forge-1"]
+FORGE_K8S_CLUSTERS = ["forge-0"]
 
 AWS_ACCOUNT = (
     subprocess.check_output(


### PR DESCRIPTION
Only have one forge cluster for now for landing. I will spin up another one for experimentation called `forge-exp` that must be manually invoked via `./scripts/fgi/run .... -W forge-exp`.
We can spin up more forge clusters as we need the capacity, (e.g. `forge-`)