### PR TITLE
[aptos-cli] Cleanup CLI part 2

### DIFF
--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -523,7 +523,7 @@ mod tests {
             "9FF98E82355EB13098F3B1157AC018A725C62C0E0820F422000814CDBA407835"
         );
 
-        let res = tokio::task::spawn_blocking(move || faucet_client.create_account(address))
+        let res = tokio::task::spawn_blocking(move || faucet_client.create_account(address).await)
             .await
             .unwrap();
         res.unwrap();
@@ -547,8 +547,8 @@ mod tests {
         let address = AuthenticationKey::ed25519(&pub_key).derived_address();
         let (res1, res2) = tokio::task::spawn_blocking(move || {
             (
-                faucet_client.create_account(address),
-                faucet_client.fund(address, 10),
+                faucet_client.create_account(address).await,
+                faucet_client.fund(address, 10).await,
             )
         })
         .await

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -6,17 +6,17 @@
 //! TODO: Examples
 //!
 
-use crate::common::types::{
-    account_address_from_public_key, CliError, CliTypedResult, EncodingOptions, ExtractPublicKey,
-    PublicKeyInputOptions, WriteTransactionOptions,
+use crate::common::{
+    types::{
+        account_address_from_public_key, CliError, CliTypedResult, EncodingOptions,
+        ExtractPublicKey, FaucetOptions, PublicKeyInputOptions, WriteTransactionOptions,
+    },
+    utils::send_transaction,
 };
-use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
-use aptos_rest_client::{Client as RestClient, Response, Transaction};
-use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
+use aptos_rest_client::FaucetClient;
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_address::AccountAddress;
 use clap::Parser;
-use reqwest;
 
 /// Command to create a new account on-chain
 ///
@@ -31,10 +31,8 @@ pub struct CreateAccount {
     /// Flag for using faucet to create the account
     #[clap(long)]
     use_faucet: bool,
-
-    /// Initial coins to fund when using the faucet
-    #[clap(long, default_value = "10000")]
-    initial_coins: u64,
+    #[clap(flatten)]
+    faucet_options: FaucetOptions,
 }
 
 impl CreateAccount {
@@ -43,7 +41,6 @@ impl CreateAccount {
             .public_key_options
             .extract_public_key(self.encoding_options.encoding)?;
         let address = account_address_from_public_key(&public_key_to_create);
-
         if self.use_faucet {
             self.create_account_with_faucet(address).await
         } else {
@@ -52,84 +49,23 @@ impl CreateAccount {
         .map(|_| format!("Account Created at {}", address))
     }
 
-    async fn get_account(
-        &self,
-        account: AccountAddress,
-    ) -> Result<serde_json::Value, reqwest::Error> {
-        reqwest::get(format!(
-            "{}accounts/{}",
-            self.write_options.rest_options.url, account
-        ))
-        .await?
-        .json()
-        .await
-    }
-
-    async fn get_sequence_number(&self, account: AccountAddress) -> CliTypedResult<u64> {
-        let account_response = self
-            .get_account(account)
-            .await
-            .map_err(|err| CliError::ApiError(err.to_string()))?;
-        let sequence_number = &account_response["sequence_number"];
-        match sequence_number.as_str() {
-            Some(number) => Ok(number.parse::<u64>().unwrap()),
-            None => Err(CliError::ApiError("Sequence number not found".to_string())),
-        }
-    }
-
-    async fn post_account(
-        &self,
-        address: AccountAddress,
-        sender_key: Ed25519PrivateKey,
-        sender_address: AccountAddress,
-        sequence_number: u64,
-    ) -> CliTypedResult<Response<Transaction>> {
-        let client = RestClient::new(reqwest::Url::clone(&self.write_options.rest_options.url));
-        let transaction_factory = TransactionFactory::new(self.write_options.chain_id)
-            .with_gas_unit_price(1)
-            .with_max_gas_amount(self.write_options.max_gas);
-        let sender_account = &mut LocalAccount::new(sender_address, sender_key, sequence_number);
-        let transaction = sender_account.sign_with_transaction_builder(
-            transaction_factory
-                .payload(aptos_stdlib::encode_create_account_script_function(address)),
+    /// Creates an account and funds it from the faucet
+    async fn create_account_with_faucet(self, address: AccountAddress) -> CliTypedResult<()> {
+        let faucet_client = FaucetClient::new(
+            self.faucet_options.faucet_url.to_string(),
+            self.write_options.rest_options.url.to_string(),
         );
-        client
-            .submit_and_wait(&transaction)
+        faucet_client
+            .fund(address, self.faucet_options.num_coins)
             .await
             .map_err(|err| CliError::ApiError(err.to_string()))
     }
 
-    async fn create_account_with_faucet(self, address: AccountAddress) -> CliTypedResult<()> {
-        let response = reqwest::Client::new()
-            // TODO: Currently, we are just using mint 0 to create an account using the faucet
-            // We should make a faucet endpoint for creating an account
-            .post(format!(
-                "{}/mint?amount={}&auth_key={}",
-                "https://faucet.devnet.aptoslabs.com", self.initial_coins, address
-            ))
-            .send()
-            .await
-            .map_err(|err| CliError::ApiError(err.to_string()))?;
-        if response.status() == 200 {
-            Ok(())
-        } else {
-            Err(CliError::ApiError(format!(
-                "Faucet issue: {}",
-                response.status()
-            )))
-        }
-    }
-
+    /// Creates an account and does not fund it
     async fn create_account_with_key(self, address: AccountAddress) -> CliTypedResult<()> {
-        let sender_private_key = self
-            .write_options
-            .private_key_options
-            .extract_private_key(self.encoding_options.encoding)?;
-        let sender_public_key = sender_private_key.public_key();
-        let sender_address = account_address_from_public_key(&sender_public_key);
-        let sequence_number = self.get_sequence_number(sender_address).await?;
-        self.post_account(address, sender_private_key, sender_address, sequence_number)
-            .await?;
-        Ok(())
+        let payload = aptos_stdlib::encode_create_account_script_function(address);
+        send_transaction(self.encoding_options, self.write_options, payload)
+            .await
+            .map(|_| ())
     }
 }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     common::{
-        types::{CliConfig, CliError, CliTypedResult},
+        types::{CliConfig, CliError, CliTypedResult, EncodingOptions, PrivateKeyInputOptions},
         utils::prompt_yes,
     },
     op::key::GenerateKey,
@@ -13,7 +13,12 @@ use clap::Parser;
 
 /// Tool to initialize current directory for the aptos tool
 #[derive(Debug, Parser)]
-pub struct InitTool {}
+pub struct InitTool {
+    #[clap(flatten)]
+    private_key_options: PrivateKeyInputOptions,
+    #[clap(flatten)]
+    encoding_options: EncodingOptions,
+}
 
 impl InitTool {
     pub async fn execute(self) -> CliTypedResult<()> {
@@ -29,21 +34,35 @@ impl InitTool {
             CliConfig::default()
         };
 
-        eprintln!("Enter your private key as a hex literal (0x...) [No input: Generate new key]");
-        let input = read_line("Private key")?;
-        let input = input.trim();
-        let private_key = if input.is_empty() {
-            eprintln!("No key given, generating key...");
-            GenerateKey::generate_ed25519_in_memory()
+        // If someone provided an input private key, don't ask them to pass it in
+        let private_key = if let Some(private_key) = self
+            .private_key_options
+            .extract_private_key_no_config(self.encoding_options.encoding)?
+        {
+            private_key
         } else {
-            Ed25519PrivateKey::from_encoded_string(input)
-                .map_err(|err| CliError::UnableToParse("Ed25519PrivateKey", err.to_string()))?
+            private_key_prompt()?
         };
+
         config.private_key = Some(private_key);
         config.save()?;
         eprintln!("Aptos is now set up!  Run `aptos help` for more information about commands");
 
         Ok(())
+    }
+}
+
+/// Read the private key from the command line prompt
+fn private_key_prompt() -> CliTypedResult<Ed25519PrivateKey> {
+    eprintln!("Enter your private key as a hex literal (0x...) [No input: Generate new key]");
+    let input = read_line("Private key")?;
+    let input = input.trim();
+    if input.is_empty() {
+        eprintln!("No key given, generating key...");
+        Ok(GenerateKey::generate_ed25519_in_memory())
+    } else {
+        Ed25519PrivateKey::from_encoded_string(input)
+            .map_err(|err| CliError::UnableToParse("Ed25519PrivateKey", err.to_string()))
     }
 }
 

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -11,6 +11,7 @@ use aptos_types::{chain_id::ChainId, transaction::authenticator::AuthenticationK
 use clap::{ArgEnum, Parser};
 use itertools::Itertools;
 use move_core_types::account_address::AccountAddress;
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
@@ -266,7 +267,7 @@ pub struct PrivateKeyInputOptions {
 
 impl PrivateKeyInputOptions {
     pub fn extract_private_key(&self, encoding: EncodingType) -> CliTypedResult<Ed25519PrivateKey> {
-        if Some(private_key) = self.extract_private_key_no_config(encoding)? {
+        if let Some(private_key) = self.extract_private_key_no_config(encoding)? {
             Ok(private_key)
         } else if let Some(private_key) = CliConfig::load()?.private_key {
             Ok(private_key)
@@ -289,7 +290,7 @@ impl PrivateKeyInputOptions {
             let key = key.as_bytes().to_vec();
             encoding.decode_key("--private-key", key).map(Some)
         } else {
-            None
+            Ok(None)
         }
     }
 }
@@ -391,6 +392,17 @@ pub struct MovePackageDir {
     /// Note: This will fail if there are duplicates in the Move.toml file remove those first.
     #[clap(long, parse(try_from_str = parse_map), default_value = "")]
     pub named_addresses: BTreeMap<String, AccountAddress>,
+}
+
+/// Options for using the faucet
+#[derive(Debug, Parser)]
+pub struct FaucetOptions {
+    /// URL for the faucet
+    #[clap(long, default_value = "https://faucet.devnet.aptoslabs.com")]
+    pub(crate) faucet_url: Url,
+    /// Number of coins to fund to the account
+    #[clap(long, default_value = "10000")]
+    pub(crate) num_coins: u64,
 }
 
 const PARSE_MAP_SYNTAX_MSG: &str = "Invalid syntax for map.  Example: Name=Value,Name2=Value";


### PR DESCRIPTION
## Motivation

We had duplicate work on using the faucet and the rest client in CreateAccount, so I've cleaned it up.

Additionally,added ability to pass in a private key to `init` so you don't have to type it in.

