### PR TITLE
Update crypto

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,14 +13,6 @@ jobs:
     steps:
       - dev-setup
       - run: cargo x bench --no-run
-  crypto:
-    docker:
-      - image: cimg/base:stable
-    resource_class: medium
-    steps:
-      - dev-setup
-      - run: cargo nextest --nextest-profile ci --package aptos-crypto --features='u32' --no-default-features
-      - run: cargo nextest --nextest-profile ci --package aptos-crypto --features='u64' --no-default-features
   lint:
     docker:
       - image: cimg/base:2020.01
@@ -210,7 +202,6 @@ workflows:
         - equal: [ canary, << pipeline.git.branch >> ]
     jobs:
 #      - build-benchmarks
-      - crypto
       - e2e-test
       - lint
       - unit-test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,9 +292,9 @@ dependencies = [
  "byteorder",
  "bytes",
  "criterion",
- "curve25519-dalek-fiat",
+ "curve25519-dalek",
  "digest 0.9.0",
- "ed25519-dalek-fiat",
+ "ed25519-dalek",
  "hex",
  "hkdf",
  "mirai-annotations",
@@ -314,7 +314,7 @@ dependencies = [
  "thiserror",
  "tiny-keccak",
  "trybuild",
- "x25519-dalek-fiat",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -2446,6 +2446,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.5.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "curve25519-dalek-fiat"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2750,6 +2763,20 @@ checksum = "eed12bbf7b5312f8da1c2722bc06d8c6b12c2d86a7fb35a194c7f3e6fc2bbe39"
 dependencies = [
  "serde 1.0.136",
  "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "git+https://github.com/dalek-cryptography/ed25519-dalek?rev=44488e43b8d61fa8263b146f9a1beba5549f8b0e#44488e43b8d61fa8263b146f9a1beba5549f8b0e"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.8.4",
+ "serde 1.0.136",
+ "serde_bytes",
+ "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -9409,12 +9436,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "x25519-dalek-fiat"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3519d56987103ef084eba6ddfc3be45b7eaee08f2d60bc8495cdca30362a32"
+name = "x25519-dalek"
+version = "2.0.0-pre.1"
+source = "git+https://github.com/dalek-cryptography/x25519-dalek?rev=3fc0108d7dee1c434158169f5a64b1f08e7bc12d#3fc0108d7dee1c434158169f5a64b1f08e7bc12d"
 dependencies = [
- "curve25519-dalek-fiat",
+ "curve25519-dalek",
  "rand_core 0.6.3",
  "zeroize",
 ]
@@ -9436,9 +9462,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
+checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8740,7 +8740,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.52"
 bytes = "1.0.1"
-curve25519-dalek = { version = "0.1.0", package = "curve25519-dalek-fiat", default-features = false, features = ["std"] }
+curve25519-dalek = { version = "3", default-features = false }
 digest = "0.9.0"
-ed25519-dalek = { version = "0.1.0", package = "ed25519-dalek-fiat", default-features = false, features = ["std", "serde"] }
+ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", rev = "44488e43b8d61fa8263b146f9a1beba5549f8b0e", features = ["std", "serde"] }
 hex = "0.4.3"
 hkdf = "0.10.0"
 once_cell = "1.7.2"
@@ -30,7 +30,7 @@ sha2 = "0.9.3"
 static_assertions = "1.1.0"
 thiserror = "1.0.24"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
-x25519-dalek = { version = "0.1.0", package = "x25519-dalek-fiat", default-features = false, features = ["std"] }
+x25519-dalek = { version = "2.0.0-pre.1" }
 aes-gcm = "0.8.0"
 aptos-crypto-derive = { path = "../aptos-crypto-derive", version = "0.0.3" }
 bcs = "0.1.2"
@@ -48,13 +48,10 @@ serde_json = "1.0.64"
 trybuild = "1.0.41"
 
 [features]
-default = ["fiat"]
+default = []
 assert-private-keys-not-cloneable = []
 cloneable-private-keys = []
 fuzzing = ["proptest", "proptest-derive", "cloneable-private-keys"]
-fiat = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend", "x25519-dalek/fiat_u64_backend"]
-u64 = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend", "x25519-dalek/u64_backend"]
-u32 = ["curve25519-dalek/u32_backend", "ed25519-dalek/u32_backend", "x25519-dalek/u32_backend"]
 
 [[bench]]
 name = "noise"

--- a/crates/aptos-crypto/benches/noise.rs
+++ b/crates/aptos-crypto/benches/noise.rs
@@ -35,7 +35,7 @@ fn benchmarks(c: &mut Criterion) {
         let responder_static = responder_static.to_bytes();
 
         let mut first_message = [0u8; handshake_init_msg_len(0)];
-        let mut second_message = [0u8; handshake_init_msg_len(0)];
+        let mut second_message = [0u8; handshake_resp_msg_len(0)];
 
         b.iter(|| {
             let initiator_static =

--- a/crates/aptos-crypto/src/ed25519.rs
+++ b/crates/aptos-crypto/src/ed25519.rs
@@ -247,7 +247,7 @@ impl SigningKey for Ed25519PrivateKey {
 impl Uniform for Ed25519PrivateKey {
     fn generate<R>(rng: &mut R) -> Self
     where
-        R: ::rand::RngCore + ::rand::CryptoRng,
+        R: ::rand::RngCore + ::rand::CryptoRng + ::rand_core::CryptoRng + ::rand_core::RngCore,
     {
         Ed25519PrivateKey(ed25519_dalek::SecretKey::generate(rng))
     }

--- a/crates/aptos-crypto/src/lib.rs
+++ b/crates/aptos-crypto/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
-//! This feature gets turned on only if aptos-crypto is compiled via MIRAI in a nightly build.
-#![cfg_attr(mirai, allow(incomplete_features), feature(const_generics))]
 
 //! A library supplying various cryptographic primitives
 pub mod compat;
@@ -22,9 +20,6 @@ pub mod x25519;
 #[cfg(test)]
 mod unit_tests;
 
-#[cfg(mirai)]
-mod tags;
-
 pub use self::traits::*;
 pub use hash::HashValue;
 
@@ -33,37 +28,3 @@ pub use hash::HashValue;
 pub use once_cell as _once_cell;
 #[doc(hidden)]
 pub use serde_name as _serde_name;
-
-// We use [formally verified arithmetic](https://crates.io/crates/fiat-crypto)
-// in maintained forks of the dalek suite of libraries ({curve, ed,
-// x}25519-dalek). This is controlled by a feature in the forked crates
-// ('fiat_u64_backend'), which we turn on by default.
-#[cfg(not(any(feature = "fiat", feature = "u64", feature = "u32")))]
-compile_error!(
-    "no dalek arithmetic backend cargo feature enabled! \
-     please enable one of: fiat, u64, u32"
-);
-
-#[cfg(all(feature = "fiat", feature = "u64"))]
-compile_error!(
-    "at most one dalek arithmetic backend cargo feature should be enabled! \
-     please enable exactly one of: fiat, u64, u32"
-);
-
-#[cfg(all(feature = "fiat", feature = "u32"))]
-compile_error!(
-    "at most one dalek arithmetic backend cargo feature should be enabled! \
-     please enable exactly one of: fiat, u64, u32"
-);
-
-#[cfg(all(feature = "u64", feature = "u32"))]
-compile_error!(
-    "at most one dalek arithmetic backend cargo feature should be enabled! \
-     please enable exactly one of: fiat, u64, u32"
-);
-
-// MIRAI's tag analysis makes use of the incomplete const_generics feature, so the module
-// containing the definitions of MIRAI tag types should not get compiled in a release build.
-// The code below fails a build of the crate if mirai is on but debug_assertions is not.
-#[cfg(all(mirai, not(debug_assertions)))]
-compile_error!("MIRAI can only be used to compile the crate in a debug build!");

--- a/crates/aptos-crypto/src/unit_tests/ed25519_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/ed25519_test.rs
@@ -188,6 +188,7 @@ proptest! {
     // modifying the public key and the R component, under a pathological yet
     // admissible s < l value for the signature. It shows the difference
     // between `verify` and `verify_strict` in ed25519-dalek
+    #[ignore]
     #[test]
     fn verify_sig_strict_torsion(idx in 0usize..8usize){
         let message = b"hello_world";
@@ -438,6 +439,7 @@ proptest! {
 }
 
 // Test against known small subgroup public keys.
+#[ignore]
 #[test]
 fn test_publickey_smallorder() {
     for torsion_point in &EIGHT_TORSION {

--- a/crates/aptos-crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/multi_ed25519_test.rs
@@ -154,6 +154,7 @@ fn test_multi_ed25519_public_key_serialization() {
 }
 
 // Test against known small subgroup public key.
+#[ignore]
 #[test]
 fn test_publickey_smallorder() {
     // A small group point with threshold 1 (last byte).

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { version = "1.17.0", features = ["bytes", "fs", "full", "io-std", "io-u
 tokio-util = { version = "0.6.9", features = ["codec", "compat", "futures-io", "io"] }
 tracing = { version = "0.1.32", features = ["attributes", "log", "std", "tracing-attributes"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
-zeroize = { version = "1.5.3", features = ["alloc", "zeroize_derive"] }
+zeroize = { version = "1.4.0", features = ["alloc", "zeroize_derive"] }
 
 [build-dependencies]
 Inflector = { version = "0.11.4", features = ["heavyweight", "lazy_static", "regex"] }
@@ -104,7 +104,7 @@ tokio = { version = "1.17.0", features = ["bytes", "fs", "full", "io-std", "io-u
 tokio-util = { version = "0.6.9", features = ["codec", "compat", "futures-io", "io"] }
 tracing = { version = "0.1.32", features = ["attributes", "log", "std", "tracing-attributes"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
-zeroize = { version = "1.5.3", features = ["alloc", "zeroize_derive"] }
+zeroize = { version = "1.4.0", features = ["alloc", "zeroize_derive"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 hashbrown = { version = "0.11.2", default-features = false, features = ["inline-more", "raw"] }

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -55,7 +55,7 @@ tokio = { version = "1.17.0", features = ["bytes", "fs", "full", "io-std", "io-u
 tokio-util = { version = "0.6.9", features = ["codec", "compat", "futures-io", "io"] }
 tracing = { version = "0.1.32", features = ["attributes", "log", "std", "tracing-attributes"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
-zeroize = { version = "1.4.0", features = ["alloc", "zeroize_derive"] }
+zeroize = { version = "1.5.4", features = ["alloc", "zeroize_derive"] }
 
 [build-dependencies]
 Inflector = { version = "0.11.4", features = ["heavyweight", "lazy_static", "regex"] }
@@ -104,7 +104,7 @@ tokio = { version = "1.17.0", features = ["bytes", "fs", "full", "io-std", "io-u
 tokio-util = { version = "0.6.9", features = ["codec", "compat", "futures-io", "io"] }
 tracing = { version = "0.1.32", features = ["attributes", "log", "std", "tracing-attributes"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
-zeroize = { version = "1.4.0", features = ["alloc", "zeroize_derive"] }
+zeroize = { version = "1.5.4", features = ["alloc", "zeroize_derive"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 hashbrown = { version = "0.11.2", default-features = false, features = ["inline-more", "raw"] }


### PR DESCRIPTION
Our crypto dependencies will inevitably bit rot and we've forked far too long from what everyone else in Rust is using.

This moves us to the upstream dalek crates, strips out using the "verified u64 backend", and also eliminates the strict checking of public keys. If we perceive that we need strict checking, we should either add it back in, in some other fashion -- e.g., when registering on-chain, performing strict verification, or using some sort of a cache.

I'll rebase this once the 1.59 PR lands