### PR TITLE
[Network] Increase the default rate limiter size.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -43,7 +43,7 @@ pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 1;
 pub const MAX_INBOUND_CONNECTIONS: usize = 100;
 pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024; /* 16 MiB */
 pub const CONNECTION_BACKOFF_BASE: u64 = 2;
-pub const IP_BYTE_BUCKET_RATE: usize = 102400 /* 100 KiB */;
+pub const IP_BYTE_BUCKET_RATE: usize = 102400 * 5 /* 500 KiB */;
 pub const IP_BYTE_BUCKET_SIZE: usize = IP_BYTE_BUCKET_RATE;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]


### PR DESCRIPTION
## Motivation

Now that we've reduced the default number of outbound connections to 1 and set a maximum number of inbound connections at ~1000, we're seeing the rate limiter consistently slow down network traffic (even though we're only averaging ~6MB/sec per VFN 🤔). Let's 5x the rate limiter and see how the outbound traffic behaves on the public VFNs. 

Motivation for this includes:
- Testing! Let's learn how our network behaves in the wild.
- There's no point enabling state sync v2 if we're always going to be network rate limited. It has to fetch data faster to process it faster. 😄 
- Intermittent health check failures because of RPC timeouts (likely because of the rate limiter).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

None.

## Related PRs

None.
