### PR TITLE
[State Sync] Add simple unit tests for the storage synchronizer.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,6 +2688,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "diffus"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,6 +2800,12 @@ name = "dissimilar"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31ad93652f40969dead8d4bf897a41e9462095152eb21c56e5830537e41179dd"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dtoa"
@@ -3113,6 +3125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits 0.2.14",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,6 +3220,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d758e60b45e8d749c89c1b389ad8aee550f86aa12e2b9298b546dda7a82ab1"
 
 [[package]]
 name = "framework"
@@ -4491,6 +4518,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
+name = "mockall"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d4d70639a72f972725db16350db56da68266ca368b2a1fe26724a903ad3d6b8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "lazy_static 1.4.0",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
+]
+
+[[package]]
 name = "move-abigen"
 version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=476305d239ce6afafce15a297c8c3839dd8465b6#476305d239ce6afafce15a297c8c3839dd8465b6"
@@ -5450,6 +5504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6025,6 +6085,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
 dependencies = [
  "vcpkg",
+]
+
+[[package]]
+name = "predicates"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
+dependencies = [
+ "difflib",
+ "float-cmp",
+ "itertools",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
+dependencies = [
+ "predicates-core",
+ "termtree",
 ]
 
 [[package]]
@@ -7093,7 +7183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static 1.4.0",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -7401,6 +7491,7 @@ dependencies = [
 name = "state-sync-driver"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-config",
  "aptos-crypto",
  "aptos-data-client",
@@ -7413,6 +7504,7 @@ dependencies = [
  "aptos-vm",
  "aptos-workspace-hack",
  "aptosdb",
+ "bcs",
  "channel",
  "claim",
  "consensus-notifications",
@@ -7423,6 +7515,8 @@ dependencies = [
  "executor-types",
  "futures",
  "mempool-notifications",
+ "mockall",
+ "move-core-types",
  "network",
  "once_cell",
  "serde 1.0.136",
@@ -7901,6 +7995,12 @@ dependencies = [
  "redox_syscall 0.2.13",
  "redox_termios",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "testcases"
@@ -8424,7 +8524,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -34,7 +34,10 @@ mempool-notifications = { path = "../../inter-component/mempool-notifications" }
 storage-interface = { path = "../../../storage/storage-interface" }
 
 [dev-dependencies]
+anyhow = "1.0.52"
+bcs = "0.1.2"
 claim = "0.5.0"
+mockall = "0.11.0"
 
 channel = { path = "../../../crates/channel" }
 aptosdb = { path = "../../../storage/aptosdb" }
@@ -43,6 +46,7 @@ aptos-temppath = { path = "../../../crates/aptos-temppath" }
 aptos-time-service = { path = "../../../crates/aptos-time-service", features = ["async", "testing"] }
 aptos-vm = { path = "../../../aptos-move/aptos-vm" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "476305d239ce6afafce15a297c8c3839dd8465b6", features=["address32"] }
 network = { path = "../../../network", features = ["fuzzing"] }
 storage-service-client = { path = "../../storage-service/client" }
 vm-genesis = { path = "../../../aptos-move/vm-genesis", features = ["fuzzing"] }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -811,7 +811,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
             let epoch_change_proofs = self.verified_epoch_states.all_epoch_ending_ledger_infos();
 
             // Initialize the account state synchronizer
-            self.storage_synchronizer.initialize_account_synchronizer(
+            let _ = self.storage_synchronizer.initialize_account_synchronizer(
                 epoch_change_proofs,
                 ledger_info_to_sync,
                 transaction_output_to_sync.clone(),

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -72,7 +72,7 @@ impl DriverFactory {
         };
 
         // Create the storage synchronizer
-        let storage_synchronizer = StorageSynchronizer::new(
+        let (storage_synchronizer, _, _) = StorageSynchronizer::new(
             node_config.state_sync.state_sync_driver,
             chunk_executor,
             commit_notification_sender,

--- a/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
@@ -49,7 +49,7 @@ pub struct CommittedAccounts {
 }
 
 /// A commit notification for new transactions
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CommittedTransactions {
     pub events: Vec<ContractEvent>,
     pub transactions: Vec<Transaction>,

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -489,9 +489,6 @@ fn spawn_state_snapshot_receiver<ChunkExecutor: ChunkExecutorTrait + 'static>(
         loop {
             ::futures::select! {
                 storage_data_chunk = state_snapshot_listener.select_next_some() => {
-                    // We've received an account states chunk
-                    decrement_pending_data_chunks(pending_transaction_chunks.clone());
-
                     // Process the chunk
                     match storage_data_chunk {
                         StorageDataChunk::Accounts(notification_id, account_states_with_proof) => {
@@ -521,6 +518,7 @@ fn spawn_state_snapshot_receiver<ChunkExecutor: ChunkExecutorTrait + 'static>(
                                             send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
                                         }
 
+                                        decrement_pending_data_chunks(pending_transaction_chunks.clone());
                                         continue; // Wait for the next chunk
                                     }
 
@@ -551,6 +549,7 @@ fn spawn_state_snapshot_receiver<ChunkExecutor: ChunkExecutorTrait + 'static>(
                                     if let Err(error) = finalized_result {
                                       send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
                                     }
+                                    decrement_pending_data_chunks(pending_transaction_chunks.clone());
                                     return; // There's nothing left to do!
                                 },
                                 Err(error) => {
@@ -563,6 +562,7 @@ fn spawn_state_snapshot_receiver<ChunkExecutor: ChunkExecutorTrait + 'static>(
                             panic!("Invalid storage data chunk sent to state snapshot receiver: {:?}", storage_data_chunk);
                         }
                     }
+                    decrement_pending_data_chunks(pending_transaction_chunks.clone());
                 }
             }
         }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -1,32 +1,55 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::tests::{
-    utils,
-    utils::{create_ledger_info_at_version, create_test_transaction},
+use crate::{
+    driver_factory::DriverFactory,
+    tests::utils::{create_ledger_info_at_version, create_transaction},
 };
+use aptos_config::config::{NodeConfig, RoleType};
+use aptos_data_client::aptosnet::AptosNetDataClient;
+use aptos_infallible::RwLock;
+use aptos_time_service::TimeService;
+use aptos_types::{
+    move_resource::MoveStorage,
+    on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
+    transaction::{Transaction, WriteSetPayload},
+    waypoint::Waypoint,
+};
+use aptos_vm::AptosVM;
+use aptosdb::AptosDB;
 use claim::assert_err;
-use consensus_notifications::ConsensusNotificationSender;
+use consensus_notifications::{ConsensusNotificationSender, ConsensusNotifier};
+use data_streaming_service::streaming_client::new_streaming_service_client_listener_pair;
+use event_notifications::{
+    EventNotificationSender, EventSubscriptionService, ReconfigNotificationListener,
+};
+use executor::chunk_executor::ChunkExecutor;
+use executor_test_helpers::bootstrap_genesis;
+use mempool_notifications::MempoolNotificationListener;
+use network::application::{interface::MultiNetworkSender, storage::PeerMetadataStorage};
+use std::{collections::HashMap, sync::Arc};
+use storage_interface::{DbReader, DbReaderWriter};
+use storage_service_client::StorageServiceClient;
 
 // TODO(joshlind): extend these tests to cover more functionality!
 
 #[tokio::test]
 async fn test_consensus_commit_notification() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _) = utils::create_full_node_driver();
+    let (_full_node_driver, consensus_notifier, _, _) = create_full_node_driver();
 
     // Verify that full nodes can't process commit notifications
     let result = consensus_notifier
-        .notify_new_commit(vec![create_test_transaction()], vec![])
+        .notify_new_commit(vec![create_transaction()], vec![])
         .await;
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _) = utils::create_validator_driver();
+    let (_validator_driver, consensus_notifier, _, _) = create_validator_driver();
 
     // Send a new commit notification and verify the node isn't bootstrapped
     let result = consensus_notifier
-        .notify_new_commit(vec![create_test_transaction()], vec![])
+        .notify_new_commit(vec![create_transaction()], vec![])
         .await;
     assert_err!(result);
 }
@@ -34,7 +57,7 @@ async fn test_consensus_commit_notification() {
 #[tokio::test]
 async fn test_consensus_sync_request() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _) = utils::create_full_node_driver();
+    let (_full_node_driver, consensus_notifier, _, _) = create_full_node_driver();
 
     // Verify that full nodes can't process sync requests
     let result = consensus_notifier
@@ -43,11 +66,117 @@ async fn test_consensus_sync_request() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _) = utils::create_validator_driver();
+    let (_validator_driver, consensus_notifier, _, _) = create_validator_driver();
 
     // Send a new sync request and verify the node isn't bootstrapped
     let result = consensus_notifier
         .sync_to_target(create_ledger_info_at_version(0))
         .await;
     assert_err!(result);
+}
+
+/// Creates a state sync driver for a validator node
+pub fn create_validator_driver() -> (
+    DriverFactory,
+    ConsensusNotifier,
+    MempoolNotificationListener,
+    ReconfigNotificationListener,
+) {
+    let mut node_config = NodeConfig::default();
+    node_config.base.role = RoleType::Validator;
+
+    create_driver_for_tests(node_config, Waypoint::default())
+}
+
+/// Creates a state sync driver for a full node
+pub fn create_full_node_driver() -> (
+    DriverFactory,
+    ConsensusNotifier,
+    MempoolNotificationListener,
+    ReconfigNotificationListener,
+) {
+    let mut node_config = NodeConfig::default();
+    node_config.base.role = RoleType::FullNode;
+
+    create_driver_for_tests(node_config, Waypoint::default())
+}
+
+/// Creates a state sync driver using the given node config and waypoint
+fn create_driver_for_tests(
+    node_config: NodeConfig,
+    waypoint: Waypoint,
+) -> (
+    DriverFactory,
+    ConsensusNotifier,
+    MempoolNotificationListener,
+    ReconfigNotificationListener,
+) {
+    // Create test aptos database
+    let db_path = aptos_temppath::TempPath::new();
+    db_path.create_as_dir().unwrap();
+    let (db, db_rw) = DbReaderWriter::wrap(AptosDB::new_for_test(db_path.path()));
+
+    // Bootstrap the genesis transaction
+    let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
+    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
+    bootstrap_genesis::<AptosVM>(&db_rw, &genesis_txn).unwrap();
+
+    // Create the event subscription service and notify initial configs
+    let storage: Arc<dyn DbReader> = db;
+    let synced_version = (&*storage).fetch_synced_version().unwrap();
+    let mut event_subscription_service = EventSubscriptionService::new(
+        ON_CHAIN_CONFIG_REGISTRY,
+        Arc::new(RwLock::new(db_rw.clone())),
+    );
+    let reconfiguration_subscriber = event_subscription_service
+        .subscribe_to_reconfigurations()
+        .unwrap();
+    event_subscription_service
+        .notify_initial_configs(synced_version)
+        .unwrap();
+
+    // Create consensus and mempool notifiers and listeners
+    let (consensus_notifier, consensus_listener) =
+        consensus_notifications::new_consensus_notifier_listener_pair(1000);
+    let (mempool_notifier, mempool_listener) =
+        mempool_notifications::new_mempool_notifier_listener_pair();
+
+    // Create the chunk executor
+    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()).unwrap());
+
+    // Create a streaming service client
+    let (streaming_service_client, _) = new_streaming_service_client_listener_pair();
+
+    // Create a test aptos data client
+    let network_client = StorageServiceClient::new(
+        MultiNetworkSender::new(HashMap::new()),
+        PeerMetadataStorage::new(&[]),
+    );
+    let (aptos_data_client, _) = AptosNetDataClient::new(
+        node_config.state_sync.aptos_data_client,
+        node_config.state_sync.storage_service,
+        TimeService::mock(),
+        network_client,
+    );
+
+    // Create and spawn the driver
+    let driver_factory = DriverFactory::create_and_spawn_driver(
+        false,
+        &node_config,
+        waypoint,
+        db_rw,
+        chunk_executor,
+        mempool_notifier,
+        consensus_listener,
+        event_subscription_service,
+        aptos_data_client,
+        streaming_service_client,
+    );
+
+    (
+        driver_factory,
+        consensus_notifier,
+        mempool_listener,
+        reconfiguration_subscriber,
+    )
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -1,0 +1,312 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tests::utils::create_transaction_info;
+use anyhow::Result;
+use aptos_crypto::HashValue;
+use aptos_types::{
+    account_address::AccountAddress,
+    contract_event::{ContractEvent, EventByVersionWithProof, EventWithProof},
+    epoch_change::EpochChangeProof,
+    event::EventKey,
+    ledger_info::LedgerInfoWithSignatures,
+    proof::{
+        AccumulatorConsistencyProof, SparseMerkleProof, SparseMerkleRangeProof,
+        TransactionAccumulatorSummary,
+    },
+    state_proof::StateProof,
+    state_store::{
+        state_key::StateKey,
+        state_value::{
+            StateKeyAndValue, StateValue, StateValueChunkWithProof, StateValueWithProof,
+        },
+    },
+    transaction::{
+        AccountTransactionsWithProof, Transaction, TransactionInfo, TransactionListWithProof,
+        TransactionOutputListWithProof, TransactionToCommit, TransactionWithProof, Version,
+    },
+};
+use executor_types::ChunkExecutorTrait;
+use mockall::mock;
+use std::sync::Arc;
+use storage_interface::{
+    DbReader, DbReaderWriter, DbWriter, Order, StartupInfo, StateSnapshotReceiver, TreeState,
+};
+
+// TODO(joshlind): if we see these as generally useful, we should
+// modify the definitions in the rest of the code.
+
+/// Creates a mock chunk executor
+pub fn create_mock_executor() -> MockChunkExecutor {
+    MockChunkExecutor::new()
+}
+
+/// Creates a mock database reader
+pub fn create_mock_db_reader() -> MockDatabaseReader {
+    MockDatabaseReader::new()
+}
+
+/// Creates a mock database reader writer
+pub fn create_mock_reader_writer(
+    reader: Option<MockDatabaseReader>,
+    writer: Option<MockDatabaseWriter>,
+) -> DbReaderWriter {
+    let mut reader = reader.unwrap_or_else(create_mock_db_reader);
+    reader
+        .expect_get_latest_transaction_info_option()
+        .returning(|| Ok(Some((0, create_transaction_info()))));
+
+    let writer = writer.unwrap_or_else(create_mock_db_writer);
+    DbReaderWriter {
+        reader: Arc::new(reader),
+        writer: Arc::new(writer),
+    }
+}
+
+/// Creates a mock database writer
+pub fn create_mock_db_writer() -> MockDatabaseWriter {
+    MockDatabaseWriter::new()
+}
+
+/// Creates a mock state snapshot receiver
+pub fn create_mock_receiver() -> MockSnapshotReceiver {
+    MockSnapshotReceiver::new()
+}
+
+// This automatically creates a MockChunkExecutor.
+mock! {
+    pub ChunkExecutor {}
+    impl ChunkExecutorTrait for ChunkExecutor {
+        fn execute_chunk<'a>(
+            &self,
+            txn_list_with_proof: TransactionListWithProof,
+            verified_target_li: &LedgerInfoWithSignatures,
+            epoch_change_li: Option<&'a LedgerInfoWithSignatures>,
+        ) -> Result<()>;
+
+        fn apply_chunk<'a>(
+            &self,
+            txn_output_list_with_proof: TransactionOutputListWithProof,
+            verified_target_li: &LedgerInfoWithSignatures,
+            epoch_change_li: Option<&'a LedgerInfoWithSignatures>,
+        ) -> anyhow::Result<()>;
+
+        fn execute_and_commit_chunk<'a>(
+            &self,
+            txn_list_with_proof: TransactionListWithProof,
+            verified_target_li: &LedgerInfoWithSignatures,
+            epoch_change_li: Option<&'a LedgerInfoWithSignatures>,
+        ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
+
+        fn apply_and_commit_chunk<'a>(
+            &self,
+            txn_output_list_with_proof: TransactionOutputListWithProof,
+            verified_target_li: &LedgerInfoWithSignatures,
+            epoch_change_li: Option<&'a LedgerInfoWithSignatures>,
+        ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
+
+        fn commit_chunk(&self) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
+
+        fn reset(&self) -> Result<()>;
+    }
+}
+
+// This automatically creates a MockDataReader.
+mock! {
+    pub DatabaseReader {}
+    impl DbReader for DatabaseReader {
+        fn get_epoch_ending_ledger_infos(
+            &self,
+            start_epoch: u64,
+            end_epoch: u64,
+        ) -> Result<EpochChangeProof>;
+
+        fn get_transactions(
+            &self,
+            start_version: Version,
+            batch_size: u64,
+            ledger_version: Version,
+            fetch_events: bool,
+        ) -> Result<TransactionListWithProof>;
+
+        fn get_transaction_by_hash(
+            &self,
+            hash: HashValue,
+            ledger_version: Version,
+            fetch_events: bool,
+        ) -> Result<Option<TransactionWithProof>>;
+
+        fn get_transaction_by_version(
+            &self,
+            version: Version,
+            ledger_version: Version,
+            fetch_events: bool,
+        ) -> Result<TransactionWithProof>;
+
+        fn get_first_txn_version(&self) -> Result<Option<Version>>;
+
+        fn get_first_write_set_version(&self) -> Result<Option<Version>>;
+
+        fn get_transaction_outputs(
+            &self,
+            start_version: Version,
+            limit: u64,
+            ledger_version: Version,
+        ) -> Result<TransactionOutputListWithProof>;
+
+        fn get_events(
+            &self,
+            event_key: &EventKey,
+            start: u64,
+            order: Order,
+            limit: u64,
+        ) -> Result<Vec<(u64, ContractEvent)>>;
+
+        fn get_events_with_proofs(
+            &self,
+            event_key: &EventKey,
+            start: u64,
+            order: Order,
+            limit: u64,
+            known_version: Option<u64>,
+        ) -> Result<Vec<EventWithProof>>;
+
+        fn get_block_timestamp(&self, version: u64) -> Result<u64>;
+
+        fn get_event_by_version_with_proof(
+            &self,
+            event_key: &EventKey,
+            event_version: u64,
+            proof_version: u64,
+        ) -> Result<EventByVersionWithProof>;
+
+        fn get_last_version_before_timestamp(
+            &self,
+            _timestamp: u64,
+            _ledger_version: Version,
+        ) -> Result<Version>;
+
+        fn get_latest_state_value(&self, state_key: StateKey) -> Result<Option<StateValue>>;
+
+        fn get_latest_ledger_info_option(&self) -> Result<Option<LedgerInfoWithSignatures>>;
+
+        fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures>;
+
+        fn get_latest_version_option(&self) -> Result<Option<Version>>;
+
+        fn get_latest_version(&self) -> Result<Version>;
+
+        fn get_latest_commit_metadata(&self) -> Result<(Version, u64)>;
+
+        fn get_startup_info(&self) -> Result<Option<StartupInfo>>;
+
+        fn get_account_transaction(
+            &self,
+            address: AccountAddress,
+            seq_num: u64,
+            include_events: bool,
+            ledger_version: Version,
+        ) -> Result<Option<TransactionWithProof>>;
+
+        fn get_account_transactions(
+            &self,
+            address: AccountAddress,
+            seq_num: u64,
+            limit: u64,
+            include_events: bool,
+            ledger_version: Version,
+        ) -> Result<AccountTransactionsWithProof>;
+
+        fn get_state_proof_with_ledger_info(
+            &self,
+            known_version: u64,
+            ledger_info: LedgerInfoWithSignatures,
+        ) -> Result<StateProof>;
+
+        fn get_state_proof(&self, known_version: u64) -> Result<StateProof>;
+
+        fn get_state_value_with_proof(
+            &self,
+            state_key: StateKey,
+            version: Version,
+            ledger_version: Version,
+        ) -> Result<StateValueWithProof>;
+
+        fn get_state_value_with_proof_by_version(
+            &self,
+            state_key: &StateKey,
+            version: Version,
+        ) -> Result<(Option<StateValue>, SparseMerkleProof<StateValue>)>;
+
+        fn get_latest_tree_state(&self) -> Result<TreeState>;
+
+        fn get_epoch_ending_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
+
+        fn get_latest_transaction_info_option(&self) -> Result<Option<(Version, TransactionInfo)>>;
+
+        fn get_accumulator_root_hash(&self, _version: Version) -> Result<HashValue>;
+
+        fn get_accumulator_consistency_proof(
+            &self,
+            _client_known_version: Option<Version>,
+            _ledger_version: Version,
+        ) -> Result<AccumulatorConsistencyProof>;
+
+        fn get_accumulator_summary(
+            &self,
+            ledger_version: Version,
+        ) -> Result<TransactionAccumulatorSummary>;
+
+        fn get_state_leaf_count(&self, version: Version) -> Result<usize>;
+
+        fn get_state_value_chunk_with_proof(
+            &self,
+            version: Version,
+            start_idx: usize,
+            chunk_size: usize,
+        ) -> Result<StateValueChunkWithProof>;
+
+        fn get_state_prune_window(&self) -> Option<usize>;
+    }
+}
+
+// This automatically creates a MockDatabaseWriter.
+mock! {
+    pub DatabaseWriter {}
+    impl DbWriter for DatabaseWriter {
+        fn get_state_snapshot_receiver(
+            &self,
+            version: Version,
+            expected_root_hash: HashValue,
+        ) -> Result<Box<dyn StateSnapshotReceiver<StateKeyAndValue>>>;
+
+        fn finalize_state_snapshot(
+            &self,
+            version: Version,
+            output_with_proof: TransactionOutputListWithProof,
+        ) -> Result<()>;
+
+        fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()>;
+
+        fn save_transactions<'a>(
+            &self,
+            txns_to_commit: &[TransactionToCommit],
+            first_version: Version,
+            ledger_info_with_sigs: Option<&'a LedgerInfoWithSignatures>,
+        ) -> Result<()>;
+
+        fn delete_genesis(&self) -> Result<()>;
+    }
+}
+
+// This automatically creates a MockSnapshotReceiver.
+mock! {
+    pub SnapshotReceiver {}
+    impl StateSnapshotReceiver<StateKeyAndValue> for SnapshotReceiver {
+        fn add_chunk(&mut self, chunk: Vec<(HashValue, StateKeyAndValue)>, proof: SparseMerkleRangeProof) -> Result<()>;
+
+        fn finish(self) -> Result<()>;
+
+        fn finish_box(self: Box<Self>) -> Result<()>;
+    }
+}

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mod.rs
@@ -2,4 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod driver;
+mod mocks;
+mod storage_synchronizer;
 mod utils;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -1,168 +1,68 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::driver_factory::DriverFactory;
-use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519Signature},
     HashValue, PrivateKey, Uniform,
 };
-use aptos_data_client::aptosnet::AptosNetDataClient;
-use aptos_infallible::RwLock;
-use aptos_time_service::TimeService;
 use aptos_types::{
     account_address::AccountAddress,
     block_info::BlockInfo,
     chain_id::ChainId,
+    contract_event::ContractEvent,
+    event::EventKey,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    move_resource::MoveStorage,
-    on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
-    transaction::{
-        RawTransaction, Script, SignedTransaction, Transaction, TransactionPayload, Version,
-        WriteSetPayload,
+    proof::{
+        SparseMerkleRangeProof, TransactionAccumulatorRangeProof, TransactionInfoListWithProof,
     },
-    waypoint::Waypoint,
+    state_store::state_value::StateValueChunkWithProof,
+    transaction::{
+        RawTransaction, Script, SignedTransaction, Transaction, TransactionInfo,
+        TransactionListWithProof, TransactionOutput, TransactionOutputListWithProof,
+        TransactionPayload, TransactionStatus, Version,
+    },
+    vm_status::KeptVMStatus,
+    write_set::WriteSet,
 };
-use aptos_vm::AptosVM;
-use aptosdb::AptosDB;
-use consensus_notifications::ConsensusNotifier;
-use data_streaming_service::streaming_client::new_streaming_service_client_listener_pair;
-use event_notifications::{
-    EventNotificationSender, EventSubscriptionService, ReconfigNotificationListener,
-};
-use executor::chunk_executor::ChunkExecutor;
-use executor_test_helpers::bootstrap_genesis;
-use mempool_notifications::MempoolNotificationListener;
-use network::application::{interface::MultiNetworkSender, storage::PeerMetadataStorage};
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
-use storage_interface::{DbReader, DbReaderWriter};
-use storage_service_client::StorageServiceClient;
+use move_core_types::language_storage::TypeTag;
+use std::collections::BTreeMap;
 
-/// Creates a state sync driver with the given config and waypoint
-#[allow(dead_code)]
-pub fn create_driver_with_config_and_waypoint(
-    node_config: NodeConfig,
-    waypoint: Waypoint,
-) -> (
-    DriverFactory,
-    ConsensusNotifier,
-    MempoolNotificationListener,
-    ReconfigNotificationListener,
-) {
-    create_driver_for_tests(node_config, waypoint)
+/// Creates a test epoch ending ledger info
+pub fn create_epoch_ending_ledger_info() -> LedgerInfoWithSignatures {
+    let ledger_info = LedgerInfo::new(BlockInfo::random(0), HashValue::random());
+    LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
 }
 
-/// Creates a state sync driver for a validator node
-pub fn create_validator_driver() -> (
-    DriverFactory,
-    ConsensusNotifier,
-    MempoolNotificationListener,
-    ReconfigNotificationListener,
-) {
-    let mut node_config = NodeConfig::default();
-    node_config.base.role = RoleType::Validator;
-
-    create_driver_for_tests(node_config, Waypoint::default())
+/// Creates a single test event
+pub fn create_event() -> ContractEvent {
+    ContractEvent::new(
+        EventKey::random(),
+        0,
+        TypeTag::Bool,
+        bcs::to_bytes(&0).unwrap(),
+    )
 }
 
-/// Creates a state sync driver for a full node
-pub fn create_full_node_driver() -> (
-    DriverFactory,
-    ConsensusNotifier,
-    MempoolNotificationListener,
-    ReconfigNotificationListener,
-) {
-    let mut node_config = NodeConfig::default();
-    node_config.base.role = RoleType::FullNode;
-
-    create_driver_for_tests(node_config, Waypoint::default())
+/// Creates a new ledger info with signatures at the specified version
+pub fn create_ledger_info_at_version(version: Version) -> LedgerInfoWithSignatures {
+    let block_info = BlockInfo::new(0, 0, HashValue::zero(), HashValue::zero(), version, 0, None);
+    let ledger_info = LedgerInfo::new(block_info, HashValue::random());
+    LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
 }
 
-/// Creates a state sync driver using the given node config and waypoint
-fn create_driver_for_tests(
-    node_config: NodeConfig,
-    waypoint: Waypoint,
-) -> (
-    DriverFactory,
-    ConsensusNotifier,
-    MempoolNotificationListener,
-    ReconfigNotificationListener,
-) {
-    // Create test aptos database
-    let db_path = aptos_temppath::TempPath::new();
-    db_path.create_as_dir().unwrap();
-    let (db, db_rw) = DbReaderWriter::wrap(AptosDB::new_for_test(db_path.path()));
-
-    // Bootstrap the genesis transaction
-    let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
-    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
-    bootstrap_genesis::<AptosVM>(&db_rw, &genesis_txn).unwrap();
-
-    // Create the event subscription service and notify initial configs
-    let storage: Arc<dyn DbReader> = db;
-    let synced_version = (&*storage).fetch_synced_version().unwrap();
-    let mut event_subscription_service = EventSubscriptionService::new(
-        ON_CHAIN_CONFIG_REGISTRY,
-        Arc::new(RwLock::new(db_rw.clone())),
-    );
-    let reconfiguration_subscriber = event_subscription_service
-        .subscribe_to_reconfigurations()
-        .unwrap();
-    event_subscription_service
-        .notify_initial_configs(synced_version)
-        .unwrap();
-
-    // Create consensus and mempool notifiers and listeners
-    let (consensus_notifier, consensus_listener) =
-        consensus_notifications::new_consensus_notifier_listener_pair(1000);
-    let (mempool_notifier, mempool_listener) =
-        mempool_notifications::new_mempool_notifier_listener_pair();
-
-    // Create the chunk executor
-    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()).unwrap());
-
-    // Create a streaming service client
-    let (streaming_service_client, _) = new_streaming_service_client_listener_pair();
-
-    // Create a test aptos data client
-    let network_client = StorageServiceClient::new(
-        MultiNetworkSender::new(HashMap::new()),
-        PeerMetadataStorage::new(&[]),
-    );
-    let (aptos_data_client, _) = AptosNetDataClient::new(
-        node_config.state_sync.aptos_data_client,
-        node_config.state_sync.storage_service,
-        TimeService::mock(),
-        network_client,
-    );
-
-    // Create and spawn the driver
-    let driver_factory = DriverFactory::create_and_spawn_driver(
-        false,
-        &node_config,
-        waypoint,
-        db_rw,
-        chunk_executor,
-        mempool_notifier,
-        consensus_listener,
-        event_subscription_service,
-        aptos_data_client,
-        streaming_service_client,
-    );
-
-    (
-        driver_factory,
-        consensus_notifier,
-        mempool_listener,
-        reconfiguration_subscriber,
+/// Creates a test transaction output list with proof
+pub fn create_output_list_with_proof() -> TransactionOutputListWithProof {
+    let transaction_info_list_with_proof = create_transaction_info_list_with_proof();
+    let transaction_and_output = (create_transaction(), create_transaction_output());
+    TransactionOutputListWithProof::new(
+        vec![transaction_and_output],
+        Some(0),
+        transaction_info_list_with_proof,
     )
 }
 
 /// Creates a single test transaction
-pub fn create_test_transaction() -> Transaction {
+pub fn create_transaction() -> Transaction {
     let private_key = Ed25519PrivateKey::generate_for_testing();
     let public_key = private_key.public_key();
 
@@ -186,9 +86,60 @@ pub fn create_test_transaction() -> Transaction {
     Transaction::UserTransaction(signed_transaction)
 }
 
-/// Creates a new ledger info with signatures at the specified version
-pub fn create_ledger_info_at_version(version: Version) -> LedgerInfoWithSignatures {
-    let block_info = BlockInfo::new(0, 0, HashValue::zero(), HashValue::zero(), version, 0, None);
-    let ledger_info = LedgerInfo::new(block_info, HashValue::random());
-    LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
+/// Creates a test transaction info
+pub fn create_transaction_info() -> TransactionInfo {
+    TransactionInfo::new(
+        HashValue::random(),
+        HashValue::random(),
+        HashValue::random(),
+        0,
+        KeptVMStatus::Executed,
+    )
+}
+
+/// Creates a test transaction info list with proof
+pub fn create_transaction_info_list_with_proof() -> TransactionInfoListWithProof {
+    TransactionInfoListWithProof::new(
+        TransactionAccumulatorRangeProof::new_empty(),
+        vec![create_transaction_info()],
+    )
+}
+
+/// Creates a test transaction list with proof
+pub fn create_transaction_list_with_proof() -> TransactionListWithProof {
+    let transaction_info_list_with_proof = create_transaction_info_list_with_proof();
+    TransactionListWithProof::new(
+        vec![create_transaction()],
+        None,
+        Some(0),
+        transaction_info_list_with_proof,
+    )
+}
+
+/// Creates a single test transaction output
+pub fn create_transaction_output() -> TransactionOutput {
+    TransactionOutput::new(
+        WriteSet::default(),
+        vec![],
+        0,
+        TransactionStatus::Keep(KeptVMStatus::Executed),
+    )
+}
+
+/// Creates a test StateValueChunkWithProof
+pub fn create_state_value_chunk_with_proof(last_chunk: bool) -> StateValueChunkWithProof {
+    let right_siblings = if last_chunk {
+        vec![]
+    } else {
+        vec![HashValue::random()]
+    };
+    StateValueChunkWithProof {
+        first_index: 0,
+        last_index: 100,
+        first_key: HashValue::random(),
+        last_key: HashValue::random(),
+        raw_values: vec![],
+        proof: SparseMerkleRangeProof::new(right_siblings),
+        root_hash: HashValue::random(),
+    }
 }


### PR DESCRIPTION
## Motivation

This PR adds some simple unit tests to the storage synchronizer component of the state sync driver. To achieve this, we use the `mockall` crate to mock the storage synchronizer dependencies in the unit tests.

The PR offers the following commits:
1. First, update the storage synchronizer to return the join handles of the executor, committer and account synchronizer tasks. This allows us to reference these handles in the code.
2. Second, add the unit tests for the storage synchronizer. Here, we use `mock!` to mock the dependencies and add new unit tests.

Note:
- I'm not a huge fan of mockist style testing. I'd rather have a better end-to-end testing harness to test overall behaviours. But, we don't currently have this harness in place. So, this is a temporary stop-gap to prevent code breakages.
- I chose the `mockall` crate because it is well-known and provided what I needed. Others exist, but I didn't play around with them too much 😄 My opinion of the crate is so-so. More good than bad. 'cc @sitalkedia 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The new unit tests pass.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245