### PR TITLE
[helm] add option to disable api endpoints

### DIFF
--- a/terraform/testnet/testnet/files/commands.txt
+++ b/terraform/testnet/testnet/files/commands.txt
@@ -1,2 +1,0 @@
-a c
-a mb 0 1 XUS

--- a/terraform/testnet/testnet/templates/genesis.yaml
+++ b/terraform/testnet/testnet/templates/genesis.yaml
@@ -92,7 +92,7 @@ spec:
           {{- if .Values.service.fullnode.enableOnchainDiscovery }}
           # wait for DNS getting created
           sleep 300
-          {{- else }}
+          {{- end }}
           for N in $(seq 0 $(({{ .Values.genesis.numValidators}}-1))); do
             {{- if .Values.localVaultBackend }}
             export VAULT_ADDR="http://val${N}-aptos-validator-vault:8200"

--- a/terraform/testnet/testnet/templates/ingress.yaml
+++ b/terraform/testnet/testnet/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.fullnode.exposeApi }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,16 +29,6 @@ spec:
         backend:
           service:
             name: {{ include "testnet.fullname" . }}-faucet
-            port:
-              number: 80
-  - host: mon.{{ .Values.service.domain }}
-    http:
-      paths:
-      - path: /*
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "testnet.fullname" . }}-monitoring
             port:
               number: 80
   {{- if .Values.service.pfn.exposeApi }}
@@ -98,3 +89,4 @@ spec:
             name: {{ include "testnet.fullname" . }}-api
             port:
               number: 80
+{{- end }}

--- a/terraform/testnet/testnet/templates/monitoring.yaml
+++ b/terraform/testnet/testnet/templates/monitoring.yaml
@@ -66,16 +66,24 @@ metadata:
   labels:
     {{- include "testnet.labels" . | nindent 4 }}
   annotations:
-    alb.ingress.kubernetes.io/healthcheck-path: /api/health
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+    {{- if .Values.service.domain }}
+    external-dns.alpha.kubernetes.io/hostname: mon.{{ .Values.service.domain }}
+    {{- end }}
 spec:
   selector:
     {{- include "testnet.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/name: monitoring
   ports:
-  - port: 80
+  - name: grafana-http
+    port: 80
     targetPort: 3000
-  type: NodePort
-  externalTrafficPolicy: Local
+  type: LoadBalancer
+  {{- with .Values.service.monitoring.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
 
 ---
 

--- a/terraform/testnet/testnet/values.yaml
+++ b/terraform/testnet/testnet/values.yaml
@@ -72,6 +72,7 @@ faucet:
 service:
   fullnode:
     enableOnchainDiscovery: false
+    exposeApi: false
     loadBalancerSourceRanges:
   monitoring:
     loadBalancerSourceRanges:


### PR DESCRIPTION
- move monitoring back to it's own lb so it can be exposed separately
- add option to disable api/faucet endpoint exposure on testnet deployment 