### PR TITLE
[Terraform/Helm] Remove rate limiter.

### DIFF
--- a/terraform/helm/fullnode/files/fullnode.yaml
+++ b/terraform/helm/fullnode/files/fullnode.yaml
@@ -16,10 +16,14 @@ full_node_networks:
   {{- end }}
   seeds:
     {{- (get .Values.aptos_chains .Values.chain.name).seeds | default dict | toYaml | nindent 6 }}
+  {{- if .Values.fullnode_inbound_rate_limit }}
   inbound_rate_limit_config:
     {{- .Values.fullnode_inbound_rate_limit | toYaml | nindent 6 }}
+  {{- end }}
+  {{- if .Values.fullnode_outbound_rate_limit }}
   outbound_rate_limit_config:
     {{- .Values.fullnode_outbound_rate_limit | toYaml | nindent 6 }}
+  {{- end }}
   max_inbound_connections: {{ .Values.fullnode_max_inbound_connections }}
 storage:
   backup_service_address: "0.0.0.0:6186"

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -12,16 +12,6 @@ fullnode_identity:
   # Set this to start fullnode from an existing key.
   # If not set, it will generate a random one on startup.
 
-fullnode_inbound_rate_limit:
-  enabled: true
-  ip_byte_bucket_rate: 1048576
-  ip_byte_bucket_size: 1048576
-  initial_bucket_fill_percentage: 25
-fullnode_outbound_rate_limit:
-  enabled: true
-  ip_byte_bucket_rate: 1048576
-  ip_byte_bucket_size: 1048576
-  initial_bucket_fill_percentage: 25
 fullnode_max_inbound_connections: 1000
 
 rust_log: info

--- a/terraform/helm/validator/values.yaml
+++ b/terraform/helm/validator/values.yaml
@@ -152,16 +152,6 @@ fullnode:
   affinity: {}
   config:
     max_inbound_connections: 1000
-    inbound_rate_limit:
-      enabled: true
-      ip_byte_bucket_rate: 1048576
-      ip_byte_bucket_size: 1048576
-      initial_bucket_fill_percentage: 25
-    outbound_rate_limit:
-      enabled: true
-      ip_byte_bucket_rate: 1048576
-      ip_byte_bucket_size: 1048576
-      initial_bucket_fill_percentage: 25
 
 keymanager:
   image:


### PR DESCRIPTION
## Motivation

This PR updates our terraform/helm code to not apply rate limiters by default. I discovered they are still enabled in `alden-net` on the VFNs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

None.

## Related PRs

None.
