### PR TITLE
update move dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "aptos-vm",
  "aptos-workspace-hack",
  "bcs",
+ "clap 3.1.6",
  "datatest-stable",
  "either",
  "framework",
@@ -1041,7 +1042,6 @@ dependencies = [
  "move-core-types",
  "move-transactional-test-runner",
  "once_cell",
- "structopt",
  "vm-genesis",
 ]
 
@@ -1153,7 +1153,7 @@ dependencies = [
  "bytes",
  "cc",
  "chrono",
- "clap",
+ "clap 2.34.0",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-queue",
@@ -1167,7 +1167,6 @@ dependencies = [
  "generic-array 0.14.5",
  "hashbrown 0.11.2",
  "hyper",
- "indexmap",
  "itertools",
  "libc",
  "log",
@@ -1682,7 +1681,7 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -1892,10 +1891,40 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static 1.4.0",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2 1.0.36",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -2173,7 +2202,7 @@ checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
- "clap",
+ "clap 2.34.0",
  "criterion-plot",
  "csv",
  "itertools",
@@ -2555,12 +2584,12 @@ dependencies = [
  "aptos-vm",
  "aptos-workspace-hack",
  "bcs",
+ "clap 3.1.6",
  "datatest-stable",
  "diem-framework-releases",
  "move-cli",
  "move-core-types",
  "move-vm-types",
- "structopt",
 ]
 
 [[package]]
@@ -2702,6 +2731,12 @@ name = "dissimilar"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "dtoa"
@@ -2938,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "evm-exec-utils"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "dirs",
@@ -3290,7 +3325,7 @@ dependencies = [
  "aptos-vm",
  "aptos-workspace-hack",
  "bcs",
- "clap",
+ "clap 3.1.6",
  "datatest-stable",
  "dir-diff",
  "include_dir",
@@ -3329,7 +3364,7 @@ dependencies = [
  "aptos-types",
  "aptos-workspace-hack",
  "bcs",
- "clap",
+ "clap 3.1.6",
  "include_dir",
  "log",
  "move-binary-format",
@@ -3795,6 +3830,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -4601,11 +4642,11 @@ checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
- "heck",
+ "heck 0.3.3",
  "log",
  "move-bytecode-verifier",
  "move-command-line-common",
@@ -4618,7 +4659,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "mirai-annotations",
@@ -4635,7 +4676,7 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "mirai-annotations",
  "workspace-hack",
@@ -4644,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4661,7 +4702,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -4674,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "mirai-annotations",
@@ -4688,9 +4729,10 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
+ "clap 3.1.6",
  "crossterm 0.21.0",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4698,7 +4740,6 @@ dependencies = [
  "move-disassembler",
  "move-ir-types",
  "regex",
- "structopt",
  "tui",
  "workspace-hack",
 ]
@@ -4706,10 +4747,11 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.6",
  "codespan-reporting",
  "colored",
  "difference",
@@ -4740,7 +4782,6 @@ dependencies = [
  "read-write-set-dynamic",
  "serde 1.0.136",
  "serde_yaml",
- "structopt",
  "tempfile",
  "walkdir",
  "workspace-hack",
@@ -4749,7 +4790,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "difference",
@@ -4763,10 +4804,11 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.6",
  "codespan-reporting",
  "difference",
  "hex",
@@ -4783,7 +4825,7 @@ dependencies = [
  "once_cell",
  "petgraph 0.5.1",
  "regex",
- "structopt",
+ "sha3 0.9.1",
  "tempfile",
  "walkdir",
  "workspace-hack",
@@ -4792,7 +4834,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.3"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4811,10 +4853,11 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.6",
  "codespan",
  "colored",
  "move-binary-format",
@@ -4826,16 +4869,16 @@ dependencies = [
  "once_cell",
  "petgraph 0.5.1",
  "serde 1.0.136",
- "structopt",
  "workspace-hack",
 ]
 
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
+ "clap 3.1.6",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4845,14 +4888,13 @@ dependencies = [
  "move-core-types",
  "move-coverage",
  "move-ir-types",
- "structopt",
  "workspace-hack",
 ]
 
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4872,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4903,10 +4945,11 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.6",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -4916,14 +4959,13 @@ dependencies = [
  "move-ir-types",
  "move-symbol-pool",
  "serde_json",
- "structopt",
  "workspace-hack",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4943,7 +4985,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "hex",
@@ -4957,7 +4999,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "hex",
@@ -4972,7 +5014,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4999,10 +5041,11 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
+ "clap 3.1.6",
  "colored",
  "move-abigen",
  "move-binary-format",
@@ -5023,7 +5066,6 @@ dependencies = [
  "serde 1.0.136",
  "serde_yaml",
  "sha2",
- "structopt",
  "tempfile",
  "toml",
  "walkdir",
@@ -5033,12 +5075,12 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap",
+ "clap 3.1.6",
  "codespan",
  "codespan-reporting",
  "futures",
@@ -5072,7 +5114,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5101,7 +5143,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5113,7 +5155,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5129,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5157,10 +5199,11 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
+ "clap 3.1.6",
  "codespan-reporting",
  "itertools",
  "move-binary-format",
@@ -5170,14 +5213,13 @@ dependencies = [
  "move-vm-runtime",
  "num",
  "serde 1.0.136",
- "structopt",
  "workspace-hack",
 ]
 
 [[package]]
 name = "move-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "log",
  "move-binary-format",
@@ -5199,7 +5241,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "once_cell",
  "serde 1.0.136",
@@ -5207,13 +5249,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-table-extension"
+version = "0.1.0"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "downcast-rs",
+ "itertools",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-vm-runtime",
+ "move-vm-types",
+ "once_cell",
+ "sha3 0.9.1",
+ "smallvec",
+ "walkdir",
+ "workspace-hack",
+]
+
+[[package]]
 name = "move-to-yul"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "atty",
- "clap",
+ "clap 3.1.6",
  "codespan",
  "codespan-reporting",
  "ethnum",
@@ -5240,7 +5304,6 @@ dependencies = [
  "serde_json",
  "sha3 0.9.1",
  "simplelog",
- "structopt",
  "toml",
  "workspace-hack",
 ]
@@ -5248,9 +5311,10 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
+ "clap 3.1.6",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -5272,7 +5336,6 @@ dependencies = [
  "once_cell",
  "rayon",
  "regex",
- "structopt",
  "tempfile",
  "workspace-hack",
 ]
@@ -5280,12 +5343,14 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
+ "clap 3.1.6",
  "colored",
  "evm",
  "evm-exec-utils",
+ "itertools",
  "move-binary-format",
  "move-bytecode-utils",
  "move-command-line-common",
@@ -5295,21 +5360,22 @@ dependencies = [
  "move-resource-viewer",
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
+ "move-table-extension",
  "move-to-yul",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
+ "once_cell",
  "primitive-types",
  "rayon",
  "regex",
- "structopt",
  "workspace-hack",
 ]
 
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "fail",
  "mirai-annotations",
@@ -5327,7 +5393,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5339,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "bcs",
  "mirai-annotations",
@@ -5841,6 +5907,15 @@ checksum = "fb233f06c2307e1f5ce2ecad9f8121cffbbee2c95428f44ea85222e460d0d213"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6574,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6591,7 +6666,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7188,7 +7263,7 @@ checksum = "b5cf21ac6679c60495e22ed041e2c913740f0332597c6a64bbcba04dbcb39249"
 dependencies = [
  "bcs",
  "bincode",
- "heck",
+ "heck 0.3.3",
  "include_dir",
  "maplit",
  "serde 1.0.136",
@@ -7954,12 +8029,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "lazy_static 1.4.0",
  "structopt-derive",
 ]
@@ -7970,7 +8051,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2 1.0.36",
  "quote 1.0.15",
@@ -8177,6 +8258,12 @@ dependencies = [
  "smawk",
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -8556,7 +8643,7 @@ dependencies = [
  "aptos-types",
  "aptos-workspace-hack",
  "bcs",
- "heck",
+ "heck 0.3.3",
  "move-core-types",
  "regex",
  "serde-generate",
@@ -9255,13 +9342,15 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/diem/move?rev=68b169fd0427ecfa717de5e0376e8127d629bc4e#68b169fd0427ecfa717de5e0376e8127d629bc4e"
+source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "arrayvec 0.5.2",
  "block-buffer 0.9.0",
  "bstr",
  "byteorder",
  "bytes",
+ "clap 2.34.0",
+ "clap 3.1.6",
  "codespan-reporting",
  "crossbeam-utils",
  "crunchy",
@@ -9270,6 +9359,7 @@ dependencies = [
  "evm-runtime",
  "getrandom 0.2.5",
  "hex",
+ "indexmap",
  "libc",
  "log",
  "memchr",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -33,8 +33,8 @@ aptos-types = { path = "../types" }
 aptos-workspace-hack = { version = "0.1", path = "../crates/aptos-workspace-hack" }
 aptos-api-types = { path = "./types", package = "aptos-api-types" }
 storage-interface = { path = "../storage/storage-interface" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-resource-viewer = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-resource-viewer = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 [dev-dependencies]
 goldenfile = "1.1.0"

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -21,9 +21,9 @@ aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-hack" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-resource-viewer = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-resource-viewer = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 [dev-dependencies]
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }

--- a/aptos-move/aptos-resource-viewer/Cargo.toml
+++ b/aptos-move/aptos-resource-viewer/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2018"
 
 [dependencies]
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-resource-viewer = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-resource-viewer = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-types = { path = "../../types"  }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 anyhow = "1.0.52"

--- a/aptos-move/aptos-transaction-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-transaction-benchmarks/Cargo.toml
@@ -19,8 +19,8 @@ language-e2e-tests = { path = "../e2e-tests" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 
-read-write-set = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-read-write-set-dynamic = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+read-write-set = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+read-write-set-dynamic = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-vm = { path = "../aptos-vm" }
 diem-framework-releases = { path = "../framework/DPN/releases" }
 

--- a/aptos-move/aptos-transactional-test-harness/Cargo.toml
+++ b/aptos-move/aptos-transactional-test-harness/Cargo.toml
@@ -12,19 +12,19 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = "3.1.6"
 either = "1.6.1"
 once_cell = "1.7.2"
 anyhow = "1.0.52"
-structopt = "0.3.21"
 bcs = "0.1.2"
 hex = "0.4.3"
 
 # Move dependencies
-move-transactional-test-runner = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-command-line-common = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-transactional-test-runner = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-command-line-common = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 # Diem-Move dependencies
 language-e2e-tests = { path = "../e2e-tests" }

--- a/aptos-move/aptos-transactional-test-harness/src/diem_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/diem_test_harness.rs
@@ -26,6 +26,7 @@ use aptos_types::{
     vm_status::KeptVMStatus,
 };
 use aptos_vm::AptosVM;
+use clap::StructOpt;
 use language_e2e_tests::data_store::{FakeDataStore, GENESIS_CHANGE_SET_FRESH};
 use move_binary_format::file_format::{CompiledModule, CompiledScript};
 use move_command_line_common::files::verify_and_create_named_address_mapping;
@@ -52,7 +53,6 @@ use std::{
     fmt,
     path::Path,
 };
-use structopt::StructOpt;
 use vm_genesis::GENESIS_KEYPAIR;
 
 /*************************************************************************************************
@@ -136,20 +136,20 @@ struct DiemRunArgs {
     #[structopt(long = "show-events")]
     show_events: bool,
 
-    #[structopt(long = "secondary-signers", parse(try_from_str = SignerAndKeyPair::parse))]
+    #[structopt(long = "secondary-signers", parse(try_from_str = SignerAndKeyPair::parse), multiple_values(true))]
     secondary_signers: Option<Vec<SignerAndKeyPair>>,
 }
 
 /// Diem-specifc arguments for the init command.
 #[derive(StructOpt, Debug)]
 struct DiemInitArgs {
-    #[structopt(long = "private-keys", parse(try_from_str = parse_named_private_key))]
+    #[structopt(long = "private-keys", parse(try_from_str = parse_named_private_key), multiple_values(true))]
     private_keys: Option<Vec<(Identifier, Ed25519PrivateKey)>>,
 
-    #[structopt(long = "validators", parse(try_from_str = parse_identifier))]
+    #[structopt(long = "validators", parse(try_from_str = parse_identifier), multiple_values(true))]
     validators: Option<Vec<Identifier>>,
 
-    #[structopt(long = "parent-vasps", parse(try_from_str = ParentVaspInitArgs::parse))]
+    #[structopt(long = "parent-vasps", parse(try_from_str = ParentVaspInitArgs::parse), multiple_values(true))]
     parent_vasps: Option<Vec<ParentVaspInitArgs>>,
 }
 

--- a/aptos-move/aptos-validator-interface/Cargo.toml
+++ b/aptos-move/aptos-validator-interface/Cargo.toml
@@ -18,5 +18,5 @@ aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 storage-interface = { path = "../../storage/storage-interface" }
 scratchpad = { path = "../../storage/scratchpad" }
 aptos-state-view = { path = "../../storage/state-view" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 bcs = "0.1.2"

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -24,16 +24,16 @@ aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-stdlib = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-stdlib = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 framework =  { path = "../framework" }
 serde_json = "1.0.64"
 serde = { version = "1.0.124", default-features = false }
-read-write-set-dynamic = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e"}
+read-write-set-dynamic = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa"}
 
 mvhashmap = { path = "../mvhashmap" }
 aptos-parallel-executor = {path = "../parallel-executor" }

--- a/aptos-move/df-cli/Cargo.toml
+++ b/aptos-move/df-cli/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.52"
 bcs = "0.1.2"
-structopt = "0.3.21"
+clap = "3.1.6"
 
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-cli = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-cli = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-vm = { path = "../aptos-vm" }
 diem-framework-releases = { path = "../framework/DPN/releases" }
 

--- a/aptos-move/df-cli/src/main.rs
+++ b/aptos-move/df-cli/src/main.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use clap::StructOpt;
 use move_cli::{Command, Move};
 use move_core_types::errmap::ErrorMapping;
 use move_vm_types::gas_schedule::INITIAL_COST_SCHEDULE;
-use structopt::StructOpt;
 
 #[derive(StructOpt)]
 pub struct DfCli {
@@ -26,7 +26,7 @@ pub enum DfCommands {
 fn main() -> Result<()> {
     let error_descriptions: ErrorMapping =
         bcs::from_bytes(diem_framework_releases::current_error_descriptions())?;
-    let args = DfCli::from_args();
+    let args = DfCli::parse();
     match &args.cmd {
         DfCommands::Command(cmd) => move_cli::run_cli(
             aptos_vm::natives::aptos_natives(),

--- a/aptos-move/e2e-tests-replay/Cargo.toml
+++ b/aptos-move/e2e-tests-replay/Cargo.toml
@@ -14,13 +14,13 @@ structopt = "0.3.21"
 walkdir = "2.3.1"
 
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-types = { path = "../../types", features = ["fuzzing"] }
 framework =  { path = "../framework" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 language-e2e-tests = { path = "../e2e-tests" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-model = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-model = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }

--- a/aptos-move/e2e-tests-replay/src/main.rs
+++ b/aptos-move/e2e-tests-replay/src/main.rs
@@ -92,7 +92,7 @@ pub fn main() -> Result<()> {
         settings.no_expr_check = true;
     }
 
-    let env = run_model_builder(&dpn_files(), &[])?;
+    let env = run_model_builder(vec![(dpn_files(), BTreeMap::<String, _>::new())], vec![])?;
     let interpreter = StacklessBytecodeInterpreter::new(&env, None, settings);
     for trace in args.trace_files {
         aptos_e2e_tests_replay::replay(trace, &interpreter, &flags)?;

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -21,13 +21,13 @@ hex = "0.4.3"
 serde = { version = "1.0.124", default-features = false }
 
 ## Move dependencies
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-ir-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-read-write-set = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-command-line-common = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-ir-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+read-write-set = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-command-line-common = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 ## Diem-Move dependencies
 aptos-writeset-generator = { path = "../writeset-transaction-generator" }

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -16,13 +16,13 @@ bcs = "0.1.2"
 proptest = "1.0.0"
 
 ## Move dependencies
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-ir-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-read-write-set = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-ir-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+read-write-set = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 ## Diem-Move dependencies
 language-e2e-tests = { path = "../e2e-tests" }

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -10,29 +10,29 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-abigen = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-docgen = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-command-line-common = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-errmapgen = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-prover = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-abigen = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-docgen = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-command-line-common = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-errmapgen = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-prover = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 transaction-builder-generator = { path = "../transaction-builder-generator" }
-move-stdlib = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-symbol-pool = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-package = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-stdlib = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-symbol-pool = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-package = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 bcs = "0.1.2"
 anyhow = "1.0.52"
-clap = "2.33.3"
+clap = "3.1.6"
 log = "0.4.14"
 rayon = "1.5.0"
 sha2 = "0.9.3"
@@ -45,8 +45,8 @@ tempfile = "3.2.0"
 [dev-dependencies]
 datatest-stable = "0.1.1"
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
-move-cli = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-unit-test = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-cli = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-unit-test = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-transactional-test-harness = { path = "../aptos-transactional-test-harness" }
 
 dir-diff = "0.3.2"

--- a/aptos-move/framework/DPN/releases/Cargo.toml
+++ b/aptos-move/framework/DPN/releases/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 
 
 [dependencies]
-move-command-line-common = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-command-line-common = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-crypto = { path = "../../../../crates/aptos-crypto" }
 aptos-types = { path = "../../../../types" }
 aptos-workspace-hack = { path = "../../../../crates/aptos-workspace-hack" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 framework-releases = { path = "../../releases" }
 
 anyhow = "1.0.52"
@@ -24,4 +24,4 @@ bcs = "0.1.2"
 once_cell = "1.7.2"
 
 [dev-dependencies]
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }

--- a/aptos-move/framework/aptos-framework/releases/Cargo.toml
+++ b/aptos-move/framework/aptos-framework/releases/Cargo.toml
@@ -11,11 +11,11 @@ publish = false
 
 
 [dependencies]
-move-command-line-common = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-command-line-common = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-crypto = { path = "../../../../crates/aptos-crypto" }
 aptos-types = { path = "../../../../types" }
 aptos-workspace-hack = { path = "../../../../crates/aptos-workspace-hack" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 framework-releases = { path = "../../releases" }
 
 anyhow = "1.0.52"

--- a/aptos-move/framework/releases/Cargo.toml
+++ b/aptos-move/framework/releases/Cargo.toml
@@ -10,21 +10,21 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-command-line-common = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-package = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-command-line-common = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-package = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 bcs = "0.1.2"
 anyhow = "1.0.52"
-clap = "2.33.3"
+clap = "3.1.6"
 log = "0.4.14"
 rayon = "1.5.0"
 sha2 = "0.9.3"

--- a/aptos-move/genesis-viewer/Cargo.toml
+++ b/aptos-move/genesis-viewer/Cargo.toml
@@ -13,11 +13,11 @@ edition = "2018"
 bcs = "0.1.2"
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 aptos-resource-viewer = { path = "../aptos-resource-viewer"}
 vm-genesis = { path = "../vm-genesis" }
 diem-framework-releases = { path = "../framework/DPN/releases" }
-move-vm-test-utils = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-vm-test-utils = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 structopt = "0.3.21"

--- a/aptos-move/move-examples/Cargo.toml
+++ b/aptos-move/move-examples/Cargo.toml
@@ -13,11 +13,11 @@ aptos-vm = { path = "../aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 framework = { path = "../framework" }
 structopt = "0.3.21"
-move-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-package = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-stdlib = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-unit-test = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-package = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-stdlib = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-unit-test = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 [dev-dependencies]
-move-cli = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-cli = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 tempfile = "3.2.0"

--- a/aptos-move/transaction-builder-generator/Cargo.toml
+++ b/aptos-move/transaction-builder-generator/Cargo.toml
@@ -19,7 +19,7 @@ serde_yaml = "0.8.17"
 
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 serde-reflection = "0.3.5"
 serde-generate = "0.20.6"
 bcs = "0.1.2"

--- a/aptos-move/transaction-replay/Cargo.toml
+++ b/aptos-move/transaction-replay/Cargo.toml
@@ -19,15 +19,15 @@ aptos-state-view = { path = "../../storage/state-view" }
 aptos-validator-interface = { path = "../aptos-validator-interface" }
 aptosdb = { path = "../../storage/aptosdb" }
 aptos-vm = { path = "../aptos-vm" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e"}
-move-cli = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-test-utils = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa"}
+move-cli = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-test-utils = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-resource-viewer = { path = "../aptos-resource-viewer" }
 framework =  { path = "../framework" }
-move-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 bcs = "0.1.2"
 difference = "2.0.0"
 

--- a/aptos-move/vm-genesis/Cargo.toml
+++ b/aptos-move/vm-genesis/Cargo.toml
@@ -14,23 +14,23 @@ anyhow = "1.0.52"
 once_cell = "1.7.2"
 rand = "0.8.3"
 
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 bcs = "0.1.2"
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-bytecode-utils = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e"}
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-bytecode-utils = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa"}
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 framework =  { path = "../framework" }
 diem-framework-releases = { path = "../framework/DPN/releases" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder"}
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-vm = { path = "../aptos-vm" }
-read-write-set = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+read-write-set = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/aptos-move/writeset-transaction-generator/Cargo.toml
+++ b/aptos-move/writeset-transaction-generator/Cargo.toml
@@ -21,22 +21,22 @@ serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
 once_cell = "1.7.2"
 
-move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-bytecode-verifier = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-types = { path = "../../types" }
 diem-framework-releases = { path = "../framework/DPN/releases" }
 framework =  { path = "../framework" }
-move-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 bcs = "0.1.2"
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-transaction-replay = { path = "../transaction-replay" }
 aptosdb = { path = "../../storage/aptosdb" }
 aptos-vm = { path = "../aptos-vm" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e"}
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
-move-vm-runtime = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-vm-test-utils = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-read-write-set = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa"}
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
+move-vm-runtime = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-vm-test-utils = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+read-write-set = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -28,4 +28,4 @@ aptos-crypto = { path = "../aptos-crypto" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { version = "0.1", path = "../aptos-workspace-hack" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -30,7 +30,6 @@ futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.17", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
 hyper = { version = "0.14.17", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
-indexmap = { version = "1.8.0", default-features = false, features = ["std"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
 libc = { version = "0.2.119", features = ["std"] }
 log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }
@@ -78,7 +77,6 @@ futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.17", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
 hyper = { version = "0.14.17", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
-indexmap = { version = "1.8.0", default-features = false, features = ["std"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
 libc = { version = "0.2.119", features = ["std"] }
 log = { version = "0.4.14", default-features = false, features = ["serde", "std"] }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -28,7 +28,7 @@ aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-hack" }
 scratchpad = { path = "../../storage/scratchpad" }
@@ -46,7 +46,7 @@ aptos-config = { path = "../../config" }
 aptos-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptosdb = { path = "../../storage/aptosdb" }
-move-ir-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-ir-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 storage-interface = { path = "../../storage/storage-interface", features=["fuzzing"] }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 vm-genesis = { path = "../../aptos-move/vm-genesis" }

--- a/network/discovery/Cargo.toml
+++ b/network/discovery/Cargo.toml
@@ -27,7 +27,7 @@ aptos-time-service = {path = "../../crates/aptos-time-service"}
 aptos-secure-storage = { path = "../../secure/storage" }
 aptos-types = {path = "../../types"}
 aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-hack" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 network = {path = "../../network"}
 short-hex-str = { path = "../../crates/short-hex-str" }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -16,6 +16,6 @@ serde = { version = "1.0.124", features = ["derive"] }
 
 aptos-crypto = { path = "../crates/aptos-crypto", version = "0.0.3" }
 aptos-types = { path = "../types", version = "0.0.3"}
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", version = "0.0.3", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", version = "0.0.3", features=["address32"] }
 aptos-transaction-builder = { path = "./transaction-builder", version = "0.0.3" }
 aptos-workspace-hack = { version = "0.1", path = "../crates/aptos-workspace-hack" }

--- a/sdk/transaction-builder/Cargo.toml
+++ b/sdk/transaction-builder/Cargo.toml
@@ -15,7 +15,7 @@ bcs = "0.1.2"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["derive"] }
 
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", version = "0.0.3", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", version = "0.0.3", features=["address32"] }
 aptos-types = { path = "../../types", version = "0.0.3" }
 
 proptest = { version = "1.0.0", optional = true }
@@ -25,7 +25,7 @@ aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-h
 [dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features = ["fuzzing", "address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features = ["fuzzing", "address32"] }
 
 [features]
 default = []

--- a/state-sync/inter-component/consensus-notifications/Cargo.toml
+++ b/state-sync/inter-component/consensus-notifications/Cargo.toml
@@ -23,4 +23,4 @@ aptos-workspace-hack = { version = "0.1", path = "../../../crates/aptos-workspac
 [dev-dependencies]
 claim = "0.5.0"
 
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }

--- a/state-sync/inter-component/event-notifications/Cargo.toml
+++ b/state-sync/inter-component/event-notifications/Cargo.toml
@@ -34,5 +34,5 @@ aptos-temppath = { path = "../../../crates/aptos-temppath" }
 aptos-vm = { path = "../../../aptos-move/aptos-vm" }
 aptosdb = { path = "../../../storage/aptosdb" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 vm-genesis = { path = "../../../aptos-move/vm-genesis", features = ["fuzzing"] }

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -63,7 +63,7 @@ aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
 aptosdb = { path = "../../storage/aptosdb" }
 executor-test-helpers = { path = "../../execution/executor-test-helpers" }
 memsocket = { path = "../../network/memsocket" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 network = { path = "../../network", features = ["fuzzing", "testing"] }
 network-builder = { path  = "../../network/builder" }
 storage-service = { path = "../../storage/storage-service" }

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -35,5 +35,5 @@ claim = "0.5.0"
 
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-types = { path = "../../../types" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 storage-interface = { path = "../../../storage/storage-interface" }

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -35,7 +35,7 @@ aptos-temppath = { path = "../../crates/aptos-temppath", optional = true }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-hack" }
 executor-types = { path = "../../execution/executor-types", optional = true }
-move-core-types = {git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"]}
+move-core-types = {git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"]}
 
 num-variants = { path = "../../crates/num-variants" }
 schemadb = { path = "../schemadb" }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -23,7 +23,7 @@ aptos-state-view = { path = "../state-view" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-hack" }
 scratchpad = { path = "../scratchpad" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 
 [features]
 default = []

--- a/testsuite/aptos-fuzzer/Cargo.toml
+++ b/testsuite/aptos-fuzzer/Cargo.toml
@@ -41,14 +41,14 @@ aptos-mempool = { path = "../../mempool" }
 aptos-types = { path = "../../types", features = ["fuzzing"] }
 aptos-vault-client = { path = "../../secure/storage/vault", features = ["fuzzing"] }
 aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
-move-vm-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features = ["fuzzing"] }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features = ["fuzzing", "address32"] }
+move-vm-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features = ["fuzzing"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features = ["fuzzing", "address32"] }
 network = { path = "../../network", features = ["fuzzing"] }
 safety-rules = { path = "../../consensus/safety-rules", features = ["fuzzing", "testing"]  }
 scratchpad = { path = "../../storage/scratchpad", features = ["fuzzing"]}
 state-sync-v1 = { path = "../../state-sync/state-sync-v1", features = ["fuzzing", "aptosdb"]  }
 storage-interface = { path = "../../storage/storage-interface" }
-move-binary-format = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features = ["fuzzing"] }
+move-binary-format = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features = ["fuzzing"] }
 
 [dev-dependencies]
 rusty-fork = "0.3.0"

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -25,7 +25,7 @@ aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive"}
 aptos-types = { path = "../../types", features=["fuzzing"] }
 aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-hack" }
 network = { path = "../../network" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["fuzzing", "address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["fuzzing", "address32"] }
 
 [[bin]]
 name = "compute"

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -30,10 +30,10 @@ aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-hack" }
 forge = { path = "../forge" }
-move-command-line-common = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-ir-compiler = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-stdlib = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
-move-package = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-command-line-common = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-ir-compiler = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-stdlib = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
+move-package = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 
 
 [dev-dependencies]

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -30,8 +30,8 @@ tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"]
 bcs = "0.1.2"
 aptos-crypto = { path = "../crates/aptos-crypto", version = "0.0.3" }
 aptos-crypto-derive = { path = "../crates/aptos-crypto-derive", version = "0.0.3" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", version = "0.0.3", features=["address32"] }
-move-read-write-set-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", version = "0.0.3", features=["address32"] }
+move-read-write-set-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" }
 aptos-workspace-hack = { version = "0.1", path = "../crates/aptos-workspace-hack" }
 
 [dev-dependencies]
@@ -41,7 +41,7 @@ proptest-derive = "0.3.0"
 serde_json = "1.0.64"
 
 aptos-crypto = { path = "../crates/aptos-crypto", features = ["fuzzing"] }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features = ["fuzzing","address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features = ["fuzzing","address32"] }
 
 [features]
 default = []

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -31,7 +31,7 @@ aptos-types = { path = "../types", features = ["fuzzing"] }
 aptos-vm = { path = "../aptos-move/aptos-vm" }
 aptosdb = { path = "../storage/aptosdb", features = ["fuzzing"] }
 vm-genesis = { path = "../aptos-move/vm-genesis" }
-move-core-types = { git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] }
+move-core-types = { git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] }
 
 [features]
 default = []

--- a/x.toml
+++ b/x.toml
@@ -78,11 +78,11 @@ third-party = [
     # Exclude the fail crate because the failpoints feature should only be enabled
     # for certain builds.
     { name = "fail" },
-    { name = "move-binary-format", git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" },
-    { name = "move-core-types", git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e", features=["address32"] },
-    { name = "move-stdlib", git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" },
-    { name = "move-vm-runtime", git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" },
-    { name = "move-vm-types", git = "https://github.com/diem/move", rev = "68b169fd0427ecfa717de5e0376e8127d629bc4e" },
+    { name = "move-binary-format", git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" },
+    { name = "move-core-types", git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa", features=["address32"] },
+    { name = "move-stdlib", git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" },
+    { name = "move-vm-runtime", git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" },
+    { name = "move-vm-types", git = "https://github.com/diem/move", rev = "3fe033b112eae7df2d15ab3467624165ae510caa" },
 ]
 
 # This follows the same syntax as CargoOptionsSummary in guppy.


### PR DESCRIPTION
## Motivation

Trying to leverage
https://github.com/diem/move/pull/144
https://github.com/diem/move/pull/151
https://github.com/diem/move/pull/150

needs to adapt to breaking change
https://github.com/diem/move/pull/145
and https://github.com/diem/move/pull/130 (after fixing it with https://github.com/diem/move/pull/162 (will update the rev again after this lands))



### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

existing coverage
(ran with local overwrite of the move repo)