### PR TITLE
[Cleanup] Remove auth_key_prefix

### DIFF
--- a/aptos-move/aptos-keygen/src/lib.rs
+++ b/aptos-move/aptos-keygen/src/lib.rs
@@ -36,15 +36,13 @@ impl KeyGen {
         (private_key, public_key)
     }
 
-    /// Same as `generate_keypair`, but returns a tuple of (private_key, auth_key_prefix, account_addr) instead.
+    /// Same as `generate_keypair`, but returns a tuple of (private_key, auth_key, account_addr) instead.
     pub fn generate_credentials_for_account_creation(
         &mut self,
     ) -> (Ed25519PrivateKey, Vec<u8>, AccountAddress) {
         let (private_key, public_key) = self.generate_keypair();
         let auth_key = AuthenticationKey::ed25519(&public_key).to_vec();
-        const AUTH_KEY_PREFIX_LENGTH: usize = AuthenticationKey::LENGTH - AccountAddress::LENGTH;
-        let auth_key_prefix = auth_key[..AUTH_KEY_PREFIX_LENGTH].to_vec();
-        let account_addr = AccountAddress::from_bytes(&auth_key[AUTH_KEY_PREFIX_LENGTH..]).unwrap();
-        (private_key, auth_key_prefix, account_addr)
+        let account_addr = AccountAddress::from_bytes(&auth_key).unwrap();
+        (private_key, auth_key, account_addr)
     }
 }

--- a/aptos-move/aptos-keygen/src/main.rs
+++ b/aptos-move/aptos-keygen/src/main.rs
@@ -3,7 +3,7 @@
 
 use aptos_crypto::ValidCryptoMaterialStringExt;
 use aptos_keygen::KeyGen;
-use aptos_types::{account_address::AccountAddress, transaction::authenticator::AuthenticationKey};
+use aptos_types::transaction::authenticator::AuthenticationKey;
 
 fn main() {
     let mut keygen = KeyGen::from_os_rng();
@@ -15,12 +15,10 @@ fn main() {
     println!();
 
     let auth_key = AuthenticationKey::ed25519(&pubkey).to_vec();
-    let prefix_length = auth_key.len() - AccountAddress::LENGTH;
-    let auth_key_prefix = &auth_key[..prefix_length];
-    let account_addr = &auth_key[prefix_length..];
+    let account_addr = &auth_key[..];
 
-    println!("Auth Key Prefix:");
-    println!("{}", hex::encode(auth_key_prefix));
+    println!("Auth Key:");
+    println!("{}", hex::encode(account_addr));
     println!();
 
     println!("Account Address:");

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -565,11 +565,9 @@ impl<'a> AptosTestAdapter<'a> {
 
         validator_private_key: Ed25519PrivateKey,
         validator_account_addr: AccountAddress,
-        _validator_auth_key_prefix: Vec<u8>,
 
         operator_private_key: Ed25519PrivateKey,
         operator_account_addr: AccountAddress,
-        _operator_auth_key_prefix: Vec<u8>,
     ) {
         // Step 1. Create validator account.
         let parameters = self
@@ -695,7 +693,6 @@ impl<'a> AptosTestAdapter<'a> {
     fn create_parent_vasp_account(
         &mut self,
         _validator_name: Identifier,
-        _auth_key_prefix: Vec<u8>,
         account_addr: AccountAddress,
         _currency_type_name: TypeName,
     ) {
@@ -810,10 +807,10 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
                         )
                     }
 
-                    let (validator_private_key, validator_auth_key_prefix, validator_account_addr) =
+                    let (validator_private_key, _, validator_account_addr) =
                         keygen.generate_credentials_for_account_creation();
 
-                    let (operator_private_key, operator_auth_key_prefix, operator_account_addr) =
+                    let (operator_private_key, _, operator_account_addr) =
                         keygen.generate_credentials_for_account_creation();
 
                     named_address_mapping.insert(
@@ -833,10 +830,8 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
                         validator_name,
                         validator_private_key,
                         validator_account_addr,
-                        validator_auth_key_prefix,
                         operator_private_key,
                         operator_account_addr,
-                        operator_auth_key_prefix,
                     ));
                 }
             }
@@ -858,7 +853,7 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
                         )
                     }
 
-                    let (private_key, auth_key_prefix, account_addr) =
+                    let (private_key, _, account_addr) =
                         keygen.generate_credentials_for_account_creation();
                     named_address_mapping.insert(
                         parent_vasp_name.to_string(),
@@ -871,7 +866,6 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
                     // only available after the AptosTestAdapter has been fully initialized.
                     parent_vasps_to_create.push((
                         parent_vasp_name,
-                        auth_key_prefix,
                         account_addr,
                         parent_vasp_init_args.currency_type,
                     ));
@@ -891,33 +885,22 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
             validator_name,
             validator_private_key,
             validator_account_addr,
-            validator_auth_key_prefix,
             operator_private_key,
             operator_account_addr,
-            operator_auth_key_prefix,
         ) in validators_to_create
         {
             adapter.create_validator_account(
                 validator_name,
                 validator_private_key,
                 validator_account_addr,
-                validator_auth_key_prefix,
                 operator_private_key,
                 operator_account_addr,
-                operator_auth_key_prefix,
             );
         }
 
         // Create parent vasp accounts
-        for (parent_vasp_name, auth_key_prefix, account_addr, currency_type_name) in
-            parent_vasps_to_create
-        {
-            adapter.create_parent_vasp_account(
-                parent_vasp_name,
-                auth_key_prefix,
-                account_addr,
-                currency_type_name,
-            );
+        for (parent_vasp_name, account_addr, currency_type_name) in parent_vasps_to_create {
+            adapter.create_parent_vasp_account(parent_vasp_name, account_addr, currency_type_name);
         }
 
         adapter

--- a/aptos-move/e2e-tests/src/account.rs
+++ b/aptos-move/e2e-tests/src/account.rs
@@ -175,11 +175,6 @@ impl Account {
         AuthenticationKey::ed25519(&self.pubkey).to_vec()
     }
 
-    /// Return the first 16 bytes of the account's auth key
-    pub fn auth_key_prefix(&self) -> Vec<u8> {
-        AuthenticationKey::ed25519(&self.pubkey).prefix().to_vec()
-    }
-
     pub fn transaction(&self) -> TransactionBuilder {
         TransactionBuilder::new(self.clone())
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Remove the auth_key_prefix. This is not longer needed after 32-byte migration

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
## Test Plan
cargo test

