### PR TITLE
[DB] DB Pruner refactoring for ability to add more pruners

### DIFF
--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -3,7 +3,7 @@
 
 use crate::AptosValidatorInterface;
 use anyhow::{anyhow, Result};
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_types::{
     account_address::AccountAddress,
     account_state::AccountState,
@@ -22,7 +22,7 @@ impl DBDebuggerInterface {
         Ok(Self(Arc::new(AptosDB::open(
             db_root_path,
             true,
-            None,
+            NO_OP_STORAGE_PRUNER_CONFIG,
             RocksdbConfig::default(),
             true, /* account_count_migration, ignored anyway */
         )?)))

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -444,7 +444,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         AptosDB::open(
             &node_config.storage.dir(),
             false, /* readonly */
-            node_config.storage.prune_window,
+            node_config.storage.storage_pruner_config,
             node_config.storage.rocksdb_config,
             node_config.storage.account_count_migration,
         )

--- a/config/management/genesis/src/verify.rs
+++ b/config/management/genesis/src/verify.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_ACCOUNT, OWNER_KEY,
     SAFETY_DATA, VALIDATOR_NETWORK_KEY, WAYPOINT,
@@ -212,7 +212,7 @@ fn compute_genesis(
     let aptosdb = AptosDB::open(
         db_path,
         false,
-        None,
+        NO_OP_STORAGE_PRUNER_CONFIG,
         RocksdbConfig::default(),
         true, /* account_count_migration */
     )

--- a/config/management/genesis/src/waypoint.rs
+++ b/config/management/genesis/src/waypoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_management::{config::ConfigPath, error::Error, secure_backend::SharedBackend};
 use aptos_temppath::TempPath;
 use aptos_types::{chain_id::ChainId, transaction::Transaction, waypoint::Waypoint};
@@ -43,7 +43,7 @@ pub fn create_genesis_waypoint(genesis: &Transaction) -> Result<Waypoint, Error>
     let aptosdb = AptosDB::open(
         &path,
         false,
-        None,
+        NO_OP_STORAGE_PRUNER_CONFIG,
         RocksdbConfig::default(),
         true, /* account_count_migration */
     )

--- a/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, format_err, Context, Result};
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Transaction, waypoint::Waypoint};
 use aptos_vm::AptosVM;
@@ -54,7 +54,7 @@ fn main() -> Result<()> {
         AptosDB::open(
             &opt.db_dir,
             false,
-            None, /* pruner */
+            NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
             RocksdbConfig::default(),
             opt.account_count_migration,
         )

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -5,7 +5,10 @@ use crate::{
     transaction_executor::TransactionExecutor, transaction_generator::TransactionGenerator,
     TransactionCommitter,
 };
-use aptos_config::{config::RocksdbConfig, utils::get_genesis_txn};
+use aptos_config::{
+    config::{RocksdbConfig, StoragePrunerConfig},
+    utils::get_genesis_txn,
+};
 use aptos_jellyfish_merkle::metrics::{
     DIEM_JELLYFISH_INTERNAL_ENCODED_BYTES, DIEM_JELLYFISH_LEAF_ENCODED_BYTES,
     DIEM_JELLYFISH_STORAGE_READS,
@@ -31,7 +34,7 @@ pub fn run(
     init_account_balance: u64,
     block_size: usize,
     db_dir: impl AsRef<Path>,
-    prune_window: Option<u64>,
+    storage_pruner_config: StoragePrunerConfig,
 ) {
     println!("Initializing...");
 
@@ -46,8 +49,8 @@ pub fn run(
     let (db, db_rw) = DbReaderWriter::wrap(
         AptosDB::open(
             &db_dir,
-            false,        /* readonly */
-            prune_window, /* pruner */
+            false,                 /* readonly */
+            storage_pruner_config, /* pruner */
             RocksdbConfig::default(),
             true, /* account_count_migration */
         )

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -10,7 +10,7 @@ use crate::{
     transaction_committer::TransactionCommitter, transaction_executor::TransactionExecutor,
     transaction_generator::TransactionGenerator,
 };
-use aptos_config::config::{NodeConfig, RocksdbConfig};
+use aptos_config::config::{NodeConfig, RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_logger::prelude::*;
 
 use aptos_vm::AptosVM;
@@ -28,8 +28,8 @@ pub fn init_db_and_executor(config: &NodeConfig) -> (Arc<dyn DbReader>, BlockExe
     let (db, dbrw) = DbReaderWriter::wrap(
         AptosDB::open(
             &config.storage.dir(),
-            false, /* readonly */
-            None,  /* pruner */
+            false,                       /* readonly */
+            NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
             RocksdbConfig::default(),
             true, /* account_count_migration */
         )
@@ -57,8 +57,8 @@ pub fn run_benchmark(
 
     AptosDB::open(
         &source_dir,
-        true, /* readonly */
-        None, /* pruner */
+        true,                        /* readonly */
+        NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
         RocksdbConfig::default(),
         true, /* account_count_migration */
     )
@@ -128,6 +128,7 @@ pub fn run_benchmark(
 
 #[cfg(test)]
 mod tests {
+    use aptos_config::config::NO_OP_STORAGE_PRUNER_CONFIG;
     use aptos_temppath::TempPath;
 
     #[test]
@@ -142,7 +143,7 @@ mod tests {
             10, /* init_account_balance */
             5,  /* block_size */
             storage_dir.as_ref(),
-            None, /* prune_window */
+            NO_OP_STORAGE_PRUNER_CONFIG, /* prune_window */
         );
 
         super::run_benchmark(

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_config::config::StoragePrunerConfig;
 use aptos_secure_push_metrics::MetricsPusher;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -30,7 +31,10 @@ enum Command {
         init_account_balance: u64,
 
         #[structopt(long)]
-        prune_window: Option<u64>,
+        state_store_prune_window: Option<u64>,
+
+        #[structopt(long)]
+        default_store_prune_window: Option<u64>,
     },
     RunExecutor {
         #[structopt(
@@ -68,14 +72,15 @@ fn main() {
             data_dir,
             num_accounts,
             init_account_balance,
-            prune_window,
+            state_store_prune_window,
+            default_store_prune_window,
         } => {
             executor_benchmark::db_generator::run(
                 num_accounts,
                 init_account_balance,
                 opt.block_size,
                 data_dir,
-                prune_window,
+                StoragePrunerConfig::new(state_store_prune_window, default_store_prune_window),
             );
         }
         Command::RunExecutor {

--- a/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
@@ -164,7 +164,10 @@ pub fn state_sync_v1_network_config() -> AppConfig {
 #[cfg(any(test, feature = "fuzzing"))]
 mod tests {
     use crate::StateSyncMultiplexer;
-    use aptos_config::{config::RocksdbConfig, utils::get_genesis_txn};
+    use aptos_config::{
+        config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG},
+        utils::get_genesis_txn,
+    };
     use aptos_crypto::HashValue;
     use aptos_data_client::aptosnet::AptosNetDataClient;
     use aptos_genesis_tool::test_config;
@@ -193,7 +196,14 @@ mod tests {
     fn test_new_initialized_configs() {
         // Create a test database
         let tmp_dir = TempPath::new();
-        let db = AptosDB::open(&tmp_dir, false, None, RocksdbConfig::default(), true).unwrap();
+        let db = AptosDB::open(
+            &tmp_dir,
+            false,
+            NO_OP_STORAGE_PRUNER_CONFIG,
+            RocksdbConfig::default(),
+            true,
+        )
+        .unwrap();
         let (_, db_rw) = DbReaderWriter::wrap(db);
 
         // Bootstrap the database

--- a/storage/accumulator/src/lib.rs
+++ b/storage/accumulator/src/lib.rs
@@ -363,7 +363,6 @@ where
             leaf_index,
             self.num_leaves
         );
-
         let siblings = self.get_siblings(leaf_index, |_p| true)?;
         Ok(AccumulatorProof::new(siblings))
     }

--- a/storage/aptosdb/src/aptossum/mod.rs
+++ b/storage/aptosdb/src/aptossum/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::{AptosDB, Order, MAX_LIMIT};
 use anyhow::{ensure, format_err, Result};
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_types::{
     account_address::AccountAddress,
     account_state_blob::AccountStateBlob,
@@ -22,8 +22,8 @@ impl Aptossum {
     pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Result<Self> {
         let db = AptosDB::open(
             db_root_path,
-            true, /* read only */
-            None, /* no prune_window */
+            true,                        /* read only */
+            NO_OP_STORAGE_PRUNER_CONFIG, /* no prune_window */
             RocksdbConfig::default(),
             true, /* account_count_migration, ignored anyway */
         )?;

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -56,7 +56,7 @@ use crate::{
     transaction_store::TransactionStore,
 };
 use anyhow::{ensure, format_err, Result};
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, StoragePrunerConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_crypto::hash::{HashValue, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use aptos_logger::prelude::*;
 use aptos_types::{
@@ -226,7 +226,6 @@ pub struct AptosDB {
     system_store: SystemStore,
     rocksdb_property_reporter: RocksdbPropertyReporter,
     pruner: Option<Pruner>,
-    prune_window: Option<u64>,
 }
 
 impl AptosDB {
@@ -250,7 +249,11 @@ impl AptosDB {
         ]
     }
 
-    fn new_with_db(db: DB, prune_window: Option<u64>, account_count_migration: bool) -> Self {
+    fn new_with_db(
+        db: DB,
+        storage_pruner_config: StoragePrunerConfig,
+        account_count_migration: bool,
+    ) -> Self {
         let db = Arc::new(db);
 
         AptosDB {
@@ -261,20 +264,22 @@ impl AptosDB {
             transaction_store: Arc::new(TransactionStore::new(Arc::clone(&db))),
             system_store: SystemStore::new(Arc::clone(&db)),
             rocksdb_property_reporter: RocksdbPropertyReporter::new(Arc::clone(&db)),
-            pruner: prune_window.map(|n| Pruner::new(Arc::clone(&db), n)),
-            prune_window,
+            pruner: match storage_pruner_config {
+                NO_OP_STORAGE_PRUNER_CONFIG => None,
+                _ => Some(Pruner::new(Arc::clone(&db), storage_pruner_config)),
+            },
         }
     }
 
     pub fn open<P: AsRef<Path> + Clone>(
         db_root_path: P,
         readonly: bool,
-        prune_window: Option<u64>,
+        storage_pruner_config: StoragePrunerConfig,
         rocksdb_config: RocksdbConfig,
         account_count_migration: bool, // ignored when opening readonly
     ) -> Result<Self> {
         ensure!(
-            prune_window.is_none() || !readonly,
+            storage_pruner_config.eq(&NO_OP_STORAGE_PRUNER_CONFIG) || !readonly,
             "Do not set prune_window when opening readonly.",
         );
 
@@ -307,7 +312,7 @@ impl AptosDB {
             )
         };
 
-        let ret = Self::new_with_db(db, prune_window, account_count_migration);
+        let ret = Self::new_with_db(db, storage_pruner_config, account_count_migration);
         info!(
             path = path,
             time_ms = %instant.elapsed().as_millis(),
@@ -335,7 +340,7 @@ impl AptosDB {
                 Self::column_families(),
                 &rocksdb_opts,
             )?,
-            None, // prune_window
+            NO_OP_STORAGE_PRUNER_CONFIG,
             true, // account_count_migration
         ))
     }
@@ -345,8 +350,8 @@ impl AptosDB {
     pub fn new_for_test<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
         Self::open(
             db_root_path,
-            false, /* readonly */
-            None,  /* pruner */
+            false,                       /* readonly */
+            NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
             RocksdbConfig::default(),
             true, /* account_count_migration */
         )
@@ -1207,7 +1212,9 @@ impl DbReader for AptosDB {
     }
 
     fn get_state_prune_window(&self) -> Option<usize> {
-        self.prune_window.map(|u| u as usize)
+        self.pruner
+            .as_ref()
+            .map(|x| x.get_state_store_pruner_window() as usize)
     }
 }
 

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -63,10 +63,18 @@ pub static DIEM_STORAGE_PRUNE_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!("aptos_storage_prune_window", "Aptos storage prune window").unwrap()
 });
 
-pub static DIEM_STORAGE_PRUNER_LEAST_READABLE_STATE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+pub static DIEM_STATE_STORAGE_PRUNER_LEAST_READABLE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_pruner_least_readable_state_version",
-        "Aptos storage pruner least readable state version"
+        "aptos_state_storage_pruner_least_readable_version",
+        "Aptos state storage pruner least readable state version"
+    )
+    .unwrap()
+});
+
+pub static DIEM_TRANSACTION_PRUNER_LEAST_READABLE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_transaction_pruner_least_readable_version",
+        "Aptos transaction pruner least readable state version"
     )
     .unwrap()
 });

--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -1,4 +1,4 @@
-// Copyright (c) The Aptos Foundation
+// Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::transaction::Version;

--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -1,0 +1,25 @@
+// Copyright (c) The Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_types::transaction::Version;
+
+/// Defines the trait for pruner for different DB
+pub trait DBPruner {
+    /// Initialize the pruner and record the least readable version
+    fn initialize(&self);
+    /// Performs the actual pruning, a target version is passed, which is the target the pruner
+    /// tries to prune.
+    fn prune(&self, max_versions: usize) -> anyhow::Result<Version>;
+    /// Initializes the least readable version stored in underlying DB storage
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version>;
+    /// Returns the least readable version stores in the DB pruner
+    fn least_readable_version(&self) -> Version;
+    /// Sets the target version for the pruner
+    fn set_target_version(&self, target_version: Version);
+    /// Returns the target version for the DB pruner
+    fn target_version(&self) -> Version;
+    /// Records the current progress of the pruner by updating the least readable version
+    fn record_progress(&self, least_readable_version: Version);
+    /// True if there is pruning work pending to be done
+    fn is_pruning_pending(&self) -> bool;
+}

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -4,31 +4,22 @@
 //! This module provides `Pruner` which manages a thread pruning old data in the background and is
 //! meant to be triggered by other threads as they commit new data to the DB.
 
-use crate::{
-    metrics::{
-        DIEM_STORAGE_OTHER_TIMERS_SECONDS, DIEM_STORAGE_PRUNER_LEAST_READABLE_STATE_VERSION,
-        DIEM_STORAGE_PRUNE_WINDOW,
-    },
-    schema::{
-        jellyfish_merkle_node::JellyfishMerkleNodeSchema, stale_node_index::StaleNodeIndexSchema,
-    },
-};
-use anyhow::Result;
+use crate::metrics::DIEM_STORAGE_PRUNE_WINDOW;
+
+use aptos_config::config::StoragePrunerConfig;
 use aptos_infallible::Mutex;
-use aptos_jellyfish_merkle::StaleNodeIndex;
-use aptos_logger::prelude::*;
+
 use aptos_types::transaction::Version;
-use schemadb::{ReadOptions, SchemaBatch, SchemaIterator, DB};
+use schemadb::DB;
 use std::{
-    iter::Peekable,
     sync::{
-        atomic::{AtomicU64, Ordering},
-        mpsc::{channel, Receiver, Sender},
         Arc,
+        mpsc::{channel, Sender},
     },
-    thread::{sleep, JoinHandle},
+    thread::{JoinHandle, sleep},
     time::{Duration, Instant},
 };
+use worker::{Command, Worker};
 
 /// The `Pruner` is meant to be part of a `AptosDB` instance and runs in the background to prune old
 /// data.
@@ -37,50 +28,71 @@ use std::{
 /// quits the worker thread eagerly without waiting for all pending work to be done.
 #[derive(Debug)]
 pub(crate) struct Pruner {
-    /// Other than the latest version, how many historical versions to keep being readable. For
-    /// example, this being 0 means keep only the latest version.
-    historical_versions_to_keep: u64,
+    /// DB version window, which dictates how many versions of state store
+    /// to keep.
+    state_store_prune_window: Version,
+    /// DB version window, which dictates how many version of other stoes like transaction, ledger
+    /// info, events etc to keep.
+    default_prune_window: Version,
     /// The worker thread handle, created upon Pruner instance construction and joined upon its
     /// destruction. It only becomes `None` after joined in `drop()`.
     worker_thread: Option<JoinHandle<()>>,
     /// The sender side of the channel talking to the worker thread.
     command_sender: Mutex<Sender<Command>>,
     /// (For tests) A way for the worker thread to inform the `Pruner` the pruning progress. If it
-    /// sets this atomic value to `V`, all versions before `V` can no longer be accessed.
+    /// sets value to `V`, all versions before `V` can no longer be accessed. This is protected by Mutex
+    /// as this is accessed both by the Pruner thread and the worker thread.
     #[allow(dead_code)]
-    worker_progress: Arc<AtomicU64>,
+    least_readable_version: Arc<Mutex<Vec<Version>>>,
 }
 
 impl Pruner {
     /// Creates a worker thread that waits on a channel for pruning commands.
-    pub fn new(db: Arc<DB>, historical_versions_to_keep: u64) -> Self {
+    pub fn new(db: Arc<DB>, storage_pruner_config: StoragePrunerConfig) -> Self {
         let (command_sender, command_receiver) = channel();
 
-        let worker_progress = Arc::new(AtomicU64::new(0));
-        let worker_progress_clone = Arc::clone(&worker_progress);
+        let least_readable_version = Arc::new(Mutex::new(vec![0, 0]));
+        let worker_progress_clone = Arc::clone(&least_readable_version);
 
-        DIEM_STORAGE_PRUNE_WINDOW.set(historical_versions_to_keep as i64);
+        DIEM_STORAGE_PRUNE_WINDOW
+            .set(storage_pruner_config.state_store_prune_window.unwrap() as i64);
+        let worker = Worker::new(db, command_receiver, least_readable_version);
         let worker_thread = std::thread::Builder::new()
             .name("aptosdb_pruner".into())
-            .spawn(move || Worker::new(db, command_receiver, worker_progress_clone).work())
+            .spawn(move || worker.work())
             .expect("Creating pruner thread should succeed.");
 
         Self {
-            historical_versions_to_keep,
+            state_store_prune_window: storage_pruner_config
+                .state_store_prune_window
+                .expect("State store prune window must be specified"),
+            default_prune_window: storage_pruner_config
+                .default_prune_window
+                .expect("Default prune window must be specified"),
             worker_thread: Some(worker_thread),
             command_sender: Mutex::new(command_sender),
-            worker_progress,
+            least_readable_version: worker_progress_clone,
         }
+    }
+
+    pub fn get_state_store_pruner_window(&self) -> Version {
+        self.state_store_prune_window.clone()
     }
 
     /// Sends pruning command to the worker thread when necessary.
     pub fn wake(&self, latest_version: Version) {
-        if latest_version > self.historical_versions_to_keep {
-            let least_readable_version = latest_version - self.historical_versions_to_keep;
+        if latest_version > self.state_store_prune_window
+            || latest_version > self.default_prune_window
+        {
+            let least_readable_state_store_version = latest_version - self.state_store_prune_window;
+            let least_readable_default_store_version = latest_version - self.default_prune_window;
             self.command_sender
                 .lock()
                 .send(Command::Prune {
-                    least_readable_version,
+                    target_db_versions: vec![
+                        least_readable_state_store_version,
+                        least_readable_default_store_version,
+                    ],
                 })
                 .expect("Receiver should not destruct prematurely.");
         }
@@ -89,17 +101,21 @@ impl Pruner {
     /// (For tests only.) Notifies the worker thread and waits for it to finish its job by polling
     /// an internal counter.
     #[cfg(test)]
-    pub fn wake_and_wait(&self, latest_version: Version) -> Result<()> {
+    pub fn wake_and_wait(&self, latest_version: Version) -> anyhow::Result<()> {
         self.wake(latest_version);
 
-        if latest_version > self.historical_versions_to_keep {
-            let least_readable_version = latest_version - self.historical_versions_to_keep;
+        if latest_version > self.state_store_prune_window
+            || latest_version > self.default_prune_window
+        {
+            let least_readable_state_store_version = latest_version - self.state_store_prune_window;
             // Assuming no big pruning chunks will be issued by a test.
-            const TIMEOUT: Duration = Duration::from_secs(10);
+            const TIMEOUT: Duration = Duration::from_secs(60);
             let end = Instant::now() + TIMEOUT;
 
             while Instant::now() < end {
-                if self.worker_progress.load(Ordering::Relaxed) >= least_readable_version {
+                if *self.least_readable_version.lock().get(0).unwrap()
+                    >= least_readable_state_store_version
+                {
                     return Ok(());
                 }
                 sleep(Duration::from_millis(1));
@@ -124,289 +140,7 @@ impl Drop for Pruner {
     }
 }
 
-enum Command {
-    Quit,
-    Prune { least_readable_version: Version },
-}
-
-struct Worker {
-    db: Arc<DB>,
-    command_receiver: Receiver<Command>,
-    target_least_readable_version: Version,
-    /// Keeps a record of the pruning progress. If this equals to version `V`, we know versions
-    /// smaller than `V` are no longer readable.
-    /// This being an atomic value is to communicate the info with the Pruner thread (for tests).
-    least_readable_version: Arc<AtomicU64>,
-    /// Indicates if there's NOT any pending work to do currently, to hint
-    /// `Self::receive_commands()` to `recv()` blocking-ly.
-    blocking_recv: bool,
-    index_min_nonpurged_version: Version,
-    index_purged_at: Instant,
-}
-
-impl Worker {
-    const MAX_VERSIONS_TO_PRUNE_PER_BATCH: usize = 100;
-
-    fn new(
-        db: Arc<DB>,
-        command_receiver: Receiver<Command>,
-        least_readable_version: Arc<AtomicU64>,
-    ) -> Self {
-        Self {
-            db,
-            command_receiver,
-            least_readable_version,
-            target_least_readable_version: 0,
-            blocking_recv: true,
-            index_min_nonpurged_version: 0,
-            index_purged_at: Instant::now(),
-        }
-    }
-
-    fn work(mut self) {
-        self.initialize();
-
-        while self.receive_commands() {
-            // Process a reasonably small batch of work before trying to receive commands again,
-            // in case `Command::Quit` is received (that's when we should quit.)
-            let least_readable_version = self.least_readable_version.load(Ordering::Relaxed);
-            match prune_state(
-                Arc::clone(&self.db),
-                least_readable_version,
-                self.target_least_readable_version,
-                Self::MAX_VERSIONS_TO_PRUNE_PER_BATCH,
-            ) {
-                Ok(new_least_readable_version) => {
-                    self.record_progress(new_least_readable_version);
-
-                    // Make next recv() blocking if nothing left to do.
-                    self.blocking_recv = new_least_readable_version == least_readable_version // did nothing
-                        || new_least_readable_version == self.target_least_readable_version; // did all
-
-                    // Try to purge the log.
-                    if let Err(e) = self.maybe_purge_index() {
-                        warn!(
-                            error = ?e,
-                            "Failed purging state node index, ignored.",
-                        );
-                    }
-                }
-                Err(e) => {
-                    error!(
-                        error = ?e,
-                        "Error pruning stale state nodes.",
-                    );
-                    // On error, stop retrying vigorously by making next recv() blocking.
-                    self.blocking_recv = true;
-                }
-            }
-        }
-    }
-
-    /// Find out the first undeleted item in the stale node index.
-    ///
-    /// Seeking from the beginning (version 0) is potentially costly, we do it once upon worker
-    /// thread start, record the progress and seek from that position afterwards.
-    fn initialize(&mut self) {
-        loop {
-            match self.get_least_readable_version() {
-                Ok(least_readable_version) => {
-                    info!(
-                        least_readable_version = least_readable_version,
-                        "[state pruner worker] initialized."
-                    );
-                    self.target_least_readable_version = least_readable_version;
-                    self.record_progress(least_readable_version);
-                    return;
-                }
-                Err(e) => {
-                    error!(
-                        error = ?e,
-                        "[state pruner worker] Error on first seek. Retrying in 1 second.",
-                    );
-                    sleep(Duration::from_secs(1));
-                }
-            }
-        }
-    }
-
-    fn get_least_readable_version(&self) -> Result<Version> {
-        let mut iter = self
-            .db
-            .iter::<StaleNodeIndexSchema>(ReadOptions::default())?;
-        iter.seek_to_first();
-        Ok(iter.next().transpose()?.map_or(0, |(index, _)| {
-            index
-                .stale_since_version
-                .checked_sub(1)
-                .expect("Nothing is stale since version 0.")
-        }))
-    }
-
-    /// Log the progress.
-    fn record_progress(&mut self, least_readable_version: Version) {
-        self.least_readable_version
-            .store(least_readable_version, Ordering::Relaxed);
-        DIEM_STORAGE_PRUNER_LEAST_READABLE_STATE_VERSION.set(least_readable_version as i64);
-    }
-
-    /// Tries to receive all pending commands, blocking waits for the next command if no work needs
-    /// to be done, otherwise quits with `true` to allow the outer loop to do some work before
-    /// getting back here.
-    ///
-    /// Returns `false` if `Command::Quit` is received, to break the outer loop and let
-    /// `work_loop()` return.
-    fn receive_commands(&mut self) -> bool {
-        loop {
-            let command = if self.blocking_recv {
-                // Worker has nothing to do, blocking wait for the next command.
-                self.command_receiver
-                    .recv()
-                    .expect("Sender should not destruct prematurely.")
-            } else {
-                // Worker has pending work to do, non-blocking recv.
-                match self.command_receiver.try_recv() {
-                    Ok(command) => command,
-                    // Channel has drained, yield control to the outer loop.
-                    Err(_) => return true,
-                }
-            };
-
-            match command {
-                // On `Command::Quit` inform the outer loop to quit by returning `false`.
-                Command::Quit => return false,
-                Command::Prune {
-                    least_readable_version,
-                } => {
-                    if least_readable_version > self.target_least_readable_version {
-                        self.target_least_readable_version = least_readable_version;
-                        // Switch to non-blocking to allow some work to be done after the
-                        // channel has drained.
-                        self.blocking_recv = false;
-                    }
-                }
-            }
-        }
-    }
-
-    /// Purge the stale node index so that after restart not too much already pruned stuff is dealt
-    /// with again (although no harm is done deleting those then non-existent things.)
-    ///
-    /// We issue (range) deletes on the index only periodically instead of after every pruning batch
-    /// to avoid sending too many deletions to the DB, which takes disk space and slows it down.
-    fn maybe_purge_index(&mut self) -> Result<()> {
-        const MIN_INTERVAL: Duration = Duration::from_secs(60);
-        const MIN_VERSIONS: u64 = 60000;
-
-        // A deletion is issued at most once in one minute and when the pruner has progressed by at
-        // least 60000 versions (assuming the pruner deletes as slow as 1000 versions per second,
-        // this imposes at most one minute of work in vain after restarting.)
-        let now = Instant::now();
-        if now - self.index_purged_at > MIN_INTERVAL {
-            let least_readable_version = self.least_readable_version.load(Ordering::Relaxed);
-
-            if least_readable_version - self.index_min_nonpurged_version + 1 > MIN_VERSIONS {
-                let new_min_non_purged_version = least_readable_version + 1;
-                self.db.range_delete::<StaleNodeIndexSchema, Version>(
-                    &self.index_min_nonpurged_version,
-                    &new_min_non_purged_version, // end is exclusive
-                )?;
-                self.index_min_nonpurged_version = new_min_non_purged_version;
-                self.index_purged_at = now;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-struct StaleNodeIndicesByVersionIterator<'a> {
-    inner: Peekable<SchemaIterator<'a, StaleNodeIndexSchema>>,
-    target_least_readable_version: Version,
-}
-
-impl<'a> StaleNodeIndicesByVersionIterator<'a> {
-    fn new(
-        db: &'a DB,
-        least_readable_version: Version,
-        target_least_readable_version: Version,
-    ) -> Result<Self> {
-        let mut iter = db.iter::<StaleNodeIndexSchema>(ReadOptions::default())?;
-        iter.seek(&least_readable_version)?;
-
-        Ok(Self {
-            inner: iter.peekable(),
-            target_least_readable_version,
-        })
-    }
-
-    fn next_result(&mut self) -> Result<Option<Vec<StaleNodeIndex>>> {
-        match self.inner.next().transpose()? {
-            None => Ok(None),
-            Some((index, _)) => {
-                let version = index.stale_since_version;
-                if version > self.target_least_readable_version {
-                    return Ok(None);
-                }
-
-                let mut indices = vec![index];
-                while let Some(res) = self.inner.peek() {
-                    if let Ok((index_ref, _)) = res {
-                        if index_ref.stale_since_version != version {
-                            break;
-                        }
-                    }
-
-                    let (index, _) = self.inner.next().transpose()?.expect("Should be Some.");
-                    indices.push(index);
-                }
-
-                Ok(Some(indices))
-            }
-        }
-    }
-}
-
-impl<'a> Iterator for StaleNodeIndicesByVersionIterator<'a> {
-    type Item = Result<Vec<StaleNodeIndex>>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.next_result().transpose()
-    }
-}
-
-pub fn prune_state(
-    db: Arc<DB>,
-    least_readable_version: Version,
-    target_least_readable_version: Version,
-    max_versions: usize,
-) -> Result<Version> {
-    let indices = StaleNodeIndicesByVersionIterator::new(
-        &db,
-        least_readable_version,
-        target_least_readable_version,
-    )?
-    .take(max_versions) // Iterator<Item = Result<Vec<StaleNodeIndex>>>
-    .collect::<Result<Vec<_>>>()? // now Vec<Vec<StaleNodeIndex>>
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
-
-    if indices.is_empty() {
-        Ok(least_readable_version)
-    } else {
-        let _timer = DIEM_STORAGE_OTHER_TIMERS_SECONDS
-            .with_label_values(&["pruner_commit"])
-            .start_timer();
-        let new_least_readable_version = indices.last().expect("Should exist.").stale_since_version;
-        let mut batch = SchemaBatch::new();
-        indices
-            .into_iter()
-            .try_for_each(|index| batch.delete::<JellyfishMerkleNodeSchema>(&index.node_key))?;
-        db.write_schemas(batch)?;
-        Ok(new_least_readable_version)
-    }
-}
-
-#[cfg(test)]
-mod test;
+mod db_pruner;
+pub(crate) mod worker;
+pub(crate) mod state_store;
+pub(crate) mod transaction_store;

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -16,8 +16,7 @@ use std::{
         mpsc::{channel, Sender},
         Arc,
     },
-    thread::{sleep, JoinHandle},
-    time::{Duration, Instant},
+    thread::JoinHandle,
 };
 use worker::{Command, Worker};
 
@@ -46,7 +45,9 @@ pub(crate) struct Pruner {
     least_readable_version: Arc<Mutex<Vec<Version>>>,
 }
 
+#[cfg(test)]
 const STATE_STORE_PRUNER_INDEX: usize = 0;
+#[cfg(test)]
 const TRANSACTION_STORE_PRUNER_INDEX: usize = 1;
 
 impl Pruner {
@@ -79,7 +80,7 @@ impl Pruner {
     }
 
     pub fn get_state_store_pruner_window(&self) -> Version {
-        self.state_store_prune_window.clone()
+        self.state_store_prune_window
     }
 
     /// Sends pruning command to the worker thread when necessary.
@@ -109,6 +110,11 @@ impl Pruner {
         latest_version: Version,
         transaction_store_index: usize,
     ) -> anyhow::Result<()> {
+        use std::{
+            thread::sleep,
+            time::{Duration, Instant},
+        };
+
         self.wake(latest_version);
 
         if latest_version > self.state_store_prune_window

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -2,18 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    DIEM_STORAGE_OTHER_TIMERS_SECONDS,
-    jellyfish_merkle_node::JellyfishMerkleNodeSchema, metrics::DIEM_STATE_STORAGE_PRUNER_LEAST_READABLE_VERSION,
-    pruner::db_pruner::DBPruner, stale_node_index::StaleNodeIndexSchema,
+    jellyfish_merkle_node::JellyfishMerkleNodeSchema,
+    metrics::DIEM_STATE_STORAGE_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
+    stale_node_index::StaleNodeIndexSchema, DIEM_STORAGE_OTHER_TIMERS_SECONDS,
 };
 use aptos_infallible::Mutex;
 use aptos_jellyfish_merkle::StaleNodeIndex;
 use aptos_logger::{error, info, warn};
 use aptos_types::transaction::{AtomicVersion, Version};
-use schemadb::{DB, ReadOptions, SchemaBatch, SchemaIterator};
+use schemadb::{ReadOptions, SchemaBatch, SchemaIterator, DB};
 use std::{
     iter::Peekable,
-    sync::{Arc, atomic::Ordering},
+    sync::{atomic::Ordering, Arc},
     thread::sleep,
     time::{Duration, Instant},
 };

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -1,0 +1,267 @@
+// Copyright (c) The Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    DIEM_STORAGE_OTHER_TIMERS_SECONDS,
+    jellyfish_merkle_node::JellyfishMerkleNodeSchema, metrics::DIEM_STATE_STORAGE_PRUNER_LEAST_READABLE_VERSION,
+    pruner::db_pruner::DBPruner, stale_node_index::StaleNodeIndexSchema,
+};
+use aptos_infallible::Mutex;
+use aptos_jellyfish_merkle::StaleNodeIndex;
+use aptos_logger::{error, info, warn};
+use aptos_types::transaction::{AtomicVersion, Version};
+use schemadb::{DB, ReadOptions, SchemaBatch, SchemaIterator};
+use std::{
+    iter::Peekable,
+    sync::{Arc, atomic::Ordering},
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+#[cfg(test)]
+mod test;
+
+pub struct StateStorePruner {
+    db: Arc<DB>,
+    index_min_nonpurged_version: AtomicVersion,
+    index_purged_at: Mutex<Instant>,
+    /// Keeps track of the target version that the pruner needs to achieve.
+    target_version: AtomicVersion,
+    least_readable_version: AtomicVersion,
+}
+
+impl DBPruner for StateStorePruner {
+    /// Find out the first undeleted item in the stale node index.
+    ///
+    /// Seeking from the beginning (version 0) is potentially costly, we do it once upon worker
+    /// thread start, record the progress and seek from that position afterwards.
+    fn initialize(&self) {
+        loop {
+            match self.initialize_least_readable_version() {
+                Ok(least_readable_version) => {
+                    info!(
+                        least_readable_version = least_readable_version,
+                        "[state pruner worker] initialized."
+                    );
+                    self.record_progress(least_readable_version);
+                    return;
+                }
+                Err(e) => {
+                    error!(
+                        error = ?e,
+                        "[state pruner worker] Error on first seek. Retrying in 1 second.",
+                    );
+                    sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    }
+
+    fn prune(&self, max_versions: usize) -> anyhow::Result<Version> {
+        let least_readable_version = self.least_readable_version.load(Ordering::Relaxed);
+        let target_version = self.target_version();
+        return match prune_state_store(
+            self.db.clone(),
+            least_readable_version,
+            target_version,
+            max_versions,
+        ) {
+            Ok(new_least_readable_version) => {
+                self.record_progress(new_least_readable_version);
+                // Try to purge the log.
+                if let Err(e) = self.maybe_purge_index() {
+                    warn!(
+                        error = ?e,
+                        "Failed purging state node index, ignored.",
+                    );
+                }
+                Ok(new_least_readable_version)
+            }
+            Err(e) => {
+                error!(
+                    error = ?e,
+                    "Error pruning stale state nodes.",
+                );
+                Err(e)
+                // On error, stop retrying vigorously by making next recv() blocking.
+            }
+        };
+    }
+
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
+        let mut iter = self
+            .db
+            .iter::<StaleNodeIndexSchema>(ReadOptions::default())?;
+        iter.seek_to_first();
+        Ok(iter.next().transpose()?.map_or(0, |(index, _)| {
+            index
+                .stale_since_version
+                .checked_sub(1)
+                .expect("Nothing is stale since version 0.")
+        }))
+    }
+
+    fn least_readable_version(&self) -> Version {
+        let version = self.least_readable_version.load(Ordering::Relaxed);
+        version
+    }
+
+    fn set_target_version(&self, target_version: Version) {
+        self.target_version.store(target_version, Ordering::Relaxed);
+    }
+
+    fn target_version(&self) -> Version {
+        let version = self.target_version.load(Ordering::Relaxed);
+        version
+    }
+
+    fn record_progress(&self, least_readable_version: Version) {
+        self.least_readable_version
+            .store(least_readable_version, Ordering::Relaxed);
+        DIEM_STATE_STORAGE_PRUNER_LEAST_READABLE_VERSION.set(least_readable_version as i64);
+    }
+
+    fn is_pruning_pending(&self) -> bool {
+        self.least_readable_version() >= self.target_version()
+    }
+}
+
+impl StateStorePruner {
+    pub fn new(
+        db: Arc<DB>,
+        index_min_nonpurged_version: Version,
+        index_purged_at: Instant,
+    ) -> Self {
+        StateStorePruner {
+            db,
+            index_min_nonpurged_version: AtomicVersion::new(index_min_nonpurged_version),
+            index_purged_at: Mutex::new(index_purged_at),
+            target_version: AtomicVersion::new(0),
+            least_readable_version: AtomicVersion::new(0),
+        }
+    }
+
+    /// Purge the stale node index so that after restart not too much already pruned stuff is dealt
+    /// with again (although no harm is done deleting those then non-existent things.)
+    ///
+    /// We issue (range) deletes on the index only periodically instead of after every pruning batch
+    /// to avoid sending too many deletions to the DB, which takes disk space and slows it down.
+    fn maybe_purge_index(&self) -> anyhow::Result<()> {
+        const MIN_INTERVAL: Duration = Duration::from_secs(10);
+        const MIN_VERSIONS: u64 = 60000;
+
+        // A deletion is issued at most once in one minute and when the pruner has progressed by at
+        // least 60000 versions (assuming the pruner deletes as slow as 1000 versions per second,
+        // this imposes at most one minute of work in vain after restarting.)
+        let now = Instant::now();
+        if now - *self.index_purged_at.lock() > MIN_INTERVAL
+            && self.least_readable_version.load(Ordering::Relaxed)
+                - self.index_min_nonpurged_version()
+                + 1
+                > MIN_VERSIONS
+        {
+            let new_min_non_purged_version =
+                self.least_readable_version.load(Ordering::Relaxed) + 1;
+            self.db.range_delete::<StaleNodeIndexSchema, Version>(
+                &self.index_min_nonpurged_version(),
+                &new_min_non_purged_version, // end is exclusive
+            )?;
+            self.index_min_nonpurged_version
+                .store(new_min_non_purged_version, Ordering::Relaxed);
+            *self.index_purged_at.lock() = now;
+        }
+        Ok(())
+    }
+    pub fn index_min_nonpurged_version(&self) -> Version {
+        self.index_min_nonpurged_version.load(Ordering::Relaxed)
+    }
+
+    pub fn target_version(&self) -> Version {
+        self.target_version.load(Ordering::Relaxed)
+    }
+}
+
+pub fn prune_state_store(
+    db: Arc<DB>,
+    least_readable_version: Version,
+    target_version: Version,
+    max_versions: usize,
+) -> anyhow::Result<Version> {
+    let indices =
+        StaleNodeIndicesByVersionIterator::new(&db, least_readable_version, target_version)?
+            .take(max_versions) // Iterator<Item = Result<Vec<StaleNodeIndex>>>
+            .collect::<anyhow::Result<Vec<_>>>()? // now Vec<Vec<StaleNodeIndex>>
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+
+    if indices.is_empty() {
+        Ok(least_readable_version)
+    } else {
+        let _timer = DIEM_STORAGE_OTHER_TIMERS_SECONDS
+            .with_label_values(&["pruner_commit"])
+            .start_timer();
+        let new_least_readable_version = indices.last().expect("Should exist.").stale_since_version;
+        let mut batch = SchemaBatch::new();
+        indices
+            .into_iter()
+            .try_for_each(|index| batch.delete::<JellyfishMerkleNodeSchema>(&index.node_key))?;
+        db.write_schemas(batch)?;
+        Ok(new_least_readable_version)
+    }
+}
+
+struct StaleNodeIndicesByVersionIterator<'a> {
+    inner: Peekable<SchemaIterator<'a, StaleNodeIndexSchema>>,
+    target_least_readable_version: Version,
+}
+
+impl<'a> StaleNodeIndicesByVersionIterator<'a> {
+    fn new(
+        db: &'a DB,
+        least_readable_version: Version,
+        target_least_readable_version: Version,
+    ) -> anyhow::Result<Self> {
+        let mut iter = db.iter::<StaleNodeIndexSchema>(ReadOptions::default())?;
+        iter.seek(&least_readable_version)?;
+
+        Ok(Self {
+            inner: iter.peekable(),
+            target_least_readable_version,
+        })
+    }
+
+    fn next_result(&mut self) -> anyhow::Result<Option<Vec<StaleNodeIndex>>> {
+        match self.inner.next().transpose()? {
+            None => Ok(None),
+            Some((index, _)) => {
+                let version = index.stale_since_version;
+                if version > self.target_least_readable_version {
+                    return Ok(None);
+                }
+
+                let mut indices = vec![index];
+                while let Some(res) = self.inner.peek() {
+                    if let Ok((index_ref, _)) = res {
+                        if index_ref.stale_since_version != version {
+                            break;
+                        }
+                    }
+
+                    let (index, _) = self.inner.next().transpose()?.expect("Should be Some.");
+                    indices.push(index);
+                }
+
+                Ok(Some(indices))
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for StaleNodeIndicesByVersionIterator<'a> {
+    type Item = anyhow::Result<Vec<StaleNodeIndex>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_result().transpose()
+    }
+}

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) The Aptos Foundation
+// Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
@@ -102,8 +102,7 @@ impl DBPruner for StateStorePruner {
     }
 
     fn least_readable_version(&self) -> Version {
-        let version = self.least_readable_version.load(Ordering::Relaxed);
-        version
+        self.least_readable_version.load(Ordering::Relaxed)
     }
 
     fn set_target_version(&self, target_version: Version) {
@@ -111,8 +110,7 @@ impl DBPruner for StateStorePruner {
     }
 
     fn target_version(&self) -> Version {
-        let version = self.target_version.load(Ordering::Relaxed);
-        version
+        self.target_version.load(Ordering::Relaxed)
     }
 
     fn record_progress(&self, least_readable_version: Version) {

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -1,8 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::pruner::*;
-use crate::{change_set::ChangeSet, state_store::StateStore, AptosDB};
+use crate::{change_set::ChangeSet, pruner::*, state_store::StateStore, AptosDB};
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
 use aptos_types::{account_address::AccountAddress, account_state_blob::AccountStateBlob};
@@ -79,14 +78,18 @@ fn test_state_store_pruner() {
 
     // Prune till version=0.
     {
-        pruner.wake_and_wait(0 /* latest_version */).unwrap();
+        pruner
+            .wake_and_wait(0 /* latest_version */, STATE_STORE_PRUNER_INDEX)
+            .unwrap();
         verify_state_in_store(state_store, address, Some(&value0), 0);
         verify_state_in_store(state_store, address, Some(&value1), 1);
         verify_state_in_store(state_store, address, Some(&value2), 2);
     }
     // Prune till version=1.
     {
-        pruner.wake_and_wait(1 /* latest_version */).unwrap();
+        pruner
+            .wake_and_wait(1 /* latest_version */, STATE_STORE_PRUNER_INDEX)
+            .unwrap();
         // root0 is gone.
         assert!(state_store
             .get_account_state_with_proof_by_version(address, 0)
@@ -97,7 +100,9 @@ fn test_state_store_pruner() {
     }
     // Prune till version=2.
     {
-        pruner.wake_and_wait(2 /* latest_version */).unwrap();
+        pruner
+            .wake_and_wait(2 /* latest_version */, STATE_STORE_PRUNER_INDEX)
+            .unwrap();
         // root1 is gone.
         assert!(state_store
             .get_account_state_with_proof_by_version(address, 1)

--- a/storage/aptosdb/src/pruner/transaction_store/mod.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/mod.rs
@@ -1,0 +1,104 @@
+// Copyright (c) The Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    metrics::DIEM_TRANSACTION_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
+    stale_node_index::StaleNodeIndexSchema, transaction::TransactionSchema,
+};
+use aptos_logger::{error, info};
+use aptos_types::transaction::{AtomicVersion, Version};
+use schemadb::{ReadOptions, DB};
+use std::{
+    cmp::min,
+    sync::{atomic::Ordering, Arc},
+    thread::sleep,
+    time::Duration,
+};
+
+pub struct TransactionStorePruner {
+    db: Arc<DB>,
+    /// Keeps track of the target version that the pruner needs to achieve.
+    target_version: AtomicVersion,
+    least_readable_version: AtomicVersion,
+}
+
+impl DBPruner for TransactionStorePruner {
+    fn initialize(&self) {
+        loop {
+            match self.initialize_least_readable_version() {
+                Ok(least_readable_version) => {
+                    info!(
+                        least_readable_version = least_readable_version,
+                        "[transaction pruner] initialized."
+                    );
+                    self.record_progress(least_readable_version);
+                    return;
+                }
+                Err(e) => {
+                    error!(
+                        error = ?e,
+                        "[transaction pruner] Error on first seek. Retrying in 1 second.",
+                    );
+                    sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    }
+
+    fn prune(&self, max_versions: usize) -> anyhow::Result<Version> {
+        let mut iter = self.db.iter::<TransactionSchema>(ReadOptions::default())?;
+        let least_readable_version = self.least_readable_version();
+        let current_target_version = min(
+            least_readable_version + max_versions as u64,
+            self.target_version(),
+        );
+        iter.seek(&least_readable_version)?;
+        self.db.range_delete::<StaleNodeIndexSchema, Version>(
+            &self.least_readable_version(),
+            &current_target_version,
+        )?;
+        Ok(current_target_version)
+    }
+
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
+        let mut iter = self.db.iter::<TransactionSchema>(ReadOptions::default())?;
+        iter.seek_to_first();
+        let version = iter
+            .next()
+            .transpose()?
+            .map_or(0, |(version, _)| return version);
+        Ok(version)
+    }
+
+    fn least_readable_version(&self) -> Version {
+        self.least_readable_version.load(Ordering::Relaxed)
+    }
+
+    fn record_progress(&self, least_readable_version: Version) {
+        self.least_readable_version
+            .store(least_readable_version, Ordering::Relaxed);
+        DIEM_TRANSACTION_PRUNER_LEAST_READABLE_VERSION.set(least_readable_version as i64);
+    }
+
+    fn target_version(&self) -> Version {
+        self.target_version.load(Ordering::Relaxed)
+    }
+
+    fn is_pruning_pending(&self) -> bool {
+        self.least_readable_version() >= self.target_version()
+    }
+
+    fn set_target_version(&self, target_version: Version) {
+        self.target_version.store(target_version, Ordering::Relaxed)
+    }
+}
+
+impl TransactionStorePruner {
+    pub fn new(db: Arc<DB>) -> Self {
+        TransactionStorePruner {
+            db,
+            target_version: AtomicVersion::new(0),
+            least_readable_version: AtomicVersion::new(0),
+        }
+    }
+}

--- a/storage/aptosdb/src/pruner/transaction_store/mod.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/mod.rs
@@ -1,15 +1,19 @@
-// Copyright (c) The Aptos Foundation
+// Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-
-mod test;
 
 use crate::{
     metrics::DIEM_TRANSACTION_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
-    transaction::TransactionSchema,
+    transaction::TransactionSchema, transaction_accumulator::TransactionAccumulatorSchema,
+    transaction_by_account::TransactionByAccountSchema,
+    transaction_by_hash::TransactionByHashSchema, transaction_info::TransactionInfoSchema,
 };
+use aptos_crypto::hash::CryptoHash;
 use aptos_logger::{error, info};
-use aptos_types::transaction::{AtomicVersion, Version};
-use schemadb::{ReadOptions, DB};
+use aptos_types::{
+    proof::position::Position,
+    transaction::{AtomicVersion, Transaction, Version},
+};
+use schemadb::{ReadOptions, SchemaBatch, DB};
 use std::{
     cmp::min,
     sync::{atomic::Ordering, Arc},
@@ -48,17 +52,22 @@ impl DBPruner for TransactionStorePruner {
     }
 
     fn prune(&self, max_versions: usize) -> anyhow::Result<Version> {
-        let mut iter = self.db.iter::<TransactionSchema>(ReadOptions::default())?;
         let least_readable_version = self.least_readable_version();
+        // Current target version  might be less than the target version to ensure we don't prune
+        // more than max_version in one go.
         let current_target_version = min(
             least_readable_version + max_versions as u64,
             self.target_version(),
         );
-        iter.seek(&least_readable_version)?;
-        self.db.range_delete::<TransactionSchema, Version>(
-            &self.least_readable_version(),
-            &current_target_version,
-        )?;
+        let candidate_transactions = self
+            .get_pruning_candidate_transactions(least_readable_version, current_target_version)?;
+        let mut db_batch = SchemaBatch::new();
+        self.prune_transaction_by_hash(&candidate_transactions, &mut db_batch)?;
+        self.prune_transaction_schema(current_target_version, &mut db_batch)?;
+        self.prune_transaction_by_account(&candidate_transactions, &mut db_batch)?;
+        self.prune_transaction_accumulator(current_target_version, &mut db_batch)?;
+        self.db.write_schemas(db_batch)?;
+
         self.record_progress(current_target_version);
         Ok(current_target_version)
     }
@@ -66,10 +75,7 @@ impl DBPruner for TransactionStorePruner {
     fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
         let mut iter = self.db.iter::<TransactionSchema>(ReadOptions::default())?;
         iter.seek_to_first();
-        let version = iter
-            .next()
-            .transpose()?
-            .map_or(0, |(version, _)| return version);
+        let version = iter.next().transpose()?.map_or(0, |(version, _)| version);
         Ok(version)
     }
 
@@ -104,4 +110,87 @@ impl TransactionStorePruner {
             least_readable_version: AtomicVersion::new(0),
         }
     }
+
+    fn get_pruning_candidate_transactions(
+        &self,
+        start: Version,
+        end: Version,
+    ) -> anyhow::Result<Vec<Transaction>> {
+        let mut transactions: Vec<Transaction> = vec![];
+        let mut iter = self.db.iter::<TransactionSchema>(ReadOptions::default())?;
+        iter.seek(&start)?;
+        for x in iter {
+            let (version, transaction) = x?;
+            if version == end {
+                break;
+            }
+            transactions.push(transaction);
+        }
+        Ok(transactions)
+    }
+
+    fn prune_transaction_by_hash(
+        &self,
+        transactions: &[Transaction],
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        for transaction in transactions {
+            db_batch.delete::<TransactionByHashSchema>(&transaction.hash())?;
+        }
+        Ok(())
+    }
+
+    fn prune_transaction_by_account(
+        &self,
+        transactions: &[Transaction],
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        for transaction in transactions {
+            if let Transaction::UserTransaction(txn) = transaction {
+                db_batch
+                    .delete::<TransactionByAccountSchema>(&(txn.sender(), txn.sequence_number()))?;
+            }
+        }
+        Ok(())
+    }
+
+    fn prune_transaction_schema(
+        &self,
+        current_target_version: Version,
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        db_batch.delete_range::<TransactionSchema>(
+            &self.least_readable_version(),
+            &current_target_version,
+        )?;
+        db_batch.delete_range::<TransactionInfoSchema>(
+            &self.least_readable_version(),
+            &current_target_version,
+        )?;
+        Ok(())
+    }
+
+    fn prune_transaction_accumulator(
+        &self,
+        current_target_version: Version,
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        let least_readable_position = if self.least_readable_version() > 0 {
+            let x = Position::root_from_leaf_index(self.least_readable_version());
+            x.left_child()
+        } else {
+            // Handle this as a special case when least_readable_version is 0
+            Position::root_from_leaf_index(self.least_readable_version())
+        };
+        let target_position = Position::root_from_leaf_index(current_target_version).left_child();
+
+        db_batch.delete_range::<TransactionAccumulatorSchema>(
+            &least_readable_position,
+            &target_position,
+        )?;
+        Ok(())
+    }
 }
+
+#[cfg(test)]
+mod test;

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -1,0 +1,95 @@
+// Copyright (c) The Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{pruner::*, AptosDB, ChangeSet, TransactionStore};
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519Signature},
+    PrivateKey, Uniform,
+};
+use aptos_temppath::TempPath;
+
+use aptos_types::{
+    account_address::AccountAddress,
+    chain_id::ChainId,
+    transaction::{RawTransaction, Script, SignedTransaction, Transaction, TransactionPayload},
+};
+
+/// Creates a single test transaction
+fn create_test_transaction(sequence_number: u64) -> Transaction {
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+
+    let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+    let raw_transaction = RawTransaction::new(
+        AccountAddress::random(),
+        sequence_number,
+        transaction_payload,
+        0,
+        0,
+        "".into(),
+        0,
+        ChainId::new(10),
+    );
+    let signed_transaction = SignedTransaction::new(
+        raw_transaction,
+        public_key,
+        Ed25519Signature::dummy_signature(),
+    );
+
+    Transaction::UserTransaction(signed_transaction)
+}
+
+fn verify_transaction_in_store(
+    transaction_store: &TransactionStore,
+    expected_value: &Transaction,
+    version: Version,
+) {
+    let txn = transaction_store.get_transaction(version).unwrap();
+    assert_eq!(txn, *expected_value)
+}
+
+#[test]
+fn test_txn_store_pruner() {
+    let tmp_dir = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp_dir);
+    let transaction_store = &aptos_db.transaction_store;
+    let num_transaction = 50;
+    let mut transactions: Vec<Transaction> = vec![];
+
+    let pruner = Pruner::new(
+        Arc::clone(&aptos_db.db),
+        StoragePrunerConfig {
+            state_store_prune_window: Some(0),
+            default_prune_window: Some(0),
+        }, /* historical_versions_to_keep */
+    );
+
+    for i in 0..num_transaction {
+        let transaction = create_test_transaction(i);
+        transactions.push(transaction.clone());
+        let mut cs = ChangeSet::new();
+        transaction_store
+            .put_transaction(i, &transaction, &mut cs)
+            .unwrap();
+        aptos_db.db.write_schemas(cs.batch).unwrap();
+    }
+
+    // start pruning transaction in the batch of 2 and verify transactions have been pruned from DB
+    for i in (0..=num_transaction).step_by(2) {
+        pruner
+            .wake_and_wait(i /* latest_version */, TRANSACTION_STORE_PRUNER_INDEX)
+            .unwrap();
+        // ensure that all transaction up to i * 2 has been pruned
+        for j in 0..i {
+            assert!(transaction_store.get_transaction(j).is_err());
+        }
+        // ensure all other are valid in DB
+        for j in i..num_transaction {
+            verify_transaction_in_store(
+                transaction_store,
+                transactions.get(j as usize).unwrap(),
+                j,
+            );
+        }
+    }
+}

--- a/storage/aptosdb/src/pruner/worker.rs
+++ b/storage/aptosdb/src/pruner/worker.rs
@@ -1,0 +1,140 @@
+// Copyright (c) The Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+use aptos_types::transaction::Version;
+use schemadb::DB;
+
+use crate::pruner::{
+    db_pruner::DBPruner,
+    transaction_store::TransactionStorePruner,
+};
+use aptos_infallible::Mutex;
+
+use std::{
+    sync::{mpsc::Receiver, Arc},
+    time::Instant,
+};
+use crate::pruner::state_store::StateStorePruner;
+
+/// Maintains all the DBPruners and periodically calls the db_pruner's prune method to prune the DB.
+/// This also exposes API to report the progress to the parent thread.
+pub struct Worker {
+    command_receiver: Receiver<Command>,
+    /// Keeps tracks of all the DB pruners
+    db_pruners: Vec<Mutex<Arc<dyn DBPruner + Send + Sync>>>,
+    /// Keeps a record of the pruning progress. If this equals to version `V`, we know versions
+    /// smaller than `V` are no longer readable.
+    /// This being an atomic value is to communicate the info with the Pruner thread (for tests).
+    least_readable_versions: Arc<Mutex<Vec<Version>>>,
+    /// Indicates if there's NOT any pending work to do currently, to hint
+    /// `Self::receive_commands()` to `recv()` blocking-ly.
+    blocking_recv: bool,
+}
+
+impl Worker {
+    const MAX_VERSIONS_TO_PRUNE_PER_BATCH: usize = 100;
+
+    pub(crate) fn new(
+        db: Arc<DB>,
+        command_receiver: Receiver<Command>,
+        least_readable_versions: Arc<Mutex<Vec<Version>>>,
+    ) -> Self {
+        Self {
+            db_pruners: vec![
+                Mutex::new(Arc::new(StateStorePruner::new(
+                    Arc::clone(&db),
+                    0,
+                    Instant::now(),
+                ))),
+                Mutex::new(Arc::new(TransactionStorePruner::new(Arc::clone(&db)))),
+            ],
+            command_receiver,
+            least_readable_versions,
+            blocking_recv: true,
+        }
+    }
+
+    pub(crate) fn work(mut self) {
+        for db_pruner in &self.db_pruners {
+            db_pruner.lock().initialize();
+        }
+        while self.receive_commands() {
+            // Process a reasonably small batch of work before trying to receive commands again,
+            // in case `Command::Quit` is received (that's when we should quit.)
+            for db_pruner in &self.db_pruners {
+                let result = db_pruner
+                    .lock()
+                    .prune(Self::MAX_VERSIONS_TO_PRUNE_PER_BATCH);
+                match result {
+                    Ok(_) => {
+                        // Make next recv() blocking if nothing left to do.
+                        self.blocking_recv = db_pruner.lock().is_pruning_pending();
+                    }
+                    Err(_) => {
+                        // On error, stop retrying vigorously by making next recv() blocking.
+                        self.blocking_recv = true;
+                    }
+                }
+            }
+            self.record_progress();
+        }
+    }
+
+    fn record_progress(&mut self) {
+        let mut updated_least_readable_versions: Vec<Version> = Vec::new();
+        for x in &self.db_pruners {
+            updated_least_readable_versions.push(x.lock().least_readable_version().clone())
+        }
+        *self.least_readable_versions.lock() = updated_least_readable_versions;
+    }
+
+    /// Tries to receive all pending commands, blocking waits for the next command if no work needs
+    /// to be done, otherwise quits with `true` to allow the outer loop to do some work before
+    /// getting back here.
+    ///
+    /// Returns `false` if `Command::Quit` is received, to break the outer loop and let
+    /// `work_loop()` return.
+    fn receive_commands(&mut self) -> bool {
+        loop {
+            let command = if self.blocking_recv {
+                // Worker has nothing to do, blocking wait for the next command.
+                self.command_receiver
+                    .recv()
+                    .expect("Sender should not destruct prematurely.")
+            } else {
+                // Worker has pending work to do, non-blocking recv.
+                match self.command_receiver.try_recv() {
+                    Ok(command) => command,
+                    // Channel has drained, yield control to the outer loop.
+                    Err(_) => return true,
+                }
+            };
+
+            match command {
+                // On `Command::Quit` inform the outer loop to quit by returning `false`.
+                Command::Quit => return false,
+                Command::Prune { target_db_versions } => {
+                    for i in 0..target_db_versions.len() {
+                        let new_target_version = *target_db_versions.get(i).unwrap();
+                        if new_target_version
+                            > self.db_pruners.get(i).unwrap().lock().target_version()
+                        {
+                            // Switch to non-blocking to allow some work to be done after the
+                            // channel has drained.
+                            self.blocking_recv = false;
+                        }
+                        self.db_pruners
+                            .get(i)
+                            .unwrap()
+                            .lock()
+                            .set_target_version(new_target_version);
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub enum Command {
+    Quit,
+    Prune { target_db_versions: Vec<Version> },
+}

--- a/storage/aptosdb/src/pruner/worker.rs
+++ b/storage/aptosdb/src/pruner/worker.rs
@@ -3,17 +3,14 @@
 use aptos_types::transaction::Version;
 use schemadb::DB;
 
-use crate::pruner::{
-    db_pruner::DBPruner,
-    transaction_store::TransactionStorePruner,
-};
+use crate::pruner::{db_pruner::DBPruner, transaction_store::TransactionStorePruner};
 use aptos_infallible::Mutex;
 
+use crate::pruner::state_store::StateStorePruner;
 use std::{
     sync::{mpsc::Receiver, Arc},
     time::Instant,
 };
-use crate::pruner::state_store::StateStorePruner;
 
 /// Maintains all the DBPruners and periodically calls the db_pruner's prune method to prune the DB.
 /// This also exposes API to report the progress to the parent thread.

--- a/storage/aptosdb/src/pruner/worker.rs
+++ b/storage/aptosdb/src/pruner/worker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) The Aptos Foundation
+// Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use aptos_types::transaction::Version;
 use schemadb::DB;
@@ -79,7 +79,7 @@ impl Worker {
     fn record_progress(&mut self) {
         let mut updated_least_readable_versions: Vec<Version> = Vec::new();
         for x in &self.db_pruners {
-            updated_least_readable_versions.push(x.lock().least_readable_version().clone())
+            updated_least_readable_versions.push(x.lock().least_readable_version())
         }
         *self.least_readable_versions.lock() = updated_least_readable_versions;
     }

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -3,7 +3,7 @@
 
 use super::*;
 use crate::{pruner, AptosDB};
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_jellyfish_merkle::restore::JellyfishMerkleRestore;
 use aptos_temppath::TempPath;
 use aptos_types::{
@@ -60,7 +60,7 @@ fn prune_stale_indices(
     target_least_readable_version: Version,
     limit: usize,
 ) {
-    pruner::prune_state(
+    pruner::state_store::prune_state_store(
         Arc::clone(&store.db),
         least_readable_version,
         target_least_readable_version,
@@ -405,7 +405,7 @@ proptest! {
             let db2 = AptosDB::open(
                 &tgt_tmp_dir,
                 false, /* readonly */
-                None,  /* pruner */
+                NO_OP_STORAGE_PRUNER_CONFIG,  /* pruner config */
                 RocksdbConfig::default(),
                 true, /* account_count_migration */
             ).unwrap();
@@ -495,7 +495,7 @@ proptest! {
             let db = AptosDB::open(
                 &tmp_dir,
                 false, /* read_only */
-                None,
+                NO_OP_STORAGE_PRUNER_CONFIG,
                 RocksdbConfig::default(),
                 false, /* account_count_migration */
             ).unwrap();

--- a/storage/aptosdb/src/transaction_store/test.rs
+++ b/storage/aptosdb/src/transaction_store/test.rs
@@ -30,7 +30,6 @@ proptest! {
         let (gens, write_sets):(Vec<_>, Vec<_>) = gens_and_write_sets.into_iter().unzip();
         let txns = init_store(universe, gens, store);
 
-
         // write sets
         let mut cs = ChangeSet::new();
         for (ver, ws) in write_sets.iter().enumerate() {

--- a/storage/backup/backup-cli/src/bin/replay-verify.rs
+++ b/storage/backup/backup-cli/src/bin/replay-verify.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use aptos_config::config::NO_OP_STORAGE_PRUNER_CONFIG;
 use aptos_logger::{prelude::*, Level, Logger};
 use aptos_types::transaction::Version;
 use aptosdb::{AptosDB, GetRestoreHandler};
@@ -55,8 +56,8 @@ async fn main_impl() -> Result<()> {
     let opt = Opt::from_args();
     let restore_handler = Arc::new(AptosDB::open(
         opt.db_dir,
-        false, /* read_only */
-        None,  /* pruner */
+        false,                       /* read_only */
+        NO_OP_STORAGE_PRUNER_CONFIG, /* pruner config */
         opt.rocksdb_opt.into(),
         true, /* account_count_migration */
     )?)

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod stream;
 pub mod test_utils;
 
 use anyhow::{anyhow, Result};
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_crypto::HashValue;
 use aptos_infallible::duration_since_epoch;
 use aptos_jellyfish_merkle::{restore::JellyfishMerkleRestore, NodeBatch, TreeWriter};
@@ -169,8 +169,8 @@ impl TryFrom<GlobalRestoreOpt> for GlobalRestoreOptions {
         let run_mode = if let Some(db_dir) = &opt.db_dir {
             let restore_handler = Arc::new(AptosDB::open(
                 db_dir,
-                false, /* read_only */
-                None,  /* pruner */
+                false,                       /* read_only */
+                NO_OP_STORAGE_PRUNER_CONFIG, /* pruner config */
                 opt.rocksdb_opt.into(),
                 opt.account_count_migration,
             )?)

--- a/storage/inspector/src/main.rs
+++ b/storage/inspector/src/main.rs
@@ -4,7 +4,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_logger::info;
 use aptosdb::AptosDB;
 use diem_framework_releases::name_for_script;
@@ -169,8 +169,8 @@ fn main() {
 
     let db = AptosDB::open(
         p,
-        true, /* readonly */
-        None, /* pruner */
+        true,                        /* readonly */
+        NO_OP_STORAGE_PRUNER_CONFIG, /* pruner config */
         RocksdbConfig::default(),
         true, /* account_count_migration, ignored anyway */
     )

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -32,7 +32,7 @@ use std::fmt;
 mod position_test;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct Position(u64);
+pub struct Position(pub u64);
 // invariant Position.0 < u64::max_value() - 1
 
 #[derive(Debug, Eq, PartialEq)]

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -51,10 +51,11 @@ pub use script::{
     TypeArgumentABI,
 };
 
-use std::{collections::BTreeSet, hash::Hash, ops::Deref};
+use std::{collections::BTreeSet, hash::Hash, ops::Deref, sync::atomic::AtomicU64};
 pub use transaction_argument::{parse_transaction_argument, TransactionArgument, VecBytes};
 
 pub type Version = u64; // Height - also used for MVCC in StateDB
+pub type AtomicVersion = AtomicU64;
 
 // In StateDB, things readable by the genesis transaction are under this version.
 pub const PRE_GENESIS_VERSION: Version = u64::max_value();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is the PR for supporting ledger history pruning. See https://github.com/aptos-labs/aptos-core/issues/103 for more details. Following changes have been added. 
1. Refactoring the existing pruner, so that we can add support for more pruner in next diff. 
2. Implementation of transaction pruner, which prunes all transaction-related data from DB before a certain version



## Test Plan

Added UTs for testing the pruner.
