### PR TITLE
[gitignore] Ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ target-out-docker
 
 # Doc generation output
 *.md.old
+
+# Vim swap files
+*.swp
+*.swo


### PR DESCRIPTION
I keep accidentally adding vim swap files, and there shouldn't be a reason to add them, so I'm adding them to the .gitignore