### PR TITLE
[State Sync] Support proof verification and add tests for validator bootstrapping.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -3,14 +3,16 @@
 
 use crate::{
     error::Error,
-    notification_handlers::{CommitNotification, ErrorNotification},
+    notification_handlers::{CommitNotification, CommittedTransactions, ErrorNotification},
 };
 use aptos_config::config::StateSyncDriverConfig;
 use aptos_logger::prelude::*;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValueChunkWithProof,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof},
+    transaction::{
+        Transaction, TransactionListWithProof, TransactionOutput, TransactionOutputListWithProof,
+    },
 };
 use data_streaming_service::data_notification::NotificationId;
 use executor_types::ChunkExecutorTrait;
@@ -441,10 +443,13 @@ fn spawn_state_snapshot_receiver<ChunkExecutor: ChunkExecutorTrait + 'static>(
         loop {
             ::futures::select! {
                 storage_data_chunk = state_snapshot_listener.select_next_some() => {
-                    // Commit the account states chunk
+                    // We've received an account states chunk
+                    decrement_atomic(pending_transaction_chunks.clone());
+
+                    // Process the chunk
                     match storage_data_chunk {
                         StorageDataChunk::Accounts(notification_id, account_states_with_proof) => {
-                            let all_accounts_synced = account_states_with_proof.proof.right_siblings().is_empty();
+                            let all_accounts_synced = account_states_with_proof.is_last_chunk();
                             let last_committed_account_index = account_states_with_proof.last_index;
 
                             // Attempt to the commit the chunk
@@ -454,40 +459,63 @@ fn spawn_state_snapshot_receiver<ChunkExecutor: ChunkExecutorTrait + 'static>(
                             );
                             match commit_result {
                                 Ok(()) => {
-                                    // Send a commit notification to the commit listener
-                                    let commit_notification = CommitNotification::new_committed_accounts(all_accounts_synced, last_committed_account_index);
-                                    if let Err(error) = commit_notification_sender.send(commit_notification).await {
-                                        let error = format!("Failed to send account commit notification! Error: {:?}", error);
-                                        send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
-                                    } else if all_accounts_synced {
-                                        // We're done synchronizing account states. Finalize storage and reset the executor.
-                                        let finalized_result = if let Err(error) = state_snapshot_receiver.finish_box() {
-                                            Err(format!("Failed to finish the account states synchronization! Error: {:?}", error))
-                                        } else if let Err(error) = storage.finalize_state_snapshot(version, target_output_with_proof) {
-                                            Err(format!("Failed to finalize the state snapshot! Error: {:?}", error))
-                                        } else if let Err(error) = storage.save_ledger_infos(&epoch_change_proofs) {
-                                            Err(format!("Failed to save all epoch ending ledger infos! Error: {:?}", error))
-                                        } else if let Err(error) = chunk_executor.reset() { // Reset the chunk executor (to read the latest db state)
-                                            Err(format!("Failed to reset the chunk executor after account states synchronization! Error: {:?}", error))
-                                        } else {
-                                            Ok(())
-                                        };
-
-                                        // Notify the state sync driver of any errors
-                                        if let Err(error) = finalized_result {
+                                    if !all_accounts_synced {
+                                        // Send a commit notification to the  listener
+                                        let commit_notification = CommitNotification::new_committed_accounts(all_accounts_synced, last_committed_account_index, None);
+                                        if let Err(error) = commit_notification_sender.send(commit_notification).await {
+                                            let error = format!("Failed to send account commit notification! Error: {:?}", error);
                                             send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
                                         }
 
-                                        decrement_atomic(pending_transaction_chunks.clone());
-                                        return;
+                                        continue; // Wait for the next chunk
                                     }
+
+                                    // All accounts have been synced! Finalize storage, reset
+                                    // the executor and send a commit notification to the listener.
+                                    let (transactions, outputs): (Vec<Transaction>, Vec<TransactionOutput>) =
+                                            target_output_with_proof
+                                                .transactions_and_outputs
+                                                .clone()
+                                                .into_iter()
+                                                .unzip();
+                                        let events = outputs
+                                            .into_iter()
+                                            .map(|output| output.events().to_vec())
+                                            .flatten()
+                                            .collect::<Vec<_>>();
+                                    let committed_transaction = CommittedTransactions {
+                                            events,
+                                            transactions,
+                                        };
+
+                                    let commit_notification = CommitNotification::new_committed_accounts(all_accounts_synced, last_committed_account_index, Some(committed_transaction));
+                                    let finalized_result = if let Err(error) = state_snapshot_receiver.finish_box() {
+                                        Err(format!("Failed to finish the account states synchronization! Error: {:?}", error))
+                                    } else if let Err(error) = storage.finalize_state_snapshot(version, target_output_with_proof) {
+                                        Err(format!("Failed to finalize the state snapshot! Error: {:?}", error))
+                                    } else if let Err(error) = storage.save_ledger_infos(&epoch_change_proofs) {
+                                        Err(format!("Failed to save all epoch ending ledger infos! Error: {:?}", error))
+                                    } else if let Err(error) = chunk_executor.reset() {
+                                        Err(format!("Failed to reset the chunk executor after account states synchronization! Error: {:?}", error))
+                                    } else if let Err(error) = commit_notification_sender.send(commit_notification).await {
+                                       Err(format!("Failed to send the final account commit notification! Error: {:?}", error))
+                                    } else {
+                                        Ok(())
+                                    };
+
+                                    // Notify the state sync driver of any errors
+                                    if let Err(error) = finalized_result {
+                                      send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
+                                    }
+
+                                    // There's nothing left to do!
+                                    return;
                                 },
                                 Err(error) => {
                                     let error = format!("Failed to commit account states chunk! Error: {:?}", error);
                                     send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
                                 }
                             }
-                            decrement_atomic(pending_transaction_chunks.clone());
                         },
                         storage_data_chunk => {
                             panic!("Invalid storage data chunk sent to state snapshot receiver: {:?}", storage_data_chunk);

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -15,7 +15,7 @@ use aptos_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
     proof::{definition::LeafCount, position::FrozenSubTreeIterator},
-    transaction::{Transaction, TransactionInfo, Version},
+    transaction::{Transaction, TransactionInfo, TransactionOutput, Version},
 };
 use schemadb::DB;
 use std::sync::Arc;
@@ -97,5 +97,18 @@ pub fn save_transactions(
     ledger_store.put_transaction_infos(first_version, txn_infos, &mut cs)?;
     event_store.put_events_multiple_versions(first_version, events, &mut cs)?;
 
+    db.write_schemas(cs.batch)
+}
+
+pub fn save_transaction_outputs(
+    db: Arc<DB>,
+    transaction_store: Arc<TransactionStore>,
+    first_version: Version,
+    transaction_outputs: Vec<TransactionOutput>,
+) -> Result<()> {
+    let mut cs = ChangeSet::new();
+    for output in transaction_outputs {
+        transaction_store.put_write_set(first_version, output.write_set(), &mut cs)?;
+    }
     db.write_schemas(cs.batch)
 }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1384,13 +1384,14 @@ impl DbWriter for AptosDB {
                 frozen_subtrees,
             )?;
 
-            // Insert the target transactions, infos and events into the database
+            // Insert the target transactions, outputs, infos and events into the database
             let (transactions, outputs): (Vec<Transaction>, Vec<TransactionOutput>) =
                 output_with_proof
                     .transactions_and_outputs
                     .into_iter()
                     .unzip();
             let events = outputs
+                .clone()
                 .into_iter()
                 .map(|output| output.events().to_vec())
                 .collect::<Vec<_>>();
@@ -1404,6 +1405,12 @@ impl DbWriter for AptosDB {
                 &transactions,
                 &transaction_infos,
                 &events,
+            )?;
+            restore_utils::save_transaction_outputs(
+                self.db.clone(),
+                self.transaction_store.clone(),
+                version,
+                outputs,
             )
         })
     }

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use aptos_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
 use aptos_rest_client::Client as RestClient;
-use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
-use aptos_types::PeerId;
+use aptos_sdk::types::LocalAccount;
+use aptos_types::{account_address::AccountAddress, PeerId};
 use forge::{LocalSwarm, NodeExt, Swarm, SwarmExt};
 use std::{
     fs,
@@ -136,7 +136,6 @@ async fn test_full_node_continuous_sync_transactions() {
 
 /// Creates a new full node using the given config and swarm
 async fn create_full_node(full_node_config: NodeConfig, swarm: &mut LocalSwarm) -> PeerId {
-    // Create the fullnode
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
     let vfn_peer_id = swarm
         .add_validator_fullnode(
@@ -164,14 +163,10 @@ async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_c
     // Execute a number of transactions on the validator
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
     let validator_client = swarm.validator(validator_peer_id).unwrap().rest_client();
-    let transaction_factory = swarm.chain_info().transaction_factory();
-
-    let mut account_0 = create_and_fund_account(&mut swarm, 1000).await;
-    let mut account_1 = create_and_fund_account(&mut swarm, 1000).await;
+    let (mut account_0, mut account_1) = create_test_accounts(&mut swarm).await;
     execute_transactions(
         &mut swarm,
         &validator_client,
-        &transaction_factory,
         &mut account_0,
         &account_1,
         epoch_changes,
@@ -185,25 +180,17 @@ async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_c
         .restart()
         .await
         .unwrap();
-    swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
-        .await
-        .unwrap();
+    wait_for_all_nodes(&mut swarm).await;
 
     // Execute more transactions on the validator and verify the fullnode catches up
-    execute_transactions(
+    execute_transactions_and_wait(
         &mut swarm,
         &validator_client,
-        &transaction_factory,
         &mut account_1,
         &account_0,
         epoch_changes,
     )
     .await;
-    swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
-        .await
-        .unwrap();
 }
 
 #[tokio::test]
@@ -256,36 +243,24 @@ async fn test_validator_sync(mut swarm: LocalSwarm) {
         .validator(validator_peer_ids[0])
         .unwrap()
         .rest_client();
-    let transaction_factory = swarm.chain_info().transaction_factory();
-    let mut account_0 = create_and_fund_account(&mut swarm, 1000).await;
-    let mut account_1 = create_and_fund_account(&mut swarm, 1000).await;
-    execute_transactions(
+    let (mut account_0, mut account_1) = create_test_accounts(&mut swarm).await;
+    execute_transactions_and_wait(
         &mut swarm,
         &validator_client_0,
-        &transaction_factory,
         &mut account_0,
         &account_1,
         true,
     )
     .await;
-    swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
-        .await
-        .unwrap();
 
     // Stop validator 1 and delete the storage
     let validator_1 = validator_peer_ids[1];
-    swarm.validator_mut(validator_1).unwrap().stop();
-    let node_config = swarm.validator_mut(validator_1).unwrap().config().clone();
-    let state_db_path = node_config.storage.dir().join("aptosdb");
-    assert!(state_db_path.as_path().exists());
-    fs::remove_dir_all(state_db_path).unwrap();
+    stop_validator_and_delete_storage(&mut swarm, validator_1);
 
     // Execute more transactions
     execute_transactions(
         &mut swarm,
         &validator_client_0,
-        &transaction_factory,
         &mut account_1,
         &account_0,
         true,
@@ -294,25 +269,116 @@ async fn test_validator_sync(mut swarm: LocalSwarm) {
 
     // Restart validator 1 and wait for all nodes to catchup
     swarm.validator_mut(validator_1).unwrap().start().unwrap();
-    swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
-        .await
-        .unwrap();
+    wait_for_all_nodes(&mut swarm).await;
 
     // Execute multiple transactions and verify validator 1 can sync
-    execute_transactions(
+    execute_transactions_and_wait(
         &mut swarm,
         &validator_client_0,
-        &transaction_factory,
         &mut account_0,
         &account_1,
         true,
     )
     .await;
-    swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
-        .await
-        .unwrap();
+}
+
+#[tokio::test]
+async fn test_validator_failure_bootstrap_outputs() {
+    // Create a swarm of 4 validators with state sync v2 enabled (account
+    // bootstrapping and transaction output application).
+    let mut swarm = new_local_swarm_with_aptos(4).await;
+    for validator in swarm.validators_mut() {
+        let mut config = validator.config().clone();
+        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+        config.state_sync.state_sync_driver.bootstrapping_mode =
+            BootstrappingMode::DownloadLatestAccountStates;
+        config.state_sync.state_sync_driver.continuous_syncing_mode =
+            ContinuousSyncingMode::ApplyTransactionOutputs;
+        config.save(validator.config_path()).unwrap();
+        validator.restart().await.unwrap();
+    }
+
+    // Test the ability of the validators to sync
+    test_all_validator_failures(swarm).await;
+}
+
+#[tokio::test]
+async fn test_validator_failure_bootstrap_execution() {
+    // Create a swarm of 4 validators with state sync v2 enabled (account
+    // bootstrapping and transaction execution).
+    let mut swarm = new_local_swarm_with_aptos(4).await;
+    for validator in swarm.validators_mut() {
+        let mut config = validator.config().clone();
+        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+        config.state_sync.state_sync_driver.bootstrapping_mode =
+            BootstrappingMode::DownloadLatestAccountStates;
+        config.state_sync.state_sync_driver.continuous_syncing_mode =
+            ContinuousSyncingMode::ExecuteTransactions;
+        config.save(validator.config_path()).unwrap();
+        validator.restart().await.unwrap();
+    }
+
+    // Test the ability of the validators to sync
+    test_all_validator_failures(swarm).await;
+}
+
+/// A helper method that tests that all validators can sync after a failure and
+/// continue to stay up-to-date.
+async fn test_all_validator_failures(mut swarm: LocalSwarm) {
+    // Launch the swarm and wait for it to be ready
+    swarm.launch().await.unwrap();
+
+    // Execute multiple transactions through validator 0
+    let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+    let validator_0 = validator_peer_ids[0];
+    let validator_client_0 = swarm.validator(validator_0).unwrap().rest_client();
+    let (mut account_0, mut account_1) = create_test_accounts(&mut swarm).await;
+    execute_transactions_and_wait(
+        &mut swarm,
+        &validator_client_0,
+        &mut account_0,
+        &account_1,
+        true,
+    )
+    .await;
+
+    // Go through each validator, stop the node, delete the storage and wait for it to come back
+    for validator in validator_peer_ids.clone() {
+        stop_validator_and_delete_storage(&mut swarm, validator);
+        swarm.validator_mut(validator).unwrap().start().unwrap();
+        wait_for_all_nodes(&mut swarm).await;
+    }
+
+    // Execute multiple transactions (no epoch changes) and verify validator 0 can sync
+    execute_transactions_and_wait(
+        &mut swarm,
+        &validator_client_0,
+        &mut account_1,
+        &account_0,
+        false,
+    )
+    .await;
+
+    // Go through each validator, stop the node, delete the storage and wait for it to come back
+    for validator in validator_peer_ids.clone() {
+        stop_validator_and_delete_storage(&mut swarm, validator);
+        swarm.validator_mut(validator).unwrap().start().unwrap();
+        wait_for_all_nodes(&mut swarm).await;
+    }
+
+    // Execute multiple transactions (with epoch changes) and verify validator 0 can sync
+    let validator_client_1 = swarm
+        .validator(validator_peer_ids[0])
+        .unwrap()
+        .rest_client();
+    execute_transactions_and_wait(
+        &mut swarm,
+        &validator_client_1,
+        &mut account_1,
+        &account_0,
+        true,
+    )
+    .await;
 }
 
 #[tokio::test]
@@ -332,13 +398,10 @@ async fn test_single_validator_failure() {
     // Execute multiple transactions
     let validator = swarm.validators_mut().next().unwrap();
     let validator_client = validator.rest_client();
-    let transaction_factory = swarm.chain_info().transaction_factory();
-    let mut account_0 = create_and_fund_account(&mut swarm, 1000).await;
-    let mut account_1 = create_and_fund_account(&mut swarm, 1000).await;
+    let (mut account_0, mut account_1) = create_test_accounts(&mut swarm).await;
     execute_transactions(
         &mut swarm,
         &validator_client,
-        &transaction_factory,
         &mut account_0,
         &account_1,
         true,
@@ -354,7 +417,6 @@ async fn test_single_validator_failure() {
     execute_transactions(
         &mut swarm,
         &validator_client,
-        &transaction_factory,
         &mut account_1,
         &account_0,
         true,
@@ -368,16 +430,17 @@ async fn test_single_validator_failure() {
 async fn execute_transactions(
     swarm: &mut LocalSwarm,
     client: &RestClient,
-    transaction_factory: &TransactionFactory,
     sender: &mut LocalAccount,
     receiver: &LocalAccount,
     execute_epoch_changes: bool,
 ) {
     let num_transfers = 10;
+
+    let transaction_factory = swarm.chain_info().transaction_factory();
     if execute_epoch_changes {
         transfer_and_reconfig(
             client,
-            transaction_factory,
+            &transaction_factory,
             swarm.chain_info().root_account,
             sender,
             receiver,
@@ -387,7 +450,47 @@ async fn execute_transactions(
     } else {
         for _ in 0..num_transfers {
             // Execute simple transfer transactions
-            transfer_coins(client, transaction_factory, sender, receiver, 1).await;
+            transfer_coins(client, &transaction_factory, sender, receiver, 1).await;
         }
     }
+}
+
+/// Executes transactions and waits for all nodes to catch up
+async fn execute_transactions_and_wait(
+    swarm: &mut LocalSwarm,
+    client: &RestClient,
+    sender: &mut LocalAccount,
+    receiver: &LocalAccount,
+    epoch_changes: bool,
+) {
+    execute_transactions(swarm, client, sender, receiver, epoch_changes).await;
+    wait_for_all_nodes(swarm).await;
+}
+
+/// Waits for all nodes to catch up
+async fn wait_for_all_nodes(swarm: &mut LocalSwarm) {
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .await
+        .unwrap();
+}
+
+/// Creates and funds two test accounts
+async fn create_test_accounts(swarm: &mut LocalSwarm) -> (LocalAccount, LocalAccount) {
+    let token_amount = 1000;
+    let account_0 = create_and_fund_account(swarm, token_amount).await;
+    let account_1 = create_and_fund_account(swarm, token_amount).await;
+    (account_0, account_1)
+}
+
+/// Stops the specified validator and deletes storage
+fn stop_validator_and_delete_storage(swarm: &mut LocalSwarm, validator: AccountAddress) {
+    // Stop the validator
+    swarm.validator_mut(validator).unwrap().stop();
+
+    // Delete the validator storage
+    let node_config = swarm.validator_mut(validator).unwrap().config().clone();
+    let state_db_path = node_config.storage.dir().join("aptosdb");
+    assert!(state_db_path.as_path().exists());
+    fs::remove_dir_all(state_db_path).unwrap();
 }

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use anyhow::ensure;
 use aptos_crypto::{
-    hash::{CryptoHash, CryptoHasher},
+    hash::{CryptoHash, CryptoHasher, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
 use aptos_crypto_derive::CryptoHasher;
@@ -81,6 +81,17 @@ pub struct StateValueChunkWithProof {
     pub raw_values: Vec<(HashValue, StateValue)>, // The account blobs in the chunk
     pub proof: SparseMerkleRangeProof, // The proof to ensure the chunk is in the account states
     pub root_hash: HashValue,          // The root hash of the sparse merkle tree for this chunk
+}
+
+impl StateValueChunkWithProof {
+    /// Returns true iff this chunk is the last chunk (i.e., there are no
+    /// more state values to write to storage after this chunk).
+    pub fn is_last_chunk(&self) -> bool {
+        let right_siblings = self.proof.right_siblings();
+        right_siblings
+            .iter()
+            .all(|sibling| *sibling == *SPARSE_MERKLE_PLACEHOLDER_HASH)
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Motivation

This PR makes several improvements to state sync, including proof verification for account state bootstrapping and adding smoke tests.

The PR offers the following commits:
1. Add two new smoke tests to ensure that validators can fail and recover by downloading all account states. As part of this commit, we also clean up some code duplication. Note: the smoke tests currently fail.
2. Update the state sync driver to: (i) implement final proof verification for account state bootstrapping; (ii) notify the event subscription service once a node has completed downloading all account states; and (iii) save the transaction outputs to storage when finalizing the state snapshot receiver (i.e., finalizing an account state snapshot). After this commit, the smoke tests added in (1) now pass!
3. Reduce the debug log frequency of the data streaming service through sampling. This is to avoid log spamming.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The new (and existing) smoke tests cover this functionality.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245