### PR TITLE
[State Sync] Make timeouts configurable.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -80,6 +80,7 @@ pub struct StateSyncDriverConfig {
     pub enable_state_sync_v2: bool,            // If the node should sync with state sync v2
     pub continuous_syncing_mode: ContinuousSyncingMode, // The mode by which to sync after bootstrapping
     pub progress_check_interval_ms: u64, // The interval (ms) at which to check state sync progress
+    pub max_stream_wait_time_ms: u64,    // The max time (ms) to wait for a data stream notification
 }
 
 /// The default state sync driver config will be the one that gets (and keeps)
@@ -91,6 +92,7 @@ impl Default for StateSyncDriverConfig {
             enable_state_sync_v2: false,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
+            max_stream_wait_time_ms: 2000,
         }
     }
 }

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -80,6 +80,7 @@ pub struct StateSyncDriverConfig {
     pub enable_state_sync_v2: bool,            // If the node should sync with state sync v2
     pub continuous_syncing_mode: ContinuousSyncingMode, // The mode by which to sync after bootstrapping
     pub progress_check_interval_ms: u64, // The interval (ms) at which to check state sync progress
+    pub max_connection_deadline_secs: u64, // The max time (secs) to wait for connections from peers
     pub max_stream_wait_time_ms: u64,    // The max time (ms) to wait for a data stream notification
 }
 
@@ -92,6 +93,7 @@ impl Default for StateSyncDriverConfig {
             enable_state_sync_v2: false,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
+            max_connection_deadline_secs: 10,
             max_stream_wait_time_ms: 2000,
         }
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -436,8 +436,12 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
     async fn process_active_stream_notifications(&mut self) -> Result<(), Error> {
         loop {
             // Fetch and process any data notifications
-            let data_notification =
-                utils::get_data_notification(self.active_data_stream.as_mut()).await?;
+            let max_stream_wait_time_ms = self.driver_configuration.config.max_stream_wait_time_ms;
+            let data_notification = utils::get_data_notification(
+                max_stream_wait_time_ms,
+                self.active_data_stream.as_mut(),
+            )
+            .await?;
             match data_notification.data_payload {
                 DataPayload::AccountStatesWithProof(account_states_with_proof) => {
                     self.process_account_states_payload(

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -131,8 +131,12 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
     ) -> Result<(), Error> {
         loop {
             // Fetch and process any data notifications
-            let data_notification =
-                utils::get_data_notification(self.active_data_stream.as_mut()).await?;
+            let max_stream_wait_time_ms = self.driver_configuration.config.max_stream_wait_time_ms;
+            let data_notification = utils::get_data_notification(
+                max_stream_wait_time_ms,
+                self.active_data_stream.as_mut(),
+            )
+            .await?;
             match data_notification.data_payload {
                 DataPayload::ContinuousTransactionOutputsWithProof(
                     ledger_info_with_sigs,

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -33,8 +33,6 @@ use tokio_stream::wrappers::IntervalStream;
 
 // TODO(joshlind): use structured logging!
 
-const MAX_CONNECTION_DEADLINE_SECS: u64 = 10;
-
 /// The configuration of the state sync driver
 #[derive(Clone)]
 pub struct DriverConfiguration {
@@ -471,9 +469,11 @@ impl<
             && self.driver_configuration.waypoint.version() == 0
         {
             if let Some(start_time) = self.start_time {
-                if let Some(connection_deadline) =
-                    start_time.checked_add(Duration::from_secs(MAX_CONNECTION_DEADLINE_SECS))
-                {
+                if let Some(connection_deadline) = start_time.checked_add(Duration::from_secs(
+                    self.driver_configuration
+                        .config
+                        .max_connection_deadline_secs,
+                )) {
                     if SystemTime::now()
                         .duration_since(connection_deadline)
                         .is_ok()


### PR DESCRIPTION
## Motivation

This PR makes two important timeouts configurable in the state sync code: `max_stream_wait_time_ms` and `max_connection_deadline_secs`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually tested the variable changes.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245