### PR TITLE
[circleci] fix dockerhub push dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,11 +109,12 @@ jobs:
           shell: /bin/bash
           command: |
             ret=0
-            for img in "${DOCKERHUB_IMAGES[@]}"
+            for img in "${AWS_ECR_IMAGES[@]}"
             do
               docker pull "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" || ret=$?
             done
             exit $ret
+      - dockerhub-setup
       - run:
           name: Tag image
           shell: /bin/bash
@@ -125,7 +126,6 @@ jobs:
               docker tag "${AWS_ECR_ACCOUNT_URL}/aptos/${img}:${IMAGE_TAG}" "${DOCKERHUB_ORG}/${img}:${ADDL_IMAGE_TAG}" || ret=$?
             done
             exit $ret
-      - dockerhub-setup
       - run:
           name: Push image to Dockerhub
           shell: /bin/bash


### PR DESCRIPTION
Do `dockerhub-setup` before tagging images, so that it can be tagged the final name/tag as pushed to dockerhub 

Fixes this https://app.circleci.com/pipelines/github/aptos-labs/aptos-core/1869/workflows/bfdf715a-0142-4027-97a3-e274fd01e11e/jobs/9287 failed image push to dockerhub on devnet branch cut