### PR TITLE
[docker-compose] remove hardcoded seed peer

### DIFF
--- a/docker/compose/public_full_node/docker-compose.yaml
+++ b/docker/compose/public_full_node/docker-compose.yaml
@@ -6,16 +6,8 @@
 # public_full_node.yaml. The config is pretty well documented and aligns with instructions herein.
 # It is intended for use with testnet but can be easily modified for other systems.
 #
-# Testnet genesis and waypoint can be acquired at the following URLs:
-# * https://testnet.aptos.com/genesis.blob
-# * https://testnet.aptos.com/waypoint.txt
-# Testnet's genesis does not support onchain discovery and also requires a seed_addrs to be added
-# to the full_node_networks and the discovery method to be set to "none" (this step has been
-# completed):
-#     discovery_method: "none"
-#     seed_addrs:
-#         4223dd0eeb0b0d78720a8990700955e1:
-#             - "/dns4/fn.testnet.aptos.com/tcp/6182/ln-noise-ik/b6fd31624af370085cc3f872437bb4d9384b31a11b33b9591ddfaaed5a28b613/ln-handshake/0"
+# TODO:
+# * add url for genesis blob and waypoint
 #
 # TODO:
 #   * Directions on the correct image

--- a/docker/compose/public_full_node/public_full_node.yaml
+++ b/docker/compose/public_full_node/public_full_node.yaml
@@ -19,13 +19,7 @@ full_node_networks:
       # prevent remote, incoming connections.
       listen_address: "/ip4/127.0.0.1/tcp/6180"
       network_id: "public"
-      # Testnet does not have the right discovery entry points on-chain so this is used instead
-      seeds:
-        D4C4FB4956D899E55289083F45AC5D84:
-          addresses:
-            - "/dns4/fn.testnet.aptos.com/tcp/6182/ln-noise-ik/d29d01bed8ab6c30921b327823f7e92c63f8371456fb110256e8c0e8911f4938/ln-handshake/0"
-          role: "ValidatorFullNode"
 
 json_rpc:
-    # This specifies your JSON-RPC endpoint. Intentionally on public so that Docker can export it.
+    # This specifies your REST API endpoint. Intentionally on public so that Docker can export it.
     address: 0.0.0.0:8080


### PR DESCRIPTION
- seed peer is no longer needed
- TODO: will probably dump genesis.blob and waypoint to S3 bucket and then update this url. since I'm going to lockdown the access to validator deployment