### PR TITLE
[State Sync] Add metrics for advertised data sizes and ranges.

### DIFF
--- a/state-sync/aptos-data-client/src/aptosnet/metrics.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/metrics.rs
@@ -3,7 +3,8 @@
 
 use aptos_crypto::_once_cell::sync::Lazy;
 use aptos_metrics::{
-    register_histogram_vec, register_int_counter_vec, HistogramTimer, HistogramVec, IntCounterVec,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, HistogramTimer,
+    HistogramVec, IntCounterVec, IntGaugeVec,
 };
 
 /// The special label TOTAL_COUNT stores the sum of all values in the counter.
@@ -49,10 +50,74 @@ pub static REQUEST_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Gauge for the highest advertised data
+pub static HIGHEST_ADVERTISED_DATA: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_data_client_highest_advertised_data",
+        "Gauge related to the highest advertised data",
+        &["data_type"]
+    )
+    .unwrap()
+});
+
+/// Gauge for the lowest advertised data
+pub static LOWEST_ADVERTISED_DATA: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_data_client_lowest_advertised_data",
+        "Gauge related to the lowest advertised data",
+        &["data_type"]
+    )
+    .unwrap()
+});
+
+/// Gauge for the optimal chunk sizes
+pub static OPTIMAL_CHUNK_SIZES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_data_client_optimal_chunk_sizes",
+        "Gauge related to the optimal chunk sizes",
+        &["data_type"]
+    )
+    .unwrap()
+});
+
+/// An enum representing the various types of data that can be
+/// fetched via the data client.
+pub enum DataType {
+    AccountStates,
+    LedgerInfos,
+    TransactionOutputs,
+    Transactions,
+}
+
+impl DataType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DataType::AccountStates => "account_states",
+            DataType::LedgerInfos => "ledger_infos",
+            DataType::TransactionOutputs => "transaction_outputs",
+            DataType::Transactions => "transactions",
+        }
+    }
+
+    pub fn get_all_types() -> Vec<DataType> {
+        vec![
+            DataType::AccountStates,
+            DataType::LedgerInfos,
+            DataType::TransactionOutputs,
+            DataType::Transactions,
+        ]
+    }
+}
+
 /// Increments the given counter with the provided label values.
 pub fn increment_counter(counter: &Lazy<IntCounterVec>, label: String) {
     counter.with_label_values(&[&label]).inc();
     counter.with_label_values(&[TOTAL_COUNT_LABEL]).inc();
+}
+
+/// Sets the gauge with the specific label and value
+pub fn set_gauge(counter: &Lazy<IntGaugeVec>, label: String, value: u64) {
+    counter.with_label_values(&[&label]).set(value as i64);
 }
 
 /// Starts the timer for the provided histogram and label values.

--- a/state-sync/aptos-data-client/src/lib.rs
+++ b/state-sync/aptos-data-client/src/lib.rs
@@ -380,4 +380,29 @@ impl AdvertisedData {
             None
         }
     }
+
+    /// Returns the lowest advertised version containing all account states
+    pub fn lowest_account_states_version(&self) -> Option<Version> {
+        get_lowest_version_from_range_set(&self.account_states)
+    }
+
+    /// Returns the lowest advertised transaction output version
+    pub fn lowest_transaction_output_version(&self) -> Option<Version> {
+        get_lowest_version_from_range_set(&self.transaction_outputs)
+    }
+
+    /// Returns the lowest advertised transaction version
+    pub fn lowest_transaction_version(&self) -> Option<Version> {
+        get_lowest_version_from_range_set(&self.transactions)
+    }
+}
+
+/// Returns the lowest version from the given set of data ranges
+fn get_lowest_version_from_range_set(
+    data_ranges: &[CompleteDataRange<Version>],
+) -> Option<Version> {
+    data_ranges
+        .iter()
+        .map(|data_range| data_range.lowest())
+        .min()
 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
@@ -6,7 +6,6 @@ use crate::{
     error::Error,
     logging::{LogEntry, LogEvent, LogSchema},
     metrics,
-    metrics::increment_counter,
     streaming_client::{
         StreamRequest, StreamRequestMessage, StreamingServiceListener, TerminateStreamRequest,
     },
@@ -128,7 +127,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
     ) -> Result<(), Error> {
         // Increment the stream termination counter
         let notification_feedback = &terminate_request.notification_feedback;
-        increment_counter(
+        metrics::increment_counter(
             &metrics::TERMINATE_DATA_STREAM,
             notification_feedback.get_label().into(),
         );
@@ -164,7 +163,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
         request_message: &StreamRequestMessage,
     ) -> Result<DataStreamListener, Error> {
         // Increment the stream creation counter
-        increment_counter(
+        metrics::increment_counter(
             &metrics::CREATE_DATA_STREAM,
             request_message.stream_request.get_label().into(),
         );
@@ -208,7 +207,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
     /// Refreshes the global data summary by communicating with the Aptos data client
     fn refresh_global_data_summary(&mut self) {
         if let Err(error) = self.fetch_global_data_summary() {
-            increment_counter(
+            metrics::increment_counter(
                 &metrics::GLOBAL_DATA_SUMMARY_ERROR,
                 error.get_label().into(),
             );
@@ -251,7 +250,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
                             .error(&error))
                     );
                 } else {
-                    increment_counter(
+                    metrics::increment_counter(
                         &metrics::CHECK_STREAM_PROGRESS_ERROR,
                         error.get_label().into(),
                     );


### PR DESCRIPTION
## Motivation

This PR adds additional metrics to the Aptos Data Client. Specifically, it helps to track advertised data type availability in the network and the current set of optimal chunk sizes.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually inspected the metrics being emitted.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245