### PR TITLE
[State Sync] Make the Aptos Data Client slightly more intelligent.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -351,7 +351,7 @@ fn setup_aptos_data_client(
         .enable_all()
         .build()
         .expect("Failed to create aptos data client!");
-    aptos_data_client_runtime.spawn(data_summary_poller.start());
+    aptos_data_client_runtime.spawn(data_summary_poller.start_poller());
 
     (aptos_data_client, aptos_data_client_runtime)
 }

--- a/state-sync/aptos-data-client/src/aptosnet/logging.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/logging.rs
@@ -40,7 +40,7 @@ impl<'a> LogSchema<'a> {
 #[derive(Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LogEntry {
-    DataSummaryPollerStart,
+    DataSummaryPoller,
     PeerStates,
     StorageServiceRequest,
     StorageServiceResponse,

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -139,7 +139,7 @@ async fn test_request_works_only_when_data_available() {
     ::aptos_logger::Logger::init_for_testing();
     let (mut mock_network, mock_time, client, poller) = MockNetwork::new();
 
-    tokio::spawn(poller.start());
+    tokio::spawn(poller.start_poller());
 
     // this request should fail because no peers are currently connected
     let error = client
@@ -361,7 +361,7 @@ async fn bad_peer_is_eventually_added_back() {
     // Add a connected peer.
     mock_network.add_connected_peer();
 
-    tokio::spawn(poller.start());
+    tokio::spawn(poller.start_poller());
     tokio::spawn(async move {
         while let Some((_, _, request, response_sender)) = mock_network.next_request().await {
             match request {

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
@@ -244,9 +244,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
             if let Err(error) = self.update_progress_of_data_stream(data_stream_id) {
                 if matches!(error, Error::NoDataToFetch(_)) {
                     sample!(
-                        SampleRate::Duration(Duration::from_secs(
-                            NO_DATA_TO_FETCH_LOG_FREQ_SECS
-                        )),
+                        SampleRate::Duration(Duration::from_secs(NO_DATA_TO_FETCH_LOG_FREQ_SECS)),
                         info!(LogSchema::new(LogEntry::CheckStreamProgress)
                             .stream_id(*data_stream_id)
                             .event(LogEvent::Pending)


### PR DESCRIPTION
## Motivation

This PR updates the Aptos data client to make the selection of peers to poll slightly more intelligent (i.e, see the issue that this PR resolves: https://github.com/aptos-labs/aptos-core/issues/244). At a high-level, the PR ensures that: (i) newly connected nodes are polled immediately; and (ii) when rotating through existing peers, we poll the peer with the oldest timestamp (i.e., the oldest data).

The PR offers the following commits:
1. Avoid logging an error when there's no data to fetch. If the node is up-to-date, we don't want to throw an error. Instead, just log intermittently.
2. Make the data summary poller more intelligent (as described above). The commit also does various other cleanups along the way (given that this code is a little bit messy).
3. Add a new unit test to ensure the selection of peers behaves correctly.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've added a new unit test that covers this functionality.

## Related PRs

None.