### PR TITLE
[Documentation] Fix broken links in "Getting Started"

### DIFF
--- a/developer-docs-site/docs/tutorials/getting-started.md
+++ b/developer-docs-site/docs/tutorials/getting-started.md
@@ -36,6 +36,6 @@ source ~/.cargo/env
 
 * Faucet endpoint: [https://faucet.devnet.aptoslabs.com](https://faucet.devnet.aptoslabs.com)
 * REST interface endpoint: [https://fullnode.devnet.aptoslabs.com](https://fullnode.devnet.aptoslabs.com)
-* [Genesis](https://devnet.aptos.com/genesis.blob)
-* [Waypoint](https://devnet.aptos.com/waypoint.txt)
-* [ChainID](https://devnet.aptos.com/chainid.txt)
+* [Genesis](https://devnet.aptoslabs.com/genesis.blob)
+* [Waypoint](https://devnet.aptoslabs.com/waypoint.txt)
+* [ChainID](https://devnet.aptoslabs.com/chainid.txt)


### PR DESCRIPTION
## Motivation

This PR offers some fixes to the "Getting Started" developer documents file: https://aptos.dev/tutorials/getting-started

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually inspected the files.

## Related PRs

None.
