### PR TITLE
trivial: remove version constraint on move-core-types

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -35,7 +35,7 @@ aptos-vm = { path = "../aptos-move/aptos-vm" }
 aptos-workspace-hack = { version = "0.1", path = "../crates/aptos-workspace-hack" }
 aptos-api-types = { path = "./types", package = "aptos-api-types" }
 storage-interface = { path = "../storage/storage-interface" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e", version = "0.0.4", features=["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e", features=["address32"] }
 move-resource-viewer = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e" }
 
 [dev-dependencies]


### PR DESCRIPTION


## Motivation
Upstream has bumped the version number, we've been using revision hashes to indicate dependency, and we used version="0.0.3" inconsistently (some places with the version and some not)

https://github.com/move-language/move/pull/68

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y
## Test Plan
existing coverage