### PR TITLE
[circleci] dump container info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,14 @@ jobs:
             fi
             circleci-agent step halt
       - docker-compose-setup
+      - run:
+          name: Check docker-compose status
+          shell: /bin/bash
+          command: |
+            if [ -n "$DOCKER_COMPOSE_BLOCKING" ]; then
+              exit $DOCKER_COMPOSE_EXIT_CODE
+            fi
+            circleci-agent step halt
       - dev-setup
       - run:
           name: Install Node + Yarn
@@ -399,15 +407,26 @@ commands:
       - run:
           name: Verify testnet docker-compose up
           shell: /bin/bash
+          working_directory: docker/compose/validator-testnet
           command: |
+            DOCKER_COMPOSE_EXIT_CODE=1
             for i in $(seq 60); do
               curl -s -w "\n%{http_code}\n" localhost:8080 | tee >(tail -1 > validator_ret.txt)
               curl -s -w "\n%{http_code}\n" -X POST 'localhost:8000/mint?pub_key=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d&amount=20000000' \
                 | tee >(tail -1 > faucet_ret.txt)
               if [ "$(cat validator_ret.txt)" = "200" ] && [ "$(cat faucet_ret.txt)" = "200" ]; then
                 echo "Both validator and faucet healthy"
-                exit 0
+                DOCKER_COMPOSE_EXIT_CODE=0
+                break
               fi
               sleep 1
             done
-            exit 1
+            echo "export DOCKER_COMPOSE_EXIT_CODE=$DOCKER_COMPOSE_EXIT_CODE" >> $BASH_ENV
+      - run:
+          name: Check docker-compose resources
+          shell: /bin/bash
+          working_directory: docker/compose/validator-testnet
+          command: |
+            set -x
+            docker container ls -a
+            docker-compose logs


### PR DESCRIPTION
so we can debug
* `DOCKER_COMPOSE_BLOCKING` env var so we can at least try running docker-compose without having it block the entire workflow
* Dump container info after attempting docker-compose up

After this lands, we can set `DOCKER_COMPOSE_ENABLED` without `DOCKER_COMPOSE_BLOCKING` to slow roll the ecosystem tests back, and observe the flakiness.