### PR TITLE
[docs] fix formatting on run-a-local-testnet.md

### DIFF
--- a/developer-docs-site/docs/tutorials/run-a-local-testnet.md
+++ b/developer-docs-site/docs/tutorials/run-a-local-testnet.md
@@ -39,7 +39,8 @@ Note: this command runs `aptos-node` from a genesis-only ledger state. If you wa
 
 1. Start your local validator network
 2. Copy the *Aptos root key path* and use it to replace the `mint-key-file-path` below 
-3. Run the following command to start a Faucet: ```
+3. Run the following command to start a Faucet:
+```
    cargo run --package aptos-faucet -- \
       --chain-id TESTING \
       --mint-key-file-path "/tmp/694173aa3bbe019499bbd5cf3fe0e2fc/mint.key" \


### PR DESCRIPTION
formatting fix. website looks like this currently: 
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/12578616/161606042-2f26a558-1ebd-4dbf-9f65-b22546a316ca.png">
