### PR TITLE
[api] ability to create MoveValue::Struct from json

### DIFF
--- a/api/src/tests/converter_test.rs
+++ b/api/src/tests/converter_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{current_function_name, tests::new_test_context};
-use aptos_api_types::{AsConverter, MoveConverter};
+use aptos_api_types::{AsConverter, MoveConverter, MoveType};
 use aptos_vm::data_cache::AsMoveResolver;
 use move_core_types::{
     account_address::AccountAddress,
@@ -11,6 +11,7 @@ use move_core_types::{
 };
 use serde::Serialize;
 use serde_json::json;
+use std::convert::TryInto;
 
 #[tokio::test]
 async fn test_parse_move_value() {
@@ -55,9 +56,10 @@ fn assert_parse_move_value<'r, R: MoveResolver, V: Serialize>(
     json_value: V,
     expected_move_value: VmMoveValue,
 ) {
-    let move_type = serde_json::from_value(json!(json_move_type)).unwrap();
+    let move_type: MoveType = serde_json::from_value(json!(json_move_type)).unwrap();
+    let type_tag = move_type.try_into().unwrap();
     let move_value = converter
-        .try_into_move_value(&move_type, json!(json_value))
+        .try_into_vm_value(&type_tag, json!(json_value))
         .unwrap();
     assert_eq!(move_value, expected_move_value);
 }

--- a/api/src/tests/converter_test.rs
+++ b/api/src/tests/converter_test.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 use std::convert::TryInto;
 
 #[tokio::test]
-async fn test_parse_move_value() {
+async fn test_value_conversion() {
     let context = new_test_context(current_function_name!());
     let address = AccountAddress::from_hex_literal("0x1").unwrap();
 
@@ -22,24 +22,24 @@ async fn test_parse_move_value() {
     let resolver = state_view.as_move_resolver();
     let converter = resolver.as_converter();
 
-    assert_parse_move_value(&converter, "u8", 1i32, VmMoveValue::U8(1));
-    assert_parse_move_value(&converter, "u64", "1", VmMoveValue::U64(1));
-    assert_parse_move_value(&converter, "u128", "1", VmMoveValue::U128(1));
-    assert_parse_move_value(&converter, "bool", true, VmMoveValue::Bool(true));
-    assert_parse_move_value(&converter, "address", "0x1", VmMoveValue::Address(address));
-    assert_parse_move_value(
+    assert_value_conversion(&converter, "u8", 1i32, VmMoveValue::U8(1));
+    assert_value_conversion(&converter, "u64", "1", VmMoveValue::U64(1));
+    assert_value_conversion(&converter, "u128", "1", VmMoveValue::U128(1));
+    assert_value_conversion(&converter, "bool", true, VmMoveValue::Bool(true));
+    assert_value_conversion(&converter, "address", "0x1", VmMoveValue::Address(address));
+    assert_value_conversion(
         &converter,
         "vector<u8>",
         "0x0102",
         VmMoveValue::Vector(vec![VmMoveValue::U8(1), VmMoveValue::U8(2)]),
     );
-    assert_parse_move_value(
+    assert_value_conversion(
         &converter,
         "vector<u64>",
         ["1", "2"],
         VmMoveValue::Vector(vec![VmMoveValue::U64(1), VmMoveValue::U64(2)]),
     );
-    assert_parse_move_value(
+    assert_value_conversion(
         &converter,
         "0x1::GUID::ID",
         json!({"addr": "0x1", "creation_num": "1"}),
@@ -50,16 +50,21 @@ async fn test_parse_move_value() {
     );
 }
 
-fn assert_parse_move_value<'r, R: MoveResolver, V: Serialize>(
+fn assert_value_conversion<'r, R: MoveResolver, V: Serialize>(
     converter: &MoveConverter<'r, R>,
     json_move_type: &str,
     json_value: V,
-    expected_move_value: VmMoveValue,
+    expected_vm_value: VmMoveValue,
 ) {
     let move_type: MoveType = serde_json::from_value(json!(json_move_type)).unwrap();
     let type_tag = move_type.try_into().unwrap();
-    let move_value = converter
+    let vm_value = converter
         .try_into_vm_value(&type_tag, json!(json_value))
         .unwrap();
-    assert_eq!(move_value, expected_move_value);
+    assert_eq!(vm_value, expected_vm_value);
+
+    let vm_bytes = vm_value.undecorate().simple_serialize().unwrap();
+    let move_value_back = converter.try_into_move_value(&type_tag, &vm_bytes).unwrap();
+    let json_value_back = serde_json::to_value(move_value_back).unwrap();
+    assert_eq!(json_value_back, json!(json_value));
 }

--- a/api/src/tests/converter_test.rs
+++ b/api/src/tests/converter_test.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{current_function_name, tests::new_test_context};
+use aptos_api_types::{AsConverter, MoveConverter};
+use aptos_vm::data_cache::AsMoveResolver;
+use move_core_types::{
+    account_address::AccountAddress,
+    resolver::MoveResolver,
+    value::{MoveStruct, MoveValue as VmMoveValue},
+};
+use serde::Serialize;
+use serde_json::json;
+
+#[tokio::test]
+async fn test_parse_move_value() {
+    let context = new_test_context(current_function_name!());
+    let address = AccountAddress::from_hex_literal("0x1").unwrap();
+
+    let state_view = context.latest_state_view();
+    let resolver = state_view.as_move_resolver();
+    let converter = resolver.as_converter();
+
+    assert_parse_move_value(&converter, "u8", 1i32, VmMoveValue::U8(1));
+    assert_parse_move_value(&converter, "u64", "1", VmMoveValue::U64(1));
+    assert_parse_move_value(&converter, "u128", "1", VmMoveValue::U128(1));
+    assert_parse_move_value(&converter, "bool", true, VmMoveValue::Bool(true));
+    assert_parse_move_value(&converter, "address", "0x1", VmMoveValue::Address(address));
+    assert_parse_move_value(
+        &converter,
+        "vector<u8>",
+        "0x0102",
+        VmMoveValue::Vector(vec![VmMoveValue::U8(1), VmMoveValue::U8(2)]),
+    );
+    assert_parse_move_value(
+        &converter,
+        "vector<u64>",
+        ["1", "2"],
+        VmMoveValue::Vector(vec![VmMoveValue::U64(1), VmMoveValue::U64(2)]),
+    );
+    assert_parse_move_value(
+        &converter,
+        "0x1::GUID::ID",
+        json!({"addr": "0x1", "creation_num": "1"}),
+        VmMoveValue::Struct(MoveStruct::Runtime(vec![
+            VmMoveValue::U64(1),
+            VmMoveValue::Address(address),
+        ])),
+    );
+}
+
+fn assert_parse_move_value<'r, R: MoveResolver, V: Serialize>(
+    converter: &MoveConverter<'r, R>,
+    json_move_type: &str,
+    json_value: V,
+    expected_move_value: VmMoveValue,
+) {
+    let move_type = serde_json::from_value(json!(json_move_type)).unwrap();
+    let move_value = converter
+        .try_into_move_value(&move_type, json!(json_value))
+        .unwrap();
+    assert_eq!(move_value, expected_move_value);
+}

--- a/api/src/tests/mod.rs
+++ b/api/src/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod accounts_test;
+mod converter_test;
 mod events_test;
 mod golden_output;
 mod index_test;

--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -43,6 +43,7 @@ use executor::block_executor::BlockExecutor;
 use rand::SeedableRng;
 use serde_json::{json, Value};
 use std::{boxed::Box, collections::BTreeMap, sync::Arc};
+use storage_interface::state_view::DbStateView;
 use vm_validator::vm_validator::VMValidator;
 use warp::http::header::CONTENT_TYPE;
 
@@ -142,6 +143,12 @@ impl TestContext {
 
     pub fn root_account(&self) -> LocalAccount {
         LocalAccount::new(aptos_root_address(), self.root_keys.root_key.clone(), 0)
+    }
+
+    pub fn latest_state_view(&self) -> DbStateView {
+        self.context
+            .state_view_at_version(self.get_latest_ledger_info().version())
+            .unwrap()
     }
 
     pub fn gen_account(&mut self) -> LocalAccount {

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -577,6 +577,10 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
         }
     }
 
+    pub fn try_into_move_value(&self, typ: &TypeTag, bytes: &[u8]) -> Result<MoveValue> {
+        self.inner.view_value(typ, bytes)?.try_into()
+    }
+
     fn explain_function_index(&self, module_id: &ModuleId, function: &u16) -> Result<String> {
         let code = self.inner.get_module(&module_id.clone())? as Rc<dyn Bytecode>;
         let func = code.function_handle_at(FunctionHandleIndex::new(*function));


### PR DESCRIPTION

## Motivation

This will be useful for the client to pass in a table key, where
0x1::GUID::ID is a common type for a key.



### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

y

## Test Plan
unit test
## Related PRs
depends on https://github.com/move-language/move/pull/56 and https://github.com/move-language/move/pull/63