### PR TITLE
[State Sync v1] Don't print out all events emitted.

### DIFF
--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -187,8 +187,7 @@ impl<C: ChunkExecutorTrait> ExecutorProxyTrait for ExecutorProxy<C> {
 
     fn publish_event_notifications(&mut self, events: Vec<ContractEvent>) -> Result<(), Error> {
         info!(LogSchema::new(LogEntry::Reconfig)
-            .count(events.len())
-            .reconfig_events(events.clone()));
+            .count(events.len()));
 
         let synced_version = (&*self.storage).fetch_synced_version().map_err(|error| {
             Error::UnexpectedError(format!("Failed to fetch storage synced version: {}", error))


### PR DESCRIPTION
## Motivation

This PR updates the state sync v1 code to avoid printing out all emitted events. The events are being displayed in long byte strings, causing unnecessary spam in the logs. I'm not sure if there's been a recent change to cause this, but it's not necessary to keep logging this 😄 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually inspected the logs.

## Related PRs

None.