### PR TITLE
[sccache] Make cargo home same syntax as git home

### DIFF
--- a/x.toml
+++ b/x.toml
@@ -11,7 +11,7 @@ prefix = "sccache/aptos/"
 public = true
 region = "us-west-2"
 endpoint = "https://s3-us-west-2.amazonaws.com"
-required-cargo-home = "/opt/cargo/"
+required-cargo-home = "/opt/cargo"
 required-git-home = "/opt/git/aptos-core"
 envs = [
    #To debug sccache uncomment the two lines below.


### PR DESCRIPTION
The extra slash at the end caused some issues with installing things
with cargo, and we should just be consistent with our two inputs.

I do find a significant speedup with my sccache, though I was having a few weird build issues with it.

Anyone using `sccache` will have to remove the `/` at the end.