### PR TITLE
[tf] split variables for enabling api on fullnode

### DIFF
--- a/terraform/fullnode/fullnode/templates/ingress.yaml
+++ b/terraform/fullnode/fullnode/templates/ingress.yaml
@@ -19,8 +19,8 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     {{- end }}
-    {{- if .Values.ingress.wafAclId }}
-    alb.ingress.kubernetes.io/waf-acl-id: {{ .Values.ingress.wafAclId }}
+    {{- if .Values.ingress.wafAclArn }}
+    alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn }}
     {{- end }}
 spec:
   rules:

--- a/terraform/fullnode/fullnode/values.yaml
+++ b/terraform/fullnode/fullnode/values.yaml
@@ -22,7 +22,7 @@ service:
 
 ingress:
   acm_certificate:
-  wafAclId:
+  wafAclArn:
   loadBalancerSourceRanges:
 
 monitoring:

--- a/terraform/testnet/testnet/templates/ingress.yaml
+++ b/terraform/testnet/testnet/templates/ingress.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.service.fullnode.exposeApi }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -19,8 +18,12 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate }}
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     {{- end }}
+    {{- if .Values.ingress.wafAclArn }}
+    alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn }}
+    {{- end }}
 spec:
   rules:
+  {{- if .Values.faucet.enabled }}
   - host: faucet.{{ .Values.service.domain }}
     http:
       paths:
@@ -31,6 +34,7 @@ spec:
             name: {{ include "testnet.fullname" . }}-faucet
             port:
               number: 80
+  {{- end }}
   {{- if .Values.service.pfn.exposeApi }}
   - host: pfn.{{ .Values.service.domain }}
     http:
@@ -45,15 +49,6 @@ spec:
   {{- end }}
   - http:
       paths:
-      {{- if .Values.faucet.enabled }}
-      - path: /mint
-        pathType: Exact
-        backend:
-          service:
-            name: {{ include "testnet.fullname" . }}-faucet
-            port:
-              number: 80
-      {{- end }}
       - path: /waypoint.txt
         pathType: Exact
         backend:
@@ -82,6 +77,7 @@ spec:
             name: {{ include "testnet.fullname" . }}-waypoint
             port:
               number: 80
+      {{- if .Values.service.fullnode.exposeApi }}
       - path: /*
         pathType: Prefix
         backend:
@@ -89,4 +85,4 @@ spec:
             name: {{ include "testnet.fullname" . }}-api
             port:
               number: 80
-{{- end }}
+      {{- end }}

--- a/terraform/testnet/testnet/values.yaml
+++ b/terraform/testnet/testnet/values.yaml
@@ -84,6 +84,7 @@ service:
 
 ingress:
   acm_certificate:
+  wafAclArn:
   loadBalancerSourceRanges:
 
 monitoring:


### PR DESCRIPTION
- Update testnet lb to expose waypoint/genesis separately from rest api.
- also use wafv2 instead, for rate limiting.