### PR TITLE
[Hackthon] Add a move message board demo

### DIFF
--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -32,3 +32,8 @@ fn move_unit_tests() {
 fn aptos_move_unit_tests() {
     run_tests_for_pkg("aptos-framework");
 }
+
+#[test]
+fn example_unit_tests() {
+    run_tests_for_pkg("../../developer-docs-site/static/move_demo");
+}

--- a/developer-docs-site/static/move_demo/Move.toml
+++ b/developer-docs-site/static/move_demo/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "MessageBoard"
+version = "0.0.1"
+
+[dependencies]
+CoreFramework = { local = "../../../aptos-move/framework/core" }
+MoveStdlib = { local = "../../../aptos-move/framework/move-stdlib" }
+MoveNursery = {local = "../../../aptos-move/framework/move-stdlib/nursery"}
+
+[addresses]
+Std = "0x1"
+VMReserved = "0x0"
+CoreFramework = "0x1"
+CoreResources = "0xA550C18"
+MessageBoard = "0x2"

--- a/developer-docs-site/static/move_demo/sources/ACLMessageBoard.move
+++ b/developer-docs-site/static/move_demo/sources/ACLMessageBoard.move
@@ -1,0 +1,181 @@
+/// This module demonstrates a basic messageboard using ACL to control the access.
+/// Admins can
+///     (1) create their messageboard
+///     (2) add a partipant to its access control list (ACL)
+///     (3) remove a participant from its ACL
+/// participant can
+///     (1) register for the board
+///     (2) send a new message
+///
+/// The module also emits events for subscribers
+///     (1) message change event, this event contains the board, message and message author
+module MessageBoard::ACLBasedMB{
+    use Std::ACL::Self;
+    use Std::Event::{Self, EventHandle};
+    use Std::Signer;
+    use Std::Vector;
+
+    // Error map
+    const EACCOUNT_NOT_IN_ACL: u64 = 1;
+    const ECANNOT_REMOVE_ADMIN_FROM_ACL: u64 = 2;
+
+    struct ACLBasedMB has key {
+        participants: ACL::ACL,
+        pinned_post: vector<u8>
+    }
+
+    struct MessageChangeEventHandle has key {
+        change_events: EventHandle<MessageChangeEvent>
+    }
+
+    /// emit an event from participant account showing the board and the new message
+    struct MessageChangeEvent has store, drop {
+        message: vector<u8>,
+        participant: address
+    }
+
+    /// create the message board and move the resource to signer
+    public fun message_board_init_internal(account: &signer) {
+        let board = ACLBasedMB{
+            participants: ACL::empty(),
+            pinned_post: Vector::empty<u8>()
+        };
+        ACL::add(&mut board.participants, Signer::address_of(account));
+        move_to(account, board);
+        move_to(account, MessageChangeEventHandle{
+            change_events: Event::new_event_handle<MessageChangeEvent>(account)
+        })
+    }
+
+    /// init message board
+    public(script) fun message_board_init(account: signer) {
+        message_board_init_internal(&account);
+    }
+
+    public fun view_message(board_addr: address): vector<u8> acquires ACLBasedMB {
+        let post = borrow_global<ACLBasedMB>(board_addr).pinned_post;
+        copy post
+    }
+
+    /// board owner control adding new participants
+    public fun add_participant_internal(account: &signer, participant: address) acquires ACLBasedMB {
+        let board = borrow_global_mut<ACLBasedMB>(Signer::address_of(account));
+        ACL::add(&mut board.participants, participant);
+    }
+
+    public(script) fun add_participant(account: signer, participant: address) acquires ACLBasedMB {
+        add_participant_internal(&account, participant);
+    }
+
+    /// remove a participant from the ACL
+    public(script) fun remove_participant(account: signer, participant: address) acquires ACLBasedMB {
+        let board = borrow_global_mut<ACLBasedMB>(Signer::address_of(&account));
+        assert!(Signer::address_of(&account) != participant, ECANNOT_REMOVE_ADMIN_FROM_ACL);
+        ACL::remove(&mut board.participants, participant);
+    }
+
+    /// an account publish the message to update the notice
+    public fun send_pinned_message_internal(
+        account: &signer, board_addr: address, message: vector<u8>
+    ) acquires ACLBasedMB, MessageChangeEventHandle {
+        let board = borrow_global<ACLBasedMB>(board_addr);
+        assert!(ACL::contains(&board.participants, Signer::address_of(account)), EACCOUNT_NOT_IN_ACL);
+
+        let board = borrow_global_mut<ACLBasedMB>(board_addr);
+        board.pinned_post = message;
+
+        let send_acct = Signer::address_of(account);
+        let event_handle = borrow_global_mut<MessageChangeEventHandle>(board_addr);
+        Event::emit_event<MessageChangeEvent>(
+            &mut event_handle.change_events,
+            MessageChangeEvent{
+                message,
+                participant: send_acct
+            }
+        );
+    }
+
+    public(script) fun send_pinned_message(
+        account: signer, board_addr: address, message: vector<u8>
+    ) acquires ACLBasedMB, MessageChangeEventHandle {
+        send_pinned_message_internal(&account, board_addr, message);
+    }
+
+    /// an account can send events containing message
+    public(script) fun send_message_to(
+        board_addr: address, message: vector<u8>
+    ) acquires MessageChangeEventHandle {
+        let event_handle = borrow_global_mut<MessageChangeEventHandle>(board_addr);
+        Event::emit_event<MessageChangeEvent>(
+            &mut event_handle.change_events,
+            MessageChangeEvent{
+                message,
+                participant: board_addr
+            }
+        );
+    }
+}
+
+#[test_only]
+module MessageBoard::MessageBoardTests {
+    use Std::UnitTest;
+    use Std::Vector;
+    use Std::Signer;
+
+    use MessageBoard::ACLBasedMB;
+
+    const  HELLO_WORLD: vector<u8> = vector<u8>[150, 145, 154, 154, 157, 040, 167, 157, 162, 154, 144];
+    const  BOB_IS_HERE: vector<u8> = vector<u8>[142, 157, 142, 040, 151, 163, 040, 150, 145, 162, 145];
+
+    #[test]
+    fun test_init_messageboard() {
+        let (alice, _) = create_two_signers();
+        ACLBasedMB::message_board_init_internal(&alice);
+        ACLBasedMB::send_pinned_message_internal(&alice, Signer::address_of(&alice), HELLO_WORLD);
+    }
+
+    #[test]
+    fun test_send_pinned_message() {
+        let (alice, bob) = create_two_signers();
+        ACLBasedMB::message_board_init_internal(&alice);
+        ACLBasedMB::add_participant_internal(&alice, Signer::address_of(&bob));
+        ACLBasedMB::send_pinned_message_internal(&bob, Signer::address_of(&alice), BOB_IS_HERE);
+        let message = ACLBasedMB::view_message(Signer::address_of(&alice));
+        assert!( message == BOB_IS_HERE, 1);
+        let message = ACLBasedMB::view_message(Signer::address_of(&alice));
+        assert!( message == BOB_IS_HERE, 1);
+    }
+
+    #[test]
+    public(script) fun test_send_message_v_cap() {
+        let (alice, _) = create_two_signers();
+        ACLBasedMB::message_board_init_internal(&alice);
+        ACLBasedMB::send_message_to(Signer::address_of(&alice), BOB_IS_HERE);
+    }
+
+    #[test]
+    fun read_message_multiple_times() {
+        let (alice, bob) = create_two_signers();
+        ACLBasedMB::message_board_init_internal(&alice);
+        ACLBasedMB::add_participant_internal(&alice, Signer::address_of(&bob));
+        ACLBasedMB::send_pinned_message_internal(&bob, Signer::address_of(&alice), BOB_IS_HERE);
+        let message = ACLBasedMB::view_message(Signer::address_of(&alice));
+        assert!( message == BOB_IS_HERE, 1);
+        let message = ACLBasedMB::view_message(Signer::address_of(&alice));
+        assert!( message == BOB_IS_HERE, 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 1)]
+    fun test_add_new_participant() {
+        let (alice, bob) = create_two_signers();
+        ACLBasedMB::message_board_init_internal(&alice);
+        ACLBasedMB::send_pinned_message_internal(&bob, Signer::address_of(&alice), BOB_IS_HERE);
+    }
+
+    #[test_only]
+    fun create_two_signers(): (signer, signer) {
+        let signers = &mut UnitTest::create_signers_for_testing(2);
+        (Vector::pop_back(signers), Vector::pop_back(signers))
+    }
+}

--- a/developer-docs-site/static/move_demo/sources/CAPMessageBoard.move
+++ b/developer-docs-site/static/move_demo/sources/CAPMessageBoard.move
@@ -1,0 +1,209 @@
+/// This module demonstrates a basic messageboard using capability to control the access.
+/// Admin can
+///     (1) create their messageboard
+///     (2) offer participants capability to update the pinned message
+///     (3) remove the capability from a participant
+/// participant can
+///     (1) register for the board
+///     (2) redeem the offered capability to update pinned message
+///     (3) send a new message
+///
+/// The module also emits two types of events for subscribes
+///     (1) message cap update event, this event contains the board address and participant offered capability
+///     (2) message change event, this event contains the board, message and message author
+module MessageBoard::CapBasedMB {
+    use Std::Event::{Self, EventHandle};
+    use Std::Offer;
+    use Std::Signer;
+    use Std::Vector;
+
+    // Error map
+    const EACCOUNT_NO_NOTICE_CAP: u64 = 1;
+    const EONLY_ADMIN_CAN_REMOVE_NOTICE_CAP: u64 = 2;
+
+    struct CapBasedMB has key {
+        pinned_post: vector<u8>
+    }
+
+    /// provide the capability to alert the board message
+    struct MessageChangeCapability has key, store {
+        board: address
+    }
+
+    struct MessageCapEventHandle has key {
+        change_events: EventHandle<MessageCapUpdateEvent>
+    }
+
+    /// emit an event from board acct showing the new participant with posting capability
+    struct MessageCapUpdateEvent has store, drop {
+        participant: address,
+    }
+
+    struct MessageChangeEventHandle has key {
+        change_events: EventHandle<MessageChangeEvent>
+    }
+
+    /// emit an event from participant account showing the board and the new message
+    struct MessageChangeEvent has store, drop {
+        message: vector<u8>,
+        participant: address
+    }
+
+    /// init the message board and move the resource to signer
+    public fun message_board_init_internal(account: &signer) {
+        let board = CapBasedMB{
+            pinned_post: Vector::empty<u8>()
+        };
+        let board_addr = Signer::address_of(account);
+        move_to(account, board);
+        let notice_cap = MessageChangeCapability{ board: board_addr };
+        move_to(account, notice_cap);
+        move_to(account, MessageChangeEventHandle{
+            change_events: Event::new_event_handle<MessageChangeEvent>(account)
+        });
+        move_to(account, MessageCapEventHandle{
+            change_events: Event::new_event_handle<MessageCapUpdateEvent>(account)
+        })
+    }
+
+    /// create the message board and move the resource to signer
+    public(script) fun message_board_init(account: signer) {
+        message_board_init_internal(&account);
+    }
+
+    /// directly view message
+    public fun view_message(board_addr: address): vector<u8> acquires CapBasedMB {
+        let post = borrow_global<CapBasedMB>(board_addr).pinned_post;
+        copy post
+    }
+
+    /// board owner controls adding new participants
+    public(script) fun add_participant(account: signer, participant: address) acquires MessageCapEventHandle {
+        add_participant_internal(&account, participant);
+    }
+
+    public fun add_participant_internal(account: &signer, participant: address) acquires MessageCapEventHandle {
+        let board_addr = Signer::address_of(account);
+        Offer::create(account, MessageChangeCapability{ board: board_addr }, participant);
+
+        let event_handle = borrow_global_mut<MessageCapEventHandle>(board_addr);
+
+        Event::emit_event<MessageCapUpdateEvent>(
+            &mut event_handle.change_events,
+            MessageCapUpdateEvent{
+                participant
+            }
+        );
+    }
+
+    public(script) fun claim_notice_cap(account: signer, board: address) {
+        claim_notice_cap_internal(&account, board);
+    }
+
+    /// claim offered capability
+    public fun claim_notice_cap_internal(account: &signer, board: address) {
+        let notice_cap = Offer::redeem<MessageChangeCapability>(
+            account, board);
+        move_to(account, notice_cap);
+    }
+
+    /// remove a participant capability to publish notice
+    public(script) fun remove_participant(account: signer, participant: address) acquires MessageChangeCapability {
+        let cap = borrow_global_mut<MessageChangeCapability>(participant);
+        assert!(Signer::address_of(&account) == cap.board, EONLY_ADMIN_CAN_REMOVE_NOTICE_CAP);
+        let cap = move_from<MessageChangeCapability>(participant);
+        let MessageChangeCapability{ board: _ } = cap;
+    }
+
+    /// only the participant with right capability can publish the message
+    public fun send_pinned_message_internal(
+        cap: &MessageChangeCapability, sender: address, board_addr: address, message: vector<u8>
+    ) acquires MessageChangeEventHandle, CapBasedMB {
+        assert!(cap.board == board_addr, EACCOUNT_NO_NOTICE_CAP);
+        let board = borrow_global_mut<CapBasedMB>(board_addr);
+        board.pinned_post = message;
+        let event_handle = borrow_global_mut<MessageChangeEventHandle>(board_addr);
+        Event::emit_event<MessageChangeEvent>(
+            &mut event_handle.change_events,
+            MessageChangeEvent{
+                message,
+                participant: sender
+            }
+        );
+    }
+
+    public(script) fun send_pinned_message(
+        account: signer, board_addr: address, message: vector<u8>
+    ) acquires MessageChangeCapability, MessageChangeEventHandle, CapBasedMB {
+        let cap = borrow_global<MessageChangeCapability>(Signer::address_of(&account));
+        send_pinned_message_internal(cap, Signer::address_of(&account), board_addr, message);
+    }
+
+    /// an account can send events containing message
+    public(script) fun send_message_to(
+        board_addr: address, message: vector<u8>
+    ) acquires MessageChangeEventHandle {
+        let event_handle = borrow_global_mut<MessageChangeEventHandle>(board_addr);
+        Event::emit_event<MessageChangeEvent>(
+            &mut event_handle.change_events,
+            MessageChangeEvent{
+                message,
+                participant: board_addr
+            }
+        );
+    }
+}
+
+#[test_only]
+module MessageBoard::MessageBoardCapTests {
+    use Std::UnitTest;
+    use Std::Vector;
+    use Std::Signer;
+    use MessageBoard::CapBasedMB;
+
+
+    const HELLO_WORLD: vector<u8> = vector<u8>[150, 145, 154, 154, 157, 040, 167, 157, 162, 154, 144];
+    const BOB_IS_HERE: vector<u8> = vector<u8>[142, 157, 142, 040, 151, 163, 040, 150, 145, 162, 145];
+
+    #[test]
+    public(script) fun test_init_messageboard_v_cap() {
+        let (alice, _) = create_two_signers();
+        CapBasedMB::message_board_init_internal(&alice);
+        let board_addr = Signer::address_of(&alice);
+        CapBasedMB::send_pinned_message(alice, board_addr, HELLO_WORLD);
+    }
+
+    #[test]
+    public(script) fun test_send_pinned_message_v_cap() {
+        let (alice, bob) = create_two_signers();
+        CapBasedMB::message_board_init_internal(&alice);
+        CapBasedMB::add_participant_internal(&alice, Signer::address_of(&bob));
+        CapBasedMB::claim_notice_cap_internal(&bob, Signer::address_of(&alice));
+        CapBasedMB::send_pinned_message(bob, Signer::address_of(&alice), BOB_IS_HERE);
+        let message = CapBasedMB::view_message(Signer::address_of(&alice));
+        assert!(message == BOB_IS_HERE, 1)
+    }
+
+    #[test]
+    public(script) fun test_send_message_v_cap() {
+        let (alice, _) = create_two_signers();
+        CapBasedMB::message_board_init_internal(&alice);
+        CapBasedMB::send_message_to(Signer::address_of(&alice), BOB_IS_HERE);
+    }
+
+    #[test]
+    #[expected_failure]
+    public(script) fun test_add_new_participant_v_cap() {
+        let (alice, bob) = create_two_signers();
+        CapBasedMB::message_board_init_internal(&alice);
+        CapBasedMB::add_participant_internal(&alice, Signer::address_of(&bob));
+        CapBasedMB::send_pinned_message(bob, Signer::address_of(&alice), BOB_IS_HERE);
+    }
+
+    #[test_only]
+    fun create_two_signers(): (signer, signer) {
+        let signers = &mut UnitTest::create_signers_for_testing(2);
+        (Vector::pop_back(signers), Vector::pop_back(signers))
+    }
+}
+


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add two message board demos. one for ACL and the other use capability


**Followup**:
how to demo this through the cli or rest_call
### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan
Added move unit test
`cargo test -p framework -- --exact example_unit_tests
` passed
