### PR TITLE
[circleci] tag images with addl_tag and git rev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,27 +64,30 @@ jobs:
       - checkout
       - aws-setup
       - run: echo "export IMAGE_TAG=dev_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
+      - run: echo "export ADDL_IMAGE_TAG=<<parameters.addl_tag>>_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
       - run:
           name: Build or skip
           shell: /bin/bash
           command: |
+            # Check if an image is already built at this image tag
             MANIFEST=$(aws ecr batch-get-image --repository-name aptos/validator --image-ids imageTag=$IMAGE_TAG --query 'images[].imageManifest' --output text)
             echo $MANIFEST
             if [ -z "$MANIFEST" ]; then
               echo "Image tag $IMAGE_TAG not present. Starting build all..."
-              ./docker/build-aws.sh --build-all --version $(git rev-parse --short=8 HEAD) --addl_tags "<<parameters.addl_tag>>"
+              ./docker/build-aws.sh --build-all --version $(git rev-parse --short=8 HEAD) --addl_tags "<<parameters.addl_tag>>,${ADDL_IMAGE_TAG}"
             else
               echo "Image tag $IMAGE_TAG already present. Skipping build..."
               echo "Continue retagging to <<parameters.addl_tag>>"
-              imgs=( validator forge init validator_tcb tools faucet )
               ret=0
-              for img in "${imgs[@]}"
+              for img in "${AWS_ECR_IMAGES[@]}"
               do
+                # Get the image manifest for the already-built image and put it at different image tags
                 MANIFEST=$(aws ecr batch-get-image --repository-name aptos/${img} --image-ids imageTag=$IMAGE_TAG --query 'images[].imageManifest' --output text)
-                put_img_out=$(aws ecr put-image --repository-name aptos/${img} --image-tag main --image-manifest "$MANIFEST" 2>&1)
+                put_img_out=$(aws ecr put-image --repository-name aptos/${img} --image-tag "<<parameters.addl_tag>>" --image-manifest "$MANIFEST" 2>&1)
+                put_img_out_addl=$(aws ecr put-image --repository-name aptos/${img} --image-tag "${ADDL_IMAGE_TAG}" --image-manifest "$MANIFEST" 2>&1)
                 ret=$?
                 # ok if image tag exists and cannot overwrite
-                echo $put_img_out | grep 'ImageAlreadyExistsException' && ret=0
+                echo $put_img_out $put_img_out_addl | grep 'ImageAlreadyExistsException' && ret=0
               done
               exit $ret
             fi
@@ -100,13 +103,13 @@ jobs:
       - aws-setup
       - aws-ecr-setup
       - run: echo "export IMAGE_TAG=dev_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
+      - run: echo "export ADDL_IMAGE_TAG=<<parameters.addl_tag>>_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
       - run:
           name: Get latest built main image
           shell: /bin/bash
           command: |
-            imgs=( validator forge init validator_tcb tools faucet )
             ret=0
-            for img in "${imgs[@]}"
+            for img in "${DOCKERHUB_IMAGES[@]}"
             do
               docker pull "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" || ret=$?
             done
@@ -115,13 +118,11 @@ jobs:
           name: Tag image
           shell: /bin/bash
           command: |
-            imgs=( validator forge init validator_tcb tools faucet )
-            org=aptoslab
             ret=0
-            for img in "${imgs[@]}"
+            for img in "${DOCKERHUB_IMAGES[@]}"
             do
-              docker tag "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" "${org}/${img}:${IMAGE_TAG}"
-              docker tag "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" "${org}/${img}:<<parameters.addl_tag>>" || ret=$?
+              docker tag "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" "${DOCKERHUB_ORG}/${img}:${IMAGE_TAG}"
+              docker tag "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" "${DOCKERHUB_ORG}/${img}:${ADDL_IMAGE_TAG}" || ret=$?
             done
             exit $ret
       - dockerhub-setup
@@ -129,14 +130,11 @@ jobs:
           name: Push image to Dockerhub
           shell: /bin/bash
           command: |
-            # imgs=( validator forge init validator_tcb tools faucet )
-            imgs=( validator forge init validator_tcb tools faucet )
-            org=aptoslab
             ret=0
-            for img in "${imgs[@]}"
+            for img in "${DOCKERHUB_IMAGES[@]}"
             do
-              docker push "${org}/${img}:${IMAGE_TAG}"
-              docker push "${org}/${img}:<<parameters.addl_tag>>" || ret=$?
+              docker push "${DOCKERHUB_ORG}/${img}:${IMAGE_TAG}"
+              docker push "${DOCKERHUB_ORG}/${img}:${ADDL_IMAGE_TAG}" || ret=$?
             done
             exit $ret
   forge-k8s-test:
@@ -336,6 +334,7 @@ commands:
           name: Compose AWS Env Variables
           command: |
             echo 'export AWS_ECR_ACCOUNT_URL="${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.${AWS_REGION}.amazonaws.com"' >> $BASH_ENV
+            echo "export AWS_ECR_IMAGES=( validator forge init validator_tcb tools faucet txn-emitter )" >> $BASH_ENV
       - aws-ecr/ecr-login
   ### Sets up the permissions for using Dockerhub
   dockerhub-setup:
@@ -344,3 +343,9 @@ commands:
           name: Docker login
           command: |
             echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+      - run:
+          name: Compose DockerHub Env Variables
+          command: |
+            # the images that exist in dockerhub org
+            echo "export DOCKERHUB_ORG=aptoslab" >> $BASH_ENV
+            echo "export DOCKERHUB_IMAGES=( validator forge init validator_tcb tools faucet )" >> $BASH_ENV


### PR DESCRIPTION
Previously we were tagging images using the following strategy:
* `dev_<REV>` for all builds that pass through CI
* `main` for continuous build on main branch
* `devnet` for weekly devnet branch cut

We expire `dev_<REV>` image tags to prevent old images building up, and `main` and `devnet` tags are mutable and exist primarily for convenience, and ideally shouldn't be used in production most cases. So currently there's no suitable image for production systems that isn't either expired or mutated. We haven't hit this issue yet because we reset devnet weekly and often cache pulled images  (in EKS).

This PR makes it such that each time we cut `main` or `devnet` images, we also make corresponding `main_<REV>` and `devnet_<REV>` images. This ensures that we don't lose old `main` or `devnet` images, and can deploy releases with `devnet_<REV>` images.