### PR TITLE
[tf][validator] enable prom remote_write

### DIFF
--- a/terraform/helm/validator/files/prometheus.yml
+++ b/terraform/helm/validator/files/prometheus.yml
@@ -147,3 +147,17 @@ scrape_configs:
   tls_config:
     insecure_skip_verify: true
 {{ end }}
+
+{{ if .Values.monitoring.prometheus.remote_write.enabled }}
+{{ with .Values.monitoring.prometheus.remote_write }}
+remote_write:
+  - url: {{ .url }}
+    sigv4:
+      region: {{ .region }}
+    queue_config:
+      max_samples_per_send: 1000
+      max_shards: 200
+      capacity: 2500
+{{ end }}
+{{ end }}
+

--- a/terraform/helm/validator/templates/monitoring.yaml
+++ b/terraform/helm/validator/templates/monitoring.yaml
@@ -118,6 +118,8 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aptos-validator.fullname" . }}-prometheus
+  annotations:
+{{- toYaml .Values.monitoring.serviceAccount.annotations | nindent 4 }}
   labels:
     {{- include "aptos-validator.labels" . | nindent 4 }}
 

--- a/terraform/helm/validator/values.yaml
+++ b/terraform/helm/validator/values.yaml
@@ -237,6 +237,10 @@ monitoring:
   fullKubernetesScrape: false
   useKubeStateMetrics: false
   prometheus:
+    remote_write:
+      enabled: false
+      url:
+      region:
     image:
       repo: prom/prometheus
       tag: v2.27.1@sha256:ca9e612ba1b6382ccf3642e21c9ee328ed4baa49fe84600ead7b7790c139aab4
@@ -310,6 +314,8 @@ monitoring:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    annotations: {}
 
 logging:
   vector:

--- a/terraform/testnet/main.tf
+++ b/terraform/testnet/main.tf
@@ -52,19 +52,6 @@ module "validator" {
   trusted_instance_type   = var.trusted_instance_type
 }
 
-output "vpc_id" {
-  value     = module.validator.vpc_id
-  sensitive = true
-}
-
-output "aws_subnet_private" {
-  value = module.validator.aws_subnet_private
-}
-
-output "cluster_security_group_id" {
-  value = module.validator.cluster_security_group_id
-}
-
 data "aws_eks_cluster" "aptos" {
   name = "aptos-${terraform.workspace}"
 }

--- a/terraform/testnet/outputs.tf
+++ b/terraform/testnet/outputs.tf
@@ -1,0 +1,16 @@
+output "vpc_id" {
+  value     = module.validator.vpc_id
+  sensitive = true
+}
+
+output "aws_subnet_private" {
+  value = module.validator.aws_subnet_private
+}
+
+output "cluster_security_group_id" {
+  value = module.validator.cluster_security_group_id
+}
+
+output "oidc_provider" {
+    value = module.validator.oidc_provider
+}


### PR DESCRIPTION
* Enable `remote_write` for validators' onboard prometheus. To use sigv4 for authenticated push, it's useful to override the service account annotations for OIDC integration.
* Refactor `testnet` TF outputs to a new file for readability 


