### PR TITLE
[DPN_CLEAN] Remove DiemID

### DIFF
--- a/crates/aptos-faucet/src/mint.rs
+++ b/crates/aptos-faucet/src/mint.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for Response {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct MintParams {
     pub amount: Option<u64>,
     pub pub_key: Ed25519PublicKey,
@@ -73,6 +73,7 @@ impl std::fmt::Display for MintParams {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "<Mint {:?} to {:?}>", self.amount, self.receiver())
     }
+
 }
 
 impl MintParams {

--- a/types/src/account_config/resources/mod.rs
+++ b/types/src/account_config/resources/mod.rs
@@ -17,7 +17,6 @@ pub mod preburn_queue;
 pub mod preburn_with_metadata;
 pub mod role;
 pub mod vasp;
-pub mod vasp_domain;
 pub mod withdraw_capability;
 
 pub use account::*;
@@ -36,5 +35,4 @@ pub use preburn_queue::*;
 pub use preburn_with_metadata::*;
 pub use role::*;
 pub use vasp::*;
-pub use vasp_domain::*;
 pub use withdraw_capability::*;

--- a/types/src/account_config/resources/role.rs
+++ b/types/src/account_config/resources/role.rs
@@ -3,7 +3,6 @@
 
 use crate::account_config::resources::{
     ChildVASP, Credential, DesignatedDealer, DesignatedDealerPreburns, ParentVASP,
-    VASPDomainManager, VASPDomains,
 };
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +12,6 @@ pub enum AccountRole {
     ParentVASP {
         vasp: ParentVASP,
         credential: Credential,
-        vasp_domains: Option<VASPDomains>,
     },
     ChildVASP(ChildVASP),
     DesignatedDealer {
@@ -21,9 +19,7 @@ pub enum AccountRole {
         preburn_balances: DesignatedDealerPreburns,
         designated_dealer: DesignatedDealer,
     },
-    TreasuryCompliance {
-        vasp_domain_manager: VASPDomainManager,
-    },
+    TreasuryCompliance,
     Unknown,
     // TODO: add other roles
 }

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -8,7 +8,7 @@ use crate::{
         currency_code_from_type_tag, AccountResource, AccountRole, BalanceResource, CRSNResource,
         ChainIdResource, ChildVASP, Credential, CurrencyInfoResource, DesignatedDealer,
         DesignatedDealerPreburns, DiemAccountResource, FreezingBit, ParentVASP,
-        PreburnQueueResource, PreburnResource, VASPDomainManager, VASPDomains,
+        PreburnQueueResource, PreburnResource,
     },
     block_metadata::DiemBlockResource,
     diem_timestamp::DiemTimestampResource,
@@ -127,14 +127,9 @@ impl AccountState {
             match (
                 self.get_resource::<ParentVASP>(),
                 self.get_resource::<Credential>(),
-                self.get_resource::<VASPDomains>(),
             ) {
-                (Ok(Some(vasp)), Ok(Some(credential)), Ok(vasp_domains)) => {
-                    Ok(Some(AccountRole::ParentVASP {
-                        vasp,
-                        credential,
-                        vasp_domains,
-                    }))
+                (Ok(Some(vasp)), Ok(Some(credential))) => {
+                    Ok(Some(AccountRole::ParentVASP { vasp, credential }))
                 }
                 _ => Ok(None),
             }
@@ -168,13 +163,6 @@ impl AccountState {
                         designated_dealer,
                     }))
                 }
-                _ => Ok(None),
-            }
-        } else if self.0.contains_key(&VASPDomainManager::resource_path()) {
-            match self.get_resource::<VASPDomainManager>() {
-                Ok(Some(vasp_domain_manager)) => Ok(Some(AccountRole::TreasuryCompliance {
-                    vasp_domain_manager,
-                })),
                 _ => Ok(None),
             }
         } else {

--- a/types/src/contract_event.rs
+++ b/types/src/contract_event.rs
@@ -6,7 +6,7 @@ use crate::{
         AdminTransactionEvent, BaseUrlRotationEvent, BurnEvent, CancelBurnEvent,
         ComplianceKeyRotationEvent, CreateAccountEvent, MintEvent, NewBlockEvent, NewEpochEvent,
         PreburnEvent, ReceivedMintEvent, ReceivedPaymentEvent, SentPaymentEvent,
-        ToXDXExchangeRateUpdateEvent, VASPDomainEvent,
+        ToXDXExchangeRateUpdateEvent,
     },
     event::EventKey,
     ledger_info::LedgerInfo,
@@ -249,16 +249,6 @@ impl TryFrom<&ContractEvent> for CreateAccountEvent {
     fn try_from(event: &ContractEvent) -> Result<Self> {
         if event.type_tag != TypeTag::Struct(Self::struct_tag()) {
             anyhow::bail!("Expected CreateAccountEvent")
-        }
-        Self::try_from_bytes(&event.event_data)
-    }
-}
-
-impl TryFrom<&ContractEvent> for VASPDomainEvent {
-    type Error = Error;
-    fn try_from(event: &ContractEvent) -> Result<Self> {
-        if event.type_tag != TypeTag::Struct(Self::struct_tag()) {
-            anyhow::bail!("Expected VASPDomainEvent")
         }
         Self::try_from_bytes(&event.event_data)
     }

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -12,7 +12,6 @@ pub mod block_info;
 pub mod block_metadata;
 pub mod chain_id;
 pub mod contract_event;
-pub mod diem_id_identifier;
 pub mod diem_timestamp;
 pub mod epoch_change;
 pub mod epoch_state;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

DiemID is the human readable ID used in legacy DPN. As we are getting rid of DPN related code, we want to remove this DiemID

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
Cargo test passed
cargo test --package diem-faucet passed
cargo test --package smoke-test no consistent failed tests.

