### PR TITLE
[circleci] require devnet branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,8 @@ workflows:
       - docker-build-push:
           context: aws-dev
           addl_tag: devnet
+          requires:
+            - require-branch
       - ecr-dockerhub-mirror:
           context:
             - aws-dev


### PR DESCRIPTION
fix circleci config to require devnet branch before building docker images for `devnet` tag.