### PR TITLE
[tf][testnet] cleanup unused vars

### DIFF
--- a/terraform/helm/validator/templates/validator.yaml
+++ b/terraform/helm/validator/templates/validator.yaml
@@ -224,7 +224,7 @@ spec:
     ports:
     - protocol: TCP
       port: 6180
-  {{- if .Values.exposeValidatorJsonRpc }}
+  {{- if .Values.exposeValidatorRestApi }}
   # REST API from HAproxy
   - from:
     - podSelector:

--- a/terraform/testnet/main.tf
+++ b/terraform/testnet/main.tf
@@ -145,7 +145,8 @@ resource "helm_release" "validator" {
   values = [
     module.validator.helm_values,
     jsonencode({
-      localVaultBackend = var.enable_dev_vault # Toggle dev vault mode
+      exposeValidatorRestApi = var.enable_forge
+      localVaultBackend      = var.enable_dev_vault # Toggle dev vault mode
       validator = {
         name = "val${count.index}"
       }
@@ -159,17 +160,6 @@ resource "helm_release" "validator" {
         external = {
           type = "NodePort"
         }
-      }
-      fullnode = {
-        groups = [
-          {
-            name          = "fullnode"
-            replicas      = 1
-            enableJsonRpc = true
-            # Forge requires REST API
-            enableApi = var.enable_forge || var.enable_api
-          }
-        ]
       }
       monitoring = {
         fullKubernetesScrape = false

--- a/terraform/testnet/variables.tf
+++ b/terraform/testnet/variables.tf
@@ -111,11 +111,6 @@ variable "pfn_logger_helm_values" {
   default     = {}
 }
 
-variable "enable_explorer" {
-  description = "Enable Aptos Explorer on the cluster"
-  default     = false
-}
-
 variable "enable_forge" {
   description = "Enable Forge test framework, also creating an internal helm repo"
   default     = false
@@ -148,11 +143,6 @@ variable "explorer_image_repo" {
 
 variable "explorer_image_tag" {
   default = "latest"
-}
-
-variable "enable_api" {
-  description = "Enables the REST API on fullnodes"
-  default     = false
 }
 
 variable "enable_dev_vault" {


### PR DESCRIPTION
Remove vars:
* var.enable_api -- API should be enabled on the default fullnode group, otherwise can override via helm values
* var.enable_explorer: this doesn't exist anymore


Rename helm value:
* exposeValidatorJsonRpc --> exposeValidatorRestApi -- and enable it automatically on Forge clusters