### PR TITLE
[tf][gcp] small fixes

### DIFF
--- a/terraform/fullnode/gcp/auth.tf
+++ b/terraform/fullnode/gcp/auth.tf
@@ -21,7 +21,7 @@ resource "google_project_iam_member" "gke-monitoring" {
 }
 
 resource "google_project_iam_custom_role" "k8s-debugger" {
-  role_id     = "container.debugger"
+  role_id     = "container.debugger.${terraform.workspace}"
   title       = "Kubernetes Engine Debugger"
   description = "Additional permissions to debug Kubernetes Engine workloads"
   permissions = [

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -32,7 +32,7 @@ provider "helm" {
 resource "helm_release" "fullnode" {
   count            = var.num_fullnodes
   name             = "${terraform.workspace}${count.index}"
-  chart            = var.helm_chart
+  chart            = "${path.module}/../../helm/fullnode"
   max_history      = 100
   wait             = false
   namespace        = var.k8s_namespace

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -13,11 +13,6 @@ variable "zone" {
   type        = string
 }
 
-variable "helm_chart" {
-  description = "Path to aptos-fullnode Helm chart file"
-  default     = "../../helm/fullnode"
-}
-
 variable "helm_values" {
   description = "Map of values to pass to Helm"
   type        = any


### PR DESCRIPTION
- add workspace name to k8s debugger role, so that we can create multiple deployment without duplicating the name
- use module path for helm chart, so that we can use the terraform as module