### PR TITLE
[API] MoveConverter::try_into_vm_value() special-cases ASCII::String

### DIFF
--- a/api/src/tests/converter_test.rs
+++ b/api/src/tests/converter_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{current_function_name, tests::new_test_context};
-use aptos_api_types::{AsConverter, MoveConverter, MoveType};
+use aptos_api_types::{new_vm_ascii_string, AsConverter, MoveConverter, MoveType};
 use aptos_vm::data_cache::AsMoveResolver;
 use move_core_types::{
     account_address::AccountAddress,
@@ -27,6 +27,12 @@ async fn test_value_conversion() {
     assert_value_conversion(&converter, "u128", "1", VmMoveValue::U128(1));
     assert_value_conversion(&converter, "bool", true, VmMoveValue::Bool(true));
     assert_value_conversion(&converter, "address", "0x1", VmMoveValue::Address(address));
+    assert_value_conversion(
+        &converter,
+        "0x1::ASCII::String",
+        "hello",
+        new_vm_ascii_string("hello"),
+    );
     assert_value_conversion(
         &converter,
         "vector<u8>",

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -17,7 +17,7 @@ mod transaction;
 pub use account::AccountData;
 pub use address::Address;
 pub use bytecode::Bytecode;
-pub use convert::{AsConverter, MoveConverter};
+pub use convert::{new_vm_ascii_string, AsConverter, MoveConverter};
 pub use error::Error;
 pub use event_key::EventKey;
 pub use hash::HashValue;


### PR DESCRIPTION
## Motivation

So that a string can be passed in as a table key when querying (new API coming up in https://github.com/aptos-labs/aptos-core/pull/393)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Y
## Test Plan
unittest