### PR TITLE
[aptos-cli] Fix cli inputs

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -6,11 +6,11 @@
 //! TODO: Examples
 //!
 
-use crate::common::types::{
-    account_address_from_public_key, ExtractPublicKey, PublicKeyInputOptions,
-};
 use crate::{
-    common::types::{EncodingOptions, NodeOptions, PrivateKeyInputOptions},
+    common::types::{
+        account_address_from_public_key, EncodingOptions, ExtractPublicKey, NodeOptions,
+        PrivateKeyInputOptions, PublicKeyInputOptions,
+    },
     CliResult, Error as CommonError,
 };
 use anyhow::Error;
@@ -42,6 +42,7 @@ pub struct CreateAccount {
     public_key_input_options: PublicKeyInputOptions,
 
     /// Chain ID
+    #[clap(long)]
     chain_id: u8,
 }
 

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -23,6 +23,7 @@ pub struct ListResources {
     node: NodeOptions,
 
     /// Address of account you want to list resources for
+    #[clap(long)]
     account: AccountAddress,
 }
 

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{ExtractPublicKey, PrivateKeyInputOptions};
 use crate::{
     common::{
-        types::{EncodingOptions, EncodingType, Error, KeyType, SaveFile},
+        types::{
+            EncodingOptions, EncodingType, Error, ExtractPublicKey, KeyType,
+            PrivateKeyInputOptions, SaveFile,
+        },
         utils::{append_file_extension, check_if_file_exists, to_common_result, write_to_file},
     },
     CliResult,

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -1,9 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::types::{ExtractPublicKey, PrivateKeyInputOptions};
 use crate::{
     common::{
-        types::{EncodingOptions, EncodingType, Error, KeyInputOptions, KeyType, SaveFile},
+        types::{EncodingOptions, EncodingType, Error, KeyType, SaveFile},
         utils::{append_file_extension, check_if_file_exists, to_common_result, write_to_file},
     },
     CliResult,
@@ -44,7 +45,7 @@ impl KeyTool {
 #[derive(Debug, Parser)]
 pub struct ExtractPeer {
     #[clap(flatten)]
-    key_input_options: KeyInputOptions,
+    private_key_input_options: PrivateKeyInputOptions,
     #[clap(flatten)]
     output_file_options: SaveFile,
     #[clap(flatten)]
@@ -58,7 +59,7 @@ impl ExtractPeer {
 
         // Load key based on public or private
         let public_key = self
-            .key_input_options
+            .private_key_input_options
             .extract_x25519_public_key(self.encoding_options.encoding)?;
 
         // Build peer info


### PR DESCRIPTION
## Motivation

After reading through @kent-white's code (trying to extend the client), I realized the stuff I wrote earlier for keys didn't make sense.  So, I've removed the "private & public" combined key pieces to separate ones (which can also just have a trait to extract from both).  Ideally, we should look later into making the default for list to be your own account address (which can be derived from the local config).

Additionally, I just made sure everything is a --flag so you're not surprised that you need to type in a random chain id number.
