### PR TITLE
[tooling] Improve ergonomics on inputs of private / public keys for all tooling

### DIFF
--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos::{common::types::EncodingType, op::key::load_key};
+use aptos::common::types::EncodingType;
 use aptos_crypto::ed25519;
 use aptos_logger::info;
 use aptos_sdk::types::{
@@ -67,8 +67,9 @@ async fn main() {
         args.maximum_amount,
     );
 
-    let key: ed25519::Ed25519PrivateKey =
-        load_key(Path::new(&args.mint_key_file_path), EncodingType::BCS).unwrap();
+    let key: ed25519::Ed25519PrivateKey = EncodingType::BCS
+        .load_key(Path::new(&args.mint_key_file_path))
+        .unwrap();
 
     let faucet_address: AccountAddress =
         args.mint_account_address.unwrap_or_else(aptos_root_address);

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -2,7 +2,7 @@
 name = "aptos"
 version = "0.1.0"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
-description = "Aptos tool for management of nodes and interacting with blockchain"
+description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"
 homepage = "https://aptoslabs.com"
 license = "Apache-2.0"

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 /// CLI tool for interacting with the Aptos blockchain and nodes
 ///
 #[derive(Parser)]
-#[clap(name = "aptos")]
+#[clap(name = "aptos", author, version, propagate_version = true)]
 pub enum Tool {
     #[clap(subcommand)]
     Move(move_tool::MoveTool),

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -3,26 +3,21 @@
 
 use crate::{
     common::{
-        types::{EncodingOptions, EncodingType, Error, KeyInputOptions, KeyType, PromptOptions},
-        utils::{append_file_extension, prompt_yes, to_common_result},
+        types::{EncodingOptions, EncodingType, Error, KeyInputOptions, KeyType, SaveFile},
+        utils::{append_file_extension, check_if_file_exists, to_common_result, write_to_file},
     },
     CliResult,
 };
 use aptos_config::config::{Peer, PeerRole};
 use aptos_crypto::{
     ed25519, ed25519::Ed25519PrivateKey, x25519, PrivateKey, Uniform, ValidCryptoMaterial,
-    ValidCryptoMaterialStringExt,
 };
 use aptos_types::account_address::{from_identity_public_key, AccountAddress};
-use clap::{ArgEnum, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use rand::SeedableRng;
-use serde::Serialize;
 use std::{
     collections::{HashMap, HashSet},
-    fs::File,
-    io::Write,
     path::{Path, PathBuf},
-    str::FromStr,
 };
 
 pub const PUBLIC_KEY_EXTENSION: &str = "pub";
@@ -43,66 +38,57 @@ impl KeyTool {
     }
 }
 
-#[derive(Debug, ArgEnum, Clone)]
-enum KeyPairType {
-    Public,
-    Private,
-}
-
-impl FromStr for KeyPairType {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "public" => Ok(KeyPairType::Public),
-            "private" => Ok(KeyPairType::Private),
-            _ => Err(Error::CommandArgumentError("Invalid key type".to_string())),
-        }
-    }
-}
-
 /// CLI tool for extracting full peer information for an upstream peer
+///
+/// A `private-key` or `public-key` can be given encoded on the command line, or
+/// a `private-key-file` or a `public-key-file` can be given to read from.
+/// The `output_file` will be a YAML serialized peer information for use in network config.
 #[derive(Debug, Parser)]
 pub struct ExtractPeer {
     #[clap(flatten)]
     key_input_options: KeyInputOptions,
-    /// Peer config output file
-    #[structopt(long, parse(from_os_str))]
-    output_file: Option<PathBuf>,
+    #[clap(flatten)]
+    output_file_options: SaveFile,
     #[clap(flatten)]
     encoding_options: EncodingOptions,
-    #[clap(flatten)]
-    prompt_options: PromptOptions,
 }
 
 impl ExtractPeer {
     pub fn execute(self) -> Result<HashMap<AccountAddress, Peer>, Error> {
-        // If saving to file, check if file exists
-        if let Some(output_file) = self.output_file.as_ref() {
-            check_if_file_exists(output_file.as_path(), self.prompt_options.assume_yes)?;
-        }
+        // Check output file exists
+        self.output_file_options.check_file()?;
 
         // Load key based on public or private
         let public_key = self
             .key_input_options
             .extract_public_key(self.encoding_options.encoding)?;
 
-        let (peer_id, peer) = build_peer_from_public_key(public_key);
+        // Build peer info
+        // TODO: Take in an address?
+        let peer_id = from_identity_public_key(public_key);
+        let mut public_keys = HashSet::new();
+        public_keys.insert(public_key);
+
+        let peer = Peer::new(Vec::new(), public_keys, PeerRole::Upstream);
 
         let mut map = HashMap::new();
         map.insert(peer_id, peer);
 
-        // Save to file if we're doing that
-        if let Some(output_file) = self.output_file {
-            save_to_yaml(output_file.as_path(), "seeds", &map)?;
-        }
+        // Save to file
+        let yaml =
+            serde_yaml::to_string(&map).map_err(|err| Error::UnexpectedError(err.to_string()))?;
+        self.output_file_options
+            .save_to_file("Extracted peer", yaml.as_bytes())?;
         Ok(map)
     }
 }
 
 /// Generates a `x25519` or `ed25519` key.
 ///
-/// This can be used for generating an identity.
+/// This can be used for generating an identity.  Two files will be created
+/// `output_file` and `output_file.pub`.  `output_file` will contain the private
+/// key encoded with the `encoding` and `output_file.pub` will contain the public
+/// key encoded with the `encoding`.
 #[derive(Debug, Parser)]
 pub struct GenerateKey {
     /// Key type: `x25519` or `ed25519`
@@ -133,45 +119,39 @@ impl GenerateKey {
 
     /// A test friendly typed key generation for x25519 keys.
     pub fn generate_x25519(
-        encoding_type: EncodingType,
+        encoding: EncodingType,
         key_file: &Path,
     ) -> Result<(x25519::PrivateKey, x25519::PublicKey), Error> {
         let args = format!(
-            "generate --key-type {key_type:?} --key-file {key_file} --encoding {encoding_type:?} --assume-yes",
+            "generate --key-type {key_type:?} --output-file {key_file} --encoding {encoding:?} --assume-yes",
             key_type = KeyType::X25519,
             key_file = key_file.to_str().unwrap(),
-            encoding_type = encoding_type,
+            encoding = encoding,
         );
         let command = GenerateKey::parse_from(args.split_whitespace());
         command.execute()?;
         Ok((
-            load_key(key_file, encoding_type)?,
-            load_key(
-                &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?,
-                encoding_type,
-            )?,
+            encoding.load_key(key_file)?,
+            encoding.load_key(&append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
         ))
     }
 
     /// A test friendly typed key generation for e25519 keys.
     pub fn generate_ed25519(
-        encoding_type: EncodingType,
+        encoding: EncodingType,
         key_file: &Path,
     ) -> Result<(ed25519::Ed25519PrivateKey, ed25519::Ed25519PublicKey), Error> {
         let args = format!(
-            "generate --key-type {key_type:?} --key-file {key_file} --encoding {encoding_type:?} --assume-yes",
+            "generate --key-type {key_type:?} --output-file {key_file} --encoding {encoding:?} --assume-yes",
             key_type = KeyType::Ed25519,
             key_file = key_file.to_str().unwrap(),
-            encoding_type = encoding_type,
+            encoding = encoding,
         );
         let command = GenerateKey::parse_from(args.split_whitespace());
         command.execute()?;
         Ok((
-            load_key(key_file, encoding_type)?,
-            load_key(
-                &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?,
-                encoding_type,
-            )?,
+            encoding.load_key(key_file)?,
+            encoding.load_key(&append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
         ))
     }
 
@@ -184,26 +164,29 @@ impl GenerateKey {
 
 #[derive(Debug, Parser)]
 pub struct SaveKey {
-    /// Private key output file name.  Public key will be saved to <key-file>.pub
-    #[clap(long, parse(from_os_str))]
-    key_file: PathBuf,
+    #[clap(flatten)]
+    file_options: SaveFile,
     #[clap(flatten)]
     encoding_options: EncodingOptions,
-    #[clap(flatten)]
-    prompt_options: PromptOptions,
 }
 
 impl SaveKey {
     /// Public key file name
     fn public_key_file(&self) -> Result<PathBuf, Error> {
-        append_file_extension(&self.key_file, PUBLIC_KEY_EXTENSION)
+        append_file_extension(
+            self.file_options.output_file.as_path(),
+            PUBLIC_KEY_EXTENSION,
+        )
     }
 
     /// Check if the key file exists already
     pub fn check_key_file(&self) -> Result<(), Error> {
         // Check if file already exists
-        check_if_file_exists(&self.key_file, self.prompt_options.assume_yes)?;
-        check_if_file_exists(&self.public_key_file()?, self.prompt_options.assume_yes)
+        self.file_options.check_file()?;
+        check_if_file_exists(
+            &self.public_key_file()?,
+            self.file_options.prompt_options.assume_yes,
+        )
     }
 
     /// Saves a key to a file encoded in a string
@@ -212,110 +195,21 @@ impl SaveKey {
         key: &Key,
         key_name: &'static str,
     ) -> Result<HashMap<&'static str, PathBuf>, Error> {
-        let encoded_private_key = encode_key(self.encoding_options.encoding, key, key_name)?;
-        let encoded_public_key =
-            encode_key(self.encoding_options.encoding, &key.public_key(), key_name)?;
+        let encoded_private_key = self.encoding_options.encoding.encode_key(key, key_name)?;
+        let encoded_public_key = self
+            .encoding_options
+            .encoding
+            .encode_key(&key.public_key(), key_name)?;
 
         // Write private and public keys to files
         let public_key_file = self.public_key_file()?;
-        write_to_file(&self.key_file, key_name, &encoded_private_key)?;
+        self.file_options
+            .save_to_file(key_name, &encoded_private_key)?;
         write_to_file(&public_key_file, key_name, &encoded_public_key)?;
 
         let mut map = HashMap::new();
-        map.insert("PrivateKey Path", self.key_file.clone());
+        map.insert("PrivateKey Path", self.file_options.output_file.clone());
         map.insert("PublicKey Path", public_key_file);
         Ok(map)
     }
-}
-
-/// Encodes `Key` into one of the `EncodingType`s
-pub fn encode_key<Key: ValidCryptoMaterial>(
-    encoding: EncodingType,
-    key: &Key,
-    key_name: &str,
-) -> Result<Vec<u8>, Error> {
-    Ok(match encoding {
-        EncodingType::Hex => hex::encode_upper(key.to_bytes()).into_bytes(),
-        EncodingType::BCS => {
-            bcs::to_bytes(key).map_err(|err| Error::BCS(key_name.to_string(), err))?
-        }
-        EncodingType::Base64 => base64::encode(key.to_bytes()).into_bytes(),
-    })
-}
-
-/// Write a `&[u8]` to a file
-fn write_to_file(key_file: &Path, name: &str, encoded: &[u8]) -> Result<(), Error> {
-    let mut file = File::create(key_file).map_err(|e| Error::IO(name.to_string(), e))?;
-    file.write_all(encoded)
-        .map_err(|e| Error::IO(name.to_string(), e))
-}
-
-/// Checks if a file exists, being overridden by `--assume-yes`
-fn check_if_file_exists(file: &Path, assume_yes: bool) -> Result<(), Error> {
-    if file.exists()
-        && !assume_yes
-        && !prompt_yes(
-            format!(
-                "{:?} already exists, are you sure you want to overwrite it?",
-                file.as_os_str()
-            )
-            .as_str(),
-        )
-    {
-        Err(Error::AbortedError)
-    } else {
-        Ok(())
-    }
-}
-
-/// Loads a key from a file
-pub fn load_key<Key: ValidCryptoMaterial>(
-    path: &Path,
-    encoding: EncodingType,
-) -> Result<Key, Error> {
-    let data = std::fs::read(&path).map_err(|err| {
-        Error::UnableToReadFile(path.to_str().unwrap().to_string(), err.to_string())
-    })?;
-
-    decode_key(data, encoding)
-}
-
-/// Decodes an encoded key given the known encoding
-pub fn decode_key<Key: ValidCryptoMaterial>(
-    data: Vec<u8>,
-    encoding: EncodingType,
-) -> Result<Key, Error> {
-    match encoding {
-        EncodingType::BCS => {
-            bcs::from_bytes(&data).map_err(|err| Error::BCS("Key".to_string(), err))
-        }
-        EncodingType::Hex => {
-            let hex_string = String::from_utf8(data).unwrap();
-            Key::from_encoded_string(hex_string.trim())
-                .map_err(|err| Error::UnableToParse("Key", err.to_string()))
-        }
-        EncodingType::Base64 => {
-            let string = String::from_utf8(data).unwrap();
-            let bytes = base64::decode(string.trim())
-                .map_err(|err| Error::UnableToParse("Key", err.to_string()))?;
-            Key::try_from(bytes.as_slice())
-                .map_err(|err| Error::UnexpectedError(format!("Failed to parse key {}", err)))
-        }
-    }
-}
-
-fn save_to_yaml<T: Serialize>(path: &Path, input_name: &str, item: &T) -> Result<(), Error> {
-    let yaml =
-        serde_yaml::to_string(item).map_err(|err| Error::UnexpectedError(err.to_string()))?;
-    write_to_file(path, input_name, yaml.as_bytes())
-}
-
-fn build_peer_from_public_key(public_key: x25519::PublicKey) -> (AccountAddress, Peer) {
-    let peer_id = from_identity_public_key(public_key);
-    let mut public_keys = HashSet::new();
-    public_keys.insert(public_key);
-    (
-        peer_id,
-        Peer::new(Vec::new(), public_keys, PeerRole::Upstream),
-    )
 }

--- a/crates/aptos/src/op/mod.rs
+++ b/crates/aptos/src/op/mod.rs
@@ -13,7 +13,7 @@ pub mod key;
 
 /// CLI tool for performing operational tasks
 ///
-#[derive(Debug, ArgEnum, Subcommand)]
+#[derive(ArgEnum, Debug, Subcommand)]
 pub enum OpTool {
     #[clap(subcommand)]
     Key(key::KeyTool),

--- a/crates/transaction-emitter/src/cluster.rs
+++ b/crates/transaction-emitter/src/cluster.rs
@@ -5,7 +5,7 @@
 
 use crate::{instance::Instance, query_sequence_numbers};
 use anyhow::{format_err, Result};
-use aptos::{common::types::EncodingType, op::key::load_key};
+use aptos::common::types::EncodingType;
 use aptos_crypto::{
     ed25519,
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
@@ -54,7 +54,8 @@ impl Cluster {
             dummy_key_pair()
         } else {
             KeyPair::from(
-                load_key::<ed25519::Ed25519PrivateKey>(Path::new(mint_file), EncodingType::BCS)
+                EncodingType::BCS
+                    .load_key::<ed25519::Ed25519PrivateKey>(Path::new(mint_file))
                     .unwrap(),
             )
         };

--- a/crates/transaction-emitter/src/lib.rs
+++ b/crates/transaction-emitter/src/lib.rs
@@ -39,7 +39,7 @@ pub mod atomic_histogram;
 pub mod cluster;
 pub mod instance;
 
-use aptos::{common::types::EncodingType, op::key::load_key};
+use aptos::common::types::EncodingType;
 use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use aptos_sdk::{
     transaction_builder::aptos_stdlib,
@@ -378,7 +378,7 @@ impl<'t> TxnEmitter<'t> {
         index: usize,
     ) -> Result<LocalAccount> {
         let file = "vasp".to_owned() + index.to_string().as_str() + ".key";
-        let mint_key: Ed25519PrivateKey = load_key(Path::new(&file), EncodingType::BCS).unwrap();
+        let mint_key: Ed25519PrivateKey = EncodingType::BCS.load_key(Path::new(&file)).unwrap();
         let account_key = AccountKey::from_private_key(mint_key);
         let address = account_key.authentication_key().derived_address();
         let sequence_number = query_sequence_numbers(client, &[address])


### PR DESCRIPTION
* Added version information to the tool
* Added ergonomics that allow us to have many different inputs for different types of tools around keys and properly load different encodings, while not allowing duplicate input types.

## Examples:

### Help:
```
$ ./aptos help
aptos 0.1.0
Aptos Labs <opensource@aptoslabs.com>
CLI tool for interacting with the Aptos blockchain and nodes

USAGE:
    aptos <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    help    Print this message or the help of the given subcommand(s)
    op      CLI tool for performing operational tasks

$ ./aptos op help
aptos-op 0.1.0
CLI tool for performing operational tasks

USAGE:
    aptos op <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    help    Print this message or the help of the given subcommand(s)
    key     CLI tool for generating, inspecting, and interacting with keys

$ ./aptos op key help
aptos-op-key 0.1.0
CLI tool for generating, inspecting, and interacting with keys

USAGE:
    aptos op key <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    extract-peer    CLI tool for extracting full peer information for an upstream peer
    generate        Generates a `x25519` or `ed25519` key
    help            Print this message or the help of the given subcommand(s)

$ ./aptos op key generate --help
aptos-op-key-generate 0.1.0
Generates a `x25519` or `ed25519` key.

This can be used for generating an identity.  Two files will be created `output_file` and
`output_file.pub`.  `output_file` will contain the private key encoded with the `encoding` and
`output_file.pub` will contain the public key encoded with the `encoding`.

USAGE:
    aptos op key generate [OPTIONS] --output-file <OUTPUT_FILE>

OPTIONS:
        --assume-yes
            Assume yes for all yes/no prompts

        --encoding <ENCODING>
            Encoding of data as `base64`, `bcs`, or `hex`

            [default: hex]

    -h, --help
            Print help information

        --key-type <KEY_TYPE>
            Key type: `x25519` or `ed25519`

            [default: ed25519]

        --output-file <OUTPUT_FILE>
            Output file name

    -V, --version
            Print version information

$ ./aptos op key extract-peer --help
aptos-op-key-extract-peer 0.1.0
CLI tool for extracting full peer information for an upstream peer

A `private-key` or `public-key` can be given encoded on the command line, or a `private-key-file` or
a `public-key-file` can be given to read from. The `output_file` will be a YAML serialized peer
information for use in network config.

USAGE:
    aptos op key extract-peer [OPTIONS] --output-file <OUTPUT_FILE>

OPTIONS:
        --assume-yes
            Assume yes for all yes/no prompts

        --encoding <ENCODING>
            Encoding of data as `base64`, `bcs`, or `hex`

            [default: hex]

    -h, --help
            Print help information

        --output-file <OUTPUT_FILE>
            Output file name

        --private-key <PRIVATE_KEY>
            Private key encoded in a type as shown in `encoding`

        --private-key-file <PRIVATE_KEY_FILE>
            Private key input file name

        --public-key <PUBLIC_KEY>
            Public key encoded in a type as shown in `encoding`

        --public-key-file <PUBLIC_KEY_FILE>
            Public key input file name

    -V, --version
            Print version information
```

### Running tools
```
$ ./aptos op key generate --encoding base64 --key-type x25519 --output-file test
{
  "Result": {
    "PrivateKey Path": "test",
    "PublicKey Path": "test.pub"
  }
}

$ cat test
mFVPw9wX6CVzgz6FkR2TR7jL/dLbHEk7HUGTaGG4JHM=

$ cat test.pub
AIzVVhoRM45tC3gt6A8KK7k3GbmcI2bTsdTZ4EmI5E4=

$ ./aptos op key extract-peer --encoding base64 --output-file peer_info.yaml
{
  "Error": "Invalid arguments: One of ['--private-key', '--private-key-file', '--public-key', '--public-key-file'] must be used"
}

$ ./aptos op key extract-peer --encoding base64 --output-file peer_info.yaml --private-key mFVPw9wX6CVzgz6FkR2TR7jL/dLbHEk7HUGTaGG4JHM=
{
  "Result": {
    "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e": {
      "addresses": [],
      "keys": [
        "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e"
      ],
      "role": "Upstream"
    }
  }
}

$ cat peer_info.yaml
---
008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e:
  addresses: []
  keys:
    - 008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e
  role: Known

$ ./aptos op key extract-peer --encoding base64 --output-file peer_info.yaml --private-key-file test
"peer_info.yaml" already exists, are you sure you want to overwrite it? [yes/no] >
yes
{
  "Result": {
    "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e": {
      "addresses": [],
      "keys": [
        "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e"
      ],
      "role": "Upstream"
    }
  }
}

$ cat peer_info.yaml
---
008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e:
  addresses: []
  keys:
    - 008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e
  role: Upstream

$ ./aptos op key extract-peer --encoding base64 --output-file peer_info.yaml --public-key-file test.pub --assume-yes
{
  "Result": {
    "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e": {
      "addresses": [],
      "keys": [
        "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e"
      ],
      "role": "Upstream"
    }
  }
}

$ cat peer_info.yaml
---
008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e:
  addresses: []
  keys:
    - 008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e
  role: Upstream

$ ./aptos op key extract-peer --encoding base64 --output-file peer_info.yaml --public-key AIzVVhoRM45tC3gt6A8KK7k3GbmcI2bTsdTZ4EmI5E4= --assume-yes
{
  "Result": {
    "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e": {
      "addresses": [],
      "keys": [
        "008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e"
      ],
      "role": "Upstream"
    }
  }
}

$ cat peer_info.yaml
---
008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e:
  addresses: []
  keys:
    - 008cd5561a11338e6d0b782de80f0a2bb93719b99c2366d3b1d4d9e04988e44e
  role: Upstream
  
$ ./aptos op key generate --encoding hex --key-type x25519 --output-file hex
{
  "Result": {
    "PrivateKey Path": "hex",
    "PublicKey Path": "hex.pub"
  }
}

$ ./aptos op key extract-peer --encoding hex --output-file peer_info.yaml --public-key-file hex.pub --assume-yes
{
  "Result": {
    "dcb1de8a9d3d9c026bb36e586b48c4358a4ef2b62bb7f0db9fcb7c883d3ce35f": {
      "addresses": [],
      "keys": [
        "dcb1de8a9d3d9c026bb36e586b48c4358a4ef2b62bb7f0db9fcb7c883d3ce35f"
      ],
      "role": "Upstream"
    }
  }
}

$ cat peer_info.yaml
---
dcb1de8a9d3d9c026bb36e586b48c4358a4ef2b62bb7f0db9fcb7c883d3ce35f:
  addresses: []
  keys:
    - dcb1de8a9d3d9c026bb36e586b48c4358a4ef2b62bb7f0db9fcb7c883d3ce35f
  role: Upstream
```

### Failure to have 2 competing inputs
```
$ ./aptos op key extract-peer --output-file peer_node.yaml --private-key-file test --public-key-file test.pub
error: The argument '--private-key-file <PRIVATE_KEY_FILE>' cannot be used with '--public-key-file <PUBLIC_KEY_FILE>'

USAGE:
    aptos op key extract-peer --output-file <OUTPUT_FILE> --output-file <OUTPUT_FILE> --private-key-file <PRIVATE_KEY_FILE>

For more information try --help
```