### PR TITLE
[Storage] [Pruner] Add more pruning functionality for ledger store pr…

### DIFF
--- a/storage/aptosdb/src/change_set.rs
+++ b/storage/aptosdb/src/change_set.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 /// To be specific it carries a batch of db alternations and counter increases that'll be converted
 /// to DB alternations on "sealing". This is required to be converted to `SealedChangeSet` before
 /// committing to the DB.
-pub(crate) struct ChangeSet {
+pub struct ChangeSet {
     /// A batch of db alternations.
     pub batch: SchemaBatch,
     /// Counter bumps to be made on commit.

--- a/storage/aptosdb/src/event_store/mod.rs
+++ b/storage/aptosdb/src/event_store/mod.rs
@@ -30,8 +30,9 @@ use aptos_types::{
     proof::{position::Position, EventAccumulatorProof, EventProof},
     transaction::Version,
 };
-use schemadb::{schema::ValueCodec, ReadOptions, SchemaIterator, DB};
+use schemadb::{schema::ValueCodec, ReadOptions, SchemaBatch, SchemaIterator, DB};
 use std::{
+    collections::{hash_map::Entry, HashMap, HashSet},
     convert::{TryFrom, TryInto},
     iter::Peekable,
     sync::Arc,
@@ -119,7 +120,7 @@ impl EventStore {
         Ok((event, proof))
     }
 
-    fn get_txn_ver_by_seq_num(&self, event_key: &EventKey, seq_num: u64) -> Result<u64> {
+    pub fn get_txn_ver_by_seq_num(&self, event_key: &EventKey, seq_num: u64) -> Result<u64> {
         let (ver, _) = self
             .db
             .get::<EventByKeySchema>(&(*event_key, seq_num))?
@@ -127,7 +128,7 @@ impl EventStore {
         Ok(ver)
     }
 
-    fn get_event_by_key(
+    pub fn get_event_by_key(
         &self,
         event_key: &EventKey,
         seq_num: u64,
@@ -359,6 +360,73 @@ impl EventStore {
         version
             .checked_sub(1)
             .ok_or_else(|| format_err!("A block with non-zero seq num started at version 0."))
+    }
+
+    /// Prunes the events by key store for a set of events
+    pub fn prune_events_by_key(
+        &self,
+        candidate_events: &[ContractEvent],
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        let mut sequence_range_by_event_keys: HashMap<EventKey, (u64, u64)> = HashMap::new();
+
+        candidate_events.iter().for_each(|event| {
+            let event_key = event.key();
+            // Events should be sorted by sequence numbers, so the first sequence number for the
+            // event key should be the minimum
+            match sequence_range_by_event_keys.entry(*event_key) {
+                Entry::Occupied(mut occupied) => {
+                    occupied.insert((occupied.get().0, event.sequence_number()));
+                }
+                Entry::Vacant(vacant) => {
+                    vacant.insert((event.sequence_number(), event.sequence_number()));
+                }
+            }
+        });
+
+        for (event_key, (min, max)) in sequence_range_by_event_keys {
+            db_batch
+                .delete_range_inclusive::<EventByKeySchema>(&(event_key, min), &(event_key, max));
+        }
+        Ok(())
+    }
+
+    /// Prunes events by accumulator store for a range of version in [begin, end)
+    pub fn prune_event_accumulator(
+        &self,
+        begin: Version,
+        end: Version,
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        db_batch.delete_range::<EventAccumulatorSchema>(
+            &(begin, Position::from_inorder_index(0)),
+            &(end, Position::from_inorder_index(0)),
+        )
+    }
+
+    /// Prunes events by version store for a set of events in version range [begin, end)
+    pub fn prune_events_by_version(
+        &self,
+        event_keys: HashSet<EventKey>,
+        begin: Version,
+        end: Version,
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        for event_key in event_keys {
+            db_batch
+                .delete_range::<EventByVersionSchema>(&(event_key, begin, 0), &(event_key, end, 0));
+        }
+        Ok(())
+    }
+
+    /// Prunes the event schema for a range of version in [begin, end)
+    pub fn prune_event_schema(
+        &self,
+        begin: Version,
+        end: Version,
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        db_batch.delete_range::<EventSchema>(&(begin, 0_u64), &(end, 0_u64))
     }
 }
 

--- a/storage/aptosdb/src/ledger_counters/mod.rs
+++ b/storage/aptosdb/src/ledger_counters/mod.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 /// Types of ledger counters.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, ToPrimitive, NumVariants)]
 #[cfg_attr(test, derive(Arbitrary))]
-pub(crate) enum LedgerCounter {
+pub enum LedgerCounter {
     EventsCreated = 101,
 
     NewStateLeaves = 201,
@@ -89,7 +89,7 @@ impl InnerLedgerCounters {
 }
 
 /// Represents `LedgerCounter` bumps yielded by saving a batch of transactions.
-pub(crate) struct LedgerCounterBumps {
+pub struct LedgerCounterBumps {
     bumps: InnerLedgerCounters,
 }
 

--- a/storage/aptosdb/src/ledger_store/ledger_info_test.rs
+++ b/storage/aptosdb/src/ledger_store/ledger_info_test.rs
@@ -4,49 +4,8 @@
 use super::*;
 use crate::{change_set::ChangeSet, AptosDB};
 use aptos_temppath::TempPath;
-use aptos_types::{
-    proptest_types::{AccountInfoUniverse, LedgerInfoWithSignaturesGen},
-    transaction::Version,
-};
+use ledger_info_test_utils::*;
 use proptest::{collection::vec, prelude::*};
-use std::path::Path;
-
-fn arb_ledger_infos_with_sigs() -> impl Strategy<Value = Vec<LedgerInfoWithSignatures>> {
-    (
-        any_with::<AccountInfoUniverse>(3),
-        vec((any::<LedgerInfoWithSignaturesGen>(), 1..10usize), 1..10),
-    )
-        .prop_map(|(mut universe, gens)| {
-            let ledger_infos_with_sigs: Vec<_> = gens
-                .into_iter()
-                .map(|(ledger_info_gen, block_size)| {
-                    ledger_info_gen.materialize(&mut universe, block_size)
-                })
-                .collect();
-            assert_eq!(get_first_epoch(&ledger_infos_with_sigs), 0);
-            ledger_infos_with_sigs
-        })
-}
-
-fn get_first_epoch(ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> u64 {
-    ledger_infos_with_sigs
-        .first()
-        .unwrap()
-        .ledger_info()
-        .epoch()
-}
-
-fn get_last_epoch(ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> u64 {
-    ledger_infos_with_sigs.last().unwrap().ledger_info().epoch()
-}
-
-fn get_last_version(ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> Version {
-    ledger_infos_with_sigs
-        .last()
-        .unwrap()
-        .ledger_info()
-        .version()
-}
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(20))]
@@ -174,23 +133,6 @@ proptest! {
             assert!(startup_info.synced_tree_state.is_none());
         }
     }
-}
-
-fn set_up(path: &impl AsRef<Path>, ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> AptosDB {
-    let db = AptosDB::new_for_test(path);
-    let store = &db.ledger_store;
-
-    // Write LIs to DB.
-    let mut cs = ChangeSet::new();
-    ledger_infos_with_sigs
-        .iter()
-        .map(|info| store.put_ledger_info(info, &mut cs))
-        .collect::<Result<Vec<_>>>()
-        .unwrap();
-    store.db.write_schemas(cs.batch).unwrap();
-    store.set_latest_ledger_info(ledger_infos_with_sigs.last().unwrap().clone());
-
-    db
 }
 
 fn put_transaction_infos(db: &AptosDB, txn_infos: &[TransactionInfo]) {

--- a/storage/aptosdb/src/ledger_store/ledger_info_test_utils.rs
+++ b/storage/aptosdb/src/ledger_store/ledger_info_test_utils.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::{AptosDB, ChangeSet};
+use aptos_types::{
+    ledger_info::LedgerInfoWithSignatures,
+    proptest_types::{AccountInfoUniverse, LedgerInfoWithSignaturesGen},
+    transaction::Version,
+};
+use proptest::{
+    arbitrary::{any, any_with},
+    collection::vec,
+    prelude::Strategy,
+};
+use std::path::Path;
+
+pub fn arb_ledger_infos_with_sigs() -> impl Strategy<Value = Vec<LedgerInfoWithSignatures>> {
+    (
+        any_with::<AccountInfoUniverse>(3),
+        vec((any::<LedgerInfoWithSignaturesGen>(), 1..50usize), 1..50),
+    )
+        .prop_map(|(mut universe, gens)| {
+            let ledger_infos_with_sigs: Vec<_> = gens
+                .into_iter()
+                .map(|(ledger_info_gen, block_size)| {
+                    ledger_info_gen.materialize(&mut universe, block_size)
+                })
+                .collect();
+            assert_eq!(get_first_epoch(&ledger_infos_with_sigs), 0);
+            ledger_infos_with_sigs
+        })
+}
+
+pub fn get_first_epoch(ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> u64 {
+    ledger_infos_with_sigs
+        .first()
+        .unwrap()
+        .ledger_info()
+        .epoch()
+}
+
+pub fn get_last_epoch(ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> u64 {
+    ledger_infos_with_sigs.last().unwrap().ledger_info().epoch()
+}
+
+pub fn get_last_version(ledger_infos_with_sigs: &[LedgerInfoWithSignatures]) -> Version {
+    ledger_infos_with_sigs
+        .last()
+        .unwrap()
+        .ledger_info()
+        .version()
+}
+
+pub fn set_up(
+    path: &impl AsRef<Path>,
+    ledger_infos_with_sigs: &[LedgerInfoWithSignatures],
+) -> AptosDB {
+    let db = AptosDB::new_for_test(path);
+    let store = &db.ledger_store;
+
+    // Write LIs to DB.
+    let mut cs = ChangeSet::new();
+    ledger_infos_with_sigs
+        .iter()
+        .map(|info| store.put_ledger_info(info, &mut cs))
+        .collect::<anyhow::Result<Vec<_>>>()
+        .unwrap();
+    store.db.write_schemas(cs.batch).unwrap();
+    store.set_latest_ledger_info(ledger_infos_with_sigs.last().unwrap().clone());
+    db
+}

--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -1,16 +1,43 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_logger::{error, info};
 use aptos_types::transaction::Version;
+use std::{cmp::min, thread::sleep, time::Duration};
 
 /// Defines the trait for pruner for different DB
 pub trait DBPruner {
-    /// Initialize the pruner and record the least readable version
-    fn initialize(&self);
+    /// Find out the first undeleted item in the stale node index.
+    ///
+    /// Seeking from the beginning (version 0) is potentially costly, we do it once upon worker
+    /// thread start, record the progress and seek from that position afterwards.
+    fn initialize(&self) {
+        loop {
+            match self.initialize_least_readable_version() {
+                Ok(least_readable_version) => {
+                    info!(
+                        least_readable_version = least_readable_version,
+                        "{} initialized.",
+                        self.name()
+                    );
+                    self.record_progress(least_readable_version);
+                    return;
+                }
+                Err(e) => {
+                    error!(
+                        error = ?e,
+                        "{} Error on first seek. Retrying in 1 second.", self.name()
+                    );
+                    sleep(Duration::from_secs(1));
+                }
+            }
+        }
+    }
+    fn name(&self) -> &'static str;
 
     /// Performs the actual pruning, a target version is passed, which is the target the pruner
     /// tries to prune.
-    fn prune(&self, max_versions: usize) -> anyhow::Result<Version>;
+    fn prune(&self, max_versions: u64) -> anyhow::Result<Version>;
 
     /// Initializes the least readable version stored in underlying DB storage
     fn initialize_least_readable_version(&self) -> anyhow::Result<Version>;
@@ -24,9 +51,21 @@ pub trait DBPruner {
     /// Returns the target version for the DB pruner
     fn target_version(&self) -> Version;
 
+    /// Returns the target version for the current pruning round - this might be different from the
+    /// target_version() because we need to keep max_version in account.
+    fn get_currrent_batch_target(&self, max_versions: Version) -> Version {
+        // Current target version  might be less than the target version to ensure we don't prune
+        // more than max_version in one go.
+        min(
+            self.least_readable_version() + max_versions as u64,
+            self.target_version(),
+        )
+    }
     /// Records the current progress of the pruner by updating the least readable version
     fn record_progress(&self, least_readable_version: Version);
 
     /// True if there is pruning work pending to be done
-    fn is_pruning_pending(&self) -> bool;
+    fn is_pruning_pending(&self) -> bool {
+        self.target_version() >= self.least_readable_version()
+    }
 }

--- a/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
@@ -1,0 +1,121 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    event::EventSchema, metrics::DIEM_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
+    EventStore,
+};
+use aptos_types::{
+    contract_event::ContractEvent,
+    event::EventKey,
+    transaction::{AtomicVersion, Version},
+};
+use itertools::Itertools;
+use schemadb::{ReadOptions, SchemaBatch, DB};
+use std::{
+    collections::HashSet,
+    sync::{atomic::Ordering, Arc},
+};
+
+pub const EVENT_STORE_PRUNER_NAME: &str = "event store pruner";
+
+pub struct EventStorePruner {
+    db: Arc<DB>,
+    event_store: Arc<EventStore>,
+    /// Keeps track of the target version that the pruner needs to achieve.
+    target_version: AtomicVersion,
+    least_readable_version: AtomicVersion,
+}
+
+impl DBPruner for EventStorePruner {
+    fn name(&self) -> &'static str {
+        EVENT_STORE_PRUNER_NAME
+    }
+
+    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+        // Current target version  might be less than the target version to ensure we don't prune
+        // more than max_version in one go.
+        let mut db_batch = SchemaBatch::new();
+        let current_target_version = self.get_currrent_batch_target(max_versions);
+        let candidate_events = self
+            .get_pruning_candidate_events(self.least_readable_version(), current_target_version)?;
+
+        let event_keys: HashSet<EventKey> =
+            candidate_events.iter().map(|event| *event.key()).collect();
+
+        self.event_store.prune_events_by_version(
+            event_keys,
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+
+        self.event_store
+            .prune_events_by_key(&candidate_events, &mut db_batch)?;
+
+        self.event_store.prune_event_accumulator(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+
+        self.event_store.prune_event_schema(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+
+        self.db.write_schemas(db_batch)?;
+
+        self.record_progress(current_target_version);
+        Ok(current_target_version)
+    }
+
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
+        let mut iter = self.db.iter::<EventSchema>(ReadOptions::default())?;
+        iter.seek_to_first();
+        let version = iter.next().transpose()?.map_or(0, |(key, _)| key.0);
+        Ok(version)
+    }
+
+    fn least_readable_version(&self) -> Version {
+        self.least_readable_version.load(Ordering::Relaxed)
+    }
+
+    fn set_target_version(&self, target_version: Version) {
+        self.target_version.store(target_version, Ordering::Relaxed)
+    }
+
+    fn target_version(&self) -> Version {
+        self.target_version.load(Ordering::Relaxed)
+    }
+
+    fn record_progress(&self, least_readable_version: Version) {
+        self.least_readable_version
+            .store(least_readable_version, Ordering::Relaxed);
+        DIEM_PRUNER_LEAST_READABLE_VERSION
+            .with_label_values(&["event_store"])
+            .set(least_readable_version as i64);
+    }
+}
+
+impl EventStorePruner {
+    pub(in crate::pruner) fn new(db: Arc<DB>, event_store: Arc<EventStore>) -> Self {
+        EventStorePruner {
+            db,
+            event_store,
+            target_version: AtomicVersion::new(0),
+            least_readable_version: AtomicVersion::new(0),
+        }
+    }
+
+    fn get_pruning_candidate_events(
+        &self,
+        start: Version,
+        end: Version,
+    ) -> anyhow::Result<Vec<ContractEvent>> {
+        self.event_store
+            .get_events_by_version_iter(start, (end - start) as usize)?
+            .flatten_ok()
+            .collect()
+    }
+}

--- a/storage/aptosdb/src/pruner/event_store/mod.rs
+++ b/storage/aptosdb/src/pruner/event_store/mod.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod event_store_pruner;
 #[cfg(test)]
 mod test;
-pub(crate) mod transaction_store_pruner;
-pub(crate) mod write_set_pruner;

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -1,0 +1,154 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{pruner::*, AptosDB, ChangeSet};
+use aptos_proptest_helpers::Index;
+use aptos_temppath::TempPath;
+use aptos_types::{
+    contract_event::ContractEvent,
+    proptest_types::{AccountInfoUniverse, ContractEventGen},
+};
+use proptest::{collection::vec, prelude::*, proptest};
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn test_event_store_pruner(
+        mut universe in any_with::<AccountInfoUniverse>(3),
+        gen_batches in vec(vec((any::<Index>(), any::<ContractEventGen>()), 0..=2), 0..100),
+    ) {
+        let event_batches = gen_batches
+            .into_iter()
+            .map(|gens| {
+                gens.into_iter()
+                    .map(|(index, gen)| gen.materialize(*index, &mut universe))
+                    .collect()
+            })
+            .collect();
+
+        verify_event_store_pruner(event_batches);
+    }
+
+}
+
+fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
+    let tmp_dir = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp_dir);
+    let event_store = &aptos_db.event_store;
+    let mut cs = ChangeSet::new();
+    let num_versions = events.len();
+    let pruner = Pruner::new(
+        Arc::clone(&aptos_db.db),
+        StoragePrunerConfig {
+            state_store_prune_window: Some(0),
+            default_prune_window: Some(0),
+        },
+        Arc::clone(&aptos_db.transaction_store),
+        Arc::clone(&aptos_db.ledger_store),
+        Arc::clone(&aptos_db.event_store),
+    );
+
+    // Write events to DB
+    for (version, events_for_version) in events.iter().enumerate() {
+        event_store
+            .put_events(version as u64, events_for_version, &mut cs)
+            .unwrap();
+    }
+    aptos_db.db.write_schemas(cs.batch).unwrap();
+
+    // start pruning events batches of size 2 and verify transactions have been pruned from DB
+    for i in (0..=num_versions).step_by(2) {
+        pruner
+            .wake_and_wait(
+                i as u64, /* latest_version */
+                PrunerIndex::EventStorePrunerIndex as usize,
+            )
+            .unwrap();
+        // ensure that all events up to i * 2 has been pruned
+        for j in 0..i {
+            verify_events_not_in_store(j as u64, event_store);
+            verify_event_by_key_not_in_store(&events, j as u64, event_store);
+            verify_event_by_version_not_in_store(&events, j as u64, event_store);
+        }
+        // ensure all other events are valid in DB
+        for j in i..num_versions {
+            verify_events_in_store(&events, j as u64, event_store);
+            verify_event_by_key_in_store(&events, j as u64, event_store);
+            verify_event_by_version_in_store(&events, j as u64, event_store);
+        }
+    }
+}
+
+fn verify_event_by_key_not_in_store(
+    events: &[Vec<ContractEvent>],
+    version: Version,
+    event_store: &Arc<EventStore>,
+) {
+    for event in &events[version as usize] {
+        assert!(event_store
+            .get_txn_ver_by_seq_num(event.key(), event.sequence_number())
+            .is_err())
+    }
+}
+
+fn verify_event_by_key_in_store(
+    events: &[Vec<ContractEvent>],
+    version: Version,
+    event_store: &Arc<EventStore>,
+) {
+    for event in events.get(version as usize).unwrap() {
+        assert_eq!(
+            event_store
+                .get_txn_ver_by_seq_num(event.key(), event.sequence_number())
+                .unwrap(),
+            version
+        );
+    }
+}
+
+fn verify_event_by_version_not_in_store(
+    events: &[Vec<ContractEvent>],
+    version: Version,
+    event_store: &Arc<EventStore>,
+) {
+    for event in events.get(version as usize).unwrap() {
+        assert!(event_store
+            .get_latest_sequence_number(version, event.key())
+            .unwrap()
+            .is_none());
+    }
+}
+
+fn verify_event_by_version_in_store(
+    events: &[Vec<ContractEvent>],
+    version: Version,
+    event_store: &Arc<EventStore>,
+) {
+    for event in events.get(version as usize).unwrap() {
+        assert!(event_store
+            .get_latest_sequence_number(version, event.key())
+            .unwrap()
+            .is_some());
+    }
+}
+
+fn verify_events_not_in_store(version: Version, event_store: &Arc<EventStore>) {
+    assert!(event_store
+        .get_events_by_version(version)
+        .unwrap()
+        .is_empty());
+}
+
+fn verify_events_in_store(
+    events: &[Vec<ContractEvent>],
+    version: Version,
+    event_store: &Arc<EventStore>,
+) {
+    let events_from_db = event_store.get_events_by_version(version as u64).unwrap();
+    assert_eq!(
+        events_from_db.len(),
+        events.get(version as usize).unwrap().len()
+    );
+    assert_eq!(events_from_db, events[version as usize]);
+}

--- a/storage/aptosdb/src/pruner/ledger_store/epoch_info_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/epoch_info_pruner.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    epoch_by_version::EpochByVersionSchema, metrics::DIEM_PRUNER_LEAST_READABLE_VERSION,
+    pruner::db_pruner::DBPruner, LedgerStore,
+};
+use aptos_types::transaction::{AtomicVersion, Version};
+use schemadb::{ReadOptions, SchemaBatch, DB};
+use std::sync::{atomic::Ordering, Arc};
+
+pub const EPOCH_INFO_PRUNER_NAME: &str = "epoch info pruner";
+
+pub struct EpochInfoPruner {
+    db: Arc<DB>,
+    /// Keeps track of the target version that the pruner needs to achieve.
+    ledger_store: Arc<LedgerStore>,
+    target_version: AtomicVersion,
+    /// Keeps track of least readable version for epoch by version store
+    least_readable_version: AtomicVersion,
+}
+
+impl DBPruner for EpochInfoPruner {
+    fn name(&self) -> &'static str {
+        EPOCH_INFO_PRUNER_NAME
+    }
+
+    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+        let current_target_version = self.get_currrent_batch_target(max_versions);
+        let mut db_batch = SchemaBatch::new();
+
+        self.ledger_store.prune_epoch_by_version(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+        self.db.write_schemas(db_batch)?;
+        self.record_progress(current_target_version);
+        Ok(current_target_version)
+    }
+
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
+        let mut iter = self
+            .db
+            .iter::<EpochByVersionSchema>(ReadOptions::default())?;
+        iter.seek_to_first();
+        let version = iter.next().transpose()?.map_or(0, |(version, _)| version);
+        Ok(version)
+    }
+
+    fn least_readable_version(&self) -> Version {
+        self.least_readable_version.load(Ordering::Relaxed)
+    }
+
+    fn set_target_version(&self, target_version: Version) {
+        self.target_version.store(target_version, Ordering::Relaxed)
+    }
+
+    fn target_version(&self) -> Version {
+        self.target_version.load(Ordering::Relaxed)
+    }
+
+    fn record_progress(&self, least_readable_version: Version) {
+        self.least_readable_version
+            .store(least_readable_version, Ordering::Relaxed);
+        DIEM_PRUNER_LEAST_READABLE_VERSION
+            .with_label_values(&["epoch_store"])
+            .set(least_readable_version as i64);
+    }
+}
+
+impl EpochInfoPruner {
+    pub fn new(db: Arc<DB>, ledger_store: Arc<LedgerStore>) -> Self {
+        EpochInfoPruner {
+            db,
+            ledger_store,
+            target_version: AtomicVersion::new(0),
+            least_readable_version: AtomicVersion::new(0),
+        }
+    }
+}

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    metrics::DIEM_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
+    schema::ledger_counters::LedgerCountersSchema, LedgerStore,
+};
+use aptos_types::transaction::{AtomicVersion, Version};
+use schemadb::{ReadOptions, SchemaBatch, DB};
+use std::sync::{atomic::Ordering, Arc};
+
+pub const LEDGER_STORE_PRUNER_NAME: &str = "ledger store pruner";
+
+pub struct LedgerStorePruner {
+    db: Arc<DB>,
+    /// Keeps track of the target version that the pruner needs to achieve.
+    ledger_store: Arc<LedgerStore>,
+    target_version: AtomicVersion,
+    least_readable_version: AtomicVersion,
+}
+
+impl DBPruner for LedgerStorePruner {
+    fn name(&self) -> &'static str {
+        LEDGER_STORE_PRUNER_NAME
+    }
+
+    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+        let current_target_version = self.get_currrent_batch_target(max_versions);
+        let mut db_batch = SchemaBatch::new();
+        self.ledger_store.prune_ledger_couners(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+        self.db.write_schemas(db_batch)?;
+        self.record_progress(current_target_version);
+        Ok(current_target_version)
+    }
+
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
+        let mut iter = self
+            .db
+            .iter::<LedgerCountersSchema>(ReadOptions::default())?;
+        iter.seek_to_first();
+        let version = iter.next().transpose()?.map_or(0, |(version, _)| version);
+        Ok(version)
+    }
+
+    fn least_readable_version(&self) -> Version {
+        self.least_readable_version.load(Ordering::Relaxed)
+    }
+
+    fn set_target_version(&self, target_version: Version) {
+        self.target_version.store(target_version, Ordering::Relaxed)
+    }
+
+    fn target_version(&self) -> Version {
+        self.target_version.load(Ordering::Relaxed)
+    }
+
+    fn record_progress(&self, least_readable_version: Version) {
+        self.least_readable_version
+            .store(least_readable_version, Ordering::Relaxed);
+        DIEM_PRUNER_LEAST_READABLE_VERSION
+            .with_label_values(&["ledger_store"])
+            .set(least_readable_version as i64);
+    }
+}
+
+impl LedgerStorePruner {
+    pub fn new(db: Arc<DB>, ledger_store: Arc<LedgerStore>) -> Self {
+        LedgerStorePruner {
+            db,
+            ledger_store,
+            target_version: AtomicVersion::new(0),
+            least_readable_version: AtomicVersion::new(0),
+        }
+    }
+}

--- a/storage/aptosdb/src/pruner/ledger_store/mod.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod epoch_info_pruner;
+pub(crate) mod ledger_store_pruner;
 #[cfg(test)]
 mod test;
-pub(crate) mod transaction_store_pruner;
-pub(crate) mod write_set_pruner;

--- a/storage/aptosdb/src/pruner/ledger_store/test.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/test.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    epoch_by_version::EpochByVersionSchema, ledger_store::ledger_info_test_utils::*,
+    pruner::PrunerIndex, Pruner,
+};
+use aptos_config::config::StoragePrunerConfig;
+use aptos_temppath::TempPath;
+use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use proptest::prelude::*;
+use std::{collections::BTreeMap, sync::Arc};
+
+use crate::schema::ledger_info::LedgerInfoSchema;
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn test_ledger_store_pruner(
+        (ledger_infos_with_sigs, _start_epoch, _end_epoch) in arb_ledger_infos_with_sigs()
+            .prop_flat_map(|ledger_infos_with_sigs| {
+                let first_epoch = get_first_epoch(&ledger_infos_with_sigs);
+                let last_epoch = get_last_epoch(&ledger_infos_with_sigs);
+                (
+                    Just(ledger_infos_with_sigs),
+                    first_epoch..=last_epoch,
+                )
+            })
+            .prop_flat_map(|(ledger_infos_with_sigs, start_epoch)| {
+                let last_epoch = get_last_epoch(&ledger_infos_with_sigs);
+                (
+                    Just(ledger_infos_with_sigs),
+                    Just(start_epoch),
+                    (start_epoch..=last_epoch),
+                )
+            })
+    ) {
+        verify_ledger_store_pruner(ledger_infos_with_sigs)
+    }
+}
+
+fn verify_ledger_store_pruner(ledger_info_with_sigs: Vec<LedgerInfoWithSignatures>) {
+    let tmp_dir = TempPath::new();
+    let aptos_db = set_up(&tmp_dir, &ledger_info_with_sigs);
+    let pruner = Pruner::new(
+        Arc::clone(&aptos_db.db),
+        StoragePrunerConfig {
+            state_store_prune_window: Some(0),
+            default_prune_window: Some(0),
+        },
+        Arc::clone(&aptos_db.transaction_store),
+        Arc::clone(&aptos_db.ledger_store),
+        Arc::clone(&aptos_db.event_store),
+    );
+    // Get the vector of epoch to the latest version in the epoch
+    let epoch_to_latest_version: BTreeMap<u64, u64> = ledger_info_with_sigs
+        .iter()
+        .map(|x| (x.ledger_info().epoch(), x.ledger_info().version()))
+        .collect();
+
+    for (epoch, version) in &epoch_to_latest_version {
+        pruner
+            .wake_and_wait(*version, PrunerIndex::EpochStorePrunerIndex as usize)
+            .unwrap();
+
+        for (inner_epoch, inner_version) in &epoch_to_latest_version {
+            // LedgerInfoSchema is not pruned, so we can read the ledger info schema and epoch by version
+            // from the DB.
+            assert!(aptos_db
+                .db
+                .get::<LedgerInfoSchema>(inner_epoch)
+                .unwrap()
+                .is_some());
+            if inner_epoch < epoch {
+                assert!(aptos_db
+                    .db
+                    .get::<EpochByVersionSchema>(inner_version)
+                    .unwrap()
+                    .is_none())
+            } else if *inner_epoch < &(epoch_to_latest_version.len() as u64) - 1 {
+                // Check for epoch by version exists for all epoch except for the last one. For last
+                // one this is not valid as the next epoch is not defined.
+                assert!(aptos_db
+                    .db
+                    .get::<EpochByVersionSchema>(inner_version)
+                    .unwrap()
+                    .is_some())
+            }
+        }
+    }
+}

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -5,6 +5,8 @@
 //! meant to be triggered by other threads as they commit new data to the DB.
 
 mod db_pruner;
+pub(crate) mod event_store;
+mod ledger_store;
 pub(crate) mod state_store;
 pub(crate) mod transaction_store;
 pub(crate) mod worker;
@@ -14,7 +16,7 @@ use crate::metrics::DIEM_STORAGE_PRUNE_WINDOW;
 use aptos_config::config::StoragePrunerConfig;
 use aptos_infallible::Mutex;
 
-use crate::TransactionStore;
+use crate::{EventStore, LedgerStore, TransactionStore};
 use aptos_types::transaction::Version;
 use schemadb::DB;
 use std::{
@@ -55,6 +57,10 @@ pub(crate) struct Pruner {
 pub enum PrunerIndex {
     StateStorePrunerIndex,
     TransactionStorePrunerIndex,
+    _LedgerStorePrunerIndex,
+    EventStorePrunerIndex,
+    EpochStorePrunerIndex,
+    WriteSetPrunerIndex,
 }
 
 impl Pruner {
@@ -63,10 +69,12 @@ impl Pruner {
         db: Arc<DB>,
         storage_pruner_config: StoragePrunerConfig,
         transaction_store: Arc<TransactionStore>,
+        ledger_store: Arc<LedgerStore>,
+        event_store: Arc<EventStore>,
     ) -> Self {
         let (command_sender, command_receiver) = channel();
 
-        let least_readable_version = Arc::new(Mutex::new(vec![0, 0]));
+        let least_readable_version = Arc::new(Mutex::new(vec![0, 0, 0, 0, 0, 0]));
         let worker_progress_clone = Arc::clone(&least_readable_version);
 
         DIEM_STORAGE_PRUNE_WINDOW
@@ -74,6 +82,8 @@ impl Pruner {
         let worker = Worker::new(
             db,
             transaction_store,
+            ledger_store,
+            event_store,
             command_receiver,
             least_readable_version,
         );
@@ -111,6 +121,10 @@ impl Pruner {
             .send(Command::Prune {
                 target_db_versions: vec![
                     least_readable_state_store_version,
+                    least_readable_default_store_version,
+                    least_readable_default_store_version,
+                    least_readable_default_store_version,
+                    least_readable_default_store_version,
                     least_readable_default_store_version,
                 ],
             })

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -58,6 +58,8 @@ fn test_state_store_pruner() {
             default_prune_window: Some(0),
         },
         Arc::clone(transaction_store),
+        Arc::clone(&aptos_db.ledger_store),
+        Arc::clone(&aptos_db.event_store),
     );
 
     let _root0 = put_account_state_set(
@@ -160,17 +162,19 @@ fn test_worker_quit_eagerly() {
         let worker = Worker::new(
             Arc::clone(&db),
             Arc::clone(&aptos_db.transaction_store),
+            Arc::clone(&aptos_db.ledger_store),
+            Arc::clone(&aptos_db.event_store),
             command_receiver,
             Arc::new(Mutex::new(vec![0, 0])), /* progress */
         );
         command_sender
             .send(Command::Prune {
-                target_db_versions: vec![1, 0],
+                target_db_versions: vec![1, 0, 0, 0, 0, 0],
             })
             .unwrap();
         command_sender
             .send(Command::Prune {
-                target_db_versions: vec![2, 0],
+                target_db_versions: vec![2, 0, 0, 0, 0, 0],
             })
             .unwrap();
         command_sender.send(Command::Quit).unwrap();

--- a/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
@@ -1,0 +1,106 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    metrics::DIEM_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
+    transaction::TransactionSchema, TransactionStore,
+};
+use aptos_types::transaction::{AtomicVersion, Transaction, Version};
+use schemadb::{ReadOptions, SchemaBatch, DB};
+use std::sync::{atomic::Ordering, Arc};
+
+pub const TRANSACTION_STORE_PRUNER_NAME: &str = "transaction store pruner";
+
+pub struct TransactionStorePruner {
+    db: Arc<DB>,
+    transaction_store: Arc<TransactionStore>,
+    /// Keeps track of the target version that the pruner needs to achieve.
+    target_version: AtomicVersion,
+    least_readable_version: AtomicVersion,
+}
+
+impl DBPruner for TransactionStorePruner {
+    fn name(&self) -> &'static str {
+        TRANSACTION_STORE_PRUNER_NAME
+    }
+
+    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+        let least_readable_version = self.least_readable_version();
+        // Current target version  might be less than the target version to ensure we don't prune
+        // more than max_version in one go.
+        let current_target_version = self.get_currrent_batch_target(max_versions);
+        let candidate_transactions = self
+            .get_pruning_candidate_transactions(least_readable_version, current_target_version)?;
+        let mut db_batch = SchemaBatch::new();
+        self.transaction_store
+            .prune_transaction_by_hash(&candidate_transactions, &mut db_batch)?;
+        self.transaction_store
+            .prune_transaction_by_account(&candidate_transactions, &mut db_batch)?;
+        self.transaction_store.prune_transaction_schema(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+        self.transaction_store.prune_transaction_info_schema(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+        self.transaction_store.prune_transaction_accumulator(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+        self.db.write_schemas(db_batch)?;
+
+        self.record_progress(current_target_version);
+        Ok(current_target_version)
+    }
+
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
+        let mut iter = self.db.iter::<TransactionSchema>(ReadOptions::default())?;
+        iter.seek_to_first();
+        let version = iter.next().transpose()?.map_or(0, |(version, _)| version);
+        Ok(version)
+    }
+
+    fn least_readable_version(&self) -> Version {
+        self.least_readable_version.load(Ordering::Relaxed)
+    }
+
+    fn set_target_version(&self, target_version: Version) {
+        self.target_version.store(target_version, Ordering::Relaxed)
+    }
+
+    fn target_version(&self) -> Version {
+        self.target_version.load(Ordering::Relaxed)
+    }
+
+    fn record_progress(&self, least_readable_version: Version) {
+        self.least_readable_version
+            .store(least_readable_version, Ordering::Relaxed);
+        DIEM_PRUNER_LEAST_READABLE_VERSION
+            .with_label_values(&["transaction_store"])
+            .set(least_readable_version as i64);
+    }
+}
+
+impl TransactionStorePruner {
+    pub(in crate::pruner) fn new(db: Arc<DB>, transaction_store: Arc<TransactionStore>) -> Self {
+        TransactionStorePruner {
+            db,
+            transaction_store,
+            target_version: AtomicVersion::new(0),
+            least_readable_version: AtomicVersion::new(0),
+        }
+    }
+
+    fn get_pruning_candidate_transactions(
+        &self,
+        start: Version,
+        end: Version,
+    ) -> anyhow::Result<Vec<Transaction>> {
+        self.transaction_store
+            .get_transaction_iter(start, (end - start) as usize)?
+            .collect()
+    }
+}

--- a/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    metrics::DIEM_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
+    write_set::WriteSetSchema, TransactionStore,
+};
+use aptos_types::transaction::{AtomicVersion, Version};
+use schemadb::{ReadOptions, SchemaBatch, DB};
+use std::sync::{atomic::Ordering, Arc};
+
+pub const TRANSACTION_STORE_PRUNER_NAME: &str = "transaction store pruner";
+
+pub struct WriteSetPruner {
+    db: Arc<DB>,
+    transaction_store: Arc<TransactionStore>,
+    /// Keeps track of the target version that the pruner needs to achieve.
+    target_version: AtomicVersion,
+    least_readable_version: AtomicVersion,
+}
+
+impl DBPruner for WriteSetPruner {
+    fn name(&self) -> &'static str {
+        TRANSACTION_STORE_PRUNER_NAME
+    }
+
+    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+        // Current target version  might be less than the target version to ensure we don't prune
+        // more than max_version in one go.
+        let mut db_batch = SchemaBatch::new();
+        let current_target_version = self.get_currrent_batch_target(max_versions);
+        self.transaction_store.prune_write_set(
+            self.least_readable_version(),
+            current_target_version,
+            &mut db_batch,
+        )?;
+        self.db.write_schemas(db_batch)?;
+
+        self.record_progress(current_target_version);
+        Ok(current_target_version)
+    }
+
+    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
+        let mut iter = self.db.iter::<WriteSetSchema>(ReadOptions::default())?;
+        iter.seek_to_first();
+        let version = iter.next().transpose()?.map_or(0, |(version, _)| version);
+        Ok(version)
+    }
+
+    fn least_readable_version(&self) -> Version {
+        self.least_readable_version.load(Ordering::Relaxed)
+    }
+
+    fn set_target_version(&self, target_version: Version) {
+        self.target_version.store(target_version, Ordering::Relaxed)
+    }
+
+    fn target_version(&self) -> Version {
+        self.target_version.load(Ordering::Relaxed)
+    }
+    fn record_progress(&self, least_readable_version: Version) {
+        self.least_readable_version
+            .store(least_readable_version, Ordering::Relaxed);
+        DIEM_PRUNER_LEAST_READABLE_VERSION
+            .with_label_values(&["write_set"])
+            .set(least_readable_version as i64);
+    }
+}
+
+impl WriteSetPruner {
+    pub(in crate::pruner) fn new(db: Arc<DB>, transaction_store: Arc<TransactionStore>) -> Self {
+        WriteSetPruner {
+            db,
+            transaction_store,
+            target_version: AtomicVersion::new(0),
+            least_readable_version: AtomicVersion::new(0),
+        }
+    }
+}

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -244,6 +244,17 @@ impl TransactionStore {
         Ok(())
     }
 
+    /// Prune the transaction schema store between a range of version in [begin, end)
+    pub fn prune_write_set(
+        &self,
+        begin: Version,
+        end: Version,
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<()> {
+        db_batch.delete_range::<WriteSetSchema>(&begin, &end)?;
+        Ok(())
+    }
+
     /// Prune the transaction schema store between a range of version in [begin, end).
     pub fn prune_transaction_accumulator(
         &self,


### PR DESCRIPTION
Second PR for DB pruning functionality. See https://github.com/aptos-labs/aptos-core/pull/212 for the first one.

## Motivation

See https://github.com/aptos-labs/aptos-core/issues/103 for motivation. This PR adds functionality for pruning various stores like transaction, event, ledger, epoch etc.

There are few more TODOs that I will address in subsequent PRs as follows

1. Currently all Pruners prune independently which can leave different store out of sync. Will modify the prune API for the pruners to retun a schema batch instead and prune the records atomically.
2. Adding a new Pruner is cumbersome and error prone as there are multiple places where we need to store the index. Will clean that up.
3. Make max version as a config knob. 


## Test Plan

Added comprehensive unit tests for each pruner


## Related PRs

https://github.com/aptos-labs/aptos-core/pull/212

