### PR TITLE
Add WriteSet to transactions

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -1071,6 +1071,7 @@ components:
         - success
         - vm_status
         - accumulator_root_hash
+        - changes
       properties:
         version:
           $ref: '#/components/schemas/Uint64'
@@ -1093,6 +1094,10 @@ components:
             Human readable transaction execution result message from Aptos VM.
         accumulator_root_hash:
           $ref: '#/components/schemas/HexEncodedBytes'
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/WriteSetChange'
     UserTransaction:
       title: User Transaction
       type: object
@@ -1315,12 +1320,15 @@ components:
       type: object
       required:
         - type
+        - state_key_hash
         - address
         - module
       properties:
         type:
           type: string
           example: "delete_module"
+        state_key_hash:
+          $ref: '#/components/schemas/HexEncodedBytes'
         address:
           $ref: '#/components/schemas/Address'
         module:
@@ -1331,12 +1339,15 @@ components:
       description: Delete account resource change.
       required:
         - type
+        - state_key_hash
         - address
         - resource
       properties:
         type:
           type: string
           example: "delete_resource"
+        state_key_hash:
+          $ref: '#/components/schemas/HexEncodedBytes'
         address:
           $ref: '#/components/schemas/Address'
         resource:
@@ -1347,12 +1358,15 @@ components:
       description: Write move module
       required:
         - type
+        - state_key_hash
         - address
         - data
       properties:
         type:
           type: string
           example: "write_module"
+        state_key_hash:
+          $ref: '#/components/schemas/HexEncodedBytes'
         address:
           $ref: '#/components/schemas/Address'
         data:
@@ -1363,12 +1377,15 @@ components:
       description: Write account resource
       required:
         - type
+        - state_key_hash
         - address
         - data
       properties:
         type:
           type: string
           example: "write_resource"
+        state_key_hash:
+          $ref: '#/components/schemas/HexEncodedBytes'
         address:
           $ref: '#/components/schemas/Address'
         data:

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_genesis_transaction.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_genesis_transaction.json
@@ -9,6 +9,4823 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x7034cb258af7d4dcb09edfed43e69adbe12e3f66186a9039b32b4837aa042345",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0x1",
+        "state_key_hash": "0x3502b05382fba777545b45a0a9d40e86cdde7c3afbde19c748ce8b5f142c2b46",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0x1",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x2919ba9c5f550ed4b85f3735ef6129545750d68d91a11574e905939dd78055f8",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b01000802080e031671048701100597015b07f201fa0108ec0320068c040a0a96040b0ca104d0020df10604000000010002000300040700000507000202070100000006000100000700020000080304000009040300000a050600000b040100000c040100000d000700000e080300000f090a0000100605000011060b00030d0d07010003130e0f010001140707000315101101000316120a010002171301010002181411010002190a140100021a111401000c040d040f041004110512051305140501060801010101060a020108000102010801010a0201030107080102070801080000010b020108010302030301060a090002060a0900030106090001070a090001090002070a0900090001060b02010900010b0201090003030302054153434949064572726f7273064f7074696f6e06566563746f72044368617206537472696e6718616c6c5f636861726163746572735f7072696e7461626c650861735f6279746573046279746504636861720a696e746f5f62797465731169735f7072696e7461626c655f636861720d69735f76616c69645f63686172066c656e67746808706f705f6368617209707573685f6368617206737472696e670a7472795f737472696e6705627974657306626f72726f7710696e76616c69645f617267756d656e7408706f705f6261636b09707573685f6261636b0769735f736f6d650c64657374726f795f736f6d65046e6f6e6504736f6d650000000000000000000000000000000000000000000000000000000000000001030800000000000000000002010802010201120a02000100000c230a00100038000c030600000000000000000c02280a020a0323030c05200a0010000a023801140c010b011105200317051b0b000109020b02060100000000000000160c020506280802010100000a030b001000020201000004050b0013000c010b0102030100000a090a00110603060700110e270b001200020401000006050b0013010c010b010205010000010e0a003120260305050a0b00317e250c01050c090c010b0102060100000a040b00317f2502070100000a040b001101380002080100000a050b000f003802120002090100000a070b000f000e011001143803020a0100000b0c0b00110b0c010e01380403090700110e270b013805020b01000015210e0038000c020600000000000000000c01280a010a0223030b051c0e000a013801140c030b03110620031505173806020b01060100000000000000160c010505280b0012013807020100000000",
+          "abi": {
+            "address": "0x1",
+            "name": "ASCII",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "all_characters_printable",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::ASCII::String"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "as_bytes",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::ASCII::String"
+                ],
+                "return": [
+                  "&vector<u8>"
+                ]
+              },
+              {
+                "name": "byte",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "0x1::ASCII::Char"
+                ],
+                "return": [
+                  "u8"
+                ]
+              },
+              {
+                "name": "char",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u8"
+                ],
+                "return": [
+                  "0x1::ASCII::Char"
+                ]
+              },
+              {
+                "name": "into_bytes",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "0x1::ASCII::String"
+                ],
+                "return": [
+                  "vector<u8>"
+                ]
+              },
+              {
+                "name": "is_printable_char",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u8"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "is_valid_char",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u8"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "length",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::ASCII::String"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "pop_char",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&mut 0x1::ASCII::String"
+                ],
+                "return": [
+                  "0x1::ASCII::Char"
+                ]
+              },
+              {
+                "name": "push_char",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&mut 0x1::ASCII::String",
+                  "0x1::ASCII::Char"
+                ],
+                "return": []
+              },
+              {
+                "name": "string",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "vector<u8>"
+                ],
+                "return": [
+                  "0x1::ASCII::String"
+                ]
+              },
+              {
+                "name": "try_string",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "vector<u8>"
+                ],
+                "return": [
+                  "0x1::Option::Option<0x1::ASCII::String>"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "Char",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "byte",
+                    "type": "u8"
+                  }
+                ]
+              },
+              {
+                "name": "String",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "bytes",
+                    "type": "vector<u8>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x2fe51d3f72e53bc3068e56d32558e8b4f4709a6342457a41e8bd78dc95f78470",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000c01001c021c0c0328f301049b020605a102a40107c503d10908960d2006b60dde020a9410260cba10a6060de016040fe41602000100020003000400050006000700080009000a000b000c000d000e00010c00000f0800073d04000010000100001100020000120002000013030400001401050000150005000016060100001707010000180601000019070100001a080100001b000900001c000400001d000a00001e0b0100001f0c010000200d010000210c01000022020100002303010000240e010000250f01000026100100073311010003340a0a0003350a0a000136130401000d37150a010005381116000d3917010100083a010100063b1101000b3c0301000c3c030100033e0a0a00073f191a0009401a0100054111000003420a0a000a4301090003440a0a000845010a0002460114000447040400071b0009000748000a0003490a0a000a4a1d09001a001b141d14010500020c0a0202060c0a02010a02010c030c050a0203060c050a02050c03030303010101030a060c050a020a020a020a020a020a020a0201070c030a0203030302090c030a020a050a0a0203030302080c030a02030303020a02030c0301050c030a02030201060c020a020c01060900010201060a090001060502070a09000a09000607080005080203030302060c0301080204030306080005020708000501060a020747656e65736973074163636f756e740342435307436861696e4964064572726f72730448617368065369676e65720f53797374656d4164647265737365730854657374436f696e0954696d657374616d700e5472616e73616374696f6e4665651b5472616e73616374696f6e5075626c697368696e674f7074696f6e0f56616c696461746f72436f6e6669671756616c696461746f724f70657261746f72436f6e66696706566563746f7218436861696e53706563696669634163636f756e74496e666f0e6372656174655f6163636f756e74176372656174655f6163636f756e745f696e7465726e616c186372656174655f6163636f756e745f756e636865636b6564196372656174655f61757468656e7469636174696f6e5f6b65791d6372656174655f636f72655f6672616d65776f726b5f6163636f756e740d6372656174655f7369676e6572186372656174655f76616c696461746f725f6163636f756e74216372656174655f76616c696461746f725f6163636f756e745f696e7465726e616c216372656174655f76616c696461746f725f6f70657261746f725f6163636f756e742a6372656174655f76616c696461746f725f6f70657261746f725f6163636f756e745f696e7465726e616c086570696c6f677565096578697374735f6174166765745f61757468656e7469636174696f6e5f6b6579136765745f73657175656e63655f6e756d6265720a696e697469616c697a650f6d6f64756c655f70726f6c6f6775651b6d756c74695f6167656e745f7363726970745f70726f6c6f6775650f70726f6c6f6775655f636f6d6d6f6e19726f746174655f61757468656e7469636174696f6e5f6b657922726f746174655f61757468656e7469636174696f6e5f6b65795f696e7465726e616c0f7363726970745f70726f6c6f6775651177726974657365745f6570696c6f6775651177726974657365745f70726f6c6f6775651261757468656e7469636174696f6e5f6b65790f73657175656e63655f6e756d6265720c73656c665f616464726573730b6d6f64756c655f616464720b6d6f64756c655f6e616d65147363726970745f70726f6c6f6775655f6e616d65146d6f64756c655f70726f6c6f6775655f6e616d651677726974657365745f70726f6c6f6775655f6e616d65196d756c74695f6167656e745f70726f6c6f6775655f6e616d6512757365725f6570696c6f6775655f6e616d651677726974657365745f6570696c6f6775655f6e616d651663757272656e63795f636f64655f726571756972656408726567697374657211616c72656164795f7075626c697368656410696e76616c69645f617267756d656e7408746f5f6279746573066c656e6774680e626f72726f775f6164647265737306617070656e640e6173736572745f67656e65736973146173736572745f636f72655f7265736f75726365077075626c69736804436f696e0e6c696d69745f6578636565646564087769746864726177086275726e5f6665650a616464726573735f6f661072657175697265735f616464726573731169735f6d6f64756c655f616c6c6f7765640d696e76616c69645f73746174650b6e6f775f7365636f6e64730367657408736861335f3235360a62616c616e63655f6f660d6e6f745f7075626c69736865641169735f7363726970745f616c6c6f776564000000000000000000000000000000000000000000000000000000000000000103080000000000000000030807000000000000000308060000000000000003080400000000000000030805000000000000000308030000000000000003080a00000000000000030809000000000000000308020000000000000003080b0000000000000003080100000000000000030808000000000000000410ffffffffffffffff00000000000000000308ec030000000000000308ef030000000000000308ed030000000000000308e9030000000000000308f2030000000000000308f1030000000000000308f0030000000000000308f3030000000000000308eb030000000000000308ea030000000000000308ee0300000000000005200000000000000000000000000000000000000000000000000000000000000000052000000000000000000000000000000000000000000000000000000000000000010520000000000000000000000000000000000000000000000000000000000a550c18000203270a02280329050102092a052b0a022c0a022d0a022e0a022f0a02300a02310a0232010002000005070b001101010c010e011117020101000001180a00290020030707001118270a00071822030e07031119270a00071922031507021119270b001102020200000012170a0011050c020e0038000c010e01380106200000000000000021030e07051119270e020a010600000000000000000b0012002d000b020b01020300000004110b010c020d020b00111c380038020e02380106200000000000000021030f07051119270b0202040300000507111e07191102010c000b0002050002000602000001050e000b010b0211070207010000050a0b00111f0b011101010c030e030b021120020802000001050e000b010b0211090209010000050a0b00111f0b011101010c030e030b021121020a0000010018380a030a0426030707041119270b030b04170c080a02350a083518070c25031607041122270b020b08180c0a0e000b0a11230c070b0711240e0011250c060a06110d0c090a0935070c23032e070a1122270b062a000c050b09060100000000000000160b050f0015020b01000001030b002900020c0100010001050b002b00100114020d0100010001050b002b00100014020e01000001170a001125071a21030a0b000107081126270b000b010b020b030b040b050b060b070b080b0912012d01020f00000100010e1127030507121128270b000b010b020b030b040b050b06111102100000000103070711192711000001001b5911290b0523030707171119270e0011250c0a112a0b06210311070e1119270a0a29000317070d1119270a0a2b000c090b02112b0a091001142103260b090107101119270a0135070c2303300b090107141122270a010a0910001426033b0b090107161119270b010b0910001421034407151119270b030b04180c080a0a112c034e070f1119270b0a112d0c070b070b08260358070f11192702120200010001040e000b0111130213010001001c190b0011250c030a03110b03090700112e270e01380106200000000000000021031107051119270b032a000c020b010b020f0115021400000100010f0e07112f030607131128270b000b010b020b030b040b050b06111102150000000103070b111927160000000103071111192700010000000000",
+          "abi": {
+            "address": "0x1",
+            "name": "Account",
+            "friends": [
+              "0x1::Genesis"
+            ],
+            "exposed_functions": [
+              {
+                "name": "create_account",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_account_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "signer",
+                  "vector<u8>"
+                ]
+              },
+              {
+                "name": "create_core_framework_account",
+                "visibility": "friend",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "signer"
+                ]
+              },
+              {
+                "name": "create_validator_account",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_validator_account_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_validator_operator_account",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_validator_operator_account_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "exists_at",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "get_authentication_key",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "vector<u8>"
+                ]
+              },
+              {
+                "name": "get_sequence_number",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "bool"
+                ],
+                "return": []
+              },
+              {
+                "name": "rotate_authentication_key",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "rotate_authentication_key_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "vector<u8>"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "Account",
+                "is_native": false,
+                "abilities": [
+                  "store",
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "authentication_key",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "sequence_number",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "self_address",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "ChainSpecificAccountInfo",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "module_addr",
+                    "type": "address"
+                  },
+                  {
+                    "name": "module_name",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "script_prologue_name",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "module_prologue_name",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "writeset_prologue_name",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "multi_agent_prologue_name",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "user_epilogue_name",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "writeset_epilogue_name",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "currency_code_required",
+                    "type": "bool"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xe7c46aba2fa4aa3b56c0adee4075dc8d2518ea3d3c35d094584f52c44d7e54e7",
+        "data": {
+          "bytecode": "0xa11ceb0b0500000006010002030206050807070f0d081c200c3c04000000010001010001060900010a020342435308746f5f627974657300000000000000000000000000000000000000000000000000000000000000010001020000",
+          "abi": {
+            "address": "0x1",
+            "name": "BCS",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "to_bytes",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&T0"
+                ],
+                "return": [
+                  "vector<u8>"
+                ]
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xaee1008f6bec7a796661e761e643736d4ce392281ee2efe1f97f3fc7f556b364",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b010006020604030a4604500a055a4b07a501a30108c8022006e8021e0a8603080c8e03f1030dff0604000000010002000007000003000100000402030000050003000006030400000705060000080506000009050600020407030100010b030300020c08090100020d060b0100020e0c060100020f0e0f0100070109010a010b010c010206080003010101060800010301080002070800030001060a090002060a09000301060900020a0103010a090002070a0900090001070102070a090003010709000607080003070103030309426974566563746f72064572726f727306566563746f720c69735f696e6465785f736574066c656e677468206c6f6e676573745f7365745f73657175656e63655f7374617274696e675f6174036e6577037365740a73686966745f6c65667405756e736574096269745f6669656c6410696e76616c69645f617267756d656e7406626f72726f7705656d70747909707573685f6261636b0a626f72726f775f6d7574000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000308000400000000000000020204030a0a010001000006110a010a001000380023030b0b000107001108270b0010000b01380114020101000006040b0010003800020201000003260a010a0010011423030b0b000107001108270a010c020a020a0010011423031405220a000a02110020031a051d0b000105220b02060100000000000000160c02050d0b020b011702030100000a250a0006000000000000000024030707011108270a00070223030e07011108270600000000000000000c0238020c01280a020a0023031805200d010938030b02060100000000000000160c020512280b000b01120002040100000d140a010a001000380023030b0b000107001108270b000f000b0138040c02080b02150205010000105d0a010a0010011426030705220a00100038000c070600000000000000000c050a050a07230312051f0a000f000a0538040c04090b04150b05060100000000000000160c05050d0b0001055c0a010c060a060a0010011423032b05450a000a060c030c020b022e0b0311000335053b0a000a060a0117110405400a000a060a011711060b06060100000000000000160c0605240a001001140b01170c060a060a00100114230352055a0a000a0611060b06060100000000000000160c06054b0b000102060100000d140a010a001000380023030b0b000107001108270b000f000b0138040c02090b0215020001000000",
+          "abi": {
+            "address": "0x1",
+            "name": "BitVector",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "is_index_set",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::BitVector::BitVector",
+                  "u64"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "length",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::BitVector::BitVector"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "longest_set_sequence_starting_at",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::BitVector::BitVector",
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "new",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "0x1::BitVector::BitVector"
+                ]
+              },
+              {
+                "name": "set",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&mut 0x1::BitVector::BitVector",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "shift_left",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&mut 0x1::BitVector::BitVector",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "unset",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&mut 0x1::BitVector::BitVector",
+                  "u64"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "BitVector",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "length",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "bit_field",
+                    "type": "vector<bool>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x87b07aa352041a9cb02fdf5ef467f5b2c0be6f867836ecd668e51b9972386bee",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b01000c020c0e031a4d046704056b2d079801ad0308c5042006e504580abd05170cd405ad010d8107040000000100020003000400050006080000070600020e0401060100080001000009010200000a030100000b010400041301010003140301000515060400011602020004170701000218090101060119020200041a010100031b030100011c020200021d030a010609080e08050c03030a050500010301060c01010201070800010503060c050301080102070b020109000900010b0201090005426c6f636b064572726f7273054576656e740f53797374656d4164647265737365730954696d657374616d700c56616c696461746f725365740d426c6f636b4d657461646174610d4e6577426c6f636b4576656e740e626c6f636b5f70726f6c6f677565186765745f63757272656e745f626c6f636b5f68656967687419696e697469616c697a655f626c6f636b5f6d657461646174610e69735f696e697469616c697a656406686569676874106e65775f626c6f636b5f6576656e74730b4576656e7448616e646c6505726f756e640870726f706f7365721470726576696f75735f626c6f636b5f766f7465731174696d655f6d6963726f7365636f6e6473106173736572745f6f7065726174696e67096173736572745f766d0c69735f76616c696461746f721072657175697265735f61646472657373127570646174655f676c6f62616c5f74696d650a656d69745f6576656e740d6e6f745f7075626c69736865640e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c6973686564106e65775f6576656e745f68616e646c6500000000000000000000000000000000000000000000000000000000000000010308000000000000000003080100000000000000052000000000000000000000000000000000000000000000000000000000000000000520000000000000000000000000000000000000000000000000000000000a550c180002020c030d0b020108010102040f031005110a0512030000000100052b11040e0011050a040702210308050b080c05050e0a0411060c050b050313070111072707032a000c060e000a040a0211080a06100014060100000000000000160a060f00150b060f010b010b040b030b0212013800020101000100010a110303050700110a2707032b0010001402020100000112110b0a00110c110320030b0b00010700110d270a000600000000000000000b00380112002d000203000000010307032900020000000100",
+          "abi": {
+            "address": "0x1",
+            "name": "Block",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "get_current_block_height",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "initialize_block_metadata",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "BlockMetadata",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "height",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "new_block_events",
+                    "type": "0x1::Event::EventHandle<0x1::Block::NewBlockEvent>"
+                  }
+                ]
+              },
+              {
+                "name": "NewBlockEvent",
+                "is_native": false,
+                "abilities": [
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "round",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "proposer",
+                    "type": "address"
+                  },
+                  {
+                    "name": "previous_block_votes",
+                    "type": "vector<address>"
+                  },
+                  {
+                    "name": "time_microseconds",
+                    "type": "u64"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xfe8b9a022a52739d1e52f5391da7cb6e9caf54e93962f3d727c49bee337d240a",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000d01000802081803206e048e011205a00178079802ae0208c6042006e604140afa04150b8f05080c9705d8020def07080ef707080000000100020003000403010001000508010001000608010001000702010001000800010100000900020100000a03040102000b00040100000c05040100000d06070100000e08040102000f0904010000100a07010000110b07010003140d0e010003150304010002160b070001170f0f0003180410010003190d120100031a130c0100011b0f0f00011c0f0f00090c0a0c0b0c0e0702070f0c100c06070a0702060c060900010b00010900010b0301090002070a0900090000030b00010900060900060c020b03010900060900010502070a0900060900030b0001090006090005020b0001090006090001060c01090002060a090006090001010103010a090004070a0900060900010302010302070a090003030505050a4361706162696c697479064572726f7273065369676e657206566563746f72034361701043617044656c65676174655374617465084361705374617465094c696e65617243617007616371756972650e616371756972655f6c696e6561720b6164645f656c656d656e74066372656174650864656c6567617465106c696e6561725f726f6f745f616464720e72656d6f76655f656c656d656e74067265766f6b6509726f6f745f616464721076616c69646174655f6163717569726504726f6f740964656c65676174657308636f6e7461696e7309707573685f6261636b0a616464726573735f6f6611616c72656164795f7075626c697368656405656d70747908696e6465785f6f660672656d6f76650d696e76616c69645f73746174650d6e6f745f7075626c69736865640000000000000000000000000000000000000000000000000000000000000001030800000000000000000308010000000000000000020112050102011205020201130a050302011205000c030c020c010c00010002010204040b00380039000201010002010204040b0038003901020200000008120a000e010c030c020b022e0b03380120030b050f0b000b01380205110b0001020301000007110a00110c0c020b023b0220030c0b00010700110d270b00380339023f0202040100010207180a02110c0c030a033b030307050a0b0201020b020e0037001439033f030e003700143c0236010b033804020501000004040e00370214020600000011150a000b010c030c020b022e0b0338050c050c040b04030d05120b000b0538060105140b00010207010002010207120a023b032003050506020a023e033a03010e003700143c0236010e023807020801000004040e003700140209000002010214280b00110c0c020a023b030307051e0a023d033703140c030a033b02031207011111270a033d0237010e023808031b07011111270b030c0105260a023b02032407001112270b020c010b01020000020003000100000c010c020c030c00",
+          "abi": {
+            "address": "0x1",
+            "name": "Capability",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "acquire",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&signer",
+                  "&T0"
+                ],
+                "return": [
+                  "0x1::Capability::Cap<T0>"
+                ]
+              },
+              {
+                "name": "acquire_linear",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&signer",
+                  "&T0"
+                ],
+                "return": [
+                  "0x1::Capability::LinearCap<T0>"
+                ]
+              },
+              {
+                "name": "create",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&signer",
+                  "&T0"
+                ],
+                "return": []
+              },
+              {
+                "name": "delegate",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "0x1::Capability::Cap<T0>",
+                  "&T0",
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "linear_root_addr",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "0x1::Capability::LinearCap<T0>",
+                  "&T0"
+                ],
+                "return": [
+                  "address"
+                ]
+              },
+              {
+                "name": "revoke",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "0x1::Capability::Cap<T0>",
+                  "&T0",
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "root_addr",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "0x1::Capability::Cap<T0>",
+                  "&T0"
+                ],
+                "return": [
+                  "address"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "Cap",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [],
+                    "is_phantom": true
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "root",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "CapDelegateState",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [],
+                    "is_phantom": true
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "root",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "CapState",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [],
+                    "is_phantom": true
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "delegates",
+                    "type": "vector<address>"
+                  }
+                ]
+              },
+              {
+                "name": "LinearCap",
+                "is_native": false,
+                "abilities": [
+                  "drop"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [],
+                    "is_phantom": true
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "root",
+                    "type": "address"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xe428253ccf0b18f3d8300c6a0d29de93abcdc526e88728abeb85d57aec558935",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000a01000a020a04030e2305310e073f940108d3012006f3012c0a9f02050ca402370ddb020200000001000200030004000008000005000100000602000004080000000409000000030a030000020b030400010c05050000010202060c0201060c0105010307436861696e4964064572726f7273065369676e65720f53797374656d4164647265737365730954696d657374616d70036765740a696e697469616c697a65026964106173736572745f6f7065726174696e670e6173736572745f67656e65736973146173736572745f636f72655f7265736f757263650a616464726573735f6f6611616c72656164795f7075626c69736865640000000000000000000000000000000000000000000000000000000000000001030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201070200010001000006110207012b001000140201010000001211030a0011040a001105290020030d0b000107001106270b000b0112002d0002000000",
+          "abi": {
+            "address": "0x1",
+            "name": "ChainId",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "get",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "u8"
+                ]
+              },
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "u8"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "ChainId",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "id",
+                    "type": "u8"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xd7d01f14e6e00800c0211d2e6d0626f9330cc447b0c13c10974481f8dcc7d25a",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b01000c020c04031024043402053615074ba60108f101200691022c0abd02060cc3023f0d82030200000001000200030004000500000800000600010000070201000409010100030a000100010b030300050c01050100020d010100050401060c0002060c0a0201030102010a090001070a020f436f6e73656e737573436f6e666967064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d7006566563746f720a696e697469616c697a650373657406636f6e6669670e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c697368656405656d7074790b7265636f6e6669677572650000000000000000000000000000000000000000000000000000000000000001030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201080a0200010000011111020a0011030701290020030c0b000107001104270b00380012002d00020101000100060b0b00110307012a000f000c020b010b0215110602000000",
+          "abi": {
+            "address": "0x1",
+            "name": "ConsensusConfig",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "set",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "vector<u8>"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "ConsensusConfig",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "config",
+                    "type": "vector<u8>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x5e829d633d861f80a0d3c5c4a88204062c0ab681484838700be0d4f411727670",
+        "data": {
+          "bytecode": "0xa11ceb0b0500000007010002030237053906073f9d0108dc012006fc011e0c9a0292010000000100000000020000000003000000000400000000050000000006000000000701000000080000000009000000000a000000000b000000010302020300064572726f727311616c72656164795f7075626c697368656406637573746f6d08696e7465726e616c10696e76616c69645f617267756d656e740d696e76616c69645f73746174650e6c696d69745f6578636565646564046d616b650d6e6f745f7075626c69736865641072657175697265735f616464726573731372657175697265735f6361706162696c6974790d72657175697265735f726f6c6500000000000000000000000000000000000000000000000000000000000000010201060201ff02010a02010702010102010802010502010202010402010300010000020407000b0011060201010000020407010b0011060202010000020407020b0011060203010000020407030b0011060204010000020407040b0011060205010000020407050b001106020600000002070b00340b0131082f160207010000020407060b0011060208010000020407070b0011060209010000020407080b001106020a010000020407090b0011060200",
+          "abi": {
+            "address": "0x1",
+            "name": "Errors",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "already_published",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "custom",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "invalid_argument",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "invalid_state",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "limit_exceeded",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "not_published",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "requires_address",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "requires_capability",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "requires_role",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "u64"
+                ]
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xd08a133ae22fc988a2cb20313b2568273f971076d6e313a41ecea1b5a47e3132",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000c0100060206120318290441040545330778a80108a002200ac002170bd702020cd902640dbd03060ec30304000000010002000304010601000408000005060002020600000600010106000702010106000803040106000905000106000a06010106010e090a0100020f05080005080407010b000109000002070b00010900090001060b000109000106080301060c030a0203090001090001080301060900010a020102054576656e740342435304475549440b4576656e7448616e646c65144576656e7448616e646c6547656e657261746f720b47554944577261707065720e64657374726f795f68616e646c650a656d69745f6576656e740467756964106e65775f6576656e745f68616e646c651477726974655f746f5f6576656e745f73746f726507636f756e7465720461646472096c656e5f627974657308746f5f62797465730663726561746500000000000000000000000000000000000000000000000000000000000000010002020b030808020102020b030c050202020d0208080300070001000001050b003a000101020101000001120a003700100138000a003701140b0138010a00370114060100000000000000160b00360115020201000001040b003700100102030100000b0706000000000000000031280b0011061202390002040002000001020100000007020700",
+          "abi": {
+            "address": "0x1",
+            "name": "Event",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "destroy_handle",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "drop",
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "0x1::Event::EventHandle<T0>"
+                ],
+                "return": []
+              },
+              {
+                "name": "emit_event",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "drop",
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Event::EventHandle<T0>",
+                  "T0"
+                ],
+                "return": []
+              },
+              {
+                "name": "guid",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "drop",
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&0x1::Event::EventHandle<T0>"
+                ],
+                "return": [
+                  "&0x1::GUID::GUID"
+                ]
+              },
+              {
+                "name": "new_event_handle",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "drop",
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&signer"
+                ],
+                "return": [
+                  "0x1::Event::EventHandle<T0>"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "EventHandle",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "drop",
+                      "store"
+                    ],
+                    "is_phantom": true
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "counter",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "guid",
+                    "type": "0x1::Event::GUIDWrapper"
+                  }
+                ]
+              },
+              {
+                "name": "EventHandleGenerator",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "counter",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "addr",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "GUIDWrapper",
+                "is_native": false,
+                "abilities": [
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "len_bytes",
+                    "type": "u8"
+                  },
+                  {
+                    "name": "guid",
+                    "type": "0x1::GUID::GUID"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x9d2a6ab98492524c0d5976309b99aa7918eed8931aeb7714a29fd166188f2086",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000a0100040204040308280530170747930108da012006fa01440abe02050cc30293020dd6040200000001000007000002000100000302010000040302000005010200000601040000070302000109020200010a02020002030301080001030203080001010401040404000204040c4669786564506f696e743332064572726f7273146372656174655f66726f6d5f726174696f6e616c156372656174655f66726f6d5f7261775f76616c75650a6469766964655f7536340d6765745f7261775f76616c75650769735f7a65726f0c6d756c7469706c795f7536340576616c756510696e76616c69645f617267756d656e740e6c696d69745f6578636565646564000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000308030000000000000003080200000000000000030804000000000000000410ffffffffffffffff000000000000000000020108030001000005310a003531402f0c050b013531202f0c040a04320000000000000000000000000000000022031107001106270b050b041a0c030a03320000000000000000000000000000000022031a051d080c0205210b00060000000000000000210c020b02032607041106270a03070525032d07041107270b03341200020101000006030b0012000202010000071f0e0110001406000000000000000022030907021106270b003531202f0c030b030e01100014351a0c020a02070525031c07011107270b0234020301000006040e00100014020401000006060e0010001406000000000000000021020501000007160b00350e0110001435180c030b033120300c020a02070525031307031107270b023402000000",
+          "abi": {
+            "address": "0x1",
+            "name": "FixedPoint32",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "create_from_rational",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64",
+                  "u64"
+                ],
+                "return": [
+                  "0x1::FixedPoint32::FixedPoint32"
+                ]
+              },
+              {
+                "name": "create_from_raw_value",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "0x1::FixedPoint32::FixedPoint32"
+                ]
+              },
+              {
+                "name": "divide_u64",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64",
+                  "0x1::FixedPoint32::FixedPoint32"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "get_raw_value",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "0x1::FixedPoint32::FixedPoint32"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "is_zero",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "0x1::FixedPoint32::FixedPoint32"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "multiply_u64",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64",
+                  "0x1::FixedPoint32::FixedPoint32"
+                ],
+                "return": [
+                  "u64"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "FixedPoint32",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "value",
+                    "type": "u64"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x6381f16dc6bae2e614dba7bb20b67727a383e30bab1b8bd6680a89f5644543b5",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000a010004020410031446055a2f078901fd010886032006a6030a0ab003170cc703ba020d8106080000000100020e0000000600000308000004070000050001000006020300000704010000080501000009060700000a060400000b080900000c000a00000d040700000e060300000f0b070000100b04000011000c00011400040001060c01080102050301080301050205060800010608010103020608010608030101010800010608030002030708020447554944065369676e6572104372656174654361706162696c6974790947656e657261746f7202494406637265617465096372656174655f69640b6372656174655f696d706c166372656174655f776974685f6361706162696c6974790c6372656174696f6e5f6e756d0f63726561746f725f616464726573730565715f69641567656e5f6372656174655f6361706162696c697479156765745f6e6578745f6372656174696f6e5f6e756d0269640f69645f6372656174696f6e5f6e756d1269645f63726561746f725f61646472657373117075626c6973685f67656e657261746f72046164647207636f756e7465720a616464726573735f6f6600000000000000000000000000000000000000000000000000000000000000010308000000000000000000020112050102010e0803020201130303020209031205000100010204120a00110d0c010a012902200308050d0b0006000000000000000012022d02050f0b00010b01110202010100000c040b010b0012030202000001020d120a002a020c020a021000140c010a01060100000000000000160b020f00150b010b00120312010203010001020c080a00290203050700270b00110202040100000c050b00100110021402050100000c050b00100110031402060100000c050b0010010b0121020701000004120a00110d0c010a012902200308050d0b0006000000000000000012022d02050f0b00010b011200020801000102070f0a00290220030505080600000000000000000c01050d0b002b021000140c010b0102090100000c040b00100114020a0100000c040b00100214020b0100000c040b00100314020c0100000c050b0006000000000000000012022d0202020001000300030100",
+          "abi": {
+            "address": "0x1",
+            "name": "GUID",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "create",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": [
+                  "0x1::GUID::GUID"
+                ]
+              },
+              {
+                "name": "create_id",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address",
+                  "u64"
+                ],
+                "return": [
+                  "0x1::GUID::ID"
+                ]
+              },
+              {
+                "name": "create_with_capability",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address",
+                  "&0x1::GUID::CreateCapability"
+                ],
+                "return": [
+                  "0x1::GUID::GUID"
+                ]
+              },
+              {
+                "name": "creation_num",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::GUID::GUID"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "creator_address",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::GUID::GUID"
+                ],
+                "return": [
+                  "address"
+                ]
+              },
+              {
+                "name": "eq_id",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::GUID::GUID",
+                  "&0x1::GUID::ID"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "gen_create_capability",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": [
+                  "0x1::GUID::CreateCapability"
+                ]
+              },
+              {
+                "name": "get_next_creation_num",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "id",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::GUID::GUID"
+                ],
+                "return": [
+                  "0x1::GUID::ID"
+                ]
+              },
+              {
+                "name": "id_creation_num",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::GUID::ID"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "id_creator_address",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::GUID::ID"
+                ],
+                "return": [
+                  "address"
+                ]
+              },
+              {
+                "name": "publish_generator",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "CreateCapability",
+                "is_native": false,
+                "abilities": [
+                  "drop",
+                  "store",
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "addr",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "GUID",
+                "is_native": false,
+                "abilities": [
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "id",
+                    "type": "0x1::GUID::ID"
+                  }
+                ]
+              },
+              {
+                "name": "Generator",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "counter",
+                    "type": "u64"
+                  }
+                ]
+              },
+              {
+                "name": "ID",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "creation_num",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "addr",
+                    "type": "address"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x825604f38d0c62c17921995d0d6ab57da6cf371316640b3c12456e9bb081685e",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000901002202220603289f0104c7010c05d301cc01079f03960508b5082006d50889010cde09b9040000000100020003000400050006000700080009000a000b000c000d000e000f00100524040106010011000100001202010000130301000f14060701000f15090a010007160b0c0001170d010001180e010001190c0f00011a0d01000d1b0c08000c1c1001000c1d1101000e1e1001000112120100011f0c1300012001050004120b01000e210b010010121401000b1215010004220e01000a121601000812140100082317010005250b180106052618010106031219010006120b010002270b010009280b0100030503080405040819071a070a0c0a0c0a0a020a0a020a0a020a0c0a0a020a0a020a0a020a0a02000a0c0a020a0a02010a020a0202030a02030a060c0a020a0a02010a020a0202030a0203140a020a02030303030303030303060c050a020a02060c050a020a020a02010c01060a09000103010a0202060a0900030106090001060c010503060c050a0202060c0a02010102060c0505060c050a020a020a020a060c050a020a020a020a020a020a020a0201020c0a0202060c0304060c0a020a020303060c0a0a020103060c0503010b0001090002060c020747656e65736973074163636f756e7405426c6f636b07436861696e49640f436f6e73656e737573436f6e666967054576656e740f5265636f6e66696775726174696f6e065369676e65720854657374436f696e0954696d657374616d701b5472616e73616374696f6e5075626c697368696e674f7074696f6e08564d436f6e6669670f56616c696461746f72436f6e6669671756616c696461746f724f70657261746f72436f6e6669670c56616c696461746f7253657406566563746f720756657273696f6e226372656174655f696e697469616c697a655f6f776e6572735f6f70657261746f72730a696e697469616c697a6513696e697469616c697a655f696e7465726e616c066c656e67746806626f72726f770a616464726573735f6f66216372656174655f76616c696461746f725f6163636f756e745f696e7465726e616c22726f746174655f61757468656e7469636174696f6e5f6b65795f696e7465726e616c096578697374735f61742a6372656174655f76616c696461746f725f6f70657261746f725f6163636f756e745f696e7465726e616c0e6765745f68756d616e5f6e616d650c7365745f6f70657261746f720a7365745f636f6e666967166164645f76616c696461746f725f696e7465726e616c176372656174655f6163636f756e745f696e7465726e616c1d6372656174655f636f72655f6672616d65776f726b5f6163636f756e7418696e697469616c697a655f76616c696461746f725f736574037365740d6d696e745f696e7465726e616c0b4576656e7448616e646c65106e65775f6576656e745f68616e646c650e64657374726f795f68616e646c6519696e697469616c697a655f626c6f636b5f6d65746164617461147365745f74696d655f6861735f737461727465640000000000000000000000000000000000000000000000000000000000000001052000000000000000000000000000000000000000000000000000000000000000010a0208074163636f756e740a02100f7363726970745f70726f6c6f6775650a02100f6d6f64756c655f70726f6c6f6775650a02121177726974657365745f70726f6c6f6775650a0209086570696c6f6775650a02121177726974657365745f6570696c6f6775650000000004aa010e0138000c130e0238010c120a130a1221030c060000000000000000270e0338010c110b120a11210315060000000000000000270e0538000c100b110a1021031e060000000000000000270e0638010c0f0b100a0f210327060000000000000000270e0738010c0e0b0f0a0e210330060000000000000000270e0838010c140b0e0a14210339060000000000000000270e0938010c0d0b140b0d210342060000000000000000270600000000000000000c0c0a0c0a1323034905a9010e010a0c38020c190a1911050c1a0e020a0c3803140c1c0e000a1a0b1c11060e030a0c3803140c1b0a190b1b11070e050a0c38020c150a1511050c160e060a0c3803140c180a161108200372057e0e000a160a1811090e070a0c3803140c170a150b1711070a16110a0b18210389010b19010b1501060000000000000000270b190b16110b0e080a0c3803140c1d0e090a0c3803140c0b0e040a0c3803140c0a0b150a1a0b0a0b1d0b0b110c0e000b1a110d0b0c060100000000000000160c0c05440201000000010c0e000b010b020b030b040b050b060b070b080b091102020200000005430a000700070107020703070407020705070609110e0a001105110f01010a000a01110711100c0a0e0a0b0111070a0011110a0011120a000b0711130a000b040b050b0911140a000b0811150a000b020b0311160a000640420f000000000011170a000a00110506ffffffffffffffff11180a00380438050a00380438050a000b06111b0a00111c0a00111d0b00111e0200",
+          "abi": {
+            "address": "0x1",
+            "name": "Genesis",
+            "friends": [],
+            "exposed_functions": [],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xe2ae97cbf2c1281ac9db9c74afd12dda59793a59b62fe45d10671cb38611bc06",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000601000203020a050c03070f170826200c4608000000010000000002000000010a02044861736808736861325f32353608736861335f3235360000000000000000000000000000000000000000000000000000000000000001000102000101020000",
+          "abi": {
+            "address": "0x1",
+            "name": "Hash",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "sha2_256",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "vector<u8>"
+                ],
+                "return": [
+                  "vector<u8>"
+                ]
+              },
+              {
+                "name": "sha3_256",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "vector<u8>"
+                ],
+                "return": [
+                  "vector<u8>"
+                ]
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x575c96840ac15e64ebd62878d4af35b88806031ae2f323ed1a6237b48674e1fd",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000d010006020606030c9b0104a7011a05c1019c0107dd028c0208e90420068905140a9d05070ba405020ca605e9030d8f09020e910902000000010002000007010000000300010100000402030100000504010100000604050100000706070100000806080100000909080102000a02080100000b0a070100000c0b080103000d00050100000e00050100000f0706010000100806010000110a08010000120a06010001140c0c0002030d01010002040e030100021510050100020611050100021612070100021714080100021815070100021907120100021a081201000b0811081208130814080a08150816081708180819080c080d0801060b000109000106090001070b000109000107090002060b000109000609000101010b0001090000010900020b00010900090002070b00010900090002060b000109000900010302060a09000302070a09000302060900060a090001060a090002060a0900060900010a09000209000a090001070a090002070a09000900020900060a0900020900070a0900030b000109000b00010900070a0900064f7074696f6e064572726f727306566563746f7206626f72726f770a626f72726f775f6d757413626f72726f775f776974685f64656661756c7408636f6e7461696e730c64657374726f795f6e6f6e650c64657374726f795f736f6d651464657374726f795f776974685f64656661756c7407657874726163740466696c6c106765745f776974685f64656661756c740769735f6e6f6e650769735f736f6d65046e6f6e6504736f6d6504737761700c737761705f6f725f66696c6c0376656310696e76616c69645f617267756d656e740869735f656d7074790d64657374726f795f656d70747908706f705f6261636b09707573685f6261636b05656d7074790973696e676c65746f6e00000000000000000000000000000000000000000000000000000000000000010308000000000000000003080100000000000000000201130a0900000800010000070d0a00380003080b000107011110270b00370006000000000000000038010201010000070e0a002e380003090b000107011110270b003600060000000000000000380202020100000f140b0037000c030a0338030307050c0b03010b010c0205120b01010b0306000000000000000038010c020b02020301000007050b0037000b0138040204010000120c0e003805030607001110270b003a000c010b013806020501000013100e003800030607011110270b003a000c020d0238070c010b0238060b01020601000013100b003a000c030d032e38030308050b0b010c02050e0d0338070c020b020207010000070d0a002e380003090b000107011110270b0036003807020801000014100b0036000c020a022e3803030c0b020107001110270b020b013808020901000016130b0037000c030a0338030307050c0b03010b010c0205110b030600000000000000003801140c020b02020a01000007040b0037003803020b01000007050b003700380320020c010000070338093900020d01000007040b00380a3900020e01000017140a002e380003090b000107011110270b0036000c030a0338070c020b030b0138080b02020f01000018160b0036000c040a042e38030308050b380b0c02050f0a043807380c0c020b020c030b040b0138080b03020000000800",
+          "abi": {
+            "address": "0x1",
+            "name": "Option",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "borrow",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&0x1::Option::Option<T0>"
+                ],
+                "return": [
+                  "&T0"
+                ]
+              },
+              {
+                "name": "borrow_mut",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Option::Option<T0>"
+                ],
+                "return": [
+                  "&mut T0"
+                ]
+              },
+              {
+                "name": "borrow_with_default",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&0x1::Option::Option<T0>",
+                  "&T0"
+                ],
+                "return": [
+                  "&T0"
+                ]
+              },
+              {
+                "name": "contains",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&0x1::Option::Option<T0>",
+                  "&T0"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "destroy_none",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "0x1::Option::Option<T0>"
+                ],
+                "return": []
+              },
+              {
+                "name": "destroy_some",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "0x1::Option::Option<T0>"
+                ],
+                "return": [
+                  "T0"
+                ]
+              },
+              {
+                "name": "destroy_with_default",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "drop"
+                    ]
+                  }
+                ],
+                "params": [
+                  "0x1::Option::Option<T0>",
+                  "T0"
+                ],
+                "return": [
+                  "T0"
+                ]
+              },
+              {
+                "name": "extract",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Option::Option<T0>"
+                ],
+                "return": [
+                  "T0"
+                ]
+              },
+              {
+                "name": "fill",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Option::Option<T0>",
+                  "T0"
+                ],
+                "return": []
+              },
+              {
+                "name": "get_with_default",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "copy",
+                      "drop"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&0x1::Option::Option<T0>",
+                  "T0"
+                ],
+                "return": [
+                  "T0"
+                ]
+              },
+              {
+                "name": "is_none",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&0x1::Option::Option<T0>"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "is_some",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&0x1::Option::Option<T0>"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "none",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [],
+                "return": [
+                  "0x1::Option::Option<T0>"
+                ]
+              },
+              {
+                "name": "some",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "T0"
+                ],
+                "return": [
+                  "0x1::Option::Option<T0>"
+                ]
+              },
+              {
+                "name": "swap",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Option::Option<T0>",
+                  "T0"
+                ],
+                "return": [
+                  "T0"
+                ]
+              },
+              {
+                "name": "swap_or_fill",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Option::Option<T0>",
+                  "T0"
+                ],
+                "return": [
+                  "0x1::Option::Option<T0>"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "Option",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [],
+                    "is_phantom": false
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "vec",
+                    "type": "vector<T0>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x0f9c518f531ac3d732301355e37e9dc9d48fa443047f4c18cf3fc65d8fc33bfe",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000c01000e020e1203205c047c040580012807a801c00408e805200688065e0ae606170cfd069d030d9a0a060fa00a0c0006000700080009000a000b000c000d0800000e0800000f0600021a040106010010000100001101010000120001000013000100001401020000150101000016010100051c000100011d030300011e030300021f060101060420000700062101010001220303000323070300022400080106062501020006260103000a050f0501060c0001010103020107080001080202070b0301090009000105010b0301090004010107080003074163636f756e740f436f6e73656e737573436f6e6669671b5472616e73616374696f6e5075626c697368696e674f7074696f6e08564d436f6e6669670c56616c696461746f725365740756657273696f6e0f5265636f6e66696775726174696f6e064572726f7273054576656e740447554944065369676e65720f53797374656d4164647265737365730954696d657374616d700d436f6e66696775726174696f6e1644697361626c655265636f6e66696775726174696f6e0d4e657745706f63684576656e741764697361626c655f7265636f6e66696775726174696f6e22656d69745f67656e657369735f7265636f6e66696775726174696f6e5f6576656e7416656e61626c655f7265636f6e66696775726174696f6e0a696e697469616c697a65177265636f6e66696775726174696f6e5f656e61626c65640b7265636f6e6669677572650c7265636f6e6669677572655f0565706f6368196c6173745f7265636f6e66696775726174696f6e5f74696d65066576656e74730b4576656e7448616e646c650b64756d6d795f6669656c64146173736572745f636f72655f7265736f757263650d696e76616c69645f73746174650d6e6f745f7075626c69736865640a656d69745f6576656e740a616464726573735f6f660e6173736572745f67656e6573697311616c72656164795f7075626c6973686564156765745f6e6578745f6372656174696f6e5f6e756d106e65775f6576656e745f68616e646c650a69735f67656e65736973106e6f775f6d6963726f7365636f6e6473000000000000000000000000000000000000000000000000000000000000000103080100000000000000030800000000000000000308030000000000000003080400000000000000030802000000000000000308ffffffffffffffff0520000000000000000000000000000000000000000000000000000000000a550c1800020317031803190b030108020102011b01020201170300000000010e0a001107110403090b000107011108270b000912012d01020100000100042c070629000306070111092707062a000c010a0110001406000000000000000021031005170a01100114060000000000000000210c000519090c000b0003200b010107011108270601000000000000000a010f00150a010f020b011000141202380002020000010101100a001107110420030a0b000107011108270b00110b2c011301010203010000011f110c0a0011070706290020030c0b00010701110d270a00110b110e0604000000000000002103170b000107031108270a000600000000000000000600000000000000000b00380112002d00020400000001040706290120020503000100010211060206000001000945111003030506080c00050a1111060000000000000000210c000b00030d0510080c0105131104200c010b01031605170207062a000c0211110c030a030a0210011421032305260b0201020a030a021001142403310b020107021108270b030a020f01150a02100014060100000000000000160a020f00150a020f020b02100014120238000200000001000200000001000200030004000500",
+          "abi": {
+            "address": "0x1",
+            "name": "Reconfiguration",
+            "friends": [
+              "0x1::Account",
+              "0x1::ConsensusConfig",
+              "0x1::TransactionPublishingOption",
+              "0x1::VMConfig",
+              "0x1::ValidatorSet",
+              "0x1::Version"
+            ],
+            "exposed_functions": [
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "reconfigure",
+                "visibility": "friend",
+                "generic_type_params": [],
+                "params": [],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "Configuration",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "epoch",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "last_reconfiguration_time",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "events",
+                    "type": "0x1::Event::EventHandle<0x1::Reconfiguration::NewEpochEvent>"
+                  }
+                ]
+              },
+              {
+                "name": "DisableReconfiguration",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "dummy_field",
+                    "type": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "NewEpochEvent",
+                "is_native": false,
+                "abilities": [
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "epoch",
+                    "type": "u64"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x1c7e2c034ee74231f152214ed7888b888736f3f52518b75d7af69570d338bb7a",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000601000203020a050c0c0718310849200c6908000000010001000002020100010a020101030a020a020a02095369676e617475726517656432353531395f76616c69646174655f7075626b65790e656432353531395f7665726966790000000000000000000000000000000000000000000000000000000000000001000102000101020000",
+          "abi": {
+            "address": "0x1",
+            "name": "Signature",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "ed25519_validate_pubkey",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "vector<u8>"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "ed25519_verify",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>"
+                ],
+                "return": [
+                  "bool"
+                ]
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xdf3fee0bf8e5d44605b4b6d43bdf7616bf18a223c0a953d58f49d03330a9a3f8",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000601000203020a050c090715210836200c561000000001000100000200020001060c010501060500065369676e65720a616464726573735f6f660e626f72726f775f6164647265737300000000000000000000000000000000000000000000000000000000000000010001000003040b00110114020101020000",
+          "abi": {
+            "address": "0x1",
+            "name": "Signer",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "address_of",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": [
+                  "address"
+                ]
+              },
+              {
+                "name": "borrow_address",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": [
+                  "&address"
+                ]
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x776aab497ed2722389b1ea4e9d5c9fad0080a95d34c5c20b0873e68f317a842d",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000901000402040403080b04130205151c073155088601200aa601050cab0120000000010000070000020001000104030101040102060c0a020a020a02030a0200010800070c0a020a020a02030a0209000b53696d706c65546f6b656e05546f6b656e136372656174655f73696d706c655f746f6b656e0c6d616769635f6e756d626572216372656174655f746f6b656e5f776974685f6d657461646174615f7363726970740000000000000000000000000000000000000000000000000000000000000001000201030300020000010a0b000b010b020b030b040b05062a00000000000000120038000200",
+          "abi": {
+            "address": "0x1",
+            "name": "SimpleToken",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "create_simple_token",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "u64",
+                  "vector<u8>"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "SimpleToken",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "magic_number",
+                    "type": "u64"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x708a4495d604e5104a7491529cefcd59d146666ae3e54b1cb642afc2a7886f6f",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b01000c020c140320ab0104cb012205ed01f70107e403dd0508c1092006e109360a970a390cd00abe080d8e131c00000001000200030004000500060400000704000008080000090800030b0400000a00010100000c020100000d030100000e040500000f06010000100708000011090100001209010000130a010000140b010000150c0100001607010000170d010000180d010000190e0f00052a11080100052b12100100052c13010100042d010500012e090700032f150500053011050100053117180100033201190003331a010005341c1d010002350901000536011e0100053720080100053820230100053917100100033a2901000f1010101110110f150f160f190f1b071c0711071d071e07150719071b0f000f1e0f02070a0900070a09000004060c0508040301070a080002060a080005010303060c03030105010101060c0107080303060c0a020a0202060c0a0202060c0502070a08000501080001090001060a090001070a090002070a09000900060804030503080007080101060804040708000303080402070a0900030107090001080402070804080403060800030302060a09000301060900010a09000106080302060a0900060900030507080207080304050103070803020103040503030306030a08000a08000a08000a0800080102050708030403030307080106050804030800010708010205080404050804080007080103070a08000503055374616b65065369676e65720f53797374656d4164647265737365730854657374436f696e0954696d657374616d7006566563746f720a44656c65676174696f6e095374616b65506f6f6c0d56616c696461746f72496e666f0c56616c696461746f7253657406617070656e6404436f696e0e64656c65676174655f7374616b6511646973747269627574655f7265776172640466696e6418696e697469616c697a655f76616c696461746f725f7365740c69735f76616c696461746f72126a6f696e5f76616c696461746f725f736574136c656176655f76616c696461746f725f7365740c6f6e5f6e65775f65706f63681c72656769737465725f76616c696461746f725f63616e64696461746514726f746174655f636f6e73656e7375735f6b6579117570646174655f7374616b655f706f6f6c0f77697468647261775f6163746976651177697468647261775f696e6163746976651177697468647261775f696e7465726e616c04636f696e0466726f6d116c6f636b65645f756e74696c5f736563730d63757272656e745f7374616b650661637469766508696e6163746976650e70656e64696e675f6163746976651070656e64696e675f696e6163746976650a7374616b655f706f6f6c10636f6e73656e7375735f7075626b65790f6e6574776f726b5f6164647265737310636f6e73656e7375735f736368656d650d6d696e696d756d5f7374616b650d6d6178696d756d5f7374616b650a76616c696461746f7273156c6173745f7570646174655f74696d655f736563730869735f656d70747908706f705f6261636b09707573685f6261636b0b6e6f775f7365636f6e64730a616464726573735f6f660576616c7565066c656e6774680a626f72726f775f6d7574047a65726f056d6572676506626f72726f77146173736572745f636f72655f7265736f7572636505656d70747908636f6e7461696e7308696e6465785f6f660b737761705f72656d6f7665076465706f7369740000000000000000000000000000000000000000000000000000000000000001030880510100000000000308100e0000000000000520000000000000000000000000000000000000000000000000000000000a550c180002031a08041b051c030102051d031e0a08001f0a0800200a0800210a0800020203220801230a02240a02030205250226032703280a0529030000000001100a012e3800200306050b0a000a013801380205000b01010b000102010000020203143411120c070b070700160a0323030c0b0001060000000000000000270a012a020f000c090b020c040b030c050b0011130c060b040b060b0512000c080b011105032005250b090f010b08380305330a091002140e0810031114160a090f02150b090f040b0838030202000000161d0600000000000000000c020a002e38040c030a020a0323030b051a0a000a0238050c0111170c040b010f030b0411180b02060100000000000000160c0205060b000102030000001b220600000000000000000c030a0038040c040a030a0423030a051e0a000a0338060c020b021005140a0121031505190b00010b03020b03060100000000000000160c0305050b00010600000000000000002704000000010b0a00111a0b0031000b010b023807111212032d030205000001031f080a002b030c010b0110060e0038080206000002020321380b0011130c010a012a020c0207022a030c030a0310060e0138082003150b03010b0201060000000000000000270a0210001002140a031007142603240b03010b0201060000000000000000270b0210001002140a031008142503310b0301060000000000000000270a0311080b030f060b0138090207000002020322220b0011130c0107022a030c040a0410060e01380a0c030c020b0203120b0401060000000000000000270a0411080a040f060b03380b010b041006380c06000000000000000024032106000000000000000027020800000102242d11120c020a001009140701160a0223030e0b0001060000000000000000270b020a000f09150600000000000000000c030a001006380c0c040a030a0423031d052a0a0010060a03380d140c010b01110b0b03060100000000000000160c0305180b000102090000002516380e0c04380e0c05380e0c06380e0c070600000000000000000b040b070b050b0612010c080b000b080b010b0212022d02020a000002020326170b0011130c0207022a030c030b010a022a020f0a150a0310060e023808031105140b03110805160b0301020b0000010227340b002a020f000c040a040f0411020a040f0b11020a040f040a040f01380f0a040f0c0a040f0b380f0600000000000000000c010600000000000000000c020a04100438040c030a020a03230321052f0b010a0410040a02380610031114160c010b02060100000000000000160c02051c0b010b040f0215020c0000020203282f0b0011130c0211120c040a012a020f000c070a070f0c0a02110e0c050b0111050c060b0620031505200b07010b05130001010c030b020b03111f052e0e05100d140b0423032a0b0701060000000000000000270b070f0b0b053803020d000001022a150b0011130c020b012a020f000c050b050f0c0a02110e0c040b04130001010c030b020b03111f020e0000002b0d0a000b010c030c020b022e0b0311030c040b000b043810020200010301000000010100010303030103020304020101040102000200",
+          "abi": {
+            "address": "0x1",
+            "name": "Stake",
+            "friends": [],
+            "exposed_functions": [],
+            "structs": [
+              {
+                "name": "Delegation",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "coin",
+                    "type": "0x1::TestCoin::Coin"
+                  },
+                  {
+                    "name": "from",
+                    "type": "address"
+                  },
+                  {
+                    "name": "locked_until_secs",
+                    "type": "u64"
+                  }
+                ]
+              },
+              {
+                "name": "StakePool",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "current_stake",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "active",
+                    "type": "vector<0x1::Stake::Delegation>"
+                  },
+                  {
+                    "name": "inactive",
+                    "type": "vector<0x1::Stake::Delegation>"
+                  },
+                  {
+                    "name": "pending_active",
+                    "type": "vector<0x1::Stake::Delegation>"
+                  },
+                  {
+                    "name": "pending_inactive",
+                    "type": "vector<0x1::Stake::Delegation>"
+                  }
+                ]
+              },
+              {
+                "name": "ValidatorInfo",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "stake_pool",
+                    "type": "0x1::Stake::StakePool"
+                  },
+                  {
+                    "name": "consensus_pubkey",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "network_address",
+                    "type": "vector<u8>"
+                  }
+                ]
+              },
+              {
+                "name": "ValidatorSet",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "consensus_scheme",
+                    "type": "u8"
+                  },
+                  {
+                    "name": "minimum_stake",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "maximum_stake",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "validators",
+                    "type": "vector<address>"
+                  },
+                  {
+                    "name": "last_update_time_secs",
+                    "type": "u64"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xc4aebacf8a405ac49ac6021ebfdaf607b74d008ee4ad3d46c01c2419179d1535",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000701000603061e05240a072e8f0108bd012006dd01580cb5024000000001000200030001000004020100000500010000060203000207000200010804040001060c000105010101030f53797374656d416464726573736573064572726f7273065369676e6572146173736572745f636f72655f7265736f757263651c6173736572745f636f72655f7265736f757263655f61646472657373096173736572745f766d1869735f636f72655f7265736f757263655f616464726573730a616464726573735f6f661072657175697265735f6164647265737300000000000000000000000000000000000000000000000000000000000000010308000000000000000003080100000000000000052000000000000000000000000000000000000000000000000000000000000000000520000000000000000000000000000000000000000000000000000000000a550c180001000001040b0011041101020101000001070b00110303060700110527020201000001090b00110407022103080701110527020301000001040b000703210200",
+          "abi": {
+            "address": "0x1",
+            "name": "SystemAddresses",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "assert_core_resource",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "assert_core_resource_address",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "assert_vm",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "is_core_resource_address",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "bool"
+                ]
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x6fd26ff28836349d70c072893be8cd17d3f5fbd0c1588c0639733f61fd1ed8f1",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000d010008020816031e8c0104aa011a05c401d101079503d20108e70420068705140a9b05150bb005040cb405e9020d9d08060ea308060000000100020003000004020400040000040402040004000202070100000005000102040400060203020404000700040204040008050602040400090708020404000a0807020404000b0009020404000c0a07020404000d020b02040402110d040100011206060002050d0e01000305100e0100030612130100031314060100031407150100030a1507010002151819010002160719010002170d04010003181b070100031912180100060b09060b060c0f0d0f0e0f0f0f100f110612061306140f150f02060b0002090009010609000106090102070b00020900090106090001070901010101060b000209000901010300010b000209000901010b02010303070b00020900090109000901020900090102030b02010301060b0201090001060900010b01020900090102060a09000304070b000209000901060900030b02010302070a0900030107090001060a0900010a0900010a0b010209000901020303010900010b0201090003070b0002090009010609000b02010302070a0900090006070b0002090009010609000309000b0201030901055461626c65064572726f7273064f7074696f6e06566563746f720c5461626c65456c656d656e7406626f72726f770a626f72726f775f6d75740c636f6e7461696e735f6b657905636f756e74066372656174650d64657374726f795f656d7074790466696e6406696e736572740672656d6f76650464617461036b65790576616c75650769735f736f6d6510696e76616c69645f617267756d656e74066c656e67746805656d70747904736f6d65046e6f6e650769735f6e6f6e6509707573685f6261636b0b737761705f72656d6f7665000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000002010e0a0b0102090009010102020f0900100901000b010b000100000c160a000b0138000c030e033801030c0b00010701110a270e033802140c020b0037000b02380337010201010000111b0a000b010c030c020b022e0b0338000c050e05380103110b00010701110a270e053802140c040b0036000b0438043601020201000009070b000b0138000c020e023801020301000007040b00370038050204010000070338063900020501000016060b003a000c010b013807020600000017260a00370038050c030600000000000000000c020a020a0323030b05200a0037000a02380337020a01210314051b0b00010b01010b023808020b02060100000000000000160c0205060b00010b0101380902070100001a180a000e010c040c030b032e0b0438000c050e05380a03110b00010700110a270b0036000b010b023901380b02080100001c1f0a000b010c030c020b022e0b0338000c060e06380103110b00010701110a270e063802140c040b0036000b04380c3a010c070c050b050b0702000001010100000b010b020b00",
+          "abi": {
+            "address": "0x1",
+            "name": "Table",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "borrow",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&0x1::Table::Table<T0, T1>",
+                  "&T0"
+                ],
+                "return": [
+                  "&T1"
+                ]
+              },
+              {
+                "name": "borrow_mut",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Table::Table<T0, T1>",
+                  "&T0"
+                ],
+                "return": [
+                  "&mut T1"
+                ]
+              },
+              {
+                "name": "contains_key",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&0x1::Table::Table<T0, T1>",
+                  "&T0"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "count",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&0x1::Table::Table<T0, T1>"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "create",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [],
+                "return": [
+                  "0x1::Table::Table<T0, T1>"
+                ]
+              },
+              {
+                "name": "destroy_empty",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "0x1::Table::Table<T0, T1>"
+                ],
+                "return": []
+              },
+              {
+                "name": "insert",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Table::Table<T0, T1>",
+                  "T0",
+                  "T1"
+                ],
+                "return": []
+              },
+              {
+                "name": "remove",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&mut 0x1::Table::Table<T0, T1>",
+                  "&T0"
+                ],
+                "return": [
+                  "T0",
+                  "T1"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "Table",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ],
+                    "is_phantom": false
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ],
+                    "is_phantom": false
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "data",
+                    "type": "vector<0x1::Table::TableElement<T0, T1>>"
+                  }
+                ]
+              },
+              {
+                "name": "TableElement",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ],
+                    "is_phantom": false
+                  },
+                  {
+                    "constraints": [
+                      "store"
+                    ],
+                    "is_phantom": false
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "key",
+                    "type": "T0"
+                  },
+                  {
+                    "name": "value",
+                    "type": "T1"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xa1e8b314992e07fcc8027b38c1c807c818d0c18f359f7a3e9c272c05623351ae",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000c01000e020e340342ce010490021a05aa02d10107fb03f10508ec0920068c0a540ae00a450ca50bbb060de011100ff0110200010002000300040005000600070008080000090c00000a0400000b0800000c0400000d0800000e0c00000f0600001006000011080003040701000002300401060100120001000013020300001404030000150503000016060300001707030000180803000019090300001a000a00001b000b00001c0c0300001d0d0300001e0e0300001f0f030000200703000021030100002203100000230e030000240f0300002511010000260c04000027030400013201010004330700000334150a0100033515160100063618190100053707030006381b01010006351c1601000139010100063a1d030100033b03200100033c19200100063d03210100013e010100023f072401060240270301060141010100180119011a171c171d171f1720012101221724232425252325250105010302060c080200010802020802060801010c01060c020c05020508020101010b0a010302060c03020708020802030c050303060c050301040106080201060801020708030303070a0804030b0a010301060b0a0109000106090001080402070a09000301090005070a080403070a08040608040301060a090002060a09000302070a09000900030307030305060a0804060804030b0a010303010b0a010900010a09000306080607080305010808010b0b01090001080703080207080907080902070b0b010900090003050307030e5472616e73616374696f6e4665650854657374436f696e064572726f7273054576656e74064f7074696f6e065369676e65720f53797374656d41646472657373657306566563746f720742616c616e63650e4275726e4361706162696c69747904436f696e08436f696e496e666f1744656c6567617465644d696e744361706162696c6974790b44656c65676174696f6e730e4d696e744361706162696c6974790d52656365697665644576656e740953656e744576656e740e5472616e736665724576656e74730a62616c616e63655f6f66046275726e086275726e5f676173146275726e5f776974685f6361706162696c69747915636c61696d5f6d696e745f6361706162696c6974791e636c61696d5f6d696e745f6361706162696c6974795f696e7465726e616c1864656c65676174655f6d696e745f6361706162696c697479076465706f736974096578697374735f61740f66696e645f64656c65676174696f6e0a696e697469616c697a65056d65726765046d696e740d6d696e745f696e7465726e616c0872656769737465720e7363616c696e675f666163746f720c746f74616c5f737570706c79087472616e73666572117472616e736665725f696e7465726e616c0576616c7565087769746864726177047a65726f04636f696e0b64756d6d795f6669656c640b746f74616c5f76616c756502746f05696e6e657206616d6f756e740466726f6d0b73656e745f6576656e74730b4576656e7448616e646c650f72656365697665645f6576656e74730d6e6f745f7075626c69736865640a616464726573735f6f660769735f736f6d6506626f72726f770b737761705f72656d6f7665146173736572745f636f72655f7265736f75726365066c656e67746810696e76616c69645f617267756d656e7409707573685f6261636b046e6f6e6504736f6d6505656d70747911616c72656164795f7075626c6973686564106e65775f6576656e745f68616e646c650a656d69745f6576656e740e6c696d69745f6578636565646564000000000000000000000000000000000000000000000000000000000000000103080300000000000000030801000000000000000308020000000000000003080400000000000000030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201280802010201290102020125030302022a0421030402012b050502012c0a080406020129010702022d032e050802022d032b050902022f0b0b010808310b0b0108070001000100030c0a002900030607021116270b002b0010001001140201010002010312080b0011172b010c020b010b02110302020300020103120707052b010c010b000b01110302030000010313100b0013020c0307052a030c020a021002140b0335170b020f021502040200010503030e001105020501000105141d0a00111711090c030e033800030b0b00010703270e033801140c0207052a050f030c010b010b0238021304010b000912062d060206020001051a2d0e00111b07052a050f030c040600000000000000000c060a060a042e380323030f05280a040a060c030c020b022e0b0338040c050b051004140a012203230b04010700111e270b06060100000000000000160c0605080b040b01120438050207010001001e110a0011000c020b002a000f000f010c030b0113020c040b020b04160b0315020801000003030b0029000209000001051f2807052b0510030c010600000000000000000c030a0138030c0538060c040a030a0523031005260a010a0338040c020b021004140a0021031b05210b01010b0338070c0405260b03060100000000000000160c03050b0b04020a01000003160a00111b0a000912062d060a000912012d010a0032000000000000000000000000000000000b0112032d030a00380812052d050b00110e020b010000010c0b0113020c020a001001140b02160b000f0115020c02000300030603050e000b010b02110d020d01000300030622170b0011170c050b052b06010b010a021202110707052a030c040a041002140b0235160b040f0215020e01000004170a001117290020030a0b000107011123270a00060000000000000000120212002d000a000a0038090b00380a12092d09020f01000103030507052b03100514021001000103030507052b031002140211020002000903050e000b010b02111202120100020009261c0a000a0211140c030a010b0311070a0011172a090c050b050f060a020a011208380b0b012a090c040b040f070b020b0011171207380c021301000003040b00100114021401000100281a0b0011170c020a0211000c030a030a0126030d07041126270b022a000f000f010c040b030a01170b04150b0112020215010000030306000000000000000012020200000200030005000400030109000901000000",
+          "abi": {
+            "address": "0x1",
+            "name": "TestCoin",
+            "friends": [
+              "0x1::TransactionFee"
+            ],
+            "exposed_functions": [
+              {
+                "name": "balance_of",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "burn",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "0x1::TestCoin::Coin"
+                ],
+                "return": []
+              },
+              {
+                "name": "burn_gas",
+                "visibility": "friend",
+                "generic_type_params": [],
+                "params": [
+                  "0x1::TestCoin::Coin"
+                ],
+                "return": []
+              },
+              {
+                "name": "claim_mint_capability",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "claim_mint_capability_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "delegate_mint_capability",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "deposit",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address",
+                  "0x1::TestCoin::Coin"
+                ],
+                "return": []
+              },
+              {
+                "name": "exists_at",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "merge",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&mut 0x1::TestCoin::Coin",
+                  "0x1::TestCoin::Coin"
+                ],
+                "return": []
+              },
+              {
+                "name": "mint",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "mint_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "register",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "scaling_factor",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "total_supply",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "u128"
+                ]
+              },
+              {
+                "name": "transfer",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "transfer_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "value",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::TestCoin::Coin"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "withdraw",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "u64"
+                ],
+                "return": [
+                  "0x1::TestCoin::Coin"
+                ]
+              },
+              {
+                "name": "zero",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "0x1::TestCoin::Coin"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "Balance",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "coin",
+                    "type": "0x1::TestCoin::Coin"
+                  }
+                ]
+              },
+              {
+                "name": "BurnCapability",
+                "is_native": false,
+                "abilities": [
+                  "store",
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "dummy_field",
+                    "type": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "Coin",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "value",
+                    "type": "u64"
+                  }
+                ]
+              },
+              {
+                "name": "CoinInfo",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "total_value",
+                    "type": "u128"
+                  },
+                  {
+                    "name": "scaling_factor",
+                    "type": "u64"
+                  }
+                ]
+              },
+              {
+                "name": "DelegatedMintCapability",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "to",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "Delegations",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "inner",
+                    "type": "vector<0x1::TestCoin::DelegatedMintCapability>"
+                  }
+                ]
+              },
+              {
+                "name": "MintCapability",
+                "is_native": false,
+                "abilities": [
+                  "store",
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "dummy_field",
+                    "type": "bool"
+                  }
+                ]
+              },
+              {
+                "name": "ReceivedEvent",
+                "is_native": false,
+                "abilities": [
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "amount",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "from",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "SentEvent",
+                "is_native": false,
+                "abilities": [
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "amount",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "to",
+                    "type": "address"
+                  }
+                ]
+              },
+              {
+                "name": "TransferEvents",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "sent_events",
+                    "type": "0x1::Event::EventHandle<0x1::TestCoin::SentEvent>"
+                  },
+                  {
+                    "name": "received_events",
+                    "type": "0x1::Event::EventHandle<0x1::TestCoin::ReceivedEvent>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xe8aa027cc8ba73bb82e029247e4071a79a437bd4ee493d2c5f7fee90caf9565e",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b010006020604030a41054b150760aa02088a032006aa036c0a9604050c9b04c7010de205020fe405020001000200030004080000050000000006000000000700010000080001000009000200000a000200000b030000000c030000000d040000010f020200021003000002110300000112020200000101010301060c03060c050301080002070800030747656e657369730954696d657374616d70064572726f72730f53797374656d4164647265737365731743757272656e7454696d654d6963726f7365636f6e64730e6173736572745f67656e65736973106173736572745f6f7065726174696e670a69735f67656e657369730c69735f6f7065726174696e67106e6f775f6d6963726f7365636f6e64730b6e6f775f7365636f6e6473147365745f74696d655f6861735f73746172746564207365745f74696d655f6861735f737461727465645f666f725f74657374696e67127570646174655f676c6f62616c5f74696d650c6d6963726f7365636f6e64730d696e76616c69645f7374617465146173736572745f636f72655f7265736f75726365096173736572745f766d10696e76616c69645f617267756d656e740000000000000000000000000000000000000000000000000000000000000001030800000000000000000308010000000000000003080200000000000000030840420f00000000000520000000000000000000000000000000000000000000000000000000000a550c18052000000000000000000000000000000000000000000000000000000000000000000002010e030001000000061102030507001109270201010000000611030305070111092702020100000004070429002002030100000003070429000204010001000006110107042b001000140205010001000004110407031a0206030000050811000a00110a0b0006000000000000000012002d00020701000000030b001106020801000100062711010b00110b07042a000c030a031000140c040b01070521030f05190b040a022103180b03010702110c2705220b040a022303220b03010702110c270b020b030f0015020000000000",
+          "abi": {
+            "address": "0x1",
+            "name": "Timestamp",
+            "friends": [
+              "0x1::Genesis"
+            ],
+            "exposed_functions": [
+              {
+                "name": "assert_genesis",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": []
+              },
+              {
+                "name": "assert_operating",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": []
+              },
+              {
+                "name": "is_genesis",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "is_operating",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "now_microseconds",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "now_seconds",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "set_time_has_started",
+                "visibility": "friend",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "set_time_has_started_for_testing",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "update_global_time",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "u64"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "CurrentTimeMicroseconds",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "microseconds",
+                    "type": "u64"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xd47f5c819e9f189b2abfc16705c61c7c52183d9acafad7bcee5495dc4038e9aa",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000d01000c020c340340ba0104fa013205ac02940307c005ad0508ed0a20068d0b90010a9d0c620bff0c020c810dec070ded14160e8315020000000100020003000400050006040000070800000808000000040000090700000a08010400010c0700030307010000020e0700050504020400040002020600000b000100000d020300000f04050000100603000011070800001209030000130a08010400140b03010400150c03000016000300001701030000180d030000190d0300001a0d030104001b0e0300001c0f1000001d110100022c101300052d1516020404052e1819020404052f151b02040404300d130005311c030204040532031e02040401331f200003342223010003352526010005232721020404032e2528010002320d290002272a08000336032301000537182602040412141317141a161a1717171a161419211a211b171c211617162b0d22162d06221f21202b122b12171714172b172d132b142b02060c080301080305060c0806080608060b0701030002060c030208060808050c0a020a020a020306060c080608060806030806010808060c0a020a020a02030a0207060c0806080608060308060900070c0a020a020a02030a020900040c0a020a020a0201060c020803070803010608030106080803060c0608080303070800070b090208060800050105020806080002070b09020900090106090001070901020806080402060b0902090009010609000106090102080605020900090103070b0902090009010900090103050800070b090208060800010b090209000901010a020108060103010900010b070109000b080a05070800070b09020806080003070b0902080808030603080308030804080801060b07010900010101060b0902090009010106090001080a0106080a020808080303050808070b05010900020808090006070b09020808080306080805070803070b090208080803080308030806070800070b090208060800050808080607080409070b090208080803060808080308080503070b090208080803070803080305546f6b656e0541534349490447554944064f7074696f6e065369676e6572055461626c650a436f6c6c656374696f6e0b436f6c6c656374696f6e730747616c6c65727909546f6b656e446174610d546f6b656e4d6574616461746115636c61696d5f746f6b656e5f6f776e65727368697006537472696e67116372656174655f636f6c6c656374696f6e0249441b6372656174655f636f6c6c656374696f6e5f616e645f746f6b656e1f6372656174655f66696e6974655f636f6c6c656374696f6e5f7363726970740c6372656174655f746f6b656e136372656174655f746f6b656e5f7363726970741a6372656174655f746f6b656e5f776974685f6d65746164617461216372656174655f746f6b656e5f776974685f6d657461646174615f736372697074226372656174655f756e6c696d697465645f636f6c6c656374696f6e5f7363726970740d6465706f7369745f746f6b656e0d64657374726f795f746f6b656e16696e697469616c697a655f636f6c6c656374696f6e7312696e697469616c697a655f67616c6c65727919696e697469616c697a655f746f6b656e5f6d657461646174610b6d657267655f746f6b656e08746f6b656e5f69640e77697468647261775f746f6b656e06746f6b656e730e636c61696d65645f746f6b656e730b6465736372697074696f6e046e616d650375726905636f756e74076d6178696d756d0b636f6c6c656374696f6e730767616c6c6572790269640a636f6c6c656374696f6e0762616c616e636506737570706c79086d657461646174611269645f63726561746f725f616464726573730a626f72726f775f6d757406626f72726f770672656d6f76650a616464726573735f6f6606696e736572740663726561746506737472696e6704736f6d650769735f736f6d65046e6f6e650c636f6e7461696e735f6b65790000000000000000000000000000000000000000000000000000000000000001030800000000000000000308020000000000000003080300000000000000030801000000000000000a020d0c48656c6c6f2c20576f726c640a021918436f6c6c656374696f6e3a2048656c6c6f2c20576f726c640a02121168747470733a2f2f6170746f732e6465760a021413546f6b656e3a2048656c6c6f2c20546f6b656e0a020d0c48656c6c6f2c20546f6b656e0002071e0b0902080608041f0b09020806052008062108062208062303240b070103010201250b090208060800020201260b09020808080303020427080821080628080629030402052708082008062108062a032208060502012b0b09020808090005220001000101122e0e01100011110c040b042a010f010c030b030e01100238000c020a0210030e011004380110051406010000000000000021031805280a020f060e011004380201010b020f060e011004140b0011153803052c0b02010b00010b010201010001011d270a0011150c050a052901200308050a0a00110b0a05290220030f05120b00110c05140b00010b052a010f010c07380438050b010a020b030600000000000000000b0412000c060b070e02140b06380602020000020102051c070411180c020a00070511180e021407061118060100000000000000380711010b000e021407071118070811180b010706111811040c030b020b03020302000101030b0e000b0111180b0211180b0311180b043807110102040100020102245a0a0011150c070a072a010f010c090b090e0138000c080a0810073808031005230a08100338090c0a0a081007380a0c0c0b0a0b0c142203230b08010b00010702270a072a020f080c0b0a00111d0c060e06111e0c100e10140e03140e01140a0412030c0d0e10140b020e03140a040b0512040c0f0b04060100000000000000210344054a0a080f060e03140b0738030b080f030b030b0f380b0b000b0d11000c0e0b0b0e10140b0e380c0b1002050200020102030d0e000b0111180b0211180b0311180b040b05111811040102060100030102052c1d0a0011150c070a073b00200308050a0a00380d0b000b010b020b030b040b0511040c080b073c000c090b0936000e08140b06380e0b080207010003010205030e0e000b0111180b0211180b0311180b040b0511180b06380f01020802000101030a0e000b0111180b0211180b03111838101101020901000201022e2d0a0011150c040a042902200308050a0a00110c0b000b0111000c070b042a020f080c060a060e0710000c030c020b022e0b033811031d05260b060e07100038120c050b070b05110e052c0b060e071000140b07380c020a000001012f1f0b0013030c010c020c070c060e0611110c050b052a010f010c040b040e0238000c030b030f030e0738130c080a081005140b01170b080f0515020b00000003050b00381412012d01020c00000003050b00381512022d02020d00000003050b00381639003f00020e0100010103190a011000140e0010001421030c0b01010701270a01100a140e00100a14160b010f0a150b00110a020f01000003030b00100002100100010230410b0011150c070b072a020f080c090a090a010c040c030b032e0b043817100a140c080a080a0226031c0b01010b09010700270a080a0221032105290b090b0138180c0b010b0b0c05053f0b090b0138120c0a0b080a02170a0a0f0a150a0a1000140a0a1004140b0a1002140b0212030c050b050203000100030200000301040300010006020005000303092200",
+          "abi": {
+            "address": "0x1",
+            "name": "Token",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "claim_token_ownership",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "0x1::Token::Token"
+                ],
+                "return": [
+                  "0x1::Token::Token"
+                ]
+              },
+              {
+                "name": "create_collection",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "0x1::ASCII::String",
+                  "0x1::ASCII::String",
+                  "0x1::ASCII::String",
+                  "0x1::Option::Option<u64>"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_finite_collection_script",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_token",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "0x1::ASCII::String",
+                  "0x1::ASCII::String",
+                  "0x1::ASCII::String",
+                  "u64",
+                  "0x1::ASCII::String"
+                ],
+                "return": [
+                  "0x1::GUID::ID"
+                ]
+              },
+              {
+                "name": "create_token_script",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "u64",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_token_with_metadata",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "&signer",
+                  "0x1::ASCII::String",
+                  "0x1::ASCII::String",
+                  "0x1::ASCII::String",
+                  "u64",
+                  "0x1::ASCII::String",
+                  "T0"
+                ],
+                "return": [
+                  "0x1::GUID::ID"
+                ]
+              },
+              {
+                "name": "create_token_with_metadata_script",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ]
+                  }
+                ],
+                "params": [
+                  "signer",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "u64",
+                  "vector<u8>",
+                  "T0"
+                ],
+                "return": []
+              },
+              {
+                "name": "create_unlimited_collection_script",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "deposit_token",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "0x1::Token::Token"
+                ],
+                "return": []
+              },
+              {
+                "name": "merge_token",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "0x1::Token::Token",
+                  "&mut 0x1::Token::Token"
+                ],
+                "return": []
+              },
+              {
+                "name": "token_id",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::Token::Token"
+                ],
+                "return": [
+                  "&0x1::GUID::ID"
+                ]
+              },
+              {
+                "name": "withdraw_token",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "&0x1::GUID::ID",
+                  "u64"
+                ],
+                "return": [
+                  "0x1::Token::Token"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "Collection",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "tokens",
+                    "type": "0x1::Table::Table<0x1::ASCII::String, 0x1::Token::TokenData>"
+                  },
+                  {
+                    "name": "claimed_tokens",
+                    "type": "0x1::Table::Table<0x1::ASCII::String, address>"
+                  },
+                  {
+                    "name": "description",
+                    "type": "0x1::ASCII::String"
+                  },
+                  {
+                    "name": "name",
+                    "type": "0x1::ASCII::String"
+                  },
+                  {
+                    "name": "uri",
+                    "type": "0x1::ASCII::String"
+                  },
+                  {
+                    "name": "count",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "maximum",
+                    "type": "0x1::Option::Option<u64>"
+                  }
+                ]
+              },
+              {
+                "name": "Collections",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "collections",
+                    "type": "0x1::Table::Table<0x1::ASCII::String, 0x1::Token::Collection>"
+                  }
+                ]
+              },
+              {
+                "name": "Gallery",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "gallery",
+                    "type": "0x1::Table::Table<0x1::GUID::ID, 0x1::Token::Token>"
+                  }
+                ]
+              },
+              {
+                "name": "Token",
+                "is_native": false,
+                "abilities": [
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "id",
+                    "type": "0x1::GUID::ID"
+                  },
+                  {
+                    "name": "name",
+                    "type": "0x1::ASCII::String"
+                  },
+                  {
+                    "name": "collection",
+                    "type": "0x1::ASCII::String"
+                  },
+                  {
+                    "name": "balance",
+                    "type": "u64"
+                  }
+                ]
+              },
+              {
+                "name": "TokenData",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "id",
+                    "type": "0x1::GUID::ID"
+                  },
+                  {
+                    "name": "description",
+                    "type": "0x1::ASCII::String"
+                  },
+                  {
+                    "name": "name",
+                    "type": "0x1::ASCII::String"
+                  },
+                  {
+                    "name": "supply",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "uri",
+                    "type": "0x1::ASCII::String"
+                  }
+                ]
+              },
+              {
+                "name": "TokenMetadata",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [
+                  {
+                    "constraints": [
+                      "store"
+                    ],
+                    "is_phantom": false
+                  }
+                ],
+                "fields": [
+                  {
+                    "name": "metadata",
+                    "type": "0x1::Table::Table<0x1::GUID::ID, T0>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x6dc54b259b9bb92b3b16b65951338f1a968cd840df016cc3bd13423fb357c6b9",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b01000e020e1e032c8c0104b8011a05d201960207e803e20208ca062006ea06680ad2070f0ce107b2030d930b02000000010002000300040005000600000800020707000505040204000400060604000118070003030701000000080001000009020100000a000100000b020100000c030400000d050100000e060100000f070100041105090005120b0c02040405130b0e02040405140f1002040405151101020404061612010002171304000119151400031a01160100061b170100060c180400051c0111020404051d1a1b020404051e1c01020404061f1d1e0006201f20000621210100090a0a0d0b0d0a0a0c0d1010130a140a130d150a140d090d150d03060c0506080100040c05050302060c0301080101060c04060c0506080103050c0505030307080105070b0202050b020208010803070b0202080108030b020208010803050803010502050b02020801080302070b020209000901060900010709010208010803020900090101060b0202090009010103010b02020900090102060c0803020503010804010a02010b0501090005060c0804080408040b05010306060c0804080408040308040a070b0202050b0202080108030605070b020208010803060801070b020208010803070803070b0202050b02020801080305080306080102060b020209000901060900010103070b0202090009010900090103060c0608010301080301060803010608010208030708030e546f6b656e5472616e73666572730541534349490447554944064f7074696f6e065369676e6572055461626c6505546f6b656e0249440c63616e63656c5f6f666665721363616e63656c5f6f666665725f73637269707405636c61696d0c636c61696d5f7363726970740c6372656174655f746f6b656e1a696e697469616c697a655f746f6b656e5f7472616e7366657273056f666665720c6f666665725f7363726970740e70656e64696e675f636c61696d730a616464726573735f6f660a626f72726f775f6d75740672656d6f766505636f756e740d64657374726f795f656d7074790d6465706f7369745f746f6b656e096372656174655f696406537472696e6706737472696e67046e6f6e65116372656174655f636f6c6c656374696f6e066372656174650c636f6e7461696e735f6b657906696e736572740e77697468647261775f746f6b656e08746f6b656e5f69640b6d657267655f746f6b656e00000000000000000000000000000000000000000000000000000000000000010a020d0c48656c6c6f2c20576f726c640a021918436f6c6c656374696f6e3a2048656c6c6f2c20576f726c640a02121168747470733a2f2f6170746f732e6465760a021413546f6b656e3a2048656c6c6f2c20546f6b656e0a020d0c48656c6c6f2c20546f6b656e000201100b0202050b020208010803000100010008250a0011080c080b082a000f000c050a050e0138000c060a060b0238010c09010b062e3802060000000000000000210317051f0b050e0138030c07010b07380405210b05010b000b09110d02010200010004090b020b03110e0c040e000b010e04110002020100010008250a0011080c080b012a000f000c050a050e0838000c060a060b0238010c09010b062e3802060000000000000000210317051f0b050e0838030c07010b07380405210b05010b000b09110d02030200010004090b020b03110e0c040e000b010e041102020400000014170700110f0c020a000701110f0e02140702110f380511110b000b020703110f0704110f0b010702110f1112020500000001050b00380612002d0002060100010019410a0011080c0b0a0b2900200308050a0a0011050b0b2a000f000c0a0a0a0e010c050c040b042e0b053807200319051d0a0a0a01380838090b0a0e0138000c080b000b020b0311160c0c0e0c11170c0d0a080a0d0c070c060b062e0b07380a0333053b0b080b0d380b0c090b0c0b09111805400b080b0d140b0c380c020702000100040a0b020b03110e0c050e000b010e050b04110602000000",
+          "abi": {
+            "address": "0x1",
+            "name": "TokenTransfers",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "cancel_offer",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "&0x1::GUID::ID"
+                ],
+                "return": []
+              },
+              {
+                "name": "cancel_offer_script",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "address",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "claim",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "&0x1::GUID::ID"
+                ],
+                "return": []
+              },
+              {
+                "name": "claim_script",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "address",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "offer",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "&0x1::GUID::ID",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "offer_script",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "address",
+                  "u64",
+                  "u64"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "TokenTransfers",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "pending_claims",
+                    "type": "0x1::Table::Table<address, 0x1::Table::Table<0x1::GUID::ID, 0x1::Token::Token>>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x48b12d7c6cecb34c8eb16fbcd16aa94e0af6d25d801ff614cfe256255f4a86e4",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000801000402040403080a051204071637084d200c6d0b0f780200010002010304000004000100010500010001080000074163636f756e740e5472616e73616374696f6e4665650854657374436f696e04436f696e086275726e5f666565086275726e5f67617300000000000000000000000000000000000000000000000000000000000000010003000001030b00110102000000",
+          "abi": {
+            "address": "0x1",
+            "name": "TransactionFee",
+            "friends": [
+              "0x1::Account"
+            ],
+            "exposed_functions": [
+              {
+                "name": "burn_fee",
+                "visibility": "friend",
+                "generic_type_params": [],
+                "params": [
+                  "0x1::TestCoin::Coin"
+                ],
+                "return": []
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x420ef68d76eb27ca3b115aa143bcbb21fed31303e38840c11e7a0a88046e4dfa",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b01000c020c04031034044406054a35077fa10208a0032006c0032c0aec03090cf50390010d850504000000010002000300040005000008000006000100000701020000080302000009040100040c010100030d050100010e060600050f0a02010005100c02010002110101000709070b080b03060c0a0a020100010101060a02020c0101060c0103010608000201060800010201060a0900010a0202060a0900060900010708001b5472616e73616374696f6e5075626c697368696e674f7074696f6e064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d7006566563746f720a696e697469616c697a651169735f6d6f64756c655f616c6c6f7765641169735f7363726970745f616c6c6f7765641d7365745f6d6f64756c655f7075626c697368696e675f616c6c6f776564117363726970745f616c6c6f775f6c697374196d6f64756c655f7075626c697368696e675f616c6c6f7765640e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c69736865640869735f656d70747908636f6e7461696e730b7265636f6e6669677572650000000000000000000000000000000000000000000000000000000000000001030801000000000000000520000000000000000000000000000000000000000000000000000000000a550c180002020a0a0a020b0100010000011211040a0011050701290020030c0b000107001106270b000b010b0212002d00020101000100070707012b000c000b00100014020201000100081e0a003800030405080b0001080207012b000c020a0210013801031005170b00010b0201080c01051c0b0210010b0038020c010b010203020001000d0b0e00110507012a000c020b010b020f00151109020001000000",
+          "abi": {
+            "address": "0x1",
+            "name": "TransactionPublishingOption",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "vector<vector<u8>>",
+                  "bool"
+                ],
+                "return": []
+              },
+              {
+                "name": "is_module_allowed",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "is_script_allowed",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&vector<u8>"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "set_module_publishing_allowed",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "bool"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "TransactionPublishingOption",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "script_allow_list",
+                    "type": "vector<vector<u8>>"
+                  },
+                  {
+                    "name": "module_publishing_allowed",
+                    "type": "bool"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x18cc12a7c4f97627fbfa0ef6cc5cc6a0e45a3950e5cf30b2c01926c731fdb227",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000a01000a020a0c03162d0543220765bf0408a4052006c405360afa052b0ca50694020db9081a000000010002000300040005070000060700000008000007000100000802010004180101000319040100011a050500041b010100011c050500011d050500021e01010004060c0a020a0203000c0c030303030303030303030301080001060c01030107080008564d436f6e666967064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d700c476173436f6e7374616e74730b4761735363686564756c650a696e697469616c697a65117365745f6761735f636f6e7374616e74731b676c6f62616c5f6d656d6f72795f7065725f627974655f636f737421676c6f62616c5f6d656d6f72795f7065725f627974655f77726974655f636f7374196d696e5f7472616e73616374696f6e5f6761735f756e697473186c617267655f7472616e73616374696f6e5f6375746f666616696e7472696e7369635f6761735f7065725f627974651b6d6178696d756d5f6e756d6265725f6f665f6761735f756e697473166d696e5f70726963655f7065725f6761735f756e6974166d61785f70726963655f7065725f6761735f756e69741d6d61785f7472616e73616374696f6e5f73697a655f696e5f6279746573176761735f756e69745f7363616c696e675f666163746f721464656661756c745f6163636f756e745f73697a6514696e737472756374696f6e5f7363686564756c650f6e61746976655f7363686564756c650d6761735f636f6e7374616e74730c6761735f7363686564756c650e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c6973686564106173736572745f6f7065726174696e6710696e76616c69645f617267756d656e740d6e6f745f7075626c69736865640b7265636f6e666967757265000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000520000000000000000000000000000000000000000000000000000000000a550c1800020b09030a030b030c030d030e030f031003110312031303010203140a02150a0216080002020117080100010000032111020a0011030702290220030c0b000107001104270604000000000000000609000000000000000658020000000000000658020000000000000608000000000000000600093d00000000000b0306102700000000000006001000000000000006e80300000000000006200300000000000012000c040b000b010b020b04120112022d02020102000102064a11050e0011030a070a0825030a07011106270a030a062503110701110627070229020317070011072707022a020f000f010c0c0b010a0c0f02150b020a0c0f03150b030a0c0f04150b040a0c0f05150b050a0c0f06150b060a0c0f07150b070a0c0f08150b080a0c0f09150b090a0c0f0a150b0a0a0c0f0b150b0b0b0c0f0c15110802020001020000000100020003000400050006000700080009000a00",
+          "abi": {
+            "address": "0x1",
+            "name": "VMConfig",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "set_gas_constants",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64",
+                  "u64"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "GasConstants",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "global_memory_per_byte_cost",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "global_memory_per_byte_write_cost",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "min_transaction_gas_units",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "large_transaction_cutoff",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "intrinsic_gas_per_byte",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "maximum_number_of_gas_units",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "min_price_per_gas_unit",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "max_price_per_gas_unit",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "max_transaction_size_in_bytes",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "gas_unit_scaling_factor",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "default_account_size",
+                    "type": "u64"
+                  }
+                ]
+              },
+              {
+                "name": "GasSchedule",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "instruction_schedule",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "native_schedule",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "gas_constants",
+                    "type": "0x1::VMConfig::GasConstants"
+                  }
+                ]
+              },
+              {
+                "name": "VMConfig",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "gas_schedule",
+                    "type": "0x1::VMConfig::GasSchedule"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xcfc7b653713b0a0bb5d71145fdfa2f4769b13f3a48ea60ebd1f59ddbb5624953",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b01000e020e0e031c72048e0110059e014e07ec01820408ee0520068e06280ab6061d0cd306fb020dce090a0000000100020003000400050006000707000000080002020701000000080001000009000200000a030400000b000500000c000000000d030400000e000100000f0607000010080700001109070000120a070001190c0c00021a0d010100011b0c0c00021c0d0e0100051d070700041e080000011f0c0c00022007100100032105010002221210010006230001000c020e020c000e001202120014021400010501010108000106080001060a02010a0202060c0a020001060c05060c050a020a020a0202060c0501060b02010800010301060b020109000106090001060801010b02010900010708010109000f56616c696461746f72436f6e666967064572726f7273064f7074696f6e095369676e6174757265065369676e65720954696d657374616d701756616c696461746f724f70657261746f72436f6e66696706436f6e6669670d6578697374735f636f6e6669670a6765745f636f6e666967146765745f636f6e73656e7375735f7075626b65790e6765745f68756d616e5f6e616d650c6765745f6f70657261746f721f6765745f76616c696461746f725f6e6574776f726b5f6164647265737365730869735f76616c6964077075626c6973680f72656d6f76655f6f70657261746f720a7365745f636f6e6669670c7365745f6f70657261746f7210636f6e73656e7375735f7075626b65791b76616c696461746f725f6e6574776f726b5f6164647265737365731a66756c6c6e6f64655f6e6574776f726b5f61646472657373657306636f6e666967106f70657261746f725f6163636f756e740a68756d616e5f6e616d650d6e6f745f7075626c69736865640769735f736f6d6510696e76616c69645f617267756d656e7406626f72726f77106173736572745f6f7065726174696e670a616464726573735f6f6611616c72656164795f7075626c6973686564046e6f6e6517656432353531395f76616c69646174655f7075626b657904736f6d651d6861735f76616c696461746f725f6f70657261746f725f636f6e666967000000000000000000000000000000000000000000000000000000000000000103080200000000000000030801000000000000000308030000000000000003080000000000000000000203130a02140a02150a02010203160b02010800170b020105180a020000000007030b0029010201010001010b160a00110003060703110b270b002b0110000c010a01380003120b01010703110d270b01380114020201000007030b0010010203010001010f0d0a00290103060703110b270b002b010c010b011002140204010001010f170a00290103060703110b270b002b010c010a011003380203120b01010703110d270b011003380314020501000007030b001004020601000101010e0a0029010304050a0b002b01100038000c01050c090c010b0102070100000712110f0a001110290120030b0b000107031111270b00380438050b0112012d01020801000101000f0b0011100c010a01110003090703110b2738050b012a010f031502090100010111210b0011100a0111042103090701110d270a021113030f0700110d270a01110003150703110b270b012a010c050b020b030b04120038060b050f0015020a0100010100180a01111503080b00010702110d270b0011100c020a02110003110703110b270b0138070b022a010f0315020100000001020101000100",
+          "abi": {
+            "address": "0x1",
+            "name": "ValidatorConfig",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "get_config",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "0x1::ValidatorConfig::Config"
+                ]
+              },
+              {
+                "name": "get_consensus_pubkey",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::ValidatorConfig::Config"
+                ],
+                "return": [
+                  "&vector<u8>"
+                ]
+              },
+              {
+                "name": "get_human_name",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "vector<u8>"
+                ]
+              },
+              {
+                "name": "get_operator",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "address"
+                ]
+              },
+              {
+                "name": "get_validator_network_addresses",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&0x1::ValidatorConfig::Config"
+                ],
+                "return": [
+                  "&vector<u8>"
+                ]
+              },
+              {
+                "name": "is_valid",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "publish",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "remove_operator",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "set_config",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "set_operator",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "Config",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "consensus_pubkey",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "validator_network_addresses",
+                    "type": "vector<u8>"
+                  },
+                  {
+                    "name": "fullnode_network_addresses",
+                    "type": "vector<u8>"
+                  }
+                ]
+              },
+              {
+                "name": "ValidatorConfig",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "config",
+                    "type": "0x1::Option::Option<0x1::ValidatorConfig::Config>"
+                  },
+                  {
+                    "name": "operator_account",
+                    "type": "0x1::Option::Option<address>"
+                  },
+                  {
+                    "name": "human_name",
+                    "type": "vector<u8>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xaa0460c1e08bc01719e73aed182ce339ece3ac47ee279ec5c7945d0f2b6854d1",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000a010008020804030c23052f120741ac0108ed0120068d020a0a9702060c9d02470de4020200000001000200030000080000040001000005000200000603040001080505000309040400020a060000010b0505000105010a02010102060c0a0200010301060c1756616c696461746f724f70657261746f72436f6e666967064572726f7273065369676e65720954696d657374616d700e6765745f68756d616e5f6e616d651d6861735f76616c696461746f725f6f70657261746f725f636f6e666967077075626c6973680a68756d616e5f6e616d650d6e6f745f7075626c6973686564106173736572745f6f7065726174696e670a616464726573735f6f6611616c72656164795f7075626c6973686564000000000000000000000000000000000000000000000000000000000000000103080000000000000000000201070a020001000100040b0a001101030607001103270b002b00100014020101000004030b0029000202010000041011040a001105110120030b0b000107001106270b000b0112002d0002000000",
+          "abi": {
+            "address": "0x1",
+            "name": "ValidatorOperatorConfig",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "get_human_name",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "vector<u8>"
+                ]
+              },
+              {
+                "name": "has_validator_operator_config",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "publish",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "vector<u8>"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "ValidatorOperatorConfig",
+                "is_native": false,
+                "abilities": [
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "human_name",
+                    "type": "vector<u8>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xa8a8db4b583979b4cdc0dcf2397e025f9a3f25b8c98a2b556f71a97a6fb28f24",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000b0100120212120324c80104ec0114058002a60107a603960608bc092006dc099a010af60a150c8b0bd9050de410080000000100020003000400050006000700080009070000000b00070d0700020207010000000a000100000b020100000c030400000e040500000f060700001001080000110901000012040a0000130b0a00001400010000150201000016080100001702010000180c0a000019010300062001010005210901000722040a00012303030001240303000725040500062601030008270f0101000828101101000229130a0100022813110100082a15030100022b16170100022c01170100062d010100012e030300082f0118010008301b160100013103030003320101000733040400043409040008351b1e0100160e170e180319031a0e1b031c031f0e200e250e020c050002060c050103010501080202060a080005010b03010301080101060c01010205060a080002070a080003070508020303070a08000802080101080002070a0900090002060a09000301060900020b030103080101060b0301090003030306080001060a0900010900010b03010900010a09000208010503030b030103080102070a090003010708010501030b030103070800080101070900040708020802030708000c56616c696461746f72536574064572726f7273064f7074696f6e0f5265636f6e66696775726174696f6e065369676e65720f53797374656d4164647265737365730954696d657374616d700f56616c696461746f72436f6e66696706566563746f720d56616c696461746f72496e666f0d6164645f76616c696461746f72166164645f76616c696461746f725f696e7465726e616c196765745f6974685f76616c696461746f725f6164647265737306436f6e666967146765745f76616c696461746f725f636f6e666967146765745f76616c696461746f725f696e6465785f1b6765745f76616c696461746f725f73797374656d5f636f6e66696718696e697469616c697a655f76616c696461746f725f7365740c69735f76616c696461746f720d69735f76616c696461746f725f1072656d6f76655f76616c696461746f721972656d6f76655f76616c696461746f725f696e7465726e616c1b7365745f76616c696461746f725f73797374656d5f636f6e6669671d7570646174655f636f6e6669675f616e645f7265636f6e6669677572651a7570646174655f6974685f76616c696461746f725f696e666f5f1276616c696461746f725f7365745f73697a65046164647216636f6e73656e7375735f766f74696e675f706f77657206636f6e666967176c6173745f636f6e6669675f7570646174655f74696d6506736368656d650a76616c696461746f7273106173736572745f6f7065726174696e67146173736572745f636f72655f7265736f757263650869735f76616c696410696e76616c69645f617267756d656e740e6c696d69745f65786365656465640a6765745f636f6e666967106e6f775f6d6963726f7365636f6e647309707573685f6261636b06626f72726f770769735f736f6d65066c656e67746804736f6d65046e6f6e650e6173736572745f67656e6573697311616c72656164795f7075626c697368656405656d7074790b737761705f72656d6f76650d6e6f745f7075626c69736865640b7265636f6e6669677572650c6765745f6f70657261746f720a616464726573735f6f660a626f72726f775f6d75740000000000000000000000000000000000000000000000000000000000000001030802000000000000000308000000000000000003080600000000000000030808000000000000000308010000000000000003080400000000000000030807000000000000000308030000000000000003080500000000000000030800a3e111000000000308ffffffffffffffff030800010000000000000520000000000000000000000000000000000000000000000000000000000a550c180002041a051b031c08021d030102021e021f0a0800000200010101040e000b0111010201010001010d31110f0b0011100a01111103090704111227110e070b230310070611132711050c080a010e081000110820031b07001112270a0111140c070d080f000c060b010c020b070c0311150c050b060b020601000000000000000b030b05120038000b08110b02020100010108100a00110e230307070811122711050c010e0110000b003801100114020301000101121611050c020e0210000b0011040c010e013802030d07071112270e0210000e013803143801100214020400000014230a0038040c030600000000000000000c020a020a0323030a051f0a000a0238010c040b041001140a01210315051a0b00010b023805020b02060100000000000000160c0205050b000138060205010001010104070c2b011402060100000112111d0a001110070c290120030c0b00010701111e270b003100380712012d0102070100010119090b000c0211050c010b020e0110001108020800000007070b010b0011040c020e02380202090200010101040e000b01110a020a010001011a1c110f0b00111011050c040e0410000b0111040c030e033802031007071112270e033803140c020d040f000b023808010b04110b020b000001011c0f110f070c290103070701112127070c2a010c010b000b01151122020c010001011d49110f0a0111230b00112421030a070511122711050c060e0610000b0111040c040e043802031707071112270e043803140c030d060f000a03110d0c020b02032305480d060f000b0338090c050a05100314070a0709172503350b0501070311132711150a051003140709162403420b0501070211132711150b050f03150b06110b020d0000001f330a002e38040c040a010b04260309050d0b000109020b000b0138090c050a051001141111200318051c0b050109020a0510011411140c030b050f020c020a022e0e0321032a052e0b020109020b030b021508020e01000101080611050c000e001000380402010100000002000300",
+          "abi": {
+            "address": "0x1",
+            "name": "ValidatorSet",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "add_validator",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "add_validator_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "get_ith_validator_address",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "u64"
+                ],
+                "return": [
+                  "address"
+                ]
+              },
+              {
+                "name": "get_validator_config",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "0x1::ValidatorConfig::Config"
+                ]
+              },
+              {
+                "name": "get_validator_system_config",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "0x1::ValidatorSet::ValidatorSet"
+                ]
+              },
+              {
+                "name": "initialize_validator_set",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer"
+                ],
+                "return": []
+              },
+              {
+                "name": "is_validator",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "address"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "remove_validator",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "remove_validator_internal",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "update_config_and_reconfigure",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "address"
+                ],
+                "return": []
+              },
+              {
+                "name": "validator_set_size",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [],
+                "return": [
+                  "u64"
+                ]
+              }
+            ],
+            "structs": [
+              {
+                "name": "ValidatorInfo",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "addr",
+                    "type": "address"
+                  },
+                  {
+                    "name": "consensus_voting_power",
+                    "type": "u64"
+                  },
+                  {
+                    "name": "config",
+                    "type": "0x1::ValidatorConfig::Config"
+                  },
+                  {
+                    "name": "last_config_update_time",
+                    "type": "u64"
+                  }
+                ]
+              },
+              {
+                "name": "ValidatorSet",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "scheme",
+                    "type": "u8"
+                  },
+                  {
+                    "name": "validators",
+                    "type": "vector<0x1::ValidatorSet::ValidatorInfo>"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x7b913990d5df68402b1438807a139b8fdc76cdf985ab635a6f09166406c6fe97",
+        "data": {
+          "bytecode": "0xa11ceb0b0500000006010008030823052b22074de30108b002200cd0024c0000000100020003000400010000050001000006020100010703010003080401000209050600010a040100050c050a020a020a0200030c0a020505060c050a020a020a0202060c050105010a021256616c696461746f725365745363726970740f56616c696461746f72436f6e6669671756616c696461746f724f70657261746f72436f6e6669670c56616c696461746f725365741972656769737465725f76616c696461746f725f636f6e666967247365745f76616c696461746f725f636f6e6669675f616e645f7265636f6e666967757265167365745f76616c696461746f725f6f70657261746f720a7365745f636f6e6669671d7570646174655f636f6e6669675f616e645f7265636f6e6669677572650e6765745f68756d616e5f6e616d650c7365745f6f70657261746f7200000000000000000000000000000000000000000000000000000000000000010002000001070e000b010b020b030b0411030201020000010a0e000a010b020b030b0411030e000b0111040202020000010b0a0211050b01210307060000000000000000270e000b0211060200",
+          "abi": {
+            "address": "0x1",
+            "name": "ValidatorSetScript",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "register_validator_config",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "set_validator_config_and_reconfigure",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "address",
+                  "vector<u8>",
+                  "vector<u8>",
+                  "vector<u8>"
+                ],
+                "return": []
+              },
+              {
+                "name": "set_validator_operator",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "vector<u8>",
+                  "address"
+                ],
+                "return": []
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0x676c1655de1362f3510ed359bafb9c86d69f436ac28477427f1e92a7594e50c7",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000801000203026004621205745907cd01930108e002200680030a0c8a038904000000010001010000020203010000030405010000040607010000050801010000060108010000070609010000080a07010000090a0b0100000a0c0d0100000b0e010100000c040d0100000d0c010100000e0d080100000f0f0101000010040d01000c0d070d090d0a0d040d080d010d0e0d050d02070a09000a09000002060a0900030106090002070a0900030107090002060a09000609000101010a090002010301060a0900010301070a090001090002070a0900090003070a090003030203030303070a0900030303030306566563746f7206617070656e6406626f72726f770a626f72726f775f6d757408636f6e7461696e730d64657374726f795f656d70747905656d70747908696e6465785f6f660869735f656d707479066c656e67746808706f705f6261636b09707573685f6261636b0672656d6f766507726576657273650973696e676c65746f6e04737761700b737761705f72656d6f76650000000000000000000000000000000000000000000000000000000000000001030800000000000000000001000001110d0138000e013801200307050c0a000d013802380305020b00010b0138040201010200020102000301000010220600000000000000000c020a0038050c030a020a0323030a051c0a000a0238060a0121031105170b00010b010108020b02060100000000000000160c0205050b00010b0101090204010200050102000601000010240600000000000000000c020a0038050c030a020a0323030a051d0a000a0238060a0121031105180b00010b0101080b02020b02060100000000000000160c0205050b00010b010109060000000000000000020701000001050b003805060000000000000000210208010200090102000a0102000b01000011260a002e38050c040a010a04260309050d0b00010700270b04060100000000000000170c040a010a0423031605230a000c030a010c020b01060100000000000000160c010b030b020a01380705110b003802020c01000012270a002e38050c030a03060000000000000000210309050c0b0001020600000000000000000c020b03060100000000000000170c010a020a0123031705240a000a020a0138070b02060100000000000000160c020b01060100000000000000170c0105120b0001020d010000080738080c010d010b0038030b01020e0102000f0100000b160a002e38012003090b00010700270a002e3805060100000000000000170c020a000b010b0238070b0038020200",
+          "abi": {
+            "address": "0x1",
+            "name": "Vector",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "append",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>",
+                  "vector<T0>"
+                ],
+                "return": []
+              },
+              {
+                "name": "borrow",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&vector<T0>",
+                  "u64"
+                ],
+                "return": [
+                  "&T0"
+                ]
+              },
+              {
+                "name": "borrow_mut",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>",
+                  "u64"
+                ],
+                "return": [
+                  "&mut T0"
+                ]
+              },
+              {
+                "name": "contains",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&vector<T0>",
+                  "&T0"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "destroy_empty",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "vector<T0>"
+                ],
+                "return": []
+              },
+              {
+                "name": "empty",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [],
+                "return": [
+                  "vector<T0>"
+                ]
+              },
+              {
+                "name": "index_of",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&vector<T0>",
+                  "&T0"
+                ],
+                "return": [
+                  "bool",
+                  "u64"
+                ]
+              },
+              {
+                "name": "is_empty",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&vector<T0>"
+                ],
+                "return": [
+                  "bool"
+                ]
+              },
+              {
+                "name": "length",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&vector<T0>"
+                ],
+                "return": [
+                  "u64"
+                ]
+              },
+              {
+                "name": "pop_back",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>"
+                ],
+                "return": [
+                  "T0"
+                ]
+              },
+              {
+                "name": "push_back",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>",
+                  "T0"
+                ],
+                "return": []
+              },
+              {
+                "name": "remove",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>",
+                  "u64"
+                ],
+                "return": [
+                  "T0"
+                ]
+              },
+              {
+                "name": "reverse",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>"
+                ],
+                "return": []
+              },
+              {
+                "name": "singleton",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "T0"
+                ],
+                "return": [
+                  "vector<T0>"
+                ]
+              },
+              {
+                "name": "swap",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>",
+                  "u64",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "swap_remove",
+                "visibility": "public",
+                "generic_type_params": [
+                  {
+                    "constraints": []
+                  }
+                ],
+                "params": [
+                  "&mut vector<T0>",
+                  "u64"
+                ],
+                "return": [
+                  "T0"
+                ]
+              }
+            ],
+            "structs": []
+          }
+        }
+      },
+      {
+        "type": "write_module",
+        "address": "0x1",
+        "state_key_hash": "0xdec45f7e3f30d6fc6197b91d3ddac37ae607eb051cd91c7792c012d88bc7d004",
+        "data": {
+          "bytecode": "0xa11ceb0b050000000a01000a020a04030e280536120748b70108ff0120069f02360ad502050cda025f0db903020000000100020003000400000f000005000100000602010004080101000309030100010a040400010b040400010c040400020d01010002060c0300020c0301060c010302070800030756657273696f6e064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d700a696e697469616c697a650b7365745f76657273696f6e056d616a6f720e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c69736865640d6e6f745f7075626c697368656410696e76616c69645f617267756d656e740b7265636f6e666967757265000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201070300010000011111020a0011030702290020030c0b000107001104270b000b0112002d00020102000100051d0e001103070229000308070011052707022b001000140c030b030a01230314070111062707022a000c020b010b020f0015110702000000",
+          "abi": {
+            "address": "0x1",
+            "name": "Version",
+            "friends": [],
+            "exposed_functions": [
+              {
+                "name": "initialize",
+                "visibility": "public",
+                "generic_type_params": [],
+                "params": [
+                  "&signer",
+                  "u64"
+                ],
+                "return": []
+              },
+              {
+                "name": "set_version",
+                "visibility": "script",
+                "generic_type_params": [],
+                "params": [
+                  "signer",
+                  "u64"
+                ],
+                "return": []
+              }
+            ],
+            "structs": [
+              {
+                "name": "Version",
+                "is_native": false,
+                "abilities": [
+                  "copy",
+                  "drop",
+                  "store",
+                  "key"
+                ],
+                "generic_type_params": [],
+                "fields": [
+                  {
+                    "name": "major",
+                    "type": "u64"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x57df581bdc8eb537f2e0daefe0c91bcefd4e184d31d5a25fe8728c69cc560486",
+        "data": {
+          "type": "0x1::Account::ChainSpecificAccountInfo",
+          "data": {
+            "currency_code_required": false,
+            "module_addr": "0x1",
+            "module_name": "0x4163636f756e74",
+            "module_prologue_name": "0x6d6f64756c655f70726f6c6f677565",
+            "multi_agent_prologue_name": "0x7363726970745f70726f6c6f677565",
+            "script_prologue_name": "0x7363726970745f70726f6c6f677565",
+            "user_epilogue_name": "0x6570696c6f677565",
+            "writeset_epilogue_name": "0x77726974657365745f6570696c6f677565",
+            "writeset_prologue_name": "0x77726974657365745f70726f6c6f677565"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "0",
+            "new_block_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x17589738079487b2af997d2ed0bd6d4332205e7c450220e74566c09b1905e617",
+        "data": {
+          "type": "0x1::ChainId::ChainId",
+          "data": {
+            "id": 4
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x2d7368fa67450cf0b7eed0331f147d354815137feb76fff2b7c0fc60ad5bb800",
+        "data": {
+          "type": "0x1::ConsensusConfig::ConsensusConfig",
+          "data": {
+            "config": "0x0101010a000000000000001400000000000000"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x3481c9601d3bb1d800c5b728e684b1201dfc2829d75259d5ef5ea4b045b15a53",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "6"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x764438e1151d8c09aa5f9043996c768cd364e7cb7df8621503f56c554da89f02",
+        "data": {
+          "type": "0x1::Reconfiguration::Configuration",
+          "data": {
+            "epoch": "1",
+            "events": {
+              "counter": "1",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "4"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "last_reconfiguration_time": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x8b49e451a3bb4f865d2a238e81d34b1ac813183a4bdf7bd63aca56b49bf9d81f",
+        "data": {
+          "type": "0x1::TestCoin::BurnCapability",
+          "data": {
+            "dummy_field": false
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x3f1c23fdebea87635e8e87e193c97b9e2748a6f90c09f3c8b22677803a4e5b80",
+        "data": {
+          "type": "0x1::TestCoin::Delegations",
+          "data": {
+            "inner": []
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x8e3acba2e68effb510e78950ae72f9b491614c742266e73b19f46210ef729ba7",
+        "data": {
+          "type": "0x1::TestCoin::MintCapability",
+          "data": {
+            "dummy_field": false
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xcf66e2ca4e76897cebaa518a193ad55e73868487052899ce87b2d0d4c9496316",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xeee160d734240e9a9250c523c7aefc2fa613bf0e63f5445622efcab6d1fcce1d",
+        "data": {
+          "type": "0x1::TransactionPublishingOption::TransactionPublishingOption",
+          "data": {
+            "module_publishing_allowed": true,
+            "script_allow_list": []
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xda497579d98e160f73853a824ab66764eb06ac6f5e7d256e02192948c2cf608f",
+        "data": {
+          "type": "0x1::VMConfig::VMConfig",
+          "data": {
+            "gas_schedule": {
+              "gas_constants": {
+                "default_account_size": "800",
+                "gas_unit_scaling_factor": "1000",
+                "global_memory_per_byte_cost": "4",
+                "global_memory_per_byte_write_cost": "9",
+                "intrinsic_gas_per_byte": "8",
+                "large_transaction_cutoff": "600",
+                "max_price_per_gas_unit": "10000",
+                "max_transaction_size_in_bytes": "4096",
+                "maximum_number_of_gas_units": "4000000",
+                "min_price_per_gas_unit": "0",
+                "min_transaction_gas_units": "600"
+              },
+              "instruction_schedule": "0x47010000000000000001000000000000007e02000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000020000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000006c0400000000000001000000000000000200000000000000010000000000000002000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000030000000000000001000000000000000200000000000000010000000000000002000000000000000100000000000000010000000000000001000000000000000200000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000002000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000290000000000000001000000000000001500000000000000010000000000000017000000000000000100000000000000cb0100000000000001000000000000000d00000000000000010000000000000001000000000000000100000000000000020000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000200000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000460200000000000001000000000000000200000000000000010000000000000002000000000000000100000000000000220000000000000001000000000000000f0000000000000001000000000000000e0000000000000001000000000000000d0000000000000001000000000000001b0000000000000001000000000000005400000000000000010000000000000062000000000000000100000000000000360500000000000001000000000000006e07000000000000010000000000000035000000000000000100000000000000e30000000000000001000000000000003c0200000000000001000000000000009c050000000000000100000000000000",
+              "native_schedule": "0x1215000000000000000100000000000000400000000000000001000000000000003d000000000000000100000000000000170d0000000000000100000000000000b50000000000000001000000000000006200000000000000010000000000000054000000000000000100000000000000360500000000000001000000000000006e07000000000000010000000000000035000000000000000100000000000000e30000000000000001000000000000003c0200000000000001000000000000009c0500000000000001000000000000001a0000000000000001000000000000006101000000000000010000000000000018000000000000000100000000000000d400000000000000010000000000000034000000000000000100000000000000"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xc6f78e93890778db8b389336a35b69d5a4f07a08d6a22f44351fc0caefdeefc4",
+        "data": {
+          "type": "0x1::ValidatorSet::ValidatorSet",
+          "data": {
+            "scheme": 0,
+            "validators": [
+              {
+                "addr": "0xf85fd00e30cd388d2609db24d6cc44f2652f27413456938eaa059f65231647cc",
+                "config": {
+                  "consensus_pubkey": "0xcc62332e34bb2d5cd69f60efbb2a36cb916c7eb458301ea36636c4dbb012bd88",
+                  "fullnode_network_addresses": "0x012d040000000000050c1c07203432fbf5b666fa771269cc7eb227146d3b16858f177a317ae8c349db210feb780800",
+                  "validator_network_addresses": "0x012d0400000000000524180720d5db8911156f3441c0757d97b8580cb639853454ec1a560f4927cf4acdfbd1080800"
+                },
+                "consensus_voting_power": "1",
+                "last_config_update_time": "0"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x40ac0f46a93aa0ea000476aca120a17a18418f173264d4c7d72ff25b11395377",
+        "data": {
+          "type": "0x1::Version::Version",
+          "data": {
+            "major": "4"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x5fe56f2863f3ad7b7c5634ebe50a4aca579a43fcffed03d31e1bd13e729669e7",
+        "state_key_hash": "0xa4d5bb6608634f157b269dc31fb59b782cc2edb1fcefbd77d7975d6dac04f903",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x5fe56f2863f3ad7b7c5634ebe50a4aca579a43fcffed03d31e1bd13e729669e7",
+            "self_address": "0x5fe56f2863f3ad7b7c5634ebe50a4aca579a43fcffed03d31e1bd13e729669e7",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x5fe56f2863f3ad7b7c5634ebe50a4aca579a43fcffed03d31e1bd13e729669e7",
+        "state_key_hash": "0x7804dea12ab48e01dd5f28ce39831c505c7317b3d23d647c2a734eb5a99a8195",
+        "data": {
+          "type": "0x1::ValidatorOperatorConfig::ValidatorOperatorConfig",
+          "data": {
+            "human_name": "0x305f6f70657261746f72"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xf85fd00e30cd388d2609db24d6cc44f2652f27413456938eaa059f65231647cc",
+        "state_key_hash": "0xd20b0f35cf774f42e920b02768b0fe4de80a67c21f44b1d9c075ebb138546194",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x2d133ddd281bb6205558357cc6ac75661817e9aaeac3afebc32842759cbf7fa9",
+            "self_address": "0xf85fd00e30cd388d2609db24d6cc44f2652f27413456938eaa059f65231647cc",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xf85fd00e30cd388d2609db24d6cc44f2652f27413456938eaa059f65231647cc",
+        "state_key_hash": "0x705247e183c238b149f57d407af70f10b14b59d45d00feecb8bdf09349c6c794",
+        "data": {
+          "type": "0x1::ValidatorConfig::ValidatorConfig",
+          "data": {
+            "config": {
+              "vec": [
+                {
+                  "consensus_pubkey": "0xcc62332e34bb2d5cd69f60efbb2a36cb916c7eb458301ea36636c4dbb012bd88",
+                  "fullnode_network_addresses": "0x012d040000000000050c1c07203432fbf5b666fa771269cc7eb227146d3b16858f177a317ae8c349db210feb780800",
+                  "validator_network_addresses": "0x012d0400000000000524180720d5db8911156f3441c0757d97b8580cb639853454ec1a560f4927cf4acdfbd1080800"
+                }
+              ]
+            },
+            "human_name": "0x305f6f776e6572",
+            "operator_account": {
+              "vec": [
+                "0x5fe56f2863f3ad7b7c5634ebe50a4aca579a43fcffed03d31e1bd13e729669e7"
+              ]
+            }
+          }
+        }
+      }
+    ],
     "payload": {
       "type": "write_set_payload",
       "write_set": {
@@ -17,6 +4834,7 @@
           {
             "type": "write_resource",
             "address": "0x1",
+            "state_key_hash": "0x3502b05382fba777545b45a0a9d40e86cdde7c3afbde19c748ce8b5f142c2b46",
             "data": {
               "type": "0x1::Account::Account",
               "data": {
@@ -29,6 +4847,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x2919ba9c5f550ed4b85f3735ef6129545750d68d91a11574e905939dd78055f8",
             "data": {
               "bytecode": "0xa11ceb0b050000000b01000802080e031671048701100597015b07f201fa0108ec0320068c040a0a96040b0ca104d0020df10604000000010002000300040700000507000202070100000006000100000700020000080304000009040300000a050600000b040100000c040100000d000700000e080300000f090a0000100605000011060b00030d0d07010003130e0f010001140707000315101101000316120a010002171301010002181411010002190a140100021a111401000c040d040f041004110512051305140501060801010101060a020108000102010801010a0201030107080102070801080000010b020108010302030301060a090002060a0900030106090001070a090001090002070a0900090001060b02010900010b0201090003030302054153434949064572726f7273064f7074696f6e06566563746f72044368617206537472696e6718616c6c5f636861726163746572735f7072696e7461626c650861735f6279746573046279746504636861720a696e746f5f62797465731169735f7072696e7461626c655f636861720d69735f76616c69645f63686172066c656e67746808706f705f6368617209707573685f6368617206737472696e670a7472795f737472696e6705627974657306626f72726f7710696e76616c69645f617267756d656e7408706f705f6261636b09707573685f6261636b0769735f736f6d650c64657374726f795f736f6d65046e6f6e6504736f6d650000000000000000000000000000000000000000000000000000000000000001030800000000000000000002010802010201120a02000100000c230a00100038000c030600000000000000000c02280a020a0323030c05200a0010000a023801140c010b011105200317051b0b000109020b02060100000000000000160c020506280802010100000a030b001000020201000004050b0013000c010b0102030100000a090a00110603060700110e270b001200020401000006050b0013010c010b010205010000010e0a003120260305050a0b00317e250c01050c090c010b0102060100000a040b00317f2502070100000a040b001101380002080100000a050b000f003802120002090100000a070b000f000e011001143803020a0100000b0c0b00110b0c010e01380403090700110e270b013805020b01000015210e0038000c020600000000000000000c01280a010a0223030b051c0e000a013801140c030b03110620031505173806020b01060100000000000000160c010505280b0012013807020100000000",
               "abi": {
@@ -208,6 +5027,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x2fe51d3f72e53bc3068e56d32558e8b4f4709a6342457a41e8bd78dc95f78470",
             "data": {
               "bytecode": "0xa11ceb0b050000000c01001c021c0c0328f301049b020605a102a40107c503d10908960d2006b60dde020a9410260cba10a6060de016040fe41602000100020003000400050006000700080009000a000b000c000d000e00010c00000f0800073d04000010000100001100020000120002000013030400001401050000150005000016060100001707010000180601000019070100001a080100001b000900001c000400001d000a00001e0b0100001f0c010000200d010000210c01000022020100002303010000240e010000250f01000026100100073311010003340a0a0003350a0a000136130401000d37150a010005381116000d3917010100083a010100063b1101000b3c0301000c3c030100033e0a0a00073f191a0009401a0100054111000003420a0a000a4301090003440a0a000845010a0002460114000447040400071b0009000748000a0003490a0a000a4a1d09001a001b141d14010500020c0a0202060c0a02010a02010c030c050a0203060c050a02050c03030303010101030a060c050a020a020a020a020a020a020a0201070c030a0203030302090c030a020a050a0a0203030302080c030a02030303020a02030c0301050c030a02030201060c020a020c01060900010201060a090001060502070a09000a09000607080005080203030302060c0301080204030306080005020708000501060a020747656e65736973074163636f756e740342435307436861696e4964064572726f72730448617368065369676e65720f53797374656d4164647265737365730854657374436f696e0954696d657374616d700e5472616e73616374696f6e4665651b5472616e73616374696f6e5075626c697368696e674f7074696f6e0f56616c696461746f72436f6e6669671756616c696461746f724f70657261746f72436f6e66696706566563746f7218436861696e53706563696669634163636f756e74496e666f0e6372656174655f6163636f756e74176372656174655f6163636f756e745f696e7465726e616c186372656174655f6163636f756e745f756e636865636b6564196372656174655f61757468656e7469636174696f6e5f6b65791d6372656174655f636f72655f6672616d65776f726b5f6163636f756e740d6372656174655f7369676e6572186372656174655f76616c696461746f725f6163636f756e74216372656174655f76616c696461746f725f6163636f756e745f696e7465726e616c216372656174655f76616c696461746f725f6f70657261746f725f6163636f756e742a6372656174655f76616c696461746f725f6f70657261746f725f6163636f756e745f696e7465726e616c086570696c6f677565096578697374735f6174166765745f61757468656e7469636174696f6e5f6b6579136765745f73657175656e63655f6e756d6265720a696e697469616c697a650f6d6f64756c655f70726f6c6f6775651b6d756c74695f6167656e745f7363726970745f70726f6c6f6775650f70726f6c6f6775655f636f6d6d6f6e19726f746174655f61757468656e7469636174696f6e5f6b657922726f746174655f61757468656e7469636174696f6e5f6b65795f696e7465726e616c0f7363726970745f70726f6c6f6775651177726974657365745f6570696c6f6775651177726974657365745f70726f6c6f6775651261757468656e7469636174696f6e5f6b65790f73657175656e63655f6e756d6265720c73656c665f616464726573730b6d6f64756c655f616464720b6d6f64756c655f6e616d65147363726970745f70726f6c6f6775655f6e616d65146d6f64756c655f70726f6c6f6775655f6e616d651677726974657365745f70726f6c6f6775655f6e616d65196d756c74695f6167656e745f70726f6c6f6775655f6e616d6512757365725f6570696c6f6775655f6e616d651677726974657365745f6570696c6f6775655f6e616d651663757272656e63795f636f64655f726571756972656408726567697374657211616c72656164795f7075626c697368656410696e76616c69645f617267756d656e7408746f5f6279746573066c656e6774680e626f72726f775f6164647265737306617070656e640e6173736572745f67656e65736973146173736572745f636f72655f7265736f75726365077075626c69736804436f696e0e6c696d69745f6578636565646564087769746864726177086275726e5f6665650a616464726573735f6f661072657175697265735f616464726573731169735f6d6f64756c655f616c6c6f7765640d696e76616c69645f73746174650b6e6f775f7365636f6e64730367657408736861335f3235360a62616c616e63655f6f660d6e6f745f7075626c69736865641169735f7363726970745f616c6c6f776564000000000000000000000000000000000000000000000000000000000000000103080000000000000000030807000000000000000308060000000000000003080400000000000000030805000000000000000308030000000000000003080a00000000000000030809000000000000000308020000000000000003080b0000000000000003080100000000000000030808000000000000000410ffffffffffffffff00000000000000000308ec030000000000000308ef030000000000000308ed030000000000000308e9030000000000000308f2030000000000000308f1030000000000000308f0030000000000000308f3030000000000000308eb030000000000000308ea030000000000000308ee0300000000000005200000000000000000000000000000000000000000000000000000000000000000052000000000000000000000000000000000000000000000000000000000000000010520000000000000000000000000000000000000000000000000000000000a550c18000203270a02280329050102092a052b0a022c0a022d0a022e0a022f0a02300a02310a0232010002000005070b001101010c010e011117020101000001180a00290020030707001118270a00071822030e07031119270a00071922031507021119270b001102020200000012170a0011050c020e0038000c010e01380106200000000000000021030e07051119270e020a010600000000000000000b0012002d000b020b01020300000004110b010c020d020b00111c380038020e02380106200000000000000021030f07051119270b0202040300000507111e07191102010c000b0002050002000602000001050e000b010b0211070207010000050a0b00111f0b011101010c030e030b021120020802000001050e000b010b0211090209010000050a0b00111f0b011101010c030e030b021121020a0000010018380a030a0426030707041119270b030b04170c080a02350a083518070c25031607041122270b020b08180c0a0e000b0a11230c070b0711240e0011250c060a06110d0c090a0935070c23032e070a1122270b062a000c050b09060100000000000000160b050f0015020b01000001030b002900020c0100010001050b002b00100114020d0100010001050b002b00100014020e01000001170a001125071a21030a0b000107081126270b000b010b020b030b040b050b060b070b080b0912012d01020f00000100010e1127030507121128270b000b010b020b030b040b050b06111102100000000103070711192711000001001b5911290b0523030707171119270e0011250c0a112a0b06210311070e1119270a0a29000317070d1119270a0a2b000c090b02112b0a091001142103260b090107101119270a0135070c2303300b090107141122270a010a0910001426033b0b090107161119270b010b0910001421034407151119270b030b04180c080a0a112c034e070f1119270b0a112d0c070b070b08260358070f11192702120200010001040e000b0111130213010001001c190b0011250c030a03110b03090700112e270e01380106200000000000000021031107051119270b032a000c020b010b020f0115021400000100010f0e07112f030607131128270b000b010b020b030b040b050b06111102150000000103070b111927160000000103071111192700010000000000",
               "abi": {
@@ -440,6 +5260,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xe7c46aba2fa4aa3b56c0adee4075dc8d2518ea3d3c35d094584f52c44d7e54e7",
             "data": {
               "bytecode": "0xa11ceb0b0500000006010002030206050807070f0d081c200c3c04000000010001010001060900010a020342435308746f5f627974657300000000000000000000000000000000000000000000000000000000000000010001020000",
               "abi": {
@@ -470,6 +5291,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xaee1008f6bec7a796661e761e643736d4ce392281ee2efe1f97f3fc7f556b364",
             "data": {
               "bytecode": "0xa11ceb0b050000000b010006020604030a4604500a055a4b07a501a30108c8022006e8021e0a8603080c8e03f1030dff0604000000010002000007000003000100000402030000050003000006030400000705060000080506000009050600020407030100010b030300020c08090100020d060b0100020e0c060100020f0e0f0100070109010a010b010c010206080003010101060800010301080002070800030001060a090002060a09000301060900020a0103010a090002070a0900090001070102070a090003010709000607080003070103030309426974566563746f72064572726f727306566563746f720c69735f696e6465785f736574066c656e677468206c6f6e676573745f7365745f73657175656e63655f7374617274696e675f6174036e6577037365740a73686966745f6c65667405756e736574096269745f6669656c6410696e76616c69645f617267756d656e7406626f72726f7705656d70747909707573685f6261636b0a626f72726f775f6d7574000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000308000400000000000000020204030a0a010001000006110a010a001000380023030b0b000107001108270b0010000b01380114020101000006040b0010003800020201000003260a010a0010011423030b0b000107001108270a010c020a020a0010011423031405220a000a02110020031a051d0b000105220b02060100000000000000160c02050d0b020b011702030100000a250a0006000000000000000024030707011108270a00070223030e07011108270600000000000000000c0238020c01280a020a0023031805200d010938030b02060100000000000000160c020512280b000b01120002040100000d140a010a001000380023030b0b000107001108270b000f000b0138040c02080b02150205010000105d0a010a0010011426030705220a00100038000c070600000000000000000c050a050a07230312051f0a000f000a0538040c04090b04150b05060100000000000000160c05050d0b0001055c0a010c060a060a0010011423032b05450a000a060c030c020b022e0b0311000335053b0a000a060a0117110405400a000a060a011711060b06060100000000000000160c0605240a001001140b01170c060a060a00100114230352055a0a000a0611060b06060100000000000000160c06054b0b000102060100000d140a010a001000380023030b0b000107001108270b000f000b0138040c02090b0215020001000000",
               "abi": {
@@ -582,6 +5404,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x87b07aa352041a9cb02fdf5ef467f5b2c0be6f867836ecd668e51b9972386bee",
             "data": {
               "bytecode": "0xa11ceb0b050000000b01000c020c0e031a4d046704056b2d079801ad0308c5042006e504580abd05170cd405ad010d8107040000000100020003000400050006080000070600020e0401060100080001000009010200000a030100000b010400041301010003140301000515060400011602020004170701000218090101060119020200041a010100031b030100011c020200021d030a010609080e08050c03030a050500010301060c01010201070800010503060c050301080102070b020109000900010b0201090005426c6f636b064572726f7273054576656e740f53797374656d4164647265737365730954696d657374616d700c56616c696461746f725365740d426c6f636b4d657461646174610d4e6577426c6f636b4576656e740e626c6f636b5f70726f6c6f677565186765745f63757272656e745f626c6f636b5f68656967687419696e697469616c697a655f626c6f636b5f6d657461646174610e69735f696e697469616c697a656406686569676874106e65775f626c6f636b5f6576656e74730b4576656e7448616e646c6505726f756e640870726f706f7365721470726576696f75735f626c6f636b5f766f7465731174696d655f6d6963726f7365636f6e6473106173736572745f6f7065726174696e67096173736572745f766d0c69735f76616c696461746f721072657175697265735f61646472657373127570646174655f676c6f62616c5f74696d650a656d69745f6576656e740d6e6f745f7075626c69736865640e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c6973686564106e65775f6576656e745f68616e646c6500000000000000000000000000000000000000000000000000000000000000010308000000000000000003080100000000000000052000000000000000000000000000000000000000000000000000000000000000000520000000000000000000000000000000000000000000000000000000000a550c180002020c030d0b020108010102040f031005110a0512030000000100052b11040e0011050a040702210308050b080c05050e0a0411060c050b050313070111072707032a000c060e000a040a0211080a06100014060100000000000000160a060f00150b060f010b010b040b030b0212013800020101000100010a110303050700110a2707032b0010001402020100000112110b0a00110c110320030b0b00010700110d270a000600000000000000000b00380112002d000203000000010307032900020000000100",
               "abi": {
@@ -661,6 +5484,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xfe8b9a022a52739d1e52f5391da7cb6e9caf54e93962f3d727c49bee337d240a",
             "data": {
               "bytecode": "0xa11ceb0b050000000d01000802081803206e048e011205a00178079802ae0208c6042006e604140afa04150b8f05080c9705d8020def07080ef707080000000100020003000403010001000508010001000608010001000702010001000800010100000900020100000a03040102000b00040100000c05040100000d06070100000e08040102000f0904010000100a07010000110b07010003140d0e010003150304010002160b070001170f0f0003180410010003190d120100031a130c0100011b0f0f00011c0f0f00090c0a0c0b0c0e0702070f0c100c06070a0702060c060900010b00010900010b0301090002070a0900090000030b00010900060900060c020b03010900060900010502070a0900060900030b0001090006090005020b0001090006090001060c01090002060a090006090001010103010a090004070a0900060900010302010302070a090003030505050a4361706162696c697479064572726f7273065369676e657206566563746f72034361701043617044656c65676174655374617465084361705374617465094c696e65617243617007616371756972650e616371756972655f6c696e6561720b6164645f656c656d656e74066372656174650864656c6567617465106c696e6561725f726f6f745f616464720e72656d6f76655f656c656d656e74067265766f6b6509726f6f745f616464721076616c69646174655f6163717569726504726f6f740964656c65676174657308636f6e7461696e7309707573685f6261636b0a616464726573735f6f6611616c72656164795f7075626c697368656405656d70747908696e6465785f6f660672656d6f76650d696e76616c69645f73746174650d6e6f745f7075626c69736865640000000000000000000000000000000000000000000000000000000000000001030800000000000000000308010000000000000000020112050102011205020201130a050302011205000c030c020c010c00010002010204040b00380039000201010002010204040b0038003901020200000008120a000e010c030c020b022e0b03380120030b050f0b000b01380205110b0001020301000007110a00110c0c020b023b0220030c0b00010700110d270b00380339023f0202040100010207180a02110c0c030a033b030307050a0b0201020b020e0037001439033f030e003700143c0236010b033804020501000004040e00370214020600000011150a000b010c030c020b022e0b0338050c050c040b04030d05120b000b0538060105140b00010207010002010207120a023b032003050506020a023e033a03010e003700143c0236010e023807020801000004040e003700140209000002010214280b00110c0c020a023b030307051e0a023d033703140c030a033b02031207011111270a033d0237010e023808031b07011111270b030c0105260a023b02032407001112270b020c010b01020000020003000100000c010c020c030c00",
               "abi": {
@@ -862,6 +5686,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xe428253ccf0b18f3d8300c6a0d29de93abcdc526e88728abeb85d57aec558935",
             "data": {
               "bytecode": "0xa11ceb0b050000000a01000a020a04030e2305310e073f940108d3012006f3012c0a9f02050ca402370ddb020200000001000200030004000008000005000100000602000004080000000409000000030a030000020b030400010c05050000010202060c0201060c0105010307436861696e4964064572726f7273065369676e65720f53797374656d4164647265737365730954696d657374616d70036765740a696e697469616c697a65026964106173736572745f6f7065726174696e670e6173736572745f67656e65736973146173736572745f636f72655f7265736f757263650a616464726573735f6f6611616c72656164795f7075626c69736865640000000000000000000000000000000000000000000000000000000000000001030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201070200010001000006110207012b001000140201010000001211030a0011040a001105290020030d0b000107001106270b000b0112002d0002000000",
               "abi": {
@@ -911,6 +5736,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xd7d01f14e6e00800c0211d2e6d0626f9330cc447b0c13c10974481f8dcc7d25a",
             "data": {
               "bytecode": "0xa11ceb0b050000000b01000c020c04031024043402053615074ba60108f101200691022c0abd02060cc3023f0d82030200000001000200030004000500000800000600010000070201000409010100030a000100010b030300050c01050100020d010100050401060c0002060c0a0201030102010a090001070a020f436f6e73656e737573436f6e666967064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d7006566563746f720a696e697469616c697a650373657406636f6e6669670e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c697368656405656d7074790b7265636f6e6669677572650000000000000000000000000000000000000000000000000000000000000001030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201080a0200010000011111020a0011030701290020030c0b000107001104270b00380012002d00020101000100060b0b00110307012a000f000c020b010b0215110602000000",
               "abi": {
@@ -960,6 +5786,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x5e829d633d861f80a0d3c5c4a88204062c0ab681484838700be0d4f411727670",
             "data": {
               "bytecode": "0xa11ceb0b0500000007010002030237053906073f9d0108dc012006fc011e0c9a0292010000000100000000020000000003000000000400000000050000000006000000000701000000080000000009000000000a000000000b000000010302020300064572726f727311616c72656164795f7075626c697368656406637573746f6d08696e7465726e616c10696e76616c69645f617267756d656e740d696e76616c69645f73746174650e6c696d69745f6578636565646564046d616b650d6e6f745f7075626c69736865641072657175697265735f616464726573731372657175697265735f6361706162696c6974790d72657175697265735f726f6c6500000000000000000000000000000000000000000000000000000000000000010201060201ff02010a02010702010102010802010502010202010402010300010000020407000b0011060201010000020407010b0011060202010000020407020b0011060203010000020407030b0011060204010000020407040b0011060205010000020407050b001106020600000002070b00340b0131082f160207010000020407060b0011060208010000020407070b0011060209010000020407080b001106020a010000020407090b0011060200",
               "abi": {
@@ -1085,6 +5912,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xd08a133ae22fc988a2cb20313b2568273f971076d6e313a41ecea1b5a47e3132",
             "data": {
               "bytecode": "0xa11ceb0b050000000c0100060206120318290441040545330778a80108a002200ac002170bd702020cd902640dbd03060ec30304000000010002000304010601000408000005060002020600000600010106000702010106000803040106000905000106000a06010106010e090a0100020f05080005080407010b000109000002070b00010900090001060b000109000106080301060c030a0203090001090001080301060900010a020102054576656e740342435304475549440b4576656e7448616e646c65144576656e7448616e646c6547656e657261746f720b47554944577261707065720e64657374726f795f68616e646c650a656d69745f6576656e740467756964106e65775f6576656e745f68616e646c651477726974655f746f5f6576656e745f73746f726507636f756e7465720461646472096c656e5f627974657308746f5f62797465730663726561746500000000000000000000000000000000000000000000000000000000000000010002020b030808020102020b030c050202020d0208080300070001000001050b003a000101020101000001120a003700100138000a003701140b0138010a00370114060100000000000000160b00360115020201000001040b003700100102030100000b0706000000000000000031280b0011061202390002040002000001020100000007020700",
               "abi": {
@@ -1233,6 +6061,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x9d2a6ab98492524c0d5976309b99aa7918eed8931aeb7714a29fd166188f2086",
             "data": {
               "bytecode": "0xa11ceb0b050000000a0100040204040308280530170747930108da012006fa01440abe02050cc30293020dd6040200000001000007000002000100000302010000040302000005010200000601040000070302000109020200010a02020002030301080001030203080001010401040404000204040c4669786564506f696e743332064572726f7273146372656174655f66726f6d5f726174696f6e616c156372656174655f66726f6d5f7261775f76616c75650a6469766964655f7536340d6765745f7261775f76616c75650769735f7a65726f0c6d756c7469706c795f7536340576616c756510696e76616c69645f617267756d656e740e6c696d69745f6578636565646564000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000308030000000000000003080200000000000000030804000000000000000410ffffffffffffffff000000000000000000020108030001000005310a003531402f0c050b013531202f0c040a04320000000000000000000000000000000022031107001106270b050b041a0c030a03320000000000000000000000000000000022031a051d080c0205210b00060000000000000000210c020b02032607041106270a03070525032d07041107270b03341200020101000006030b0012000202010000071f0e0110001406000000000000000022030907021106270b003531202f0c030b030e01100014351a0c020a02070525031c07011107270b0234020301000006040e00100014020401000006060e0010001406000000000000000021020501000007160b00350e0110001435180c030b033120300c020a02070525031307031107270b023402000000",
               "abi": {
@@ -1334,6 +6163,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x6381f16dc6bae2e614dba7bb20b67727a383e30bab1b8bd6680a89f5644543b5",
             "data": {
               "bytecode": "0xa11ceb0b050000000a010004020410031446055a2f078901fd010886032006a6030a0ab003170cc703ba020d8106080000000100020e0000000600000308000004070000050001000006020300000704010000080501000009060700000a060400000b080900000c000a00000d040700000e060300000f0b070000100b04000011000c00011400040001060c01080102050301080301050205060800010608010103020608010608030101010800010608030002030708020447554944065369676e6572104372656174654361706162696c6974790947656e657261746f7202494406637265617465096372656174655f69640b6372656174655f696d706c166372656174655f776974685f6361706162696c6974790c6372656174696f6e5f6e756d0f63726561746f725f616464726573730565715f69641567656e5f6372656174655f6361706162696c697479156765745f6e6578745f6372656174696f6e5f6e756d0269640f69645f6372656174696f6e5f6e756d1269645f63726561746f725f61646472657373117075626c6973685f67656e657261746f72046164647207636f756e7465720a616464726573735f6f6600000000000000000000000000000000000000000000000000000000000000010308000000000000000000020112050102010e0803020201130303020209031205000100010204120a00110d0c010a012902200308050d0b0006000000000000000012022d02050f0b00010b01110202010100000c040b010b0012030202000001020d120a002a020c020a021000140c010a01060100000000000000160b020f00150b010b00120312010203010001020c080a00290203050700270b00110202040100000c050b00100110021402050100000c050b00100110031402060100000c050b0010010b0121020701000004120a00110d0c010a012902200308050d0b0006000000000000000012022d02050f0b00010b011200020801000102070f0a00290220030505080600000000000000000c01050d0b002b021000140c010b0102090100000c040b00100114020a0100000c040b00100214020b0100000c040b00100314020c0100000c050b0006000000000000000012022d0202020001000300030100",
               "abi": {
@@ -1548,6 +6378,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x825604f38d0c62c17921995d0d6ab57da6cf371316640b3c12456e9bb081685e",
             "data": {
               "bytecode": "0xa11ceb0b050000000901002202220603289f0104c7010c05d301cc01079f03960508b5082006d50889010cde09b9040000000100020003000400050006000700080009000a000b000c000d000e000f00100524040106010011000100001202010000130301000f14060701000f15090a010007160b0c0001170d010001180e010001190c0f00011a0d01000d1b0c08000c1c1001000c1d1101000e1e1001000112120100011f0c1300012001050004120b01000e210b010010121401000b1215010004220e01000a121601000812140100082317010005250b180106052618010106031219010006120b010002270b010009280b0100030503080405040819071a070a0c0a0c0a0a020a0a020a0a020a0c0a0a020a0a020a0a020a0a02000a0c0a020a0a02010a020a0202030a02030a060c0a020a0a02010a020a0202030a0203140a020a02030303030303030303060c050a020a02060c050a020a020a02010c01060a09000103010a0202060a0900030106090001060c010503060c050a0202060c0a02010102060c0505060c050a020a020a020a060c050a020a020a020a020a020a020a0201020c0a0202060c0304060c0a020a020303060c0a0a020103060c0503010b0001090002060c020747656e65736973074163636f756e7405426c6f636b07436861696e49640f436f6e73656e737573436f6e666967054576656e740f5265636f6e66696775726174696f6e065369676e65720854657374436f696e0954696d657374616d701b5472616e73616374696f6e5075626c697368696e674f7074696f6e08564d436f6e6669670f56616c696461746f72436f6e6669671756616c696461746f724f70657261746f72436f6e6669670c56616c696461746f7253657406566563746f720756657273696f6e226372656174655f696e697469616c697a655f6f776e6572735f6f70657261746f72730a696e697469616c697a6513696e697469616c697a655f696e7465726e616c066c656e67746806626f72726f770a616464726573735f6f66216372656174655f76616c696461746f725f6163636f756e745f696e7465726e616c22726f746174655f61757468656e7469636174696f6e5f6b65795f696e7465726e616c096578697374735f61742a6372656174655f76616c696461746f725f6f70657261746f725f6163636f756e745f696e7465726e616c0e6765745f68756d616e5f6e616d650c7365745f6f70657261746f720a7365745f636f6e666967166164645f76616c696461746f725f696e7465726e616c176372656174655f6163636f756e745f696e7465726e616c1d6372656174655f636f72655f6672616d65776f726b5f6163636f756e7418696e697469616c697a655f76616c696461746f725f736574037365740d6d696e745f696e7465726e616c0b4576656e7448616e646c65106e65775f6576656e745f68616e646c650e64657374726f795f68616e646c6519696e697469616c697a655f626c6f636b5f6d65746164617461147365745f74696d655f6861735f737461727465640000000000000000000000000000000000000000000000000000000000000001052000000000000000000000000000000000000000000000000000000000000000010a0208074163636f756e740a02100f7363726970745f70726f6c6f6775650a02100f6d6f64756c655f70726f6c6f6775650a02121177726974657365745f70726f6c6f6775650a0209086570696c6f6775650a02121177726974657365745f6570696c6f6775650000000004aa010e0138000c130e0238010c120a130a1221030c060000000000000000270e0338010c110b120a11210315060000000000000000270e0538000c100b110a1021031e060000000000000000270e0638010c0f0b100a0f210327060000000000000000270e0738010c0e0b0f0a0e210330060000000000000000270e0838010c140b0e0a14210339060000000000000000270e0938010c0d0b140b0d210342060000000000000000270600000000000000000c0c0a0c0a1323034905a9010e010a0c38020c190a1911050c1a0e020a0c3803140c1c0e000a1a0b1c11060e030a0c3803140c1b0a190b1b11070e050a0c38020c150a1511050c160e060a0c3803140c180a161108200372057e0e000a160a1811090e070a0c3803140c170a150b1711070a16110a0b18210389010b19010b1501060000000000000000270b190b16110b0e080a0c3803140c1d0e090a0c3803140c0b0e040a0c3803140c0a0b150a1a0b0a0b1d0b0b110c0e000b1a110d0b0c060100000000000000160c0c05440201000000010c0e000b010b020b030b040b050b060b070b080b091102020200000005430a000700070107020703070407020705070609110e0a001105110f01010a000a01110711100c0a0e0a0b0111070a0011110a0011120a000b0711130a000b040b050b0911140a000b0811150a000b020b0311160a000640420f000000000011170a000a00110506ffffffffffffffff11180a00380438050a00380438050a000b06111b0a00111c0a00111d0b00111e0200",
               "abi": {
@@ -1562,6 +6393,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xe2ae97cbf2c1281ac9db9c74afd12dda59793a59b62fe45d10671cb38611bc06",
             "data": {
               "bytecode": "0xa11ceb0b050000000601000203020a050c03070f170826200c4608000000010000000002000000010a02044861736808736861325f32353608736861335f3235360000000000000000000000000000000000000000000000000000000000000001000102000101020000",
               "abi": {
@@ -1599,6 +6431,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x575c96840ac15e64ebd62878d4af35b88806031ae2f323ed1a6237b48674e1fd",
             "data": {
               "bytecode": "0xa11ceb0b050000000d010006020606030c9b0104a7011a05c1019c0107dd028c0208e90420068905140a9d05070ba405020ca605e9030d8f09020e910902000000010002000007010000000300010100000402030100000504010100000604050100000706070100000806080100000909080102000a02080100000b0a070100000c0b080103000d00050100000e00050100000f0706010000100806010000110a08010000120a06010001140c0c0002030d01010002040e030100021510050100020611050100021612070100021714080100021815070100021907120100021a081201000b0811081208130814080a08150816081708180819080c080d0801060b000109000106090001070b000109000107090002060b000109000609000101010b0001090000010900020b00010900090002070b00010900090002060b000109000900010302060a09000302070a09000302060900060a090001060a090002060a0900060900010a09000209000a090001070a090002070a09000900020900060a0900020900070a0900030b000109000b00010900070a0900064f7074696f6e064572726f727306566563746f7206626f72726f770a626f72726f775f6d757413626f72726f775f776974685f64656661756c7408636f6e7461696e730c64657374726f795f6e6f6e650c64657374726f795f736f6d651464657374726f795f776974685f64656661756c7407657874726163740466696c6c106765745f776974685f64656661756c740769735f6e6f6e650769735f736f6d65046e6f6e6504736f6d6504737761700c737761705f6f725f66696c6c0376656310696e76616c69645f617267756d656e740869735f656d7074790d64657374726f795f656d70747908706f705f6261636b09707573685f6261636b05656d7074790973696e676c65746f6e00000000000000000000000000000000000000000000000000000000000000010308000000000000000003080100000000000000000201130a0900000800010000070d0a00380003080b000107011110270b00370006000000000000000038010201010000070e0a002e380003090b000107011110270b003600060000000000000000380202020100000f140b0037000c030a0338030307050c0b03010b010c0205120b01010b0306000000000000000038010c020b02020301000007050b0037000b0138040204010000120c0e003805030607001110270b003a000c010b013806020501000013100e003800030607011110270b003a000c020d0238070c010b0238060b01020601000013100b003a000c030d032e38030308050b0b010c02050e0d0338070c020b020207010000070d0a002e380003090b000107011110270b0036003807020801000014100b0036000c020a022e3803030c0b020107001110270b020b013808020901000016130b0037000c030a0338030307050c0b03010b010c0205110b030600000000000000003801140c020b02020a01000007040b0037003803020b01000007050b003700380320020c010000070338093900020d01000007040b00380a3900020e01000017140a002e380003090b000107011110270b0036000c030a0338070c020b030b0138080b02020f01000018160b0036000c040a042e38030308050b380b0c02050f0a043807380c0c020b020c030b040b0138080b03020000000800",
               "abi": {
@@ -1882,6 +6715,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x0f9c518f531ac3d732301355e37e9dc9d48fa443047f4c18cf3fc65d8fc33bfe",
             "data": {
               "bytecode": "0xa11ceb0b050000000c01000e020e1203205c047c040580012807a801c00408e805200688065e0ae606170cfd069d030d9a0a060fa00a0c0006000700080009000a000b000c000d0800000e0800000f0600021a040106010010000100001101010000120001000013000100001401020000150101000016010100051c000100011d030300011e030300021f060101060420000700062101010001220303000323070300022400080106062501020006260103000a050f0501060c0001010103020107080001080202070b0301090009000105010b0301090004010107080003074163636f756e740f436f6e73656e737573436f6e6669671b5472616e73616374696f6e5075626c697368696e674f7074696f6e08564d436f6e6669670c56616c696461746f725365740756657273696f6e0f5265636f6e66696775726174696f6e064572726f7273054576656e740447554944065369676e65720f53797374656d4164647265737365730954696d657374616d700d436f6e66696775726174696f6e1644697361626c655265636f6e66696775726174696f6e0d4e657745706f63684576656e741764697361626c655f7265636f6e66696775726174696f6e22656d69745f67656e657369735f7265636f6e66696775726174696f6e5f6576656e7416656e61626c655f7265636f6e66696775726174696f6e0a696e697469616c697a65177265636f6e66696775726174696f6e5f656e61626c65640b7265636f6e6669677572650c7265636f6e6669677572655f0565706f6368196c6173745f7265636f6e66696775726174696f6e5f74696d65066576656e74730b4576656e7448616e646c650b64756d6d795f6669656c64146173736572745f636f72655f7265736f757263650d696e76616c69645f73746174650d6e6f745f7075626c69736865640a656d69745f6576656e740a616464726573735f6f660e6173736572745f67656e6573697311616c72656164795f7075626c6973686564156765745f6e6578745f6372656174696f6e5f6e756d106e65775f6576656e745f68616e646c650a69735f67656e65736973106e6f775f6d6963726f7365636f6e6473000000000000000000000000000000000000000000000000000000000000000103080100000000000000030800000000000000000308030000000000000003080400000000000000030802000000000000000308ffffffffffffffff0520000000000000000000000000000000000000000000000000000000000a550c1800020317031803190b030108020102011b01020201170300000000010e0a001107110403090b000107011108270b000912012d01020100000100042c070629000306070111092707062a000c010a0110001406000000000000000021031005170a01100114060000000000000000210c000519090c000b0003200b010107011108270601000000000000000a010f00150a010f020b011000141202380002020000010101100a001107110420030a0b000107011108270b00110b2c011301010203010000011f110c0a0011070706290020030c0b00010701110d270a00110b110e0604000000000000002103170b000107031108270a000600000000000000000600000000000000000b00380112002d00020400000001040706290120020503000100010211060206000001000945111003030506080c00050a1111060000000000000000210c000b00030d0510080c0105131104200c010b01031605170207062a000c0211110c030a030a0210011421032305260b0201020a030a021001142403310b020107021108270b030a020f01150a02100014060100000000000000160a020f00150a020f020b02100014120238000200000001000200000001000200030004000500",
               "abi": {
@@ -1972,6 +6806,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x1c7e2c034ee74231f152214ed7888b888736f3f52518b75d7af69570d338bb7a",
             "data": {
               "bytecode": "0xa11ceb0b050000000601000203020a050c0c0718310849200c6908000000010001000002020100010a020101030a020a020a02095369676e617475726517656432353531395f76616c69646174655f7075626b65790e656432353531395f7665726966790000000000000000000000000000000000000000000000000000000000000001000102000101020000",
               "abi": {
@@ -2011,6 +6846,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xdf3fee0bf8e5d44605b4b6d43bdf7616bf18a223c0a953d58f49d03330a9a3f8",
             "data": {
               "bytecode": "0xa11ceb0b050000000601000203020a050c090715210836200c561000000001000100000200020001060c010501060500065369676e65720a616464726573735f6f660e626f72726f775f6164647265737300000000000000000000000000000000000000000000000000000000000000010001000003040b00110114020101020000",
               "abi": {
@@ -2048,6 +6884,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x776aab497ed2722389b1ea4e9d5c9fad0080a95d34c5c20b0873e68f317a842d",
             "data": {
               "bytecode": "0xa11ceb0b050000000901000402040403080b04130205151c073155088601200aa601050cab0120000000010000070000020001000104030101040102060c0a020a020a02030a0200010800070c0a020a020a02030a0209000b53696d706c65546f6b656e05546f6b656e136372656174655f73696d706c655f746f6b656e0c6d616769635f6e756d626572216372656174655f746f6b656e5f776974685f6d657461646174615f7363726970740000000000000000000000000000000000000000000000000000000000000001000201030300020000010a0b000b010b020b030b040b05062a00000000000000120038000200",
               "abi": {
@@ -2094,6 +6931,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x708a4495d604e5104a7491529cefcd59d146666ae3e54b1cb642afc2a7886f6f",
             "data": {
               "bytecode": "0xa11ceb0b050000000b01000c020c140320ab0104cb012205ed01f70107e403dd0508c1092006e109360a970a390cd00abe080d8e131c00000001000200030004000500060400000704000008080000090800030b0400000a00010100000c020100000d030100000e040500000f06010000100708000011090100001209010000130a010000140b010000150c0100001607010000170d010000180d010000190e0f00052a11080100052b12100100052c13010100042d010500012e090700032f150500053011050100053117180100033201190003331a010005341c1d010002350901000536011e0100053720080100053820230100053917100100033a2901000f1010101110110f150f160f190f1b071c0711071d071e07150719071b0f000f1e0f02070a0900070a09000004060c0508040301070a080002060a080005010303060c03030105010101060c0107080303060c0a020a0202060c0a0202060c0502070a08000501080001090001060a090001070a090002070a09000900060804030503080007080101060804040708000303080402070a0900030107090001080402070804080403060800030302060a09000301060900010a09000106080302060a0900060900030507080207080304050103070803020103040503030306030a08000a08000a08000a0800080102050708030403030307080106050804030800010708010205080404050804080007080103070a08000503055374616b65065369676e65720f53797374656d4164647265737365730854657374436f696e0954696d657374616d7006566563746f720a44656c65676174696f6e095374616b65506f6f6c0d56616c696461746f72496e666f0c56616c696461746f7253657406617070656e6404436f696e0e64656c65676174655f7374616b6511646973747269627574655f7265776172640466696e6418696e697469616c697a655f76616c696461746f725f7365740c69735f76616c696461746f72126a6f696e5f76616c696461746f725f736574136c656176655f76616c696461746f725f7365740c6f6e5f6e65775f65706f63681c72656769737465725f76616c696461746f725f63616e64696461746514726f746174655f636f6e73656e7375735f6b6579117570646174655f7374616b655f706f6f6c0f77697468647261775f6163746976651177697468647261775f696e6163746976651177697468647261775f696e7465726e616c04636f696e0466726f6d116c6f636b65645f756e74696c5f736563730d63757272656e745f7374616b650661637469766508696e6163746976650e70656e64696e675f6163746976651070656e64696e675f696e6163746976650a7374616b655f706f6f6c10636f6e73656e7375735f7075626b65790f6e6574776f726b5f6164647265737310636f6e73656e7375735f736368656d650d6d696e696d756d5f7374616b650d6d6178696d756d5f7374616b650a76616c696461746f7273156c6173745f7570646174655f74696d655f736563730869735f656d70747908706f705f6261636b09707573685f6261636b0b6e6f775f7365636f6e64730a616464726573735f6f660576616c7565066c656e6774680a626f72726f775f6d7574047a65726f056d6572676506626f72726f77146173736572745f636f72655f7265736f7572636505656d70747908636f6e7461696e7308696e6465785f6f660b737761705f72656d6f7665076465706f7369740000000000000000000000000000000000000000000000000000000000000001030880510100000000000308100e0000000000000520000000000000000000000000000000000000000000000000000000000a550c180002031a08041b051c030102051d031e0a08001f0a0800200a0800210a0800020203220801230a02240a02030205250226032703280a0529030000000001100a012e3800200306050b0a000a013801380205000b01010b000102010000020203143411120c070b070700160a0323030c0b0001060000000000000000270a012a020f000c090b020c040b030c050b0011130c060b040b060b0512000c080b011105032005250b090f010b08380305330a091002140e0810031114160a090f02150b090f040b0838030202000000161d0600000000000000000c020a002e38040c030a020a0323030b051a0a000a0238050c0111170c040b010f030b0411180b02060100000000000000160c0205060b000102030000001b220600000000000000000c030a0038040c040a030a0423030a051e0a000a0338060c020b021005140a0121031505190b00010b03020b03060100000000000000160c0305050b00010600000000000000002704000000010b0a00111a0b0031000b010b023807111212032d030205000001031f080a002b030c010b0110060e0038080206000002020321380b0011130c010a012a020c0207022a030c030a0310060e0138082003150b03010b0201060000000000000000270a0210001002140a031007142603240b03010b0201060000000000000000270b0210001002140a031008142503310b0301060000000000000000270a0311080b030f060b0138090207000002020322220b0011130c0107022a030c040a0410060e01380a0c030c020b0203120b0401060000000000000000270a0411080a040f060b03380b010b041006380c06000000000000000024032106000000000000000027020800000102242d11120c020a001009140701160a0223030e0b0001060000000000000000270b020a000f09150600000000000000000c030a001006380c0c040a030a0423031d052a0a0010060a03380d140c010b01110b0b03060100000000000000160c0305180b000102090000002516380e0c04380e0c05380e0c06380e0c070600000000000000000b040b070b050b0612010c080b000b080b010b0212022d02020a000002020326170b0011130c0207022a030c030b010a022a020f0a150a0310060e023808031105140b03110805160b0301020b0000010227340b002a020f000c040a040f0411020a040f0b11020a040f040a040f01380f0a040f0c0a040f0b380f0600000000000000000c010600000000000000000c020a04100438040c030a020a03230321052f0b010a0410040a02380610031114160c010b02060100000000000000160c02051c0b010b040f0215020c0000020203282f0b0011130c0211120c040a012a020f000c070a070f0c0a02110e0c050b0111050c060b0620031505200b07010b05130001010c030b020b03111f052e0e05100d140b0423032a0b0701060000000000000000270b070f0b0b053803020d000001022a150b0011130c020b012a020f000c050b050f0c0a02110e0c040b04130001010c030b020b03111f020e0000002b0d0a000b010c030c020b022e0b0311030c040b000b043810020200010301000000010100010303030103020304020101040102000200",
               "abi": {
@@ -2213,6 +7051,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xc4aebacf8a405ac49ac6021ebfdaf607b74d008ee4ad3d46c01c2419179d1535",
             "data": {
               "bytecode": "0xa11ceb0b050000000701000603061e05240a072e8f0108bd012006dd01580cb5024000000001000200030001000004020100000500010000060203000207000200010804040001060c000105010101030f53797374656d416464726573736573064572726f7273065369676e6572146173736572745f636f72655f7265736f757263651c6173736572745f636f72655f7265736f757263655f61646472657373096173736572745f766d1869735f636f72655f7265736f757263655f616464726573730a616464726573735f6f661072657175697265735f6164647265737300000000000000000000000000000000000000000000000000000000000000010308000000000000000003080100000000000000052000000000000000000000000000000000000000000000000000000000000000000520000000000000000000000000000000000000000000000000000000000a550c180001000001040b0011041101020101000001070b00110303060700110527020201000001090b00110407022103080701110527020301000001040b000703210200",
               "abi": {
@@ -2266,6 +7105,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x6fd26ff28836349d70c072893be8cd17d3f5fbd0c1588c0639733f61fd1ed8f1",
             "data": {
               "bytecode": "0xa11ceb0b050000000d010008020816031e8c0104aa011a05c401d101079503d20108e70420068705140a9b05150bb005040cb405e9020d9d08060ea308060000000100020003000004020400040000040402040004000202070100000005000102040400060203020404000700040204040008050602040400090708020404000a0807020404000b0009020404000c0a07020404000d020b02040402110d040100011206060002050d0e01000305100e0100030612130100031314060100031407150100030a1507010002151819010002160719010002170d04010003181b070100031912180100060b09060b060c0f0d0f0e0f0f0f100f110612061306140f150f02060b0002090009010609000106090102070b00020900090106090001070901010101060b000209000901010300010b000209000901010b02010303070b00020900090109000901020900090102030b02010301060b0201090001060900010b01020900090102060a09000304070b000209000901060900030b02010302070a0900030107090001060a0900010a0900010a0b010209000901020303010900010b0201090003070b0002090009010609000b02010302070a0900090006070b0002090009010609000309000b0201030901055461626c65064572726f7273064f7074696f6e06566563746f720c5461626c65456c656d656e7406626f72726f770a626f72726f775f6d75740c636f6e7461696e735f6b657905636f756e74066372656174650d64657374726f795f656d7074790466696e6406696e736572740672656d6f76650464617461036b65790576616c75650769735f736f6d6510696e76616c69645f617267756d656e74066c656e67746805656d70747904736f6d65046e6f6e650769735f6e6f6e6509707573685f6261636b0b737761705f72656d6f7665000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000002010e0a0b0102090009010102020f0900100901000b010b000100000c160a000b0138000c030e033801030c0b00010701110a270e033802140c020b0037000b02380337010201010000111b0a000b010c030c020b022e0b0338000c050e05380103110b00010701110a270e053802140c040b0036000b0438043601020201000009070b000b0138000c020e023801020301000007040b00370038050204010000070338063900020501000016060b003a000c010b013807020600000017260a00370038050c030600000000000000000c020a020a0323030b05200a0037000a02380337020a01210314051b0b00010b01010b023808020b02060100000000000000160c0205060b00010b0101380902070100001a180a000e010c040c030b032e0b0438000c050e05380a03110b00010700110a270b0036000b010b023901380b02080100001c1f0a000b010c030c020b022e0b0338000c060e06380103110b00010701110a270e063802140c040b0036000b04380c3a010c070c050b050b0702000001010100000b010b020b00",
               "abi": {
@@ -2517,6 +7357,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xa1e8b314992e07fcc8027b38c1c807c818d0c18f359f7a3e9c272c05623351ae",
             "data": {
               "bytecode": "0xa11ceb0b050000000c01000e020e340342ce010490021a05aa02d10107fb03f10508ec0920068c0a540ae00a450ca50bbb060de011100ff0110200010002000300040005000600070008080000090c00000a0400000b0800000c0400000d0800000e0c00000f0600001006000011080003040701000002300401060100120001000013020300001404030000150503000016060300001707030000180803000019090300001a000a00001b000b00001c0c0300001d0d0300001e0e0300001f0f030000200703000021030100002203100000230e030000240f0300002511010000260c04000027030400013201010004330700000334150a0100033515160100063618190100053707030006381b01010006351c1601000139010100063a1d030100033b03200100033c19200100063d03210100013e010100023f072401060240270301060141010100180119011a171c171d171f1720012101221724232425252325250105010302060c080200010802020802060801010c01060c020c05020508020101010b0a010302060c03020708020802030c050303060c050301040106080201060801020708030303070a0804030b0a010301060b0a0109000106090001080402070a09000301090005070a080403070a08040608040301060a090002060a09000302070a09000900030307030305060a0804060804030b0a010303010b0a010900010a09000306080607080305010808010b0b01090001080703080207080907080902070b0b010900090003050307030e5472616e73616374696f6e4665650854657374436f696e064572726f7273054576656e74064f7074696f6e065369676e65720f53797374656d41646472657373657306566563746f720742616c616e63650e4275726e4361706162696c69747904436f696e08436f696e496e666f1744656c6567617465644d696e744361706162696c6974790b44656c65676174696f6e730e4d696e744361706162696c6974790d52656365697665644576656e740953656e744576656e740e5472616e736665724576656e74730a62616c616e63655f6f66046275726e086275726e5f676173146275726e5f776974685f6361706162696c69747915636c61696d5f6d696e745f6361706162696c6974791e636c61696d5f6d696e745f6361706162696c6974795f696e7465726e616c1864656c65676174655f6d696e745f6361706162696c697479076465706f736974096578697374735f61740f66696e645f64656c65676174696f6e0a696e697469616c697a65056d65726765046d696e740d6d696e745f696e7465726e616c0872656769737465720e7363616c696e675f666163746f720c746f74616c5f737570706c79087472616e73666572117472616e736665725f696e7465726e616c0576616c7565087769746864726177047a65726f04636f696e0b64756d6d795f6669656c640b746f74616c5f76616c756502746f05696e6e657206616d6f756e740466726f6d0b73656e745f6576656e74730b4576656e7448616e646c650f72656365697665645f6576656e74730d6e6f745f7075626c69736865640a616464726573735f6f660769735f736f6d6506626f72726f770b737761705f72656d6f7665146173736572745f636f72655f7265736f75726365066c656e67746810696e76616c69645f617267756d656e7409707573685f6261636b046e6f6e6504736f6d6505656d70747911616c72656164795f7075626c6973686564106e65775f6576656e745f68616e646c650a656d69745f6576656e740e6c696d69745f6578636565646564000000000000000000000000000000000000000000000000000000000000000103080300000000000000030801000000000000000308020000000000000003080400000000000000030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201280802010201290102020125030302022a0421030402012b050502012c0a080406020129010702022d032e050802022d032b050902022f0b0b010808310b0b0108070001000100030c0a002900030607021116270b002b0010001001140201010002010312080b0011172b010c020b010b02110302020300020103120707052b010c010b000b01110302030000010313100b0013020c0307052a030c020a021002140b0335170b020f021502040200010503030e001105020501000105141d0a00111711090c030e033800030b0b00010703270e033801140c0207052a050f030c010b010b0238021304010b000912062d060206020001051a2d0e00111b07052a050f030c040600000000000000000c060a060a042e380323030f05280a040a060c030c020b022e0b0338040c050b051004140a012203230b04010700111e270b06060100000000000000160c0605080b040b01120438050207010001001e110a0011000c020b002a000f000f010c030b0113020c040b020b04160b0315020801000003030b0029000209000001051f2807052b0510030c010600000000000000000c030a0138030c0538060c040a030a0523031005260a010a0338040c020b021004140a0021031b05210b01010b0338070c0405260b03060100000000000000160c03050b0b04020a01000003160a00111b0a000912062d060a000912012d010a0032000000000000000000000000000000000b0112032d030a00380812052d050b00110e020b010000010c0b0113020c020a001001140b02160b000f0115020c02000300030603050e000b010b02110d020d01000300030622170b0011170c050b052b06010b010a021202110707052a030c040a041002140b0235160b040f0215020e01000004170a001117290020030a0b000107011123270a00060000000000000000120212002d000a000a0038090b00380a12092d09020f01000103030507052b03100514021001000103030507052b031002140211020002000903050e000b010b02111202120100020009261c0a000a0211140c030a010b0311070a0011172a090c050b050f060a020a011208380b0b012a090c040b040f070b020b0011171207380c021301000003040b00100114021401000100281a0b0011170c020a0211000c030a030a0126030d07041126270b022a000f000f010c040b030a01170b04150b0112020215010000030306000000000000000012020200000200030005000400030109000901000000",
               "abi": {
@@ -2897,6 +7738,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xe8aa027cc8ba73bb82e029247e4071a79a437bd4ee493d2c5f7fee90caf9565e",
             "data": {
               "bytecode": "0xa11ceb0b050000000b010006020604030a41054b150760aa02088a032006aa036c0a9604050c9b04c7010de205020fe405020001000200030004080000050000000006000000000700010000080001000009000200000a000200000b030000000c030000000d040000010f020200021003000002110300000112020200000101010301060c03060c050301080002070800030747656e657369730954696d657374616d70064572726f72730f53797374656d4164647265737365731743757272656e7454696d654d6963726f7365636f6e64730e6173736572745f67656e65736973106173736572745f6f7065726174696e670a69735f67656e657369730c69735f6f7065726174696e67106e6f775f6d6963726f7365636f6e64730b6e6f775f7365636f6e6473147365745f74696d655f6861735f73746172746564207365745f74696d655f6861735f737461727465645f666f725f74657374696e67127570646174655f676c6f62616c5f74696d650c6d6963726f7365636f6e64730d696e76616c69645f7374617465146173736572745f636f72655f7265736f75726365096173736572745f766d10696e76616c69645f617267756d656e740000000000000000000000000000000000000000000000000000000000000001030800000000000000000308010000000000000003080200000000000000030840420f00000000000520000000000000000000000000000000000000000000000000000000000a550c18052000000000000000000000000000000000000000000000000000000000000000000002010e030001000000061102030507001109270201010000000611030305070111092702020100000004070429002002030100000003070429000204010001000006110107042b001000140205010001000004110407031a0206030000050811000a00110a0b0006000000000000000012002d00020701000000030b001106020801000100062711010b00110b07042a000c030a031000140c040b01070521030f05190b040a022103180b03010702110c2705220b040a022303220b03010702110c270b020b030f0015020000000000",
               "abi": {
@@ -3008,6 +7850,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xd47f5c819e9f189b2abfc16705c61c7c52183d9acafad7bcee5495dc4038e9aa",
             "data": {
               "bytecode": "0xa11ceb0b050000000d01000c020c340340ba0104fa013205ac02940307c005ad0508ed0a20068d0b90010a9d0c620bff0c020c810dec070ded14160e8315020000000100020003000400050006040000070800000808000000040000090700000a08010400010c0700030307010000020e0700050504020400040002020600000b000100000d020300000f04050000100603000011070800001209030000130a08010400140b03010400150c03000016000300001701030000180d030000190d0300001a0d030104001b0e0300001c0f1000001d110100022c101300052d1516020404052e1819020404052f151b02040404300d130005311c030204040532031e02040401331f200003342223010003352526010005232721020404032e2528010002320d290002272a08000336032301000537182602040412141317141a161a1717171a161419211a211b171c211617162b0d22162d06221f21202b122b12171714172b172d132b142b02060c080301080305060c0806080608060b0701030002060c030208060808050c0a020a020a020306060c080608060806030806010808060c0a020a020a02030a0207060c0806080608060308060900070c0a020a020a02030a020900040c0a020a020a0201060c020803070803010608030106080803060c0608080303070800070b090208060800050105020806080002070b09020900090106090001070901020806080402060b0902090009010609000106090102080605020900090103070b0902090009010900090103050800070b090208060800010b090209000901010a020108060103010900010b070109000b080a05070800070b09020806080003070b0902080808030603080308030804080801060b07010900010101060b0902090009010106090001080a0106080a020808080303050808070b05010900020808090006070b09020808080306080805070803070b090208080803080308030806070800070b090208060800050808080607080409070b090208080803060808080308080503070b090208080803070803080305546f6b656e0541534349490447554944064f7074696f6e065369676e6572055461626c650a436f6c6c656374696f6e0b436f6c6c656374696f6e730747616c6c65727909546f6b656e446174610d546f6b656e4d6574616461746115636c61696d5f746f6b656e5f6f776e65727368697006537472696e67116372656174655f636f6c6c656374696f6e0249441b6372656174655f636f6c6c656374696f6e5f616e645f746f6b656e1f6372656174655f66696e6974655f636f6c6c656374696f6e5f7363726970740c6372656174655f746f6b656e136372656174655f746f6b656e5f7363726970741a6372656174655f746f6b656e5f776974685f6d65746164617461216372656174655f746f6b656e5f776974685f6d657461646174615f736372697074226372656174655f756e6c696d697465645f636f6c6c656374696f6e5f7363726970740d6465706f7369745f746f6b656e0d64657374726f795f746f6b656e16696e697469616c697a655f636f6c6c656374696f6e7312696e697469616c697a655f67616c6c65727919696e697469616c697a655f746f6b656e5f6d657461646174610b6d657267655f746f6b656e08746f6b656e5f69640e77697468647261775f746f6b656e06746f6b656e730e636c61696d65645f746f6b656e730b6465736372697074696f6e046e616d650375726905636f756e74076d6178696d756d0b636f6c6c656374696f6e730767616c6c6572790269640a636f6c6c656374696f6e0762616c616e636506737570706c79086d657461646174611269645f63726561746f725f616464726573730a626f72726f775f6d757406626f72726f770672656d6f76650a616464726573735f6f6606696e736572740663726561746506737472696e6704736f6d650769735f736f6d65046e6f6e650c636f6e7461696e735f6b65790000000000000000000000000000000000000000000000000000000000000001030800000000000000000308020000000000000003080300000000000000030801000000000000000a020d0c48656c6c6f2c20576f726c640a021918436f6c6c656374696f6e3a2048656c6c6f2c20576f726c640a02121168747470733a2f2f6170746f732e6465760a021413546f6b656e3a2048656c6c6f2c20546f6b656e0a020d0c48656c6c6f2c20546f6b656e0002071e0b0902080608041f0b09020806052008062108062208062303240b070103010201250b090208060800020201260b09020808080303020427080821080628080629030402052708082008062108062a032208060502012b0b09020808090005220001000101122e0e01100011110c040b042a010f010c030b030e01100238000c020a0210030e011004380110051406010000000000000021031805280a020f060e011004380201010b020f060e011004140b0011153803052c0b02010b00010b010201010001011d270a0011150c050a052901200308050a0a00110b0a05290220030f05120b00110c05140b00010b052a010f010c07380438050b010a020b030600000000000000000b0412000c060b070e02140b06380602020000020102051c070411180c020a00070511180e021407061118060100000000000000380711010b000e021407071118070811180b010706111811040c030b020b03020302000101030b0e000b0111180b0211180b0311180b043807110102040100020102245a0a0011150c070a072a010f010c090b090e0138000c080a0810073808031005230a08100338090c0a0a081007380a0c0c0b0a0b0c142203230b08010b00010702270a072a020f080c0b0a00111d0c060e06111e0c100e10140e03140e01140a0412030c0d0e10140b020e03140a040b0512040c0f0b04060100000000000000210344054a0a080f060e03140b0738030b080f030b030b0f380b0b000b0d11000c0e0b0b0e10140b0e380c0b1002050200020102030d0e000b0111180b0211180b0311180b040b05111811040102060100030102052c1d0a0011150c070a073b00200308050a0a00380d0b000b010b020b030b040b0511040c080b073c000c090b0936000e08140b06380e0b080207010003010205030e0e000b0111180b0211180b0311180b040b0511180b06380f01020802000101030a0e000b0111180b0211180b03111838101101020901000201022e2d0a0011150c040a042902200308050a0a00110c0b000b0111000c070b042a020f080c060a060e0710000c030c020b022e0b033811031d05260b060e07100038120c050b070b05110e052c0b060e071000140b07380c020a000001012f1f0b0013030c010c020c070c060e0611110c050b052a010f010c040b040e0238000c030b030f030e0738130c080a081005140b01170b080f0515020b00000003050b00381412012d01020c00000003050b00381512022d02020d00000003050b00381639003f00020e0100010103190a011000140e0010001421030c0b01010701270a01100a140e00100a14160b010f0a150b00110a020f01000003030b00100002100100010230410b0011150c070b072a020f080c090a090a010c040c030b032e0b043817100a140c080a080a0226031c0b01010b09010700270a080a0221032105290b090b0138180c0b010b0b0c05053f0b090b0138120c0a0b080a02170a0a0f0a150a0a1000140a0a1004140b0a1002140b0212030c050b050203000100030200000301040300010006020005000303092200",
               "abi": {
@@ -3337,6 +8180,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x6dc54b259b9bb92b3b16b65951338f1a968cd840df016cc3bd13423fb357c6b9",
             "data": {
               "bytecode": "0xa11ceb0b050000000b01000e020e1e032c8c0104b8011a05d201960207e803e20208ca062006ea06680ad2070f0ce107b2030d930b02000000010002000300040005000600000800020707000505040204000400060604000118070003030701000000080001000009020100000a000100000b020100000c030400000d050100000e060100000f070100041105090005120b0c02040405130b0e02040405140f1002040405151101020404061612010002171304000119151400031a01160100061b170100060c180400051c0111020404051d1a1b020404051e1c01020404061f1d1e0006201f20000621210100090a0a0d0b0d0a0a0c0d1010130a140a130d150a140d090d150d03060c0506080100040c05050302060c0301080101060c04060c0506080103050c0505030307080105070b0202050b020208010803070b0202080108030b020208010803050803010502050b02020801080302070b020209000901060900010709010208010803020900090101060b0202090009010103010b02020900090102060c0803020503010804010a02010b0501090005060c0804080408040b05010306060c0804080408040308040a070b0202050b0202080108030605070b020208010803060801070b020208010803070803070b0202050b02020801080305080306080102060b020209000901060900010103070b0202090009010900090103060c0608010301080301060803010608010208030708030e546f6b656e5472616e73666572730541534349490447554944064f7074696f6e065369676e6572055461626c6505546f6b656e0249440c63616e63656c5f6f666665721363616e63656c5f6f666665725f73637269707405636c61696d0c636c61696d5f7363726970740c6372656174655f746f6b656e1a696e697469616c697a655f746f6b656e5f7472616e7366657273056f666665720c6f666665725f7363726970740e70656e64696e675f636c61696d730a616464726573735f6f660a626f72726f775f6d75740672656d6f766505636f756e740d64657374726f795f656d7074790d6465706f7369745f746f6b656e096372656174655f696406537472696e6706737472696e67046e6f6e65116372656174655f636f6c6c656374696f6e066372656174650c636f6e7461696e735f6b657906696e736572740e77697468647261775f746f6b656e08746f6b656e5f69640b6d657267655f746f6b656e00000000000000000000000000000000000000000000000000000000000000010a020d0c48656c6c6f2c20576f726c640a021918436f6c6c656374696f6e3a2048656c6c6f2c20576f726c640a02121168747470733a2f2f6170746f732e6465760a021413546f6b656e3a2048656c6c6f2c20546f6b656e0a020d0c48656c6c6f2c20546f6b656e000201100b0202050b020208010803000100010008250a0011080c080b082a000f000c050a050e0138000c060a060b0238010c09010b062e3802060000000000000000210317051f0b050e0138030c07010b07380405210b05010b000b09110d02010200010004090b020b03110e0c040e000b010e04110002020100010008250a0011080c080b012a000f000c050a050e0838000c060a060b0238010c09010b062e3802060000000000000000210317051f0b050e0838030c07010b07380405210b05010b000b09110d02030200010004090b020b03110e0c040e000b010e041102020400000014170700110f0c020a000701110f0e02140702110f380511110b000b020703110f0704110f0b010702110f1112020500000001050b00380612002d0002060100010019410a0011080c0b0a0b2900200308050a0a0011050b0b2a000f000c0a0a0a0e010c050c040b042e0b053807200319051d0a0a0a01380838090b0a0e0138000c080b000b020b0311160c0c0e0c11170c0d0a080a0d0c070c060b062e0b07380a0333053b0b080b0d380b0c090b0c0b09111805400b080b0d140b0c380c020702000100040a0b020b03110e0c050e000b010e050b04110602000000",
               "abi": {
@@ -3438,6 +8282,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x48b12d7c6cecb34c8eb16fbcd16aa94e0af6d25d801ff614cfe256255f4a86e4",
             "data": {
               "bytecode": "0xa11ceb0b050000000801000402040403080a051204071637084d200c6d0b0f780200010002010304000004000100010500010001080000074163636f756e740e5472616e73616374696f6e4665650854657374436f696e04436f696e086275726e5f666565086275726e5f67617300000000000000000000000000000000000000000000000000000000000000010003000001030b00110102000000",
               "abi": {
@@ -3464,6 +8309,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x420ef68d76eb27ca3b115aa143bcbb21fed31303e38840c11e7a0a88046e4dfa",
             "data": {
               "bytecode": "0xa11ceb0b050000000b01000c020c04031034044406054a35077fa10208a0032006c0032c0aec03090cf50390010d850504000000010002000300040005000008000006000100000701020000080302000009040100040c010100030d050100010e060600050f0a02010005100c02010002110101000709070b080b03060c0a0a020100010101060a02020c0101060c0103010608000201060800010201060a0900010a0202060a0900060900010708001b5472616e73616374696f6e5075626c697368696e674f7074696f6e064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d7006566563746f720a696e697469616c697a651169735f6d6f64756c655f616c6c6f7765641169735f7363726970745f616c6c6f7765641d7365745f6d6f64756c655f7075626c697368696e675f616c6c6f776564117363726970745f616c6c6f775f6c697374196d6f64756c655f7075626c697368696e675f616c6c6f7765640e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c69736865640869735f656d70747908636f6e7461696e730b7265636f6e6669677572650000000000000000000000000000000000000000000000000000000000000001030801000000000000000520000000000000000000000000000000000000000000000000000000000a550c180002020a0a0a020b0100010000011211040a0011050701290020030c0b000107001106270b000b010b0212002d00020101000100070707012b000c000b00100014020201000100081e0a003800030405080b0001080207012b000c020a0210013801031005170b00010b0201080c01051c0b0210010b0038020c010b010203020001000d0b0e00110507012a000c020b010b020f00151109020001000000",
               "abi": {
@@ -3539,6 +8385,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x18cc12a7c4f97627fbfa0ef6cc5cc6a0e45a3950e5cf30b2c01926c731fdb227",
             "data": {
               "bytecode": "0xa11ceb0b050000000a01000a020a0c03162d0543220765bf0408a4052006c405360afa052b0ca50694020db9081a000000010002000300040005070000060700000008000007000100000802010004180101000319040100011a050500041b010100011c050500011d050500021e01010004060c0a020a0203000c0c030303030303030303030301080001060c01030107080008564d436f6e666967064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d700c476173436f6e7374616e74730b4761735363686564756c650a696e697469616c697a65117365745f6761735f636f6e7374616e74731b676c6f62616c5f6d656d6f72795f7065725f627974655f636f737421676c6f62616c5f6d656d6f72795f7065725f627974655f77726974655f636f7374196d696e5f7472616e73616374696f6e5f6761735f756e697473186c617267655f7472616e73616374696f6e5f6375746f666616696e7472696e7369635f6761735f7065725f627974651b6d6178696d756d5f6e756d6265725f6f665f6761735f756e697473166d696e5f70726963655f7065725f6761735f756e6974166d61785f70726963655f7065725f6761735f756e69741d6d61785f7472616e73616374696f6e5f73697a655f696e5f6279746573176761735f756e69745f7363616c696e675f666163746f721464656661756c745f6163636f756e745f73697a6514696e737472756374696f6e5f7363686564756c650f6e61746976655f7363686564756c650d6761735f636f6e7374616e74730c6761735f7363686564756c650e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c6973686564106173736572745f6f7065726174696e6710696e76616c69645f617267756d656e740d6e6f745f7075626c69736865640b7265636f6e666967757265000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000520000000000000000000000000000000000000000000000000000000000a550c1800020b09030a030b030c030d030e030f031003110312031303010203140a02150a0216080002020117080100010000032111020a0011030702290220030c0b000107001104270604000000000000000609000000000000000658020000000000000658020000000000000608000000000000000600093d00000000000b0306102700000000000006001000000000000006e80300000000000006200300000000000012000c040b000b010b020b04120112022d02020102000102064a11050e0011030a070a0825030a07011106270a030a062503110701110627070229020317070011072707022a020f000f010c0c0b010a0c0f02150b020a0c0f03150b030a0c0f04150b040a0c0f05150b050a0c0f06150b060a0c0f07150b070a0c0f08150b080a0c0f09150b090a0c0f0a150b0a0a0c0f0b150b0b0b0c0f0c15110802020001020000000100020003000400050006000700080009000a00",
               "abi": {
@@ -3681,6 +8528,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xcfc7b653713b0a0bb5d71145fdfa2f4769b13f3a48ea60ebd1f59ddbb5624953",
             "data": {
               "bytecode": "0xa11ceb0b050000000b01000e020e0e031c72048e0110059e014e07ec01820408ee0520068e06280ab6061d0cd306fb020dce090a0000000100020003000400050006000707000000080002020701000000080001000009000200000a030400000b000500000c000000000d030400000e000100000f0607000010080700001109070000120a070001190c0c00021a0d010100011b0c0c00021c0d0e0100051d070700041e080000011f0c0c00022007100100032105010002221210010006230001000c020e020c000e001202120014021400010501010108000106080001060a02010a0202060c0a020001060c05060c050a020a020a0202060c0501060b02010800010301060b020109000106090001060801010b02010900010708010109000f56616c696461746f72436f6e666967064572726f7273064f7074696f6e095369676e6174757265065369676e65720954696d657374616d701756616c696461746f724f70657261746f72436f6e66696706436f6e6669670d6578697374735f636f6e6669670a6765745f636f6e666967146765745f636f6e73656e7375735f7075626b65790e6765745f68756d616e5f6e616d650c6765745f6f70657261746f721f6765745f76616c696461746f725f6e6574776f726b5f6164647265737365730869735f76616c6964077075626c6973680f72656d6f76655f6f70657261746f720a7365745f636f6e6669670c7365745f6f70657261746f7210636f6e73656e7375735f7075626b65791b76616c696461746f725f6e6574776f726b5f6164647265737365731a66756c6c6e6f64655f6e6574776f726b5f61646472657373657306636f6e666967106f70657261746f725f6163636f756e740a68756d616e5f6e616d650d6e6f745f7075626c69736865640769735f736f6d6510696e76616c69645f617267756d656e7406626f72726f77106173736572745f6f7065726174696e670a616464726573735f6f6611616c72656164795f7075626c6973686564046e6f6e6517656432353531395f76616c69646174655f7075626b657904736f6d651d6861735f76616c696461746f725f6f70657261746f725f636f6e666967000000000000000000000000000000000000000000000000000000000000000103080200000000000000030801000000000000000308030000000000000003080000000000000000000203130a02140a02150a02010203160b02010800170b020105180a020000000007030b0029010201010001010b160a00110003060703110b270b002b0110000c010a01380003120b01010703110d270b01380114020201000007030b0010010203010001010f0d0a00290103060703110b270b002b010c010b011002140204010001010f170a00290103060703110b270b002b010c010a011003380203120b01010703110d270b011003380314020501000007030b001004020601000101010e0a0029010304050a0b002b01100038000c01050c090c010b0102070100000712110f0a001110290120030b0b000107031111270b00380438050b0112012d01020801000101000f0b0011100c010a01110003090703110b2738050b012a010f031502090100010111210b0011100a0111042103090701110d270a021113030f0700110d270a01110003150703110b270b012a010c050b020b030b04120038060b050f0015020a0100010100180a01111503080b00010702110d270b0011100c020a02110003110703110b270b0138070b022a010f0315020100000001020101000100",
               "abi": {
@@ -3851,6 +8699,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xaa0460c1e08bc01719e73aed182ce339ece3ac47ee279ec5c7945d0f2b6854d1",
             "data": {
               "bytecode": "0xa11ceb0b050000000a010008020804030c23052f120741ac0108ed0120068d020a0a9702060c9d02470de4020200000001000200030000080000040001000005000200000603040001080505000309040400020a060000010b0505000105010a02010102060c0a0200010301060c1756616c696461746f724f70657261746f72436f6e666967064572726f7273065369676e65720954696d657374616d700e6765745f68756d616e5f6e616d651d6861735f76616c696461746f725f6f70657261746f725f636f6e666967077075626c6973680a68756d616e5f6e616d650d6e6f745f7075626c6973686564106173736572745f6f7065726174696e670a616464726573735f6f6611616c72656164795f7075626c6973686564000000000000000000000000000000000000000000000000000000000000000103080000000000000000000201070a020001000100040b0a001101030607001103270b002b00100014020101000004030b0029000202010000041011040a001105110120030b0b000107001106270b000b0112002d0002000000",
               "abi": {
@@ -3913,6 +8762,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xa8a8db4b583979b4cdc0dcf2397e025f9a3f25b8c98a2b556f71a97a6fb28f24",
             "data": {
               "bytecode": "0xa11ceb0b050000000b0100120212120324c80104ec0114058002a60107a603960608bc092006dc099a010af60a150c8b0bd9050de410080000000100020003000400050006000700080009070000000b00070d0700020207010000000a000100000b020100000c030400000e040500000f060700001001080000110901000012040a0000130b0a00001400010000150201000016080100001702010000180c0a000019010300062001010005210901000722040a00012303030001240303000725040500062601030008270f0101000828101101000229130a0100022813110100082a15030100022b16170100022c01170100062d010100012e030300082f0118010008301b160100013103030003320101000733040400043409040008351b1e0100160e170e180319031a0e1b031c031f0e200e250e020c050002060c050103010501080202060a080005010b03010301080101060c01010205060a080002070a080003070508020303070a08000802080101080002070a0900090002060a09000301060900020b030103080101060b0301090003030306080001060a0900010900010b03010900010a09000208010503030b030103080102070a090003010708010501030b030103070800080101070900040708020802030708000c56616c696461746f72536574064572726f7273064f7074696f6e0f5265636f6e66696775726174696f6e065369676e65720f53797374656d4164647265737365730954696d657374616d700f56616c696461746f72436f6e66696706566563746f720d56616c696461746f72496e666f0d6164645f76616c696461746f72166164645f76616c696461746f725f696e7465726e616c196765745f6974685f76616c696461746f725f6164647265737306436f6e666967146765745f76616c696461746f725f636f6e666967146765745f76616c696461746f725f696e6465785f1b6765745f76616c696461746f725f73797374656d5f636f6e66696718696e697469616c697a655f76616c696461746f725f7365740c69735f76616c696461746f720d69735f76616c696461746f725f1072656d6f76655f76616c696461746f721972656d6f76655f76616c696461746f725f696e7465726e616c1b7365745f76616c696461746f725f73797374656d5f636f6e6669671d7570646174655f636f6e6669675f616e645f7265636f6e6669677572651a7570646174655f6974685f76616c696461746f725f696e666f5f1276616c696461746f725f7365745f73697a65046164647216636f6e73656e7375735f766f74696e675f706f77657206636f6e666967176c6173745f636f6e6669675f7570646174655f74696d6506736368656d650a76616c696461746f7273106173736572745f6f7065726174696e67146173736572745f636f72655f7265736f757263650869735f76616c696410696e76616c69645f617267756d656e740e6c696d69745f65786365656465640a6765745f636f6e666967106e6f775f6d6963726f7365636f6e647309707573685f6261636b06626f72726f770769735f736f6d65066c656e67746804736f6d65046e6f6e650e6173736572745f67656e6573697311616c72656164795f7075626c697368656405656d7074790b737761705f72656d6f76650d6e6f745f7075626c69736865640b7265636f6e6669677572650c6765745f6f70657261746f720a616464726573735f6f660a626f72726f775f6d75740000000000000000000000000000000000000000000000000000000000000001030802000000000000000308000000000000000003080600000000000000030808000000000000000308010000000000000003080400000000000000030807000000000000000308030000000000000003080500000000000000030800a3e111000000000308ffffffffffffffff030800010000000000000520000000000000000000000000000000000000000000000000000000000a550c180002041a051b031c08021d030102021e021f0a0800000200010101040e000b0111010201010001010d31110f0b0011100a01111103090704111227110e070b230310070611132711050c080a010e081000110820031b07001112270a0111140c070d080f000c060b010c020b070c0311150c050b060b020601000000000000000b030b05120038000b08110b02020100010108100a00110e230307070811122711050c010e0110000b003801100114020301000101121611050c020e0210000b0011040c010e013802030d07071112270e0210000e013803143801100214020400000014230a0038040c030600000000000000000c020a020a0323030a051f0a000a0238010c040b041001140a01210315051a0b00010b023805020b02060100000000000000160c0205050b000138060205010001010104070c2b011402060100000112111d0a001110070c290120030c0b00010701111e270b003100380712012d0102070100010119090b000c0211050c010b020e0110001108020800000007070b010b0011040c020e02380202090200010101040e000b01110a020a010001011a1c110f0b00111011050c040e0410000b0111040c030e033802031007071112270e033803140c020d040f000b023808010b04110b020b000001011c0f110f070c290103070701112127070c2a010c010b000b01151122020c010001011d49110f0a0111230b00112421030a070511122711050c060e0610000b0111040c040e043802031707071112270e043803140c030d060f000a03110d0c020b02032305480d060f000b0338090c050a05100314070a0709172503350b0501070311132711150a051003140709162403420b0501070211132711150b050f03150b06110b020d0000001f330a002e38040c040a010b04260309050d0b000109020b000b0138090c050a051001141111200318051c0b050109020a0510011411140c030b050f020c020a022e0e0321032a052e0b020109020b030b021508020e01000101080611050c000e001000380402010100000002000300",
               "abi": {
@@ -4087,6 +8937,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x7b913990d5df68402b1438807a139b8fdc76cdf985ab635a6f09166406c6fe97",
             "data": {
               "bytecode": "0xa11ceb0b0500000006010008030823052b22074de30108b002200cd0024c0000000100020003000400010000050001000006020100010703010003080401000209050600010a040100050c050a020a020a0200030c0a020505060c050a020a020a0202060c050105010a021256616c696461746f725365745363726970740f56616c696461746f72436f6e6669671756616c696461746f724f70657261746f72436f6e6669670c56616c696461746f725365741972656769737465725f76616c696461746f725f636f6e666967247365745f76616c696461746f725f636f6e6669675f616e645f7265636f6e666967757265167365745f76616c696461746f725f6f70657261746f720a7365745f636f6e6669671d7570646174655f636f6e6669675f616e645f7265636f6e6669677572650e6765745f68756d616e5f6e616d650c7365745f6f70657261746f7200000000000000000000000000000000000000000000000000000000000000010002000001070e000b010b020b030b0411030201020000010a0e000a010b020b030b0411030e000b0111040202020000010b0a0211050b01210307060000000000000000270e000b0211060200",
               "abi": {
@@ -4139,6 +8990,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0x676c1655de1362f3510ed359bafb9c86d69f436ac28477427f1e92a7594e50c7",
             "data": {
               "bytecode": "0xa11ceb0b050000000801000203026004621205745907cd01930108e002200680030a0c8a038904000000010001010000020203010000030405010000040607010000050801010000060108010000070609010000080a07010000090a0b0100000a0c0d0100000b0e010100000c040d0100000d0c010100000e0d080100000f0f0101000010040d01000c0d070d090d0a0d040d080d010d0e0d050d02070a09000a09000002060a0900030106090002070a0900030107090002060a09000609000101010a090002010301060a0900010301070a090001090002070a0900090003070a090003030203030303070a0900030303030306566563746f7206617070656e6406626f72726f770a626f72726f775f6d757408636f6e7461696e730d64657374726f795f656d70747905656d70747908696e6465785f6f660869735f656d707479066c656e67746808706f705f6261636b09707573685f6261636b0672656d6f766507726576657273650973696e676c65746f6e04737761700b737761705f72656d6f76650000000000000000000000000000000000000000000000000000000000000001030800000000000000000001000001110d0138000e013801200307050c0a000d013802380305020b00010b0138040201010200020102000301000010220600000000000000000c020a0038050c030a020a0323030a051c0a000a0238060a0121031105170b00010b010108020b02060100000000000000160c0205050b00010b0101090204010200050102000601000010240600000000000000000c020a0038050c030a020a0323030a051d0a000a0238060a0121031105180b00010b0101080b02020b02060100000000000000160c0205050b00010b010109060000000000000000020701000001050b003805060000000000000000210208010200090102000a0102000b01000011260a002e38050c040a010a04260309050d0b00010700270b04060100000000000000170c040a010a0423031605230a000c030a010c020b01060100000000000000160c010b030b020a01380705110b003802020c01000012270a002e38050c030a03060000000000000000210309050c0b0001020600000000000000000c020b03060100000000000000170c010a020a0123031705240a000a020a0138070b02060100000000000000160c020b01060100000000000000170c0105120b0001020d010000080738080c010d010b0038030b01020e0102000f0100000b160a002e38012003090b00010700270a002e3805060100000000000000170c020a000b010b0238070b0038020200",
               "abi": {
@@ -4393,6 +9245,7 @@
           {
             "type": "write_module",
             "address": "0x1",
+            "state_key_hash": "0xdec45f7e3f30d6fc6197b91d3ddac37ae607eb051cd91c7792c012d88bc7d004",
             "data": {
               "bytecode": "0xa11ceb0b050000000a01000a020a04030e280536120748b70108ff0120069f02360ad502050cda025f0db903020000000100020003000400000f000005000100000602010004080101000309030100010a040400010b040400010c040400020d01010002060c0300020c0301060c010302070800030756657273696f6e064572726f72730f5265636f6e66696775726174696f6e0f53797374656d4164647265737365730954696d657374616d700a696e697469616c697a650b7365745f76657273696f6e056d616a6f720e6173736572745f67656e65736973146173736572745f636f72655f7265736f7572636511616c72656164795f7075626c69736865640d6e6f745f7075626c697368656410696e76616c69645f617267756d656e740b7265636f6e666967757265000000000000000000000000000000000000000000000000000000000000000103080000000000000000030801000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201070300010000011111020a0011030702290020030c0b000107001104270b000b0112002d00020102000100051d0e001103070229000308070011052707022b001000140c030b030a01230314070111062707022a000c020b010b020f0015110702000000",
               "abi": {
@@ -4446,6 +9299,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
             "data": {
               "type": "0x1::Account::Account",
               "data": {
@@ -4458,6 +9312,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x57df581bdc8eb537f2e0daefe0c91bcefd4e184d31d5a25fe8728c69cc560486",
             "data": {
               "type": "0x1::Account::ChainSpecificAccountInfo",
               "data": {
@@ -4476,6 +9331,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
             "data": {
               "type": "0x1::Block::BlockMetadata",
               "data": {
@@ -4498,6 +9354,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x17589738079487b2af997d2ed0bd6d4332205e7c450220e74566c09b1905e617",
             "data": {
               "type": "0x1::ChainId::ChainId",
               "data": {
@@ -4508,6 +9365,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x2d7368fa67450cf0b7eed0331f147d354815137feb76fff2b7c0fc60ad5bb800",
             "data": {
               "type": "0x1::ConsensusConfig::ConsensusConfig",
               "data": {
@@ -4518,6 +9376,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x3481c9601d3bb1d800c5b728e684b1201dfc2829d75259d5ef5ea4b045b15a53",
             "data": {
               "type": "0x1::GUID::Generator",
               "data": {
@@ -4528,6 +9387,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x764438e1151d8c09aa5f9043996c768cd364e7cb7df8621503f56c554da89f02",
             "data": {
               "type": "0x1::Reconfiguration::Configuration",
               "data": {
@@ -4551,6 +9411,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
             "data": {
               "type": "0x1::TestCoin::Balance",
               "data": {
@@ -4563,6 +9424,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x8b49e451a3bb4f865d2a238e81d34b1ac813183a4bdf7bd63aca56b49bf9d81f",
             "data": {
               "type": "0x1::TestCoin::BurnCapability",
               "data": {
@@ -4573,6 +9435,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
             "data": {
               "type": "0x1::TestCoin::CoinInfo",
               "data": {
@@ -4584,6 +9447,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x3f1c23fdebea87635e8e87e193c97b9e2748a6f90c09f3c8b22677803a4e5b80",
             "data": {
               "type": "0x1::TestCoin::Delegations",
               "data": {
@@ -4594,6 +9458,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x8e3acba2e68effb510e78950ae72f9b491614c742266e73b19f46210ef729ba7",
             "data": {
               "type": "0x1::TestCoin::MintCapability",
               "data": {
@@ -4604,6 +9469,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0xcf66e2ca4e76897cebaa518a193ad55e73868487052899ce87b2d0d4c9496316",
             "data": {
               "type": "0x1::TestCoin::TransferEvents",
               "data": {
@@ -4637,6 +9503,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
             "data": {
               "type": "0x1::Timestamp::CurrentTimeMicroseconds",
               "data": {
@@ -4647,6 +9514,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0xeee160d734240e9a9250c523c7aefc2fa613bf0e63f5445622efcab6d1fcce1d",
             "data": {
               "type": "0x1::TransactionPublishingOption::TransactionPublishingOption",
               "data": {
@@ -4658,6 +9526,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0xda497579d98e160f73853a824ab66764eb06ac6f5e7d256e02192948c2cf608f",
             "data": {
               "type": "0x1::VMConfig::VMConfig",
               "data": {
@@ -4684,6 +9553,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0xc6f78e93890778db8b389336a35b69d5a4f07a08d6a22f44351fc0caefdeefc4",
             "data": {
               "type": "0x1::ValidatorSet::ValidatorSet",
               "data": {
@@ -4706,6 +9576,7 @@
           {
             "type": "write_resource",
             "address": "0xa550c18",
+            "state_key_hash": "0x40ac0f46a93aa0ea000476aca120a17a18418f173264d4c7d72ff25b11395377",
             "data": {
               "type": "0x1::Version::Version",
               "data": {
@@ -4716,6 +9587,7 @@
           {
             "type": "write_resource",
             "address": "0x5fe56f2863f3ad7b7c5634ebe50a4aca579a43fcffed03d31e1bd13e729669e7",
+            "state_key_hash": "0xa4d5bb6608634f157b269dc31fb59b782cc2edb1fcefbd77d7975d6dac04f903",
             "data": {
               "type": "0x1::Account::Account",
               "data": {
@@ -4728,6 +9600,7 @@
           {
             "type": "write_resource",
             "address": "0x5fe56f2863f3ad7b7c5634ebe50a4aca579a43fcffed03d31e1bd13e729669e7",
+            "state_key_hash": "0x7804dea12ab48e01dd5f28ce39831c505c7317b3d23d647c2a734eb5a99a8195",
             "data": {
               "type": "0x1::ValidatorOperatorConfig::ValidatorOperatorConfig",
               "data": {
@@ -4738,6 +9611,7 @@
           {
             "type": "write_resource",
             "address": "0xf85fd00e30cd388d2609db24d6cc44f2652f27413456938eaa059f65231647cc",
+            "state_key_hash": "0xd20b0f35cf774f42e920b02768b0fe4de80a67c21f44b1d9c075ebb138546194",
             "data": {
               "type": "0x1::Account::Account",
               "data": {
@@ -4750,6 +9624,7 @@
           {
             "type": "write_resource",
             "address": "0xf85fd00e30cd388d2609db24d6cc44f2652f27413456938eaa059f65231647cc",
+            "state_key_hash": "0x705247e183c238b149f57d407af70f10b14b59d45d00feecb8bdf09349c6c794",
             "data": {
               "type": "0x1::ValidatorConfig::ValidatorConfig",
               "data": {

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_script_function_payload.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_script_function_payload.json
@@ -9,6 +9,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x98f45b65a2803ef4b16c97adcc3c9485b95de05be62435421b051823ce88f4b7",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "1",
+            "new_block_events": {
+              "counter": "1",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "1"
+          }
+        }
+      }
+    ],
     "id": "0xf44b581f23222c10916b17a369b4da039d075952b58036f2a7b561446592403c",
     "round": "1",
     "previous_block_votes": [],
@@ -25,6 +61,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xa18468709765e5ad75940aeaed145e8af265b8f31148e5d3b860deb8e50b1c3e",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "1"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+        "state_key_hash": "0xd1742838da5b852a3ff4714b21e88a0e8f09cc97d2a2d7d78aea7705fa3c51cd",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x0e60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+            "self_address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+        "state_key_hash": "0xf0e43b1c1002eb268eb3c95d032be24bd65f3caef859c88ca1b1eb0180279fc3",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+        "state_key_hash": "0xdfe49d4e38fbd3f272555234ca2bfff43df59d18ed84d8d91e2abc56c0512ffa",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+        "state_key_hash": "0x3eb9bd9e5d57ea570fc4dcfc82d8a20873cc45976b3d65dc8ad23daa46b482fe",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "0",
     "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
@@ -9,6 +9,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xcdc2362e98b33d5a4cb61fcdffd8835ef21c323534b5e55605c443bd507c6a98",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "8",
+            "new_block_events": {
+              "counter": "8",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "8"
+          }
+        }
+      }
+    ],
     "id": "0x4a876b463d1297603568c40e814d9d5396d23087a0fd641e91e0e00df6c012cd",
     "round": "1",
     "previous_block_votes": [],
@@ -25,6 +61,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x0d92f03efcf42e11059371b5347e6cd685ac599020252edc42d5aeee775af437",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "8"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+        "state_key_hash": "0x4c6bc7079c3fcd3d95f57b020cbbd5567bace022073a4a7e3c9aa7f929ebe65b",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+            "self_address": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+        "state_key_hash": "0xe736d87c24205efd01161184c302ddb8c26f5113a6b1d1c8b889b437882feae2",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+        "state_key_hash": "0xd4aef363298742ed031fd1d9eac686dc9dd61519ad7381f9cedbc574f5939a61",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+        "state_key_hash": "0x147a9d87dc6f57acbb88460c29468fc6b49705f500cdda5e826adfbef50eaf2b",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x9e4c52c179a8a4cf9189a8ba861693be8547d921c8b210ec95e9a8c29ce83623",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "7",
     "max_gas_amount": "2000",
@@ -57,6 +204,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x8898a3b3e5a8a11fe15a94f7ef029b33b97ef10cabac325bd32b4f02d7ad2ee7",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "9",
+            "new_block_events": {
+              "counter": "9",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "9"
+          }
+        }
+      }
+    ],
     "id": "0x464b5ca6488b897c005b2e17f00fc0bc8e7ed3f2ab59d607b0e3586bda1cda4e",
     "round": "1",
     "previous_block_votes": [],
@@ -73,6 +256,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x66230a43232a481b2ff56cac3290ff376493e47b692937d22218fe8fc8b68464",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "9"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x59c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+        "state_key_hash": "0xd94b5304b1deb5ce3639e7e2cfa8c0291343ed5324abf507ab8979a4bcbb959e",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x059c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+            "self_address": "0x59c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x59c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+        "state_key_hash": "0x187fd05af857e605af2df0b18cd6f2b9726baf9a531bd1d1aa4c11d3b9e96d61",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x59c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+        "state_key_hash": "0xac1ca2bce83e8a5be3af45e0eb22a75bcaf79c272778910f9241bcf778415ff3",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x59c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+        "state_key_hash": "0xb8ea4877d3a15d539974d5473078f32eaa65f9eddff84f526585070fdf22361f",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x59c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x59c02dfad19271ecb71d6ef1095d174cfcd641696135b76cd1cbf28f79e134c",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "8",
     "max_gas_amount": "2000",
@@ -105,6 +399,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xc36f7650cc99dc69dc15e860d80d681c4a590065c2851337c6f029bb9beee613",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "10",
+            "new_block_events": {
+              "counter": "10",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "10"
+          }
+        }
+      }
+    ],
     "id": "0x19d258b113d8e3e12bca2aa612b304ece5b25988818dd7234e049913233eb918",
     "round": "1",
     "previous_block_votes": [],
@@ -121,6 +451,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xbb6fcc3558ad2353c6fc8679d2e5a8aa1f052c6e4aadcc5e1b08c54d1d2bdaaa",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "10"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+        "state_key_hash": "0x0b880195fb71d40b488a550b52d17de2dd129d5f30f34855ca8b428239909fac",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+            "self_address": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+        "state_key_hash": "0x06334530a7c0cbb971583c12b2ad6fdb52c8c38cfaeea9a8d522efdbecaf942b",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+        "state_key_hash": "0x2131acd287391c8b5b57eba83c3c22d9539623fd33835cbc439dc6daa6c349ec",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+        "state_key_hash": "0x316023da5e04ebecd7ec034437eac83eb78be7b499303274f582548c928d69ea",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xd1fdd7f5e3329151d0c0f2cf8d2e7041d5c6bedea6f4cafe97677ac6e39d7333",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "9",
     "max_gas_amount": "2000",
@@ -153,6 +594,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x4bba3a73c7ca72403b75e45ed57785d24832ce90e27357a8b8c196e25851f8fc",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "11",
+            "new_block_events": {
+              "counter": "11",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "11"
+          }
+        }
+      }
+    ],
     "id": "0xb99003d30a245ac74a02e26e45cb80ee1b9c00a93345ce5f12bea9ffe04748d6",
     "round": "1",
     "previous_block_votes": [],
@@ -169,6 +646,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x55f5fd9f775a861e52476b17f09384deca212777221d84e77c653de5e5e75dff",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "11"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+        "state_key_hash": "0xa5c1c65631f4efeb904f7b0efea19b978a2c52924378c71777ead38e15fc7b03",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+            "self_address": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+        "state_key_hash": "0x764a717688baeecf53d40ed0ba3279cea14d0f8951a1d9c1507a319a80b1ac62",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+        "state_key_hash": "0x2e288c3d05b00045585128368b18d7619a65b275312aee7e4ad767f26bb6a6f1",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+        "state_key_hash": "0x2a5e591719799823be3bb152f3033dd6c38a1a044641b24b569623c98bafabb6",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x629ec1c7de426633839c3f68e4ea92581232c8cbdd579ba57478b26e5876da5f",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "10",
     "max_gas_amount": "2000",
@@ -201,6 +789,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xa2dd7ab0b516370d2b6b31b0cdcb321de16ba7bd744d9e3c08a554604d7a5024",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "12",
+            "new_block_events": {
+              "counter": "12",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "12"
+          }
+        }
+      }
+    ],
     "id": "0xea95b8f9082c10620c0d6e3fc9596b4538d0dc24bec371bb3e4634561f8892e6",
     "round": "1",
     "previous_block_votes": [],
@@ -217,6 +841,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x1277a6d3229408441951abed8949a2004ef11659dd2f060697bad92333485e33",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "12"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+        "state_key_hash": "0xd5d96a542a0cf17d7352e49e09163007b8747453f0b64147a5b58426ddec9e61",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+            "self_address": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+        "state_key_hash": "0x68848c0224e2be75854b8a5f75c7ec0cb2941d61b22a9e8e4a946717a435be60",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+        "state_key_hash": "0x61edbd7b8d9472fba6aca1bbe56a8596b46f5424d3228573ab952a7e40b477dc",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+        "state_key_hash": "0xaf80147f6422bad3603f1d4a77e37db1740bef9215166da55e2ef208495b5ad0",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x71f9cc8709deb65a1d8019f02735da21bfd43be9f8c75bbdca45560958bc65a9",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "11",
     "max_gas_amount": "2000",
@@ -249,6 +984,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x1a6b9fd914f8c372e7691f3d4928119ce0441e1ac0771d4d1fb4ce58fa2a0d39",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "13",
+            "new_block_events": {
+              "counter": "13",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "13"
+          }
+        }
+      }
+    ],
     "id": "0xa229ec3dd885442b44972526c4e8ce25a0416c3955d818bb1ab0e832877d6282",
     "round": "1",
     "previous_block_votes": [],
@@ -265,6 +1036,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x804c4bc5532dacd39a7162423389eb302a791435df97a2030bbc26549e972208",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "13"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+        "state_key_hash": "0xd9ab3694152a58d553d0d5637b47e9b23d0d958a680176a7a2ecdd85331f4af4",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x0811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+            "self_address": "0x811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+        "state_key_hash": "0x7bf634e0094c63625d5bdacc800052aafa345f0d5d184b056210d7d8336f618f",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+        "state_key_hash": "0x5d623fecd4de200f72972d59f569cdd18016978934984af1929243431d926922",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+        "state_key_hash": "0x70aad05c2708467f63fb8be86d74bdc0541e234ae14dc47752fac7aaab09765f",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x811a29fed994d121a6d1a8d422a73ddfaa9cef6cf313477409c6ca6462bdbec",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "12",
     "max_gas_amount": "2000",
@@ -297,6 +1179,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xd2c246c6946f9a34f6d6a60d9c991cfa226b036cad8d65c3ba59b0d02eec56bb",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "14",
+            "new_block_events": {
+              "counter": "14",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "14"
+          }
+        }
+      }
+    ],
     "id": "0x80ec4f332f4d1a6742c537f2bb32473b01b1dcb1caac942722a4787bb185e479",
     "round": "1",
     "previous_block_votes": [],
@@ -313,6 +1231,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xe18ac9cee3e8d7e00f4f3477251505d992eae571dbfb524338c5d04e4faab88e",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "14"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+        "state_key_hash": "0x61414a3b1ca6a2d6e51e76714fbac40c31c015c8249de83f6dad286a2a04de8a",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+            "self_address": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+        "state_key_hash": "0x88610d45620bbe0f1ab52382c7ceb3b4b73624cda9af8b76a19cd6259ae4cbc8",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+        "state_key_hash": "0xa7fe3341cb8ca11f4c583022ac3a42f59194744b922c3323fead4f80cb70c2ba",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+        "state_key_hash": "0x9be88cb4b760d26470fc19921ad50711193f57a11cb04285dfea183d27652e83",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x2466e5bfe75e3531bf24c8aa25074f165b997e19c80a36a9eccea767b263f2a4",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "13",
     "max_gas_amount": "2000",
@@ -345,6 +1374,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x635104c5a03015f1636f986e5d164f252513cb0d9ee82fe23d3ecffdfbcf1f57",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "15",
+            "new_block_events": {
+              "counter": "15",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "15"
+          }
+        }
+      }
+    ],
     "id": "0x842f736ab973e87f53b4857842789a1dd59167629b3c5cabe47dbf48827ec081",
     "round": "1",
     "previous_block_votes": [],
@@ -361,6 +1426,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x3b0c619707b48f46346bcaf3a59b3d460aa6109752d5d7ef9e980b33da6f22da",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "15"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+        "state_key_hash": "0x45aea3b168f3577a08e719429c5a7fdcc4551f2a460610ff1a33711cb36da87e",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+            "self_address": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+        "state_key_hash": "0xa1a90426d80a7f12bdda5255e87c9862e29c60ecf8b0355b4e8a79fdd507ebd7",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+        "state_key_hash": "0x32423c797d019e8ace8c33d9dcf7f3e83c77692d756f7dba454d14a74dec91b8",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+        "state_key_hash": "0xb2ae44fa9e703fb9dab2e8bddcb2d90bf9d7fdc4217ce02221c3d0632936b9c0",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xe6729b2cdb9dd280cefaa1121c496e82e94a75bf429a1e83bc2f5f605780c345",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "14",
     "max_gas_amount": "2000",
@@ -393,6 +1569,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x89fe729368fd5a553780b338ba46a3c17c6cb04a2378ba082f2c3a214989383c",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "16",
+            "new_block_events": {
+              "counter": "16",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "16"
+          }
+        }
+      }
+    ],
     "id": "0x3beda43d6e9f9b1b1bc44cdfce3574e7f7f0b2de2323a06ebc356bad614726b3",
     "round": "1",
     "previous_block_votes": [],
@@ -409,6 +1621,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x0a961e84d8070b366e223ed8ba296ea9e14f1fcad871c9f85537bc5f1dece4a1",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "16"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+        "state_key_hash": "0x3819e0e8a8023180f83e13e502ee13d9b6dc4d92ed033b8636da002212a738fe",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+            "self_address": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+        "state_key_hash": "0xb4e72aa2f6c0b0f09a05ee41f8d72c11d6a8171a96f21d620d92f32f2b3b9faf",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+        "state_key_hash": "0x23bd1e4e6ba3f68605ca6eb959cb560f6ea2736a771d92e522e4bb2af639651c",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+        "state_key_hash": "0xa990e18349ef4a927f462c4777c3eefb44911116b81e4c0b9e2d5139e05a824c",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xbc8b6a81cd04f4de0119ff7ab7ec5eb28797e5ab659071fc7f4ed8285963fbbc",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "15",
     "max_gas_amount": "2000",
@@ -441,6 +1764,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xe9f990cfe150678d97e4ecf14d4a0dd8cd5d592d1fb45774697025eb7bb007b3",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "17",
+            "new_block_events": {
+              "counter": "17",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "17"
+          }
+        }
+      }
+    ],
     "id": "0x755687120a7c6df2389c373c8fbe06bda7a61120652668dd5687fee73fac7a2c",
     "round": "1",
     "previous_block_votes": [],
@@ -457,6 +1816,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xf7d811f2df2a6c28b925cff2d873fdd17053c6163ffee76192f2d861a2a1bd77",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "17"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+        "state_key_hash": "0xc6a9f922ee3f04606940a0747a8949779b2bdcdb87c2a7b289414bfe7fe19d6f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+            "self_address": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+        "state_key_hash": "0x1468bec76352b89911522a46dfaf4e3c3ddb5ed723e1bc6a4735d4f485ba5a6b",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+        "state_key_hash": "0x1c36af51ff2cdeb39f0e7c7bc745c7cf2ac09bbb37d928be4c656643a5ad0df9",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+        "state_key_hash": "0x9aa92243c259ba084b042d14fb25f4125da7a080ed1e157d4c0714815923c1e3",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x3a005a7fa8e1c2fdab97247be839d548711d07e26b682d3f8b6bb9f6fa804332",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "16",
     "max_gas_amount": "2000",
@@ -489,6 +1959,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x678967f836f9bfff96115a2b2e9a1bc71ce3699669375510498c261e8fd1cf60",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "18",
+            "new_block_events": {
+              "counter": "18",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "18"
+          }
+        }
+      }
+    ],
     "id": "0x430d191fbc937d42f74104aa291871f4b9d120f76583a1da5d1123f2b8a0ac60",
     "round": "1",
     "previous_block_votes": [],
@@ -505,6 +2011,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x8a5d4651a5092f1e86a50b9f5defb2acdaf83af1c9628c9e50b9d2d6aa33e077",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "18"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+        "state_key_hash": "0x359c40737b2d00ee37b472fe5a03abdb7283264c1e21fe20601c9629b2b35827",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+            "self_address": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+        "state_key_hash": "0xb09a8029dfa274b90b59264458cd74e36ec27c157374bb20bfad812a29b042b5",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+        "state_key_hash": "0x5b9cc988bf95904ebec9e4a6fdde8c970d13d7d81256359c3a9a8611c14d353f",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+        "state_key_hash": "0x594be380e6b9da07e429d9a2e988cedc52bbcf9610456ff113d84f1f8e249142",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0x73cb8245b462c25d2c0792576c83f26a66456c6c26ed271769be71ec85920331",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "17",
     "max_gas_amount": "2000",
@@ -537,6 +2154,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xef8756466bdbbd663792456ec10bbe6399f7ff1ef34a3bac09ca9d212f8c825d",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "19",
+            "new_block_events": {
+              "counter": "19",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "19"
+          }
+        }
+      }
+    ],
     "id": "0x2af5203112331adc2ed6f402dca396bfe6dfa3ac8a57ea08860870fd515cf7ca",
     "round": "1",
     "previous_block_votes": [],
@@ -553,6 +2206,117 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0xd54c7ee604cf36d53fca8c7934f02eaf0dca275a3e2a8b9068c3d9dcef9df600",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+            "self_address": "0xa550c18",
+            "sequence_number": "19"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "18446744073709551615"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+        "data": {
+          "type": "0x1::TestCoin::CoinInfo",
+          "data": {
+            "scaling_factor": "1000000",
+            "total_value": "18446744073709551615"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+        "state_key_hash": "0x5160d31838ae39a6662560e18ac5ea3e799aae7121ce5834b9cf18c16c8c6567",
+        "data": {
+          "type": "0x1::Account::Account",
+          "data": {
+            "authentication_key": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+            "self_address": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+            "sequence_number": "0"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+        "state_key_hash": "0x9aceb3bcb6619623a666f0ee8a80d220856ee7d528dc31ee7689b3baaced8b22",
+        "data": {
+          "type": "0x1::GUID::Generator",
+          "data": {
+            "counter": "2"
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+        "state_key_hash": "0x0dd97334721ea9f3cc79c1cf2af38ce3caab0eb99867b585c1dcded1ee481404",
+        "data": {
+          "type": "0x1::TestCoin::Balance",
+          "data": {
+            "coin": {
+              "value": "0"
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+        "state_key_hash": "0x2b0c63c7fdbed0267adc655340afe638b98c06ae9e0c4696eb0d81435851a22d",
+        "data": {
+          "type": "0x1::TestCoin::TransferEvents",
+          "data": {
+            "received_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+                    "creation_num": "1"
+                  }
+                },
+                "len_bytes": 40
+              }
+            },
+            "sent_events": {
+              "counter": "0",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xb8e26002ab0e7a0849cb7c9618faa67dbd7c2167f944102d2dd80ab33f8491b2",
+                    "creation_num": "0"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      }
+    ],
     "sender": "0xa550c18",
     "sequence_number": "18",
     "max_gas_amount": "2000",
@@ -585,6 +2349,42 @@
     "success": true,
     "vm_status": "Executed successfully",
     "accumulator_root_hash": "0x3be9f7a0cd27dbb70beabe9e27ed2508ef0184715bc64626c121d8ca34067768",
+    "changes": [
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+        "data": {
+          "type": "0x1::Block::BlockMetadata",
+          "data": {
+            "height": "20",
+            "new_block_events": {
+              "counter": "20",
+              "guid": {
+                "guid": {
+                  "id": {
+                    "addr": "0xa550c18",
+                    "creation_num": "5"
+                  }
+                },
+                "len_bytes": 40
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "write_resource",
+        "address": "0xa550c18",
+        "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+        "data": {
+          "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+          "data": {
+            "microseconds": "20"
+          }
+        }
+      }
+    ],
     "id": "0xe451cd3c364076623c0231898be0722c08e4eb229c44cb957d29cf7370af8a1b",
     "round": "1",
     "previous_block_votes": [],

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_module_payload_bytecode.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_module_payload_bytecode.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move bytecode deserialization / verification failed, including script function not found or invalid arguments",
   "accumulator_root_hash": "0xd6180a5ad70a30d41abd41e426d90a06617b12a0a8ec55576479a3419a706063",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+          "self_address": "0xa550c18",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "18446744073709551615"
+          }
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    }
+  ],
   "sender": "0xa550c18",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_address.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_address.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move bytecode deserialization / verification failed, including script function not found or invalid arguments",
   "accumulator_root_hash": "0x548ca5651b35b16be2b9a771709e69fd0ca9309cb45f80a6b71c0426e6a6ede8",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+          "self_address": "0xa550c18",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "18446744073709551615"
+          }
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    }
+  ],
   "sender": "0xa550c18",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_arguments.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_arguments.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move bytecode deserialization / verification failed, including script function not found or invalid arguments",
   "accumulator_root_hash": "0xfe13a10c71fd498c3d2c0b800eefa5ed45e1201ce3326c3a2dddc11072476bcf",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+          "self_address": "0xa550c18",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "18446744073709551615"
+          }
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    }
+  ],
   "sender": "0xa550c18",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_module_name.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_module_name.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move bytecode deserialization / verification failed, including script function not found or invalid arguments",
   "accumulator_root_hash": "0x59c21b4735ca15db230942b5e305c102be59afb0e8a059054f5078160936dad2",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+          "self_address": "0xa550c18",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "18446744073709551615"
+          }
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    }
+  ],
   "sender": "0xa550c18",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_name.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_name.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move bytecode deserialization / verification failed, including script function not found or invalid arguments",
   "accumulator_root_hash": "0x43559a00947d0b2e0a0037c9e27890e5850d4fb450b160179dd21e6657ec2038",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+          "self_address": "0xa550c18",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "18446744073709551615"
+          }
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    }
+  ],
   "sender": "0xa550c18",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_payload_bytecode.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_payload_bytecode.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move bytecode deserialization / verification failed, including script function not found or invalid arguments",
   "accumulator_root_hash": "0x49e4e43e78aeb3a52f1c524fea2c131968baa63e1b7379518743a13121f8fbc3",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+          "self_address": "0xa550c18",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "18446744073709551615"
+          }
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    }
+  ],
   "sender": "0xa550c18",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_missing_script_function_arguments.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_missing_script_function_arguments.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move bytecode deserialization / verification failed, including script function not found or invalid arguments",
   "accumulator_root_hash": "0xbd7b3a1482de4be8ac467e646a857686c9b213a952b859d7433089fd3a83eb80",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x04a62513032e695c923632ca1b9248d11e49c9b1e83bba39974adf50bbabdd8f",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x7deeccb1080854f499ec8b4c1b213b82c5e34b925cf6875fec02d4b77adbd2d6",
+          "self_address": "0xa550c18",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x0429c60e9038d8b98b6cbddf810e3517cf3b029b8655d701962e6b1bfec59e04",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "18446744073709551615"
+          }
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    }
+  ],
   "sender": "0xa550c18",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
@@ -8,6 +8,46 @@
   "success": false,
   "vm_status": "Move abort by LIMIT_EXCEEDED - EINSUFFICIENT_BALANCE\n A limit on an amount, e.g. a currency, is exceeded. Example: withdrawal of money after account limits window\n is exhausted.\n Error codes",
   "accumulator_root_hash": "0xdd25d38068eebe924a415c2cb19a66e7cf6e02286095d8640b8547b94efdf594",
+  "changes": [
+    {
+      "type": "write_resource",
+      "address": "0xa550c18",
+      "state_key_hash": "0x79a08e0b94ebb66c0dae37a07c182d46387c347aeb83c07de6109b0503c3a24e",
+      "data": {
+        "type": "0x1::TestCoin::CoinInfo",
+        "data": {
+          "scaling_factor": "1000000",
+          "total_value": "18446744073709551615"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+      "state_key_hash": "0xd1742838da5b852a3ff4714b21e88a0e8f09cc97d2a2d7d78aea7705fa3c51cd",
+      "data": {
+        "type": "0x1::Account::Account",
+        "data": {
+          "authentication_key": "0x0e60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+          "self_address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+          "sequence_number": "1"
+        }
+      }
+    },
+    {
+      "type": "write_resource",
+      "address": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
+      "state_key_hash": "0xdfe49d4e38fbd3f272555234ca2bfff43df59d18ed84d8d91e2abc56c0512ffa",
+      "data": {
+        "type": "0x1::TestCoin::Balance",
+        "data": {
+          "coin": {
+            "value": "0"
+          }
+        }
+      }
+    }
+  ],
   "sender": "0xe60912ecb0a8c365d163d258f3b9f1b62f8f9148c207643864d7ed4a2b23159",
   "sequence_number": "0",
   "max_gas_amount": "2000",

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -133,13 +133,10 @@ impl Context {
     ) -> Result<Vec<TransactionOnChainData>> {
         let data = self
             .db
-            .get_transactions(start_version, limit as u64, ledger_version, true)?;
-        let tx_outputs =
-            self.db
-                .get_transaction_outputs(start_version, limit as u64, ledger_version)?;
+            .get_transaction_outputs(start_version, limit as u64, ledger_version)?;
 
         let txn_start_version = data
-            .first_transaction_version
+            .first_transaction_output_version
             .ok_or_else(|| format_err!("no start version from database"))?;
         ensure!(
             txn_start_version == start_version,
@@ -148,30 +145,23 @@ impl Context {
             start_version
         );
 
-        let txns = data.transactions;
         let infos = data.proof.transaction_infos;
-        let events = data.events.unwrap_or_default();
-        let changes: Vec<aptos_types::write_set::WriteSet> = tx_outputs
-            .transactions_and_outputs
-            .into_iter()
-            .map(|txo| txo.1.unpack().0)
-            .collect();
+        let transactions_and_outputs = data.transactions_and_outputs;
+
         ensure!(
-            txns.len() == infos.len() && txns.len() == events.len() && txns.len() == changes.len(),
-            "invalid data size from database: {}, {}, {}, {}",
-            txns.len(),
+            transactions_and_outputs.len() == infos.len(),
+            "invalid data size from database: {}, {}",
+            transactions_and_outputs.len(),
             infos.len(),
-            events.len(),
-            changes.len(),
         );
 
-        txns.into_iter()
+        transactions_and_outputs
+            .into_iter()
             .zip(infos.into_iter())
-            .zip(events.into_iter())
-            .zip(changes.into_iter())
             .enumerate()
-            .map(|(i, (((txn, info), events), write_set))| {
+            .map(|(i, ((txn, txn_output), info))| {
                 let version = start_version + i as u64;
+                let (write_set, events, _, _) = txn_output.unpack();
                 self.get_accumulator_root_hash(version)
                     .map(|h| (version, txn, info, events, h, write_set).into())
             })
@@ -244,12 +234,13 @@ impl Context {
         &self,
         txn: TransactionWithProof,
     ) -> Result<TransactionOnChainData> {
-        let tx_outputs = self
+        // the type is Vec<(Transaction, TransactionOutput)> - given we have one transaction here, there should only ever be one value in this array
+        let (_, txn_output) = &self
             .db
-            .get_transaction_outputs(txn.version, 1, txn.version)?;
-
+            .get_transaction_outputs(txn.version, 1, txn.version)?
+            .transactions_and_outputs[0];
         self.get_accumulator_root_hash(txn.version)
-            .map(|h| (txn, h, tx_outputs).into())
+            .map(|h| (txn, h, txn_output).into())
     }
 
     pub fn get_events(

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -250,12 +250,11 @@ impl Transactions {
         let first_version = data[0].version;
         let mut timestamp = self.context.get_block_timestamp(first_version)?;
         let resolver = self.context.move_resolver()?;
+        let converter = resolver.as_converter();
         let txns: Vec<Transaction> = data
             .into_iter()
             .map(|t| {
-                let txn = resolver
-                    .as_converter()
-                    .try_into_onchain_transaction(timestamp, t)?;
+                let txn = converter.try_into_onchain_transaction(timestamp, t)?;
                 // update timestamp, when txn is metadata block transaction
                 // new timestamp is used for the following transactions
                 timestamp = txn.timestamp();

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -475,6 +475,17 @@ pub enum WriteSetChange {
     },
 }
 
+impl WriteSetChange {
+    pub fn type_str(&self) -> &'static str {
+        match self {
+            WriteSetChange::DeleteModule { .. } => "delete_module",
+            WriteSetChange::DeleteResource { .. } => "delete_resource",
+            WriteSetChange::WriteModule { .. } => "write_module",
+            WriteSetChange::WriteResource { .. } => "write_resource",
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TransactionSignature {

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -18,7 +18,7 @@ use aptos_types::{
     contract_event::ContractEvent,
     transaction::{
         authenticator::{AccountAuthenticator, TransactionAuthenticator},
-        Script, SignedTransaction, TransactionOutputListWithProof, TransactionWithProof,
+        Script, SignedTransaction, TransactionOutput, TransactionWithProof,
     },
 };
 
@@ -75,17 +75,16 @@ impl
     From<(
         TransactionWithProof,
         aptos_crypto::HashValue,
-        TransactionOutputListWithProof,
+        &TransactionOutput,
     )> for TransactionOnChainData
 {
     fn from(
-        (txn, accumulator_root_hash, txn_output_list): (
+        (txn, accumulator_root_hash, txn_output): (
             TransactionWithProof,
             aptos_crypto::HashValue,
-            TransactionOutputListWithProof,
+            &TransactionOutput,
         ),
     ) -> Self {
-        let (_, txn_output) = &txn_output_list.transactions_and_outputs[0];
         Self {
             version: txn.version,
             transaction: txn.transaction,

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -18,7 +18,7 @@ use aptos_types::{
     contract_event::ContractEvent,
     transaction::{
         authenticator::{AccountAuthenticator, TransactionAuthenticator},
-        Script, SignedTransaction, TransactionWithProof,
+        Script, SignedTransaction, TransactionOutputListWithProof, TransactionWithProof,
     },
 };
 
@@ -55,6 +55,7 @@ pub struct TransactionOnChainData {
     pub info: aptos_types::transaction::TransactionInfo,
     pub events: Vec<ContractEvent>,
     pub accumulator_root_hash: aptos_crypto::HashValue,
+    pub changes: aptos_types::write_set::WriteSet,
 }
 
 impl From<(TransactionWithProof, aptos_crypto::HashValue)> for TransactionOnChainData {
@@ -65,6 +66,33 @@ impl From<(TransactionWithProof, aptos_crypto::HashValue)> for TransactionOnChai
             info: txn.proof.transaction_info,
             events: txn.events.unwrap_or_default(),
             accumulator_root_hash,
+            changes: Default::default(),
+        }
+    }
+}
+
+impl
+    From<(
+        TransactionWithProof,
+        aptos_crypto::HashValue,
+        TransactionOutputListWithProof,
+    )> for TransactionOnChainData
+{
+    fn from(
+        (txn, accumulator_root_hash, txn_output_list): (
+            TransactionWithProof,
+            aptos_crypto::HashValue,
+            TransactionOutputListWithProof,
+        ),
+    ) -> Self {
+        let (_, txn_output) = &txn_output_list.transactions_and_outputs[0];
+        Self {
+            version: txn.version,
+            transaction: txn.transaction,
+            info: txn.proof.transaction_info,
+            events: txn.events.unwrap_or_default(),
+            accumulator_root_hash,
+            changes: txn_output.write_set().clone(),
         }
     }
 }
@@ -76,15 +104,17 @@ impl
         aptos_types::transaction::TransactionInfo,
         Vec<ContractEvent>,
         aptos_crypto::HashValue,
+        aptos_types::write_set::WriteSet,
     )> for TransactionOnChainData
 {
     fn from(
-        (version, transaction, info, events, accumulator_root_hash): (
+        (version, transaction, info, events, accumulator_root_hash, write_set): (
             u64,
             aptos_types::transaction::Transaction,
             aptos_types::transaction::TransactionInfo,
             Vec<ContractEvent>,
             aptos_crypto::HashValue,
+            aptos_types::write_set::WriteSet,
         ),
     ) -> Self {
         Self {
@@ -93,6 +123,7 @@ impl
             info,
             events,
             accumulator_root_hash,
+            changes: write_set,
         }
     }
 }
@@ -264,6 +295,7 @@ pub struct TransactionInfo {
     pub success: bool,
     pub vm_status: String,
     pub accumulator_root_hash: HashValue,
+    pub changes: Vec<WriteSetChange>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -423,18 +455,22 @@ pub struct DirectWriteSet {
 pub enum WriteSetChange {
     DeleteModule {
         address: Address,
+        state_key_hash: String,
         module: MoveModuleId,
     },
     DeleteResource {
         address: Address,
+        state_key_hash: String,
         resource: MoveStructTag,
     },
     WriteModule {
         address: Address,
+        state_key_hash: String,
         data: MoveModuleBytecode,
     },
     WriteResource {
         address: Address,
+        state_key_hash: String,
         data: MoveResource,
     },
 }

--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -245,6 +245,7 @@ mod tests {
                     success: true,
                     vm_status: "Executed".to_string(),
                     accumulator_root_hash: HashValue::zero().into(),
+                    changes: vec![],
                 };
                 let serializable_txn: aptos_rest_client::aptos_api_types::Transaction = (
                     txn.as_signed_user_txn().unwrap(),

--- a/ecosystem/indexer/migrations/2022-04-19-003410_create_write_set_changes/down.sql
+++ b/ecosystem/indexer/migrations/2022-04-19-003410_create_write_set_changes/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE IF EXISTS write_set_changes;

--- a/ecosystem/indexer/migrations/2022-04-19-003410_create_write_set_changes/up.sql
+++ b/ecosystem/indexer/migrations/2022-04-19-003410_create_write_set_changes/up.sql
@@ -1,0 +1,25 @@
+-- Your SQL goes here
+
+CREATE TABLE write_set_changes
+(
+    -- join from "transactions"
+    transaction_hash VARCHAR(255) NOT NULL,
+
+    hash             VARCHAR(255) NOT NULL,
+
+    type             TEXT         NOT NULL,
+    address          VARCHAR(255) NOT NULL,
+
+    module           jsonb        NOT NULL,
+    resource         jsonb        NOT NULL,
+    data             jsonb        NOT NULL,
+    inserted_at      TIMESTAMP    NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    PRIMARY KEY (transaction_hash, hash),
+    CONSTRAINT fk_transactions
+        FOREIGN KEY (transaction_hash)
+            REFERENCES transactions (hash)
+);
+
+CREATE INDEX write_set_changes_tx_hash_addr_type_index ON write_set_changes (transaction_hash, address, type);

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -206,6 +206,7 @@ mod test {
 
     pub fn wipe_database(conn: &PgPoolConnection) {
         for table in [
+            "write_set_changes",
             "events",
             "user_transactions",
             "block_metadata_transactions",
@@ -241,34 +242,71 @@ mod test {
         // An abridged genesis transaction
         let genesis_txn: Transaction = serde_json::from_value(json!(
             {
-               "type":"genesis_transaction",
-               "version":"0",
-               "hash":"0x12180a4bbccf48de4d1e23b498add134328669ffc7741c8d529c6b2e3629ac99",
-               "state_root_hash":"0xb50adef3662d77e528be9e1cb5637fe5b7afd13eea317b330799f0c559c918c1",
-               "event_root_hash":"0xcbdbb1b830d1016d45a828bb3171ea81826e8315f14140acfbd7886f49fbcb40",
-               "gas_used":"0",
-               "success":true,
-               "vm_status":"Executed successfully",
-               "accumulator_root_hash":"0x188ed588547d551e652f04fccd5434c2977d6cff9e7443eb8e7c3038408caad4",
-               "payload":{
-                  "type":"write_set_payload",
-                  "write_set":{
-                     "type":"direct_write_set",
-                     "changes":[],
-                     "events":[]
+              "type": "genesis_transaction",
+              "version": "0",
+              "hash": "0x12180a4bbccf48de4d1e23b498add134328669ffc7741c8d529c6b2e3629ac99",
+              "state_root_hash": "0xb50adef3662d77e528be9e1cb5637fe5b7afd13eea317b330799f0c559c918c1",
+              "event_root_hash": "0xcbdbb1b830d1016d45a828bb3171ea81826e8315f14140acfbd7886f49fbcb40",
+              "gas_used": "0",
+              "success": true,
+              "vm_status": "Executed successfully",
+              "accumulator_root_hash": "0x188ed588547d551e652f04fccd5434c2977d6cff9e7443eb8e7c3038408caad4",
+              "payload": {
+                "type": "write_set_payload",
+                "write_set": {
+                  "type": "direct_write_set",
+                  "changes": [],
+                  "events": []
+                }
+              },
+              "events": [
+                {
+                  "key": "0x0400000000000000000000000000000000000000000000000000000000000000000000000a550c18",
+                  "sequence_number": "0",
+                  "type": "0x1::Reconfiguration::NewEpochEvent",
+                  "data": {
+                    "epoch": "1"
                   }
-               },
-               "events":[
-                  {
-                     "key":"0x0400000000000000000000000000000000000000000000000000000000000000000000000a550c18",
-                     "sequence_number":"0",
-                     "type":"0x1::Reconfiguration::NewEpochEvent",
-                     "data":{
-                        "epoch":"1"
-                     }
+                }
+              ],
+              "changes": [
+                {
+                  "type": "write_resource",
+                  "address": "0xa550c18",
+                  "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+                  "data": {
+                    "type": "0x1::Block::BlockMetadata",
+                    "data": {
+                      "height": "1",
+                      "new_block_events": {
+                        "counter": "1",
+                        "guid": {
+                          "guid": {
+                            "id": {
+                              "addr": "0xa550c18",
+                              "creation_num": "5"
+                            }
+                          },
+                          "len_bytes": 40
+                        }
+                      }
+                    }
                   }
-               ]
-            })).unwrap();
+                },
+                {
+                  "type": "write_resource",
+                  "address": "0xa550c18",
+                  "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+                  "data": {
+                    "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+                    "data": {
+                      "microseconds": "1650419261396337"
+                    }
+                  }
+                }
+              ]
+            }
+        )).unwrap();
 
         tailer
             .process_transaction(Arc::new(genesis_txn.clone()))
@@ -278,36 +316,72 @@ mod test {
         // A block_metadata_transaction
         let block_metadata_transaction: Transaction = serde_json::from_value(json!(
             {
-               "type":"block_metadata_transaction",
-               "version":"69158",
-               "hash":"0x2b7c58ed8524d228f9d0543a82e2793d04e8871df322f976b0e7bb8c5ced4ff5",
-               "state_root_hash":"0x3ead9eb40582fbc7df5e02f72280931dc3e6f1aae45dc832966b4cd972dac4b8",
-               "event_root_hash":"0x2e481956dea9c59b6fc9f823fe5f4c45efce173e42c551c1fe073b5d76a65504",
-               "gas_used":"0",
-               "success":true,
-               "vm_status":"Executed successfully",
-               "accumulator_root_hash":"0xb0ad602f805eb20c398f0f29a3504a9ef38bcc52c9c451deb9ec4a2d18807b49",
-               "id":"0xeef99391a3fc681f16963a6c03415bc0b1b12b56c00429308fa8bf46ac9eddf0",
-               "round":"57600",
-               "previous_block_votes":[
-                  "0x992da26d46e6d515a070c7f6e52376a1e674e850cb4d116babc6f870da9c258",
-                  "0xfb4d785594a018bd980b4a20556d120c53a3f50b1cff9d5aa2e26eee582a587",
-                  "0x2b7bce01a6f55e4a863c4822b154021a25588250c762ee01169b6208d6169208",
-                  "0x43a2c4cefc4725e710dadf423dd9142057208e640c623b27c6bba704380825ab",
-                  "0x4c91f3949924e988144550ece1da1bd9335cbecdd1c3ce1893f80e55376d018f",
-                  "0x61616c1208b6b3491496370e7783d48426c674bdd7d04ed1a96afe2e4d8a3930",
-                  "0x66ccccae2058641f136b79792d4d884419437826342ba84dfbbf3e52d8b3fc7d",
-                  "0x68f04222bd9f8846cda028ea5ba3846a806b04a47e1f1a4f0939f350d713b2eb",
-                  "0x6bbf2564ea4a6968df450da786b40b3f56b533a7b700c681c31b3714fc30256b",
-                  "0x735c0a1cb33689ecba65907ba05a485f98831ff610955a44abf0a986f2904612",
-                  "0x784a9514644c8ab6235aaff425381f2ea2719315a51388bc1f1e1c5afa2daaa9",
-                  "0x7a8cee78757dfe0cee3631208cc81f171d27ca6004c63ebae5814e1754a03c79",
-                  "0x803160c3a2f8e025df5a6e1110163493293dc974cc8abd43d4c1896000f4a1ec",
-                  "0xcece26ebddbadfcfbc541baddc989fa73b919b82915164bbf77ebd86c7edbc90",
-                  "0xe7be8996cbdf7db0f64abd17aa0968074b32e4b0df6560328921470e09fd608b"
-               ],
-               "proposer":"0x68f04222bd9f8846cda028ea5ba3846a806b04a47e1f1a4f0939f350d713b2eb",
-               "timestamp":"1649395495746947"
+              "type": "block_metadata_transaction",
+              "version": "69158",
+              "hash": "0x2b7c58ed8524d228f9d0543a82e2793d04e8871df322f976b0e7bb8c5ced4ff5",
+              "state_root_hash": "0x3ead9eb40582fbc7df5e02f72280931dc3e6f1aae45dc832966b4cd972dac4b8",
+              "event_root_hash": "0x2e481956dea9c59b6fc9f823fe5f4c45efce173e42c551c1fe073b5d76a65504",
+              "gas_used": "0",
+              "success": true,
+              "vm_status": "Executed successfully",
+              "accumulator_root_hash": "0xb0ad602f805eb20c398f0f29a3504a9ef38bcc52c9c451deb9ec4a2d18807b49",
+              "id": "0xeef99391a3fc681f16963a6c03415bc0b1b12b56c00429308fa8bf46ac9eddf0",
+              "round": "57600",
+              "previous_block_votes": [
+                "0x992da26d46e6d515a070c7f6e52376a1e674e850cb4d116babc6f870da9c258",
+                "0xfb4d785594a018bd980b4a20556d120c53a3f50b1cff9d5aa2e26eee582a587",
+                "0x2b7bce01a6f55e4a863c4822b154021a25588250c762ee01169b6208d6169208",
+                "0x43a2c4cefc4725e710dadf423dd9142057208e640c623b27c6bba704380825ab",
+                "0x4c91f3949924e988144550ece1da1bd9335cbecdd1c3ce1893f80e55376d018f",
+                "0x61616c1208b6b3491496370e7783d48426c674bdd7d04ed1a96afe2e4d8a3930",
+                "0x66ccccae2058641f136b79792d4d884419437826342ba84dfbbf3e52d8b3fc7d",
+                "0x68f04222bd9f8846cda028ea5ba3846a806b04a47e1f1a4f0939f350d713b2eb",
+                "0x6bbf2564ea4a6968df450da786b40b3f56b533a7b700c681c31b3714fc30256b",
+                "0x735c0a1cb33689ecba65907ba05a485f98831ff610955a44abf0a986f2904612",
+                "0x784a9514644c8ab6235aaff425381f2ea2719315a51388bc1f1e1c5afa2daaa9",
+                "0x7a8cee78757dfe0cee3631208cc81f171d27ca6004c63ebae5814e1754a03c79",
+                "0x803160c3a2f8e025df5a6e1110163493293dc974cc8abd43d4c1896000f4a1ec",
+                "0xcece26ebddbadfcfbc541baddc989fa73b919b82915164bbf77ebd86c7edbc90",
+                "0xe7be8996cbdf7db0f64abd17aa0968074b32e4b0df6560328921470e09fd608b"
+              ],
+              "proposer": "0x68f04222bd9f8846cda028ea5ba3846a806b04a47e1f1a4f0939f350d713b2eb",
+              "timestamp": "1649395495746947",
+              "changes": [
+                {
+                  "type": "write_resource",
+                  "address": "0xa550c18",
+                  "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+                  "data": {
+                    "type": "0x1::Block::BlockMetadata",
+                    "data": {
+                      "height": "1",
+                      "new_block_events": {
+                        "counter": "1",
+                        "guid": {
+                          "guid": {
+                            "id": {
+                              "addr": "0xa550c18",
+                              "creation_num": "5"
+                            }
+                          },
+                          "len_bytes": 40
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "write_resource",
+                  "address": "0xa550c18",
+                  "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+                  "data": {
+                    "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+                    "data": {
+                      "microseconds": "1650419261396337"
+                    }
+                  }
+                }
+              ]
             }
         )).unwrap();
 
@@ -317,74 +391,110 @@ mod test {
             .unwrap();
 
         // This is a block metadata transaction
-        let (tx1, ut1, bmt1, events1) =
+        let (tx1, ut1, bmt1, events1, wsc1) =
             TransactionModel::get_by_version(69158, &conn_pool.get().unwrap()).unwrap();
         assert_eq!(tx1.type_, "block_metadata_transaction");
         assert!(ut1.is_none());
         assert!(bmt1.is_some());
         assert_eq!(events1.len(), 0);
+        assert_eq!(wsc1.len(), 2);
 
         // This is the genesis transaction
-        let (tx0, ut0, bmt0, events0) =
+        let (tx0, ut0, bmt0, events0, wsc0) =
             TransactionModel::get_by_version(0, &conn_pool.get().unwrap()).unwrap();
         assert_eq!(tx0.type_, "genesis_transaction");
         assert!(ut0.is_none());
         assert!(bmt0.is_none());
         assert_eq!(events0.len(), 1);
+        assert_eq!(wsc0.len(), 2);
 
         // A user transaction, with fake events
         let user_txn: Transaction = serde_json::from_value(json!(
             {
-               "type":"user_transaction",
-               "version":"691595",
-               "hash":"0xefd4c865e00c240da0c426a37ceeda10d9b030d0e8a4fb4fb7ff452ad63401fb",
-               "state_root_hash":"0xebfe1eb7aa5321e7a7d741d927487163c34c821eaab60646ae0efd02b286c97c",
-               "event_root_hash":"0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",
-               "gas_used":"43",
-               "success":true,
-               "vm_status":"Executed successfully",
-               "accumulator_root_hash":"0x97bfd5949d32f6c9a9efad93411924bfda658a8829de384d531ee73c2f740971",
-               "sender":"0xdfd557c68c6c12b8c65908b3d3c7b95d34bb12ae6eae5a43ee30aa67a4c12494",
-               "sequence_number":"21386",
-               "max_gas_amount":"1000",
-               "gas_unit_price":"1",
-               "gas_currency_code":"XUS",
-               "expiration_timestamp_secs":"1649713172",
-               "payload":{
-                  "type":"script_function_payload",
-                  "function":"0x1::TestCoin::mint",
-                  "type_arguments":[
-
-                  ],
-                  "arguments":[
-                     "0x45b44793724a5ecc6ad85fa60949d0824cfc7f61d6bd74490b13598379313142",
-                     "20000"
-                  ]
-               },
-               "signature":{
-                  "type":"ed25519_signature",
-                  "public_key":"0x14ff6646855dad4a2dab30db773cdd4b22d6f9e6813f3e50142adf4f3efcf9f8",
-                  "signature":"0x70781112e78cc8b54b86805c016cef2478bccdef21b721542af0323276ab906c989172adffed5bf2f475f2ec3a5b284a0ac46a6aef0d79f0dbb6b85bfca0080a"
-               },
-               "events":[
-                  {
-                     "key":"0x040000000000000000000000000000000000000000000000000000000000000000000000fefefefe",
-                     "sequence_number":"0",
-                     "type":"0x1::Whatever::FakeEvent1",
-                     "data":{
-                        "amazing":"1"
-                     }
-                  },
-                  {
-                     "key":"0x040000000000000000000000000000000000000000000000000000000000000000000000fefefefe",
-                     "sequence_number":"1",
-                     "type":"0x1::Whatever::FakeEvent2",
-                     "data":{
-                        "amazing":"2"
-                     }
+              "type": "user_transaction",
+              "version": "691595",
+              "hash": "0xefd4c865e00c240da0c426a37ceeda10d9b030d0e8a4fb4fb7ff452ad63401fb",
+              "state_root_hash": "0xebfe1eb7aa5321e7a7d741d927487163c34c821eaab60646ae0efd02b286c97c",
+              "event_root_hash": "0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",
+              "gas_used": "43",
+              "success": true,
+              "vm_status": "Executed successfully",
+              "accumulator_root_hash": "0x97bfd5949d32f6c9a9efad93411924bfda658a8829de384d531ee73c2f740971",
+              "sender": "0xdfd557c68c6c12b8c65908b3d3c7b95d34bb12ae6eae5a43ee30aa67a4c12494",
+              "sequence_number": "21386",
+              "max_gas_amount": "1000",
+              "gas_unit_price": "1",
+              "gas_currency_code": "XUS",
+              "expiration_timestamp_secs": "1649713172",
+              "payload": {
+                "type": "script_function_payload",
+                "function": "0x1::TestCoin::mint",
+                "type_arguments": [],
+                "arguments": [
+                  "0x45b44793724a5ecc6ad85fa60949d0824cfc7f61d6bd74490b13598379313142",
+                  "20000"
+                ]
+              },
+              "signature": {
+                "type": "ed25519_signature",
+                "public_key": "0x14ff6646855dad4a2dab30db773cdd4b22d6f9e6813f3e50142adf4f3efcf9f8",
+                "signature": "0x70781112e78cc8b54b86805c016cef2478bccdef21b721542af0323276ab906c989172adffed5bf2f475f2ec3a5b284a0ac46a6aef0d79f0dbb6b85bfca0080a"
+              },
+              "events": [
+                {
+                  "key": "0x040000000000000000000000000000000000000000000000000000000000000000000000fefefefe",
+                  "sequence_number": "0",
+                  "type": "0x1::Whatever::FakeEvent1",
+                  "data": {
+                    "amazing": "1"
                   }
-               ],
-               "timestamp":"1649713141723410"
+                },
+                {
+                  "key": "0x040000000000000000000000000000000000000000000000000000000000000000000000fefefefe",
+                  "sequence_number": "1",
+                  "type": "0x1::Whatever::FakeEvent2",
+                  "data": {
+                    "amazing": "2"
+                  }
+                }
+              ],
+              "timestamp": "1649713141723410",
+              "changes": [
+                {
+                  "type": "write_resource",
+                  "address": "0xa550c18",
+                  "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
+                  "data": {
+                    "type": "0x1::Block::BlockMetadata",
+                    "data": {
+                      "height": "1",
+                      "new_block_events": {
+                        "counter": "1",
+                        "guid": {
+                          "guid": {
+                            "id": {
+                              "addr": "0xa550c18",
+                              "creation_num": "5"
+                            }
+                          },
+                          "len_bytes": 40
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "write_resource",
+                  "address": "0xa550c18",
+                  "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
+                  "data": {
+                    "type": "0x1::Timestamp::CurrentTimeMicroseconds",
+                    "data": {
+                      "microseconds": "1650419261396337"
+                    }
+                  }
+                }
+              ]
             }
         )).unwrap();
 
@@ -399,7 +509,7 @@ mod test {
             .unwrap();
 
         // This is a user transaction, so the bmt should be None
-        let (tx2, ut2, bmt2, events2) =
+        let (tx2, ut2, bmt2, events2, wsc2) =
             TransactionModel::get_by_version(691595, &conn_pool.get().unwrap()).unwrap();
         assert_eq!(
             tx2.hash,
@@ -411,6 +521,7 @@ mod test {
         assert_eq!(events2.len(), 2);
         assert_eq!(events2.get(0).unwrap().type_, "0x1::Whatever::FakeEvent1");
         assert_eq!(events2.get(1).unwrap().type_, "0x1::Whatever::FakeEvent2");
+        assert_eq!(wsc2.len(), 2);
 
         // Fetch the latest status
         let latest_version = tailer.set_fetcher_to_lowest_processor_version().await;

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-
 use crate::{
     database::PgDbPool,
     indexer::{
@@ -242,69 +241,195 @@ mod test {
         // An abridged genesis transaction
         let genesis_txn: Transaction = serde_json::from_value(json!(
             {
-              "type": "genesis_transaction",
-              "version": "0",
-              "hash": "0x12180a4bbccf48de4d1e23b498add134328669ffc7741c8d529c6b2e3629ac99",
-              "state_root_hash": "0xb50adef3662d77e528be9e1cb5637fe5b7afd13eea317b330799f0c559c918c1",
-              "event_root_hash": "0xcbdbb1b830d1016d45a828bb3171ea81826e8315f14140acfbd7886f49fbcb40",
-              "gas_used": "0",
-              "success": true,
-              "vm_status": "Executed successfully",
-              "accumulator_root_hash": "0x188ed588547d551e652f04fccd5434c2977d6cff9e7443eb8e7c3038408caad4",
-              "payload": {
-                "type": "write_set_payload",
-                "write_set": {
-                  "type": "direct_write_set",
-                  "changes": [],
-                  "events": []
-                }
-              },
-              "events": [
-                {
-                  "key": "0x0400000000000000000000000000000000000000000000000000000000000000000000000a550c18",
-                  "sequence_number": "0",
-                  "type": "0x1::Reconfiguration::NewEpochEvent",
-                  "data": {
-                    "epoch": "1"
-                  }
-                }
-              ],
-              "changes": [
-                {
-                  "type": "write_resource",
-                  "address": "0xa550c18",
-                  "state_key_hash": "0x220a03e13099533097731c551fe037bbf404dcf765fe4df8743022a298650e6e",
-                  "data": {
-                    "type": "0x1::Block::BlockMetadata",
-                    "data": {
-                      "height": "1",
-                      "new_block_events": {
-                        "counter": "1",
-                        "guid": {
-                          "guid": {
-                            "id": {
-                              "addr": "0xa550c18",
-                              "creation_num": "5"
-                            }
-                          },
-                          "len_bytes": 40
+               "type":"genesis_transaction",
+               "version":"0",
+               "hash":"0xa4d0d270d71cf031476dd2674d1e4a247489dfc3521c871ee37f42bd71a0a234",
+               "state_root_hash":"0x27b382a98a32256a9e6403ca1f6e26998273d77afa9e8666e7ee13679af40a7a",
+               "event_root_hash":"0xcbdbb1b830d1016d45a828bb3171ea81826e8315f14140acfbd7886f49fbcb40",
+               "gas_used":"0",
+               "success":true,
+               "vm_status":"Executed successfully",
+               "accumulator_root_hash":"0x6a527d06063dfd42c6b3a862574d5f3ec1660afb8058135edda5072712bfdb51",
+               "changes":[
+                  {
+                     "type":"write_resource",
+                     "address":"0x1",
+                     "state_key_hash":"3502b05382fba777545b45a0a9d40e86cdde7c3afbde19c748ce8b5f142c2b46",
+                     "data":{
+                        "type":"0x1::Account::Account",
+                        "data":{
+                           "authentication_key":"0x1e4dcad3d5d94307f30d51ff66d2ce784e0c2822d3138766907179bcb61f9edc",
+                           "self_address":"0x1",
+                           "sequence_number":"0"
                         }
-                      }
-                    }
+                     }
+                  },
+                  {
+                     "type":"write_module",
+                     "address":"0x1",
+                     "state_key_hash":"e428253ccf0b18f3d8300c6a0d29de93abcdc526e88728abeb85d57aec558935",
+                     "data":{
+                        "bytecode":"0xa11ceb0b050000000a01000a020a04030e2305310e073f940108d3012006f3012c0a9f02050ca402370ddb020200000001000200030004000008000005000100000602000004080000000409000000030a030000020b030400010c05050000010202060c0201060c0105010307436861696e4964064572726f7273065369676e65720f53797374656d4164647265737365730954696d657374616d70036765740a696e697469616c697a65026964106173736572745f6f7065726174696e670e6173736572745f67656e65736973146173736572745f636f72655f7265736f757263650a616464726573735f6f6611616c72656164795f7075626c69736865640000000000000000000000000000000000000000000000000000000000000001030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201070200010001000006110207012b001000140201010000001211030a0011040a001105290020030d0b000107001106270b000b0112002d0002000000",
+                        "abi":{
+                           "address":"0x1",
+                           "name":"ChainId",
+                           "friends":[
+
+                           ],
+                           "exposed_functions":[
+                              {
+                                 "name":"get",
+                                 "visibility":"public",
+                                 "generic_type_params":[
+
+                                 ],
+                                 "params":[
+
+                                 ],
+                                 "return":[
+                                    "u8"
+                                 ]
+                              },
+                              {
+                                 "name":"initialize",
+                                 "visibility":"public",
+                                 "generic_type_params":[
+
+                                 ],
+                                 "params":[
+                                    "&signer",
+                                    "u8"
+                                 ],
+                                 "return":[
+
+                                 ]
+                              }
+                           ],
+                           "structs":[
+                              {
+                                 "name":"ChainId",
+                                 "is_native":false,
+                                 "abilities":[
+                                    "key"
+                                 ],
+                                 "generic_type_params":[
+
+                                 ],
+                                 "fields":[
+                                    {
+                                       "name":"id",
+                                       "type":"u8"
+                                    }
+                                 ]
+                              }
+                           ]
+                        }
+                     }
                   }
-                },
-                {
-                  "type": "write_resource",
-                  "address": "0xa550c18",
-                  "state_key_hash": "0xf113db06626eb7724773e4e9dacecc8a6cb3a710b8b70365768168b24fe06ce3",
-                  "data": {
-                    "type": "0x1::Timestamp::CurrentTimeMicroseconds",
-                    "data": {
-                      "microseconds": "1650419261396337"
-                    }
+               ],
+               "payload":{
+                  "type":"write_set_payload",
+                  "write_set":{
+                     "type":"direct_write_set",
+                     "changes":[
+                        {
+                           "type":"write_resource",
+                           "address":"0x1",
+                           "state_key_hash":"3502b05382fba777545b45a0a9d40e86cdde7c3afbde19c748ce8b5f142c2b46",
+                           "data":{
+                              "type":"0x1::Account::Account",
+                              "data":{
+                                 "authentication_key":"0x1e4dcad3d5d94307f30d51ff66d2ce784e0c2822d3138766907179bcb61f9edc",
+                                 "self_address":"0x1",
+                                 "sequence_number":"0"
+                              }
+                           }
+                        },
+                        {
+                           "type":"write_module",
+                           "address":"0x1",
+                           "state_key_hash":"e428253ccf0b18f3d8300c6a0d29de93abcdc526e88728abeb85d57aec558935",
+                           "data":{
+                              "bytecode":"0xa11ceb0b050000000a01000a020a04030e2305310e073f940108d3012006f3012c0a9f02050ca402370ddb020200000001000200030004000008000005000100000602000004080000000409000000030a030000020b030400010c05050000010202060c0201060c0105010307436861696e4964064572726f7273065369676e65720f53797374656d4164647265737365730954696d657374616d70036765740a696e697469616c697a65026964106173736572745f6f7065726174696e670e6173736572745f67656e65736973146173736572745f636f72655f7265736f757263650a616464726573735f6f6611616c72656164795f7075626c69736865640000000000000000000000000000000000000000000000000000000000000001030800000000000000000520000000000000000000000000000000000000000000000000000000000a550c18000201070200010001000006110207012b001000140201010000001211030a0011040a001105290020030d0b000107001106270b000b0112002d0002000000",
+                              "abi":{
+                                 "address":"0x1",
+                                 "name":"ChainId",
+                                 "friends":[
+
+                                 ],
+                                 "exposed_functions":[
+                                    {
+                                       "name":"get",
+                                       "visibility":"public",
+                                       "generic_type_params":[
+
+                                       ],
+                                       "params":[
+
+                                       ],
+                                       "return":[
+                                          "u8"
+                                       ]
+                                    },
+                                    {
+                                       "name":"initialize",
+                                       "visibility":"public",
+                                       "generic_type_params":[
+
+                                       ],
+                                       "params":[
+                                          "&signer",
+                                          "u8"
+                                       ],
+                                       "return":[
+
+                                       ]
+                                    }
+                                 ],
+                                 "structs":[
+                                    {
+                                       "name":"ChainId",
+                                       "is_native":false,
+                                       "abilities":[
+                                          "key"
+                                       ],
+                                       "generic_type_params":[
+
+                                       ],
+                                       "fields":[
+                                          {
+                                             "name":"id",
+                                             "type":"u8"
+                                          }
+                                       ]
+                                    }
+                                 ]
+                              }
+                           }
+                        }
+                     ],
+                     "events":[
+                        {
+                           "key":"0x0400000000000000000000000000000000000000000000000000000000000000000000000a550c18",
+                           "sequence_number":"0",
+                           "type":"0x1::Reconfiguration::NewEpochEvent",
+                           "data":{
+                              "epoch":"1"
+                           }
+                        }
+                     ]
                   }
-                }
-              ]
+               },
+               "events":[
+                  {
+                     "key":"0x0400000000000000000000000000000000000000000000000000000000000000000000000a550c18",
+                     "sequence_number":"0",
+                     "type":"0x1::Reconfiguration::NewEpochEvent",
+                     "data":{
+                        "epoch":"1"
+                     }
+                  }
+               ]
             }
         )).unwrap();
 

--- a/ecosystem/indexer/src/lib.rs
+++ b/ecosystem/indexer/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// Increase recursion limit for `serde_json::json!` macro parsing
+#![recursion_limit = "256"]
+
 #[macro_use]
 extern crate diesel_migrations;
 

--- a/ecosystem/indexer/src/models/mod.rs
+++ b/ecosystem/indexer/src/models/mod.rs
@@ -4,3 +4,4 @@
 pub mod events;
 pub mod processor_statuses;
 pub mod transactions;
+pub mod write_set_changes;

--- a/ecosystem/indexer/src/models/write_set_changes.rs
+++ b/ecosystem/indexer/src/models/write_set_changes.rs
@@ -35,7 +35,7 @@ impl WriteSetChange {
                 module,
             } => WriteSetChange {
                 transaction_hash,
-                hash: state_key_hash.to_string(),
+                hash: state_key_hash.clone(),
                 type_: write_set_change.type_str().to_string(),
                 address: address.to_string(),
                 module: serde_json::to_value(module).unwrap(),
@@ -49,7 +49,7 @@ impl WriteSetChange {
                 resource,
             } => WriteSetChange {
                 transaction_hash,
-                hash: state_key_hash.to_string(),
+                hash: state_key_hash.clone(),
                 type_: write_set_change.type_str().to_string(),
                 address: address.to_string(),
                 module: Default::default(),
@@ -63,7 +63,7 @@ impl WriteSetChange {
                 data,
             } => WriteSetChange {
                 transaction_hash,
-                hash: state_key_hash.to_string(),
+                hash: state_key_hash.clone(),
                 type_: write_set_change.type_str().to_string(),
                 address: address.to_string(),
                 module: Default::default(),
@@ -77,7 +77,7 @@ impl WriteSetChange {
                 data,
             } => WriteSetChange {
                 transaction_hash,
-                hash: state_key_hash.to_string(),
+                hash: state_key_hash.clone(),
                 type_: write_set_change.type_str().to_string(),
                 address: address.to_string(),
                 module: Default::default(),

--- a/ecosystem/indexer/src/models/write_set_changes.rs
+++ b/ecosystem/indexer/src/models/write_set_changes.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{models::transactions::Transaction, schema::write_set_changes};
+use aptos_rest_client::aptos_api_types::WriteSetChange as APIWriteSetChange;
+use serde::Serialize;
+
+#[derive(AsChangeset, Associations, Debug, Identifiable, Insertable, Queryable, Serialize)]
+#[diesel(table_name = "write_set_changes")]
+#[belongs_to(Transaction, foreign_key = "transaction_hash")]
+#[primary_key(transaction_hash, hash)]
+pub struct WriteSetChange {
+    pub transaction_hash: String,
+    pub hash: String,
+    #[diesel(column_name = type)]
+    pub type_: String,
+    pub address: String,
+    pub module: serde_json::Value,
+    pub resource: serde_json::Value,
+    pub data: serde_json::Value,
+
+    // Default time columns
+    pub inserted_at: chrono::NaiveDateTime,
+}
+
+impl WriteSetChange {
+    pub fn from_write_set_change(
+        transaction_hash: String,
+        write_set_change: &APIWriteSetChange,
+    ) -> Self {
+        match write_set_change {
+            APIWriteSetChange::DeleteModule {
+                address,
+                state_key_hash,
+                module,
+            } => WriteSetChange {
+                transaction_hash,
+                hash: state_key_hash.to_string(),
+                type_: write_set_change.type_str().to_string(),
+                address: address.to_string(),
+                module: serde_json::to_value(module).unwrap(),
+                resource: Default::default(),
+                data: Default::default(),
+                inserted_at: chrono::Utc::now().naive_utc(),
+            },
+            APIWriteSetChange::DeleteResource {
+                address,
+                state_key_hash,
+                resource,
+            } => WriteSetChange {
+                transaction_hash,
+                hash: state_key_hash.to_string(),
+                type_: write_set_change.type_str().to_string(),
+                address: address.to_string(),
+                module: Default::default(),
+                resource: serde_json::to_value(resource).unwrap(),
+                data: Default::default(),
+                inserted_at: chrono::Utc::now().naive_utc(),
+            },
+            APIWriteSetChange::WriteModule {
+                address,
+                state_key_hash,
+                data,
+            } => WriteSetChange {
+                transaction_hash,
+                hash: state_key_hash.to_string(),
+                type_: write_set_change.type_str().to_string(),
+                address: address.to_string(),
+                module: Default::default(),
+                resource: Default::default(),
+                data: serde_json::to_value(data).unwrap(),
+                inserted_at: chrono::Utc::now().naive_utc(),
+            },
+            APIWriteSetChange::WriteResource {
+                address,
+                state_key_hash,
+                data,
+            } => WriteSetChange {
+                transaction_hash,
+                hash: state_key_hash.to_string(),
+                type_: write_set_change.type_str().to_string(),
+                address: address.to_string(),
+                module: Default::default(),
+                resource: Default::default(),
+                data: serde_json::to_value(data).unwrap(),
+                inserted_at: chrono::Utc::now().naive_utc(),
+            },
+        }
+    }
+
+    pub fn from_write_set_changes(
+        transaction_hash: String,
+        write_set_changes: &[APIWriteSetChange],
+    ) -> Option<Vec<Self>> {
+        if write_set_changes.is_empty() {
+            return None;
+        }
+        Some(
+            write_set_changes
+                .iter()
+                .map(|write_set_change| {
+                    Self::from_write_set_change(transaction_hash.clone(), write_set_change)
+                })
+                .collect::<Vec<WriteSetChangeModel>>(),
+        )
+    }
+}
+
+// Prevent conflicts with other things named `WriteSetChange`
+pub type WriteSetChangeModel = WriteSetChange;

--- a/ecosystem/indexer/src/schema.rs
+++ b/ecosystem/indexer/src/schema.rs
@@ -66,10 +66,25 @@ table! {
     }
 }
 
+table! {
+    write_set_changes (hash) {
+        transaction_hash -> Varchar,
+        hash -> Varchar,
+        #[sql_name = "type"]
+        type_ -> Text,
+        address -> Varchar,
+        module -> Jsonb,
+        resource -> Jsonb,
+        data -> Jsonb,
+        inserted_at -> Timestamp,
+    }
+}
+
 allow_tables_to_appear_in_same_query!(
     block_metadata_transactions,
     events,
     processor_statuses,
     transactions,
     user_transactions,
+    write_set_changes,
 );

--- a/ecosystem/typescript/sdk/README.md
+++ b/ecosystem/typescript/sdk/README.md
@@ -41,7 +41,7 @@ sudo apt-get install nodejs yarn
 Originally created with this:
 
 ```bash
-$  npx swagger-typescript-api -p ../api/doc/openapi.yaml -o ./src/api --modular --axios --single-http-client
+$  npx swagger-typescript-api -p ../../../api/doc/openapi.yaml -o ./src/api --modular --axios --single-http-client
 ```
 
 #### Changes to make after generation:

--- a/ecosystem/typescript/sdk/src/api/data-contracts.ts
+++ b/ecosystem/typescript/sdk/src/api/data-contracts.ts
@@ -526,6 +526,7 @@ export interface OnChainTransactionInfo {
    * Different with `Address` type, hex-encoded bytes should not trim any zeros.
    */
   accumulator_root_hash: HexEncodedBytes;
+  changes: WriteSetChange[];
 }
 
 export type UserTransaction = { type: string; events: Event[]; timestamp: TimestampUsec } & UserTransactionRequest &
@@ -626,6 +627,14 @@ export interface DeleteModule {
   type: string;
 
   /**
+   * All bytes data are represented as hex-encoded string prefixed with `0x` and fulfilled with
+   * two hex digits per byte.
+   *
+   * Different with `Address` type, hex-encoded bytes should not trim any zeros.
+   */
+  state_key_hash: HexEncodedBytes;
+
+  /**
    * Hex-encoded 16 bytes Aptos account address.
    *
    * Prefixed with `0x` and leading zeros are trimmed.
@@ -651,6 +660,14 @@ export interface DeleteModule {
 export interface DeleteResource {
   /** @example delete_resource */
   type: string;
+
+  /**
+   * All bytes data are represented as hex-encoded string prefixed with `0x` and fulfilled with
+   * two hex digits per byte.
+   *
+   * Different with `Address` type, hex-encoded bytes should not trim any zeros.
+   */
+  state_key_hash: HexEncodedBytes;
 
   /**
    * Hex-encoded 16 bytes Aptos account address.
@@ -686,6 +703,14 @@ export interface WriteModule {
   type: string;
 
   /**
+   * All bytes data are represented as hex-encoded string prefixed with `0x` and fulfilled with
+   * two hex digits per byte.
+   *
+   * Different with `Address` type, hex-encoded bytes should not trim any zeros.
+   */
+  state_key_hash: HexEncodedBytes;
+
+  /**
    * Hex-encoded 16 bytes Aptos account address.
    *
    * Prefixed with `0x` and leading zeros are trimmed.
@@ -701,6 +726,14 @@ export interface WriteModule {
 export interface WriteResource {
   /** @example write_resource */
   type: string;
+
+  /**
+   * All bytes data are represented as hex-encoded string prefixed with `0x` and fulfilled with
+   * two hex digits per byte.
+   *
+   * Different with `Address` type, hex-encoded bytes should not trim any zeros.
+   */
+  state_key_hash: HexEncodedBytes;
 
   /**
    * Hex-encoded 16 bytes Aptos account address.

--- a/ecosystem/typescript/sdk/src/api/http-client.ts
+++ b/ecosystem/typescript/sdk/src/api/http-client.ts
@@ -108,6 +108,7 @@ export class HttpClient<SecurityDataType = unknown> {
     const requestParams = this.mergeRequestParams(params, secureParams);
     const responseFormat = (format && this.format) || void 0;
 
+    // @ts-ignore
     if (type === ContentType.FormData && body && body !== null && typeof body === "object") {
       // @ts-ignore
       requestParams.headers.common = { Accept: "*/*" };


### PR DESCRIPTION
It's difficult for the indexer, and developers, to see the side effects of transactions: this exposes the write set for each transaction via the API, allowing for indexers to get a more detailed account state, and for developers to be able to better introspect transactions