### PR TITLE
[Documentation] Update run-a-fullnode.md

### DIFF
--- a/developer-docs-site/docs/tutorials/run-a-fullnode.md
+++ b/developer-docs-site/docs/tutorials/run-a-fullnode.md
@@ -36,7 +36,7 @@ You can configure a public FullNode in two ways: using the Aptos-core source cod
 1. Download the Aptos-core repository from GitHub and prepare your developer environment by running the following commands:
      ```
      git clone https://github.com/aptos-labs/aptos-core.git
-     cd aptos
+     cd aptos-core
      ./scripts/dev_setup.sh
      source ~/.cargo/env
      ```


### PR DESCRIPTION
Incorrect path in first step in the guide

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Incorrect path in second line in guide (https://aptos.dev/tutorials/run-a-fullnode/#hardware-requirements):
git clone https://github.com/aptos-labs/aptos-core.git
cd aptos
./scripts/dev_setup.sh
source ~/.cargo/env

It must be:
cd aptos-core

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This is a README change, it does not affect the algorithm

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for the release.
 * What workarounds and alternative we have if we do not push the PR.
