### PR TITLE
[aptos-telemetry] push metrics to GA4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "aptos-config",
  "aptos-crypto",
  "aptos-secure-storage",
+ "aptos-telemetry",
  "aptos-temppath",
  "aptos-types",
  "aptos-workspace-hack",
@@ -692,6 +693,7 @@ dependencies = [
  "aptos-mempool",
  "aptos-metrics",
  "aptos-secure-storage",
+ "aptos-telemetry",
  "aptos-temppath",
  "aptos-time-service",
  "aptos-types",
@@ -718,6 +720,7 @@ dependencies = [
  "network",
  "network-builder",
  "rand 0.8.4",
+ "regex",
  "state-sync-multiplexer",
  "state-sync-v1",
  "storage-client",
@@ -935,6 +938,20 @@ dependencies = [
  "storage-interface",
  "structopt",
  "tempfile",
+]
+
+[[package]]
+name = "aptos-telemetry"
+version = "0.1.0"
+dependencies = [
+ "aptos-logger",
+ "aptos-metrics",
+ "aptos-workspace-hack",
+ "reqwest",
+ "serde 1.0.136",
+ "serde_json",
+ "sysinfo",
+ "uuid",
 ]
 
 [[package]]
@@ -1169,6 +1186,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "generic-array 0.14.5",
+ "getrandom 0.2.5",
  "hashbrown 0.11.2",
  "hyper",
  "include_dir 0.7.2",
@@ -8978,6 +8996,16 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.5",
+ "serde 1.0.136",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "crates/aptos-rate-limiter",
     "crates/aptos-rest-client",
     "crates/aptos-retrier",
+    "crates/aptos-telemetry",
     "crates/aptos-temppath",
     "crates/aptos-time-service",
     "crates/aptos-workspace-hack",

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -16,6 +16,7 @@ futures = "0.3.12"
 hex = "0.4.3"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 rand = "0.8.3"
+regex = "1.5.5"
 structopt = "0.3.21"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
@@ -30,6 +31,7 @@ aptos-logger = { path = "../crates/aptos-logger" }
 aptos-mempool = { path = "../mempool" }
 aptos-metrics = { path = "../crates/aptos-metrics" }
 aptos-secure-storage = { path = "../secure/storage" }
+aptos-telemetry = { path = "../crates/aptos-telemetry" }
 aptos-temppath = { path = "../crates/aptos-temppath" }
 aptos-time-service = { path = "../crates/aptos-time-service" }
 aptos-types = { path = "../types" }

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -13,7 +13,11 @@ use aptos_config::{
 use aptos_data_client::aptosnet::AptosNetDataClient;
 use aptos_infallible::RwLock;
 use aptos_logger::{prelude::*, Logger};
-use aptos_metrics::metric_server;
+use aptos_metrics::{get_public_json_metrics, get_public_metrics, metric_server};
+use aptos_telemetry::{
+    constants::{APTOS_NODE_PUSH_METRICS, CHAIN_ID_METRIC, PEER_ID_METRIC},
+    send_data,
+};
 use aptos_time_service::TimeService;
 use aptos_types::{
     account_config::aptos_root_address,
@@ -40,6 +44,7 @@ use futures::channel::mpsc::channel;
 use mempool_notifications::MempoolNotificationSender;
 use network::application::storage::PeerMetadataStorage;
 use network_builder::builder::NetworkBuilder;
+use regex::Regex;
 use state_sync_multiplexer::{
     state_sync_v1_network_config, StateSyncMultiplexer, StateSyncRuntimes,
 };
@@ -79,6 +84,7 @@ pub struct AptosHandle {
     _mempool: Runtime,
     _network_runtimes: Vec<Runtime>,
     _state_sync_runtimes: StateSyncRuntimes,
+    _telemetry_runtime: Runtime,
 }
 
 pub fn start(config: &NodeConfig, log_file: Option<PathBuf>) {
@@ -392,6 +398,46 @@ fn setup_state_sync_storage_service(
     storage_service_runtime
 }
 
+async fn periodic_telemetry_dump(node_config: NodeConfig, db: DbReaderWriter) {
+    use futures::stream::StreamExt;
+    let mut dump_interval =
+        IntervalStream::new(tokio::time::interval(std::time::Duration::from_secs(30))).fuse();
+
+    info!("periodic_telemetry_dump task started");
+
+    loop {
+        futures::select! {
+            _ = dump_interval.select_next_some() => {
+
+                // Build the params from internal prometheus metrics
+                let mut metrics_params: HashMap<String, String> = HashMap::new();
+
+                // Measurement Protocol params must be underscore or alphanumeric
+                // Prometheus metrics use {} to represent dimensions, so rename it
+                let met = get_public_metrics();
+                let re = Regex::new(r"[\{\}]").unwrap();
+                for (k, v) in &met {
+                    metrics_params.insert(re.replace_all(k, "_").to_string(), v.to_string());
+                }
+                let met = get_public_json_metrics();
+                for (k, v) in &met {
+                    metrics_params.insert(k.to_string(), v.to_string());
+                }
+
+                // get some data we do not currently have metrics for
+                let chain_id = fetch_chain_id(&db);
+                let peer_id = match node_config.peer_id() {
+                    Some(p) => p.to_string(),
+                    None => String::new()
+                };
+                metrics_params.insert(CHAIN_ID_METRIC.to_string(), chain_id.to_string());
+                metrics_params.insert(PEER_ID_METRIC.to_string(), peer_id.to_string());
+                send_data(APTOS_NODE_PUSH_METRICS.to_string(), peer_id.to_string(), metrics_params).await;
+            }
+        }
+    }
+}
+
 async fn periodic_state_dump(node_config: NodeConfig, db: DbReaderWriter) {
     use futures::stream::StreamExt;
 
@@ -675,7 +721,17 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     debug_if
         .runtime()
         .handle()
-        .spawn(periodic_state_dump(node_config.to_owned(), db_rw));
+        .spawn(periodic_state_dump(node_config.to_owned(), db_rw.clone()));
+
+    let telemery_runtime = Builder::new_multi_thread()
+        .thread_name("aptos-telemetry")
+        .enable_all()
+        .build()
+        .expect("Failed to create aptos telemetry runtime!");
+
+    telemery_runtime
+        .handle()
+        .spawn(periodic_telemetry_dump(node_config.to_owned(), db_rw));
 
     AptosHandle {
         _api: api_runtime,
@@ -685,5 +741,6 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
         _mempool: mempool,
         _network_runtimes: network_runtimes,
         _state_sync_runtimes: state_sync_runtimes,
+        _telemetry_runtime: telemery_runtime,
     }
 }

--- a/crates/aptos-metrics/src/metric_server.rs
+++ b/crates/aptos-metrics/src/metric_server.rs
@@ -10,7 +10,10 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server, StatusCode,
 };
-use prometheus::{proto::MetricFamily, Encoder, TextEncoder};
+use prometheus::{
+    proto::{MetricFamily, MetricType},
+    Encoder, TextEncoder,
+};
 use std::{
     collections::HashMap,
     net::{SocketAddr, ToSocketAddrs},
@@ -30,6 +33,64 @@ fn encode_metrics(encoder: impl Encoder, whitelist: &'static [&'static str]) -> 
         .with_label_values(&["total_bytes"])
         .inc_by(buffer.len() as u64);
     buffer
+}
+
+fn get_metrics(fams: Vec<MetricFamily>) -> HashMap<String, String> {
+    // TODO: use an existing metric encoder (same as used by
+    // prometheus/metric-server)
+    let mut all_metrics = HashMap::new();
+    for metric_family in fams {
+        let values: Vec<_> = match metric_family.get_field_type() {
+            MetricType::COUNTER => metric_family
+                .get_metric()
+                .iter()
+                .map(|m| m.get_counter().get_value().to_string())
+                .collect(),
+            MetricType::GAUGE => metric_family
+                .get_metric()
+                .iter()
+                .map(|m| m.get_gauge().get_value().to_string())
+                .collect(),
+            MetricType::SUMMARY => panic!("Unsupported Metric 'SUMMARY'"),
+            MetricType::UNTYPED => panic!("Unsupported Metric 'UNTYPED'"),
+            MetricType::HISTOGRAM => metric_family
+                .get_metric()
+                .iter()
+                .map(|m| m.get_histogram().get_sample_count().to_string())
+                .collect(),
+        };
+        let metric_names = metric_family.get_metric().iter().map(|m| {
+            let label_strings: Vec<String> = m
+                .get_label()
+                .iter()
+                .map(|l| format!("{}={}", l.get_name(), l.get_value()))
+                .collect();
+            let labels_string = format!("{{{}}}", label_strings.join(","));
+            format!("{}{}", metric_family.get_name(), labels_string)
+        });
+
+        for (name, value) in metric_names.zip(values.into_iter()) {
+            all_metrics.insert(name, value);
+        }
+    }
+
+    all_metrics
+}
+
+pub fn get_all_metrics() -> HashMap<String, String> {
+    let all_metric_families = gather_metrics();
+    get_metrics(all_metric_families)
+}
+
+pub fn get_public_metrics() -> HashMap<String, String> {
+    let mut metric_families = gather_metrics();
+    metric_families = whitelist_metrics(metric_families, PUBLIC_METRICS);
+    get_metrics(metric_families)
+}
+
+pub fn get_public_json_metrics() -> HashMap<&'static str, String> {
+    let jmet = get_json_metrics();
+    whitelist_json_metrics(jmet, PUBLIC_METRICS)
 }
 
 // filtering metrics from the prometheus collections

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "aptos-telemetry"
+version = "0.1.0"
+authors = ["Aptos Labs <opensource@aptoslabs.com>"]
+description = "Aptos telemetry utilities"
+repository = "https://github.com/aptos-labs/aptos-core"
+homepage = "https://aptoslabs.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+reqwest = { version = "0.11.2", features = ["json"] }
+serde = { version = "1.0.124", features = ["derive"], default-features = false }
+serde_json = "1.0.64"
+sysinfo = "0.23.5"
+uuid = { version = "0.8.2", features = ["v4", "serde"] }
+
+aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-metrics = { path = "../../crates/aptos-metrics" }
+aptos-workspace-hack = { version = "0.1", path = "../aptos-workspace-hack" }

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+/// A collection of constants and default values for configuring various telemetry components.
+
+// By default, send telemetry data to Aptos Labs
+// This will help with improving the Aptos ecosystem
+// This should rotate occasionally
+pub const APTOS_GA_MEASUREMENT_ID: &str = "G-ZX4L6WPCFZ";
+pub const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
+
+pub const HTTPBIN_URL: &str = "http://httpbin.org/ip";
+pub const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
+
+// Metrics events
+pub const APTOS_NODE_PUSH_METRICS: &str = "APTOS_NODE_PUSH_METRICS";
+
+// Metrics names
+pub const IP_ADDR_METRIC: &str = "IP_ADDRESS";
+pub const GIT_REV_METRIC: &str = "GIT_REV";
+pub const CHAIN_ID_METRIC: &str = "CHAIN_ID";
+pub const PEER_ID_METRIC: &str = "PEER_ID";

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+#![recursion_limit = "128"]
+
+pub mod constants;
+
+use aptos_logger::prelude::*;
+use aptos_metrics::json_metrics::get_git_rev;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    env,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use uuid::Uuid;
+
+pub const GA_MEASUREMENT_ID: &str = "GA_MEASUREMENT_ID";
+pub const GA_API_SECRET: &str = "GA_API_SECRET";
+pub const APTOS_TELEMETRY_OPTOUT: &str = "APTOS_TELEMETRY_OPTOUT";
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MetricsDump {
+    client_id: String,
+    user_id: String,
+    timestamp_micros: String,
+    events: Vec<MetricsEvent>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct MetricsEvent {
+    name: String,
+    params: HashMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct Ip {
+    origin: String,
+}
+
+pub fn is_optout() -> bool {
+    env::var(APTOS_TELEMETRY_OPTOUT).is_ok()
+}
+
+async fn get_ip_origin() -> String {
+    let resp = reqwest::get(constants::HTTPBIN_URL).await;
+    match resp {
+        Ok(json) => match json.json::<Ip>().await {
+            Ok(ip) => ip.origin,
+            Err(_) => String::new(),
+        },
+        Err(_) => String::new(),
+    }
+}
+
+pub async fn send_data(event_name: String, user_id: String, event_params: HashMap<String, String>) {
+    if is_optout() {
+        debug!("Error sending data: optout of Aptos telemetry");
+        return;
+    }
+
+    // parse environment variables
+    let api_secret = env::var(GA_API_SECRET).unwrap_or(constants::APTOS_GA_API_SECRET.to_string());
+    let measurement_id =
+        env::var(GA_MEASUREMENT_ID).unwrap_or(constants::APTOS_GA_MEASUREMENT_ID.to_string());
+
+    // dump event params in a new hashmap with some default params to include
+    let mut new_event_params: HashMap<String, String> = event_params.clone();
+    // attempt to get IP address
+    let ip_origin = get_ip_origin().await;
+    new_event_params.insert(constants::IP_ADDR_METRIC.to_string(), ip_origin);
+    new_event_params.insert(constants::GIT_REV_METRIC.to_string(), get_git_rev());
+
+    let metrics_event = MetricsEvent {
+        name: event_name,
+        params: new_event_params,
+    };
+
+    let metrics_dump = MetricsDump {
+        client_id: Uuid::new_v4().to_string(),
+        user_id,
+        timestamp_micros: match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(n) => n.as_micros().to_string(),
+            Err(_) => String::new(),
+        },
+        events: vec![metrics_event],
+    };
+
+    let client = reqwest::Client::new();
+    let res = client
+        .post(format!(
+            "{}?&measurement_id={}&api_secret={}",
+            constants::GA4_URL,
+            measurement_id,
+            api_secret
+        ))
+        .json::<MetricsDump>(&metrics_dump)
+        .send()
+        .await;
+    match res {
+        Ok(_) => debug!("Sent telemetry data {:?}", &metrics_dump),
+        Err(e) => debug!("{:?}", e),
+    }
+}

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -18,7 +18,7 @@ use uuid::Uuid;
 
 pub const GA_MEASUREMENT_ID: &str = "GA_MEASUREMENT_ID";
 pub const GA_API_SECRET: &str = "GA_API_SECRET";
-pub const APTOS_TELEMETRY_OPTOUT: &str = "APTOS_TELEMETRY_OPTOUT";
+pub const APTOS_TELEMETRY_DISABLE: &str = "APTOS_TELEMETRY_DISABLE";
 
 #[derive(Debug, Serialize, Deserialize)]
 struct MetricsDump {
@@ -39,8 +39,8 @@ struct Ip {
     origin: String,
 }
 
-pub fn is_optout() -> bool {
-    env::var(APTOS_TELEMETRY_OPTOUT).is_ok()
+pub fn is_disable() -> bool {
+    env::var(APTOS_TELEMETRY_DISABLE).is_ok()
 }
 
 async fn get_ip_origin() -> String {
@@ -55,15 +55,15 @@ async fn get_ip_origin() -> String {
 }
 
 pub async fn send_data(event_name: String, user_id: String, event_params: HashMap<String, String>) {
-    if is_optout() {
-        debug!("Error sending data: optout of Aptos telemetry");
+    if is_disable() {
+        debug!("Error sending data: disabled Aptos telemetry");
         return;
     }
 
     // parse environment variables
-    let api_secret = env::var(GA_API_SECRET).unwrap_or(constants::APTOS_GA_API_SECRET.to_string());
+    let api_secret = env::var(GA_API_SECRET).unwrap_or_else(|_| constants::APTOS_GA_API_SECRET.to_string());
     let measurement_id =
-        env::var(GA_MEASUREMENT_ID).unwrap_or(constants::APTOS_GA_MEASUREMENT_ID.to_string());
+        env::var(GA_MEASUREMENT_ID).unwrap_or_else(|_| constants::APTOS_GA_MEASUREMENT_ID.to_string());
 
     // dump event params in a new hashmap with some default params to include
     let mut new_event_params: HashMap<String, String> = event_params.clone();

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -29,6 +29,7 @@ futures-io = { version = "0.3.21", features = ["std"] }
 futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.17", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
+getrandom = { version = "0.2.5", default-features = false, features = ["std"] }
 hyper = { version = "0.14.17", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
@@ -77,6 +78,7 @@ futures-io = { version = "0.3.21", features = ["std"] }
 futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.17", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
+getrandom = { version = "0.2.5", default-features = false, features = ["std"] }
 hyper = { version = "0.14.17", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -29,6 +29,7 @@ url = "2.2.2"
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
 aptos-secure-storage = { path = "../../secure/storage" }
+aptos-telemetry = { path = "../aptos-telemetry" }
 aptos-temppath = { path = "../aptos-temppath" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { version = "0.1", path = "../aptos-workspace-hack" }

--- a/developer-docs-site/docs/reference/telemetry.md
+++ b/developer-docs-site/docs/reference/telemetry.md
@@ -1,0 +1,34 @@
+---
+title: "Telemetry"
+slug: "telemetry"
+---
+
+At Aptos Labs, we develop software and services for the greater Aptos community and ecosystem. On top of community feedback, we use telemetry to help improve the decentralization of the network by understanding how our software is being deployed and run.
+
+The Aptos node binary collects telemetry such as software version, operating system information, and IP address. See [Types of information collected](#types-of-information-collected).
+
+The Aptos node binary does **not** collect personal information such as usernames or email addresses.
+
+Users can disable telemetry at any point. If telemetry remains enabled, Aptos node binary will send telemetry data in the background.
+
+# Disabling telemetry
+
+On macOs and Linux, you can disable telemetry by setting the `APTOS_TELEMETRY_DISABLE` environment variable to any value.
+
+```
+export APTOS_TELEMETRY_DISABLE=true
+```
+
+The above example only disables telemetry for a single session or terminal. To disable it everywhere, you must do so at shell startup.
+
+```
+echo "export APTOS_TELEMETRY_DISABLE=true" >> ~/.profile
+source ~/.profile
+```
+
+# Types of information collected
+
+* **Usage information** - Commands and subcommands that are run
+* **System information** - Operating system (Windows, Linux, macOS) and kernel information, CPU and memory utilization
+* **Software information** - Version of the Aptos node binary
+* **Node information** - Public IP address, number of inbound and outbound Aptos node connections

--- a/documentation/telemetry.md
+++ b/documentation/telemetry.md
@@ -1,0 +1,1 @@
+../developer-docs-site/docs/reference/telemetry.md


### PR DESCRIPTION
Write a new crate `aptos-telemetry` that sends basic telemetry data to help better understand the ecosystem. Currently uses the Google Analytics 4 (GA4) [Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4). Currently, we're using the `event` and `event_params` keys to get metrics from:
* public metrics from `aptos-node`. This will get us OS info, system utilization (CPU, RAM) every 30s
* rough sketch for how we can use it in `aptos` CLI.

Each push to GA4 will come with geolocation data (IPv4) which we'll use to understand geographic distribution of nodes in the ecosystem, as well as the Git revision the binary is running. Anyone can opt out of telemetry by setting `APTOS_TELEMETRY_OPTOUT`.

We could potentially massage this into `aptos-logger`, but this should be good for now.