### PR TITLE
[State Sync] Small tweaks and improvements for production execution. 

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -94,7 +94,7 @@ impl Default for StateSyncDriverConfig {
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,
-            max_stream_wait_time_ms: 2000,
+            max_stream_wait_time_ms: 10_000,
         }
     }
 }
@@ -170,8 +170,8 @@ pub struct AptosDataClientConfig {
 impl Default for AptosDataClientConfig {
     fn default() -> Self {
         Self {
-            response_timeout_ms: 3_000,
-            summary_poll_interval_ms: 300,
+            response_timeout_ms: 10_000,
+            summary_poll_interval_ms: 1_000,
         }
     }
 }

--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -45,16 +45,16 @@ mod state;
 #[cfg(test)]
 mod tests;
 
-// Useful constants for the Diem Data Client
+// Useful constants for the Aptos Data Client
 const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 5;
 const POLLER_ERROR_LOG_FREQ_SECS: u64 = 1;
 
-/// A [`AptosDataClient`] that fulfills requests from remote peers' Storage Service
+/// An [`AptosDataClient`] that fulfills requests from remote peers' Storage Service
 /// over AptosNet.
 ///
 /// The `AptosNetDataClient`:
 ///
-/// 1. Sends requests to connected AptosNet peers.
+/// 1. Sends requests to connected Aptos peers.
 /// 2. Does basic type conversions and error handling on the responses.
 /// 3. Routes requests to peers that advertise availability for that data.
 /// 4. Maintains peer scores based on each peer's observed quality of service
@@ -444,7 +444,7 @@ impl DataSummaryPoller {
     pub async fn start(self) {
         info!(
             (LogSchema::new(LogEntry::DataSummaryPollerStart)
-                .message("Starting the diem data poller!"))
+                .message("Starting the Aptos data poller!"))
         );
         let ticker = self.time_service.interval(self.poll_interval);
         futures::pin_mut!(ticker);

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -407,17 +407,10 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         let highest_known_ledger_version = highest_known_ledger_info.ledger_info().version();
 
         // Check if we've already fetched the required data for bootstrapping
-        if highest_synced_version == highest_known_ledger_version
+        if highest_synced_version >= highest_known_ledger_version
             || self.account_state_syncer.is_sync_complete
         {
             return self.bootstrapping_complete();
-        }
-
-        // Verify we haven't synced beyond the highest ledger info
-        if highest_synced_version > highest_known_ledger_version {
-            unreachable!(
-                "Synced beyond the highest ledger info! Synced version: {:?}, highest ledger version: {:?}", highest_synced_version, highest_known_ledger_version
-            );
         }
 
         // Bootstrap according to the mode

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -403,7 +403,7 @@ impl<
 
     /// Handles an error notification sent by the storage synchronizer
     async fn handle_error_notification(&mut self, error_notification: ErrorNotification) {
-        debug!(
+        info!(
             "Received an error notification from the storage synchronizer! Error: {:?}",
             error_notification.clone(),
         );

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -28,7 +28,7 @@ use tokio::runtime::Runtime;
 // TODO(joshlind): add structured logging support!
 
 // The maximum number of chunks that are pending execution or commit
-const MAX_PENDING_CHUNKS: usize = 50;
+const MAX_PENDING_CHUNKS: usize = 1000;
 
 /// Synchronizes the storage of the node by verifying and storing new data
 /// (e.g., transactions and outputs).


### PR DESCRIPTION
## Motivation

This PR offers several small tweaks and improvements to state sync to help support production execution. The commits are as follows:
1. Don't panic when the synced version is higher than the committed ledger version. This could be because the node restarted when syncing and hasn't committed the ledger info yet.
2. Small cleanups to the Aptos Data Client.
3. Tweaks to the default timeouts used when waiting for data. We need to better understand why the values need to be so high (but, one step at a time).
4. Catch empty data summaries instead of logging an error. This occurs typically on startup or when we have no peers.
5. Better logging to catch the backed-up execute/commit pipelines.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The smoke tests cover some of this functionality, but I verified most of it by connecting directly to DevNet and watching the logs/progress. 

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245