### PR TITLE
[testnet] add wait time for genesis

### DIFF
--- a/terraform/testnet/testnet/templates/genesis.yaml
+++ b/terraform/testnet/testnet/templates/genesis.yaml
@@ -89,7 +89,10 @@ spec:
           aptos-genesis-tool set-move-modules --shared-backend "$FILE_BACKEND;namespace=common" --dir {{ .Values.genesis.moveModuleDir | default "/aptos/move/modules"}}
           aptos-genesis-tool aptos-root-key --validator-backend "$VAULT_BACKEND;namespace=aptos" --shared-backend "$FILE_BACKEND;namespace=aptos"
           aptos-genesis-tool treasury-compliance-key --validator-backend "$VAULT_BACKEND;namespace=aptos" --shared-backend "$FILE_BACKEND;namespace=aptos"
-
+          {{- if .Values.service.fullnode.enableOnchainDiscovery }}
+          # wait for DNS getting created
+          sleep 300
+          {{- else }}
           for N in $(seq 0 $(({{ .Values.genesis.numValidators}}-1))); do
             {{- if .Values.localVaultBackend }}
             export VAULT_ADDR="http://val${N}-aptos-validator-vault:8200"


### PR DESCRIPTION
If `enableOnchainDiscovery` is set, we will try to create DNS records for the fullnode LB, add a bit wait time for the records to be created before proceeding.