### PR TITLE
[circleci] fix build-test-deploy workflow condition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,10 +231,9 @@ workflows:
   # Build the Docker images and run Forge tests
   build-test-deploy:
     when:
-      condition:
-        or:
-          - equal: [auto, << pipeline.git.branch >>]
-          - equal: [canary, << pipeline.git.branch >>]
+      or:
+        - equal: [auto, << pipeline.git.branch >>]
+        - equal: [canary, << pipeline.git.branch >>]
     jobs:
       #      - build-benchmarks
       - e2e-test


### PR DESCRIPTION
So we don't re-run the workflows on `main` after the PR has already landed.

This stops Forge from running twice on each PR. Once on `auto`, and another time on `main`, if you've noticed Forge posting on your PRs twice...