### PR TITLE
[Documentation] Fixing the Python Move module example

### DIFF
--- a/developer-docs-site/static/examples/python/hello_blockchain.py
+++ b/developer-docs-site/static/examples/python/hello_blockchain.py
@@ -49,7 +49,7 @@ class HelloBlockchainClient(RestClient):
         }
         txn_request = self.generate_transaction(account_from.address(), payload)
         signed_txn = self.sign_transaction(account_from, txn_request)
-        res = self.submit_transaction(signed_txn).json()
+        res = self.submit_transaction(signed_txn)
         return str(res["hash"])
     #<:!:section_3
 


### PR DESCRIPTION
## Motivation

The Python code for the first Move tutorial has a `.json()` on the return type of `self.submit_transaction(signed_txn)`, which is a Dictionary. Dictionaries do not have a `.json()` method, so this PR removes it.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The tutorial failed before this fix. After the fix, the tutorial ran smoothly.
