### PR TITLE
[helm][testnet] option to wipe the prometheus WAL

### DIFF
--- a/terraform/testnet/testnet/templates/monitoring.yaml
+++ b/terraform/testnet/testnet/templates/monitoring.yaml
@@ -171,12 +171,14 @@ spec:
       - name: prometheus
         image: {{ .prometheus.image.repo }}:{{ .prometheus.image.tag }}
         imagePullPolicy: {{ .prometheus.image.pullPolicy }}
-        args:
-        - "--web.enable-lifecycle"
-        - "--config.file=/etc/prometheus/prometheus.yml"
-        - "--storage.tsdb.min-block-duration=15m"
-        - "--storage.tsdb.max-block-duration=30m"
-        - "--storage.tsdb.retention.time={{ .prometheus.retention }}"
+        command:
+          - sh
+          - -c
+          - |
+            {{- if .prometheus.deleteWal }}
+            rm -r /prometheus/data/wal/*
+            {{- end }}
+            prometheus --web.enable-lifecycle --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.min-block-duration=15m --storage.tsdb.max-block-duration=30m --storage.tsdb.retention.time={{ .prometheus.retention }}
         resources:
           {{- toYaml .prometheus.resources | nindent 10 }}
         ports:

--- a/terraform/testnet/testnet/values.yaml
+++ b/terraform/testnet/testnet/values.yaml
@@ -107,6 +107,7 @@ monitoring:
       class:
       size: 50Gi
     retention: 15d
+    deleteWal: false
   alertmanager:
     alertRouteTrees:
       - match:


### PR DESCRIPTION
Forge clusters have been seeing prometheus OOMKill from WAL replay for some time. Provide a new helm value option `.Values.monitoring.prometheus.deleteWal` that just deletes the whole WAL before starting prometheus.

We should probably revisit all our metrics to address the metrics volume

Tested on personal intern testnet