### PR TITLE
[State Sync] Add storage functionality for genesis deletion.

### DIFF
--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod event_store;
 mod ledger_store;
 pub(crate) mod state_store;
 pub(crate) mod transaction_store;
+pub mod utils;
 pub(crate) mod worker;
 
 use crate::metrics::APTOS_STORAGE_PRUNE_WINDOW;

--- a/storage/aptosdb/src/pruner/utils.rs
+++ b/storage/aptosdb/src/pruner/utils.rs
@@ -1,0 +1,52 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module provides common utilities for the DB pruner.
+
+use crate::{
+    pruner::{
+        db_pruner::DBPruner,
+        event_store::event_store_pruner::EventStorePruner,
+        ledger_store::ledger_store_pruner::LedgerStorePruner,
+        state_store::StateStorePruner,
+        transaction_store::{
+            transaction_store_pruner::TransactionStorePruner, write_set_pruner::WriteSetPruner,
+        },
+    },
+    EventStore, LedgerStore, TransactionStore,
+};
+use aptos_infallible::Mutex;
+use schemadb::DB;
+use std::{sync::Arc, time::Instant};
+
+/// A useful utility function to instantiate all db pruners.
+pub fn create_db_pruners(
+    db: Arc<DB>,
+    transaction_store: Arc<TransactionStore>,
+    ledger_store: Arc<LedgerStore>,
+    event_store: Arc<EventStore>,
+) -> Vec<Mutex<Arc<dyn DBPruner + Send + Sync>>> {
+    vec![
+        Mutex::new(Arc::new(StateStorePruner::new(
+            Arc::clone(&db),
+            0,
+            Instant::now(),
+        ))),
+        Mutex::new(Arc::new(TransactionStorePruner::new(
+            Arc::clone(&db),
+            Arc::clone(&transaction_store),
+        ))),
+        Mutex::new(Arc::new(LedgerStorePruner::new(
+            Arc::clone(&db),
+            Arc::clone(&ledger_store),
+        ))),
+        Mutex::new(Arc::new(EventStorePruner::new(
+            Arc::clone(&db),
+            Arc::clone(&event_store),
+        ))),
+        Mutex::new(Arc::new(WriteSetPruner::new(
+            Arc::clone(&db),
+            Arc::clone(&transaction_store),
+        ))),
+    ]
+}

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -630,6 +630,14 @@ pub trait DbWriter: Send + Sync {
     ) -> Result<()> {
         unimplemented!()
     }
+
+    /// Deletes transaction data associated with the genesis transaction. This is useful for
+    /// cleaning up the database after a node has bootstrapped all accounts through state sync.
+    ///
+    /// TODO(joshlind): find a cleaner (long term) solution to avoid us having to expose this...
+    fn delete_genesis(&self) -> Result<()> {
+        unimplemented!()
+    }
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Specific issue: https://github.com/aptos-labs/aptos-core/issues/335

## Motivation

This PR updates the DBWriter interface to expose a new method to delete the genesis transaction from the database. This is required by nodes that bootstrap account states at a version `X`, where `X > 0`. In this case, the node will have no storage data below `X` except the genesis transaction (at version `0`). However, due to existing limitations around tracking the minimum (non-genesis) transaction data, the node will incorrectly advertise that it contains all transaction data *since* genesis. 

To avoid this, we delete genesis after a node has completed account states bootstrapping. As a result, the node will only advertise data starting at version `X`. 

Note:
- In an ideal world, a node wouldn't require genesis to perform account states bootstrapping at all (and we could avoid this). Or, we could more accurately track non-genesis data in storage. But, this is a lot more work and we're not there yet, so this solution will have to do.
- The PR also does some smaller cleanups along the way.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

I've tested this manually. Once we come up with a testing harness for the driver, I'll be able to automate this.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245