### PR TITLE
[aptos-cli] Cleanup cli

### DIFF
--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -68,7 +68,7 @@ async fn main() {
     );
 
     let key: ed25519::Ed25519PrivateKey = EncodingType::BCS
-        .load_key(Path::new(&args.mint_key_file_path))
+        .load_key("Ed25519PrivateKey", Path::new(&args.mint_key_file_path))
         .unwrap();
 
     let faucet_address: AccountAddress =

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -38,6 +38,20 @@ pub struct CreateAccount {
 }
 
 impl CreateAccount {
+    pub async fn execute(self) -> CliTypedResult<String> {
+        let public_key_to_create = self
+            .public_key_options
+            .extract_public_key(self.encoding_options.encoding)?;
+        let address = account_address_from_public_key(&public_key_to_create);
+
+        if self.use_faucet {
+            self.create_account_with_faucet(address).await
+        } else {
+            self.create_account_with_key(address).await
+        }
+        .map(|_| format!("Account Created at {}", address))
+    }
+
     async fn get_account(
         &self,
         account: AccountAddress,
@@ -117,19 +131,5 @@ impl CreateAccount {
         self.post_account(address, sender_private_key, sender_address, sequence_number)
             .await?;
         Ok(())
-    }
-
-    pub async fn execute(self) -> CliTypedResult<String> {
-        let public_key_to_create = self
-            .public_key_options
-            .extract_public_key(self.encoding_options.encoding)?;
-        let address = account_address_from_public_key(&public_key_to_create);
-
-        if self.use_faucet {
-            self.create_account_with_faucet(address).await
-        } else {
-            self.create_account_with_key(address).await
-        }
-        .map(|_| format!("Account Created at {}", address))
     }
 }

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -87,7 +87,7 @@ impl CreateAccount {
         let client = RestClient::new(reqwest::Url::clone(&self.write_options.rest_options.url));
         let transaction_factory = TransactionFactory::new(self.write_options.chain_id)
             .with_gas_unit_price(1)
-            .with_max_gas_amount(1000);
+            .with_max_gas_amount(self.write_options.max_gas);
         let sender_account = &mut LocalAccount::new(sender_address, sender_key, sequence_number);
         let transaction = sender_account.sign_with_transaction_builder(
             transaction_factory

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -8,18 +8,15 @@
 
 use crate::{
     common::types::{
-        account_address_from_public_key, EncodingOptions, ExtractPublicKey,
-        PublicKeyInputOptions, WriteTransactionOptions,
+        account_address_from_public_key, EncodingOptions, ExtractPublicKey, PublicKeyInputOptions,
+        WriteTransactionOptions,
     },
     CliResult, Error as CommonError,
 };
 use anyhow::Error;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
 use aptos_rest_client::{Client as RestClient, Response, Transaction};
-use aptos_sdk::{
-    transaction_builder::TransactionFactory,
-    types::{LocalAccount},
-};
+use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_address::AccountAddress;
 use clap::Parser;
@@ -62,11 +59,11 @@ impl CreateAccount {
         let account_response = self
             .get_account(account)
             .await
-            .map_err(|err| CommonError::UnexpectedError(err.to_string()))?;
+            .map_err(|err| CommonError::ApiError(err.to_string()))?;
         let sequence_number = &account_response["sequence_number"];
         match sequence_number.as_str() {
             Some(number) => Ok(number.parse::<u64>().unwrap()),
-            None => Err(CommonError::UnexpectedError(
+            None => Err(CommonError::ApiError(
                 "Sequence number not found".to_string(),
             )),
         }
@@ -104,7 +101,7 @@ impl CreateAccount {
         if response.status() == 200 {
             Ok(response.status().to_string())
         } else {
-            Err(Error::new(CommonError::UnexpectedError(format!(
+            Err(Error::new(CommonError::ApiError(format!(
                 "Faucet issue: {}",
                 response.status()
             ))))

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -46,7 +46,7 @@ impl ListResources {
         let result = self
             .get_resources()
             .await
-            .map_err(|err| CommonError::UnexpectedError(err.to_string()));
+            .map_err(|err| CommonError::ApiError(err.to_string()));
         to_common_result(result)
     }
 }

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -7,7 +7,7 @@
 //!
 
 use crate::{
-    common::{types::NodeOptions, utils::to_common_result},
+    common::{types::RestOptions, utils::to_common_result},
     CliResult, Error as CommonError,
 };
 use anyhow::Error;
@@ -20,7 +20,7 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 pub struct ListResources {
     #[clap(flatten)]
-    node: NodeOptions,
+    rest_options: RestOptions,
 
     /// Address of account you want to list resources for
     #[clap(long)]
@@ -29,7 +29,7 @@ pub struct ListResources {
 
 impl ListResources {
     async fn get_resources(self) -> Result<Vec<serde_json::Value>, Error> {
-        let client = Client::new(self.node.url);
+        let client = Client::new(self.rest_options.url);
         let response: Vec<Resource> = client
             .get_account_resources(self.account)
             .await?

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -1,11 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-//! A command to create a new account on-chain
-//!
-//! TODO: Examples
-//!
-
 use crate::common::types::CliResult;
 use clap::Subcommand;
 

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::CliResult;
+use crate::common::{types::CliResult, utils::to_common_result};
 use clap::Subcommand;
 
 pub mod create;
@@ -18,8 +18,8 @@ pub enum AccountTool {
 impl AccountTool {
     pub async fn execute(self) -> CliResult {
         match self {
-            AccountTool::Create(tool) => tool.execute().await,
-            AccountTool::List(tool) => tool.execute().await,
+            AccountTool::Create(tool) => to_common_result(tool.execute().await),
+            AccountTool::List(tool) => to_common_result(tool.execute().await),
         }
     }
 }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -4,10 +4,9 @@
 use crate::{
     common::{
         types::{CliConfig, CliError, CliTypedResult},
-        utils::{prompt_yes, to_common_success_result},
+        utils::prompt_yes,
     },
     op::key::GenerateKey,
-    CliResult,
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, ValidCryptoMaterialStringExt};
 use clap::Parser;
@@ -17,11 +16,7 @@ use clap::Parser;
 pub struct InitTool {}
 
 impl InitTool {
-    pub async fn execute(&self) -> CliResult {
-        to_common_success_result(self.execute_inner().await)
-    }
-
-    async fn execute_inner(&self) -> CliTypedResult<()> {
+    pub async fn execute(self) -> CliTypedResult<()> {
         let mut config = if CliConfig::config_exists()? {
             if !prompt_yes(
                 "Aptos already initialized, do you want to overwrite the existing config?",

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -35,14 +35,14 @@ impl InitTool {
         };
 
         eprintln!("Enter your private key as a hex literal (0x...) [No input: Generate new key]");
-        let input = read_line()?;
+        let input = read_line("Private key")?;
         let input = input.trim();
         let private_key = if input.is_empty() {
             eprintln!("No key given, generating key...");
             GenerateKey::generate_ed25519_in_memory()
         } else {
             Ed25519PrivateKey::from_encoded_string(input)
-                .map_err(|err| Error::UnableToParse("PrivateKey", err.to_string()))?
+                .map_err(|err| Error::UnableToParse("Ed25519PrivateKey", err.to_string()))?
         };
         config.private_key = Some(private_key);
         config.save()?;
@@ -53,11 +53,11 @@ impl InitTool {
 }
 
 /// Reads a line from input
-fn read_line() -> Result<String, Error> {
+fn read_line(input_name: &'static str) -> Result<String, Error> {
     let mut input_buf = String::new();
     let _ = std::io::stdin()
         .read_line(&mut input_buf)
-        .map_err(|err| Error::IO("Private key".to_string(), err))?;
+        .map_err(|err| Error::IO(input_name.to_string(), err))?;
 
     Ok(input_buf)
 }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -3,11 +3,11 @@
 
 use crate::{
     common::{
-        types::CliConfig,
+        types::{CliConfig, CliError, CliTypedResult},
         utils::{prompt_yes, to_common_success_result},
     },
     op::key::GenerateKey,
-    CliResult, Error,
+    CliResult,
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, ValidCryptoMaterialStringExt};
 use clap::Parser;
@@ -21,7 +21,7 @@ impl InitTool {
         to_common_success_result(self.execute_inner().await)
     }
 
-    async fn execute_inner(&self) -> Result<(), Error> {
+    async fn execute_inner(&self) -> CliTypedResult<()> {
         let mut config = if CliConfig::config_exists()? {
             if !prompt_yes(
                 "Aptos already initialized, do you want to overwrite the existing config?",
@@ -42,7 +42,7 @@ impl InitTool {
             GenerateKey::generate_ed25519_in_memory()
         } else {
             Ed25519PrivateKey::from_encoded_string(input)
-                .map_err(|err| Error::UnableToParse("Ed25519PrivateKey", err.to_string()))?
+                .map_err(|err| CliError::UnableToParse("Ed25519PrivateKey", err.to_string()))?
         };
         config.private_key = Some(private_key);
         config.save()?;
@@ -53,11 +53,11 @@ impl InitTool {
 }
 
 /// Reads a line from input
-fn read_line(input_name: &'static str) -> Result<String, Error> {
+fn read_line(input_name: &'static str) -> CliTypedResult<String> {
     let mut input_buf = String::new();
     let _ = std::io::stdin()
         .read_line(&mut input_buf)
-        .map_err(|err| Error::IO(input_name.to_string(), err))?;
+        .map_err(|err| CliError::IO(input_name.to_string(), err))?;
 
     Ok(input_buf)
 }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -7,7 +7,7 @@ use aptos_crypto::{
     x25519, PrivateKey, ValidCryptoMaterial, ValidCryptoMaterialStringExt,
 };
 use aptos_logger::{debug, info};
-use aptos_types::transaction::authenticator::AuthenticationKey;
+use aptos_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
 use clap::{ArgEnum, Parser};
 use itertools::Itertools;
 use move_core_types::account_address::AccountAddress;
@@ -327,8 +327,9 @@ impl SaveFile {
     }
 }
 
+/// Options specific to using the Rest endpoint
 #[derive(Debug, Parser)]
-pub struct NodeOptions {
+pub struct RestOptions {
     /// URL to a fullnode on the network
     ///
     /// Defaults to https://fullnode.devnet.aptoslabs.com
@@ -340,7 +341,19 @@ pub struct NodeOptions {
     pub url: reqwest::Url,
 }
 
-/// Options for a move package dir
+/// Options specific to submitting a private key to the Rest endpoint
+#[derive(Debug, Parser)]
+pub struct WriteTransactionOptions {
+    #[clap(flatten)]
+    pub private_key_options: PrivateKeyInputOptions,
+    #[clap(flatten)]
+    pub rest_options: RestOptions,
+    /// ChainId for the network
+    #[clap(long)]
+    pub chain_id: ChainId,
+}
+
+/// Options for compiling a move package dir
 #[derive(Debug, Parser)]
 pub struct MovePackageDir {
     /// Path to a move package (the folder with a Move.toml file)

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -352,6 +352,11 @@ pub struct WriteTransactionOptions {
     /// ChainId for the network
     #[clap(long)]
     pub chain_id: ChainId,
+    /// Maximum gas to be used to publish the package
+    ///
+    /// Defaults to 1000 gas units
+    #[clap(long, default_value_t = 1000)]
+    pub max_gas: u64,
 }
 
 /// Options for compiling a move package dir

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -22,7 +22,7 @@ pub enum Tool {
     #[clap(subcommand)]
     Move(move_tool::MoveTool),
     #[clap(subcommand)]
-    Op(op::OpTool),
+    Key(op::key::KeyTool),
 }
 
 impl Tool {
@@ -31,7 +31,7 @@ impl Tool {
             Tool::Account(tool) => tool.execute().await,
             Tool::Init(tool) => tool.execute().await,
             Tool::Move(tool) => tool.execute().await,
-            Tool::Op(tool) => tool.execute().await,
+            Tool::Key(tool) => tool.execute().await,
         }
     }
 }

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -8,7 +8,7 @@ pub mod common;
 pub mod move_tool;
 pub mod op;
 
-use crate::common::types::{CliResult, Error};
+use crate::common::types::CliResult;
 use clap::Parser;
 
 /// CLI tool for interacting with the Aptos blockchain and nodes

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -8,7 +8,7 @@ pub mod common;
 pub mod move_tool;
 pub mod op;
 
-use crate::common::types::CliResult;
+use crate::common::{types::CliResult, utils::to_common_success_result};
 use clap::Parser;
 
 /// CLI tool for interacting with the Aptos blockchain and nodes
@@ -29,7 +29,7 @@ impl Tool {
     pub async fn execute(self) -> CliResult {
         match self {
             Tool::Account(tool) => tool.execute().await,
-            Tool::Init(tool) => tool.execute().await,
+            Tool::Init(tool) => to_common_success_result(tool.execute().await),
             Tool::Move(tool) => tool.execute().await,
             Tool::Key(tool) => tool.execute().await,
         }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -125,14 +125,6 @@ pub struct PublishPackage {
     move_options: MovePackageDir,
     #[clap(flatten)]
     write_options: WriteTransactionOptions,
-    /// ChainId for the network
-    #[clap(long)]
-    chain_id: ChainId,
-    /// Maximum gas to be used to publish the package
-    ///
-    /// Defaults to 1000 gas units
-    #[clap(long, default_value_t = 1000)]
-    max_gas: u64,
 }
 
 impl PublishPackage {
@@ -160,10 +152,10 @@ impl PublishPackage {
 
         submit_transaction(
             self.write_options.rest_options.url.clone(),
-            self.chain_id,
+            self.write_options.chain_id,
             sender_key,
             compiled_payload,
-            self.max_gas,
+            self.write_options.max_gas,
         )
         .await
     }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     common::{
-        types::{EncodingOptions, MovePackageDir, NodeOptions, PrivateKeyInputOptions},
+        types::{EncodingOptions, MovePackageDir},
         utils::to_common_result,
     },
     CliResult, Error,
@@ -28,6 +28,7 @@ use move_package::{compilation::compiled_package::CompiledPackage, BuildConfig};
 use move_unit_test::UnitTestingConfig;
 use reqwest::Url;
 use std::path::Path;
+use crate::common::types::WriteTransactionOptions;
 
 /// CLI tool for performing Move tasks
 ///
@@ -120,11 +121,9 @@ pub struct PublishPackage {
     #[clap(flatten)]
     encoding_options: EncodingOptions,
     #[clap(flatten)]
-    private_key_options: PrivateKeyInputOptions,
-    #[clap(flatten)]
     move_options: MovePackageDir,
     #[clap(flatten)]
-    node_options: NodeOptions,
+    write_options: WriteTransactionOptions,
     /// ChainId for the network
     #[clap(long)]
     chain_id: ChainId,
@@ -154,11 +153,11 @@ impl PublishPackage {
 
         // Now that it's compiled, lets send it
         let sender_key = self
-            .private_key_options
+            .write_options.private_key_options
             .extract_private_key(self.encoding_options.encoding)?;
 
         submit_transaction(
-            self.node_options.url.clone(),
+            self.write_options.rest_options.url.clone(),
             self.chain_id,
             sender_key,
             compiled_payload,

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -58,7 +58,7 @@ pub struct CompilePackage {
 }
 
 impl CompilePackage {
-    pub async fn execute(&self) -> CliTypedResult<Vec<String>> {
+    pub async fn execute(self) -> CliTypedResult<Vec<String>> {
         let build_config = BuildConfig {
             additional_named_addresses: self.move_options.named_addresses.clone(),
             generate_docs: true,
@@ -84,7 +84,7 @@ pub struct TestPackage {
 }
 
 impl TestPackage {
-    pub async fn execute(&self) -> CliTypedResult<&'static str> {
+    pub async fn execute(self) -> CliTypedResult<&'static str> {
         let config = BuildConfig {
             additional_named_addresses: self.move_options.named_addresses.clone(),
             test_mode: true,
@@ -136,7 +136,7 @@ pub struct PublishPackage {
 }
 
 impl PublishPackage {
-    pub async fn execute(&self) -> CliTypedResult<aptos_rest_client::Transaction> {
+    pub async fn execute(self) -> CliTypedResult<aptos_rest_client::Transaction> {
         let build_config = BuildConfig {
             additional_named_addresses: self.move_options.named_addresses.clone(),
             generate_abis: false,

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -132,8 +132,8 @@ impl GenerateKey {
         let command = GenerateKey::parse_from(args.split_whitespace());
         command.execute()?;
         Ok((
-            encoding.load_key(key_file)?,
-            encoding.load_key(&append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
+            encoding.load_key("private_key", key_file)?,
+            encoding.load_key("public_key", &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
         ))
     }
 
@@ -151,8 +151,8 @@ impl GenerateKey {
         let command = GenerateKey::parse_from(args.split_whitespace());
         command.execute()?;
         Ok((
-            encoding.load_key(key_file)?,
-            encoding.load_key(&append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
+            encoding.load_key("private_key", key_file)?,
+            encoding.load_key("public_key", &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
         ))
     }
 
@@ -203,11 +203,11 @@ impl SaveKey {
         key: &Key,
         key_name: &'static str,
     ) -> Result<HashMap<&'static str, PathBuf>, Error> {
-        let encoded_private_key = self.encoding_options.encoding.encode_key(key, key_name)?;
+        let encoded_private_key = self.encoding_options.encoding.encode_key(key_name, key)?;
         let encoded_public_key = self
             .encoding_options
             .encoding
-            .encode_key(&key.public_key(), key_name)?;
+            .encode_key(key_name, &key.public_key())?;
 
         // Write private and public keys to files
         let public_key_file = self.public_key_file()?;

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -4,7 +4,7 @@
 use crate::{
     common::{
         types::{
-            EncodingOptions, EncodingType, Error, ExtractPublicKey, KeyType,
+            CliError, CliTypedResult, EncodingOptions, EncodingType, ExtractPublicKey, KeyType,
             PrivateKeyInputOptions, SaveFile,
         },
         utils::{append_file_extension, check_if_file_exists, to_common_result, write_to_file},
@@ -55,7 +55,7 @@ pub struct ExtractPeer {
 }
 
 impl ExtractPeer {
-    pub fn execute(self) -> Result<HashMap<AccountAddress, Peer>, Error> {
+    pub fn execute(self) -> CliTypedResult<HashMap<AccountAddress, Peer>> {
         // Check output file exists
         self.output_file_options.check_file()?;
 
@@ -76,8 +76,8 @@ impl ExtractPeer {
         map.insert(peer_id, peer);
 
         // Save to file
-        let yaml =
-            serde_yaml::to_string(&map).map_err(|err| Error::UnexpectedError(err.to_string()))?;
+        let yaml = serde_yaml::to_string(&map)
+            .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
         self.output_file_options
             .save_to_file("Extracted peer", yaml.as_bytes())?;
         Ok(map)
@@ -100,7 +100,7 @@ pub struct GenerateKey {
 }
 
 impl GenerateKey {
-    pub fn execute(self) -> Result<HashMap<&'static str, PathBuf>, Error> {
+    pub fn execute(self) -> CliTypedResult<HashMap<&'static str, PathBuf>> {
         self.save_params.check_key_file()?;
 
         // Generate a ed25519 key
@@ -111,7 +111,7 @@ impl GenerateKey {
             KeyType::X25519 => {
                 let private_key =
                     x25519::PrivateKey::from_ed25519_private_bytes(&ed25519_key.to_bytes())
-                        .map_err(|err| Error::UnexpectedError(err.to_string()))?;
+                        .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
                 self.save_params.save_key(&private_key, "x22519")
             }
             KeyType::Ed25519 => self.save_params.save_key(&ed25519_key, "ed22519"),
@@ -122,7 +122,7 @@ impl GenerateKey {
     pub fn generate_x25519(
         encoding: EncodingType,
         key_file: &Path,
-    ) -> Result<(x25519::PrivateKey, x25519::PublicKey), Error> {
+    ) -> CliTypedResult<(x25519::PrivateKey, x25519::PublicKey)> {
         let args = format!(
             "generate --key-type {key_type:?} --output-file {key_file} --encoding {encoding:?} --assume-yes",
             key_type = KeyType::X25519,
@@ -133,7 +133,10 @@ impl GenerateKey {
         command.execute()?;
         Ok((
             encoding.load_key("private_key", key_file)?,
-            encoding.load_key("public_key", &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
+            encoding.load_key(
+                "public_key",
+                &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?,
+            )?,
         ))
     }
 
@@ -141,7 +144,7 @@ impl GenerateKey {
     pub fn generate_ed25519(
         encoding: EncodingType,
         key_file: &Path,
-    ) -> Result<(ed25519::Ed25519PrivateKey, ed25519::Ed25519PublicKey), Error> {
+    ) -> CliTypedResult<(ed25519::Ed25519PrivateKey, ed25519::Ed25519PublicKey)> {
         let args = format!(
             "generate --key-type {key_type:?} --output-file {key_file} --encoding {encoding:?} --assume-yes",
             key_type = KeyType::Ed25519,
@@ -152,7 +155,10 @@ impl GenerateKey {
         command.execute()?;
         Ok((
             encoding.load_key("private_key", key_file)?,
-            encoding.load_key("public_key", &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?)?,
+            encoding.load_key(
+                "public_key",
+                &append_file_extension(key_file, PUBLIC_KEY_EXTENSION)?,
+            )?,
         ))
     }
 
@@ -162,10 +168,10 @@ impl GenerateKey {
         ed25519::Ed25519PrivateKey::generate(&mut rng)
     }
 
-    pub fn generate_x25519_in_memory() -> Result<x25519::PrivateKey, Error> {
+    pub fn generate_x25519_in_memory() -> CliTypedResult<x25519::PrivateKey> {
         let key = Self::generate_ed25519_in_memory();
         x25519::PrivateKey::from_ed25519_private_bytes(&key.to_bytes()).map_err(|err| {
-            Error::UnexpectedError(format!("Failed to convert ed25519 to x25519 {:?}", err))
+            CliError::UnexpectedError(format!("Failed to convert ed25519 to x25519 {:?}", err))
         })
     }
 }
@@ -180,7 +186,7 @@ pub struct SaveKey {
 
 impl SaveKey {
     /// Public key file name
-    fn public_key_file(&self) -> Result<PathBuf, Error> {
+    fn public_key_file(&self) -> CliTypedResult<PathBuf> {
         append_file_extension(
             self.file_options.output_file.as_path(),
             PUBLIC_KEY_EXTENSION,
@@ -188,7 +194,7 @@ impl SaveKey {
     }
 
     /// Check if the key file exists already
-    pub fn check_key_file(&self) -> Result<(), Error> {
+    pub fn check_key_file(&self) -> CliTypedResult<()> {
         // Check if file already exists
         self.file_options.check_file()?;
         check_if_file_exists(
@@ -202,7 +208,7 @@ impl SaveKey {
         &self,
         key: &Key,
         key_name: &'static str,
-    ) -> Result<HashMap<&'static str, PathBuf>, Error> {
+    ) -> CliTypedResult<HashMap<&'static str, PathBuf>> {
         let encoded_private_key = self.encoding_options.encoding.encode_key(key_name, key)?;
         let encoded_public_key = self
             .encoding_options

--- a/crates/aptos/src/op/mod.rs
+++ b/crates/aptos/src/op/mod.rs
@@ -1,28 +1,4 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-//! An operational tool for node operators
-//!
-//! TODO: Examples
-//!
-
-use crate::CliResult;
-use clap::Subcommand;
-
 pub mod key;
-
-/// CLI tool for performing operational tasks
-///
-#[derive(Debug, Subcommand)]
-pub enum OpTool {
-    #[clap(subcommand)]
-    Key(key::KeyTool),
-}
-
-impl OpTool {
-    pub async fn execute(self) -> CliResult {
-        match self {
-            OpTool::Key(tool) => tool.execute().await,
-        }
-    }
-}

--- a/crates/transaction-emitter/src/cluster.rs
+++ b/crates/transaction-emitter/src/cluster.rs
@@ -55,7 +55,7 @@ impl Cluster {
         } else {
             KeyPair::from(
                 EncodingType::BCS
-                    .load_key::<ed25519::Ed25519PrivateKey>(Path::new(mint_file))
+                    .load_key::<ed25519::Ed25519PrivateKey>("mint key pair", Path::new(mint_file))
                     .unwrap(),
             )
         };

--- a/crates/transaction-emitter/src/lib.rs
+++ b/crates/transaction-emitter/src/lib.rs
@@ -378,7 +378,9 @@ impl<'t> TxnEmitter<'t> {
         index: usize,
     ) -> Result<LocalAccount> {
         let file = "vasp".to_owned() + index.to_string().as_str() + ".key";
-        let mint_key: Ed25519PrivateKey = EncodingType::BCS.load_key(Path::new(&file)).unwrap();
+        let mint_key: Ed25519PrivateKey = EncodingType::BCS
+            .load_key("vasp private key", Path::new(&file))
+            .unwrap();
         let account_key = AccountKey::from_private_key(mint_key);
         let address = account_key.authentication_key().derived_address();
         let sequence_number = query_sequence_numbers(client, &[address])


### PR DESCRIPTION
## Motivation

Generally cleanup the documentation and interfacing of the CLI so that it's consistent across the whole tool.  Additionally moved the `key` tool to the top level because it was hanging around.

This isn't needed for the release this week