### PR TITLE
[circleci] push to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.1.0
+  aws-ecr: circleci/aws-ecr@7.3.0
   kubernetes: circleci/kubernetes@1.3.0
 
 jobs:
@@ -52,8 +53,8 @@ jobs:
       - run: cargo xtest --doc --unit --changed-since "origin/main"
       - run: cargo nextest --nextest-profile ci --partition hash:1/1 --unit --exclude backup-cli --changed-since "origin/main"
   docker-build-push:
-    docker:
-      - image: cimg/base:stable
+    machine:
+      image: ubuntu-2004:current
     resource_class: medium
     parameters:
       addl_tag:
@@ -85,6 +86,59 @@ jobs:
               done
               exit $ret
             fi
+  ecr-dockerhub-mirror:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: medium
+    parameters:
+      addl_tag:
+        description: Additional image tag
+        type: string
+        default: main
+    steps:
+      - checkout
+      - aws-setup
+      - aws-ecr-setup
+      - run: echo "export IMAGE_TAG=dev_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
+      - run:
+          name: Get latest built main image
+          shell: /bin/bash
+          command: |
+            imgs=( validator forge init validator_tcb tools faucet )
+            ret=0
+            for img in "${imgs[@]}"
+            do
+              docker pull "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" || ret=$?
+            done
+            exit $ret
+      - run:
+          name: Tag image
+          shell: /bin/bash
+          command: |
+            imgs=( validator forge init validator_tcb tools faucet )
+            org=aptoslab
+            ret=0
+            for img in "${imgs[@]}"
+            do
+              docker tag "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" "${org}/${img}:${IMAGE_TAG}"
+              docker tag "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" "${org}/${img}:<<parameters.addl_tag>>" || ret=$?
+            done
+            exit $ret
+      - dockerhub-setup
+      - run:
+          name: Push image to Dockerhub
+          shell: /bin/bash
+          command: |
+            # imgs=( validator forge init validator_tcb tools faucet )
+            imgs=( validator tools faucet )
+            org=aptoslab
+            ret=0
+            for img in "${imgs[@]}"
+            do
+              docker push "${org}/${img}:${IMAGE_TAG}"
+              docker push "${org}/${img}:<<parameters.addl_tag>>" || ret=$?
+            done
+            exit $ret
   forge-k8s:
     docker:
       - image: cimg/base:stable
@@ -169,6 +223,13 @@ workflows:
       - docker-build-push:
           context: aws-dev
           addl_tag: main
+      - ecr-dockerhub-mirror:
+          context:
+            - aws-dev
+            - docker-aptoslabsbots
+          addl_tag: main
+          requires:
+            - docker-build-push
 commands:
   dev-setup:
     steps:
@@ -182,3 +243,16 @@ commands:
       - aws-cli/install
       # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
       - aws-cli/setup
+  aws-ecr-setup:
+    steps:
+      - run:
+          name: Compose AWS Env Variables
+          command: |
+            echo 'export AWS_ECR_ACCOUNT_URL="${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.${AWS_REGION}.amazonaws.com"' >> $BASH_ENV
+      - aws-ecr/ecr-login
+  dockerhub-setup:
+    steps:
+      - run:
+          name: Docker login
+          command: |
+            echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin


### PR DESCRIPTION
Push to Dockerhub during CP, every 4 hours. Pulls the latest built image, and pushes them as `dev_<GIT REV>` and `main` to dockerhub `aptoslab`

Test with canary: https://github.com/aptos-labs/aptos-core/pull/158
Images pushed: e.g. faucet https://hub.docker.com/repository/docker/aptoslab/faucet