### PR TITLE
[forge] consensus key exportable and more logs

### DIFF
--- a/terraform/validator/vault-init/main.tf
+++ b/terraform/validator/vault-init/main.tf
@@ -91,6 +91,7 @@ resource "vault_transit_secret_backend_key" "consensus" {
   backend    = var.transit_mount
   name       = "${var.namespace}__consensus"
   type       = "ed25519"
+  exportable = true
   depends_on = [null_resource.mounts_created]
   lifecycle {
     ignore_changes = [min_decryption_version, min_encryption_version]

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -332,6 +332,7 @@ pub async fn nodes_healthcheck(nodes: Vec<&K8sNode>) -> Result<Vec<String>> {
         // perform healthcheck with retry, returning unhealthy
         let check = aptos_retrier::retry_async(k8s_retry_strategy(), || {
             Box::pin(async move {
+                println!("Attempting health check: {}", node.name());
                 match node.rest_client().get_ledger_information().await {
                     Ok(_) => {
                         println!("Node {} healthy", node.name());


### PR DESCRIPTION
Print, so circleci doesn't kill a stalling job

Export consensus key for local safety rules