### PR TITLE
[State Sync] Small cleanups.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -81,6 +81,7 @@ pub struct StateSyncDriverConfig {
     pub continuous_syncing_mode: ContinuousSyncingMode, // The mode by which to sync after bootstrapping
     pub progress_check_interval_ms: u64, // The interval (ms) at which to check state sync progress
     pub max_connection_deadline_secs: u64, // The max time (secs) to wait for connections from peers
+    pub max_consecutive_stream_notifications: u64, // The max number of notifications to process per driver loop
     pub max_pending_data_chunks: u64, // The max number of data chunks pending execution or commit
     pub max_stream_wait_time_ms: u64, // The max time (ms) to wait for a data stream notification
 }
@@ -95,6 +96,7 @@ impl Default for StateSyncDriverConfig {
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,
+            max_consecutive_stream_notifications: 10,
             max_pending_data_chunks: 100,
             max_stream_wait_time_ms: 10_000,
         }

--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -46,8 +46,9 @@ mod state;
 mod tests;
 
 // Useful constants for the Aptos Data Client
-const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 3;
-const POLLER_ERROR_LOG_FREQ_SECS: u64 = 3;
+const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 5;
+const GLOBAL_DATA_METRIC_FREQ_SECS: u64 = 1;
+const POLLER_ERROR_LOG_FREQ_SECS: u64 = 1;
 
 /// An [`AptosDataClient`] that fulfills requests from remote peers' Storage Service
 /// over AptosNet.
@@ -140,7 +141,7 @@ impl AptosNetDataClient {
             .copied()
             .ok_or_else(|| {
                 Error::DataIsUnavailable(
-                    "No connected peers are advertising that they can serve this data!".to_owned(),
+                    format!("No connected peers are advertising that they can serve this data! Request: {:?}",request),
                 )
             })
     }
@@ -203,10 +204,10 @@ impl AptosNetDataClient {
         E: Into<Error>,
     {
         let peer = self.choose_peer_for_request(&request).map_err(|error| {
-            error!(
+            debug!(
                 (LogSchema::new(LogEntry::StorageServiceRequest)
                     .event(LogEvent::PeerSelectionError)
-                    .message("Unable to select next peer")
+                    .message("Unable to select peer")
                     .error(&error))
             );
             error
@@ -556,7 +557,7 @@ impl DataSummaryPoller {
                 // Log the new global data summary and update the metrics
                 sample!(
                     SampleRate::Duration(Duration::from_secs(GLOBAL_DATA_LOG_FREQ_SECS)),
-                    debug!(
+                    info!(
                         (LogSchema::new(LogEntry::PeerStates)
                             .event(LogEvent::AggregateSummary)
                             .message(&format!(
@@ -564,7 +565,10 @@ impl DataSummaryPoller {
                                 self.data_client.get_global_data_summary()
                             )))
                     );
-                    let global_data_summary = self.data_client.global_summary_cache.read().clone();
+                );
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(GLOBAL_DATA_METRIC_FREQ_SECS)),
+                    let global_data_summary = self.data_client.get_global_data_summary();
                     update_advertised_data_metrics(global_data_summary);
                 );
             }

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -511,7 +511,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
                     Error::IntegerOverflow("Number of entries to remove has overflown!".into())
                 })?;
 
-            info!(
+            debug!(
                 (LogSchema::new(LogEntry::StreamNotification)
                     .stream_id(self.data_stream_id)
                     .event(LogEvent::Success)

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -469,7 +469,11 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
 
     /// Processes any notifications already pending on the active stream
     async fn process_active_stream_notifications(&mut self) -> Result<(), Error> {
-        loop {
+        for _ in 0..self
+            .driver_configuration
+            .config
+            .max_consecutive_stream_notifications
+        {
             // Fetch and process any data notifications
             let data_notification = self.fetch_next_data_notification().await?;
             match data_notification.data_payload {
@@ -515,6 +519,8 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
                 }
             }
         }
+
+        Ok(())
     }
 
     /// Fetches all account states (as required to bootstrap the node)

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -157,7 +157,11 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
         &mut self,
         consensus_sync_request: Arc<Mutex<Option<ConsensusSyncRequest>>>,
     ) -> Result<(), Error> {
-        loop {
+        for _ in 0..self
+            .driver_configuration
+            .config
+            .max_consecutive_stream_notifications
+        {
             // Fetch and process any data notifications
             let data_notification = self.fetch_next_data_notification().await?;
             match data_notification.data_payload {
@@ -199,6 +203,8 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
                 }
             }
         }
+
+        Ok(())
     }
 
     /// Returns the highest synced version and epoch in storage

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -169,7 +169,6 @@ impl<ChunkExecutor: ChunkExecutorTrait + 'static> StorageSynchronizer<ChunkExecu
             executor_listener,
             committer_notifier,
             pending_transaction_chunks.clone(),
-            max_pending_data_chunks as u64,
             runtime.clone(),
         );
 
@@ -336,7 +335,6 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
     mut executor_listener: mpsc::Receiver<StorageDataChunk>,
     mut committer_notifier: mpsc::Sender<NotificationId>,
     pending_transaction_chunks: Arc<AtomicU64>,
-    max_pending_data_chunks: u64,
     runtime: Option<Handle>,
 ) -> JoinHandle<()> {
     // Create an executor
@@ -402,12 +400,7 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
                             decrement_pending_data_chunks(pending_transaction_chunks.clone());
                         }
                     }
-
-                    // If the executor begins running too far ahead of the committer
-                    // let's force more yields to avoid unnecessary back pressure.
-                    if load_pending_data_chunks(pending_transaction_chunks.clone()) > max_pending_data_chunks / 2 {
-                        yield_now().await;
-                    }
+                    yield_thread().await;
                 }
             }
         }
@@ -474,6 +467,7 @@ fn spawn_committer<
                         }
                     };
                     decrement_pending_data_chunks(pending_transaction_chunks.clone());
+                    yield_thread().await;
                 }
             }
         }
@@ -547,6 +541,7 @@ fn spawn_state_snapshot_receiver<ChunkExecutor: ChunkExecutorTrait + 'static>(
                                         }
 
                                         decrement_pending_data_chunks(pending_transaction_chunks.clone());
+                                        yield_thread().await;
                                         continue; // Wait for the next chunk
                                     }
 
@@ -687,4 +682,15 @@ async fn send_storage_synchronizer_error(
 
     // Update the metrics
     metrics::increment_counter(&metrics::STORAGE_SYNCHRONIZER_ERRORS, error.get_label());
+}
+
+/// This yields the currently executing thread. This is required
+/// to avoid starvation of other threads when the system is under
+/// heavy load (see: https://github.com/aptos-labs/aptos-core/issues/623).
+///
+/// TODO(joshlind): identify a better solution. It likely requires
+/// using spawn_blocking() at a lower level, or merging runtimes.
+async fn yield_thread() {
+    // We have a 50% chance of yielding here.
+    sample!(SampleRate::Frequency(2), yield_now().await;);
 }


### PR DESCRIPTION
## Motivation

This PR offers three small cleanups to state sync (each in their own commit):
1. Clean up some of the state sync v2 logs (e.g., to avoid log spam under failure conditions).
2. Increase the frequency of yields for CPU/IO intensive threads that yield only infrequently (e.g., see: https://github.com/aptos-labs/aptos-core/issues/623)
3. Add a configurable value to set the max number of consecutive data notifications to process before yielding back to the main state sync driver loop. This should further help the above.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests cover this functionality.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245