### PR TITLE
[State Sync] Limit the chunk sizes recommended by the Aptos Data Client

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -116,12 +116,12 @@ pub struct StorageServiceConfig {
 impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
-            max_account_states_chunk_sizes: 3000,
+            max_account_states_chunk_sizes: 1000,
             max_concurrent_requests: 1000,
             max_epoch_chunk_size: 100,
             max_network_channel_size: 1000,
-            max_transaction_chunk_size: 3000,
-            max_transaction_output_chunk_size: 3000,
+            max_transaction_chunk_size: 1000,
+            max_transaction_output_chunk_size: 1000,
             storage_summary_refresh_interval_ms: 1000,
         }
     }
@@ -157,7 +157,7 @@ impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
             global_summary_refresh_interval_ms: 300,
-            max_concurrent_requests: 5,
+            max_concurrent_requests: 3,
             max_data_stream_channel_sizes: 1000,
             max_request_retry: 5,
             max_notification_id_mappings: 2000,
@@ -176,8 +176,8 @@ pub struct AptosDataClientConfig {
 impl Default for AptosDataClientConfig {
     fn default() -> Self {
         Self {
-            response_timeout_ms: 10_000,
-            summary_poll_interval_ms: 1_000,
+            response_timeout_ms: 10000,
+            summary_poll_interval_ms: 1000,
         }
     }
 }

--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -46,8 +46,8 @@ mod state;
 mod tests;
 
 // Useful constants for the Aptos Data Client
-const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 5;
-const POLLER_ERROR_LOG_FREQ_SECS: u64 = 1;
+const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 3;
+const POLLER_ERROR_LOG_FREQ_SECS: u64 = 3;
 
 /// An [`AptosDataClient`] that fulfills requests from remote peers' Storage Service
 /// over AptosNet.
@@ -115,7 +115,7 @@ impl AptosNetDataClient {
 
     /// Recompute and update the global data summary cache.
     fn update_global_summary_cache(&self) {
-        let aggregate = self.peer_states.read().aggregate_summary();
+        let aggregate = self.peer_states.read().calculate_aggregate_summary();
         *self.global_summary_cache.write() = aggregate;
     }
 

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
@@ -21,8 +21,8 @@ use tokio::time::interval;
 use tokio_stream::wrappers::IntervalStream;
 
 // Useful constants for the Data Streaming Service
-const GLOBAL_DATA_REFRESH_LOG_FREQ_SECS: u64 = 1;
-const NO_DATA_TO_FETCH_LOG_FREQ_SECS: u64 = 5;
+const GLOBAL_DATA_REFRESH_LOG_FREQ_SECS: u64 = 3;
+const NO_DATA_TO_FETCH_LOG_FREQ_SECS: u64 = 3;
 
 /// The data streaming service that responds to data stream requests.
 pub struct DataStreamingService<T> {


### PR DESCRIPTION
## Motivation

This PR updates the Aptos Data Client to cap the recommended optimal chunk sizes by the max chunk sizes specified in the storage service config. This allows the client to control how much data they're pulling per request. The PR also updates some of the config values in state sync (to make it more friendly to the decentralized setting).

The PR offers the following commits:
1. Limit the chunk sizes according to the configs and add a unit test.
2. Small tweaks to default config values.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The newly added unit test verifies the behaviour.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245