### PR TITLE
Run typescript CI against docker compose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,6 @@ executors:
     machine:
       image: ubuntu-2004:current
     resource_class: 2xlarge
-  docker-typescript-builder:
-    docker:
-      - image: circleci/node:16.13.1-browsers
 
 jobs:
   build-benchmarks:
@@ -216,40 +213,29 @@ jobs:
   docker-compose-test:
     executor: ubuntu-medium
     steps:
-      - checkout
-      - aws-setup
-      - aws-ecr-setup
-      - local-deploy-setup
-      - run: echo "export IMAGE_TAG=dev_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
-      # since we're running with `--build-all`, assume that if it passes, we have all images required for Forge
-      - run: aws ecr describe-images --repository-name="aptos/validator" --image-ids=imageTag=$IMAGE_TAG
-      - run:
-          name: Start local testnet docker-compose
-          shell: /bin/bash
-          working_directory: docker/compose/validator-testnet
-          command: |
-            export VALIDATOR_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/validator
-            export FAUCET_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/faucet
-            docker-compose up -d
-      - run:
-          name: Verify testnet docker-compose up
-          shell: /bin/bash
-          command: |
-            for i in $(seq 60); do
-              curl -s -w "\n%{http_code}\n" localhost:8080 | tee >(tail -1 > validator_ret.txt)
-              curl -s -w "\n%{http_code}\n" -X POST 'localhost:8000/mint?pub_key=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d&amount=20000000' \
-                | tee >(tail -1 > faucet_ret.txt)
-              if [ "$(cat validator_ret.txt)" = "200" ] && [ "$(cat faucet_ret.txt)" = "200" ]; then
-                echo "Both validator and faucet healthy"
-                exit 0
-              fi
-              sleep 1
-            done
-            exit 1
+      - docker-compose-setup
   sdk-typescript-test:
-    executor: docker-typescript-builder
+    executor: ubuntu-medium
     steps:
-      - checkout
+      - docker-compose-setup
+      - dev-setup
+      - run:
+          name: Install Node + Yarn
+          command: |
+            # Set up Node
+            export NODE_VERSION=16.14.2
+            curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"
+            sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1
+            rm node.tar.xz
+            sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+            # Set up Yarn
+            export PATH=~/.yarn/bin:$PATH
+            export YARN_VERSION=1.22.17
+            curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz"
+            sudo tar -xzf yarn.tar.gz -C /opt/
+            rm yarn.tar.gz
+            sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn
+            sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
       # install packages for examples
       - run: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install
       - run: cd ./ecosystem/typescript/sdk/examples/javascript && yarn install
@@ -274,10 +260,13 @@ workflows:
       - e2e-test
       - lint
       - unit-test
-      - sdk-typescript-test
       - docker-build-push:
           context: aws-dev
       - docker-compose-test:
+          context: aws-dev
+          requires:
+            - docker-build-push
+      - sdk-typescript-test:
           context: aws-dev
           requires:
             - docker-build-push
@@ -386,3 +375,40 @@ commands:
             # the images that exist in dockerhub org
             echo "export DOCKERHUB_ORG=aptoslab" >> $BASH_ENV
             echo "export DOCKERHUB_IMAGES=( validator forge init validator_tcb tools faucet )" >> $BASH_ENV
+  docker-compose-setup:
+    steps:
+      - checkout
+      - aws-setup
+      - aws-ecr-setup
+      - local-deploy-setup
+      - run: echo "export IMAGE_TAG=dev_$(git rev-parse --short=8 HEAD)" >> $BASH_ENV
+      # since we're running with `--build-all`, assume that if it passes, we have all images required for Forge
+      - run: aws ecr describe-images --repository-name="aptos/validator" --image-ids=imageTag=$IMAGE_TAG
+      - run:
+          name: Set Node/Faucet URLs
+          command: |
+            export APTOS_NODE_URL="http://localhost:8080"
+            export APTOS_FAUCET_URL="http://localhost:8000"
+      - run:
+          name: Start local testnet docker-compose
+          shell: /bin/bash
+          working_directory: docker/compose/validator-testnet
+          command: |
+            export VALIDATOR_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/validator
+            export FAUCET_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/faucet
+            docker-compose up -d
+      - run:
+          name: Verify testnet docker-compose up
+          shell: /bin/bash
+          command: |
+            for i in $(seq 60); do
+              curl -s -w "\n%{http_code}\n" localhost:8080 | tee >(tail -1 > validator_ret.txt)
+              curl -s -w "\n%{http_code}\n" -X POST 'localhost:8000/mint?pub_key=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d&amount=20000000' \
+                | tee >(tail -1 > faucet_ret.txt)
+              if [ "$(cat validator_ret.txt)" = "200" ] && [ "$(cat faucet_ret.txt)" = "200" ]; then
+                echo "Both validator and faucet healthy"
+                exit 0
+              fi
+              sleep 1
+            done
+            exit 1

--- a/ecosystem/typescript/sdk/src/faucet_client.test.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.test.ts
@@ -6,7 +6,7 @@ import { UserTransaction } from "./api/data-contracts";
 
 import { NODE_URL, FAUCET_URL } from "./util.test";
 
-test.skip(
+test(
   "full tutorial faucet flow",
   async () => {
     const client = new AptosClient(NODE_URL);


### PR DESCRIPTION
We have typescript tests, and we have docker compose. This combines the two so that on every change of the node, we always run the typescript TS SDK tests against the latest node code