### PR TITLE
Clarifying documentation build steps

### DIFF
--- a/developer-docs-site/README.md
+++ b/developer-docs-site/README.md
@@ -1,5 +1,11 @@
 # Developer Documentation
 
+   - [Installation](#installation)   
+      - [Requirements](#requirements)   
+   - [Fork and clone the Aptos repo](#fork-and-clone-the-aptos-repo)   
+   - [Build the docs locally](#build-the-docs-locally)   
+
+
 This Aptos Developer Documenatation is built using [Docusaurus 2](https://docusaurus.io/). Follow the below steps to build the docs locally and contribute.
 
 ## Installation
@@ -49,7 +55,7 @@ https://github.com/aptos-labs/aptos-core
 
 3. Start the Yarn server locally. This will also open the locally built docs in your default browser.
 
-  **NOTE**: This step will not generate static html files, but will only render the docs dynamically.
+> **NOTE**: This step will not generate static html files, but will only render the docs dynamically.
 
   ```
   yarn start

--- a/developer-docs-site/README.md
+++ b/developer-docs-site/README.md
@@ -1,41 +1,75 @@
-# Website
+# Developer Documentation
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+This Aptos Developer Documenatation is built using [Docusaurus 2](https://docusaurus.io/). Follow the below steps to build the docs locally and contribute.
 
-### Installation
+## Installation
 
-```
-$ yarn
-```
+**IMPORTANT**: These installation steps apply to macOS environment.
 
-### Local Development
+### Requirements
 
-```
-$ yarn start
-```
+Before you proceed, make sure you install the following tools.
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-### Build
+- Install [Node.js](https://nodejs.org/en/download/) by executing the below command on your Terminal:
 
 ```
-$ yarn build
+brew install node
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-Using SSH:
+- Install the latest [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) by executing the below command on your Terminal:
 
 ```
-$ USE_SSH=true yarn deploy
+brew install yarn
 ```
 
-Not using SSH:
+## Fork and clone the Aptos repo
 
-```
-$ GIT_USER=<Your GitHub username> yarn deploy
-```
+1. Fork the Aptos Core repo by clicking on the **Fork** on the top right of this repo page:
+https://github.com/aptos-labs/aptos-core
 
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+2. Clone your fork.
+
+  ```
+  git clone https://github.com/<YOUR-GITHUB-USERID>/aptos-core
+
+  ```
+
+## Build the docs locally
+
+1. `cd` into the `developer-docs-site` directory in your clone.
+
+  ```
+  cd aptos-core/developer-docs-site
+  ```
+2. Run `yarn`.
+
+  ```
+  yarn
+  ```
+
+3. Start the Yarn server locally. This will also open the locally built docs in your default browser.
+
+  **NOTE**: This step will not generate static html files, but will only render the docs dynamically.
+
+  ```
+  yarn start
+  ```
+
+4. Install Yarn dependencies.
+
+  ```
+  yarn install
+  ```
+5. Finally, build with Yarn.
+
+  ```
+  $ yarn build
+  ```
+
+This command generates static html content and places it in the `build` directory.
+
+5. Finally, use the below command to start the documentation server on your localhost.
+
+  ```
+  npm run serve
+  ```

--- a/developer-docs-site/README.md
+++ b/developer-docs-site/README.md
@@ -3,10 +3,10 @@
    - [Installation](#installation)   
       - [Requirements](#requirements)   
    - [Fork and clone the Aptos repo](#fork-and-clone-the-aptos-repo)   
-   - [Build the docs locally](#build-the-docs-locally)   
+   - [Build and serve the docs locally](#build-and-serve-the-docs-locally)   
+   - [Build static html files](#build-static-html-files)   
 
-
-This Aptos Developer Documenatation is built using [Docusaurus 2](https://docusaurus.io/). Follow the below steps to build the docs locally and contribute.
+This Aptos Developer Documenatation is built using [Docusaurus 2](https://docusaurus.io/). Follow the below steps to build the docs locally to test your contribution.
 
 ## Installation
 
@@ -30,6 +30,8 @@ brew install yarn
 
 ## Fork and clone the Aptos repo
 
+>**NOTE**: See this [GitHub documentation for how to configure for a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
+
 1. Fork the Aptos Core repo by clicking on the **Fork** on the top right of this repo page:
 https://github.com/aptos-labs/aptos-core
 
@@ -40,7 +42,7 @@ https://github.com/aptos-labs/aptos-core
 
   ```
 
-## Build the docs locally
+## Build and serve the docs locally
 
 1. `cd` into the `developer-docs-site` directory in your clone.
 
@@ -52,21 +54,26 @@ https://github.com/aptos-labs/aptos-core
   ```
   yarn
   ```
+This step will configure the Docusaurus static site generator.
 
 3. Start the Yarn server locally. This will also open the locally built docs in your default browser.
 
-> **NOTE**: This step will not generate static html files, but will only render the docs dynamically.
+> **NOTE**: This step will not generate static html files, but will render the docs dynamically.
 
   ```
   yarn start
   ```
 
-4. Install Yarn dependencies.
+## Build static html files
+
+Execute the below steps if you want to generate static html documentation files. A `build` directory will be created with the static html files and assets contained in it.
+
+1. Make sure you install Yarn dependencies.
 
   ```
   yarn install
   ```
-5. Finally, build with Yarn.
+2. Build static html files with Yarn.
 
   ```
   $ yarn build
@@ -74,7 +81,7 @@ https://github.com/aptos-labs/aptos-core
 
 This command generates static html content and places it in the `build` directory.
 
-5. Finally, use the below command to start the documentation server on your localhost.
+3. Finally, use the below command to start the documentation server on your localhost.
 
   ```
   npm run serve


### PR DESCRIPTION
The README containing instructions to build local docs could use a bit more elaboration: https://github.com/aptos-labs/aptos-core/blob/main/developer-docs-site/README.md 

I built the docs on my local Mac. Following my experience, this PR makes the below changes:

- Explicitly calls out the tools that should be installed. Also alerts that these instructions are for macOS.
- I removed the Deployment section because that felt redundant and not applicable. A developer would build the docs and locally serve them using these instructions and when satisfied with the contribution will then submit a PR. I thought the Deployment section isn't necessary. Please correct me if I am not getting this right. Thanks! 
