### PR TITLE
Updated terraform configuration to deploy aptos into the 'aptos' name…

### DIFF
--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -6,7 +6,7 @@ provider "kubernetes" {
 
 resource "kubernetes_namespace" "aptos" {
   metadata {
-    name = var.namespace
+    name = var.k8s_namespace
   }
 }
 
@@ -35,7 +35,7 @@ resource "helm_release" "fullnode" {
   chart            = var.helm_chart
   max_history      = 100
   wait             = false
-  namespace        = var.namespace
+  namespace        = var.k8s_namespace
   create_namespace = true
 
   values = [

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -4,6 +4,12 @@ provider "kubernetes" {
   token                  = data.google_client_config.provider.access_token
 }
 
+resource "kubernetes_namespace" "aptos" {
+  metadata {
+    name = var.namespace
+  }
+}
+
 resource "kubernetes_storage_class" "ssd" {
   metadata {
     name = "ssd"
@@ -24,11 +30,13 @@ provider "helm" {
 }
 
 resource "helm_release" "fullnode" {
-  count       = var.num_fullnodes
-  name        = "${terraform.workspace}${count.index}"
-  chart       = var.helm_chart
-  max_history = 100
-  wait        = false
+  count            = var.num_fullnodes
+  name             = "${terraform.workspace}${count.index}"
+  chart            = var.helm_chart
+  max_history      = 100
+  wait             = false
+  namespace        = var.namespace
+  create_namespace = true
 
   values = [
     jsonencode({

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -41,6 +41,11 @@ variable "helm_force_update" {
   default     = false
 }
 
+variable "namespace" {
+  default     = "aptos"
+  description = "Kubernetes namespace that the fullnode will be deployed into"
+}
+
 variable "k8s_api_sources" {
   description = "List of CIDR subnets which can access the Kubernetes API endpoint"
   default     = ["0.0.0.0/0"]

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -41,7 +41,7 @@ variable "helm_force_update" {
   default     = false
 }
 
-variable "namespace" {
+variable "k8s_namespace" {
   default     = "aptos"
   description = "Kubernetes namespace that the fullnode will be deployed into"
 }


### PR DESCRIPTION
…space instead of the 'default' namespace

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The aptos application was being deployed into the default namespace in Kubernetes.  It would be much better if it was deployed into its own namespace.  This is to reduce conflict with other containers that could potentially be deployed to the default namespace.  It is also much easier to organize and managed the different components of aptos if it's in its own namespace.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This command will show if the components were deployed to the aptos namespace correctly

# Aptos components should be listed
kubectl get all -n aptos

# Aptos components should not be listed
kubectl get all -n default


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
This could potential break any existing kubectl commands or other selectors that were referencing the "default" namespace

 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.

kubectl get all -n default
NAME                 TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
service/kubernetes   ClusterIP   10.104.0.1   <none>        443/TCP   149m


kubectl get all -n aptos
NAME                           READY   STATUS    RESTARTS   AGE
pod/devnet0-aptos-fullnode-0   1/1     Running   0          144m

NAME                                TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)                       AGE
service/devnet0-aptos-fullnode      ClusterIP      10.104.1.255   <none>          6186/TCP,9101/TCP             144m
service/devnet0-aptos-fullnode-lb   LoadBalancer   10.104.1.85    34.66.228.218   80:30833/TCP,6182:31813/TCP   144m

NAME                                             READY   AGE
statefulset.apps/devnet0-aptos-fullnode          1/1     144m
statefulset.apps/devnet0-aptos-fullnode-backup   0/0     144m

NAME                                                 SCHEDULE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
cronjob.batch/devnet0-aptos-fullnode-backup-verify   @daily     True      0        <none>          144m

NAME                                            COMPLETIONS   DURATION   AGE
job.batch/devnet0-aptos-fullnode-restore-kqxw   0/0           0s         11m

 * Why we must have it for the release.
 * What workarounds and alternative we have if we do not push the PR.

Without it, it will continue to work as usual in the default namespace

NOTE: Consider doing the same for the AWS terraform config


