### PR TITLE
[circleci] make forge blocking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,14 @@ jobs:
   forge-k8s-test:
     executor: ubuntu-medium
     steps:
+      - run:
+          name: Check Forge killswitch
+          shell: /bin/bash
+          command: |
+            if [ -n "$FORGE_ENABLED" ]; then
+              exit 0
+            fi
+            circleci-agent step halt
       - checkout
       - aws-setup
       - deploy-setup
@@ -173,8 +181,9 @@ jobs:
 
             cat \<<EOF > forge_comment.txt
             Forge run: ${CIRCLE_BUILD_URL}
-            Forge Test Result: \`${FORGE_REPORT_TXT}\`
+            Forge test result: \`${FORGE_REPORT_TXT}\`
             EOF
+
             # replace all newlines
             FORGE_COMMENT=$(awk '{printf "%s\\n", $0}' forge_comment.txt)
 
@@ -196,6 +205,14 @@ jobs:
                 }
               ]
             }
+      - run:
+          name: Check Forge status
+          shell: /bin/bash
+          command: |
+            if [ -n "$FORGE_BLOCKING" ]; then
+              exit $FGI_EXIT_CODE
+            fi
+            exit 0
   docker-compose-test:
     executor: ubuntu-medium
     steps:

--- a/terraform/testnet/forge/templates/forge.yaml
+++ b/terraform/testnet/forge/templates/forge.yaml
@@ -19,6 +19,7 @@ metadata:
     {{- include "forge.labels" . | nindent 4 }}
     app.kubernetes.io/name: forge-debug
 spec:
+  backoffLimit: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Make Forge blocking. Introduce two switches that operators can use to keep Forge from blocking devs in case things go wrong:
* `FORGE_BLOCKING`: if set, forge blocks PRs on failure
* `FORGE_ENABLED`: if set, forge runs on all PRs at land-time, but not necessarily blocking

Also post a better comment to the PR with the actual repro cmd