### PR TITLE
[helm] consolidate monitoring lb into testnet lb

### DIFF
--- a/terraform/testnet/testnet/templates/ingress.yaml
+++ b/terraform/testnet/testnet/templates/ingress.yaml
@@ -30,6 +30,16 @@ spec:
             name: {{ include "testnet.fullname" . }}-faucet
             port:
               number: 80
+  - host: mon.{{ .Values.service.domain }}
+    http:
+      paths:
+      - path: /*
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "testnet.fullname" . }}-monitoring
+            port:
+              number: 80
   {{- if .Values.service.pfn.exposeApi }}
   - host: pfn.{{ .Values.service.domain }}
     http:

--- a/terraform/testnet/testnet/templates/monitoring.yaml
+++ b/terraform/testnet/testnet/templates/monitoring.yaml
@@ -66,23 +66,16 @@ metadata:
   labels:
     {{- include "testnet.labels" . | nindent 4 }}
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: nlb
-    {{- if .Values.service.domain }}
-    external-dns.alpha.kubernetes.io/hostname: mon.{{ .Values.service.domain }}
-    {{- end }}
+    alb.ingress.kubernetes.io/healthcheck-path: /api/health
 spec:
   selector:
     {{- include "testnet.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/name: monitoring
   ports:
-  - name: grafana-http
-    port: 80
+  - port: 80
     targetPort: 3000
-  type: LoadBalancer
-  {{- with .Values.service.monitoring.loadBalancerSourceRanges }}
-  loadBalancerSourceRanges:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  type: NodePort
+  externalTrafficPolicy: Local
 
 ---
 


### PR DESCRIPTION
Merge monitoring lb into testnet lb so that we create 1 less nlb. It's still serve on `mon.<domain>`

we kept it separate because we can then set different IP range for access, but now we can use google auth for authentication so no need to control on IP.