### PR TITLE
[build-tools] Move /opt/git/diem to /opt/git/aptos-core

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -37,9 +37,9 @@ runs:
           sudo mkdir -p /opt/git || true
           sudo chmod -R g+rw /opt/
           sudo chgrp -R wheel /opt/
-          mv /Users/runner/work/diem/diem /opt/git/diem
-          ln -s /opt/git/diem /Users/runner/work/diem/diem
-          cd /opt/git/diem
+          mv /Users/runner/work/aptos/aptos /opt/git/aptos-core
+          ln -s /opt/git/aptos-core /Users/runner/work/aptos/aptos
+          cd /opt/git/aptos-core
         fi
 
         # prepare move lang prover tooling.
@@ -61,5 +61,5 @@ runs:
       shell: bash
       run: |
         echo 'RUST_BACKTRACE=1' | tee -a $GITHUB_ENV
-        echo 'DIEM_DUMP_LOGS=1' | tee -a $GITHUB_ENV
+        echo 'APTOS_DUMP_LOGS=1' | tee -a $GITHUB_ENV
         echo 'CARGO_INCREMENTAL=0' | tee -a $GITHUB_ENV

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ defaults:
 
 env:
   max_threads: 16
-  pre_command: cd /opt/git/diem/
+  pre_command: cd /opt/git/aptos-core/
 
 jobs:
 #  dev-setup-sh-test:
@@ -170,7 +170,7 @@ jobs:
 #    container:
 #      image: ghcr.io/diem/aptos_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
 #      volumes:
-#        - "${{github.workspace}}:/opt/git/diem"
+#        - "${{github.workspace}}:/opt/git/aptos-core"
 #    steps:
 #      - uses: actions/checkout@v2.4.0
 #        with:
@@ -304,7 +304,7 @@ jobs:
 #    container:
 #      image: ghcr.io/diem/aptos_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
 #      volumes:
-#        - "${{github.workspace}}:/opt/git/diem"
+#        - "${{github.workspace}}:/opt/git/aptos-core"
 #    steps:
 #      - uses: actions/checkout@v2.3.4
 #      - uses: ./.github/actions/build-setup

--- a/x.toml
+++ b/x.toml
@@ -12,7 +12,7 @@ public = true
 region = "us-west-2"
 endpoint = "https://s3-us-west-2.amazonaws.com"
 required-cargo-home = "/opt/cargo/"
-required-git-home = "/opt/git/diem"
+required-git-home = "/opt/git/aptos-core"
 envs = [
    #To debug sccache uncomment the two lines below.
    #["SCCACHE_ERROR_LOG","/tmp/sccache_log"],
@@ -21,7 +21,7 @@ envs = [
 
 [cargo.sccache.installer]
 version = "0.2.16-alpha.0"
-git = "https://github.com/diem/sccache.git"
+git = "https://github.com/mozilla/sccache.git"
 git-rev = "ef50d87a58260c30767520045e242ccdbdb965af"
 features = [ "s3" ]
 


### PR DESCRIPTION
If sccache works, it would work better on my t3.xlarge if it actually matched the repo name.