### PR TITLE
[storage] add delete_range and delete_range_inclusive to SchemaBatch

### DIFF
--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -99,6 +99,24 @@ pub static DIEM_SCHEMADB_DELETES: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static DIEM_SCHEMADB_RANGE_DELETES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "diem_storage_range_deletes",
+        "Diem storage range delete calls",
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
+pub static DIEM_SCHEMADB_INCLUSIVE_RANGE_DELETES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "diem_storage_range_inclusive_deletes",
+        "Diem storage range inclusive delete calls",
+        &["cf_name"]
+    )
+    .unwrap()
+});
+
 pub static DIEM_SCHEMADB_BATCH_PUT_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Provide two util functions (1) range_delete and (2) range_delete_inclusive for schemDB batch.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Related Issue
https://github.com/aptos-labs/aptos-core/issues/48

## Test Plan
add new unit test 
cargo test -p schemadb  passed

