### PR TITLE
[State Sync] Small improvements towards production deployment.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -90,7 +90,7 @@ pub struct StateSyncDriverConfig {
 impl Default for StateSyncDriverConfig {
     fn default() -> Self {
         Self {
-            bootstrapping_mode: BootstrappingMode::DownloadLatestAccountStates,
+            bootstrapping_mode: BootstrappingMode::ApplyTransactionOutputsFromGenesis,
             enable_state_sync_v2: false,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
@@ -157,9 +157,9 @@ impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
             global_summary_refresh_interval_ms: 300,
-            max_concurrent_requests: 3,
+            max_concurrent_requests: 1,
             max_data_stream_channel_sizes: 1000,
-            max_request_retry: 5,
+            max_request_retry: 3,
             max_notification_id_mappings: 2000,
             progress_check_interval_ms: 100,
         }

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -560,7 +560,7 @@ impl DataStreamEngine for ContinuousTransactionStreamEngine {
                     },
                 )]);
             } else {
-                info!(
+                debug!(
                     (LogSchema::new(LogEntry::ReceivedDataResponse)
                         .event(LogEvent::Success)
                         .message(&format!(

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -242,7 +242,11 @@ async fn test_stream_invalid_response() {
 #[tokio::test]
 async fn test_stream_out_of_order_responses() {
     // Create an epoch ending data stream
-    let streaming_service_config = DataStreamingServiceConfig::default();
+    let max_concurrent_requests = 3;
+    let streaming_service_config = DataStreamingServiceConfig {
+        max_concurrent_requests,
+        ..Default::default()
+    };
     let (mut data_stream, mut stream_listener) =
         create_epoch_ending_stream(streaming_service_config, MIN_ADVERTISED_EPOCH_END);
 
@@ -254,7 +258,10 @@ async fn test_stream_out_of_order_responses() {
 
     // Verify at least three requests have been made
     let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
-    assert_ge!(sent_requests.as_ref().unwrap().len(), 3);
+    assert_ge!(
+        sent_requests.as_ref().unwrap().len(),
+        max_concurrent_requests as usize
+    );
 
     // Set a response for the second request and verify no notifications
     set_epoch_ending_response_in_queue(&mut data_stream, 1);
@@ -309,7 +316,11 @@ async fn test_stream_out_of_order_responses() {
 #[tokio::test]
 async fn test_stream_listener_dropped() {
     // Create an epoch ending data stream
-    let streaming_service_config = DataStreamingServiceConfig::default();
+    let max_concurrent_requests = 3;
+    let streaming_service_config = DataStreamingServiceConfig {
+        max_concurrent_requests,
+        ..Default::default()
+    };
     let (mut data_stream, mut stream_listener) =
         create_epoch_ending_stream(streaming_service_config, MIN_ADVERTISED_EPOCH_END);
 
@@ -321,7 +332,10 @@ async fn test_stream_listener_dropped() {
 
     // Verify no notifications have been sent yet
     let (sent_requests, sent_notifications) = data_stream.get_sent_requests_and_notifications();
-    assert_ge!(sent_requests.as_ref().unwrap().len(), 3);
+    assert_ge!(
+        sent_requests.as_ref().unwrap().len(),
+        max_concurrent_requests as usize
+    );
     assert_eq!(sent_notifications.len(), 0);
 
     // Set a response for the first request and verify a notification is sent

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -77,7 +77,7 @@ impl DriverFactory {
             chunk_executor,
             commit_notification_sender,
             error_notification_sender,
-            storage.writer,
+            storage.clone(),
             driver_runtime.as_ref(),
         );
 


### PR DESCRIPTION
## Motivation

This PR makes some small improvements to state sync v2 as we prepare to get to a production deployment. The PR offers the following commits:
1. Update the storage synchronizer metrics to handle node crashes and reboots (e.g., initialize the progress counters on reboot).
2. Update the storage synchronizer executor thread to yield more frequently when we identify that the committer is falling behind. This is not needed today, but it's useful (e.g., if a node is configured to do too much data pre-fetching or if there is CPU thread contention).
3. Update the default state sync v2 config values to stop prefetching.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manual verification.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245