### PR TITLE
[Storage] Add support for getting key, value mapping for a key prefix

### DIFF
--- a/storage/aptosdb/src/schema/state_value_index/mod.rs
+++ b/storage/aptosdb/src/schema/state_value_index/mod.rs
@@ -18,11 +18,14 @@
 
 use crate::schema::{ensure_slice_len_eq, ensure_slice_len_gt, STATE_VALUE_INDEX_CF_NAME};
 use anyhow::Result;
-use aptos_types::{state_store::state_key::StateKey, transaction::Version};
+use aptos_types::{
+    state_store::{state_key::StateKey, state_key_prefix::StateKeyPrefix},
+    transaction::Version,
+};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use schemadb::{
     define_schema,
-    schema::{KeyCodec, ValueCodec},
+    schema::{KeyCodec, SeekKeyCodec, ValueCodec},
 };
 use std::{io::Write, mem::size_of};
 
@@ -59,6 +62,12 @@ impl ValueCodec<StateValueIndexSchema> for u8 {
     fn decode_value(data: &[u8]) -> Result<Self> {
         ensure_slice_len_eq(data, 1)?;
         Ok(data[0])
+    }
+}
+
+impl SeekKeyCodec<StateValueIndexSchema> for &StateKeyPrefix {
+    fn encode_seek_key(&self) -> Result<Vec<u8>> {
+        self.encode()
     }
 }
 

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod state_key;
+pub mod state_key_prefix;
 pub mod state_value;

--- a/types/src/state_store/state_key_prefix.rs
+++ b/types/src/state_store/state_key_prefix.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::state_store::state_key::{StateKey, StateKeyTag};
+
+// Struct for defining prefix of a state key, which can be used for finding all the values with a
+// particular key prefix
+#[derive(Debug)]
+pub struct StateKeyPrefix {
+    tag: StateKeyTag,
+    bytes: Vec<u8>,
+}
+
+impl StateKeyPrefix {
+    pub fn new(tag: StateKeyTag, bytes: Vec<u8>) -> Self {
+        Self { tag, bytes }
+    }
+
+    /// Serializes to bytes for physical storage.
+    pub fn encode(&self) -> anyhow::Result<Vec<u8>> {
+        let mut out = vec![self.tag.clone() as u8];
+        out.extend(self.bytes.clone());
+        Ok(out)
+    }
+
+    /// Checks if the current prefix is a valid prefix of a particular state_key
+    pub fn is_prefix(&self, state_key: &StateKey) -> anyhow::Result<bool> {
+        let encoded_key = state_key.encode()?;
+        let encoded_prefix = self.encode()?;
+        // Check if bytes is a sub-vector of encoded key.
+        if encoded_prefix.len() > encoded_key.len() {
+            return Ok(false);
+        }
+        Ok(encoded_prefix == encoded_key[..encoded_prefix.len()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        access_path::AccessPath,
+        state_store::{
+            state_key::{StateKey, StateKeyTag},
+            state_key_prefix::StateKeyPrefix,
+        },
+    };
+    use move_core_types::account_address::AccountAddress;
+
+    #[test]
+    fn test_state_key_prefix() {
+        let address1 = AccountAddress::new([12u8; AccountAddress::LENGTH]);
+        let address2 = AccountAddress::new([22u8; AccountAddress::LENGTH]);
+        let key1 = StateKey::AccessPath(AccessPath::new(address1, b"state_key".to_vec()));
+        let key2 = StateKey::AccessPath(AccessPath::new(address2, b"state_key".to_vec()));
+
+        let account1_key_prefx = StateKeyPrefix::new(StateKeyTag::AccessPath, address1.to_vec());
+        let account2_key_prefx = StateKeyPrefix::new(StateKeyTag::AccessPath, address2.to_vec());
+
+        assert!(account1_key_prefx.is_prefix(&key1).unwrap());
+        assert!(account2_key_prefx.is_prefix(&key2).unwrap());
+
+        assert!(!account1_key_prefx.is_prefix(&key2).unwrap());
+        assert!(!account2_key_prefx.is_prefix(&key1).unwrap());
+    }
+}


### PR DESCRIPTION
## Motivation

This will be used to replace the `get_account_state_blob` and `get_account_resources` API once we rollout fine-grained storage support for account state. The newly added API takes account address/table name as the key prefix and returns all the key, value mapping for that key prefix. 

## Test Plan

Added UTs
