### PR TITLE
[Documentation] Small fixes to old/broken wording.

### DIFF
--- a/developer-docs-site/docs/transactions/basics-life-of-txn.md
+++ b/developer-docs-site/docs/transactions/basics-life-of-txn.md
@@ -173,7 +173,7 @@ It is important to understand that executing a transaction is different from upd
 
 When mempool receives a transaction from other validators via shared mempool or from the REST service, mempool invokes `VM::ValidateTransaction()` on the VM to validate the transaction.
 
-For implementation details refer to the [Virtual Machine README](https://github.com/diem/move/tree/main/language/vm).
+For implementation details refer to the [Virtual Machine README](https://github.com/diem/move/tree/main/language/move-vm).
 
 ## Mempool
 

--- a/documentation/specifications/README.md
+++ b/documentation/specifications/README.md
@@ -1,6 +1,6 @@
 # Protocol Specification
 
-This document describes the protocol specifications for the Aptos Payment Network (LPN). The intended audience for this document are as follows:
+This document describes the protocol specifications for the Aptos Blockchain. The intended audience for this document are as follows:
 
 * Virtual Asset Service Providers (VASPs), designated dealers (DDs), and other [ecosystem developers](https://aptoslabs.com/en-US/white-paper/) who build software that can interface with the LPN.
 * Developers who work on supporting transaction validation and interface with the validation protocols.

--- a/documentation/specifications/consensus/README.md
+++ b/documentation/specifications/consensus/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The consensus specification describes the mechanism used by the Aptos Payment Network (LPN) validators to agree on both ordering and transaction execution output under byzantine fault-tolerant (BFT) conditions - at most _f_ validators (where _f_ < (_all validators_)/3) are faulty or malicious. Currently, the consensus specification is an implementation of _AptosBFT_, a BFT consensus protocol that ensures liveness and safety under partial synchrony. The [AptosBFT whitepaper](https://aptos.dev/docs/state-machine-replication-paper) describes a high level overview of the protocol, the liveness and safety proofs, and a rationale on why AptosBFT was adopted for the LPN. This document specifies how to implement the AptosBFT protocol in order to participate as a validating node in the LPN.
+The consensus specification describes the mechanism used by the Aptos validators to agree on both ordering and transaction execution output under byzantine fault-tolerant (BFT) conditions - at most _f_ validators (where _f_ < (_all validators_)/3) are faulty or malicious. Currently, the consensus specification is an implementation of _AptosBFT_, a BFT consensus protocol that ensures liveness and safety under partial synchrony. The [AptosBFT whitepaper](https://aptos.dev/docs/state-machine-replication-paper) describes a high level overview of the protocol, the liveness and safety proofs, and a rationale on why AptosBFT was adopted for the LPN. This document specifies how to implement the AptosBFT protocol in order to participate as a validating node in the LPN.
 
 This document is organized as follows:
 

--- a/documentation/specifications/crypto/README.md
+++ b/documentation/specifications/crypto/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The consensus specification describes the cryptographic operations used for
-hashing, signing and verifying throughout the Aptos Payment Network, as well as
+hashing, signing and verifying throughout the Aptos Blockchain, as well as
 on transactions submitted to this network.
 
 We do not specify any of one of these algorithms from first principles, but

--- a/documentation/specifications/state_sync/README.md
+++ b/documentation/specifications/state_sync/README.md
@@ -4,7 +4,7 @@
 
 This document describes the spec of a Aptos node's state synchronizer component,
 which is responsible for synchronizing a node's local ledger to the latest state in
-the Aptos Payment Network.
+the Aptos Blockchain.
 
 This document is organized as follows:
 
@@ -20,7 +20,7 @@ as a node in the Aptos Network
 ## Overview
 
 State Synchronizer is a system component that is responsible for syncing ledger
-state among peers in the Aptos Payment Network. Using state sync, a Aptos node
+state among peers in the Aptos Blockchain. Using state sync, a Aptos node
 can discover and update to a more recent ledger state if available with the following
 general flow:
 1. A node sends a [`GetChunkRequest`](#getchunkrequest) to a remote peer

--- a/documentation/specifications/trusted_computing_base/execution_correctness/README.md
+++ b/documentation/specifications/trusted_computing_base/execution_correctness/README.md
@@ -3,7 +3,7 @@
 ## Abstract
 
 This specification outlines the design and implementation of Aptos Execution Correctness (LEC): a secured service
-dedicated for executing transactions correctly (with the MOVE VM) and used by Consensus in the Aptos payment network.
+dedicated for executing transactions correctly (with the MOVE VM) and used by Consensus in the Aptos Blockchain.
 
 For those unfamiliar with the execution flow of TCB, we recommend reading the architecture of [Trusted Computing Base (TCB)](../README.md).
 

--- a/documentation/specifications/trusted_computing_base/key_manager/README.md
+++ b/documentation/specifications/trusted_computing_base/key_manager/README.md
@@ -1,6 +1,6 @@
 # Key Manager specification
 
-This specification outlines the design and execution of the Key Manager (KM): the primary service responsible for managing and rotating cryptographic keys used by validator nodes and validator full nodes in the Aptos payment network.
+This specification outlines the design and execution of the Key Manager (KM): the primary service responsible for managing and rotating cryptographic keys used by validator nodes and validator full nodes in the Aptos Blockchain.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Motivation

This PR makes some small fixes to old/invalid wording, e.g., "Aptos Payment Network" -> "Aptos Blockchain". It also fixes a broken URL pointer in the documentation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually inspected all of the change sites.

## Related PRs

None.