### PR TITLE
Async dependency waiting, job/workers over rayon threadpool

### DIFF
--- a/aptos-move/aptos-vm/src/parallel_executor/storage_wrapper.rs
+++ b/aptos-move/aptos-vm/src/parallel_executor/storage_wrapper.rs
@@ -32,12 +32,11 @@ impl<'a, S: StateView> StateView for VersionedView<'a, S> {
     // Get some data either through the cache or the `StateView` on a cache miss.
     fn get_state_value(&self, state_key: &StateKey) -> anyhow::Result<Option<Vec<u8>>> {
         match self.hashmap_view.read(state_key) {
-            Ok(Some(v)) => Ok(match v.as_ref() {
+            Some(v) => Ok(match v.as_ref() {
                 WriteOp::Value(w) => Some(w.clone()),
                 WriteOp::Deletion => None,
             }),
-            Ok(None) => self.base_view.get_state_value(state_key),
-            Err(err) => Err(err),
+            None => self.base_view.get_state_value(state_key),
         }
     }
 

--- a/aptos-move/parallel-executor/src/executor.rs
+++ b/aptos-move/parallel-executor/src/executor.rs
@@ -8,21 +8,19 @@ use crate::{
     task::{ExecutionStatus, ExecutorTask, Transaction, TransactionOutput},
     txn_last_input_output::{ReadDescriptor, TxnLastInputOutput},
 };
-use anyhow::{bail, Result as AResult};
 use aptos_infallible::Mutex;
 use mvhashmap::MVHashMap;
 use num_cpus;
-use rayon::{prelude::*, scope};
-use std::{
-    collections::HashSet,
-    hash::Hash,
-    marker::PhantomData,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    thread::spawn,
-};
+use once_cell::sync::Lazy;
+use rayon::prelude::*;
+use std::{collections::HashSet, hash::Hash, marker::PhantomData, sync::Arc, thread::spawn};
+
+static RAYON_EXEC_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_cpus::get())
+        .build()
+        .unwrap()
+});
 
 /// A struct that is always used by a single thread performing an execution task. The struct is
 /// passed to the VM and acts as a proxy to resolve reads first in the shared multi-version
@@ -35,7 +33,6 @@ pub struct MVHashMapView<'a, K, V> {
     versioned_map: &'a MVHashMap<K, V>,
     txn_idx: TxnIndex,
     scheduler: &'a Scheduler,
-    read_dependency: AtomicBool,
     captured_reads: Mutex<Vec<ReadDescriptor<K>>>,
 }
 
@@ -47,7 +44,7 @@ impl<'a, K: PartialOrd + Send + Clone + Hash + Eq, V: Send + Sync> MVHashMapView
     }
 
     /// Captures a read from the VM execution.
-    pub fn read(&self, key: &K) -> AResult<Option<Arc<V>>> {
+    pub fn read(&self, key: &K) -> Option<Arc<V>> {
         loop {
             match self.versioned_map.read(key, self.txn_idx) {
                 Ok((version, v)) => {
@@ -57,23 +54,39 @@ impl<'a, K: PartialOrd + Send + Clone + Hash + Eq, V: Send + Sync> MVHashMapView
                         txn_idx,
                         incarnation,
                     ));
-                    return Ok(Some(v));
+                    return Some(v);
                 }
                 Err(None) => {
                     self.captured_reads
                         .lock()
                         .push(ReadDescriptor::from_storage(key.clone()));
-                    return Ok(None);
+                    return None;
                 }
                 Err(Some(dep_idx)) => {
-                    // Don't start execution transaction `self.txn_idx` until `dep_idx` is computed.
-                    if self.scheduler.try_add_dependency(self.txn_idx, dep_idx) {
-                        // dep_idx is already executed, push `self.txn_idx` to ready queue.
-                        self.read_dependency.store(true, Ordering::Relaxed);
-                        bail!("Read dependency is not computed, retry later")
-                    } else {
-                        // Re-read, as the dependency got resolved.
-                        continue;
+                    // `self.txn_idx` estimated to depend on a write from `dep_idx`.
+                    match self.scheduler.wait_for_dependency(self.txn_idx, dep_idx) {
+                        Some(dep_condition) => {
+                            // Wait on a condition variable correpsonding to the encountered
+                            // read dependency. Once the dep_idx finishes re-execution, scheduler
+                            // will mark the dependency as resolved, and then the txn_idx will be
+                            // scheduled for re-execution, which will re-awaken cvar here.
+                            // A deadlock is not possible due to these condition variables:
+                            // suppose all threads are waiting on read dependency, and consider
+                            // one with lowest txn_idx. It observed a dependency, so some thread
+                            // aborted dep_idx. If that abort returned execution task, by
+                            // minimality (lower transactions aren't waiting), that thread would
+                            // finish execution unblock txn_idx, contradiction. Otherwise,
+                            // execution_idx in scheduler was lower at a time when at least the
+                            // thread that aborted dep_idx was alive, and again, since lower txns
+                            // than txn_idx are not blocked, so the execution of dep_idx will
+                            // eventually finish and lead to unblocking txn_idx, contradiction.
+                            let (lock, cvar) = &*dep_condition;
+                            let mut dep_resolved = lock.lock();
+                            while !*dep_resolved {
+                                dep_resolved = cvar.wait(dep_resolved).unwrap();
+                            }
+                        }
+                        None => continue,
                     }
                 }
             };
@@ -84,15 +97,12 @@ impl<'a, K: PartialOrd + Send + Clone + Hash + Eq, V: Send + Sync> MVHashMapView
     pub fn txn_idx(&self) -> TxnIndex {
         self.txn_idx
     }
-
-    /// Return whether a read dependency was encountered during VM execution.
-    pub fn read_dependency(&self) -> bool {
-        self.read_dependency.load(Ordering::Relaxed)
-    }
 }
 
 pub struct ParallelTransactionExecutor<T: Transaction, E: ExecutorTask> {
-    num_cpus: usize,
+    // number of active concurrent tasks, corresponding to the maximum number of rayon
+    // threads that may be concurrently participating in parallel execution.
+    concurrency_level: usize,
     phantom: PhantomData<(T, E)>,
 }
 
@@ -103,14 +113,15 @@ where
 {
     pub fn new() -> Self {
         Self {
-            num_cpus: num_cpus::get(),
+            // TODO: must be a configurable parameter.
+            concurrency_level: num_cpus::get(),
             phantom: PhantomData,
         }
     }
 
-    pub fn execute<'a>(
+    fn execute<'a>(
         &self,
-        version_to_execute: Version,
+        idx_to_execute: TxnIndex,
         guard: TaskGuard<'a>,
         signature_verified_block: &[T],
         last_input_output: &TxnLastInputOutput<
@@ -122,41 +133,18 @@ where
         scheduler: &'a Scheduler,
         executor: &E,
     ) -> SchedulerTask<'a> {
-        let (idx_to_execute, incarnation) = version_to_execute;
         let txn = &signature_verified_block[idx_to_execute];
-
-        // An optimization to pre-check that there are no read dependencies once prior read-set
-        // is available, to avoid an execution that will likely be discarded due to the dependency.
-        // TODO (issue 10180): remove once we have a way to suspend VM execution (so partial
-        // execution would not be discarded).
-        if let Some(read_set) = last_input_output.read_set(idx_to_execute) {
-            if read_set.iter().any(
-                |r| match versioned_data_cache.read(r.path(), idx_to_execute) {
-                    Err(Some(dep_idx)) => scheduler.try_add_dependency(idx_to_execute, dep_idx),
-                    Ok(_) | Err(None) => false,
-                },
-            ) {
-                // Transaction has a read dependency. Was not executed and thus nothing to validate.
-                return SchedulerTask::NoTask;
-            }
-        }
 
         let state_view = MVHashMapView {
             versioned_map: versioned_data_cache,
             txn_idx: idx_to_execute,
             scheduler,
-            read_dependency: AtomicBool::new(false),
             captured_reads: Mutex::new(Vec::new()),
         };
 
         // VM execution.
         let execute_result = executor.execute_transaction(&state_view, txn);
-
-        if state_view.read_dependency() {
-            // Encountered and already handled (added to Scheduler) a read dependency.
-            return SchedulerTask::NoTask;
-        }
-
+        let incarnation = scheduler.get_executing_incarnation(idx_to_execute);
         let mut prev_write_set: HashSet<T::Key> = last_input_output.write_set(idx_to_execute);
 
         // For tracking whether the recent execution wrote outside of the previous write set.
@@ -199,7 +187,7 @@ where
         scheduler.finish_execution(idx_to_execute, incarnation, writes_outside, guard)
     }
 
-    pub fn validate<'a>(
+    fn validate<'a>(
         &self,
         version_to_validate: Version,
         guard: TaskGuard<'a>,
@@ -238,6 +226,57 @@ where
         }
     }
 
+    fn work_task_with_scope(
+        &self,
+        executor_arguments: &E::Argument,
+        block: &[T],
+        last_input_output: &TxnLastInputOutput<
+            <T as Transaction>::Key,
+            <E as ExecutorTask>::Output,
+            <E as ExecutorTask>::Error,
+        >,
+        versioned_data_cache: &MVHashMap<<T as Transaction>::Key, <T as Transaction>::Value>,
+        scheduler: &Scheduler,
+    ) {
+        // Make executor for each task. TODO: fast concurrent executor.
+        let executor = E::init(*executor_arguments);
+
+        let mut scheduler_task = SchedulerTask::NoTask;
+        loop {
+            scheduler_task = match scheduler_task {
+                SchedulerTask::ValidationTask(version_to_validate, guard) => self.validate(
+                    version_to_validate,
+                    guard,
+                    last_input_output,
+                    versioned_data_cache,
+                    scheduler,
+                ),
+                SchedulerTask::ExecutionTask(idx_to_execute, None, guard) => self.execute(
+                    idx_to_execute,
+                    guard,
+                    block,
+                    last_input_output,
+                    versioned_data_cache,
+                    scheduler,
+                    &executor,
+                ),
+                SchedulerTask::ExecutionTask(_, Some(condvar), _guard) => {
+                    let (lock, cvar) = &*condvar;
+                    // Mark dependency resolved.
+                    *lock.lock() = true;
+                    // Wake up the process waiting for dependency.
+                    cvar.notify_one();
+
+                    SchedulerTask::NoTask
+                }
+                SchedulerTask::NoTask => scheduler.next_task(),
+                SchedulerTask::Done => {
+                    break;
+                }
+            }
+        }
+    }
+
     pub fn execute_transactions_parallel(
         &self,
         executor_initial_arguments: E::Argument,
@@ -250,63 +289,38 @@ where
         let num_txns = signature_verified_block.len();
         let versioned_data_cache = MVHashMap::new();
         let outcomes = OutcomeArray::new(num_txns);
-        let compute_cpus = self.num_cpus;
         let last_input_output = TxnLastInputOutput::new(num_txns);
         let scheduler = Scheduler::new(num_txns);
 
-        scope(|s| {
-            println!(
-                "Launching {} threads to execute... total txns: {:?}",
-                compute_cpus,
-                scheduler.num_txn_to_execute(),
-            );
-
-            for _ in 0..(compute_cpus) {
+        RAYON_EXEC_POOL.scope(|s| {
+            for _ in 0..self.concurrency_level {
                 s.spawn(|_| {
-                    // Make executor for each thread.
-                    let executor = E::init(executor_initial_arguments);
-
-                    let mut scheduler_task = SchedulerTask::NoTask;
-                    loop {
-                        scheduler_task = match scheduler_task {
-                            SchedulerTask::ValidationTask(version_to_validate, guard) => self
-                                .validate(
-                                    version_to_validate,
-                                    guard,
-                                    &last_input_output,
-                                    &versioned_data_cache,
-                                    &scheduler,
-                                ),
-                            SchedulerTask::ExecutionTask(version_to_execute, guard) => self
-                                .execute(
-                                    version_to_execute,
-                                    guard,
-                                    &signature_verified_block,
-                                    &last_input_output,
-                                    &versioned_data_cache,
-                                    &scheduler,
-                                    &executor,
-                                ),
-                            SchedulerTask::NoTask => scheduler.next_task(),
-                            SchedulerTask::Done => break,
-                        }
-                    }
+                    self.work_task_with_scope(
+                        &executor_initial_arguments,
+                        &signature_verified_block,
+                        &last_input_output,
+                        &versioned_data_cache,
+                        &scheduler,
+                    );
                 });
             }
         });
 
         // Extract outputs in parallel
         let valid_results_size = scheduler.num_txn_to_execute();
-        let chunk_size = (valid_results_size + 4 * compute_cpus - 1) / (4 * compute_cpus);
-        (0..valid_results_size)
-            .collect::<Vec<TxnIndex>>()
-            .par_chunks(chunk_size)
-            .map(|chunk| {
-                for idx in chunk.iter() {
-                    outcomes.set_result(*idx, last_input_output.take_output(*idx));
-                }
-            })
-            .collect::<()>();
+        let chunk_size =
+            (valid_results_size + 4 * self.concurrency_level - 1) / (4 * self.concurrency_level);
+        RAYON_EXEC_POOL.install(|| {
+            (0..valid_results_size)
+                .collect::<Vec<TxnIndex>>()
+                .par_chunks(chunk_size)
+                .map(|chunk| {
+                    for idx in chunk.iter() {
+                        outcomes.set_result(*idx, last_input_output.take_output(*idx));
+                    }
+                })
+                .collect::<()>();
+        });
 
         spawn(move || {
             // Explicit async drops.

--- a/aptos-move/parallel-executor/src/proptest_types/tests.rs
+++ b/aptos-move/parallel-executor/src/proptest_types/tests.rs
@@ -73,7 +73,6 @@ proptest! {
         prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions));
     }
 
-
     #[test]
     fn mixed_transactions(
         universe in vec(any::<[u8; 32]>(), 100),

--- a/aptos-move/parallel-executor/src/proptest_types/types.rs
+++ b/aptos-move/parallel-executor/src/proptest_types/types.rs
@@ -242,11 +242,7 @@ where
                 // Reads
                 let mut reads_result = vec![];
                 for k in reads.iter() {
-                    reads_result.push(match view.read(k) {
-                        Ok(Some(v)) => Some((*v).clone()),
-                        Ok(None) => None,
-                        Err(_) => return ExecutionStatus::Abort(0),
-                    })
+                    reads_result.push(view.read(k).map(|v| (*v).clone()));
                 }
                 ExecutionStatus::Success(Output(actual_writes.clone(), reads_result))
             }

--- a/aptos-move/writeset-transaction-generator/templates/update_parallel_execution_config.move
+++ b/aptos-move/writeset-transaction-generator/templates/update_parallel_execution_config.move
@@ -1,6 +1,0 @@
-script {
-    use DiemFramework::ParallelExecutionConfig;
-    fun main(diem_root: signer, _execute_as: signer, payload: vector<u8>) {
-        ParallelExecutionConfig::enable_parallel_execution_with_config(&diem_root, payload);
-    }
-}


### PR DESCRIPTION
Introduces worker semaphore for managing jobs over a new lazy rayon threadpool in executor.
Handles condition variables per dependency in scheduler and adds a new Suspended status.
Also adjusts tests, and changes 'Diem' to 'Aptos' at places.

Numbers seem to improve on peer to peer.

## Motivation
Avoid storage_error when dependency in encountered, seems to also improve performance.
