### PR TITLE
Add HexTrimmed method to HexString

### DIFF
--- a/ecosystem/typescript/sdk/src/faucet_client.test.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.test.ts
@@ -43,7 +43,7 @@ test(
 
     const res = await client.getAccountTransactions(account1.address(), { start: 0 });
     const tx = res.find((e) => e.type === "user_transaction") as UserTransaction;
-    expect(tx.sender).toBe(account1.address().hex());
+    expect(tx.sender).toBe(account1.address().hexTrimmed());
 
     const events = await client.getEventsByEventHandle(tx.sender, "0x1::TestCoin::TransferEvents", "sent_events");
     expect(events[0].type).toBe("0x1::TestCoin::SentEvent");

--- a/ecosystem/typescript/sdk/src/hex_string.test.ts
+++ b/ecosystem/typescript/sdk/src/hex_string.test.ts
@@ -1,13 +1,17 @@
 import { HexString } from "./hex_string";
 
 const withoutPrefix = "007711b4d0";
+const withoutPrefixTrimmed = "7711b4d0";
 const withPrefix = `0x${withoutPrefix}`;
+const withPrefixTrimmed = `0x${withoutPrefixTrimmed}`;
 
 function validate(hexString: HexString) {
   expect(hexString.hex()).toBe(withPrefix);
   expect(hexString.toString()).toBe(withPrefix);
   expect(`${hexString}`).toBe(withPrefix);
   expect(hexString.noPrefix()).toBe(withoutPrefix);
+  expect(hexString.hexTrimmed()).toBe(withPrefixTrimmed);
+  expect(hexString.noPrefixTrimmed()).toBe(withoutPrefixTrimmed);
 }
 
 test("from/to buffer", () => {

--- a/ecosystem/typescript/sdk/src/hex_string.ts
+++ b/ecosystem/typescript/sdk/src/hex_string.ts
@@ -35,8 +35,16 @@ export class HexString {
     return this.hexString;
   }
 
+  hexTrimmed(): string {
+    return `0x${this.noPrefixTrimmed()}`;
+  }
+
   noPrefix(): string {
     return this.hexString.slice(2);
+  }
+
+  noPrefixTrimmed(): string {
+    return this.noPrefix().replace(/^0+/, "");
   }
 
   toString(): string {


### PR DESCRIPTION
Fix the following error:

```
Expected: "0x0e53a5cc20119c1337f42ed2ba2ecde0a2a545d2ed84d007eb7aa35506827ec5"
    Received: "0xe53a5cc20119c1337f42ed2ba2ecde0a2a545d2ed84d007eb7aa35506827ec5"

      44 |     const res = await client.getAccountTransactions(account1.address(), { start: 0 });
      45 |     const tx = res.find((e) => e.type === "user_transaction") as UserTransaction;
    > 46 |     expect(tx.sender).toBe(account1.address().hex());
```