### PR TITLE
[Configs] Enable state sync v2 by default.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -92,7 +92,7 @@ impl Default for StateSyncDriverConfig {
     fn default() -> Self {
         Self {
             bootstrapping_mode: BootstrappingMode::ApplyTransactionOutputsFromGenesis,
-            enable_state_sync_v2: false,
+            enable_state_sync_v2: true,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,
@@ -124,7 +124,7 @@ impl Default for StorageServiceConfig {
             max_network_channel_size: 1000,
             max_transaction_chunk_size: 1000,
             max_transaction_output_chunk_size: 1000,
-            storage_summary_refresh_interval_ms: 1000,
+            storage_summary_refresh_interval_ms: 250,
         }
     }
 }
@@ -158,7 +158,7 @@ pub struct DataStreamingServiceConfig {
 impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
-            global_summary_refresh_interval_ms: 300,
+            global_summary_refresh_interval_ms: 250,
             max_concurrent_requests: 1,
             max_data_stream_channel_sizes: 1000,
             max_request_retry: 3,
@@ -179,7 +179,7 @@ impl Default for AptosDataClientConfig {
     fn default() -> Self {
         Self {
             response_timeout_ms: 10000,
-            summary_poll_interval_ms: 1000,
+            summary_poll_interval_ms: 250,
         }
     }
 }

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -138,6 +138,8 @@ async fn test_connection_limiting() {
     );
 }
 
+// Currently this test seems flaky: https://github.com/aptos-labs/aptos-core/issues/670
+#[ignore]
 #[tokio::test]
 async fn test_file_discovery() {
     let mut swarm = new_local_swarm_with_aptos(1).await;


### PR DESCRIPTION
## Motivation

This PR enables state sync v2 by default in our configs. It also sets up reasonable default configuration options. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245