### PR TITLE
[tooling] Ensure ExtractPeer creates upstream peers

### DIFF
--- a/config/management/operational/src/keys.rs
+++ b/config/management/operational/src/keys.rs
@@ -98,6 +98,7 @@ impl GenerateKey {
     }
 }
 
+/// Extracts an upstream peer config from a key
 #[derive(Debug, StructOpt)]
 pub struct ExtractPeersFromKeys {
     #[structopt(long, parse(try_from_str = parse_public_keys_hex))]
@@ -144,6 +145,7 @@ impl ExtractPeersFromKeys {
     }
 }
 
+/// Extracts an upstream peer config from a file
 #[derive(Debug, StructOpt)]
 pub struct ExtractPeerFromFile {
     /// Location to read the key
@@ -169,6 +171,7 @@ impl ExtractPeerFromFile {
     }
 }
 
+/// Extracts an upstream peer config from storage
 #[derive(Debug, StructOpt)]
 pub struct ExtractPeerFromStorage {
     #[structopt(flatten)]
@@ -209,7 +212,7 @@ fn peer_from_public_key(public_key: x25519::PublicKey) -> (AccountAddress, Peer)
     public_keys.insert(public_key);
     (
         peer_id,
-        Peer::new(Vec::new(), public_keys, PeerRole::Downstream),
+        Peer::new(Vec::new(), public_keys, PeerRole::Upstream),
     )
 }
 

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -61,7 +61,7 @@ impl FromStr for KeyPairType {
     }
 }
 
-/// CLI tool for extracting full peer information from a given public key file
+/// CLI tool for extracting full peer information for an upstream peer
 #[derive(Debug, Parser)]
 pub struct ExtractPeer {
     /// Public key input file name.
@@ -317,5 +317,8 @@ fn build_peer_from_public_key(public_key: x25519::PublicKey) -> (AccountAddress,
     let peer_id = from_identity_public_key(public_key);
     let mut public_keys = HashSet::new();
     public_keys.insert(public_key);
-    (peer_id, Peer::new(Vec::new(), public_keys, PeerRole::Known))
+    (
+        peer_id,
+        Peer::new(Vec::new(), public_keys, PeerRole::Upstream),
+    )
 }

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -609,7 +609,7 @@ async fn test_extract_peers_from_keys() {
 
         assert_eq!(1, keys.len());
         assert!(keys.contains(&key));
-        assert_eq!(PeerRole::Downstream, peer.role);
+        assert_eq!(PeerRole::Upstream, peer.role);
         assert!(peer.addresses.is_empty());
     }
 }


### PR DESCRIPTION
It was confusing for users as the default was `Downstream` though, it is mainly used for `Upstream` nodes.