### PR TITLE
[aptos-cli] Fund accounts created by the faucet

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -48,6 +48,10 @@ pub struct CreateAccount {
     /// Flag for using faucet
     #[clap(long)]
     use_faucet: bool,
+
+    /// Initial coins to fund when using the faucet
+    #[clap(long, default_value = "10000")]
+    initial_coins: u64,
 }
 
 impl CreateAccount {
@@ -101,7 +105,7 @@ impl CreateAccount {
             // We should make a faucet endpoint for creating an account
             .post(format!(
                 "{}/mint?amount={}&auth_key={}",
-                "https://faucet.devnet.aptoslabs.com", "0", address
+                "https://faucet.devnet.aptoslabs.com", self.initial_coins, address
             ))
             .send()
             .await?;


### PR DESCRIPTION
## Motivation

Turns out an account is no good without coins!  This makes an initial funding more than 0 with the faucet so people can get running with it in devnet.

This doesn't need to make it into the release, but I'd like to get it in before people start using it (and checking out locally)