### PR TITLE
[Storage][Pruner] Disable ledge info pruner by default

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -99,8 +99,9 @@ impl Default for StorageConfig {
             // depending on the size of an average account blob.
             storage_pruner_config: StoragePrunerConfig {
                 state_store_prune_window: Some(1_000_000),
-                default_prune_window: Some(10_000_000),
+                default_prune_window: Some(1_000_000_000),
                 max_version_to_prune_per_batch: Some(100),
+
             },
             data_dir: PathBuf::from("/opt/aptos/data"),
             // Default read/write/connection timeout, in milliseconds


### PR DESCRIPTION
We are seeing some performance issue with the pruner - so disabling it by default. Currently, there is no knob to disable it directly (will add that as a follow up) - we are disabling it by setting the pruning window to a max value.