### PR TITLE
 [Storage] [Pruner] Various improvements for the DB Pruner

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -50,8 +50,8 @@ pub struct StorageConfig {
 
 pub const NO_OP_STORAGE_PRUNER_CONFIG: StoragePrunerConfig = StoragePrunerConfig {
     state_store_prune_window: None,
-    default_prune_window: None,
-    max_version_to_prune_per_batch: Some(100),
+    ledger_prune_window: None,
+    pruning_batch_size: 10_000,
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -63,23 +63,22 @@ pub struct StoragePrunerConfig {
     /// This is the default pruning window for any other store except for state store. State store
     /// being big in size, we might want to configure a smaller window for state store vs other
     /// store.
-    pub default_prune_window: Option<u64>,
-
-    /// Maximum version to prune per batch, should not be too large to avoid spike in disk IO caused
-    /// by large batches in the pruner.
-    pub max_version_to_prune_per_batch: Option<u64>,
+    pub ledger_prune_window: Option<u64>,
+    /// Batch size of the versions to be sent to the pruner - this is to avoid slowdown due to
+    /// issuing too many DB calls and batch prune instead.
+    pub pruning_batch_size: usize,
 }
 
 impl StoragePrunerConfig {
     pub fn new(
         state_store_prune_window: Option<u64>,
-        default_store_prune_window: Option<u64>,
-        max_version_to_prune_per_batch: Option<u64>,
+        ledger_store_prune_window: Option<u64>,
+        pruning_batch_size: usize,
     ) -> Self {
         StoragePrunerConfig {
             state_store_prune_window,
-            default_prune_window: default_store_prune_window,
-            max_version_to_prune_per_batch,
+            ledger_prune_window: ledger_store_prune_window,
+            pruning_batch_size,
         }
     }
 }
@@ -99,8 +98,8 @@ impl Default for StorageConfig {
             // depending on the size of an average account blob.
             storage_pruner_config: StoragePrunerConfig {
                 state_store_prune_window: Some(1_000_000),
-                default_prune_window: Some(10_000_000),
-                max_version_to_prune_per_batch: Some(100),
+                ledger_prune_window: Some(10_000_000),
+                pruning_batch_size: 10_000,
             },
             data_dir: PathBuf::from("/opt/aptos/data"),
             // Default read/write/connection timeout, in milliseconds

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -35,9 +35,6 @@ enum Command {
 
         #[structopt(long)]
         default_store_prune_window: Option<u64>,
-
-        #[structopt(long)]
-        max_version_to_prune_per_batch: Option<u64>,
     },
     RunExecutor {
         #[structopt(
@@ -77,7 +74,6 @@ fn main() {
             init_account_balance,
             state_store_prune_window,
             default_store_prune_window,
-            max_version_to_prune_per_batch,
         } => {
             executor_benchmark::db_generator::run(
                 num_accounts,
@@ -87,7 +83,7 @@ fn main() {
                 StoragePrunerConfig::new(
                     Some(state_store_prune_window.unwrap_or(1_000_000)),
                     Some(default_store_prune_window.unwrap_or(10_000_000)),
-                    Some(max_version_to_prune_per_batch.unwrap_or(100)),
+                    10_000,
                 ),
             );
         }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -650,7 +650,7 @@ impl AptosDB {
 
     fn wake_pruner(&self, latest_version: Version) {
         if let Some(pruner) = self.pruner.as_ref() {
-            pruner.wake(latest_version)
+            pruner.maybe_wake_pruner(latest_version)
         }
     }
 }

--- a/storage/aptosdb/src/pruner/db_sub_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_sub_pruner.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use schemadb::SchemaBatch;
+
+/// Defines the trait for sub-pruner of a parent DB pruner
+pub trait DBSubPruner {
+    /// Performs the actual pruning, a target version is passed, which is the target the pruner
+    /// tries to prune.
+    fn prune(
+        &self,
+        db_batch: &mut SchemaBatch,
+        least_readable_version: u64,
+        target_version: u64,
+    ) -> anyhow::Result<()>;
+}

--- a/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
@@ -1,50 +1,32 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-use crate::{
-    event::EventSchema, metrics::APTOS_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
-    EventStore,
-};
-use aptos_types::{
-    contract_event::ContractEvent,
-    event::EventKey,
-    transaction::{AtomicVersion, Version},
-};
+use crate::{pruner::db_sub_pruner::DBSubPruner, EventStore};
+use aptos_types::{contract_event::ContractEvent, event::EventKey, transaction::Version};
 use itertools::Itertools;
-use schemadb::{ReadOptions, SchemaBatch, DB};
-use std::{
-    collections::HashSet,
-    sync::{atomic::Ordering, Arc},
-};
-
-pub const EVENT_STORE_PRUNER_NAME: &str = "event store pruner";
+use schemadb::SchemaBatch;
+use std::{collections::HashSet, sync::Arc};
 
 pub struct EventStorePruner {
-    db: Arc<DB>,
     event_store: Arc<EventStore>,
-    /// Keeps track of the target version that the pruner needs to achieve.
-    target_version: AtomicVersion,
-    least_readable_version: AtomicVersion,
 }
 
-impl DBPruner for EventStorePruner {
-    fn name(&self) -> &'static str {
-        EVENT_STORE_PRUNER_NAME
-    }
-
-    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
-        // Current target version  might be less than the target version to ensure we don't prune
-        // more than max_version in one go.
-        let current_target_version = self.get_currrent_batch_target(max_versions);
-        let candidate_events = self
-            .get_pruning_candidate_events(self.least_readable_version(), current_target_version)?;
+impl DBSubPruner for EventStorePruner {
+    fn prune(
+        &self,
+        db_batch: &mut SchemaBatch,
+        least_readable_version: u64,
+        target_version: u64,
+    ) -> anyhow::Result<()> {
+        let candidate_events =
+            self.get_pruning_candidate_events(least_readable_version, target_version)?;
 
         let event_keys: HashSet<EventKey> =
             candidate_events.iter().map(|event| *event.key()).collect();
 
         self.event_store.prune_events_by_version(
             event_keys,
-            self.least_readable_version(),
-            current_target_version,
+            least_readable_version,
+            target_version,
             db_batch,
         )?;
 
@@ -52,57 +34,21 @@ impl DBPruner for EventStorePruner {
             .prune_events_by_key(&candidate_events, db_batch)?;
 
         self.event_store.prune_event_accumulator(
-            self.least_readable_version(),
-            current_target_version,
+            least_readable_version,
+            target_version,
             db_batch,
         )?;
 
-        self.event_store.prune_event_schema(
-            self.least_readable_version(),
-            current_target_version,
-            db_batch,
-        )?;
+        self.event_store
+            .prune_event_schema(least_readable_version, target_version, db_batch)?;
 
-        self.record_progress(current_target_version);
-        Ok(current_target_version)
-    }
-
-    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
-        let mut iter = self.db.iter::<EventSchema>(ReadOptions::default())?;
-        iter.seek_to_first();
-        let version = iter.next().transpose()?.map_or(0, |(key, _)| key.0);
-        Ok(version)
-    }
-
-    fn least_readable_version(&self) -> Version {
-        self.least_readable_version.load(Ordering::Relaxed)
-    }
-
-    fn set_target_version(&self, target_version: Version) {
-        self.target_version.store(target_version, Ordering::Relaxed)
-    }
-
-    fn target_version(&self) -> Version {
-        self.target_version.load(Ordering::Relaxed)
-    }
-
-    fn record_progress(&self, least_readable_version: Version) {
-        self.least_readable_version
-            .store(least_readable_version, Ordering::Relaxed);
-        APTOS_PRUNER_LEAST_READABLE_VERSION
-            .with_label_values(&["event_store"])
-            .set(least_readable_version as i64);
+        Ok(())
     }
 }
 
 impl EventStorePruner {
-    pub(in crate::pruner) fn new(db: Arc<DB>, event_store: Arc<EventStore>) -> Self {
-        EventStorePruner {
-            db,
-            event_store,
-            target_version: AtomicVersion::new(0),
-            least_readable_version: AtomicVersion::new(0),
-        }
+    pub(in crate::pruner) fn new(event_store: Arc<EventStore>) -> Self {
+        EventStorePruner { event_store }
     }
 
     fn get_pruning_candidate_events(

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -42,8 +42,8 @@ fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
         Arc::clone(&aptos_db.db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
-            default_prune_window: Some(0),
-            max_version_to_prune_per_batch: Some(100),
+            ledger_prune_window: Some(0),
+            pruning_batch_size: 1,
         },
         Arc::clone(&aptos_db.transaction_store),
         Arc::clone(&aptos_db.ledger_store),
@@ -63,7 +63,7 @@ fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
         pruner
             .wake_and_wait(
                 i as u64, /* latest_version */
-                PrunerIndex::EventStorePrunerIndex as usize,
+                PrunerIndex::LedgerPrunerIndex as usize,
             )
             .unwrap();
         // ensure that all events up to i * 2 has been pruned

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_counter_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_counter_pruner.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::{pruner::db_sub_pruner::DBSubPruner, LedgerStore};
+use schemadb::SchemaBatch;
+use std::sync::Arc;
+
+pub struct LedgerCounterPruner {
+    /// Keeps track of the target version that the pruner needs to achieve.
+    ledger_store: Arc<LedgerStore>,
+}
+
+impl DBSubPruner for LedgerCounterPruner {
+    fn prune(
+        &self,
+        db_batch: &mut SchemaBatch,
+        least_readable_version: u64,
+        target_version: u64,
+    ) -> anyhow::Result<()> {
+        self.ledger_store
+            .prune_ledger_couners(least_readable_version, target_version, db_batch)?;
+        Ok(())
+    }
+}
+
+impl LedgerCounterPruner {
+    pub fn new(ledger_store: Arc<LedgerStore>) -> Self {
+        LedgerCounterPruner { ledger_store }
+    }
+}

--- a/storage/aptosdb/src/pruner/ledger_store/mod.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod ledger_counter_pruner;
 pub(crate) mod ledger_store_pruner;

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -50,8 +50,8 @@ fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {
         Arc::clone(&aptos_db.db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
-            default_prune_window: Some(0),
-            max_version_to_prune_per_batch: Some(100),
+            ledger_prune_window: Some(0),
+            pruning_batch_size: 1,
         },
         Arc::clone(transaction_store),
         Arc::clone(&aptos_db.ledger_store),
@@ -71,7 +71,7 @@ fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {
         pruner
             .wake_and_wait(
                 i as u64, /* latest_version */
-                PrunerIndex::WriteSetPrunerIndex as usize,
+                PrunerIndex::LedgerPrunerIndex as usize,
             )
             .unwrap();
         // ensure that all transaction up to i * 2 has been pruned
@@ -101,8 +101,8 @@ fn verify_txn_store_pruner(
         Arc::clone(&aptos_db.db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
-            default_prune_window: Some(0),
-            max_version_to_prune_per_batch: Some(100),
+            ledger_prune_window: Some(0),
+            pruning_batch_size: 1,
         },
         Arc::clone(transaction_store),
         Arc::clone(&aptos_db.ledger_store),
@@ -123,7 +123,7 @@ fn verify_txn_store_pruner(
         pruner
             .wake_and_wait(
                 i as u64, /* latest_version */
-                PrunerIndex::TransactionStorePrunerIndex as usize,
+                PrunerIndex::LedgerPrunerIndex as usize,
             )
             .unwrap();
         // ensure that all transaction up to i * 2 has been pruned

--- a/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
@@ -1,90 +1,46 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-use crate::{
-    metrics::APTOS_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
-    transaction::TransactionSchema, TransactionStore,
-};
-use aptos_types::transaction::{AtomicVersion, Transaction, Version};
-use schemadb::{ReadOptions, SchemaBatch, DB};
-use std::sync::{atomic::Ordering, Arc};
-
-pub const TRANSACTION_STORE_PRUNER_NAME: &str = "transaction store pruner";
+use crate::{pruner::db_sub_pruner::DBSubPruner, TransactionStore};
+use aptos_types::transaction::{Transaction, Version};
+use schemadb::SchemaBatch;
+use std::sync::Arc;
 
 pub struct TransactionStorePruner {
-    db: Arc<DB>,
     transaction_store: Arc<TransactionStore>,
-    /// Keeps track of the target version that the pruner needs to achieve.
-    target_version: AtomicVersion,
-    least_readable_version: AtomicVersion,
 }
 
-impl DBPruner for TransactionStorePruner {
-    fn name(&self) -> &'static str {
-        TRANSACTION_STORE_PRUNER_NAME
-    }
-
-    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
-        let least_readable_version = self.least_readable_version();
+impl DBSubPruner for TransactionStorePruner {
+    fn prune(
+        &self,
+        db_batch: &mut SchemaBatch,
+        least_readable_version: u64,
+        target_version: u64,
+    ) -> anyhow::Result<()> {
         // Current target version  might be less than the target version to ensure we don't prune
         // more than max_version in one go.
-        let current_target_version = self.get_currrent_batch_target(max_versions);
-        let candidate_transactions = self
-            .get_pruning_candidate_transactions(least_readable_version, current_target_version)?;
+        let candidate_transactions =
+            self.get_pruning_candidate_transactions(least_readable_version, target_version)?;
         self.transaction_store
             .prune_transaction_by_hash(&candidate_transactions, db_batch)?;
         self.transaction_store
             .prune_transaction_by_account(&candidate_transactions, db_batch)?;
         self.transaction_store.prune_transaction_schema(
-            self.least_readable_version(),
-            current_target_version,
+            least_readable_version,
+            target_version,
             db_batch,
         )?;
         self.transaction_store.prune_transaction_info_schema(
-            self.least_readable_version(),
-            current_target_version,
+            least_readable_version,
+            target_version,
             db_batch,
         )?;
-
-        self.record_progress(current_target_version);
-        Ok(current_target_version)
-    }
-
-    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
-        let mut iter = self.db.iter::<TransactionSchema>(ReadOptions::default())?;
-        iter.seek_to_first();
-        let version = iter.next().transpose()?.map_or(0, |(version, _)| version);
-        Ok(version)
-    }
-
-    fn least_readable_version(&self) -> Version {
-        self.least_readable_version.load(Ordering::Relaxed)
-    }
-
-    fn set_target_version(&self, target_version: Version) {
-        self.target_version.store(target_version, Ordering::Relaxed)
-    }
-
-    fn target_version(&self) -> Version {
-        self.target_version.load(Ordering::Relaxed)
-    }
-
-    fn record_progress(&self, least_readable_version: Version) {
-        self.least_readable_version
-            .store(least_readable_version, Ordering::Relaxed);
-        APTOS_PRUNER_LEAST_READABLE_VERSION
-            .with_label_values(&["transaction_store"])
-            .set(least_readable_version as i64);
+        Ok(())
     }
 }
 
 impl TransactionStorePruner {
-    pub(in crate::pruner) fn new(db: Arc<DB>, transaction_store: Arc<TransactionStore>) -> Self {
-        TransactionStorePruner {
-            db,
-            transaction_store,
-            target_version: AtomicVersion::new(0),
-            least_readable_version: AtomicVersion::new(0),
-        }
+    pub(in crate::pruner) fn new(transaction_store: Arc<TransactionStore>) -> Self {
+        TransactionStorePruner { transaction_store }
     }
 
     fn get_pruning_candidate_transactions(

--- a/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
@@ -1,76 +1,28 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-use crate::{
-    metrics::APTOS_PRUNER_LEAST_READABLE_VERSION, pruner::db_pruner::DBPruner,
-    write_set::WriteSetSchema, TransactionStore,
-};
-use aptos_types::transaction::{AtomicVersion, Version};
-use schemadb::{ReadOptions, SchemaBatch, DB};
-use std::sync::{atomic::Ordering, Arc};
-
-pub const TRANSACTION_STORE_PRUNER_NAME: &str = "transaction store pruner";
+use crate::{pruner::db_sub_pruner::DBSubPruner, TransactionStore};
+use schemadb::SchemaBatch;
+use std::sync::Arc;
 
 pub struct WriteSetPruner {
-    db: Arc<DB>,
     transaction_store: Arc<TransactionStore>,
-    /// Keeps track of the target version that the pruner needs to achieve.
-    target_version: AtomicVersion,
-    least_readable_version: AtomicVersion,
 }
 
-impl DBPruner for WriteSetPruner {
-    fn name(&self) -> &'static str {
-        TRANSACTION_STORE_PRUNER_NAME
-    }
-
-    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version> {
-        // Current target version  might be less than the target version to ensure we don't prune
-        // more than max_version in one go.
-        let current_target_version = self.get_currrent_batch_target(max_versions);
-        self.transaction_store.prune_write_set(
-            self.least_readable_version(),
-            current_target_version,
-            db_batch,
-        )?;
-
-        self.record_progress(current_target_version);
-        Ok(current_target_version)
-    }
-
-    fn initialize_least_readable_version(&self) -> anyhow::Result<Version> {
-        let mut iter = self.db.iter::<WriteSetSchema>(ReadOptions::default())?;
-        iter.seek_to_first();
-        let version = iter.next().transpose()?.map_or(0, |(version, _)| version);
-        Ok(version)
-    }
-
-    fn least_readable_version(&self) -> Version {
-        self.least_readable_version.load(Ordering::Relaxed)
-    }
-
-    fn set_target_version(&self, target_version: Version) {
-        self.target_version.store(target_version, Ordering::Relaxed)
-    }
-
-    fn target_version(&self) -> Version {
-        self.target_version.load(Ordering::Relaxed)
-    }
-    fn record_progress(&self, least_readable_version: Version) {
-        self.least_readable_version
-            .store(least_readable_version, Ordering::Relaxed);
-        APTOS_PRUNER_LEAST_READABLE_VERSION
-            .with_label_values(&["write_set"])
-            .set(least_readable_version as i64);
+impl DBSubPruner for WriteSetPruner {
+    fn prune(
+        &self,
+        db_batch: &mut SchemaBatch,
+        least_readable_version: u64,
+        target_version: u64,
+    ) -> anyhow::Result<()> {
+        self.transaction_store
+            .prune_write_set(least_readable_version, target_version, db_batch)?;
+        Ok(())
     }
 }
 
 impl WriteSetPruner {
-    pub(in crate::pruner) fn new(db: Arc<DB>, transaction_store: Arc<TransactionStore>) -> Self {
-        WriteSetPruner {
-            db,
-            transaction_store,
-            target_version: AtomicVersion::new(0),
-            least_readable_version: AtomicVersion::new(0),
-        }
+    pub(in crate::pruner) fn new(transaction_store: Arc<TransactionStore>) -> Self {
+        WriteSetPruner { transaction_store }
     }
 }

--- a/storage/aptosdb/src/pruner/utils.rs
+++ b/storage/aptosdb/src/pruner/utils.rs
@@ -5,13 +5,8 @@
 
 use crate::{
     pruner::{
-        db_pruner::DBPruner,
-        event_store::event_store_pruner::EventStorePruner,
-        ledger_store::ledger_store_pruner::LedgerStorePruner,
+        db_pruner::DBPruner, ledger_store::ledger_store_pruner::LedgerPruner,
         state_store::StateStorePruner,
-        transaction_store::{
-            transaction_store_pruner::TransactionStorePruner, write_set_pruner::WriteSetPruner,
-        },
     },
     EventStore, LedgerStore, TransactionStore,
 };
@@ -32,21 +27,11 @@ pub fn create_db_pruners(
             0,
             Instant::now(),
         ))),
-        Mutex::new(Arc::new(TransactionStorePruner::new(
+        Mutex::new(Arc::new(LedgerPruner::new(
             Arc::clone(&db),
             Arc::clone(&transaction_store),
-        ))),
-        Mutex::new(Arc::new(LedgerStorePruner::new(
-            Arc::clone(&db),
-            Arc::clone(&ledger_store),
-        ))),
-        Mutex::new(Arc::new(EventStorePruner::new(
-            Arc::clone(&db),
             Arc::clone(&event_store),
-        ))),
-        Mutex::new(Arc::new(WriteSetPruner::new(
-            Arc::clone(&db),
-            Arc::clone(&transaction_store),
+            Arc::clone(&ledger_store),
         ))),
     ]
 }


### PR DESCRIPTION
Two issues are being addressed in this PR as follows - 
1. Currently the way DB pruner is setup, we prune one version at a time - this puts tremendous load on DB. We need to change the pruner to batch versions for pruning
2. Currently, there are several types of pruners, and initializing each pruner is expensive. Instead, we can merge them into two pruners 1. state pruner 2. ledger pruner. Ledger pruner will have a bunch of sub-pruners but they will not need expensive initialization - we just assume that the least readable version from DB for ledger pruner applies to other sub-pruners.

