### PR TITLE
Make mint return the pending transactions as json

### DIFF
--- a/crates/aptos-faucet/Cargo.toml
+++ b/crates/aptos-faucet/Cargo.toml
@@ -18,6 +18,7 @@ hex = "0.4.3"
 rand = "0.8.3"
 reqwest = { version = "0.11.2", features = ["blocking"], default-features = false }
 serde = { version = "1.0.124", features = ["derive"] }
+serde_json = "1.0.61"
 structopt = "0.3.21"
 tokio = { version = "1.8.1", features = ["full"] }
 url = "2.2.2"

--- a/crates/aptos-faucet/README.md
+++ b/crates/aptos-faucet/README.md
@@ -34,19 +34,33 @@ which is the account sequence number of the account `0xa550c18` after executing 
 Nominally, this number can be used for looking up the submitted transaction.
 However, under load, this number may be shared by multiple transactions.
 
-If the query param `return_txns` is set, the server will respond with the transactions for creating and funding your account.
-The response HTTP body is hex encoded bytes of BCS encoded `Vec<aptos_types::transaction::SignedTransaction>`.
-
-Decode Example ([source](https://diem.github.io/client-sdk-python/diem/testnet.html#diem.testnet.Faucet)):
-
-``` python
-  de = bcs.BcsDeserializer(bytes.fromhex(response.text))
-  length = de.deserialize_len()
-
-  txns = []
-  for i in range(length):
-    txns.push(de.deserialize_any(aptos_types.SignedTransaction))
-
+If the query param `return_txns` is set, the server will respond with the transaction(s) for creating and funding your account.
+Here is an example:
+```
+  {
+    "hash": "0x92d52234640c364d484a2c833ea7b239759a5b71d44125ff16152c3c30727462",
+    "sender": "0xa550c18",
+    "sequence_number": "152",
+    "max_gas_amount": "1000000",
+    "gas_unit_price": "0",
+    "gas_currency_code": "XUS",
+    "expiration_timestamp_secs": "1646896796",
+    "payload": {
+      "type": "script_function_payload",
+      "function": "0x1::BasicScripts::mint",
+      "type_arguments": [],
+      "arguments": [
+        "0x25c62c0e0820f422000814cdba407835",
+        "1"
+      ]
+    },
+    "signature": {
+      "type": "ed25519_signature",
+      "public_key": "0xbf53669d37c17042a97b41faa58bef5ca4243f73d7536da4fb7f3565dac89c42",
+      "signature": "0x6f2234c01bc8e9495395b64bd639ff5a5dee74abcbda8b7230aa97d5076af4167092c40c46cccda070bf49fe3c9ca575a9619ba8cd0809542590892e24e1dc03"
+    }
+  }
+]
 ```
 
 You should retry the mint API call if the transaction execution fails.

--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -110,7 +110,9 @@ fn git_is_worktree_dirty() -> Result<bool> {
 pub fn git_get_upstream_remote() -> Result<String> {
     let output = Command::new("sh")
         .arg("-c")
-        .arg("git remote -v | grep \"https://github.com/aptos-labs/aptos-core.* (fetch)\" | cut -f1")
+        .arg(
+            "git remote -v | grep \"https://github.com/aptos-labs/aptos-core.* (fetch)\" | cut -f1",
+        )
         .output()
         .context("Failed to get upstream remote")?;
 


### PR DESCRIPTION
```
➜  curl -X POST http://localhost:8081/mint\?pub_key\=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d\&amount\=1\&return_txns\=true | jq

[
  {
    "hash": "0x92d52234640c364d484a2c833ea7b239759a5b71d44125ff16152c3c30727462",
    "sender": "0xa550c18",
    "sequence_number": "152",
    "max_gas_amount": "1000000",
    "gas_unit_price": "0",
    "gas_currency_code": "XUS",
    "expiration_timestamp_secs": "1646896796",
    "payload": {
      "type": "script_function_payload",
      "function": "0x1::BasicScripts::mint",
      "type_arguments": [],
      "arguments": [
        "0x25c62c0e0820f422000814cdba407835",
        "1"
      ]
    },
    "signature": {
      "type": "ed25519_signature",
      "public_key": "0xbf53669d37c17042a97b41faa58bef5ca4243f73d7536da4fb7f3565dac89c42",
      "signature": "0x6f2234c01bc8e9495395b64bd639ff5a5dee74abcbda8b7230aa97d5076af4167092c40c46cccda070bf49fe3c9ca575a9619ba8cd0809542590892e24e1dc03"
    }
  }
]
```