### PR TITLE
[aptos-metrics] gather system metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,6 +663,7 @@ dependencies = [
  "prometheus",
  "rusty-fork",
  "serde_json",
+ "sysinfo",
  "tokio",
 ]
 
@@ -8027,6 +8028,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07fa4c84a5305909b0eedfcc8d1f2fafdbede645bb700a45ecaafe681a0ac5d6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "tabular"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8654,7 +8670,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/crates/aptos-metrics/Cargo.toml
+++ b/crates/aptos-metrics/Cargo.toml
@@ -16,6 +16,7 @@ hyper = { version = "0.14.4", features = ["full"] }
 once_cell = "1.7.2"
 prometheus = { version = "0.12.0", default-features = false }
 serde_json = "1.0.64"
+sysinfo = "0.23.5"
 tokio = { version = "1.8.1", features = ["full"] }
 
 aptos-logger = { path = "../../crates/aptos-logger" }

--- a/crates/aptos-metrics/build.rs
+++ b/crates/aptos-metrics/build.rs
@@ -1,10 +1,15 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{env, process::Command};
+use std::{env, process::Command, path::Path};
+
+const GIT_INDEX: &str = "../../.git/index";
 
 /// Save revision info to environment variable
 fn main() {
+    if Path::new(GIT_INDEX).exists() {
+        println!("cargo:rerun-if-changed={}", GIT_INDEX);
+    }
     if env::var("GIT_REV").is_err() {
         let output = Command::new("git")
             .args(&["rev-parse", "--short", "HEAD"])

--- a/crates/aptos-metrics/src/json_metrics.rs
+++ b/crates/aptos-metrics/src/json_metrics.rs
@@ -2,16 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use sysinfo::{System, SystemExt};
 
 // Use to expose non-numeric metrics
 pub fn get_json_metrics() -> HashMap<String, String> {
     let mut json_metrics: HashMap<String, String> = HashMap::new();
     json_metrics = add_revision_hash(json_metrics);
+    json_metrics = add_system_info(json_metrics);
     json_metrics
 }
 
 fn add_revision_hash(mut json_metrics: HashMap<String, String>) -> HashMap<String, String> {
     json_metrics.insert("revision".to_string(), env!("GIT_REV").to_string());
+    json_metrics
+}
+
+fn add_system_info(mut json_metrics: HashMap<String, String>) -> HashMap<String, String> {
+    let mut sys = System::new();
+    sys.refresh_system();
+
+    if let Some(name) = sys.name() {
+        json_metrics.insert("system_name".to_string(), name);
+    }
+    if let Some(kernel_version) = sys.kernel_version() {
+        json_metrics.insert("system_kernel_version".to_string(), kernel_version);
+    }
+    if let Some(os_version) = sys.os_version() {
+        json_metrics.insert("system_os_version".to_string(), os_version);
+    }
+
     json_metrics
 }
 

--- a/crates/aptos-metrics/src/lib.rs
+++ b/crates/aptos-metrics/src/lib.rs
@@ -50,6 +50,7 @@
 mod json_encoder;
 pub mod json_metrics;
 pub mod metric_server;
+pub mod system_metrics;
 mod public_metrics;
 
 mod op_counters;

--- a/crates/aptos-metrics/src/metric_server.rs
+++ b/crates/aptos-metrics/src/metric_server.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     gather_metrics, json_encoder::JsonEncoder, json_metrics::get_json_metrics,
-    public_metrics::PUBLIC_METRICS, NUM_METRICS,
+    public_metrics::PUBLIC_METRICS, NUM_METRICS, system_metrics::refresh_system_metrics,
 };
 use futures::future;
 use hyper::{
@@ -119,6 +119,9 @@ async fn serve_public_metrics(req: Request<Body>) -> Result<Response<Body>, hype
 }
 
 pub fn start_server(host: String, port: u16, public_metric: bool) {
+    // Collect system metrics
+    refresh_system_metrics();
+
     // Only called from places that guarantee that host is parsable, but this must be assumed.
     let addr: SocketAddr = (host.as_str(), port)
         .to_socket_addrs()

--- a/crates/aptos-metrics/src/public_metrics.rs
+++ b/crates/aptos-metrics/src/public_metrics.rs
@@ -1,5 +1,14 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-// A list of metrics which will be made public to all the partners
-pub const PUBLIC_METRICS: &[&str] = &["aptos_connections", "revision"];
+// A list of metrics which will be made public
+pub const PUBLIC_METRICS: &[&str] = &[
+    "aptos_connections",
+    "revision",
+    "system_name",
+    "system_kernel_version",
+    "system_os_version",
+    "system_total_memory",
+    "system_used_memory",
+    "system_physical_core_count",
+];

--- a/crates/aptos-metrics/src/system_metrics.rs
+++ b/crates/aptos-metrics/src/system_metrics.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_metrics_core::{register_int_gauge_vec, IntGaugeVec};
+use once_cell::sync::Lazy;
+use sysinfo::{System, SystemExt};
+
+static TOTAL_MEMORY_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!("system_total_memory", "Total system memory", &[]).unwrap()
+});
+
+static USED_MEMORY_GAUGE: Lazy<IntGaugeVec> =
+    Lazy::new(|| register_int_gauge_vec!("system_used_memory", "Used system memory", &[]).unwrap());
+
+static PHYSICAL_CORE_COUNT_GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!("system_physical_core_count", "Physical CPU cores", &[]).unwrap()
+});
+
+pub fn refresh_system_metrics() {
+    let mut sys = System::new();
+    sys.refresh_system();
+
+    TOTAL_MEMORY_GAUGE.with_label_values(&[]).set(sys.total_memory() as i64);
+    USED_MEMORY_GAUGE.with_label_values(&[]).set(sys.used_memory() as i64);
+
+    if let Some(physical_core_count) = sys.physical_core_count() {
+        PHYSICAL_CORE_COUNT_GAUGE.with_label_values(&[]).set(physical_core_count as i64);
+    }
+}


### PR DESCRIPTION
Gather kernel and OS information and serve it on metrics endpoints. This will help us gather some insight on how fullnodes are being deployed in the ecosystem.

Also change to how we get the git rev in `aptos-metrics/build.rs`, such that any time there's a change to the git index (HEAD changes), the crate is re-built and the git rev is re-calculated. Previously, we would only get the git rev when `aptos-metrics` needed to be re-built. This is helpful for correctly getting the rev for those who are running the aptos node binary directly.

Now that we're collecting these metrics (and serving from prometheus), we have a convenient place to have nodes push these metrics over OpenTelemetry if they want. We'd simply need to gather/transform the metrics, and push over OTLP