### PR TITLE
[Scripts] package gcc-powerpc-linux-gnu doesnt exist on yum/dnf

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -375,8 +375,10 @@ function install_tidy {
 function install_gcc_powerpc_linux_gnu {
   PACKAGE_MANAGER=$1
   #Differently named packages for gcc-powerpc-linux-gnu
-  if [[ "$PACKAGE_MANAGER" == "apt-get" ]] || [[ "$PACKAGE_MANAGER" == "yum" ]]; then
+  if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
     install_pkg gcc-powerpc-linux-gnu "$PACKAGE_MANAGER"
+  elif [[ "$PACKAGE_MANAGER" == "yum" ]] || [[ "$PACKAGE_MANAGER" == "dnf" ]]; then
+    install_pkg gcc-powerpc64-linux-gnu "$PACKAGE_MANAGER"
   fi
   #if [[ "$PACKAGE_MANAGER" == "pacman" ]]; then
   #  install_pkg powerpc-linux-gnu-gcc "$PACKAGE_MANAGER"


### PR DESCRIPTION
fix: package gcc-powerpc-linux-gnu doesnt exist on Yum/Dnf

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
