### PR TITLE
[State Sync] Remove consensus sync timeout and update metrics

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -400,14 +400,6 @@ impl<
                 .error(&error)
                 .message("Failed to handle a transaction commit notification!"));
         }
-
-        // Update the last commit timestamp for the sync request
-        let consensus_sync_request = self
-            .consensus_notification_handler
-            .get_consensus_sync_request();
-        if let Some(sync_request) = consensus_sync_request.lock().as_mut() {
-            sync_request.update_last_commit_timestamp()
-        };
     }
 
     /// Handles a notification sent by the storage synchronizer for committed accounts

--- a/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
@@ -25,11 +25,9 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
-    time::{Duration, SystemTime},
 };
 
 // TODO(joshlind): make these configurable!
-const CONSENSUS_SYNC_REQUEST_TIMEOUT_MS: u64 = 60000; // 1 minute
 const MEMPOOL_COMMIT_ACK_TIMEOUT_MS: u64 = 5000; // 5 seconds
 
 /// A notification for new data that has been committed to storage
@@ -157,23 +155,13 @@ impl FusedStream for CommitNotificationListener {
 /// A consensus sync request for a specified target ledger info
 pub struct ConsensusSyncRequest {
     consensus_sync_notification: ConsensusSyncNotification,
-    last_commit_timestamp: SystemTime,
 }
 
 impl ConsensusSyncRequest {
     pub fn new(consensus_sync_notification: ConsensusSyncNotification) -> Self {
         Self {
             consensus_sync_notification,
-            last_commit_timestamp: SystemTime::now(),
         }
-    }
-
-    pub fn update_last_commit_timestamp(&mut self) {
-        self.last_commit_timestamp = SystemTime::now();
-    }
-
-    pub fn get_last_commit_timestamp(&self) -> SystemTime {
-        self.last_commit_timestamp
     }
 
     pub fn get_sync_target(&self) -> LedgerInfoWithSignatures {
@@ -284,39 +272,6 @@ impl ConsensusNotificationHandler {
                     .await?;
                 }
                 return Ok(());
-            }
-
-            // Check if the commit deadline has been exceeded (timed out since the last commit)
-            let max_time_between_commits = Duration::from_millis(CONSENSUS_SYNC_REQUEST_TIMEOUT_MS);
-            let last_commit_timestamp = self
-                .get_consensus_sync_request()
-                .lock()
-                .as_ref()
-                .expect("The sync request should exist!")
-                .get_last_commit_timestamp();
-            let next_commit_deadline = last_commit_timestamp
-                .checked_add(max_time_between_commits)
-                .ok_or_else(|| {
-                    Error::IntegerOverflow("The new commit deadline has overflown!".into())
-                })?;
-            if SystemTime::now()
-                .duration_since(next_commit_deadline)
-                .is_ok()
-            {
-                // Remove the sync request and notify consensus that the request timed out
-                let error = Error::UnexpectedError(format!(
-                    "Sync request timed out! Hit the max time between commits: {:?}",
-                    max_time_between_commits
-                ));
-                let consensus_sync_request = self.get_consensus_sync_request().lock().take();
-                if let Some(consensus_sync_request) = consensus_sync_request {
-                    self.respond_to_sync_notification(
-                        consensus_sync_request.consensus_sync_notification,
-                        Err(error.clone()),
-                    )
-                    .await?;
-                }
-                return Err(error);
             }
         }
 


### PR DESCRIPTION
## Motivation

This PR makes two small improvements to state sync (each in their own commit):
1. State sync v1 had a feature whereby if state sync wasn't able to make progress on a consensus sync request within the timeout (e.g., 60 seconds), state sync would fail and respond with an error to consensus. This doesn't make much sense: if state sync can't make progress there's a serious issue and it doesn't make sense to hand back over to consensus. Because, consensus will just invoke a new sync request and we'll keep looping like this 😄 I've removed this from state sync v2. At the very least, if we ever hit this problem, it should be easier to debug now that we won't be flip-flopping anymore.
2. Update the state sync metrics to track the latest synced and execution versions when it receives a commit notification from consensus.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests and manual verification.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245