### PR TITLE
[State Sync] Start supporting account state downloading for bootstrapping.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -286,7 +286,7 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
         state_sync_network_handles,
         mempool_notifier,
         consensus_listener,
-        db_rw.reader,
+        db_rw,
         chunk_executor,
         node_config,
         waypoint,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -138,6 +138,7 @@ impl AptosDataClient for MockAptosDataClient {
             last_key: HashValue::random(),
             account_blobs,
             proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
         };
         Ok(create_data_client_response(account_states))
     }

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -19,6 +19,7 @@ tokio-stream = "0.1.4"
 consensus-notifications = { path = "../../inter-component/consensus-notifications" }
 data-streaming-service = { path = "../data-streaming-service" }
 aptos-config = { path = "../../../config" }
+aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-data-client = { path = "../../aptos-data-client" }
 aptos-infallible = { path = "../../../crates/aptos-infallible" }
 aptos-logger = { path = "../../../crates/aptos-logger" }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -320,7 +320,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         if self.active_data_stream.is_some() {
             // We have an active data stream. Process any notifications!
             self.process_active_stream_notifications().await?;
-        } else if !self.storage_synchronizer.pending_transaction_data() {
+        } else if !self.storage_synchronizer.pending_storage_data() {
             // Fetch a new data stream to start streaming data
             self.initialize_active_data_stream(global_data_summary)
                 .await?;

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    driver::DriverConfiguration, error::Error, storage_synchronizer::StorageSynchronizerInterface,
-    utils, utils::SpeculativeStreamState,
+    driver::DriverConfiguration, error::Error, notification_handlers::CommittedAccounts,
+    storage_synchronizer::StorageSynchronizerInterface, utils, utils::SpeculativeStreamState,
 };
 use aptos_config::config::BootstrappingMode;
 use aptos_data_client::GlobalDataSummary;
@@ -817,6 +817,16 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
             notification_feedback,
         )
         .await
+    }
+
+    /// Handles a notification from the driver that new accounts have been
+    /// committed to storage.
+    pub fn handle_committed_accounts(
+        &mut self,
+        _committed_accounts: CommittedAccounts,
+    ) -> Result<(), Error> {
+        // TODO(joshlind): implement me!
+        unimplemented!();
     }
 
     /// Returns the speculative stream state. Assumes that the state exists.

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -67,7 +67,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
             self.process_active_stream_notifications(consensus_sync_request)
                 .await
         } else if self.storage_synchronizer.pending_storage_data() {
-            // Wait for any pending transaction data to be processed
+            // Wait for any pending data to be processed
             Ok(())
         } else {
             // Fetch a new data stream to start streaming data

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -66,7 +66,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
             // We have an active data stream. Process any notifications!
             self.process_active_stream_notifications(consensus_sync_request)
                 .await
-        } else if self.storage_synchronizer.pending_transaction_data() {
+        } else if self.storage_synchronizer.pending_storage_data() {
             // Wait for any pending transaction data to be processed
             Ok(())
         } else {

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -20,7 +20,7 @@ use executor_types::ChunkExecutorTrait;
 use futures::channel::mpsc;
 use mempool_notifications::MempoolNotificationSender;
 use std::sync::Arc;
-use storage_interface::DbReader;
+use storage_interface::DbReaderWriter;
 use tokio::runtime::{Builder, Runtime};
 
 /// Creates a new state sync driver and client
@@ -38,7 +38,7 @@ impl DriverFactory {
         create_runtime: bool,
         node_config: &NodeConfig,
         waypoint: Waypoint,
-        storage: Arc<dyn DbReader>,
+        storage: DbReaderWriter,
         chunk_executor: Arc<ChunkExecutor>,
         mempool_notification_sender: MempoolNotifier,
         consensus_listener: ConsensusNotificationListener,
@@ -76,6 +76,7 @@ impl DriverFactory {
             chunk_executor,
             commit_notification_sender,
             error_notification_sender,
+            storage.writer,
             driver_runtime.as_ref(),
         );
 
@@ -98,7 +99,7 @@ impl DriverFactory {
             storage_synchronizer,
             aptos_data_client,
             streaming_service_client,
-            storage,
+            storage.reader,
         );
 
         // Spawn the driver

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -21,6 +21,7 @@ use std::{
         Arc,
     },
 };
+use storage_interface::DbWriter;
 use tokio::runtime::Runtime;
 
 // TODO(joshlind): add structured logging support!
@@ -72,6 +73,9 @@ pub struct StorageSynchronizer {
 
     // The number of transaction data chunks pending execute/apply, or commit
     pending_transaction_chunks: Arc<AtomicU64>,
+
+    // The writer to storage (required for account state syncing)
+    storage: Arc<dyn DbWriter>,
 }
 
 impl StorageSynchronizer {
@@ -79,6 +83,7 @@ impl StorageSynchronizer {
         chunk_executor: Arc<ChunkExecutor>,
         commit_notification_sender: mpsc::UnboundedSender<CommitNotification>,
         error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
+        storage: Arc<dyn DbWriter>,
         runtime: Option<&Runtime>,
     ) -> Self {
         // Create a channel to notify the executor when transaction data chunks are ready
@@ -113,6 +118,7 @@ impl StorageSynchronizer {
         Self {
             executor_notifier,
             pending_transaction_chunks,
+            storage,
         }
     }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -278,7 +278,7 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
                     // Commit the executed chunk
                     match chunk_executor.commit_chunk() {
                         Ok((events, transactions)) => {
-                            let commit_notification = CommitNotification::new(events, transactions);
+                            let commit_notification = CommitNotification::new_committed_transactions(events, transactions);
                             if let Err(error) = commit_notification_sender.send(commit_notification).await {
                                 let error = format!("Failed to send commit notification! Error: {:?}", error);
                                 send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -144,7 +144,7 @@ fn create_driver_for_tests(
         false,
         &node_config,
         waypoint,
-        db_rw.reader,
+        db_rw,
         chunk_executor,
         mempool_notifier,
         consensus_listener,

--- a/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
@@ -19,7 +19,7 @@ use state_sync_v1::{
     network::{StateSyncEvents, StateSyncSender},
 };
 use std::sync::Arc;
-use storage_interface::DbReader;
+use storage_interface::DbReaderWriter;
 use tokio::runtime::Runtime;
 
 /// A struct for holding the various runtimes required by state sync v2.
@@ -68,7 +68,7 @@ impl StateSyncMultiplexer {
         network: Vec<(NetworkId, StateSyncSender, StateSyncEvents)>,
         mempool_notifier: MempoolNotifier,
         consensus_listener: ConsensusNotificationListener,
-        storage: Arc<dyn DbReader>,
+        storage: DbReaderWriter,
         chunk_executor: Arc<ChunkExecutor>,
         node_config: &NodeConfig,
         waypoint: Waypoint,
@@ -77,7 +77,7 @@ impl StateSyncMultiplexer {
         streaming_service_client: StreamingServiceClient,
     ) -> Self {
         // Notify subscribers of the initial on-chain config values
-        match (&*storage).fetch_synced_version() {
+        match (&*storage.reader).fetch_synced_version() {
             Ok(synced_version) => {
                 if let Err(error) =
                     event_subscription_service.notify_initial_configs(synced_version)
@@ -119,7 +119,7 @@ impl StateSyncMultiplexer {
                 network,
                 mempool_notifier,
                 consensus_listener,
-                storage,
+                storage.reader,
                 chunk_executor,
                 node_config,
                 waypoint,
@@ -243,7 +243,7 @@ mod tests {
             vec![],
             mempool_notifier,
             consensus_listener,
-            db_rw.reader.clone(),
+            db_rw.clone(),
             Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap()),
             &node_config,
             Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::random())),

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -105,6 +105,7 @@ async fn test_get_account_states_chunk_with_proof() {
             last_key: HashValue::zero(),
             account_blobs,
             proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
         });
     assert_eq!(response, expected_response);
 }
@@ -541,6 +542,7 @@ impl DbReader for MockDbReader {
             last_key: HashValue::zero(),
             account_blobs,
             proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
         };
         Ok(account_states_chunk_with_proof)
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -181,6 +181,7 @@ impl StateStore {
         let first_key = account_blobs.first().expect("checked to exist").0;
         let last_key = account_blobs.last().expect("checked to exist").0;
         let proof = self.get_account_state_range_proof(last_key, version)?;
+        let root_hash = self.get_root_hash(version)?;
 
         Ok(AccountStatesChunkWithProof {
             first_index: first_index as u64,
@@ -189,6 +190,7 @@ impl StateStore {
             last_key,
             account_blobs,
             proof,
+            root_hash,
         })
     }
 

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -127,13 +127,13 @@ pub trait TreeReader<V> {
     fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode<V>)>>;
 }
 
-pub trait TreeWriter<V> {
+pub trait TreeWriter<V>: Send + Sync {
     /// Writes a node batch into storage.
     fn write_node_batch(&self, node_batch: &NodeBatch<V>) -> Result<()>;
 }
 
 /// `Value` defines the types of data that can be stored in a Jellyfish Merkle tree.
-pub trait Value: Clone + CryptoHash + Serialize + DeserializeOwned {}
+pub trait Value: Clone + CryptoHash + Serialize + DeserializeOwned + Send + Sync {}
 
 /// `TestValue` defines the types of data that can be stored in a Jellyfish Merkle tree and used in
 /// tests.

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -130,7 +130,7 @@ impl TreeState {
     }
 }
 
-pub trait StateSnapshotReceiver<V> {
+pub trait StateSnapshotReceiver<V>: Send {
     fn add_chunk(
         &mut self,
         chunk: Vec<(HashValue, V)>,

--- a/types/src/account_state_blob.rs
+++ b/types/src/account_state_blob.rs
@@ -230,17 +230,13 @@ impl AccountStateWithProof {
 /// in the struct itself and not behind pointers/handles to file locations.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AccountStatesChunkWithProof {
-    pub first_index: u64,
-    // The first account index in chunk
-    pub last_index: u64,
-    // The last account index in chunk
-    pub first_key: HashValue,
-    // The first account key in chunk
-    pub last_key: HashValue,
-    // The last account key in chunk
-    pub account_blobs: Vec<(HashValue, AccountStateBlob)>,
-    // The account blobs in the chunk
+    pub first_index: u64,     // The first account index in chunk
+    pub last_index: u64,      // The last account index in chunk
+    pub first_key: HashValue, // The first account key in chunk
+    pub last_key: HashValue,  // The last account key in chunk
+    pub account_blobs: Vec<(HashValue, AccountStateBlob)>, // The account blobs in the chunk
     pub proof: SparseMerkleRangeProof, // The proof to ensure the chunk is in the account states
+    pub root_hash: HashValue, // The root hash of the sparse merkle tree for this chunk
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Note: this PR is a simple port of https://github.com/diem/diem/pull/10154 to Aptos. Other than renaming, nothing is different.

## Motivation

This PR starts adding support for account state downloading when a node is bootstrapping in state sync. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The smoke test verifies some of the new functionality.

## Related PRs

None.