### PR TITLE
[scratchpad] bug fix: branchtracker.next was not properly initialized

### DIFF
--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -28,6 +28,7 @@ aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-h
 bitvec = "0.19.4"
 criterion = "0.3.4"
 rand = "0.8.3"
+once_cell = "1.7.2"
 proptest = "1.0.0"
 
 aptos-types = { path = "../../types", features = ["fuzzing"] }

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -224,7 +224,12 @@ impl<V> Inner<V> {
         let mut links_locked = self.links.lock();
 
         let child = if links_locked.children.is_empty() {
-            self.spawn_impl(child_root, links_locked.branch_tracker.clone())
+            let child = self.spawn_impl(child_root, links_locked.branch_tracker.clone());
+            let mut branch_tracker_locked = links_locked.branch_tracker.lock();
+            if branch_tracker_locked.next.upgrade().is_none() {
+                branch_tracker_locked.next = Arc::downgrade(&child);
+            }
+            child
         } else {
             // forking a new branch
             let branch_tracker =

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -401,7 +401,7 @@ static VALUE: Lazy<AccountStateBlob> = Lazy::new(|| AccountStateBlob::from(b"val
 static LEAF: Lazy<SparseMerkleLeafNode> =
     Lazy::new(|| SparseMerkleLeafNode::new(*KEY, VALUE.hash()));
 static PROOF_READER: Lazy<ProofReader<AccountStateBlob>> = Lazy::new(|| {
-    let proof = SparseMerkleProof::new(Some(LEAF.clone()), vec![]);
+    let proof = SparseMerkleProof::new(Some(*LEAF), vec![]);
     ProofReader::new(vec![(*KEY, proof)])
 });
 


### PR DESCRIPTION
## Motivation

Fix crash discovered from the devnet.

`branchtracker.next` is only set when the head gets dropped and as a result `become_oldest()` is called on its children..

The missed case is the second SMT is spawned and it haven't become the oldest in the branch -- the branch_tracker.next should point to it on the spawn.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

unittest to reproduce and confirm fix
