### PR TITLE
[Network] Increase default rate limiter.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -43,7 +43,9 @@ pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 2;
 pub const MAX_INBOUND_CONNECTIONS: usize = 100;
 pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024; /* 16 MiB */
 pub const CONNECTION_BACKOFF_BASE: u64 = 2;
-pub const IP_BYTE_BUCKET_RATE: usize = 102400 /* 100 KiB */;
+// We estimate the max amount of data required to serve 1000 txn outputs a
+// second (currently ~1.5MB/s) and include an additional buffer.
+pub const IP_BYTE_BUCKET_RATE: usize = 2 * 1024 * 1024 /* 2 MB */;
 pub const IP_BYTE_BUCKET_SIZE: usize = IP_BYTE_BUCKET_RATE;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]


### PR DESCRIPTION
## Motivation

This PR increases the default rate limiter size. Current estimates show that to serve 1k transactions a second we need to support 700KB/s per peer. Similarly, for sending transaction outputs, we need to support 1.5 MB/s per peer. This PR increases the default to 2 MB/s. 

My hope is to get this in for the next cut so that we can see the impact (if any) the rate limiter has on the deployment at these higher values. Likewise, I'm planning to do some further investigations regarding these data sizes and how we can better scale.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

None.

## Related PRs

None.
