### PR TITLE
[circleci] test docker-compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,18 +5,31 @@ orbs:
   aws-ecr: circleci/aws-ecr@7.3.0
   kubernetes: circleci/kubernetes@1.3.0
 
-jobs:
-  build-benchmarks:
+executors:
+  ubuntu-medium:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: medium
+  ubuntu-xl:
     machine:
       image: ubuntu-2004:current
     resource_class: xlarge
+  ubuntu-2xl:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: 2xlarge
+  docker-typescript-builder:
+    docker:
+      - image: circleci/node:16.13.1-browsers
+
+jobs:
+  build-benchmarks:
+    executor: ubuntu-xl
     steps:
       - dev-setup
       - run: cargo x bench --no-run
   lint:
-    docker:
-      - image: cimg/base:2020.01
-    resource_class: medium
+    executor: ubuntu-xl
     steps:
       - dev-setup
       - run: sudo apt-get install shellcheck --assume-yes --no-install-recommends
@@ -30,24 +43,18 @@ jobs:
       - run: cargo fmt
       - run: cargo xfmt --check
   e2e-test:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: 2xlarge
+    executor: ubuntu-2xl
     steps:
       - dev-setup
       - run: RUST_BACKTRACE=full cargo nextest --nextest-profile ci --partition hash:1/1 --test-threads 5 --package smoke-test
   unit-test:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: 2xlarge
+    executor: ubuntu-2xl
     steps:
       - dev-setup
       - run: cargo xtest --doc --unit --changed-since "origin/main"
       - run: cargo nextest --nextest-profile ci --partition hash:1/1 --unit --exclude backup-cli --changed-since "origin/main"
   docker-build-push:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: medium
+    executor: ubuntu-medium
     parameters:
       addl_tag:
         description: Additional image tag
@@ -82,9 +89,7 @@ jobs:
               exit $ret
             fi
   ecr-dockerhub-mirror:
-    machine:
-      image: ubuntu-2004:current
-    resource_class: medium
+    executor: ubuntu-medium
     parameters:
       addl_tag:
         description: Additional image tag
@@ -134,10 +139,8 @@ jobs:
               docker push "${org}/${img}:<<parameters.addl_tag>>" || ret=$?
             done
             exit $ret
-  forge-k8s:
-    docker:
-      - image: cimg/base:stable
-    resource_class: medium
+  forge-k8s-test:
+    executor: ubuntu-medium
     steps:
       - checkout
       - aws-setup
@@ -175,9 +178,41 @@ jobs:
             -X POST -d "{\"body\": \"${FORGE_COMMENT}\"}" \
             "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments"
             exit 0
+  docker-compose-test:
+    executor: ubuntu-medium
+    steps:
+      - checkout
+      - aws-setup
+      - aws-ecr-setup
+      - local-deploy-setup
+      - run: echo "export IMAGE_TAG=dev_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
+      # since we're running with `--build-all`, assume that if it passes, we have all images required for Forge
+      - run: aws ecr describe-images --repository-name="aptos/validator" --image-ids=imageTag=$IMAGE_TAG
+      - run:
+          name: Start local testnet docker-compose
+          shell: /bin/bash
+          working_directory: docker/compose/validator-testnet
+          command: |
+            export VALIDATOR_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/validator
+            export FAUCET_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/faucet
+            docker-compose up -d
+      - run:
+          name: Verify testnet docker-compose up
+          shell: /bin/bash
+          command: |
+            for i in $(seq 60); do
+              curl -s -w "\n%{http_code}\n" localhost:8080 | tee >(tail -1 > validator_ret.txt)
+              curl -s -w "\n%{http_code}\n" -X POST 'localhost:8000/mint?pub_key=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d&amount=20000000' \
+                | tee >(tail -1 > faucet_ret.txt)
+              if [ "$(cat validator_ret.txt)" = "200" ] && [ "$(cat faucet_ret.txt)" = "200" ]; then
+                echo "Both validator and faucet healthy"
+                exit 0
+              fi
+              sleep 1
+            done
+            exit 1
   sdk-typescript-test:
-    docker:
-      - image: circleci/node:16.13.1-browsers
+    executor: docker-typescript-builder
     steps:
       - checkout
       # install packages for examples
@@ -198,17 +233,21 @@ workflows:
     when:
       condition:
         or:
-        - equal: [ auto, << pipeline.git.branch >> ]
-        - equal: [ canary, << pipeline.git.branch >> ]
+          - equal: [auto, << pipeline.git.branch >>]
+          - equal: [canary, << pipeline.git.branch >>]
     jobs:
-#      - build-benchmarks
+      #      - build-benchmarks
       - e2e-test
       - lint
       - unit-test
       - sdk-typescript-test
       - docker-build-push:
           context: aws-dev
-      - forge-k8s:
+      - docker-compose-test:
+          context: aws-dev
+          requires:
+            - docker-build-push
+      - forge-k8s-test:
           context: aws-dev
           requires:
             - docker-build-push
@@ -216,7 +255,7 @@ workflows:
   # Ensure the latest is built on the "devnet" branch, and mirror from ECR to Dockerhub
   devnet-branch-cut:
     when:
-      equal: [ devnet, << pipeline.git.branch >> ]
+      equal: [devnet, << pipeline.git.branch >>]
     jobs:
       - docker-build-push:
           context: aws-dev
@@ -233,8 +272,8 @@ workflows:
   continuous-push:
     when:
       and:
-      - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-      - equal: [ "continuous_push", << pipeline.schedule.name >> ]
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["continuous_push", << pipeline.schedule.name >>]
     jobs:
       - docker-build-push:
           context: aws-dev
@@ -244,8 +283,8 @@ workflows:
   nightly:
     when:
       and:
-      - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-      - equal: [ "nightly", << pipeline.schedule.name >> ]
+        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
+        - equal: ["nightly", << pipeline.schedule.name >>]
     jobs:
       - docker-build-push:
           context: aws-dev
@@ -277,6 +316,14 @@ commands:
             echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
             sudo apt-get update
             sudo apt-get install helm
+  local-deploy-setup:
+    steps:
+      - run:
+          name: Install Docker Compose
+          command: |
+            sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+            docker-compose --version
   ### Sets up the permissions required for accessing AWS resources
   aws-setup:
     steps:

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
   validator:
     # Note this image currently does not support this, will update to the appropriate minimum
     # version shortly
-    image: "aptoslab/validator:${IMAGE_TAG:-devnet}"
+    image: "${VALIDATOR_IMAGE_REPO:-aptoslab/validator}:${IMAGE_TAG:-devnet}"
     networks:
       shared:
     volumes:
@@ -43,7 +43,7 @@ services:
       - 9101
 
   faucet:
-    image: "aptoslab/faucet:${IMAGE_TAG:-devnet}"
+    image: "${FAUCET_IMAGE_REPO:-aptoslab/faucet}:${IMAGE_TAG:-devnet}"
     depends_on:
       - validator
     networks:


### PR DESCRIPTION
Start running docker-compose in CircleCI. After this, it can then be used to for e2e tests like for clients like typescript SDK and indexer etc

Few things in this PR:
* Explicitly define CircleCI executors for various use cases
* Docker-compose for `validator-testnet` now takes in `IMAGE_TAG` and `VALIDATOR_IMAGE_REPO` and `FAUCET_IMAGE_REPO` so we can use the images just built in ECR
* Test docker-compose by spinning it up and spinning on successful response. Docker-compose needs to run on `machine` executor rather than `docker` since our docker-compose mounts an image https://circleci.com/docs/2.0/building-docker-images/#mounting-folders
* Run formatter

Test: canary https://app.circleci.com/pipelines/github/aptos-labs/aptos-core/1655/workflows/4e8b04ae-c726-4b18-a3c8-bc7e6c8b3899/jobs/8381