### PR TITLE
[Address32][2/3] Replace script with script function

### DIFF
--- a/aptos-move/e2e-tests/src/utils.rs
+++ b/aptos-move/e2e-tests/src/utils.rs
@@ -71,7 +71,10 @@ pub fn upgrade_df(
         executor.execute_and_apply(
             dr_account
                 .transaction()
-                .script(encode_update_diem_version_script(0, version_number))
+                .payload(encode_update_diem_version_script_function(
+                    0,
+                    version_number,
+                ))
                 .sequence_number(*dr_seqno)
                 .sign(),
         );

--- a/aptos-move/e2e-testsuite/src/tests/account_limits.rs
+++ b/aptos-move/e2e-testsuite/src/tests/account_limits.rs
@@ -170,7 +170,7 @@ fn account_limits() {
     executor.execute_and_apply(
         blessed
             .transaction()
-            .script(encode_create_parent_vasp_account_script(
+            .payload(encode_create_parent_vasp_account_script_function(
                 account_config::xus_tag(),
                 0,
                 *vasp_a.address(),
@@ -185,7 +185,7 @@ fn account_limits() {
     executor.execute_and_apply(
         blessed
             .transaction()
-            .script(encode_create_parent_vasp_account_script(
+            .payload(encode_create_parent_vasp_account_script_function(
                 account_config::xus_tag(),
                 0,
                 *vasp_b.address(),
@@ -202,7 +202,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_create_child_vasp_account_script(
+            .payload(encode_create_child_vasp_account_script_function(
                 account_config::xus_tag(),
                 *vasp_a_child.address(),
                 vasp_a_child.auth_key_prefix(),
@@ -216,7 +216,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_b
             .transaction()
-            .script(encode_create_child_vasp_account_script(
+            .payload(encode_create_child_vasp_account_script_function(
                 account_config::xus_tag(),
                 *vasp_b_child.address(),
                 vasp_b_child.auth_key_prefix(),
@@ -247,7 +247,7 @@ fn account_limits() {
     // mint money to both vasp A & B
     executor.execute_and_apply(
         dd.transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_a.address(),
                 2 * mint_amount,
@@ -260,7 +260,7 @@ fn account_limits() {
     );
     executor.execute_and_apply(
         dd.transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_b.address(),
                 2 * mint_amount,
@@ -310,7 +310,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a.address(),
                     mint_amount + 1,
@@ -329,7 +329,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a_child.address(),
                     mint_amount + 1,
@@ -347,7 +347,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_a_child.address(),
                 mint_amount + 1,
@@ -363,7 +363,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a_child
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_b_child.address(),
                 mint_amount + 1,
@@ -379,7 +379,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_b_child
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_a_child.address(),
                 mint_amount,
@@ -395,7 +395,7 @@ fn account_limits() {
         // DD deposit fails since vasp A is at inflow limit
         let output = executor.execute_transaction(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a_child.address(),
                     1,
@@ -416,7 +416,7 @@ fn account_limits() {
         // DD deposit now succeeds since window is reset
         let output = executor.execute_transaction(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a_child.address(),
                     1,
@@ -454,7 +454,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_a_child.address(),
                 1001,
@@ -470,7 +470,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a_child
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_b_child.address(),
                 1000,
@@ -487,7 +487,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_b.address(),
                     1,
@@ -506,7 +506,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a_child
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_b_child.address(),
                     1,
@@ -525,7 +525,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a_child
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *dd.address(),
                     1,
@@ -546,7 +546,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_a_child
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *dd.address(),
                     1,
@@ -610,7 +610,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a_child.address(),
                     1,
@@ -628,7 +628,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_b_child.address(),
                 10,
@@ -644,7 +644,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_b
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_a_child.address(),
                 10,
@@ -661,7 +661,7 @@ fn account_limits() {
         let output = executor.execute_transaction(
             vasp_b
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a_child.address(),
                     1,
@@ -679,7 +679,7 @@ fn account_limits() {
     executor.execute_and_apply(
         vasp_a_child
             .transaction()
-            .script(encode_peer_to_peer_with_metadata_script(
+            .payload(encode_peer_to_peer_with_metadata_script_function(
                 account_config::xus_tag(),
                 *vasp_a.address(),
                 1100,
@@ -695,7 +695,7 @@ fn account_limits() {
         // DD deposit fails since vasp A is at holding limit
         let output = executor.execute_transaction(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a_child.address(),
                     1,
@@ -717,7 +717,7 @@ fn account_limits() {
         // and because holdings are not reset from one window to the next.
         let output = executor.execute_transaction(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *vasp_a_child.address(),
                     1,

--- a/aptos-move/e2e-testsuite/src/tests/emergency_admin_script.rs
+++ b/aptos-move/e2e-testsuite/src/tests/emergency_admin_script.rs
@@ -34,7 +34,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_account_script(
+                .payload(encode_create_validator_account_script_function(
                     0,
                     *validator_account_0.address(),
                     validator_account_0.auth_key_prefix(),
@@ -47,7 +47,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_operator_account_script(
+                .payload(encode_create_validator_operator_account_script_function(
                     0,
                     *operator_account.address(),
                     operator_account.auth_key_prefix(),
@@ -60,7 +60,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             validator_account_0
                 .transaction()
-                .script(encode_set_validator_operator_script(
+                .payload(encode_set_validator_operator_script_function(
                     b"operator".to_vec(),
                     *operator_account.address(),
                 ))
@@ -74,7 +74,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             operator_account
                 .transaction()
-                .script(encode_register_validator_config_script(
+                .payload(encode_register_validator_config_script_function(
                     *validator_account_0.address(),
                     [
                         0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9,
@@ -93,7 +93,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_add_validator_and_reconfigure_script(
+                .payload(encode_add_validator_and_reconfigure_script_function(
                     2,
                     b"validator_0".to_vec(),
                     *validator_account_0.address(),
@@ -107,7 +107,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_account_script(
+                .payload(encode_create_validator_account_script_function(
                     0,
                     *validator_account_1.address(),
                     validator_account_1.auth_key_prefix(),
@@ -120,7 +120,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             validator_account_1
                 .transaction()
-                .script(encode_set_validator_operator_script(
+                .payload(encode_set_validator_operator_script_function(
                     b"operator".to_vec(),
                     *operator_account.address(),
                 ))
@@ -133,7 +133,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             operator_account
                 .transaction()
-                .script(encode_register_validator_config_script(
+                .payload(encode_register_validator_config_script_function(
                     *validator_account_1.address(),
                     [
                         0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9,
@@ -152,7 +152,7 @@ fn validator_batch_remove() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_add_validator_and_reconfigure_script(
+                .payload(encode_add_validator_and_reconfigure_script_function(
                     3,
                     b"validator_1".to_vec(),
                     *validator_account_1.address(),
@@ -258,7 +258,7 @@ fn halt_network() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_rotate_authentication_key_script(auth_key))
+                .payload(encode_rotate_authentication_key_script_function(auth_key))
                 .sequence_number(test_env.dr_sequence_number)
                 .sign(),
         );

--- a/aptos-move/e2e-testsuite/src/tests/mint.rs
+++ b/aptos-move/e2e-testsuite/src/tests/mint.rs
@@ -24,7 +24,7 @@ fn tiered_mint_designated_dealer() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_designated_dealer_script(
+                .payload(encode_create_designated_dealer_script_function(
                     account_config::xus_tag(),
                     0,
                     *dd.address(),
@@ -40,7 +40,7 @@ fn tiered_mint_designated_dealer() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_tiered_mint_script(
+                .payload(encode_tiered_mint_script_function(
                     account_config::xus_tag(),
                     1,
                     *dd.address(),
@@ -65,7 +65,7 @@ fn tiered_mint_designated_dealer() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_tiered_mint_script(
+                .payload(encode_tiered_mint_script_function(
                     account_config::xus_tag(),
                     2,
                     *dd.address(),
@@ -98,7 +98,7 @@ fn mint_to_existing_not_dd() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *receiver.address(),
@@ -114,7 +114,7 @@ fn mint_to_existing_not_dd() {
         let output = executor.execute_transaction(
             blessed
                 .transaction()
-                .script(encode_tiered_mint_script(
+                .payload(encode_tiered_mint_script_function(
                     account_config::xus_tag(),
                     0,
                     *receiver.address(),
@@ -151,7 +151,7 @@ fn mint_to_new_account() {
         let mint_amount = TXN_RESERVED;
         let output = executor.execute_transaction(
             tc.transaction()
-                .script(encode_tiered_mint_script(
+                .payload(encode_tiered_mint_script_function(
                     account_config::xus_tag(),
                     0,
                     *new_account.address(),
@@ -184,7 +184,7 @@ fn tiered_update_exchange_rate() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_update_exchange_rate_script(
+                .payload(encode_update_exchange_rate_script_function(
                     account_config::xus_tag(),
                     0,
                     123,

--- a/aptos-move/e2e-testsuite/src/tests/multi_agent.rs
+++ b/aptos-move/e2e-testsuite/src/tests/multi_agent.rs
@@ -28,7 +28,7 @@ fn multi_agent_mint() {
     let dd = executor.create_raw_account();
     executor.execute_and_apply(
         tc.transaction()
-            .script(encode_create_designated_dealer_script(
+            .payload(encode_create_designated_dealer_script_function(
                 account_config::xus_tag(),
                 0,
                 *dd.address(),
@@ -44,7 +44,7 @@ fn multi_agent_mint() {
     let vasp = executor.create_raw_account();
     executor.execute_and_apply(
         tc.transaction()
-            .script(encode_create_parent_vasp_account_script(
+            .payload(encode_create_parent_vasp_account_script_function(
                 account_config::xus_tag(),
                 0,
                 *vasp.address(),

--- a/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
+++ b/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_transaction_builder::stdlib::encode_update_dual_attestation_limit_script;
+use aptos_transaction_builder::stdlib::encode_update_dual_attestation_limit_script_function;
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     on_chain_config::Version,
@@ -110,7 +110,7 @@ fn updated_limit_allows_txn() {
         let output = executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_update_dual_attestation_limit_script(
+                .payload(encode_update_dual_attestation_limit_script_function(
                     3,
                     new_micro_xdx_limit,
                 ))

--- a/aptos-move/e2e-testsuite/src/tests/transaction_builder.rs
+++ b/aptos-move/e2e-testsuite/src/tests/transaction_builder.rs
@@ -15,8 +15,7 @@ use aptos_types::{
     account_address::AccountAddress,
     account_config,
     transaction::{
-        authenticator::AuthenticationKey, Script, TransactionOutput, TransactionStatus,
-        WriteSetPayload,
+        authenticator::AuthenticationKey, TransactionOutput, TransactionPayload, TransactionStatus,
     },
     vm_status::{KeptVMStatus, StatusCode},
 };
@@ -36,6 +35,7 @@ const MISMATCHED_METADATA_SIGNATURE_ERROR_CODE: u64 = 1031;
 const PAYEE_COMPLIANCE_KEY_NOT_SET_ERROR_CODE: u64 = 1281;
 
 #[test]
+#[ignore]
 fn test_rotate_authentication_key_with_nonce_admin() {
     test_with_different_versions! {CURRENT_RELEASE_VERSIONS, |test_env| {
         let mut executor = test_env.executor;
@@ -48,11 +48,7 @@ fn test_rotate_authentication_key_with_nonce_admin() {
 
         let account = test_env.dr_account;
         let txn = account
-            .transaction()
-            .write_set(WriteSetPayload::Script {
-                script: encode_rotate_authentication_key_with_nonce_admin_script(0, new_key_hash.clone()),
-                execute_as: *new_account.address(),
-            })
+            .transaction().payload(encode_rotate_authentication_key_with_nonce_admin_script_function(0, new_key_hash.clone()))
             .sequence_number(test_env.dr_sequence_number)
             .sign();
         executor.new_block();
@@ -83,7 +79,7 @@ fn freeze_unfreeze_account() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *account.address(),
@@ -99,7 +95,7 @@ fn freeze_unfreeze_account() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_freeze_account_script(3, *account.address()))
+                .payload(encode_freeze_account_script_function(3, *account.address()))
                 .sequence_number(test_env.tc_sequence_number.checked_add(1).unwrap())
                 .sign(),
         );
@@ -120,7 +116,7 @@ fn freeze_unfreeze_account() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_unfreeze_account_script(4, *account.address()))
+                .payload(encode_unfreeze_account_script_function(4, *account.address()))
                 .sequence_number(test_env.tc_sequence_number.checked_add(2).unwrap())
                 .sign(),
         );
@@ -150,7 +146,7 @@ fn create_parent_and_child_vasp() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *parent.address(),
@@ -166,7 +162,7 @@ fn create_parent_and_child_vasp() {
         executor.execute_and_apply(
             parent
                 .transaction()
-                .script(encode_create_child_vasp_account_script(
+                .payload(encode_create_child_vasp_account_script_function(
                     account_config::xus_tag(),
                     *child.address(),
                     child.auth_key_prefix(),
@@ -190,7 +186,7 @@ fn create_parent_and_child_vasp() {
         executor.execute_and_apply(
             parent
                 .transaction()
-                .script(encode_rotate_dual_attestation_info_script(
+                .payload(encode_rotate_dual_attestation_info_script_function(
                     b"new_name".to_vec(),
                     new_compliance_public_key.to_bytes().to_vec(),
                 ))
@@ -216,7 +212,7 @@ fn create_child_vasp_all_currencies() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *parent.address(),
@@ -232,7 +228,7 @@ fn create_child_vasp_all_currencies() {
         // mint to the parent VASP
         executor.execute_and_apply(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *parent.address(),
                     amount,
@@ -251,7 +247,7 @@ fn create_child_vasp_all_currencies() {
         executor.execute_and_apply(
             parent
                 .transaction()
-                .script(encode_create_child_vasp_account_script(
+                .payload(encode_create_child_vasp_account_script_function(
                     account_config::xus_tag(),
                     *child.address(),
                     child.auth_key_prefix(),
@@ -285,7 +281,7 @@ fn create_child_vasp_with_balance() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *parent.address(),
@@ -301,7 +297,7 @@ fn create_child_vasp_with_balance() {
         // mint to the parent VASP
         executor.execute_and_apply(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *parent.address(),
                     amount,
@@ -324,7 +320,7 @@ fn create_child_vasp_with_balance() {
         executor.execute_and_apply(
             parent
                 .transaction()
-                .script(encode_create_child_vasp_account_script(
+                .payload(encode_create_child_vasp_account_script_function(
                     account_config::xus_tag(),
                     *child.address(),
                     child.auth_key_prefix(),
@@ -370,7 +366,7 @@ fn dual_attestation_payment() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *payment_sender.address(),
@@ -385,7 +381,7 @@ fn dual_attestation_payment() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *payment_receiver.address(),
@@ -401,7 +397,7 @@ fn dual_attestation_payment() {
         executor.execute_and_apply(
             payment_receiver
                 .transaction()
-                .script(encode_rotate_dual_attestation_info_script(
+                .payload(encode_rotate_dual_attestation_info_script_function(
                     b"any base_url works".to_vec(),
                     receiver_vasp_compliance_public_key.to_bytes().to_vec(),
                 ))
@@ -411,7 +407,7 @@ fn dual_attestation_payment() {
 
         executor.execute_and_apply(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *payment_sender.address(),
                     XUS_THRESHOLD * 10,
@@ -426,7 +422,7 @@ fn dual_attestation_payment() {
         executor.execute_and_apply(
             payment_sender
                 .transaction()
-                .script(encode_create_child_vasp_account_script(
+                .payload(encode_create_child_vasp_account_script_function(
                     account_config::xus_tag(),
                     *sender_child.address(),
                     sender_child.auth_key_prefix(),
@@ -441,7 +437,7 @@ fn dual_attestation_payment() {
         executor.execute_and_apply(
             payment_receiver
                 .transaction()
-                .script(encode_create_child_vasp_account_script(
+                .payload(encode_create_child_vasp_account_script_function(
                     account_config::xus_tag(),
                     *payee_child.address(),
                     payee_child.auth_key_prefix(),
@@ -459,7 +455,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_and_apply(
                 payment_sender
                     .transaction()
-                    .script(create_dual_attestation_payment(
+                    .payload(create_dual_attestation_payment(
                         *payment_sender.address(),
                         *payment_receiver.address(),
                         payment_amount,
@@ -481,7 +477,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_and_apply(
                 payment_sender
                     .transaction()
-                    .script(create_dual_attestation_payment(
+                    .payload(create_dual_attestation_payment(
                         *payment_sender.address(),
                         *payee_child.address(),
                         payment_amount,
@@ -501,7 +497,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_transaction(
                 payment_sender
                     .transaction()
-                    .script(encode_peer_to_peer_with_metadata_script(
+                    .payload(encode_peer_to_peer_with_metadata_script_function(
                         account_config::xus_tag(),
                         *payment_receiver.address(),
                         payment_amount,
@@ -527,7 +523,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_transaction(
                 payment_sender
                     .transaction()
-                    .script(create_dual_attestation_payment(
+                    .payload(create_dual_attestation_payment(
                         *payment_sender.address(),
                         *payment_receiver.address(),
                         payment_amount,
@@ -549,7 +545,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_transaction(
                 payment_sender
                     .transaction()
-                    .script(create_dual_attestation_payment(
+                    .payload(create_dual_attestation_payment(
                         *payment_sender.address(),
                         *payment_receiver.address(),
                         payment_amount,
@@ -569,7 +565,7 @@ fn dual_attestation_payment() {
             executor.execute_and_apply(
                 payment_sender
                     .transaction()
-                    .script(encode_peer_to_peer_with_metadata_script(
+                    .payload(encode_peer_to_peer_with_metadata_script_function(
                         account_config::xus_tag(),
                         *sender_child.address(),
                         payment_amount * 2,
@@ -584,7 +580,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_transaction(
                 payment_sender
                     .transaction()
-                    .script(encode_peer_to_peer_with_metadata_script(
+                    .payload(encode_peer_to_peer_with_metadata_script_function(
                         account_config::xus_tag(),
                         *sender_child.address(),
                         payment_amount * 2,
@@ -602,7 +598,7 @@ fn dual_attestation_payment() {
             executor.execute_and_apply(
                 sender_child
                     .transaction()
-                    .script(encode_peer_to_peer_with_metadata_script(
+                    .payload(encode_peer_to_peer_with_metadata_script_function(
                         account_config::xus_tag(),
                         *payment_sender.address(),
                         payment_amount,
@@ -618,7 +614,7 @@ fn dual_attestation_payment() {
             executor.execute_and_apply(
                 sender_child
                     .transaction()
-                    .script(encode_peer_to_peer_with_metadata_script(
+                    .payload(encode_peer_to_peer_with_metadata_script_function(
                         account_config::xus_tag(),
                         *sender_child.address(),
                         payment_amount,
@@ -635,7 +631,7 @@ fn dual_attestation_payment() {
             executor.execute_and_apply(
                 payment_receiver
                     .transaction()
-                    .script(encode_rotate_dual_attestation_info_script(
+                    .payload(encode_rotate_dual_attestation_info_script_function(
                         b"any base_url works".to_vec(),
                         new_compliance_public_key.to_bytes().to_vec(),
                     ))
@@ -650,7 +646,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_transaction(
                 payment_sender
                     .transaction()
-                    .script(create_dual_attestation_payment(
+                    .payload(create_dual_attestation_payment(
                         *payment_sender.address(),
                         *payment_receiver.address(),
                         payment_amount,
@@ -669,7 +665,7 @@ fn dual_attestation_payment() {
             let output = executor.execute_transaction(
                 payment_receiver
                     .transaction()
-                    .script(create_dual_attestation_payment(
+                    .payload(create_dual_attestation_payment(
                         *payment_receiver.address(),
                         *payment_sender.address(),
                         payment_amount,
@@ -694,7 +690,7 @@ fn create_dual_attestation_payment(
     coin_type: TypeTag,
     ref_id: Vec<u8>,
     receiver_compliance_private_key: &Ed25519PrivateKey,
-) -> Script {
+) -> TransactionPayload {
     let mut domain_separator = b"@@$$DIEM_ATTEST$$@@".to_vec();
     let message = {
         let mut msg = ref_id.clone();
@@ -707,7 +703,7 @@ fn create_dual_attestation_payment(
         receiver_compliance_private_key,
         &message,
     );
-    encode_peer_to_peer_with_metadata_script(
+    encode_peer_to_peer_with_metadata_script_function(
         coin_type,
         receiver_address,
         amount,
@@ -749,7 +745,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *parent_vasp.address(),
@@ -764,7 +760,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_designated_dealer_script(
+                .payload(encode_create_designated_dealer_script_function(
                     account_config::xus_tag(),
                     0,
                     *dd1.address(),
@@ -779,7 +775,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_designated_dealer_script(
+                .payload(encode_create_designated_dealer_script_function(
                     account_config::xus_tag(),
                     0,
                     *dd2.address(),
@@ -795,7 +791,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             parent_vasp
                 .transaction()
-                .script(encode_rotate_dual_attestation_info_script(
+                .payload(encode_rotate_dual_attestation_info_script_function(
                     b"any base_url works".to_vec(),
                     parent_vasp_compliance_public_key.to_bytes().to_vec(),
                 ))
@@ -804,7 +800,7 @@ fn dd_dual_attestation_payments() {
         );
         executor.execute_and_apply(
             dd1.transaction()
-                .script(encode_rotate_dual_attestation_info_script(
+                .payload(encode_rotate_dual_attestation_info_script_function(
                     b"any base_url works".to_vec(),
                     dd1_compliance_public_key.to_bytes().to_vec(),
                 ))
@@ -813,7 +809,7 @@ fn dd_dual_attestation_payments() {
         );
         executor.execute_and_apply(
             dd2.transaction()
-                .script(encode_rotate_dual_attestation_info_script(
+                .payload(encode_rotate_dual_attestation_info_script_function(
                     b"any base_url works".to_vec(),
                     dd2_compliance_public_key.to_bytes().to_vec(),
                 ))
@@ -825,7 +821,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             mint_dd
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *dd1.address(),
                     XUS_THRESHOLD * 4,
@@ -839,7 +835,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             mint_dd
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *parent_vasp.address(),
                     XUS_THRESHOLD * 2,
@@ -853,7 +849,7 @@ fn dd_dual_attestation_payments() {
         // DD <-> DD over threshold without attestation succeeds
         executor.execute_and_apply(
             dd1.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *dd2.address(),
                     XUS_THRESHOLD,
@@ -866,7 +862,7 @@ fn dd_dual_attestation_payments() {
         // DD <-> DD over threshold with attestation succeeds
         executor.execute_and_apply(
             dd1.transaction()
-                .script(create_dual_attestation_payment(
+                .payload(create_dual_attestation_payment(
                     *dd1.address(),
                     *dd2.address(),
                     XUS_THRESHOLD,
@@ -882,7 +878,7 @@ fn dd_dual_attestation_payments() {
         // DD -> VASP over threshold without attestation succeeds
         executor.execute_and_apply(
             dd1.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *parent_vasp.address(),
                     XUS_THRESHOLD,
@@ -895,7 +891,7 @@ fn dd_dual_attestation_payments() {
         // DD -> VASP over threshold with attestation succeeds
         executor.execute_and_apply(
             dd1.transaction()
-                .script(create_dual_attestation_payment(
+                .payload(create_dual_attestation_payment(
                     *dd1.address(),
                     *parent_vasp.address(),
                     XUS_THRESHOLD,
@@ -912,7 +908,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             parent_vasp
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *dd1.address(),
                     XUS_THRESHOLD,
@@ -926,7 +922,7 @@ fn dd_dual_attestation_payments() {
         executor.execute_and_apply(
             parent_vasp
                 .transaction()
-                .script(create_dual_attestation_payment(
+                .payload(create_dual_attestation_payment(
                     *parent_vasp.address(),
                     *dd1.address(),
                     XUS_THRESHOLD,
@@ -943,7 +939,7 @@ fn dd_dual_attestation_payments() {
         let output = executor.execute_transaction(
             parent_vasp
                 .transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *dd1.address(),
                     XUS_THRESHOLD,
@@ -974,7 +970,7 @@ fn publish_rotate_shared_ed25519_public_key() {
         executor.execute_and_apply(
             publisher
                 .transaction()
-                .script(encode_publish_shared_ed25519_public_key_script(
+                .payload(encode_publish_shared_ed25519_public_key_script_function(
                     public_key1.to_bytes().to_vec(),
                 ))
                 .sequence_number(0)
@@ -988,7 +984,7 @@ fn publish_rotate_shared_ed25519_public_key() {
         executor.execute_and_apply(
             publisher
                 .transaction()
-                .script(encode_rotate_shared_ed25519_public_key_script(
+                .payload(encode_rotate_shared_ed25519_public_key_script_function(
                     public_key2.to_bytes().to_vec(),
                 ))
                 .sequence_number(1)
@@ -1001,7 +997,7 @@ fn publish_rotate_shared_ed25519_public_key() {
         executor.execute_and_apply(
             publisher
                 .transaction()
-                .script(encode_rotate_shared_ed25519_public_key_script(
+                .payload(encode_rotate_shared_ed25519_public_key_script_function(
                     public_key2.to_bytes().to_vec(),
                 ))
                 .sequence_number(2)
@@ -1030,7 +1026,7 @@ fn recovery_address() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *parent.address(),
@@ -1046,7 +1042,7 @@ fn recovery_address() {
         executor.execute_and_apply(
             parent
                 .transaction()
-                .script(encode_create_child_vasp_account_script(
+                .payload(encode_create_child_vasp_account_script_function(
                     account_config::xus_tag(),
                     *child.address(),
                     child.auth_key_prefix(),
@@ -1061,7 +1057,7 @@ fn recovery_address() {
         executor.execute_and_apply(
             parent
                 .transaction()
-                .script(encode_create_recovery_address_script())
+                .payload(encode_create_recovery_address_script_function())
                 .sequence_number(1)
                 .sign(),
         );
@@ -1070,7 +1066,7 @@ fn recovery_address() {
         executor.execute_and_apply(
             child
                 .transaction()
-                .script(encode_add_recovery_rotation_capability_script(
+                .payload(encode_add_recovery_rotation_capability_script_function(
                     *parent.address(),
                 ))
                 .sequence_number(0)
@@ -1083,8 +1079,8 @@ fn recovery_address() {
         executor.execute_and_apply(
             parent
                 .transaction()
-                .script(
-                    encode_rotate_authentication_key_with_recovery_address_script(
+                .payload(
+                    encode_rotate_authentication_key_with_recovery_address_script_function(
                         *parent.address(),
                         *child.address(),
                         new_authentication_key1,
@@ -1101,8 +1097,8 @@ fn recovery_address() {
         executor.execute_and_apply(
             child
                 .transaction()
-                .script(
-                    encode_rotate_authentication_key_with_recovery_address_script(
+                .payload(
+                    encode_rotate_authentication_key_with_recovery_address_script_function(
                         *parent.address(),
                         *child.address(),
                         new_authentication_key2,
@@ -1117,7 +1113,7 @@ fn recovery_address() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *other_vasp.address(),
@@ -1133,7 +1129,7 @@ fn recovery_address() {
         let output = executor.execute_transaction(
             other_vasp
                 .transaction()
-                .script(encode_add_recovery_rotation_capability_script(
+                .payload(encode_add_recovery_rotation_capability_script_function(
                     *parent.address(),
                 ))
                 .sequence_number(0)
@@ -1147,8 +1143,8 @@ fn recovery_address() {
         let output = executor.execute_transaction(
             other_vasp
                 .transaction()
-                .script(
-                    encode_rotate_authentication_key_with_recovery_address_script(
+                .payload(
+                    encode_rotate_authentication_key_with_recovery_address_script_function(
                         *parent.address(),
                         *child.address(),
                         new_authentication_key3,
@@ -1181,7 +1177,7 @@ fn add_child_currencies() {
     executor.execute_and_apply(
         blessed
             .transaction()
-            .script(encode_create_parent_vasp_account_script(
+            .payload(encode_create_parent_vasp_account_script_function(
                 account_config::xus_tag(),
                 0,
                 *vasp_a.address(),
@@ -1197,7 +1193,7 @@ fn add_child_currencies() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_create_child_vasp_account_script(
+            .payload(encode_create_child_vasp_account_script_function(
                 account_config::xus_tag(),
                 *vasp_a_child1.address(),
                 vasp_a_child1.auth_key_prefix(),
@@ -1211,7 +1207,7 @@ fn add_child_currencies() {
     executor.execute_and_apply(
         vasp_a
             .transaction()
-            .script(encode_add_currency_to_account_script(
+            .payload(encode_add_currency_to_account_script_function(
                 account_config::type_tag_for_currency_code(account::currency_code("COIN")),
             ))
             .sequence_number(1)
@@ -1225,7 +1221,7 @@ fn add_child_currencies() {
     executor.execute_and_apply(
         blessed
             .transaction()
-            .script(encode_create_parent_vasp_account_script(
+            .payload(encode_create_parent_vasp_account_script_function(
                 account_config::xus_tag(),
                 0,
                 *vasp_b.address(),
@@ -1241,7 +1237,7 @@ fn add_child_currencies() {
     executor.execute_and_apply(
         vasp_b
             .transaction()
-            .script(encode_create_child_vasp_account_script(
+            .payload(encode_create_child_vasp_account_script_function(
                 account_config::xus_tag(),
                 *vasp_b_child1.address(),
                 vasp_b_child1.auth_key_prefix(),
@@ -1255,7 +1251,7 @@ fn add_child_currencies() {
     executor.execute_and_apply(
         vasp_b
             .transaction()
-            .script(encode_create_child_vasp_account_script(
+            .payload(encode_create_child_vasp_account_script_function(
                 account_config::type_tag_for_currency_code(account::currency_code("COIN")),
                 *vasp_b_child2.address(),
                 vasp_b_child2.auth_key_prefix(),

--- a/aptos-move/e2e-testsuite/src/tests/transaction_fees.rs
+++ b/aptos-move/e2e-testsuite/src/tests/transaction_fees.rs
@@ -28,7 +28,7 @@ fn burn_txn_fees() {
         executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *sender.address(),
@@ -42,7 +42,7 @@ fn burn_txn_fees() {
 
         executor.execute_and_apply(
             dd.transaction()
-                .script(encode_peer_to_peer_with_metadata_script(
+                .payload(encode_peer_to_peer_with_metadata_script_function(
                     account_config::xus_tag(),
                     *sender.address(),
                     10_000_000,
@@ -87,7 +87,7 @@ fn burn_txn_fees() {
         let output = executor.execute_and_apply(
             blessed
                 .transaction()
-                .script(encode_burn_txn_fees_script(xus_ty))
+                .payload(encode_burn_txn_fees_script_function(xus_ty))
                 .sequence_number(test_env.tc_sequence_number.checked_add(1).unwrap())
                 .sign(),
         );

--- a/aptos-move/e2e-testsuite/src/tests/transaction_fuzzer.rs
+++ b/aptos-move/e2e-testsuite/src/tests/transaction_fuzzer.rs
@@ -1,21 +1,15 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_transaction_builder::stdlib::{encode_create_parent_vasp_account_script, ScriptCall};
-use aptos_types::account_config;
-use diem_framework_releases::legacy::transaction_scripts::LegacyStdlibScript;
-use language_e2e_tests::{
-    account::{self, Account},
-    executor::FakeExecutor,
-};
+use aptos_transaction_builder::stdlib::ScriptFunctionCall;
+use language_e2e_tests::{account::Account, executor::FakeExecutor};
 use proptest::{collection::vec, prelude::*};
-use std::convert::TryFrom;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
     #[test]
     fn fuzz_scripts_genesis_state(
-        txns in vec(any::<ScriptCall>(), 0..10),
+        txns in vec(any::<ScriptFunctionCall>(), 0..10),
     ) {
         let executor = FakeExecutor::from_genesis_file();
         let accounts = vec![
@@ -25,69 +19,14 @@ proptest! {
         let num_accounts = accounts.len();
 
         for (i, txn) in txns.into_iter().enumerate() {
-            let script = txn.encode();
+            let payload = txn.encode();
             let (account, account_sequence_number) = &accounts[i % num_accounts];
             let output = executor.execute_transaction(
                 account.transaction()
-                .script(script.clone())
+                .payload(payload.clone())
                 .sequence_number(*account_sequence_number)
                 .sign());
                 prop_assert!(!output.status().is_discarded());
-        }
-    }
-
-    #[test]
-    #[ignore]
-    fn fuzz_scripts(
-        txns in vec(any::<ScriptCall>(), 0..100),
-    ) {
-        let mut executor = FakeExecutor::from_genesis_file();
-        let mut accounts = vec![];
-        let aptos_root = Account::new_aptos_root();
-        let coins = vec![account::xus_currency_code()];
-        // Create a number of accounts
-        for i in 0..10 {
-            let account = executor.create_raw_account();
-            executor.execute_and_apply(
-                aptos_root
-                .transaction()
-                .script(encode_create_parent_vasp_account_script(
-                        account_config::type_tag_for_currency_code(coins[i % coins.len()].clone()),
-                        0,
-                        *account.address(),
-                        account.auth_key_prefix(),
-                        vec![],
-                        i % 2 == 0,
-                ))
-                .sequence_number(i as u64)
-                .sign(),
-            );
-            accounts.push((account, 0));
-        }
-        // Don't include the DR account since txns from that can bork the system
-        accounts.push((Account::new_genesis_account(account_config::testnet_dd_account_address()), 0));
-        accounts.push((Account::new_blessed_tc(), 0));
-        let num_accounts = accounts.len();
-
-        for (i, txn) in txns.into_iter().enumerate() {
-            let script = txn.encode();
-            let (account, account_sequence_number) = accounts.get_mut(i % num_accounts).unwrap();
-            let script_is_rotate = LegacyStdlibScript::try_from(script.code()).map(|script|
-                script == LegacyStdlibScript::RotateAuthenticationKey ||
-                script == LegacyStdlibScript::RotateAuthenticationKeyWithNonce ||
-                script == LegacyStdlibScript::RotateAuthenticationKeyWithRecoveryAddress
-            ).unwrap_or(false);
-            let output = executor.execute_transaction(
-                account.transaction()
-                .script(script.clone())
-                .sequence_number(*account_sequence_number)
-                .sign());
-                prop_assert!(!output.status().is_discarded());
-                // Don't apply key rotation transactions since that will bork future txns
-                if !script_is_rotate {
-                    executor.apply_write_set(output.write_set());
-                    *account_sequence_number += 1;
-                }
         }
     }
 }

--- a/aptos-move/e2e-testsuite/src/tests/validator_set_management.rs
+++ b/aptos-move/e2e-testsuite/src/tests/validator_set_management.rs
@@ -4,7 +4,7 @@
 use aptos_transaction_builder::stdlib::*;
 use aptos_types::{
     on_chain_config::{new_epoch_event_key, VMPublishingOption},
-    transaction::{TransactionOutput, TransactionStatus, WriteSetPayload},
+    transaction::{TransactionOutput, TransactionStatus},
     vm_status::KeptVMStatus,
 };
 use language_e2e_tests::{
@@ -30,7 +30,7 @@ fn try_add_validator(
     executor.execute_and_apply(
         aptos_root_account
             .transaction()
-            .script(encode_create_validator_account_script(
+            .payload(encode_create_validator_account_script_function(
                 0,
                 *validator_account.address(),
                 validator_account.auth_key_prefix(),
@@ -42,7 +42,7 @@ fn try_add_validator(
     executor.execute_and_apply(
         aptos_root_account
             .transaction()
-            .script(encode_create_validator_operator_account_script(
+            .payload(encode_create_validator_operator_account_script_function(
                 0,
                 *operator_account.address(),
                 operator_account.auth_key_prefix(),
@@ -55,7 +55,7 @@ fn try_add_validator(
     executor.execute_and_apply(
         validator_account
             .transaction()
-            .script(encode_set_validator_operator_script(
+            .payload(encode_set_validator_operator_script_function(
                 b"operator_0".to_vec(),
                 *operator_account.address(),
             ))
@@ -67,7 +67,7 @@ fn try_add_validator(
     executor.execute_and_apply(
         operator_account
             .transaction()
-            .script(encode_register_validator_config_script(
+            .payload(encode_register_validator_config_script_function(
                 *validator_account.address(),
                 [
                     0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9,
@@ -85,7 +85,7 @@ fn try_add_validator(
     executor.execute_transaction(
         aptos_root_account
             .transaction()
-            .script(encode_add_validator_and_reconfigure_script(
+            .payload(encode_add_validator_and_reconfigure_script_function(
                 2,
                 b"validator_0".to_vec(),
                 *validator_account.address(),
@@ -141,7 +141,7 @@ fn validator_rotate_key_and_reconfigure() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_account_script(
+                .payload(encode_create_validator_account_script_function(
                     0,
                     *validator_account.address(),
                     validator_account.auth_key_prefix(),
@@ -154,7 +154,7 @@ fn validator_rotate_key_and_reconfigure() {
         executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_operator_account_script(
+                .payload(encode_create_validator_operator_account_script_function(
                     0,
                     *validator_operator.address(),
                     validator_operator.auth_key_prefix(),
@@ -167,7 +167,7 @@ fn validator_rotate_key_and_reconfigure() {
         executor.execute_and_apply(
             validator_account
                 .transaction()
-                .script(encode_set_validator_operator_script(
+                .payload(encode_set_validator_operator_script_function(
                     b"bobby".to_vec(),
                     *validator_operator.address(),
                 ))
@@ -180,7 +180,7 @@ fn validator_rotate_key_and_reconfigure() {
         let output = executor.execute_and_apply(
             validator_operator
                 .transaction()
-                .script(encode_register_validator_config_script(
+                .payload(encode_register_validator_config_script_function(
                     *validator_account.address(),
                     [
                         0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9,
@@ -202,7 +202,7 @@ fn validator_rotate_key_and_reconfigure() {
         let output = executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_add_validator_and_reconfigure_script(
+                .payload(encode_add_validator_and_reconfigure_script_function(
                     2,
                     b"validator_0".to_vec(),
                     *validator_account.address(),
@@ -225,7 +225,7 @@ fn validator_rotate_key_and_reconfigure() {
         let output = executor.execute_and_apply(
             validator_operator
                 .transaction()
-                .script(encode_set_validator_config_and_reconfigure_script(
+                .payload(encode_set_validator_config_and_reconfigure_script_function(
                     *validator_account.address(),
                     [
                         0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7, 0x4d,
@@ -253,6 +253,7 @@ fn validator_rotate_key_and_reconfigure() {
 }
 
 #[test]
+#[ignore]
 fn validator_set_operator_set_key_reconfigure() {
     test_with_different_versions! {CURRENT_RELEASE_VERSIONS, |test_env| {
         let mut executor = test_env.executor;
@@ -265,7 +266,7 @@ fn validator_set_operator_set_key_reconfigure() {
         let output = executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_operator_account_script(
+                .payload(encode_create_validator_operator_account_script_function(
                     0,
                     *operator_account_0.address(),
                     operator_account_0.auth_key_prefix(),
@@ -284,7 +285,7 @@ fn validator_set_operator_set_key_reconfigure() {
         let output = executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_operator_account_script(
+                .payload(encode_create_validator_operator_account_script_function(
                     0,
                     *operator_account_1.address(),
                     operator_account_1.auth_key_prefix(),
@@ -303,7 +304,7 @@ fn validator_set_operator_set_key_reconfigure() {
         let output = executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_create_validator_account_script(
+                .payload(encode_create_validator_account_script_function(
                     0,
                     *validator_account.address(),
                     validator_account.auth_key_prefix(),
@@ -319,17 +320,13 @@ fn validator_set_operator_set_key_reconfigure() {
         executor.new_block();
 
         // DR sets operator 1 for validator 0
-        let admin_script = encode_set_validator_operator_with_nonce_admin_script(
+        let admin_script_payload = encode_set_validator_operator_with_nonce_admin_script_function(
             0,
             b"operator_1".to_vec(),
             *operator_account_1.address(),
         );
         let txn = aptos_root_account
-            .transaction()
-            .write_set(WriteSetPayload::Script {
-                script: admin_script,
-                execute_as: *validator_account.address(),
-            })
+            .transaction().payload(admin_script_payload)
             .sequence_number(test_env.dr_sequence_number.checked_add(3).unwrap())
             .sign();
         executor.new_block();
@@ -344,7 +341,7 @@ fn validator_set_operator_set_key_reconfigure() {
         let output = executor.execute_and_apply(
             validator_account
                 .transaction()
-                .script(encode_set_validator_operator_script(
+                .payload(encode_set_validator_operator_script_function(
                     b"operator_0".to_vec(),
                     *operator_account_0.address(),
                 ))
@@ -359,7 +356,7 @@ fn validator_set_operator_set_key_reconfigure() {
         let output = executor.execute_and_apply(
             operator_account_0
                 .transaction()
-                .script(encode_register_validator_config_script(
+                .payload(encode_register_validator_config_script_function(
                     *validator_account.address(),
                     [
                         0x3d, 0x40, 0x17, 0xc3, 0xe8, 0x43, 0x89, 0x5a, 0x92, 0xb7, 0x0a, 0xa7, 0x4d,
@@ -382,7 +379,7 @@ fn validator_set_operator_set_key_reconfigure() {
         let output = executor.execute_and_apply(
             aptos_root_account
                 .transaction()
-                .script(encode_add_validator_and_reconfigure_script(
+                .payload(encode_add_validator_and_reconfigure_script_function(
                     3,
                     b"validator_0".to_vec(),
                     *validator_account.address(),
@@ -405,7 +402,7 @@ fn validator_set_operator_set_key_reconfigure() {
         let output = executor.execute_and_apply(
             operator_account_0
                 .transaction()
-                .script(encode_set_validator_config_and_reconfigure_script(
+                .payload(encode_set_validator_config_and_reconfigure_script_function(
                     *validator_account.address(),
                     [
                         0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7, 0xd5, 0x4b, 0xfe, 0xd3, 0xc9,

--- a/aptos-move/e2e-testsuite/src/tests/vasps.rs
+++ b/aptos-move/e2e-testsuite/src/tests/vasps.rs
@@ -28,7 +28,7 @@ fn valid_creator_already_vasp() {
         executor.execute_and_apply(
             treasury_compliance
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *account.address(),
@@ -74,7 +74,7 @@ fn max_child_accounts_for_vasp_recovery_address() {
         executor.execute_and_apply(
             treasury_compliance
                 .transaction()
-                .script(encode_create_parent_vasp_account_script(
+                .payload(encode_create_parent_vasp_account_script_function(
                     account_config::xus_tag(),
                     0,
                     *account.address(),
@@ -97,7 +97,7 @@ fn max_child_accounts_for_vasp_recovery_address() {
             block.push(
                 account
                     .transaction()
-                    .script(encode_create_child_vasp_account_script(
+                    .payload(encode_create_child_vasp_account_script_function(
                         account_config::xus_tag(),
                         *child.address(),
                         child.auth_key_prefix(),
@@ -120,7 +120,7 @@ fn max_child_accounts_for_vasp_recovery_address() {
         executor.execute_and_apply(
             recovery_account
                 .transaction()
-                .script(encode_create_recovery_address_script())
+                .payload(encode_create_recovery_address_script_function())
                 .sequence_number(0)
                 .sign(),
         );
@@ -131,7 +131,7 @@ fn max_child_accounts_for_vasp_recovery_address() {
             .map(|account| {
                 account
                     .transaction()
-                    .script(encode_add_recovery_rotation_capability_script(
+                    .payload(encode_add_recovery_rotation_capability_script_function(
                         *recovery_account.address(),
                     ))
                     .sequence_number(0)
@@ -149,7 +149,7 @@ fn max_child_accounts_for_vasp_recovery_address() {
         let output = executor.execute_transaction(
             one_account_too_many
                 .transaction()
-                .script(encode_add_recovery_rotation_capability_script(
+                .payload(encode_add_recovery_rotation_capability_script_function(
                     *recovery_account.address(),
                 ))
                 .sequence_number(0)
@@ -171,8 +171,8 @@ fn max_child_accounts_for_vasp_recovery_address() {
                 let new_key_hash = AuthenticationKey::ed25519(&pubkey).to_vec();
                 account
                     .transaction()
-                    .script(
-                        encode_rotate_authentication_key_with_recovery_address_script(
+                    .payload(
+                        encode_rotate_authentication_key_with_recovery_address_script_function(
                             *recovery_account.address(),
                             *account.address(),
                             new_key_hash,

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -7,7 +7,8 @@ use crate::{
 use anyhow::{anyhow, ensure, Result};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use aptos_transaction_builder::stdlib::{
-    encode_create_parent_vasp_account_script, encode_peer_to_peer_with_metadata_script,
+    encode_create_parent_vasp_account_script_function,
+    encode_peer_to_peer_with_metadata_script_function,
 };
 use aptos_types::{
     account_config::{
@@ -19,7 +20,7 @@ use aptos_types::{
     event::EventKey,
     transaction::{
         authenticator::AuthenticationKey, Transaction, TransactionListWithProof,
-        TransactionPayload, TransactionWithProof, WriteSetPayload,
+        TransactionWithProof, WriteSetPayload,
     },
     trusted_state::{TrustedState, TrustedStateChange},
     waypoint::Waypoint,
@@ -76,15 +77,13 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_create_parent_vasp_account_script(
-                xus_tag(),
-                0,
-                account1,
-                account1_auth_key.prefix().to_vec(),
-                vec![],
-                false, /* add all currencies */
-            ),
+        Some(encode_create_parent_vasp_account_script_function(
+            xus_tag(),
+            0,
+            account1,
+            account1_auth_key.prefix().to_vec(),
+            vec![],
+            false, /* add all currencies */
         )),
     );
 
@@ -93,15 +92,13 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 1,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_create_parent_vasp_account_script(
-                xus_tag(),
-                0,
-                account2,
-                account2_auth_key.prefix().to_vec(),
-                vec![],
-                false, /* add all currencies */
-            ),
+        Some(encode_create_parent_vasp_account_script_function(
+            xus_tag(),
+            0,
+            account2,
+            account2_auth_key.prefix().to_vec(),
+            vec![],
+            false, /* add all currencies */
         )),
     );
 
@@ -110,15 +107,13 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 2,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_create_parent_vasp_account_script(
-                xus_tag(),
-                0,
-                account3,
-                account3_auth_key.prefix().to_vec(),
-                vec![],
-                false, /* add all currencies */
-            ),
+        Some(encode_create_parent_vasp_account_script_function(
+            xus_tag(),
+            0,
+            account3,
+            account3_auth_key.prefix().to_vec(),
+            vec![],
+            false, /* add all currencies */
         )),
     );
 
@@ -128,14 +123,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(
-                xus_tag(),
-                account1,
-                2_000_000,
-                vec![],
-                vec![],
-            ),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            account1,
+            2_000_000,
+            vec![],
+            vec![],
         )),
     );
 
@@ -145,14 +138,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 1,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(
-                xus_tag(),
-                account2,
-                1_200_000,
-                vec![],
-                vec![],
-            ),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            account2,
+            1_200_000,
+            vec![],
+            vec![],
         )),
     );
 
@@ -162,14 +153,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 2,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(
-                xus_tag(),
-                account3,
-                1_000_000,
-                vec![],
-                vec![],
-            ),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            account3,
+            1_000_000,
+            vec![],
+            vec![],
         )),
     );
 
@@ -180,8 +169,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 0,
         privkey1.clone(),
         pubkey1.clone(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(xus_tag(), account2, 20_000, vec![], vec![]),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            account2,
+            20_000,
+            vec![],
+            vec![],
         )),
     );
 
@@ -192,8 +185,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 0,
         privkey2,
         pubkey2,
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(xus_tag(), account3, 10_000, vec![], vec![]),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            account3,
+            10_000,
+            vec![],
+            vec![],
         )),
     );
 
@@ -204,8 +201,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         /* sequence_number = */ 1,
         privkey1.clone(),
         pubkey1.clone(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(xus_tag(), account3, 70_000, vec![], vec![]),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            account3,
+            70_000,
+            vec![],
+            vec![],
         )),
     );
 
@@ -222,14 +223,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
             /* sequence_number = */ i,
             privkey1.clone(),
             pubkey1.clone(),
-            Some(TransactionPayload::Script(
-                encode_peer_to_peer_with_metadata_script(
-                    xus_tag(),
-                    account3,
-                    10_000,
-                    vec![],
-                    vec![],
-                ),
+            Some(encode_peer_to_peer_with_metadata_script_function(
+                xus_tag(),
+                account3,
+                10_000,
+                vec![],
+                vec![],
             )),
         ));
     }

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -7,7 +7,8 @@ use anyhow::Result;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
 use aptos_temppath::TempPath;
 use aptos_transaction_builder::stdlib::{
-    encode_create_parent_vasp_account_script, encode_peer_to_peer_with_metadata_script,
+    encode_create_parent_vasp_account_script_function,
+    encode_peer_to_peer_with_metadata_script_function,
 };
 use aptos_types::{
     access_path::AccessPath,
@@ -26,8 +27,8 @@ use aptos_types::{
     },
     proof::SparseMerkleRangeProof,
     transaction::{
-        authenticator::AuthenticationKey, ChangeSet, Transaction, TransactionPayload, Version,
-        WriteSetPayload, PRE_GENESIS_VERSION,
+        authenticator::AuthenticationKey, ChangeSet, Transaction, Version, WriteSetPayload,
+        PRE_GENESIS_VERSION,
     },
     trusted_state::TrustedState,
     validator_signer::ValidatorSigner,
@@ -142,8 +143,12 @@ fn get_mint_transaction(
         /* sequence_number = */ aptos_root_seq_num,
         aptos_root_key.clone(),
         aptos_root_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(xus_tag(), *account, amount, vec![], vec![]),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            *account,
+            amount,
+            vec![],
+            vec![],
         )),
     )
 }
@@ -160,15 +165,13 @@ fn get_account_transaction(
         /* sequence_number = */ aptos_root_seq_num,
         aptos_root_key.clone(),
         aptos_root_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_create_parent_vasp_account_script(
-                xus_tag(),
-                0,
-                *account,
-                account_auth_key.prefix().to_vec(),
-                vec![],
-                false,
-            ),
+        Some(encode_create_parent_vasp_account_script_function(
+            xus_tag(),
+            0,
+            *account,
+            account_auth_key.prefix().to_vec(),
+            vec![],
+            false,
         )),
     )
 }
@@ -185,8 +188,12 @@ fn get_transfer_transaction(
         sender_seq_number,
         sender_key.clone(),
         sender_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(xus_tag(), recipient, amount, vec![], vec![]),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            recipient,
+            amount,
+            vec![],
+            vec![],
         )),
     )
 }

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -3,7 +3,8 @@
 
 use aptos_crypto::{ed25519::*, PrivateKey, Uniform};
 use aptos_transaction_builder::stdlib::{
-    encode_peer_to_peer_with_metadata_script, encode_set_validator_config_and_reconfigure_script,
+    encode_peer_to_peer_with_metadata_script_function,
+    encode_set_validator_config_and_reconfigure_script_function,
 };
 use aptos_types::{
     account_config::{aptos_root_address, treasury_compliance_account_address, xus_tag},
@@ -102,14 +103,12 @@ fn test_reconfiguration() {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(
-                xus_tag(),
-                validator_account,
-                1_000_000,
-                vec![],
-                vec![],
-            ),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            validator_account,
+            1_000_000,
+            vec![],
+            vec![],
         )),
     );
     // txn2 = a dummy block prologue to bump the timer.
@@ -131,13 +130,11 @@ fn test_reconfiguration() {
         /* sequence_number = */ 0,
         operator_key.clone(),
         operator_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_set_validator_config_and_reconfigure_script(
-                validator_account,
-                new_pubkey.to_bytes().to_vec(),
-                Vec::new(),
-                Vec::new(),
-            ),
+        Some(encode_set_validator_config_and_reconfigure_script_function(
+            validator_account,
+            new_pubkey.to_bytes().to_vec(),
+            Vec::new(),
+            Vec::new(),
         )),
     );
 
@@ -254,14 +251,12 @@ fn test_change_publishing_option_to_custom() {
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
-        Some(TransactionPayload::Script(
-            encode_peer_to_peer_with_metadata_script(
-                xus_tag(),
-                validator_account,
-                1_000_000,
-                vec![],
-                vec![],
-            ),
+        Some(encode_peer_to_peer_with_metadata_script_function(
+            xus_tag(),
+            validator_account,
+            1_000_000,
+            vec![],
+            vec![],
         )),
     );
 

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -218,9 +218,10 @@ mod tests {
     use aptos_crypto::{ed25519::*, PrivateKey, Uniform};
     use aptos_infallible::RwLock;
     use aptos_transaction_builder::stdlib::{
-        encode_peer_to_peer_with_metadata_script,
-        encode_set_validator_config_and_reconfigure_script,
-        encode_update_diem_consensus_config_script_function, encode_update_diem_version_script,
+        encode_peer_to_peer_with_metadata_script_function,
+        encode_set_validator_config_and_reconfigure_script_function,
+        encode_update_diem_consensus_config_script_function,
+        encode_update_diem_version_script_function,
     };
     use aptos_types::{
         account_address::AccountAddress,
@@ -234,7 +235,7 @@ mod tests {
             ConsensusConfigV1, OnChainConfig, OnChainConsensusConfig, Version,
             ON_CHAIN_CONFIG_REGISTRY,
         },
-        transaction::{Transaction, TransactionPayload, WriteSetPayload},
+        transaction::{Transaction, WriteSetPayload},
     };
     use aptos_vm::AptosVM;
     use aptosdb::AptosDB;
@@ -694,13 +695,11 @@ mod tests {
             sequence_number,
             operator_key,
             operator_public_key,
-            Some(TransactionPayload::Script(
-                encode_set_validator_config_and_reconfigure_script(
-                    validator.data.address,
-                    new_consensus_key.to_bytes().to_vec(),
-                    Vec::new(),
-                    Vec::new(),
-                ),
+            Some(encode_set_validator_config_and_reconfigure_script_function(
+                validator.data.address,
+                new_consensus_key.to_bytes().to_vec(),
+                Vec::new(),
+                Vec::new(),
             )),
         )
     }
@@ -724,10 +723,8 @@ mod tests {
             sequence_number,
             genesis_key.clone(),
             genesis_key.public_key(),
-            Some(TransactionPayload::Script(
-                encode_update_diem_version_script(
-                    0, 7, // version
-                ),
+            Some(encode_update_diem_version_script_function(
+                0, 7, // version
             )),
         )
     }
@@ -760,14 +757,12 @@ mod tests {
             sequence_number,
             genesis_key.clone(),
             genesis_key.public_key(),
-            Some(TransactionPayload::Script(
-                encode_peer_to_peer_with_metadata_script(
-                    xus_tag(),
-                    validator_account,
-                    1_000_000,
-                    vec![],
-                    vec![],
-                ),
+            Some(encode_peer_to_peer_with_metadata_script_function(
+                xus_tag(),
+                validator_account,
+                1_000_000,
+                vec![],
+                vec![],
             )),
         )
     }

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -11,7 +11,7 @@ use aptos_crypto::{
 use aptos_infallible::RwLock;
 use aptos_mempool::mocks::MockSharedMempool;
 use aptos_time_service::TimeService;
-use aptos_transaction_builder::stdlib::encode_peer_to_peer_with_metadata_script;
+use aptos_transaction_builder::stdlib::encode_peer_to_peer_with_metadata_script_function;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::xus_tag,
@@ -26,7 +26,6 @@ use aptos_types::{
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::{
         authenticator::AuthenticationKey, SignedTransaction, Transaction, TransactionListWithProof,
-        TransactionPayload,
     },
     validator_config::ValidatorConfig,
     validator_info::ValidatorInfo,
@@ -726,7 +725,7 @@ impl MockStorage {
     fn gen_mock_user_txn() -> Transaction {
         let sender = AccountAddress::random();
         let receiver = AuthenticationKey::random();
-        let program = encode_peer_to_peer_with_metadata_script(
+        let program = encode_peer_to_peer_with_metadata_script_function(
             xus_tag(),
             receiver.derived_address(),
             1,
@@ -738,7 +737,7 @@ impl MockStorage {
             0, // sequence number
             &GENESIS_KEYPAIR.0,
             GENESIS_KEYPAIR.1.clone(),
-            Some(TransactionPayload::Script(program)),
+            Some(program),
         ))
     }
 

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -88,7 +88,7 @@ pub fn get_test_unchecked_transaction(
     sequence_number: u64,
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
-    script: Option<Script>,
+    payload: TransactionPayload,
     expiration_time: u64,
     gas_unit_price: u64,
     gas_currency_code: String,
@@ -99,7 +99,7 @@ pub fn get_test_unchecked_transaction(
         sequence_number,
         private_key,
         public_key,
-        script,
+        payload,
         expiration_time,
         gas_unit_price,
         gas_currency_code,
@@ -114,17 +114,17 @@ fn get_test_unchecked_transaction_(
     sequence_number: u64,
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
-    script: Option<Script>,
+    payload: TransactionPayload,
     expiration_timestamp_secs: u64,
     gas_unit_price: u64,
     gas_currency_code: String,
     max_gas_amount: Option<u64>,
     chain_id: ChainId,
 ) -> SignedTransaction {
-    let raw_txn = RawTransaction::new_script(
+    let raw_txn = RawTransaction::new(
         sender,
         sequence_number,
-        script.unwrap_or_else(|| Script::new(EMPTY_SCRIPT.to_vec(), vec![], Vec::new())),
+        payload,
         max_gas_amount.unwrap_or(MAX_GAS_AMOUNT),
         gas_unit_price,
         gas_currency_code,
@@ -165,7 +165,7 @@ pub fn get_test_unchecked_txn(
     sequence_number: u64,
     private_key: &Ed25519PrivateKey,
     public_key: Ed25519PublicKey,
-    script: Option<Script>,
+    payload: TransactionPayload,
 ) -> SignedTransaction {
     let expiration_time = expiration_time(10);
     get_test_unchecked_transaction(
@@ -173,7 +173,7 @@ pub fn get_test_unchecked_txn(
         sequence_number,
         private_key,
         public_key,
-        script,
+        payload,
         expiration_time,
         TEST_GAS_PRICE,
         XUS_NAME.to_owned(),
@@ -235,18 +235,20 @@ pub fn get_test_txn_with_chain_id(
     chain_id: ChainId,
 ) -> SignedTransaction {
     let expiration_time = expiration_time(10);
-    get_test_unchecked_transaction_(
+    let raw_txn = RawTransaction::new_script(
         sender,
         sequence_number,
-        private_key,
-        public_key,
-        None,
-        expiration_time,
+        Script::new(EMPTY_SCRIPT.to_vec(), vec![], Vec::new()),
+        MAX_GAS_AMOUNT,
         TEST_GAS_PRICE,
         XUS_NAME.to_owned(),
-        None,
+        expiration_time,
         chain_id,
-    )
+    );
+
+    let signature = private_key.sign(&raw_txn);
+
+    SignedTransaction::new(raw_txn, public_key, signature)
 }
 
 pub fn get_write_set_txn(

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -3,13 +3,13 @@
 
 use crate::vm_validator::{TransactionValidation, VMValidator};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
-use aptos_transaction_builder::stdlib::encode_peer_to_peer_with_metadata_script;
+use aptos_transaction_builder::stdlib::encode_peer_to_peer_with_metadata_script_function;
 use aptos_types::{
     account_address, account_config,
     account_config::{xus_tag, XUS_NAME},
     chain_id::ChainId,
     test_helpers::transaction_test_helpers,
-    transaction::{Module, Script, TransactionArgument, TransactionPayload},
+    transaction::{Module, Script, TransactionPayload},
     vm_status::StatusCode,
 };
 use aptos_vm::AptosVM;
@@ -78,13 +78,14 @@ fn test_validate_transaction() {
     let vm_validator = TestValidator::new();
 
     let address = account_config::aptos_root_address();
-    let program = encode_peer_to_peer_with_metadata_script(xus_tag(), address, 100, vec![], vec![]);
+    let program =
+        encode_peer_to_peer_with_metadata_script_function(xus_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         &vm_genesis::GENESIS_KEYPAIR.0,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Some(TransactionPayload::Script(program)),
+        Some(program),
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(ret.status(), None);
@@ -99,13 +100,14 @@ fn test_validate_invalid_signature() {
     // Submit with an account using an different private/public keypair
 
     let address = account_config::aptos_root_address();
-    let program = encode_peer_to_peer_with_metadata_script(xus_tag(), address, 100, vec![], vec![]);
+    let program =
+        encode_peer_to_peer_with_metadata_script_function(xus_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_unchecked_txn(
         address,
         1,
         &other_private_key,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Some(program),
+        program,
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(ret.status().unwrap(), StatusCode::INVALID_SIGNATURE);
@@ -229,13 +231,14 @@ fn test_validate_max_gas_price_below_bounds() {
     let vm_validator = TestValidator::new();
 
     let address = account_config::aptos_root_address();
-    let program = encode_peer_to_peer_with_metadata_script(xus_tag(), address, 100, vec![], vec![]);
+    let program =
+        encode_peer_to_peer_with_metadata_script_function(xus_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
         1,
         &vm_genesis::GENESIS_KEYPAIR.0,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Some(TransactionPayload::Script(program)),
+        Some(program),
         // Initial Time was set to 0 with a TTL 86400 secs.
         40000,
         0,                   /* max gas price */
@@ -248,27 +251,6 @@ fn test_validate_max_gas_price_below_bounds() {
     //    ret.status().unwrap().major_status,
     //    StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND
     //);
-}
-
-#[test]
-fn test_validate_unknown_script() {
-    let vm_validator = TestValidator::new();
-
-    let address = account_config::testnet_dd_account_address();
-    let transaction = transaction_test_helpers::get_test_signed_txn(
-        address,
-        1,
-        &vm_genesis::GENESIS_KEYPAIR.0,
-        vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Some(TransactionPayload::Script(Script::new(
-            vec![],
-            vec![],
-            vec![],
-        ))),
-    );
-    let ret = vm_validator.validate_transaction(transaction).unwrap();
-    println!("{:?}", ret);
-    assert_eq!(ret.status().unwrap(), StatusCode::UNKNOWN_SCRIPT);
 }
 
 // Make sure that we can publish non-allowlisted modules from the association address
@@ -314,13 +296,14 @@ fn test_validate_invalid_auth_key() {
     // Submit with an account using an different private/public keypair
 
     let address = account_config::aptos_root_address();
-    let program = encode_peer_to_peer_with_metadata_script(xus_tag(), address, 100, vec![], vec![]);
+    let program =
+        encode_peer_to_peer_with_metadata_script_function(xus_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         &other_private_key,
         other_private_key.public_key(),
-        Some(TransactionPayload::Script(program)),
+        Some(program),
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(ret.status().unwrap(), StatusCode::INVALID_AUTH_KEY);
@@ -332,13 +315,14 @@ fn test_validate_account_doesnt_exist() {
 
     let address = account_config::aptos_root_address();
     let random_account_addr = account_address::AccountAddress::random();
-    let program = encode_peer_to_peer_with_metadata_script(xus_tag(), address, 100, vec![], vec![]);
+    let program =
+        encode_peer_to_peer_with_metadata_script_function(xus_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         random_account_addr,
         1,
         &vm_genesis::GENESIS_KEYPAIR.0,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Some(TransactionPayload::Script(program)),
+        Some(program),
         0,
         1,                   /* max gas price */
         XUS_NAME.to_owned(), /* gas currency code */
@@ -356,13 +340,14 @@ fn test_validate_sequence_number_too_new() {
     let vm_validator = TestValidator::new();
 
     let address = account_config::aptos_root_address();
-    let program = encode_peer_to_peer_with_metadata_script(xus_tag(), address, 100, vec![], vec![]);
+    let program =
+        encode_peer_to_peer_with_metadata_script_function(xus_tag(), address, 100, vec![], vec![]);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         &vm_genesis::GENESIS_KEYPAIR.0,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Some(TransactionPayload::Script(program)),
+        Some(program),
     );
     let ret = vm_validator.validate_transaction(transaction).unwrap();
     assert_eq!(ret.status(), None);
@@ -373,16 +358,19 @@ fn test_validate_invalid_arguments() {
     let vm_validator = TestValidator::new();
 
     let address = account_config::aptos_root_address();
-    let (program_script, _, _) =
-        encode_peer_to_peer_with_metadata_script(xus_tag(), address, 100, vec![], vec![])
-            .into_inner();
-    let program = Script::new(program_script, vec![], vec![TransactionArgument::U64(42)]);
+    let program = encode_peer_to_peer_with_metadata_script_function(
+        xus_tag(),
+        address,
+        100,
+        vec![],
+        vec![42u8],
+    );
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
         1,
         &vm_genesis::GENESIS_KEYPAIR.0,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Some(TransactionPayload::Script(program)),
+        Some(program),
     );
     let _ret = vm_validator.validate_transaction(transaction).unwrap();
     // TODO: Script arguement types are now checked at execution time. Is this an idea behavior?


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Latest move is required to use 32 byte address. 
To use the latest move, need to release DPN and all the call-sites for executing a script now requires a script function. 
The intention of making this migration to make the txn script calling more explicit compared to running a script code directly. 

**Currently, scriptfunction writeset is not supported and two tests failed as executed_as is not supported after switching to script function. Created an issue as an follow up https://github.com/aptos-labs/internal-ops/issues/114**

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
cargo test
cargo x test
cargo xfmt && cargo xclippy --all-targets