### PR TITLE
Create + Delegate minting to account on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6943,6 +6943,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-crypto",
+ "aptos-faucet",
  "aptos-framework-releases",
  "aptos-genesis-tool",
  "aptos-global-constants",

--- a/crates/aptos-faucet/README.md
+++ b/crates/aptos-faucet/README.md
@@ -3,6 +3,8 @@
 Faucet is a service for creating and funding accounts on the Aptos Network.
 It is meant to be used for devnets and testnets.
 
+During startup, by default, the Faucet will use the root key to create a new account, fund it, give it permissions to
+mint, and use that new account to mint from. To avoid this behaviour, you can pass `--do-not-delgate`.
 
 ## Mint API
 
@@ -29,7 +31,7 @@ Notes:
 
 ### Response
 
-If the query param `return_txns` is not provided, or it is not "true", the server returns a json-encoded list of transaction has values. These can be used to monitor the status of submitted transactions.
+If the query param `return_txns` is not provided, or it is not "true", the server returns a json-encoded list of transaction hash values. These can be used to monitor the status of submitted transactions.
 
 If the query param `return_txns` is set, the server will respond with the transactions for creating and funding your account.
 The response HTTP body is hex encoded bytes of BCS encoded `Vec<aptos_types::transaction::SignedTransaction>`.

--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -37,18 +37,16 @@ use aptos_sdk::{
 };
 use reqwest::StatusCode;
 use serde::Deserialize;
-use std::{
-    convert::Infallible,
-    fmt,
-    sync::{Arc, Mutex},
-};
+use std::{convert::Infallible, fmt, ops::DerefMut, sync::Arc};
+use tokio::sync::Mutex;
+
 use url::Url;
 use warp::{Filter, Rejection, Reply};
 
 pub mod mint;
 
 pub struct Service {
-    pub faucet_account: Mutex<LocalAccount>,
+    pub faucet_account: Arc<Mutex<LocalAccount>>,
     pub transaction_factory: TransactionFactory,
     pub client: Client,
     endpoint: String,
@@ -64,10 +62,10 @@ impl Service {
     ) -> Self {
         let client = Client::new(Url::parse(&endpoint).expect("Invalid rest endpoint"));
         Service {
-            faucet_account: Mutex::new(faucet_account),
+            faucet_account: Arc::new(Mutex::new(faucet_account)),
             transaction_factory: TransactionFactory::new(chain_id)
                 .with_gas_unit_price(1)
-                .with_transaction_expiration_time(30),
+                .with_transaction_expiration_time(10),
             client,
             endpoint,
             maximum_amount,
@@ -115,7 +113,7 @@ fn health_route(
 }
 
 async fn handle_health(service: Arc<Service>) -> Result<Box<dyn warp::Reply>, Infallible> {
-    let faucet_address = service.faucet_account.lock().unwrap().address();
+    let faucet_address = service.faucet_account.lock().await.address();
     let faucet_account = service.client.get_account(faucet_address).await;
 
     match faucet_account {
@@ -131,6 +129,94 @@ fn accounts_routes(
     service: Arc<Service>,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     create_account_route(service.clone()).or(fund_account_route(service))
+}
+
+pub async fn delegate_account(
+    service: Arc<Service>,
+    server_url: String,
+    chain_id: ChainId,
+    maximum_amount: Option<u64>,
+) -> Arc<Service> {
+    // Create a new random account, then delegate to it
+    let delegated_account = LocalAccount::generate(&mut rand::rngs::OsRng);
+
+    // Create the account
+    service
+        .client
+        .wait_for_signed_transaction(
+            &create_account(
+                service.clone(),
+                CreateAccountParams {
+                    pub_key: delegated_account.public_key().clone(),
+                },
+            )
+            .await
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Give the new account some moolah
+    service
+        .client
+        .wait_for_signed_transaction(
+            // we hold the world ransom for  one... hundred... billion... dollars
+            &fund_account_unchecked(
+                service.clone(),
+                delegated_account.address(),
+                100_000_000_000,
+            )
+            .await
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let service = {
+        let mut faucet_account = service.faucet_account.lock().await;
+        get_and_update_seq_no(&service, faucet_account.deref_mut())
+            .await
+            .unwrap();
+        // Delegate minting to the account
+        service
+            .client
+            .submit_and_wait(&faucet_account.sign_with_transaction_builder(
+                service.transaction_factory.payload(
+                    aptos_stdlib::encode_delegate_mint_capability_script_function(
+                        delegated_account.address(),
+                    ),
+                ),
+            ))
+            .await
+            .unwrap();
+
+        Arc::new(Service::new(
+            server_url,
+            chain_id,
+            delegated_account,
+            maximum_amount,
+        ))
+    };
+    {
+        let mut faucet_account = service.faucet_account.lock().await;
+        get_and_update_seq_no(&service, faucet_account.deref_mut())
+            .await
+            .unwrap();
+
+        // claim the capability!
+        service
+            .client
+            .submit_and_wait(
+                &faucet_account.sign_with_transaction_builder(
+                    service
+                        .transaction_factory
+                        .payload(aptos_stdlib::encode_claim_mint_capability_script_function()),
+                ),
+            )
+            .await
+            .unwrap();
+    }
+    service
 }
 
 #[derive(Deserialize)]
@@ -178,32 +264,15 @@ async fn create_account(
     if service.client.get_account(params.receiver()).await.is_ok() {
         return Err(anyhow!("account already exists"));
     }
+    let mut faucet_account = service.faucet_account.lock().await;
+    get_and_update_seq_no(&service, faucet_account.deref_mut()).await?;
 
-    let faucet_account_address = service.faucet_account.lock().unwrap().address();
-    let faucet_sequence_number = service
-        .client
-        .get_account(faucet_account_address)
-        .await
-        .map_err(|_| anyhow::format_err!("faucet account {} not found", faucet_account_address))?
-        .into_inner()
-        .sequence_number;
-
-    let txn = {
-        let mut faucet_account = service.faucet_account.lock().unwrap();
-        if faucet_sequence_number > faucet_account.sequence_number() {
-            *faucet_account.sequence_number_mut() = faucet_sequence_number;
-        }
-
-        let builder = service.transaction_factory.payload(
-            aptos_stdlib::encode_create_account_script_function(
-                params.receiver(),
-                params.pre_image().into_vec(),
-            ),
-        );
-
-        faucet_account.sign_with_transaction_builder(builder)
-    };
-
+    let txn = faucet_account.sign_with_transaction_builder(service.transaction_factory.payload(
+        aptos_stdlib::encode_create_account_script_function(
+            params.receiver(),
+            params.pre_image().into_vec(),
+        ),
+    ));
     service.client.submit(&txn).await?;
     Ok(txn)
 }
@@ -247,13 +316,37 @@ async fn fund_account(
         .ok_or_else(|| anyhow::format_err!("Mint amount must be provided"))?;
     let service_amount = service.maximum_amount.unwrap_or(asked_amount);
     let amount = std::cmp::min(asked_amount, service_amount);
+    fund_account_unchecked(service, address, amount).await
+}
 
+pub(crate) async fn fund_account_unchecked(
+    service: Arc<Service>,
+    address: AccountAddress,
+    amount: u64,
+) -> Result<SignedTransaction> {
     // Check to ensure the account has already been created
     if service.client.get_account(address).await.is_err() {
         return Err(anyhow!("account doesn't exist"));
     }
 
-    let faucet_account_address = service.faucet_account.lock().unwrap().address();
+    let mut faucet_account = service.faucet_account.lock().await;
+    get_and_update_seq_no(&service, faucet_account.deref_mut()).await?;
+
+    let txn = faucet_account.sign_with_transaction_builder(
+        service
+            .transaction_factory
+            .payload(aptos_stdlib::encode_mint_script_function(address, amount)),
+    );
+
+    service.client.submit(&txn).await?;
+    Ok(txn)
+}
+
+pub(crate) async fn get_and_update_seq_no(
+    service: &Service,
+    faucet_account: &mut LocalAccount,
+) -> Result<u64> {
+    let faucet_account_address = faucet_account.address();
     let faucet_sequence_number = service
         .client
         .get_account(faucet_account_address)
@@ -262,21 +355,11 @@ async fn fund_account(
         .into_inner()
         .sequence_number;
 
-    let txn = {
-        let mut faucet_account = service.faucet_account.lock().unwrap();
-        if faucet_sequence_number > faucet_account.sequence_number() {
-            *faucet_account.sequence_number_mut() = faucet_sequence_number;
-        }
-
-        faucet_account.sign_with_transaction_builder(
-            service
-                .transaction_factory
-                .payload(aptos_stdlib::encode_mint_script_function(address, amount)),
-        )
-    };
-
-    service.client.submit(&txn).await?;
-    Ok(txn)
+    // If the onchain sequence_number is greater than what we have, update our sequence_numbers
+    if faucet_sequence_number > faucet_account.sequence_number() {
+        *faucet_account.sequence_number_mut() = faucet_sequence_number;
+    }
+    Ok(faucet_sequence_number)
 }
 
 //

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -26,6 +26,7 @@ framework =  { path = "../../aptos-move/framework" }
 diem-framework-releases = { path = "../../aptos-move/framework/DPN/releases" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-sdk = { path = "../../sdk" }
+aptos-faucet = {path = "../../crates/aptos-faucet"}
 aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }

--- a/testsuite/smoke-test/src/aptos/faucet_delegation.rs
+++ b/testsuite/smoke-test/src/aptos/faucet_delegation.rs
@@ -1,0 +1,73 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_faucet::{delegate_account, Service};
+use aptos_rest_client::Client;
+use aptos_sdk::types::{AccountKey, LocalAccount};
+use aptos_transaction_builder::aptos_stdlib;
+use forge::{AptosContext, AptosTest, Result, Test};
+use std::sync::Arc;
+
+pub struct FaucetDelegation;
+
+impl Test for FaucetDelegation {
+    fn name(&self) -> &'static str {
+        "smoke-test::aptos::faucet-delegation"
+    }
+}
+
+#[async_trait::async_trait]
+impl AptosTest for FaucetDelegation {
+    async fn run<'t>(&self, ctx: &mut AptosContext<'t>) -> Result<()> {
+        let client = Client::new(reqwest::Url::parse(ctx.url()).unwrap());
+        client.get_ledger_information().await?;
+
+        let root_clone = LocalAccount::new(
+            ctx.root_account().address(),
+            AccountKey::from_private_key(ctx.root_account().private_key().clone()),
+            0,
+        );
+
+        let service = Arc::new(Service::new(
+            ctx.url().to_string(),
+            ctx.chain_id(),
+            root_clone,
+            None,
+        ));
+
+        let new_service =
+            delegate_account(service.clone(), ctx.url().to_string(), ctx.chain_id(), None).await;
+
+        let old_root_address = ctx.root_account().address();
+        let new_account_address = new_service.faucet_account.lock().await.address();
+        assert_ne!(
+            old_root_address, new_account_address,
+            "account was not delegated!"
+        );
+
+        let starting_balance = ctx.get_balance(new_account_address).await.unwrap();
+
+        // ensure new account can mint
+        let tx = new_service
+            .faucet_account
+            .lock()
+            .await
+            .sign_with_transaction_builder(ctx.aptos_transaction_factory().payload(
+                aptos_stdlib::encode_mint_script_function(new_account_address, 1_000_000),
+            ));
+
+        let pending_txn = client.submit(&tx).await?.into_inner();
+        client.wait_for_transaction(&pending_txn).await?;
+
+        let ending_balance = ctx.get_balance(new_account_address).await.unwrap();
+
+        assert!(
+            ending_balance > starting_balance,
+            "ending balance of {} was not greater than starting balance: {}",
+            ending_balance,
+            starting_balance
+        );
+
+        Ok(())
+    }
+}

--- a/testsuite/smoke-test/src/aptos/mod.rs
+++ b/testsuite/smoke-test/src/aptos/mod.rs
@@ -11,3 +11,5 @@ mod module_publish;
 pub use module_publish::*;
 mod error_report;
 pub use error_report::*;
+mod faucet_delegation;
+pub use faucet_delegation::*;

--- a/testsuite/smoke-test/tests/forge-aptos.rs
+++ b/testsuite/smoke-test/tests/forge-aptos.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use forge::{forge_main, ForgeConfig, LocalFactory, Options, Result};
-use smoke_test::aptos::{AccountCreation, ErrorReport, GasCheck, MintTransfer, ModulePublish};
+use smoke_test::aptos::{
+    AccountCreation, ErrorReport, FaucetDelegation, GasCheck, MintTransfer, ModulePublish,
+};
 
 fn main() -> Result<()> {
     let tests = ForgeConfig::default()
@@ -12,6 +14,7 @@ fn main() -> Result<()> {
             &GasCheck,
             &ModulePublish,
             &ErrorReport,
+            &FaucetDelegation,
         ])
         .with_genesis_modules_bytes(aptos_framework_releases::current_module_blobs().to_vec());
 


### PR DESCRIPTION
by passing in `--delegate-on-start`, devnet faucet will use root mint key to create, fund, and delegate mint capability to a new account, to increase throughput