### PR TITLE
[Storage][Pruner] Fix pruning pending check

### DIFF
--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -67,6 +67,6 @@ pub trait DBPruner {
 
     /// True if there is pruning work pending to be done
     fn is_pruning_pending(&self) -> bool {
-        self.target_version() >= self.least_readable_version()
+        self.target_version() > self.least_readable_version()
     }
 }


### PR DESCRIPTION
Pruning pending check for the pruner was wrong which was causing high CPU on the test net.  This should address it.