### PR TITLE
[State Sync] Support transaction syncing from the account bootstrap version

### DIFF
--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -80,6 +80,9 @@ pub trait ChunkExecutorTrait: Send + Sync {
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
+
+    /// Resets the chunk executor by synchronizing state with storage.
+    fn reset(&self) -> Result<()>;
 }
 
 pub trait BlockExecutorTrait: Send + Sync {

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -57,11 +57,6 @@ impl<V> ChunkExecutor<V> {
         }
     }
 
-    pub fn reset(&self) -> Result<()> {
-        *self.commit_queue.lock() = ChunkCommitQueue::new_from_db(&self.db.reader)?;
-        Ok(())
-    }
-
     fn state_view(
         &self,
         latest_view: &ExecutedTrees,
@@ -167,7 +162,7 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
                 .local_synced_version(latest_view.version().unwrap_or(0))
                 .first_version_in_request(first_version_in_request)
                 .num_txns_in_request(num_txns),
-            "sync_request_executed",
+            "Executed transaction chunk!",
         );
 
         Ok(())
@@ -217,7 +212,7 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
                 .local_synced_version(latest_view.version().unwrap_or(0))
                 .first_version_in_request(first_version_in_request)
                 .num_txns_in_request(num_txns),
-            "sync_request_applied",
+            "Applied transaction output chunk!",
         );
 
         Ok(())
@@ -260,6 +255,11 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
             epoch_change_li,
         )?;
         self.commit_chunk()
+    }
+
+    fn reset(&self) -> Result<()> {
+        *self.commit_queue.lock() = ChunkCommitQueue::new_from_db(&self.db.reader)?;
+        Ok(())
     }
 }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -518,9 +518,12 @@ impl<
 
         // Drive progress depending on if we're bootstrapping or continuously syncing
         if self.bootstrapper.is_bootstrapped() {
+            // Fetch any consensus sync requests
             let consensus_sync_request = self
                 .consensus_notification_handler
                 .get_consensus_sync_request();
+
+            // Attempt to continuously sync
             if let Err(error) = self
                 .continuous_syncer
                 .drive_progress(consensus_sync_request)

--- a/storage/aptosdb/src/backup/mod.rs
+++ b/storage/aptosdb/src/backup/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod backup_handler;
 pub mod restore_handler;
+pub mod restore_utils;
 
 #[cfg(test)]
 mod test;

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    change_set::ChangeSet, event_store::EventStore, ledger_store::LedgerStore,
-    schema::transaction_accumulator::TransactionAccumulatorSchema, state_store::StateStore,
-    transaction_store::TransactionStore, AptosDB,
+    backup::restore_utils, event_store::EventStore, ledger_store::LedgerStore,
+    state_store::StateStore, transaction_store::TransactionStore, AptosDB,
 };
-use anyhow::{ensure, Result};
+use anyhow::Result;
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use aptos_jellyfish_merkle::restore::JellyfishMerkleRestore;
 use aptos_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
-    proof::{definition::LeafCount, position::FrozenSubTreeIterator},
+    proof::definition::LeafCount,
     state_store::state_value::StateValue,
     transaction::{Transaction, TransactionInfo, Version, PRE_GENESIS_VERSION},
 };
@@ -63,25 +62,7 @@ impl RestoreHandler {
     }
 
     pub fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()> {
-        ensure!(!ledger_infos.is_empty(), "No LedgerInfos to save.");
-
-        let mut cs = ChangeSet::new();
-        ledger_infos
-            .iter()
-            .map(|li| self.ledger_store.put_ledger_info(li, &mut cs))
-            .collect::<Result<Vec<_>>>()?;
-        self.db.write_schemas(cs.batch)?;
-
-        if let Some(li) = self.ledger_store.get_latest_ledger_info_option() {
-            if li.ledger_info().epoch() > ledger_infos.last().unwrap().ledger_info().epoch() {
-                // No need to update latest ledger info.
-                return Ok(());
-            }
-        }
-
-        self.ledger_store
-            .set_latest_ledger_info(ledger_infos.last().unwrap().clone());
-        Ok(())
+        restore_utils::save_ledger_infos(self.db.clone(), self.ledger_store.clone(), ledger_infos)
     }
 
     pub fn confirm_or_save_frozen_subtrees(
@@ -89,34 +70,7 @@ impl RestoreHandler {
         num_leaves: LeafCount,
         frozen_subtrees: &[HashValue],
     ) -> Result<()> {
-        let mut cs = ChangeSet::new();
-        let positions: Vec<_> = FrozenSubTreeIterator::new(num_leaves).collect();
-
-        ensure!(
-            positions.len() == frozen_subtrees.len(),
-            "Number of frozen subtree roots not expected. Expected: {}, actual: {}",
-            positions.len(),
-            frozen_subtrees.len(),
-        );
-
-        positions
-            .iter()
-            .zip(frozen_subtrees.iter().rev())
-            .map(|(p, h)| {
-                if let Some(_h) = self.db.get::<TransactionAccumulatorSchema>(p)? {
-                    ensure!(
-                        h == &_h,
-                        "Frozen subtree root does not match that already in DB. Provided: {}, in db: {}.",
-                        h,
-                        _h,
-                    );
-                } else {
-                    cs.batch.put::<TransactionAccumulatorSchema>(p, h)?;
-                }
-                Ok(())
-            })
-            .collect::<Result<Vec<_>>>()?;
-        self.db.write_schemas(cs.batch)
+        restore_utils::confirm_or_save_frozen_subtrees(self.db.clone(), num_leaves, frozen_subtrees)
     }
 
     pub fn save_transactions(
@@ -126,17 +80,16 @@ impl RestoreHandler {
         txn_infos: &[TransactionInfo],
         events: &[Vec<ContractEvent>],
     ) -> Result<()> {
-        let mut cs = ChangeSet::new();
-        for (idx, txn) in txns.iter().enumerate() {
-            self.transaction_store
-                .put_transaction(first_version + idx as Version, txn, &mut cs)?;
-        }
-        self.ledger_store
-            .put_transaction_infos(first_version, txn_infos, &mut cs)?;
-        self.event_store
-            .put_events_multiple_versions(first_version, events, &mut cs)?;
-
-        self.db.write_schemas(cs.batch)
+        restore_utils::save_transactions(
+            self.db.clone(),
+            self.ledger_store.clone(),
+            self.transaction_store.clone(),
+            self.event_store.clone(),
+            first_version,
+            txns,
+            txn_infos,
+            events,
+        )
     }
 
     pub fn get_tree_state(&self, num_transactions: LeafCount) -> Result<TreeState> {

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+///! This file contains utilities that are helpful for performing
+///! database restore operations, as required by db-restore and
+///! state sync v2.
+use crate::{
+    change_set::ChangeSet, event_store::EventStore, ledger_store::LedgerStore,
+    schema::transaction_accumulator::TransactionAccumulatorSchema,
+    transaction_store::TransactionStore,
+};
+use anyhow::{ensure, Result};
+use aptos_crypto::HashValue;
+use aptos_types::{
+    contract_event::ContractEvent,
+    ledger_info::LedgerInfoWithSignatures,
+    proof::{definition::LeafCount, position::FrozenSubTreeIterator},
+    transaction::{Transaction, TransactionInfo, Version},
+};
+use schemadb::DB;
+use std::sync::Arc;
+
+pub fn save_ledger_infos(
+    db: Arc<DB>,
+    ledger_store: Arc<LedgerStore>,
+    ledger_infos: &[LedgerInfoWithSignatures],
+) -> Result<()> {
+    ensure!(!ledger_infos.is_empty(), "No LedgerInfos to save.");
+
+    let mut cs = ChangeSet::new();
+    ledger_infos
+        .iter()
+        .map(|li| ledger_store.put_ledger_info(li, &mut cs))
+        .collect::<Result<Vec<_>>>()?;
+    db.write_schemas(cs.batch)?;
+
+    if let Some(li) = ledger_store.get_latest_ledger_info_option() {
+        if li.ledger_info().epoch() > ledger_infos.last().unwrap().ledger_info().epoch() {
+            // No need to update latest ledger info.
+            return Ok(());
+        }
+    }
+
+    ledger_store.set_latest_ledger_info(ledger_infos.last().unwrap().clone());
+    Ok(())
+}
+
+pub fn confirm_or_save_frozen_subtrees(
+    db: Arc<DB>,
+    num_leaves: LeafCount,
+    frozen_subtrees: &[HashValue],
+) -> Result<()> {
+    let mut cs = ChangeSet::new();
+    let positions: Vec<_> = FrozenSubTreeIterator::new(num_leaves).collect();
+
+    ensure!(
+        positions.len() == frozen_subtrees.len(),
+        "Number of frozen subtree roots not expected. Expected: {}, actual: {}",
+        positions.len(),
+        frozen_subtrees.len(),
+    );
+
+    positions
+        .iter()
+        .zip(frozen_subtrees.iter().rev())
+        .map(|(p, h)| {
+            if let Some(_h) = db.get::<TransactionAccumulatorSchema>(p)? {
+                ensure!(
+                        h == &_h,
+                        "Frozen subtree root does not match that already in DB. Provided: {}, in db: {}.",
+                        h,
+                        _h,
+                    );
+            } else {
+                cs.batch.put::<TransactionAccumulatorSchema>(p, h)?;
+            }
+            Ok(())
+        })
+        .collect::<Result<Vec<_>>>()?;
+    db.write_schemas(cs.batch)
+}
+
+pub fn save_transactions(
+    db: Arc<DB>,
+    ledger_store: Arc<LedgerStore>,
+    transaction_store: Arc<TransactionStore>,
+    event_store: Arc<EventStore>,
+    first_version: Version,
+    txns: &[Transaction],
+    txn_infos: &[TransactionInfo],
+    events: &[Vec<ContractEvent>],
+) -> Result<()> {
+    let mut cs = ChangeSet::new();
+    for (idx, txn) in txns.iter().enumerate() {
+        transaction_store.put_transaction(first_version + idx as Version, txn, &mut cs)?;
+    }
+    ledger_store.put_transaction_infos(first_version, txn_infos, &mut cs)?;
+    event_store.put_events_multiple_versions(first_version, events, &mut cs)?;
+
+    db.write_schemas(cs.batch)
+}

--- a/storage/aptosdb/src/event_store/mod.rs
+++ b/storage/aptosdb/src/event_store/mod.rs
@@ -39,7 +39,7 @@ use std::{
 };
 
 #[derive(Debug)]
-pub(crate) struct EventStore {
+pub struct EventStore {
     db: Arc<DB>,
 }
 

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -26,7 +26,7 @@ use schemadb::{ReadOptions, SchemaBatch, SchemaIterator, DB};
 use std::sync::Arc;
 
 #[derive(Debug)]
-pub(crate) struct TransactionStore {
+pub struct TransactionStore {
     db: Arc<DB>,
 }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -572,6 +572,38 @@ impl MoveStorage for &dyn DbReader {
 /// expected of an Aptos DB. This adds write APIs to DbReader.
 #[allow(unused_variables)]
 pub trait DbWriter: Send + Sync {
+    /// Get a (stateful) state snapshot receiver.
+    ///
+    /// Chunk of accounts need to be added via `add_chunk()` before finishing up with `finish_box()`
+    fn get_state_snapshot_receiver(
+        &self,
+        version: Version,
+        expected_root_hash: HashValue,
+    ) -> Result<Box<dyn StateSnapshotReceiver<StateValue>>> {
+        unimplemented!()
+    }
+
+    /// Finalizes a state snapshot that has already been restored to the database through
+    /// a state snapshot receiver. This is required to bootstrap the transaction accumulator
+    /// and populate transaction and event information.
+    ///
+    /// Note: this assumes that the output with proof has already been verified and that the
+    /// state snapshot was restored at the same version.
+    fn finalize_state_snapshot(
+        &self,
+        version: Version,
+        output_with_proof: TransactionOutputListWithProof,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    /// Persists the specified ledger infos.
+    ///
+    /// Note: this assumes that the ledger infos have already been verified.
+    fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()> {
+        unimplemented!()
+    }
+
     /// Persist transactions. Called by the executor module when either syncing nodes or committing
     /// blocks during normal operation.
     /// See [`AptosDB::save_transactions`].
@@ -583,17 +615,6 @@ pub trait DbWriter: Send + Sync {
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
-        unimplemented!()
-    }
-
-    /// Get a (stateful) state snapshot receiver.
-    ///
-    /// Chunk of accounts need to be added via `add_chunk()` before finishing up with `finish_box()`
-    fn get_state_snapshot_receiver(
-        &self,
-        version: Version,
-        expected_root_hash: HashValue,
-    ) -> Result<Box<dyn StateSnapshotReceiver<StateValue>>> {
         unimplemented!()
     }
 }

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -32,8 +32,7 @@ async fn test_full_node_bootstrap_accounts() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
     swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
 
-    // Enable account count support for the validator (with at most 2 accounts
-    // per storage request).
+    // Set at most 2 accounts per storage request for the validator
     let validator = swarm.validators_mut().next().unwrap();
     let mut config = validator.config().clone();
     config


### PR DESCRIPTION
## Motivation

This PR updates the state sync driver to support transaction/output syncing from the account bootstrap version. For example, if a node downloads all account states at a version `V`, the driver will begin syncing transactions/outputs from `V+1`. The flow is as follows:
1. The state sync bootstrapper will identify the most recent epoch ending version `V` and fetch the epoch ending ledger info at `V`.
2. The bootstrapper will then fetch a transaction output list with proof at version `V` (to identify the expected state root hash and bootstrap the account merkle accumulator).
3. The bootstrapper will fetch and stream all account states at version `V` and write the accounts to the database via the `state_snapshot_receiver`. Once all account states are written, the chunk executor will be reset (to force a read from the db).
4. The continuous syncer will see that the node has bootstrapped at version `V` and start syncing from `V+1`.

The PR offers the following commits:
1. Add a `reset()` method to the ChunkExecutorTrait. This is so that we can reset the executor after performing an account state sync.
2. Refactor the DB backup functionality into a `restore_utils` module so that we can share it between db-restore and state sync and update the state sync driver to start syncing from the bootstrapping version.

Remaining steps before this is finalized:
- Update the state sync code to ensure all proofs are being checked correctly and add a test to ensure bootstrapped nodes can serve correct proofs.
- Various small clean-ups and improvements (e.g., to the Aptos Data Client polling logic)
- Chaos, failure and adversary testing (!)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

There is a smoke test that covers some of this functionality. I've also manually inspected the logs to ensure the correct execution paths are taken. However, there's a still of bunch of testing that needs to happen in relation to proofs and malicious data responses.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245