### PR TITLE
[State Sync] Add fallback for blocked data streams.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -138,6 +138,20 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
         Ok(())
     }
 
+    /// Attempts to fetch a data notification from the active stream
+    async fn fetch_next_data_notification(&mut self) -> Result<DataNotification, Error> {
+        let max_stream_wait_time_ms = self.driver_configuration.config.max_stream_wait_time_ms;
+        let result =
+            utils::get_data_notification(max_stream_wait_time_ms, self.active_data_stream.as_mut())
+                .await;
+        if matches!(result, Err(Error::CriticalDataStreamTimeout(_))) {
+            // If the stream has timed out too many times, we need to reset it
+            warn!("Resetting the currently active data stream due to too many timeouts!");
+            self.reset_active_stream();
+        }
+        result
+    }
+
     /// Processes any notifications already pending on the active stream
     async fn process_active_stream_notifications(
         &mut self,
@@ -145,12 +159,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
     ) -> Result<(), Error> {
         loop {
             // Fetch and process any data notifications
-            let max_stream_wait_time_ms = self.driver_configuration.config.max_stream_wait_time_ms;
-            let data_notification = utils::get_data_notification(
-                max_stream_wait_time_ms,
-                self.active_data_stream.as_mut(),
-            )
-            .await?;
+            let data_notification = self.fetch_next_data_notification().await?;
             match data_notification.data_payload {
                 DataPayload::ContinuousTransactionOutputsWithProof(
                     ledger_info_with_sigs,

--- a/state-sync/state-sync-v2/state-sync-driver/src/error.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     BootstrapNotComplete(String),
     #[error("Failed to send callback: {0}")]
     CallbackSendFailed(String),
+    #[error("Timed-out waiting for a data stream too many times.")]
+    CriticalDataStreamTimeout(String),
     #[error("Timed-out waiting for a notification from the data stream. Timeout: {0}")]
     DataStreamNotificationTimeout(String),
     #[error("Error encountered in the event subscription service: {0}")]

--- a/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
@@ -20,6 +20,9 @@ use std::{sync::Arc, time::Duration};
 use storage_interface::{DbReader, StartupInfo};
 use tokio::time::timeout;
 
+// TODO(joshlind): make this configurable!
+pub const PENDING_DATA_LOG_FREQ_SECS: u64 = 3;
+
 /// The speculative state that tracks a data stream of transactions or outputs.
 /// This assumes all data is valid and allows the driver to speculatively verify
 /// payloads flowing along the stream without having to block on the executor or


### PR DESCRIPTION
## Motivation

This PR updates state sync to provide a fallback mechanism to handle blocked data streams (e.g., due to malicious peer responses). If we time out waiting for a data stream enough times, state sync will automatically clear the stream and request a new one.

The PR offers the following commits:
1. Add logs to show when state sync is blocked waiting for the state synchronizer.
2. Update state sync to provide a fallback mechanism for blocked data streams. Here, we: (i) reset the active data stream if it times out enough times; and (ii) update the data stream logic to avoid sending notifications along a data stream if the receiving end has been dropped.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A new unit test has been added to cover some of this functionality. The rest of the functionality will be tested when I add the new test harness.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245