### PR TITLE
Fix SDK build (export types) + Add examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,10 @@ jobs:
       - image: circleci/node:16.13.1-browsers
     steps:
       - checkout
+      # install packages for examples
+      - run: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install
+      - run: cd ./ecosystem/typescript/sdk/examples/javascript && yarn install
+      # Run package build+lint + tests
       - run: cd ./ecosystem/typescript/sdk && yarn install
       - run: cd ./ecosystem/typescript/sdk && yarn lint
       - run: cd ./ecosystem/typescript/sdk && yarn test

--- a/ecosystem/typescript/sdk/.eslintrc.js
+++ b/ecosystem/typescript/sdk/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
       "never",
     ],
     "max-classes-per-file": ["error", 10],
+    "import/prefer-default-export": "off",
   },
   settings: {
     "import/resolver": {

--- a/ecosystem/typescript/sdk/.npmignore
+++ b/ecosystem/typescript/sdk/.npmignore
@@ -1,1 +1,2 @@
 coverage
+node_modules

--- a/ecosystem/typescript/sdk/README.md
+++ b/ecosystem/typescript/sdk/README.md
@@ -7,47 +7,27 @@
 You need to connect to an [Aptos](https:/github.com/aptos-labs/aptos-core/) node to use this library, or run one
 yourself locally.
 
-Please read the [documentation][docs] for more.
-
 ## Usage
-```js
-// In Node.js
-const Aptos = require("aptos");
 
-const aptos = new AptosClient("https://fullnode.devnet.aptoslabs.com/");
-console.log(aptos);
-> { ... }
-```
-
-There you go, now you can use it:
-
-```js
-const account = new AptosAccount();
-const accountInfo = await client.getAccount(account.address());
-```
-
-### Usage with TypeScript
-You can use `aptos` like any other TypeScript module:
-
-```typescript
-import { AptosAccount, AptosClient } from "aptos"
-const aptos = new AptosClient("https://fullnode.devnet.aptoslabs.com/");
-const account = new AptosAccount();
-const accountInfo = await client.getAccount(account.address());
-```
+For Javascript or Typescript usage, check out the [`./examples`][examples] folder with ready-made `package.json` files
+to get you going quickly!
 
 If you are using the types in a `commonjs` module, like in a Node app, you just have to enable `esModuleInterop`
 and `allowSyntheticDefaultImports` in your `tsconfig` for types compatibility:
 
-```js
-"compilerOptions": {
-  "allowSyntheticDefaultImports": true,
-  "esModuleInterop": true,
+```json
+{
   ...
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true
+    ...
+  }
+}
 ```
 
-
 ### Requirements
+
 - [Node.js](https://nodejs.org)
 - [yarn](https://yarnpkg.com/)
 
@@ -57,14 +37,18 @@ sudo apt-get install nodejs yarn
 ```
 
 ### Generating Types
+
 Originally created with this:
+
 ```bash
 $  npx swagger-typescript-api -p ../api/doc/openapi.yaml -o ./src/api --modular --axios --single-http-client
 ```
-#### Changes to make after generation:
-- OpenAPI/SpecHTML routes/types deleted as they're unneeded.
-- There are a few type errors in the `http-client.ts` as the axios types are incomplete, that were fixed via `// @ts-ignore`
 
+#### Changes to make after generation:
+
+- OpenAPI/SpecHTML routes/types deleted as they're unneeded.
+- There are a few type errors in the `http-client.ts` as the axios types are incomplete, that were fixed
+  via `// @ts-ignore`
 
 ### Testing (jest)
 
@@ -72,12 +56,18 @@ $  npx swagger-typescript-api -p ../api/doc/openapi.yaml -o ./src/api --modular 
 yarn test
 ```
 
+[examples]: https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/
 
 [repo]: https://github.com/aptos-labs/aptos-core
+
 [npm-image-version]: https://img.shields.io/npm/v/aptos.svg
+
 [npm-image-downloads]: https://img.shields.io/npm/dm/aptos.svg
+
 [npm-url]: https://npmjs.org/package/aptos
+
 [discord-image]: https://img.shields.io/discord/945856774056083548?label=Discord&logo=discord&style=flat~~~~
+
 [discord-url]:  https://discord.gg/aptoslabs
 
 ## Semantic versioning

--- a/ecosystem/typescript/sdk/examples/javascript/index.js
+++ b/ecosystem/typescript/sdk/examples/javascript/index.js
@@ -1,0 +1,39 @@
+const aptos = require("aptos");
+
+const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
+const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
+
+(async () => {
+  const client = new aptos.AptosClient(NODE_URL);
+  const faucetClient = new aptos.FaucetClient(NODE_URL, FAUCET_URL, null);
+
+  const account1 = new aptos.AptosAccount();
+  await faucetClient.fundAccount(account1.address(), 5000);
+  let resources = await client.getAccountResources(account1.address());
+  let accountResource = resources.find((r) => r.type === "0x1::TestCoin::Balance");
+  console.log(`account2 coins: ${accountResource.data.coin.value}. Should be 5000!`);
+
+  const account2 = new aptos.AptosAccount();
+  await faucetClient.fundAccount(account2.address(), 0);
+  resources = await client.getAccountResources(account2.address());
+  accountResource = resources.find((r) => r.type === "0x1::TestCoin::Balance");
+  console.log(`account2 coins: ${accountResource.data.coin.value}. Should be 0!`);
+
+  const payload = {
+    type: "script_function_payload",
+    function: "0x1::TestCoin::transfer",
+    type_arguments: [],
+    arguments: [
+      account2.address().hex(),
+      "717",
+    ],
+  };
+  const txnRequest = await client.generateTransaction(account1.address(), payload);
+  const signedTxn = await client.signTransaction(account1, txnRequest);
+  const transactionRes = await client.submitTransaction(account1, signedTxn);
+  await client.waitForTransaction(transactionRes.hash);
+
+  resources = await client.getAccountResources(account2.address());
+  accountResource = resources.find((r) => r.type === "0x1::TestCoin::Balance");
+  console.log(`account2 coins: ${accountResource.data.coin.value}. Should be 717!`);
+})();

--- a/ecosystem/typescript/sdk/examples/javascript/package.json
+++ b/ecosystem/typescript/sdk/examples/javascript/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ts-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "aptos": "*"
+  }
+}

--- a/ecosystem/typescript/sdk/examples/typescript/index.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/index.ts
@@ -1,0 +1,47 @@
+import {
+  AptosClient,
+  AptosAccount,
+  FaucetClient,
+  Types,
+} from "aptos";
+
+const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
+const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
+
+(async () => {
+  const client = new AptosClient(NODE_URL);
+  const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL, null);
+
+  const account1 = new AptosAccount();
+  await faucetClient.fundAccount(account1.address(), 5000);
+  let resources = await client.getAccountResources(account1.address());
+  let accountResource = resources.find((r) => r.type === "0x1::TestCoin::Balance");
+  let balance = (accountResource.data as { "coin": { "value": string } }).coin.value;
+  console.log(`account2 coins: ${balance}. Should be 5000!`);
+
+  const account2 = new AptosAccount();
+  await faucetClient.fundAccount(account2.address(), 0);
+  resources = await client.getAccountResources(account2.address());
+  accountResource = resources.find((r) => r.type === "0x1::TestCoin::Balance");
+  balance = (accountResource.data as { "coin": { "value": string } }).coin.value;
+  console.log(`account2 coins: ${balance}. Should be 0!`);
+
+  const payload: Types.TransactionPayload = {
+    type: "script_function_payload",
+    function: "0x1::TestCoin::transfer",
+    type_arguments: [],
+    arguments: [
+      account2.address().hex(),
+      "717",
+    ],
+  };
+  const txnRequest = await client.generateTransaction(account1.address(), payload);
+  const signedTxn = await client.signTransaction(account1, txnRequest);
+  const transactionRes = await client.submitTransaction(account1, signedTxn);
+  await client.waitForTransaction(transactionRes.hash);
+
+  resources = await client.getAccountResources(account2.address());
+  accountResource = resources.find((r) => r.type === "0x1::TestCoin::Balance");
+  balance = (accountResource.data as { "coin": { "value": string } }).coin.value;
+  console.log(`account2 coins: ${balance}. Should be 717!`);
+})();

--- a/ecosystem/typescript/sdk/examples/typescript/package.json
+++ b/ecosystem/typescript/sdk/examples/typescript/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ts-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "ts-node index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "aptos": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^17.0.23",
+    "ts-node": "^10.7.0",
+    "typescript": "^4.6.3"
+  }
+}

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -8,8 +8,9 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p .",
+    "build": "rm -rf dist && tsc -p .",
     "lint": "eslint \"**/*.ts\"",
+    "push": "yarn publish --non-interactive --new-version",
     "test": "jest",
     "cov:clean": "rm -rf coverage"
   },
@@ -47,5 +48,5 @@
     "js-sha3": "^0.8.0",
     "tweetnacl": "^1.0.3"
   },
-  "version": "0.0.11"
+  "version": "0.0.15"
 }

--- a/ecosystem/typescript/sdk/src/aptos_account.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.test.ts
@@ -1,4 +1,4 @@
-import AptosAccount, { AptosAccountObject } from "./aptos_account";
+import { AptosAccount, AptosAccountObject } from "./aptos_account";
 
 const AptosAccountObject: AptosAccountObject = {
   "address": "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",

--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -2,7 +2,7 @@ import * as Nacl from "tweetnacl";
 import * as SHA3 from "js-sha3";
 import { Buffer } from "buffer/"; // the trailing slash is important!
 import { HexString, MaybeHexString } from "./hex_string";
-import Types from "./types";
+import { Types } from "./types";
 
 export interface AptosAccountObject {
   address?: string,
@@ -10,7 +10,7 @@ export interface AptosAccountObject {
   privateKeyHex: Types.HexEncodedBytes,
 }
 
-export default class AptosAccount {
+export class AptosAccount {
   readonly signingKey: Nacl.SignKeyPair;
 
   private readonly accountAddress: HexString;

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -2,30 +2,30 @@ import { AptosClient, raiseForStatus } from "./aptos_client";
 import { AnyObject } from "./util";
 import { AxiosResponse } from "axios";
 
-const nodeUrl = "https://fullnode.devnet.aptoslabs.com";
+import { NODE_URL } from "./util.test";
 
 test("gets genesis account", async () => {
-  const client = new AptosClient(nodeUrl);
+  const client = new AptosClient(NODE_URL);
   const account = await client.getAccount("0x1");
   expect(account.authentication_key.length).toBe(66);
   expect(account.sequence_number).not.toBeNull();
 });
 
 test("gets transactions", async () => {
-  const client = new AptosClient(nodeUrl);
+  const client = new AptosClient(NODE_URL);
   const transactions = await client.getTransactions();
   expect(transactions.length).toBeGreaterThan(0);
 });
 
 test("gets genesis resources", async () => {
-  const client = new AptosClient(nodeUrl);
+  const client = new AptosClient(NODE_URL);
   const resources = await client.getAccountResources("0x1");
   const accountResource = resources.find((r) => r.type === "0x1::Account::Account");
   expect((accountResource.data as AnyObject)["self_address"]).toBe("0x1");
 });
 
 test("gets account modules", async () => {
-  const client = new AptosClient(nodeUrl);
+  const client = new AptosClient(NODE_URL);
   const modules = await client.getAccountModules("0x1");
   const module = modules.find((r) => r.abi.name === "TestCoin");
   expect(module.abi.address).toBe("0x1");

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -5,8 +5,8 @@ import { Transactions } from "./api/Transactions";
 import { HttpClient } from "./api/http-client";
 import { HexString, MaybeHexString } from "./hex_string";
 import { sleep } from "./util";
-import AptosAccount from "./aptos_account";
-import Types from "./types";
+import { AptosAccount } from "./aptos_account";
+import { Types } from "./types";
 
 export class RequestError extends Error {
   response?: AxiosResponse<any, Types.AptosError>;

--- a/ecosystem/typescript/sdk/src/faucet_client.test.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.test.ts
@@ -1,16 +1,15 @@
 import { AptosClient } from "./aptos_client";
-import FaucetClient from "./faucet_client";
-import AptosAccount from "./aptos_account";
-import Types from "./types";
+import { FaucetClient } from "./faucet_client";
+import { AptosAccount } from "./aptos_account";
+import { Types } from "./types";
 import { UserTransaction } from "./api/data-contracts";
 
-const nodeUrl = "https://fullnode.devnet.aptoslabs.com";
-const faucetUrl = "https://faucet.devnet.aptoslabs.com";
+import { NODE_URL, FAUCET_URL } from "./util.test";
 
 
 test.skip("full tutorial faucet flow", async () => {
-  const client = new AptosClient(nodeUrl);
-  const faucetClient = new FaucetClient(nodeUrl, faucetUrl);
+  const client = new AptosClient(NODE_URL);
+  const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
 
   const account1 = new AptosAccount();
   const txns = await faucetClient.fundAccount(account1.address(), 5000);

--- a/ecosystem/typescript/sdk/src/faucet_client.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.ts
@@ -3,10 +3,10 @@ import axios from "axios";
 import {
   AptosClient, AptosClientConfig, raiseForStatus,
 } from "./aptos_client";
-import Types from "./types";
+import { Types } from "./types";
 import { HexString, MaybeHexString } from "./hex_string";
 
-export default class FaucetClient extends AptosClient {
+export class FaucetClient extends AptosClient {
   faucetUrl: string;
 
   constructor(nodeUrl: string, faucetUrl: string, config?: AptosClientConfig) {

--- a/ecosystem/typescript/sdk/src/hex_string.ts
+++ b/ecosystem/typescript/sdk/src/hex_string.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "buffer/"; // the trailing slash is important!
-import Types from "./types";
+import { Types } from "./types";
 
 // eslint-disable-next-line no-use-before-define
 export type MaybeHexString = HexString | string | Types.HexEncodedBytes;

--- a/ecosystem/typescript/sdk/src/types.ts
+++ b/ecosystem/typescript/sdk/src/types.ts
@@ -1,4 +1,4 @@
 // A convenience re-export from the lower level generated code
 import * as Types from "./api/data-contracts";
 
-export default Types;
+export { Types };

--- a/ecosystem/typescript/sdk/src/util.test.ts
+++ b/ecosystem/typescript/sdk/src/util.test.ts
@@ -1,0 +1,11 @@
+export const NODE_URL =
+  process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
+export const FAUCET_URL =
+  process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
+
+test("noop", () => {
+  // All TS files are compiled by default into the npm package
+  // Adding this empty test allows us to:
+  // 1. Guarantee that this test library won't get compiled
+  // 2. Prevent jest from exploding when it finds a file with no tests in it
+});


### PR DESCRIPTION
Fixes https://github.com/aptos-labs/aptos-core/issues/408 . Rustie is taking a look at running our docker compose in CI, which will unblock testing all of our SDKs against latest node builds locally