### PR TITLE
[ecosystem][indexer] Fix a flakey test

### DIFF
--- a/testsuite/smoke-test/src/indexer.rs
+++ b/testsuite/smoke-test/src/indexer.rs
@@ -93,36 +93,41 @@ impl AptosTest for Indexer {
 
             tailer.process_next_batch((version + 1) as u8).await;
 
-            // This is the genesis transaction
-            let (tx0, ut0, bmt0, events0, wsc0) =
-                TransactionModel::get_by_version(0, &conn_pool.get()?).unwrap();
-            assert_eq!(tx0.type_, "genesis_transaction");
-            assert!(ut0.is_none());
-            assert!(bmt0.is_none());
-            assert_eq!(events0.len(), 1);
-            assert_eq!(wsc0.len(), 54);
+            // Get them into the array and sort by type in order to prevent ordering from breaking tests
+            let mut transactions = vec![];
+            for v in 0..2 {
+                transactions.push(TransactionModel::get_by_version(v, &conn_pool.get()?).unwrap());
+            }
+            transactions.sort_by(|a, b| a.0.type_.partial_cmp(&b.0.type_).unwrap());
 
             // This is a block metadata transaction
-            let (tx1, ut1, bmt1, events1, wsc1) =
-                TransactionModel::get_by_version(3, &conn_pool.get()?).unwrap();
+            let (tx1, ut1, bmt1, events1, wsc1) = &transactions[0];
             assert_eq!(tx1.type_, "block_metadata_transaction");
             assert!(ut1.is_none());
             assert!(bmt1.is_some());
-            assert_eq!(events1.len(), 0);
-            assert_eq!(wsc1.len(), 2);
+            assert!(events1.is_empty());
+            assert!(!wsc1.is_empty());
+
+            // This is the genesis transaction
+            let (tx0, ut0, bmt0, events0, wsc0) = &transactions[1];
+            assert_eq!(tx0.type_, "genesis_transaction");
+            assert!(ut0.is_none());
+            assert!(bmt0.is_none());
+            assert!(!events0.is_empty());
+            assert!(wsc0.len() > 10);
 
             // This is the transfer
             let (tx2, ut2, bmt2, events2, wsc2) =
                 TransactionModel::get_by_hash(t_tx.hash.to_string().as_str(), &conn_pool.get()?)
                     .unwrap();
 
+            assert_eq!(tx2.type_, "user_transaction");
             assert_eq!(tx2.hash, t_tx.hash.to_string());
 
             // This is a user transaction, so the bmt should be None
             assert!(ut2.is_some());
             assert!(bmt2.is_none());
-            assert_eq!(wsc2.len(), 6);
-
+            assert!(wsc2.len() > 1);
             assert_eq!(events2.len(), 2);
             assert_eq!(events2.get(0).unwrap().type_, "0x1::TestCoin::SentEvent");
             assert_eq!(


### PR DESCRIPTION
Sort the transactions so we ensure they're in an expected order, and change exact matches to soft matches to ensure they don't explode when other parts of the code are changes