### PR TITLE
[Ecosystem] [upgrade move] update clap from 3.1.6 to 3.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
  "aptos-workspace-hack",
  "bcs",
  "cached-framework-packages",
- "clap 3.1.6",
+ "clap 3.1.8",
  "datatest-stable",
  "move-cli",
  "move-core-types",
@@ -163,7 +163,7 @@ dependencies = [
  "base64",
  "bcs",
  "cached-framework-packages",
- "clap 3.1.6",
+ "clap 3.1.8",
  "hex",
  "move-cli",
  "move-core-types",
@@ -1042,7 +1042,7 @@ dependencies = [
  "aptos-workspace-hack",
  "bcs",
  "cached-framework-packages",
- "clap 3.1.6",
+ "clap 3.1.8",
  "datatest-stable",
  "framework",
  "hex",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -3295,7 +3295,7 @@ dependencies = [
  "aptos-vm",
  "aptos-workspace-hack",
  "bcs",
- "clap 3.1.6",
+ "clap 3.1.8",
  "datatest-stable",
  "dir-diff",
  "include_dir 0.7.2",
@@ -4690,7 +4690,7 @@ version = "0.1.0"
 source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
- "clap 3.1.6",
+ "clap 3.1.8",
  "crossterm 0.21.0",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4709,7 +4709,7 @@ source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165a
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.6",
+ "clap 3.1.8",
  "codespan-reporting",
  "colored",
  "difference",
@@ -4766,7 +4766,7 @@ source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165a
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.6",
+ "clap 3.1.8",
  "codespan-reporting",
  "difference",
  "hex",
@@ -4815,7 +4815,7 @@ source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165a
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.6",
+ "clap 3.1.8",
  "codespan",
  "colored",
  "move-binary-format",
@@ -4836,7 +4836,7 @@ version = "0.1.0"
 source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
- "clap 3.1.6",
+ "clap 3.1.8",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4906,7 +4906,7 @@ source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165a
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.6",
+ "clap 3.1.8",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -5002,7 +5002,7 @@ source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165a
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.6",
+ "clap 3.1.8",
  "colored",
  "move-abigen",
  "move-binary-format",
@@ -5037,7 +5037,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 3.1.6",
+ "clap 3.1.8",
  "codespan",
  "codespan-reporting",
  "futures",
@@ -5160,7 +5160,7 @@ source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165a
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
- "clap 3.1.6",
+ "clap 3.1.8",
  "codespan-reporting",
  "itertools",
  "move-binary-format",
@@ -5234,7 +5234,7 @@ source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165a
 dependencies = [
  "anyhow",
  "atty",
- "clap 3.1.6",
+ "clap 3.1.8",
  "codespan",
  "codespan-reporting",
  "ethnum",
@@ -5271,7 +5271,7 @@ version = "0.1.0"
 source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
- "clap 3.1.6",
+ "clap 3.1.8",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -5303,7 +5303,7 @@ version = "0.1.0"
 source = "git+https://github.com/diem/move?rev=3fe033b112eae7df2d15ab3467624165ae510caa#3fe033b112eae7df2d15ab3467624165ae510caa"
 dependencies = [
  "anyhow",
- "clap 3.1.6",
+ "clap 3.1.8",
  "colored",
  "evm",
  "evm-exec-utils",
@@ -8713,7 +8713,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 
@@ -9315,7 +9315,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "clap 2.34.0",
- "clap 3.1.6",
+ "clap 3.1.8",
  "codespan-reporting",
  "crossbeam-utils",
  "crunchy",

--- a/aptos-move/af-cli/Cargo.toml
+++ b/aptos-move/af-cli/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.52"
 bcs = "0.1.2"
-clap = "3.1.6"
+clap = "3.1.8"
 
 aptos-vm = { path = "../aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }

--- a/aptos-move/aptos-transactional-test-harness/Cargo.toml
+++ b/aptos-move/aptos-transactional-test-harness/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.1.6"
+clap = "3.1.8"
 once_cell = "1.7.2"
 anyhow = "1.0.52"
 bcs = "0.1.2"

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -32,7 +32,7 @@ move-bytecode-utils = { git = "https://github.com/diem/move", rev = "3fe033b112e
 
 bcs = "0.1.2"
 anyhow = "1.0.52"
-clap = "3.1.6"
+clap = "3.1.8"
 log = "0.4.14"
 rayon = "1.5.0"
 sha2 = "0.9.3"

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13.0"
-clap = "3.1.6"
+clap = "3.1.8"
 hex = "0.4.3"
 rand = "0.8.3"
 serde = "1.0.124"

--- a/crates/aptos/src/move_tool/chain.rs
+++ b/crates/aptos/src/move_tool/chain.rs
@@ -3,11 +3,11 @@
 
 use crate::CliResult;
 use aptos_types::account_address::AccountAddress;
-use clap::{ArgEnum, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 
 /// CLI tool for performing onchain tasks
 ///
-#[derive(Debug, ArgEnum, Subcommand)]
+#[derive(Debug, Subcommand)]
 pub enum ChainTool {
     List(ListResources),
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -7,7 +7,7 @@
 //!
 
 use crate::CliResult;
-use clap::{ArgEnum, Parser, Subcommand};
+use clap::{Parser, Subcommand};
 use move_core_types::errmap::ErrorMapping;
 use move_vm_types::gas_schedule::INITIAL_COST_SCHEDULE;
 
@@ -15,7 +15,7 @@ pub mod chain;
 
 /// CLI tool for performing Move tasks
 ///
-#[derive(ArgEnum, Subcommand)]
+#[derive(Subcommand)]
 pub enum MoveTool {
     Command(MoveCli),
 }

--- a/crates/aptos/src/op/mod.rs
+++ b/crates/aptos/src/op/mod.rs
@@ -7,13 +7,13 @@
 //!
 
 use crate::CliResult;
-use clap::{ArgEnum, Subcommand};
+use clap::Subcommand;
 
 pub mod key;
 
 /// CLI tool for performing operational tasks
 ///
-#[derive(ArgEnum, Debug, Subcommand)]
+#[derive(Debug, Subcommand)]
 pub enum OpTool {
     #[clap(subcommand)]
     Key(key::KeyTool),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

To use the latest move, need to upgrade clap first.

Argenum can only be applied to unit variant. Delete ArgEnum from non-unit variant.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

cargo build -p aptos

