### PR TITLE
[helm][validator] 32byte peer_ids for vfn network

### DIFF
--- a/terraform/helm/validator/files/configs/fullnode.yaml
+++ b/terraform/helm/validator/files/configs/fullnode.yaml
@@ -27,7 +27,7 @@ full_node_networks:
     private: "vfn"
   listen_address: "/ip4/0.0.0.0/tcp/6181"
   seeds:
-    d58bc7bb154b38039bc9096ce04e1237:
+    00000000000000000000000000000000d58bc7bb154b38039bc9096ce04e1237:
       addresses:
       - "/dns4/{{ include "aptos-validator.fullname" . }}-validator/tcp/6181/ln-noise-ik/f0274c2774519281a8332d0bb9d8101bd58bc7bb154b38039bc9096ce04e1237/ln-handshake/0"
       role: "Validator"

--- a/terraform/helm/validator/files/configs/validator.yaml
+++ b/terraform/helm/validator/files/configs/validator.yaml
@@ -75,7 +75,7 @@ full_node_networks:
   identity:
     type: "from_config"
     key: "b0f405a3e75516763c43a2ae1d70423699f34cd68fa9f8c6bb2d67aa87d0af69"
-    peer_id: "d58bc7bb154b38039bc9096ce04e1237"
+    peer_id: "00000000000000000000000000000000d58bc7bb154b38039bc9096ce04e1237"
 
 {{- if .Values.exposeValidatorRestApi }}
 api:


### PR DESCRIPTION
Prepare for https://github.com/aptos-labs/aptos-core/pull/316.

* Apply changes in this PR to forge-0 (dev cluster), with tag `dev_circleci_f1103a4c` built from above PR 
* Test 316 in forge-0 to verify that 32byte changes work with deployment changes
* Land 316, as forge tests are not currently land-blocking
* Immediately update forge-1 with changes in this PR (CICD cluster). Forge tests for other PRs will fail until this is done, as 32byte, but still not land blocking
* 🥳 