### PR TITLE
tutorial: minor fix wrt test node config path

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -202,7 +202,7 @@ pub fn load_test_environment<R>(
 
     println!("Completed generating configuration:");
     println!("\tLog file: {:?}", log_file);
-    println!("\tConfig path: {:?}", validator_config_path);
+    println!("\tConfig path: {:?}", config_path);
     println!("\tAptos root key path: {:?}", aptos_root_key_path);
     println!("\tWaypoint: {}", config.base.waypoint.genesis_waypoint());
     println!("\tChainId: {}", ChainId::test());

--- a/developer-docs-site/docs/tutorials/run-a-local-testnet.md
+++ b/developer-docs-site/docs/tutorials/run-a-local-testnet.md
@@ -31,7 +31,7 @@ We describe each method below.
     ./scripts/dev_setup.sh
     source ~/.cargo/env
     ```
-2. Run the command: `cargo run -p aptos-node -- --test`. After starting up, the process should print its config path (e.g., `/private/var/folders/36/w0v54r116ls44q29wh8db0mh0000gn/T/f62a72f87940e3892a860c21b55b529b/0/node.yaml`) and other metadata.
+2. Run the command: `cargo run -p aptos-node -- --test`. After starting up, the process should print its config path (e.g., `/private/var/folders/36/w0v54r116ls44q29wh8db0mh0000gn/T/f62a72f87940e3892a860c21b55b529b`) and other metadata.
 
 Note: this command runs `aptos-node` from a genesis-only ledger state. If you want to reuse the ledger state produced by a previous run of `aptos-node`, use `cargo run -p aptos-node -- --test --config <config-path>`.
 


### PR DESCRIPTION


## Motivation
reduce confusion

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
```text
18:01 $ cargo run -p aptos-node -- --test --lazy --config /tmp/73ccbd0fd148a1061847b1c0dc50ffe2
    Finished dev [unoptimized + debuginfo] target(s) in 0.60s
     Running `target/debug/aptos-node --test --lazy --config /tmp/73ccbd0fd148a1061847b1c0dc50ffe2`
Entering test mode, this should never be used in production!
Completed generating configuration:
        Log file: "/tmp/73ccbd0fd148a1061847b1c0dc50ffe2/validator.log"
        Config path: "/tmp/73ccbd0fd148a1061847b1c0dc50ffe2"
        Aptos root key path: "/tmp/73ccbd0fd148a1061847b1c0dc50ffe2/mint.key"
        Waypoint: 0:8adc1307c59bf27d4070abbe046a60f923873043532acca0160bbba355766406
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/7180
        Lazy mode is enabled

Aptos is running, press ctrl-c to exit
```