### PR TITLE
Added the GCP values for the logging_service and monitoring_service i…

### DIFF
--- a/terraform/fullnode/gcp/cluster.tf
+++ b/terraform/fullnode/gcp/cluster.tf
@@ -6,8 +6,8 @@ resource "google_container_cluster" "aptos" {
 
   remove_default_node_pool = true
   initial_node_count       = 1
-  logging_service          = "none"
-  monitoring_service       = "none"
+  logging_service          = "logging.googleapis.com/kubernetes"
+  monitoring_service       = "monitoring.googleapis.com/kubernetes"
 
   release_channel {
     channel = "REGULAR"


### PR DESCRIPTION
…n cluster.tf

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The changes allow the K8S GKE cluster to capture logs and metrics as part of the Cloud Logging and Cloud Monitoring services.  

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
As part of the testing, you will see logs shown under the "Logs" tab of the aptos fullnode pod in the "Workloads" tab of the GKE cluster

## Related PRs

No related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 These changes will not break anything
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 
 * Why we must have it for the release.
 It will be easier for the operations person to see the logging and metrics of the cluster and pod in the Cloud console.

 * What workarounds and alternative we have if we do not push the PR.
 The operations person will not be able see the information through the console.  They would need to access the logs from the pod directly.
