### PR TITLE
[Circle CI] Small tweaks to defaults.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - dev-setup
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
-      - run: INDEXER_DATABASE_URL="postgresql://postgres@localhost/postgres" RUST_BACKTRACE=full cargo nextest --nextest-profile ci --partition hash:1/1 --test-threads 5 --package smoke-test
+      - run: INDEXER_DATABASE_URL="postgresql://postgres@localhost/postgres" RUST_BACKTRACE=full cargo nextest --nextest-profile ci --partition hash:1/1 --package smoke-test --retries 3
   unit-test:
     executor: ubuntu-2xl
     steps:

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,12 +1,10 @@
 [profile.ci]
-# Detect flaky tests.
-retries = 3
 # Show skipped tests in the CI output.
 status-level = "skip"
 # Show output for all tests as soon as they fail and at the end of the test run.
 failure-output = "immediate-final"
-# Do not cancel test run on the first failure.
-fail-fast = false
+# Cancel test run on the first failure. Accounts for retries.
+fail-fast = true
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
## Motivation

This PR makes 3 small tweaks to our unit and end-to-end test configurations in circle CI:
1. Retries should only be done for end-to-end tests, not unit tests. Currently, we're allowing unit tests to also be retried. I don't know when this became a requirement, but flaky unit tests should be fixed or ignored.
2. Enable fail-fast to provide faster feedback and reduce  `canary` contention. Many times, developers use `canary` as a way to identify what tests (if any) are affected by a change. If a test fails, I suspect most folks debug, run and fix that test and surrounding tests locally. Continuing to run other tests (specifically end-to-end tests) can be expensive and cause unnecessary work.
3. Use the default number of test threads for end-to-end tests instead of hard coding them. This defaults to the number of CPU cores.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tested locally.

## Related PRs

None.
