### PR TITLE
[Storage] Atomically commit all pruner changes to DB

### DIFF
--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -3,6 +3,7 @@
 
 use aptos_logger::{error, info};
 use aptos_types::transaction::Version;
+use schemadb::SchemaBatch;
 use std::{cmp::min, thread::sleep, time::Duration};
 
 /// Defines the trait for pruner for different DB
@@ -37,7 +38,7 @@ pub trait DBPruner {
 
     /// Performs the actual pruning, a target version is passed, which is the target the pruner
     /// tries to prune.
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version>;
+    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version>;
 
     /// Initializes the least readable version stored in underlying DB storage
     fn initialize_least_readable_version(&self) -> anyhow::Result<Version>;

--- a/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
@@ -31,10 +31,9 @@ impl DBPruner for EventStorePruner {
         EVENT_STORE_PRUNER_NAME
     }
 
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
         // Current target version  might be less than the target version to ensure we don't prune
         // more than max_version in one go.
-        let mut db_batch = SchemaBatch::new();
         let current_target_version = self.get_currrent_batch_target(max_versions);
         let candidate_events = self
             .get_pruning_candidate_events(self.least_readable_version(), current_target_version)?;
@@ -46,25 +45,23 @@ impl DBPruner for EventStorePruner {
             event_keys,
             self.least_readable_version(),
             current_target_version,
-            &mut db_batch,
+            db_batch,
         )?;
 
         self.event_store
-            .prune_events_by_key(&candidate_events, &mut db_batch)?;
+            .prune_events_by_key(&candidate_events, db_batch)?;
 
         self.event_store.prune_event_accumulator(
             self.least_readable_version(),
             current_target_version,
-            &mut db_batch,
+            db_batch,
         )?;
 
         self.event_store.prune_event_schema(
             self.least_readable_version(),
             current_target_version,
-            &mut db_batch,
+            db_batch,
         )?;
-
-        self.db.write_schemas(db_batch)?;
 
         self.record_progress(current_target_version);
         Ok(current_target_version)

--- a/storage/aptosdb/src/pruner/ledger_store/epoch_info_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/epoch_info_pruner.rs
@@ -24,16 +24,14 @@ impl DBPruner for EpochInfoPruner {
         EPOCH_INFO_PRUNER_NAME
     }
 
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
         let current_target_version = self.get_currrent_batch_target(max_versions);
-        let mut db_batch = SchemaBatch::new();
 
         self.ledger_store.prune_epoch_by_version(
             self.least_readable_version(),
             current_target_version,
-            &mut db_batch,
+            db_batch,
         )?;
-        self.db.write_schemas(db_batch)?;
         self.record_progress(current_target_version);
         Ok(current_target_version)
     }

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -23,15 +23,13 @@ impl DBPruner for LedgerStorePruner {
         LEDGER_STORE_PRUNER_NAME
     }
 
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
         let current_target_version = self.get_currrent_batch_target(max_versions);
-        let mut db_batch = SchemaBatch::new();
         self.ledger_store.prune_ledger_couners(
             self.least_readable_version(),
             current_target_version,
-            &mut db_batch,
+            db_batch,
         )?;
-        self.db.write_schemas(db_batch)?;
         self.record_progress(current_target_version);
         Ok(current_target_version)
     }

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -36,7 +36,7 @@ impl DBPruner for StateStorePruner {
         STATE_STORE_PRUNER_NAME
     }
 
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+    fn prune(&self, _db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
         let least_readable_version = self.least_readable_version.load(Ordering::Relaxed);
         let target_version = self.target_version();
         return match prune_state_store(

--- a/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
@@ -23,17 +23,15 @@ impl DBPruner for WriteSetPruner {
         TRANSACTION_STORE_PRUNER_NAME
     }
 
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
         // Current target version  might be less than the target version to ensure we don't prune
         // more than max_version in one go.
-        let mut db_batch = SchemaBatch::new();
         let current_target_version = self.get_currrent_batch_target(max_versions);
         self.transaction_store.prune_write_set(
             self.least_readable_version(),
             current_target_version,
-            &mut db_batch,
+            db_batch,
         )?;
-        self.db.write_schemas(db_batch)?;
 
         self.record_progress(current_target_version);
         Ok(current_target_version)


### PR DESCRIPTION


## Motivation

Atomically commit all the pruner changes so as to not leave the DB in an inconsistent state.

(Write your answer here.)

## Test Plan

Existing UT

## Related PRs

https://github.com/aptos-labs/aptos-core/pull/255#event-6287375638
