### PR TITLE
[AptosVM] MoveVmExt, SessionExt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,6 +1130,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-crypto",
+ "aptos-crypto-derive",
  "aptos-framework-releases",
  "aptos-logger",
  "aptos-metrics",

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1.16"
 
 bcs = "0.1.2"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-state-view = { path = "../../storage/state-view" }

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -115,6 +115,7 @@ pub mod aptos_vm;
 mod aptos_vm_impl;
 mod errors;
 pub mod logging;
+pub mod move_vm_ext;
 pub mod natives;
 pub mod parallel_executor;
 pub mod read_write_set_analysis;

--- a/aptos-move/aptos-vm/src/move_vm_ext.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext.rs
@@ -1,0 +1,172 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+///! MoveVM and Session wrapped, to make sure Aptos natives and extensions are always installed and
+///! taken care of after session finish.
+use crate::{
+    access_path_cache::AccessPathCache, aptos_vm_impl::convert_changeset_and_events_cached,
+    natives::aptos_natives, transaction_metadata::TransactionMetadata,
+};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
+use aptos_types::{
+    block_metadata::BlockMetadata,
+    transaction::{ChangeSet, SignatureCheckedTransaction},
+};
+use move_binary_format::errors::VMResult;
+use move_core_types::{
+    account_address::AccountAddress,
+    effects::{ChangeSet as MoveChangeSet, Event as MoveEvent},
+    resolver::MoveResolver,
+    vm_status::VMStatus,
+};
+use move_vm_runtime::{
+    move_vm::MoveVM, native_functions::NativeContextExtensions, session::Session,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    convert::TryInto,
+    ops::{Deref, DerefMut},
+};
+
+pub struct MoveVmExt {
+    inner: MoveVM,
+}
+
+impl MoveVmExt {
+    pub fn new() -> VMResult<Self> {
+        Ok(Self {
+            inner: MoveVM::new(aptos_natives())?,
+        })
+    }
+
+    pub fn new_session<'r, S: MoveResolver>(
+        &self,
+        remote: &'r S,
+        _session_id: SessionId,
+    ) -> SessionExt<'r, '_, S> {
+        // TODO: install table extension
+        let extensions = NativeContextExtensions::default();
+
+        SessionExt {
+            inner: self.inner.new_session_with_extensions(remote, extensions),
+        }
+    }
+}
+
+impl Deref for MoveVmExt {
+    type Target = MoveVM;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+#[derive(BCSCryptoHash, CryptoHasher, Deserialize, Serialize)]
+pub enum SessionId {
+    Txn {
+        sender: AccountAddress,
+        sequence_number: u64,
+    },
+    BlockMeta {
+        // block id
+        id: HashValue,
+    },
+    Genesis {
+        // id to identify this specific genesis build
+        id: HashValue,
+    },
+    // For those runs that are not a transaction and the output of which won't be committed.
+    Void,
+}
+
+impl SessionId {
+    pub fn txn(txn: &SignatureCheckedTransaction) -> Self {
+        Self::Txn {
+            sender: txn.sender(),
+            sequence_number: txn.sequence_number(),
+        }
+    }
+
+    pub fn txn_meta(txn_data: &TransactionMetadata) -> Self {
+        Self::Txn {
+            sender: txn_data.sender,
+            sequence_number: txn_data.sequence_number,
+        }
+    }
+
+    pub fn genesis(id: HashValue) -> Self {
+        Self::Genesis { id }
+    }
+
+    pub fn block_meta(block_meta: &BlockMetadata) -> Self {
+        Self::BlockMeta {
+            id: block_meta.id(),
+        }
+    }
+
+    pub fn void() -> Self {
+        Self::Void
+    }
+
+    pub fn as_uuid(&self) -> u128 {
+        u128::from_be_bytes(
+            self.hash().as_ref()[..16]
+                .try_into()
+                .expect("Slice to array conversion failed."),
+        )
+    }
+}
+
+pub struct SessionExt<'r, 'l, S> {
+    inner: Session<'r, 'l, S>,
+}
+
+impl<'r, 'l, S> SessionExt<'r, 'l, S>
+where
+    S: MoveResolver,
+{
+    pub fn finish(self) -> VMResult<SessionOutput> {
+        let (change_set, events, extensions) = self.inner.finish_with_extensions()?;
+        Ok(SessionOutput {
+            change_set,
+            events,
+            extensions,
+        })
+    }
+}
+
+impl<'r, 'l, S> Deref for SessionExt<'r, 'l, S> {
+    type Target = Session<'r, 'l, S>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'r, 'l, S> DerefMut for SessionExt<'r, 'l, S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+pub struct SessionOutput {
+    pub change_set: MoveChangeSet,
+    pub events: Vec<MoveEvent>,
+    pub extensions: NativeContextExtensions,
+}
+
+impl SessionOutput {
+    pub fn into_change_set<C: AccessPathCache>(
+        self,
+        ap_cache: &mut C,
+    ) -> Result<ChangeSet, VMStatus> {
+        // TODO: consider table change set from the table extension
+        convert_changeset_and_events_cached(ap_cache, self.change_set, self.events)
+            .map(|(write_set, events)| ChangeSet::new(write_set, events))
+    }
+
+    pub fn unpack(self) -> (MoveChangeSet, Vec<MoveEvent>, NativeContextExtensions) {
+        (self.change_set, self.events, self.extensions)
+    }
+}

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -2,13 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::format_err;
+use aptos_crypto::HashValue;
 use aptos_state_view::StateView;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{self, aptos_root_address},
     transaction::{ChangeSet, Script, Version},
 };
-use aptos_vm::{convert_changeset_and_events, data_cache::RemoteStorage};
+use aptos_vm::{
+    data_cache::RemoteStorage,
+    move_vm_ext::{MoveVmExt, SessionExt, SessionId},
+};
 use move_core_types::{
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
@@ -16,10 +20,9 @@ use move_core_types::{
     transaction_argument::convert_txn_args,
     value::{serialize_values, MoveValue},
 };
-use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::gas_schedule::GasStatus;
 
-pub struct GenesisSession<'r, 'l, S>(Session<'r, 'l, S>);
+pub struct GenesisSession<'r, 'l, S>(SessionExt<'r, 'l, S>);
 
 impl<'r, 'l, S: MoveResolver> GenesisSession<'r, 'l, S> {
     pub fn exec_func(
@@ -96,10 +99,14 @@ pub fn build_changeset<S: StateView, F>(state_view: &S, procedure: F) -> ChangeS
 where
     F: FnOnce(&mut GenesisSession<RemoteStorage<S>>),
 {
-    let move_vm = MoveVM::new(aptos_vm::natives::aptos_natives()).unwrap();
-    let (changeset, events) = {
+    let move_vm = MoveVmExt::new().unwrap();
+    let session_out = {
         let state_view_storage = RemoteStorage::new(state_view);
-        let mut session = GenesisSession(move_vm.new_session(&state_view_storage));
+        // TODO: specify an id by human and pass that in.
+        let genesis_id = HashValue::zero();
+        let mut session = GenesisSession(
+            move_vm.new_session(&state_view_storage, SessionId::genesis(genesis_id)),
+        );
         session.disable_reconfiguration();
         procedure(&mut session);
         session.enable_reconfiguration();
@@ -110,9 +117,8 @@ where
             .unwrap()
     };
 
-    let (writeset, events) = convert_changeset_and_events(changeset, events)
+    session_out
+        .into_change_set(&mut ())
         .map_err(|err| format_err!("Unexpected VM Error: {:?}", err))
-        .unwrap();
-
-    ChangeSet::new(writeset, events)
+        .unwrap()
 }


### PR DESCRIPTION

## Motivation

MoveVM and Session wrapped, to make sure Aptos natives and extensions are always installed and taken care of after session finish.

SessionId is introduced to enforce unique id required by the table extension, which we are depending on soon.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan

existing coverage
