### PR TITLE
[Logger] Make backtrace support configurable.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -96,6 +96,9 @@ pub fn start(config: &NodeConfig, log_file: Option<PathBuf>) {
         .is_async(config.logger.is_async)
         .level(config.logger.level)
         .read_env();
+    if config.logger.enable_backtrace {
+        logger.enable_backtrace();
+    }
     if let Some(log_file) = log_file {
         logger.printer(Box::new(FileWriter::new(log_file)));
     }

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 pub struct LoggerConfig {
     // channel size for the asychronous channel for node logging.
     pub chan_size: usize,
+    // Enables backtraces on error logs
+    pub enable_backtrace: bool,
     // Use async logging
     pub is_async: bool,
     // The default logging level for slog.
@@ -19,6 +21,7 @@ impl Default for LoggerConfig {
     fn default() -> LoggerConfig {
         LoggerConfig {
             chan_size: CHANNEL_SIZE,
+            enable_backtrace: false,
             is_async: true,
             level: Level::Info,
         }

--- a/crates/aptos-logger/tests/remote.rs
+++ b/crates/aptos-logger/tests/remote.rs
@@ -21,7 +21,11 @@ fn remote_end_to_end() {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap().to_string();
 
-    AptosData::builder().address(addr).is_async(true).build();
+    AptosData::builder()
+        .address(addr)
+        .is_async(true)
+        .enable_backtrace()
+        .build();
 
     let handle = std::thread::spawn(|| {
         error!("Hello");


### PR DESCRIPTION
## Motivation

This PR makes backtrace support for node error logs configurable and disables backtraces by default (e.g., in production). 

I think it still makes sense to maintain support for this functionality (e.g., when debugging complex code and in test environments) but given that these backtraces can be quite large we should disable them in production. They can always be re-enabled via a config file if we need to debug something.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Some of the tests cover this functionality.

## Related PRs

None.
