### PR TITLE
[docs] Replacing aptos.com links with aptoslabs.com links

### DIFF
--- a/developer-docs-site/docs/tutorials/getting-started.md
+++ b/developer-docs-site/docs/tutorials/getting-started.md
@@ -36,6 +36,6 @@ source ~/.cargo/env
 
 * Faucet endpoint: [https://faucet.devnet.aptoslabs.com](https://faucet.devnet.aptoslabs.com)
 * REST interface endpoint: [https://fullnode.devnet.aptoslabs.com](https://fullnode.devnet.aptoslabs.com)
-* [Genesis](https://devnet.aptos.com/genesis.blob)
-* [Waypoint](https://devnet.aptos.com/waypoint.txt)
-* [ChainID](https://devnet.aptos.com/chainid.txt)
+* [Genesis](https://devnet.aptoslabs.com/genesis.blob)
+* [Waypoint](https://devnet.aptoslabs.com/waypoint.txt)
+* [ChainID](https://devnet.aptoslabs.com/chainid.txt)


### PR DESCRIPTION
There seems to be no devnet.aptos.com. There is devnet.aptoslabs.com
though, which seems to host all of the necessary files.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Technical information on Devnet pointed to nonexistent servers. Fixing that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, the anchor "pull-requests" is nonexistent, though.

## Test Plan

No testing needed, this is only documentation fix.

## Related PRs

No related PRs.
