### PR TITLE
[aptos-cli] Use config for common inputs

### DIFF
--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -6,7 +6,10 @@
 //! TODO: Examples
 //!
 
-use crate::common::types::{CliError, CliTypedResult, RestOptions};
+use crate::common::types::{
+    account_address_from_public_key, CliConfig, CliError, CliTypedResult, RestOptions,
+};
+use aptos_crypto::PrivateKey;
 use aptos_rest_client::{types::Resource, Client};
 use aptos_types::account_address::AccountAddress;
 use clap::Parser;
@@ -20,16 +23,27 @@ pub struct ListResources {
 
     /// Address of account you want to list resources for
     #[clap(long)]
-    account: AccountAddress,
+    account: Option<AccountAddress>,
 }
 
 impl ListResources {
     // TODO: Format this in a reasonable way while providing all information
     // add options like --tokens --nfts etc
     pub(crate) async fn execute(self) -> CliTypedResult<Vec<serde_json::Value>> {
-        let client = Client::new(self.rest_options.url);
+        let account = if let Some(account) = self.account {
+            account
+        } else if let Some(private_key) = CliConfig::load()?.private_key {
+            let public_key = private_key.public_key();
+            account_address_from_public_key(&public_key)
+        } else {
+            return Err(CliError::CommandArgumentError(
+                "Please provide an account using --account or run aptos init".to_string(),
+            ));
+        };
+
+        let client = Client::new(self.rest_options.url()?);
         let response: Vec<Resource> = client
-            .get_account_resources(self.account)
+            .get_account_resources(account)
             .await
             .map_err(|err| CliError::ApiError(err.to_string()))?
             .into_inner();

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -2,14 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    account::create::CreateAccount,
     common::{
-        types::{CliConfig, CliError, CliTypedResult},
+        types::{account_address_from_public_key, CliConfig, CliError, CliTypedResult},
         utils::prompt_yes,
     },
     op::key::GenerateKey,
 };
-use aptos_crypto::{ed25519::Ed25519PrivateKey, ValidCryptoMaterialStringExt};
+use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, ValidCryptoMaterialStringExt};
 use clap::Parser;
+
+pub const DEFAULT_REST_URL: &str = "https://fullnode.devnet.aptoslabs.com";
+pub const DEFAULT_FAUCET_URL: &str = "https://faucet.devnet.aptoslabs.com";
+const NUM_DEFAULT_COINS: u64 = 10000;
 
 /// Tool to initialize current directory for the aptos tool
 #[derive(Debug, Parser)]
@@ -29,20 +34,76 @@ impl InitTool {
             CliConfig::default()
         };
 
-        eprintln!("Enter your private key as a hex literal (0x...) [No input: Generate new key]");
+        // Rest Endpoint
+        eprintln!(
+            "Enter your rest endpoint [Current: {} No input: {}]",
+            config.rest_url.unwrap_or_else(|| "None".to_string()),
+            DEFAULT_REST_URL
+        );
+        let input = read_line("Rest endpoint")?;
+        let input = input.trim();
+        let rest_url = if input.is_empty() {
+            eprintln!("No rest url given, using {}...", DEFAULT_REST_URL);
+            reqwest::Url::parse(DEFAULT_REST_URL).map_err(|err| {
+                CliError::UnexpectedError(format!("Failed to parse default rest URL {}", err))
+            })?
+        } else {
+            reqwest::Url::parse(input)
+                .map_err(|err| CliError::UnableToParse("Rest Endpoint", err.to_string()))?
+        };
+        config.rest_url = Some(rest_url.to_string());
+
+        // Faucet Endpoint
+        eprintln!(
+            "Enter your faucet endpoint [Current: {} No input: {}]",
+            config.faucet_url.unwrap_or_else(|| "None".to_string()),
+            DEFAULT_FAUCET_URL
+        );
+        let input = read_line("Faucet endpoint")?;
+        let input = input.trim();
+        let faucet_url = if input.is_empty() {
+            eprintln!("No faucet url given, using {}...", DEFAULT_FAUCET_URL);
+            reqwest::Url::parse(DEFAULT_FAUCET_URL).map_err(|err| {
+                CliError::UnexpectedError(format!("Failed to parse default faucet URL {}", err))
+            })?
+        } else {
+            reqwest::Url::parse(input)
+                .map_err(|err| CliError::UnableToParse("Faucet Endpoint", err.to_string()))?
+        };
+        config.faucet_url = Some(faucet_url.to_string());
+
+        // Private key
+        eprintln!("Enter your private key as a hex literal (0x...) [Current: {} No input: Generate new key (or keep one if present)]", config.private_key.as_ref().map(|_| "Redacted").unwrap_or("None"));
         let input = read_line("Private key")?;
         let input = input.trim();
         let private_key = if input.is_empty() {
-            eprintln!("No key given, generating key...");
-            GenerateKey::generate_ed25519_in_memory()
+            if let Some(private_key) = config.private_key {
+                eprintln!("No key given, keeping existing key...");
+                private_key
+            } else {
+                eprintln!("No key given, generating key...");
+                GenerateKey::generate_ed25519_in_memory()
+            }
         } else {
             Ed25519PrivateKey::from_encoded_string(input)
                 .map_err(|err| CliError::UnableToParse("Ed25519PrivateKey", err.to_string()))?
         };
+        let public_key = private_key.public_key();
+        let address = account_address_from_public_key(&public_key);
         config.private_key = Some(private_key);
-        config.save()?;
-        eprintln!("Aptos is now set up!  Run `aptos help` for more information about commands");
 
+        // Create account if it doesn't exist
+        let client = aptos_rest_client::Client::new(rest_url);
+        if client.get_account(address).await.is_err() {
+            eprintln!(
+                "Account {} doesn't exist, creating it and funding it with {} coins",
+                address, NUM_DEFAULT_COINS
+            );
+            CreateAccount::create_account_with_faucet(faucet_url, NUM_DEFAULT_COINS, address)
+                .await?;
+        }
+        config.save()?;
+        eprintln!("Aptos is now set up for account {}!  Run `aptos help` for more information about commands", address);
         Ok(())
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -151,8 +151,8 @@ impl PublishPackage {
             .extract_private_key(self.encoding_options.encoding)?;
 
         submit_transaction(
-            self.write_options.rest_options.url.clone(),
-            self.write_options.chain_id,
+            self.write_options.rest_options.url()?,
+            self.write_options.chain_id().await?,
             sender_key,
             compiled_payload,
             self.write_options.max_gas,


### PR DESCRIPTION
Uses config for URLs and adds ability for faucet URL on create.
Additionally, removes need for chain id and improves aptos init
experience.

1. Aptos init now creates the account for you, and puts it in the config (skips creating if it already exists)
2. You can now set a config based faucet and rest URL so you can actually test locally
3. Private keys are generated and old ones aren't wiped out (so people don't erase their wallets)

This experience is a lot easier, as you can keep your key in your config, and it'll be used across all networks you want to test upon with a static identity shared between each.  ChainIds are now no longer even asked for, we just pull them from the rest endpoint, which should make everyone's lives easier.

```
$ aptos init
Enter your rest endpoint [Current: None No input: https://fullnode.devnet.aptoslabs.com]
http://localhost:8080
Enter your faucet endpoint [Current: None No input: https://faucet.devnet.aptoslabs.com]
http://localhost:8000
Enter your private key as a hex literal (0x...) [Current: None No input: Generate new key (or keep one if present)]

No key given, generating key...
Account FC7DC6BCCE5513A1D41C79E571ACDE206674E6CB8D148A74F7530FC90AB625CC doesn't exist, creating it and funding it with 10000 coins
2022-04-26T23:19:05.095850Z [main] INFO crates/aptos/src/common/types.rs:103 Created .aptos/ folder
Aptos is now set up for account FC7DC6BCCE5513A1D41C79E571ACDE206674E6CB8D148A74F7530FC90AB625CC!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}
$ aptos account list
{
  "Result": [
    {
      "counter": "2"
    },
    {
      "authentication_key": "0xfc7dc6bcce5513a1d41c79e571acde206674e6cb8d148a74f7530fc90ab625cc",
      "self_address": "0xfc7dc6bcce5513a1d41c79e571acde206674e6cb8d148a74f7530fc90ab625cc",
      "sequence_number": "0"
    },
    {
      "coin": {
        "value": "10000"
      }
    },
...
}
$ aptos move publish --package-dir /opt/git/aptos-core/aptos-move/move-examples/ --named-addresses HelloBlockchain=FC7DC6BCCE5513A1D41C79E571ACDE206674E6CB8D148A74F7530FC90AB625CC --url http://localhost:8080
{
  "Result": {
    "type": "user_transaction",
    "version": "25277",
    "hash": "0x008354800b1bc8926f95e9ed3fd77fbca5b9e856a449fb7630f45df023f47035",
    "state_root_hash": "0x59026b56c221f70dbbf4756fdc3470601a4aa3e4d5fd3513e221dd576d7f36f0",
    "event_root_hash": "0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",
    "gas_used": "9",
    "success": true,
    "vm_status": "Executed successfully",
    "accumulator_root_hash": "0x97a7ed392c5dad7972a6ec6b2f1bdc2e5f3976bee913ca68487870a2f1477304",
...
}

```