### PR TITLE
[API] spec: struct tag regex supports multiple type parameters

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -616,7 +616,7 @@ components:
     MoveTypeTagId:
       title: Move Type Tag ID
       type: string
-      pattern: '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<>]+)$'
+      pattern: '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<, >]+)$'
       description: |
         String representation of an on-chain Move type tag that is exposed in transaction payload.
 
@@ -647,7 +647,7 @@ components:
     MoveTypeId:
       title: Move Type ID
       type: string
-      pattern: '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<>]+|^&(mut )?.+$|T\d+)$'
+      pattern: '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<, >]+|^&(mut )?.+$|T\d+)$'
       description: |
         String representation of an on-chain Move type identifier defined by the Move language.
 


### PR DESCRIPTION
## Motivation

For example `Table<T1, T2>` can be part of the tag


### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y
## Test Plan

`make` under `api`

```
Performed checks:
    not_a_server_error                              911 / 911 passed          PASSED
    status_code_conformance                         911 / 911 passed          PASSED
    content_type_conformance                        911 / 911 passed          PASSED
    response_headers_conformance                    911 / 911 passed          PASSED
    response_schema_conformance                     911 / 911 passed          PASSED
```

(used to error out like `The received response does not conform to the defined schema! Details: '0x1::Table::Table<T0, T1>' does not match '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<>]+|^&(mut )?.+$|T\d+)$' Failed validating 'pattern' in schema[2]['properties']['data']['properties']['abi']['properties']['exposed_functions']['items']['properties']['return']['items'] Headers : {'User-Agent': 'schemathesis/3.13.8', 'Accept-Encoding': 'gzip, deflate', 'Accept': '/', 'Connection': 'keep-alive'} Query : {}`)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
