### PR TITLE
[move-examples] improve testing of the first move module

### DIFF
--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -19,8 +19,8 @@ fn move_unit_tests() {
 
     move_unit_test::cargo_runner::run_tests_with_config_and_filter(
         config,
-        ".",
-        r"sources/.*\.move$",
+        "sources",
+        r".*\.move$",
         Some(&move_stdlib::move_stdlib_modules_full_path()),
         Some(aptos_natives()),
     );

--- a/developer-docs-site/docs/tutorials/first-move-module.md
+++ b/developer-docs-site/docs/tutorials/first-move-module.md
@@ -94,6 +94,8 @@ In the previous code, the two important sections are the struct `MessageHolder` 
 
 Move allows for inline tests, so we add `get_message` to make retrieving the `message` convenient and a test function `sender_can_set_message` to validate an end-to-end flow. This can be validated by running `cargo test`. There is another test under `sources/HelloBlockchainTest.move` that demonstrates another method for writing tests.
 
+This can be tested by entering `cargo test --package move-examples` at the terminal.
+
 Note: `sender_can_set_message` is a `script` function in order to call the `script` function `set_message`.
 
 ```rust


### PR DESCRIPTION
* change the source path for the first module to be more explicit to
avoid pulling in compiled code (this was breaking cargo run followed by
cargo test)
* add testing instructions to doc