### PR TITLE
[circleci] fix build main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,11 +77,13 @@ jobs:
               echo "Image tag $IMAGE_TAG already present. Skipping build..."
               echo "Continue retagging to <<parameters.addl_tag>>"
               imgs=( validator forge init validator_tcb tools faucet )
+              ret=0
               for img in "${imgs[@]}"
               do
                 MANIFEST=$(aws ecr batch-get-image --repository-name aptos/${img} --image-ids imageTag=$IMAGE_TAG --query 'images[].imageManifest' --output text)
-                aws ecr put-image --repository-name aptos/${img} --image-tag main --image-manifest $MANIFEST
+                aws ecr put-image --repository-name aptos/${img} --image-tag main --image-manifest "$MANIFEST" || ret=$?
               done
+              exit $ret
             fi
   forge-k8s:
     docker:


### PR DESCRIPTION
Fix the periodic build of `main` image: https://app.circleci.com/pipelines/github/aptos-labs/aptos-core/715/workflows/d084a41e-3e37-429a-8a0a-e8fefb75caa0/jobs/3286. Manifest is multi-line and must be quoted in bash