### PR TITLE
[testnet] make aptos-framework default framework

### DIFF
--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -47,11 +47,11 @@ COPY --from=builder /aptos/target/release/db-restore /usr/local/bin
 COPY --from=builder /aptos/target/release/aptos-transaction-replay /usr/local/bin
 
 ### Get DPN Move modules bytecodes for genesis ceremony
-RUN mkdir -p /aptos/move/build
-RUN mkdir -p /aptos/move/modules
-COPY --from=builder /aptos/aptos-move/framework/DPN/releases/artifacts/current/build /aptos/move/build
-RUN mv /aptos/move/build/**/bytecode_modules/*.mv /aptos/move/modules
-RUN rm -rf /aptos/move/build
+RUN mkdir -p /diem-framework/move/build
+RUN mkdir -p /diem-framework/move/modules
+COPY --from=builder /aptos/aptos-move/framework/DPN/releases/artifacts/current/build /diem-framework/move/build
+RUN mv /diem-framework/move/build/**/bytecode_modules/*.mv /diem-framework/move/modules
+RUN rm -rf /diem-framework/move/build
 
 ### Get experimental Move modules bytecodes for genesis ceremony
 RUN mkdir -p /experimental/move/build

--- a/terraform/testnet/testnet/templates/genesis.yaml
+++ b/terraform/testnet/testnet/templates/genesis.yaml
@@ -86,7 +86,7 @@ spec:
           kubectl get secret -o name | grep "{{ include "testnet.fullname" . }}-faucet-e" | xargs -r kubectl delete
 
           aptos-genesis-tool set-layout --shared-backend "$FILE_BACKEND;namespace=common" --path /genesis/layout.yaml
-          aptos-genesis-tool set-move-modules --shared-backend "$FILE_BACKEND;namespace=common" --dir {{ .Values.genesis.moveModuleDir | default "/aptos/move/modules"}}
+          aptos-genesis-tool set-move-modules --shared-backend "$FILE_BACKEND;namespace=common" --dir {{ .Values.genesis.moveModuleDir | default "/aptos-framework/move/modules"}}
           aptos-genesis-tool aptos-root-key --validator-backend "$VAULT_BACKEND;namespace=aptos" --shared-backend "$FILE_BACKEND;namespace=aptos"
           aptos-genesis-tool treasury-compliance-key --validator-backend "$VAULT_BACKEND;namespace=aptos" --shared-backend "$FILE_BACKEND;namespace=aptos"
           {{- if .Values.service.fullnode.enableOnchainDiscovery }}


### PR DESCRIPTION
* during the rename diem -> aptos, so renaming it to proper diem-framework
* we weren't pointing to aptos-framework in our testnet genesis.yaml