### PR TITLE
[aptos-cli] Add readme for installation and usage

### DIFF
--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -1,3 +1,20 @@
-### Aptos Tool
+# Aptos CLI Tool
 
 `aptos` is designed to be a single interface tool for debugging, development, and node operation.
+
+
+## Set up
+With Cargo:
+  1. Ensure you have `cargo` [installed](https://doc.rust-lang.org/cargo/getting-started/installation.html)
+  2. Directly install from source: `cargo install --git https://github.com/aptos-labs/aptos-core.git aptos`
+  3. Use `aptos` command
+
+## Usage
+
+```
+account    CLI tool for interacting with accounts
+help       Print this message or the help of the given subcommand(s)
+init       Tool to initialize current directory for the aptos tool
+move       CLI tool for performing Move tasks
+op         CLI tool for performing operational tasks
+```

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -12,7 +12,7 @@ use clap::Subcommand;
 pub mod create;
 pub mod list;
 
-/// Command to create a new account on-chain
+/// CLI tool for interacting with accounts
 ///
 #[derive(Debug, Subcommand)]
 pub enum AccountTool {


### PR DESCRIPTION
## Motivation
#517. We want to have instructions to download the cli tool with and without cargo. 

We will put up a release later in the week which will allow download from our github without cargo. Shortly after that we can setup brew. But I had already started updating the readme so I just wanted to get this in so we can add on top of it.

## Test Plan

`cargo install --git https://github.com/aptos-labs/aptos-core.git aptos`

## Related PRs

#517 
