### PR TITLE
[aptos-cli] Add create account command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,12 +152,16 @@ dependencies = [
 name = "aptos"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-config",
  "aptos-crypto",
  "aptos-logger",
+ "aptos-rest-client",
+ "aptos-sdk",
  "aptos-secure-storage",
  "aptos-telemetry",
  "aptos-temppath",
+ "aptos-transaction-builder",
  "aptos-types",
  "aptos-vm",
  "aptos-workspace-hack",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.52"
 base64 = "0.13.0"
 clap = "3.1.8"
 hex = "0.4.3"
@@ -28,7 +29,10 @@ aptos-logger = { path = "../aptos-logger" }
 aptos-secure-storage = { path = "../../secure/storage" }
 aptos-telemetry = { path = "../aptos-telemetry" }
 aptos-temppath = { path = "../aptos-temppath" }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
+aptos-sdk = { path = "../../sdk" }
+aptos-rest-client = { path = "../../crates/aptos-rest-client"}
 aptos-workspace-hack = { version = "0.1", path = "../aptos-workspace-hack" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 bcs = "0.1.2"

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -9,7 +9,7 @@ use crate::{
     op::key::GenerateKey,
     CliResult, Error,
 };
-use aptos_crypto::{x25519::PrivateKey, ValidCryptoMaterialStringExt};
+use aptos_crypto::{ed25519::Ed25519PrivateKey, ValidCryptoMaterialStringExt};
 use clap::Parser;
 
 /// Tool to initialize current directory for the aptos tool
@@ -39,9 +39,9 @@ impl InitTool {
         let input = input.trim();
         let private_key = if input.is_empty() {
             eprintln!("No key given, generating key...");
-            GenerateKey::generate_x25519_in_memory()?
+            GenerateKey::generate_ed25519_in_memory()
         } else {
-            PrivateKey::from_encoded_string(input)
+            Ed25519PrivateKey::from_encoded_string(input)
                 .map_err(|err| Error::UnableToParse("PrivateKey", err.to_string()))?
         };
         config.private_key = Some(private_key);

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_crypto::PrivateKey;
 use crate::common::utils::{check_if_file_exists, write_to_file};
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
@@ -277,7 +276,7 @@ impl PublicKeyInputOptions {
 #[derive(Debug, Parser)]
 pub struct KeyInputOptions {
     #[clap(flatten)]
-    private_key_options: PrivateKeyInputOptions,
+    pub private_key_options: PrivateKeyInputOptions,
     #[clap(flatten)]
     public_key_options: PublicKeyInputOptions,
 }

--- a/crates/aptos/src/create_account/mod.rs
+++ b/crates/aptos/src/create_account/mod.rs
@@ -1,0 +1,123 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+//! A command to create a new account on-chain
+//!
+//! TODO: Examples
+//!
+
+use crate::{
+    common::types::{EncodingOptions, PrivateKeyInputOptions},
+    CliResult, Error as CommonError,
+};
+use anyhow::Error;
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    PrivateKey,
+};
+use aptos_rest_client::{Client as RestClient, Response, Transaction};
+use aptos_sdk::{
+    transaction_builder::TransactionFactory,
+    types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey, LocalAccount},
+};
+use aptos_transaction_builder::aptos_stdlib;
+use aptos_types::account_address::AccountAddress;
+use clap::Parser;
+use reqwest;
+
+/// Command to create a new account on-chain
+///
+#[derive(Debug, Parser)]
+pub struct CreateAccount {
+    #[clap(flatten)]
+    private_key_input_options: PrivateKeyInputOptions,
+    #[clap(flatten)]
+    encoding_options: EncodingOptions,
+    /// Public Key of account you want to create
+    public_key: String,
+    /// Chain ID
+    chain_id: u8,
+    #[clap(
+        parse(try_from_str),
+        default_value = "https://fullnode.devnet.aptoslabs.com"
+    )]
+    node_url: reqwest::Url,
+}
+
+impl CreateAccount {
+    async fn get_account(
+        &self,
+        account: AccountAddress,
+    ) -> Result<serde_json::Value, reqwest::Error> {
+        reqwest::get(format!("{}accounts/{}", self.node_url, account))
+            .await?
+            .json()
+            .await
+    }
+
+    fn get_address(&self) -> Result<AccountAddress, Error> {
+        let public_key: Ed25519PublicKey = self
+            .encoding_options
+            .encoding
+            .decode_key(self.public_key.as_bytes().to_vec())?;
+        let auth_key = AuthenticationKey::ed25519(&public_key);
+        Ok(AccountAddress::new(*auth_key.derived_address()))
+    }
+
+    async fn get_sequence_number(&self, account: AccountAddress) -> Result<u64, CommonError> {
+        let account_response = self
+            .get_account(account)
+            .await
+            .map_err(|err| CommonError::UnexpectedError(err.to_string()))?;
+        let sequence_number = &account_response["sequence_number"];
+        match sequence_number.as_str() {
+            Some(number) => Ok(number.parse::<u64>().unwrap()),
+            None => Err(CommonError::UnexpectedError(
+                "Sequence number not found".to_string(),
+            )),
+        }
+    }
+
+    async fn post_account(
+        &self,
+        address: AccountAddress,
+        sender_key: Ed25519PrivateKey,
+        sender_address: AccountAddress,
+        sequence_number: u64,
+    ) -> Result<Response<Transaction>, Error> {
+        let client = RestClient::new(reqwest::Url::clone(&self.node_url));
+        let chain_id = ChainId::new(self.chain_id);
+        let transaction_factory = TransactionFactory::new(chain_id)
+            .with_gas_unit_price(1)
+            .with_max_gas_amount(1000);
+        let sender_account = &mut LocalAccount::new(sender_address, sender_key, sequence_number);
+        let transaction = sender_account.sign_with_transaction_builder(
+            transaction_factory
+                .payload(aptos_stdlib::encode_create_account_script_function(address)),
+        );
+        client.submit_and_wait(&transaction).await
+    }
+
+    async fn execute_inner(self) -> Result<String, Error> {
+        let private_key = self
+            .private_key_input_options
+            .extract_private_key(self.encoding_options.encoding)?
+            .unwrap();
+        let sender_address =
+            AuthenticationKey::ed25519(&private_key.public_key()).derived_address();
+        let sender_address = AccountAddress::new(*sender_address);
+        let sequence_number = self.get_sequence_number(sender_address).await;
+        let address = self.get_address()?;
+        match sequence_number {
+            Ok(sequence_number) => self
+                .post_account(address, private_key, sender_address, sequence_number)
+                .await
+                .map(|_| format!("Account Created at {}", address)),
+            Err(err) => Err(Error::new(err)),
+        }
+    }
+
+    pub async fn execute(self) -> CliResult {
+        self.execute_inner().await.map_err(|err| err.to_string())
+    }
+}

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 pub mod common;
+pub mod create_account;
 pub mod list;
 pub mod move_tool;
 pub mod op;
@@ -16,6 +17,7 @@ use clap::Parser;
 #[derive(Parser)]
 #[clap(name = "aptos", author, version, propagate_version = true)]
 pub enum Tool {
+    CreateAccount(create_account::CreateAccount),
     Init(common::init::InitTool),
     List(list::ListResources),
     #[clap(subcommand)]
@@ -27,6 +29,7 @@ pub enum Tool {
 impl Tool {
     pub async fn execute(self) -> CliResult {
         match self {
+            Tool::CreateAccount(tool) => tool.execute().await,
             Tool::Init(tool) => tool.execute().await,
             Tool::List(tool) => tool.execute().await,
             Tool::Move(tool) => tool.execute().await,

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -9,9 +9,7 @@ use crate::{
     CliResult,
 };
 use aptos_config::config::{Peer, PeerRole};
-use aptos_crypto::{
-    ed25519, ed25519::Ed25519PrivateKey, x25519, PrivateKey, Uniform, ValidCryptoMaterial,
-};
+use aptos_crypto::{ed25519, x25519, PrivateKey, Uniform, ValidCryptoMaterial};
 use aptos_types::account_address::{from_identity_public_key, AccountAddress};
 use clap::{Parser, Subcommand};
 use rand::SeedableRng;
@@ -61,7 +59,7 @@ impl ExtractPeer {
         // Load key based on public or private
         let public_key = self
             .key_input_options
-            .extract_public_key(self.encoding_options.encoding)?;
+            .extract_x25519_public_key(self.encoding_options.encoding)?;
 
         // Build peer info
         // TODO: Take in an address?
@@ -158,7 +156,7 @@ impl GenerateKey {
     /// Generates an `Ed25519PrivateKey` without saving it to disk
     pub fn generate_ed25519_in_memory() -> ed25519::Ed25519PrivateKey {
         let mut rng = rand::rngs::StdRng::from_entropy();
-        Ed25519PrivateKey::generate(&mut rng)
+        ed25519::Ed25519PrivateKey::generate(&mut rng)
     }
 
     pub fn generate_x25519_in_memory() -> Result<x25519::PrivateKey, Error> {


### PR DESCRIPTION
## Motivation

Have a basic command to create an account from CLI given account address. #470 

I also changed the common::types to generate/save/retrieve ed25519 instead of x25519 since that what will mostly be using. We needed ed25519 to sign the create_account transaction

## Test Plan

```
$ aptos create-account 22C71660317A8FA913F59F2D76A7365DDA670BD85F72D48C4DA9C5EE6A38725B 8 --private-key  882d7f91de9eb8da493e427fa8cfd8a90084846dbc96030589830ae0697ace1d
Account Created
$ aptos create-account 22C71660317A8FA913F59F2D76A7365DDA670BD85F72D48C4DA9C5EE6A38725B 8 --private-key  882d7f91de9eb8da493e427fa8cfd8a90084846dbc96030589830ae0697ace1d
transaction execution failed: Move abort by ALREADY_PUBLISHED - EACCOUNT
 Attempting to publish a resource that is already published. Example: calling an initialization function
 twice.
 Account already existed
 ```

## Related PRs

#472 #485
