### PR TITLE
[fgi] push helm charts before forge run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
     steps:
       - checkout
       - aws-setup
-      - kubernetes/install-kubectl
+      - deploy-setup
       - run: echo "export IMAGE_TAG=dev_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
       # since we're running with `--build-all`, assume that if it passes, we have all images required for Forge
       - run: aws ecr describe-images --repository-name="aptos/validator" --image-ids=imageTag=$IMAGE_TAG
@@ -259,6 +259,18 @@ commands:
       - run: sudo apt-get install build-essential ca-certificates clang curl git libssl-dev pkg-config --no-install-recommends --assume-yes
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
       - run: cat $HOME/.cargo/env >> $BASH_ENV
+  deploy-setup:
+    steps:
+      - kubernetes/install-kubectl
+      - run:
+          name: Install Helm
+          # https://helm.sh/docs/intro/install/#from-apt-debianubuntu
+          command: |
+            curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+            sudo apt-get install apt-transport-https --yes
+            echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+            sudo apt-get update
+            sudo apt-get install helm
   ### Sets up the permissions required for accessing AWS resources
   aws-setup:
     steps:

--- a/scripts/fgi/README.md
+++ b/scripts/fgi/README.md
@@ -1,8 +1,10 @@
 # fgi
 
-`fgi` is the entrypoint to the Forge unified testing framework. It is a python script with minimal dependencies
-outside of the python standard library, for portability.
+`fgi` is the entrypoint to the Forge unified testing framework. It is a python script with minimal dependencies outside of the python standard library, for portability. `fgi` must be run from the Aptos project root.
+
+To run, you must have `kubectl` and `helm` installed, and have the proper permissions to access the clusters specified in `kube.py`.
 
 ```
+# fgi must be run from the Aptos project root
 ./scripts/fgi/run -h
 ```

--- a/scripts/fgi/kube.py
+++ b/scripts/fgi/kube.py
@@ -8,7 +8,10 @@ import subprocess
 import tempfile
 import time
 
-FORGE_K8S_CLUSTERS = ["forge-1"]
+FORGE_K8S_CLUSTERS = [
+    "forge-0",
+    "forge-1",
+]
 
 WORKSPACE_CHART_BUCKETS = {
     "forge-0": "aptos-testnet-forge-0-helm-312428ba",

--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -18,6 +18,7 @@ from kube import (
     get_cluster_context,
     kube_wait_job,
     create_forge_job,
+    push_helm_charts,
 )
 
 TAG = ""
@@ -162,6 +163,7 @@ else:
 context = get_cluster_context(workspace)
 print(f"Running experiments on cluster: {workspace}")
 grafana_url = get_grafana_url(workspace)
+push_helm_charts(workspace)
 print()
 
 job_name, template = create_forge_job(
@@ -200,7 +202,7 @@ print("**********")
 
 print("==========begin-pod-logs==========")
 subprocess.call(
-    f"kubectl --context={context} logs -f -l job-name={job_name} | tee {OUTPUT_TEE}",
+    f"kubectl --context={context} logs -f -l job-name={job_name} | tee -a {OUTPUT_TEE}",
     shell=True,
 )
 print("==========end-pod-logs==========")


### PR DESCRIPTION
Code changes sometimes necessitate deployment config changes, e.g. 32byte addresses not compatible with existing VFN network in the validator helm chart, due to the peer ID being hard-coded. In such cases, the PR will fail to land since the helm charts that Forge uses are set at TF apply-time. To resolve this, Forge operator needs to coordinate with PR author and it's a whole nightmare ☠️ (read: https://github.com/aptos-labs/aptos-core/pull/316)

This PR makes the Forge client script `fgi` responsible for building the local helm charts and pushing them to S3 before the Forge test runs. Permissions need to be configured properly for the calling user to push to S3 of course, and also they need to have `helm` installed now as well.

Test: run `fgi` on `forge-0`.

```
$ ./scripts/fgi/run -W forge-0 --tag main --suite land_blocking

    __________  ____  ____________
   / ____/ __ \/ __ \/ ____/ ____/
  / /_  / / / / /_/ / / __/ __/
 / __/ / /_/ / _, _/ /_/ / /___
/_/    \____/_/ |_|\____/_____/


Running Forge on backend: kubernetes testnet

Attempting to reach Forge Kubernetes testnets...
Updated context arn:aws:eks:us-west-2:323143817725:cluster/aptos-forge-0 in /Users/rustielin/.kube/config
Updated context arn:aws:eks:us-west-2:323143817725:cluster/aptos-forge-1 in /Users/rustielin/.kube/config
Updated context arn:aws:eks:us-west-2:323143817725:cluster/aptos-forge-0 in /Users/rustielin/.kube/config
Grabbing a testnet...
Running experiments on cluster: forge-0
Error: plugin already exists
Initialized empty repository at s3://aptos-testnet-forge-0-helm-312428ba/charts
"testnet-forge-0" already exists with the same configuration, skipping
walk.go:74: found symbolic link in path: /Users/rustielin/Code/aptos-core/terraform/testnet/testnet/files/dashboards resolves to /Users/rustielin/Code/aptos-core/terraform/helm/validator/files/dashboards
Successfully packaged chart and saved it to: /var/folders/0r/0cqndyk91kb6s_xv23gdvsdw0000gn/T/tmpfnj5eepr/testnet-1.0.0.tgz
Successfully packaged chart and saved it to: /var/folders/0r/0cqndyk91kb6s_xv23gdvsdw0000gn/T/tmpfnj5eepr/aptos-validator-1.0.0.tgz
Successfully packaged chart and saved it to: /var/folders/0r/0cqndyk91kb6s_xv23gdvsdw0000gn/T/tmpfnj5eepr/aptos-fullnode-1.0.0.tgz

Specfile: /var/folders/0r/0cqndyk91kb6s_xv23gdvsdw0000gn/T/tmpqwh_ox8n.json
Creating job: forge-rustielin-1648597805
job.batch/forge-rustielin-1648597805 created
```