### PR TITLE
[Storage][pruner] Do not prune transaction accumulator

### DIFF
--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -4,9 +4,9 @@
 #![forbid(unsafe_code)]
 
 pub mod common;
+pub mod list;
 pub mod move_tool;
 pub mod op;
-pub mod list;
 
 use crate::common::types::{CliResult, Error};
 use clap::Parser;

--- a/crates/aptos/src/list/mod.rs
+++ b/crates/aptos/src/list/mod.rs
@@ -6,15 +6,9 @@
 //! TODO: Examples
 //!
 
+use crate::{common::utils::to_common_result, CliResult, Error};
 use aptos_types::account_address::AccountAddress;
-use clap::{Parser};
-use crate::{
-    common::{
-        utils::{to_common_result},
-    },
-    CliResult,
-    Error,
-};
+use clap::Parser;
 use reqwest;
 
 /// Command to list resources owned by an address
@@ -29,13 +23,22 @@ pub struct ListResources {
 
 impl ListResources {
     async fn get_resources(self) -> Result<Vec<serde_json::Value>, reqwest::Error> {
-        reqwest::get(format!("{}/accounts/{}/resources", self.node_url, self.account)).await?.json().await
+        reqwest::get(format!(
+            "{}/accounts/{}/resources",
+            self.node_url, self.account
+        ))
+        .await?
+        .json()
+        .await
     }
 
     // TODO: Format this in a reasonable way while providing all information
     // add options like --tokens --nfts etc
     pub async fn execute(self) -> CliResult {
-        let result = self.get_resources().await.map_err(|err| Error::UnexpectedError(err.to_string()));
+        let result = self
+            .get_resources()
+            .await
+            .map_err(|err| Error::UnexpectedError(err.to_string()));
         to_common_result(result)
     }
 }

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -11,9 +11,7 @@ use aptos_types::{
     transaction::{SignedTransaction, Transaction},
 };
 
-use accumulator::HashReader;
 use aptos_types::{
-    proof::position::Position,
     transaction::{TransactionInfo, Version},
     write_set::WriteSet,
 };
@@ -142,7 +140,6 @@ fn verify_txn_store_pruner(
                 ledger_version,
             );
         }
-        verify_transaction_accumulator_pruned(&ledger_store, i as u64);
     }
 }
 
@@ -189,25 +186,6 @@ fn verify_txn_in_store(
     assert!(ledger_store
         .get_transaction_proof(index, ledger_version)
         .is_ok());
-}
-
-// Ensure that transaction accumulator has been pruned as well. The idea to verify is get the
-// inorder position  of the left child of the accumulator root and ensure that all lower index
-// position from the DB should be deleted. We need to make several conversion between inorder and
-// postorder transaction because the DB stores the indices in postorder, while the APIs for the
-// accumulator deals with inorder.
-fn verify_transaction_accumulator_pruned(ledger_store: &LedgerStore, least_readable_version: u64) {
-    let least_readable_position = if least_readable_version > 0 {
-        Position::root_from_leaf_index(least_readable_version).left_child()
-    } else {
-        Position::root_from_leaf_index(least_readable_version)
-    };
-    let least_readable_position_postorder = least_readable_position.to_postorder_index();
-    for i in 0..least_readable_position_postorder {
-        assert!(ledger_store
-            .get(Position::from_postorder_index(i).unwrap())
-            .is_err())
-    }
 }
 
 fn put_txn_in_store(

--- a/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
@@ -44,11 +44,6 @@ impl DBPruner for TransactionStorePruner {
             current_target_version,
             db_batch,
         )?;
-        self.transaction_store.prune_transaction_accumulator(
-            self.least_readable_version(),
-            current_target_version,
-            db_batch,
-        )?;
 
         self.record_progress(current_target_version);
         Ok(current_target_version)

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -10,7 +10,6 @@ use crate::{
         transaction::TransactionSchema, transaction_by_account::TransactionByAccountSchema,
         transaction_by_hash::TransactionByHashSchema, write_set::WriteSetSchema,
     },
-    transaction_accumulator::TransactionAccumulatorSchema,
     transaction_info::TransactionInfoSchema,
 };
 use anyhow::{ensure, format_err, Result};
@@ -255,18 +254,6 @@ impl TransactionStore {
         Ok(())
     }
 
-    /// Prune the transaction schema store between a range of version in [begin, end).
-    pub fn prune_transaction_accumulator(
-        &self,
-        begin: Version,
-        end: Version,
-        db_batch: &mut SchemaBatch,
-    ) -> anyhow::Result<()> {
-        let begin_position = self.get_min_proof_node(begin);
-        let end_position = self.get_min_proof_node(end);
-        db_batch.delete_range::<TransactionAccumulatorSchema>(&begin_position, &end_position)?;
-        Ok(())
-    }
     /// Returns the minimum position node needed to be included in the proof of the leaf index. This
     /// will be the left child of the root if the leaf index is non zero and zero otherwise.
     pub fn get_min_proof_node(&self, leaf_index: u64) -> Position {


### PR DESCRIPTION
We depend on the transaction accumulator from origin today to serve the proof of epoch change - disabling this until we figure out a way to serve this from waypoint. 