### PR TITLE
[alert] don't expect safety-rules pod

### DIFF
--- a/terraform/helm/validator/files/rules/cluster_alerts.yml
+++ b/terraform/helm/validator/files/rules/cluster_alerts.yml
@@ -37,7 +37,7 @@ groups:
 
 {{ else }}
 # Pod status alerts using cAdvisor (by default)
-{{- range list "validator" "safety-rules" "haproxy" "logging" "monitoring"}}
+{{- range list "validator" "haproxy" "logging" "monitoring"}}
   - alert: Container metrics are missing
     expr: absent(container_start_time_seconds{container!="", container!="POD", pod=~".*{{ . }}.*"})
     for: 5m

--- a/terraform/testnet/testnet/files/rules/cluster_alerts.yml
+++ b/terraform/testnet/testnet/files/rules/cluster_alerts.yml
@@ -37,7 +37,7 @@ groups:
 
 {{ else }}
 # Pod status alerts using cAdvisor (by default)
-{{- range list "validator" "safety-rules" "haproxy" "logging" "monitoring"}}
+{{- range list "validator" "haproxy" "logging" "monitoring"}}
   - alert: Container metrics are missing
     expr: absent(container_start_time_seconds{container!="", container!="POD", pod=~".*{{ . }}.*"})
     for: 5m


### PR DESCRIPTION

## Motivation

We don't deploy the safety-rules pod any more afaik.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y

## Test Plan
Sherry's eyes