### PR TITLE
[Configs] Make "deny_unknown_fields" great again.

### DIFF
--- a/config/management/src/config.rs
+++ b/config/management/src/config.rs
@@ -54,6 +54,7 @@ use structopt::StructOpt;
 
 /// Config for aptos management tools
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(deserialize_with = "chain_id::deserialize_config_chain_id")]
     pub chain_id: ChainId,

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ApiConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ConsensusConfig {
     pub contiguous_rounds: u32,
     pub max_block_size: u64,
@@ -71,6 +71,7 @@ pub enum ConsensusProposerType {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct LeaderReputationConfig {
     pub active_weights: u64,
     pub inactive_weights: u64,

--- a/config/src/config/debug_interface_config.rs
+++ b/config/src/config/debug_interface_config.rs
@@ -5,7 +5,7 @@ use crate::utils;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct DebugInterfaceConfig {
     pub admission_control_node_debug_port: u16,
     pub address: String,

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -14,7 +14,7 @@ use std::{
 const GENESIS_DEFAULT: &str = "genesis.blob";
 
 #[derive(Clone, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ExecutionConfig {
     #[serde(skip)]
     pub genesis: Option<Transaction>,
@@ -113,6 +113,7 @@ pub enum ExecutionCorrectnessService {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RemoteExecutionService {
     pub server_address: SocketAddr,
 }

--- a/config/src/config/json_rpc_config.rs
+++ b/config/src/config/json_rpc_config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct JsonRpcConfig {
     pub address: SocketAddr,
     pub batch_size_limit: u16,

--- a/config/src/config/key_manager_config.rs
+++ b/config/src/config/key_manager_config.rs
@@ -14,7 +14,7 @@ const DEFAULT_SLEEP_PERIOD_SECS: u64 = 600; // 10 minutes
 const DEFAULT_TXN_EXPIRATION_SECS: u64 = 3600; // 1 hour
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct KeyManagerConfig {
     pub logger: LoggerConfig,
     pub json_rpc_endpoint: String,

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -5,7 +5,7 @@ use aptos_logger::{Level, CHANNEL_SIZE};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct LoggerConfig {
     // channel size for the asychronous channel for node logging.
     pub chan_size: usize,

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MempoolConfig {
     pub capacity: usize,
     pub capacity_per_user: usize,

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -56,6 +56,7 @@ pub struct DeprecatedConfig {}
 /// The config file is broken up into sections for each module
 /// so that only that module can be passed around
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct NodeConfig {
     #[serde(default)]
     pub base: BaseConfig,
@@ -90,7 +91,7 @@ pub struct NodeConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct BaseConfig {
     data_dir: PathBuf,
     pub role: RoleType,

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -46,7 +46,7 @@ pub const IP_BYTE_BUCKET_RATE: usize = 102400 /* 100 KiB */;
 pub const IP_BYTE_BUCKET_SIZE: usize = IP_BYTE_BUCKET_RATE;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct NetworkConfig {
     // Maximum backoff delay for connecting outbound to peers
     pub max_connection_delay_ms: u64,
@@ -322,6 +322,7 @@ impl Identity {
 
 /// The identity is stored within the config.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct IdentityFromConfig {
     #[serde(flatten)]
     pub key: ConfigKey<x25519::PrivateKey>,
@@ -330,6 +331,7 @@ pub struct IdentityFromConfig {
 
 /// This represents an identity in a secure-storage as defined in NodeConfig::secure.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct IdentityFromStorage {
     pub backend: SecureBackend,
     pub key_name: String,
@@ -337,6 +339,7 @@ pub struct IdentityFromStorage {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RateLimitConfig {
     /// Maximum number of bytes/s for an IP
     pub ip_byte_bucket_rate: usize,

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct SafetyRulesConfig {
     pub backend: SecureBackend,
     pub logger: LoggerConfig,
@@ -68,6 +68,7 @@ pub enum SafetyRulesService {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RemoteService {
     pub server_address: NetworkAddress,
 }

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -46,6 +46,7 @@ impl SecureBackend {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct GitHubConfig {
     /// The owner or account that hosts a repository
     pub repository_owner: String,
@@ -62,6 +63,7 @@ pub struct GitHubConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct VaultConfig {
     /// Optional SSL Certificate for the vault host, this is expected to be a full path.
     pub ca_certificate: Option<PathBuf>,
@@ -96,6 +98,7 @@ impl VaultConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct OnDiskStorageConfig {
     // Required path for on disk storage
     pub path: PathBuf,
@@ -126,11 +129,13 @@ impl Token {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenFromConfig {
     token: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TokenFromDisk {
     path: PathBuf,
 }

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct StateSyncConfig {
     // Size of chunk to request for state synchronization
     pub chunk_limit: u64,
@@ -96,7 +96,7 @@ impl Default for StateSyncDriverConfig {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct StorageServiceConfig {
     pub max_account_states_chunk_sizes: u64, // Max num of accounts per chunk
     pub max_concurrent_requests: u64,        // Max num of concurrent storage server tasks
@@ -118,7 +118,7 @@ impl Default for StorageServiceConfig {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct DataStreamingServiceConfig {
     // The interval (milliseconds) at which to refresh the global data summary.
     pub global_summary_refresh_interval_ms: u64,
@@ -157,7 +157,7 @@ impl Default for DataStreamingServiceConfig {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AptosDataClientConfig {
     pub response_timeout_ms: u64, // Timeout (in milliseconds) when waiting for a response
     pub summary_poll_interval_ms: u64, // Interval (in milliseconds) between data summary polls

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -12,7 +12,7 @@ use std::{
 /// see https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h
 /// for detailed explanations.
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct RocksdbConfig {
     pub max_open_files: i32,
     pub max_total_wal_size: u64,
@@ -33,7 +33,7 @@ impl Default for RocksdbConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
     pub address: SocketAddr,
     pub backup_service_address: SocketAddr,
@@ -61,6 +61,7 @@ pub const NO_OP_STORAGE_PRUNER_CONFIG: StoragePrunerConfig = StoragePrunerConfig
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct StoragePrunerConfig {
     /// None disables pruning. The size of the window should be calculated based on disk space
     /// availability and system TPS.

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestConfig {
     pub auth_key: Option<AuthenticationKey>,
     pub operator_key: Option<ConfigKey<Ed25519PrivateKey>>,


### PR DESCRIPTION
## Motivation

We previously removed the [`deny_unknown_fields`](https://serde.rs/container-attrs.html#deny_unknown_fields) attribute from our configuration files due to backward compatibility issues (see https://github.com/diem/diem/pull/9850). However, we no longer require backward compatibility of config files. Given that the field is pretty useful from a user experience perspective (i.e., it complains when you've messed up your config), let's bring it back for now.

Note: I actually ran into an issue locally where I had messed up the indentation of my config file and things weren't working as expected. This field found the problem immediately. 🥲

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Ran a local node with an invalid config file (i.e., where an unknown field was specified).

## Related PRs

None.
