### PR TITLE
[aptos-cli] Add profiles and smart AccountAddress processing and Add Telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,11 +182,13 @@ dependencies = [
  "serde 1.0.136",
  "serde_json",
  "serde_yaml",
+ "shadow-rs",
  "short-hex-str",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-util 0.6.9",
+ "uuid",
 ]
 
 [[package]]
@@ -2157,6 +2159,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
+name = "const_format"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bc6cd49b0ec407b680c3e380182b6ac63b73991cb7602de350352fc309b614"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
+dependencies = [
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "unicode-xid 0.2.2",
+]
+
+[[package]]
 name = "cookie"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3474,6 +3496,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "git2"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4070,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4280,6 +4321,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.13.2+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4299,6 +4352,18 @@ dependencies = [
  "cc",
  "glob",
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -7220,6 +7285,18 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "shadow-rs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47e98e36909e951f4da3908f4475f969bec92a41734dd92e883aaa11c10294b"
+dependencies = [
+ "chrono",
+ "const_format",
+ "git2",
+ "is_debug",
 ]
 
 [[package]]

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -14,6 +14,7 @@ pub const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
 
 // Metrics events
 pub const APTOS_NODE_PUSH_METRICS: &str = "APTOS_NODE_PUSH_METRICS";
+pub const APTOS_CLI_PUSH_METRICS: &str = "APTOS_CLI_PUSH_METRICS";
 
 // Metrics names
 pub const IP_ADDR_METRIC: &str = "IP_ADDRESS";

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 anyhow = "1.0.52"
@@ -20,10 +21,12 @@ reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 serde = "1.0.124"
 serde_json = "1.0.64"
 serde_yaml = "0.8.17"
+shadow-rs = "0.11.0"
 thiserror = "1.0.24"
 tempfile = "3.2.0"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
+uuid = { version = "0.8.2", features = ["v4", "serde"] }
 
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
@@ -46,3 +49,6 @@ move-core-types = { git = "https://github.com/move-language/move", rev = "1b6b75
 move-package = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e" }
 move-unit-test = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e" }
+
+[build-dependencies]
+shadow-rs = "0.11.0"

--- a/crates/aptos/build.rs
+++ b/crates/aptos/build.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -31,8 +31,9 @@ pub struct CreateAccount {
     write_options: WriteTransactionOptions,
     #[clap(flatten)]
     profile: ProfileOptions,
+    /// Address to create account for
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
-    address: AccountAddress,
+    account: AccountAddress,
     /// Flag for using faucet to create the account
     #[clap(long)]
     use_faucet: bool,
@@ -46,7 +47,7 @@ pub struct CreateAccount {
 
 impl CreateAccount {
     pub async fn execute(self) -> CliTypedResult<String> {
-        let address = self.address;
+        let address = self.account;
         if self.use_faucet {
             let faucet_url = if let Some(faucet_url) = self.faucet_url {
                 faucet_url

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -6,11 +6,7 @@
 //! TODO: Examples
 //!
 
-use crate::common::types::{
-    account_address_from_public_key, CliConfig, CliError, CliTypedResult, ProfileOptions,
-    RestOptions,
-};
-use aptos_crypto::PrivateKey;
+use crate::common::types::{CliConfig, CliError, CliTypedResult, ProfileOptions, RestOptions};
 use aptos_rest_client::{types::Resource, Client};
 use aptos_types::account_address::AccountAddress;
 use clap::Parser;
@@ -36,11 +32,10 @@ impl ListResources {
     pub(crate) async fn execute(self) -> CliTypedResult<Vec<serde_json::Value>> {
         let account = if let Some(account) = self.account {
             account
-        } else if let Some(Some(private_key)) =
-            CliConfig::load_profile(&self.profile.profile)?.map(|p| p.private_key)
+        } else if let Some(Some(account)) =
+            CliConfig::load_profile(&self.profile.profile)?.map(|p| p.account)
         {
-            let public_key = private_key.public_key();
-            account_address_from_public_key(&public_key)
+            account
         } else {
             return Err(CliError::CommandArgumentError(
                 "Please provide an account using --account or run aptos init".to_string(),

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -20,9 +20,15 @@ pub enum AccountTool {
 impl AccountTool {
     pub async fn execute(self) -> CliResult {
         match self {
-            AccountTool::Create(tool) => to_common_result(tool.execute().await),
-            AccountTool::List(tool) => to_common_result(tool.execute().await),
-            AccountTool::Transfer(tool) => to_common_result(tool.execute().await),
+            AccountTool::Create(tool) => {
+                to_common_result("CreateAccount", tool.execute().await).await
+            }
+            AccountTool::List(tool) => {
+                to_common_result("ListResources", tool.execute().await).await
+            }
+            AccountTool::Transfer(tool) => {
+                to_common_result("TransferCoins", tool.execute().await).await
+            }
         }
     }
 }

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -29,8 +29,8 @@ pub struct TransferCoins {
     profile: ProfileOptions,
 
     /// Address of account you want to send coins to
-    #[clap(long)]
-    receiving_account: AccountAddress,
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    account: AccountAddress,
 
     /// Amount of coins to transfer
     #[clap(long)]
@@ -58,7 +58,7 @@ impl TransferCoins {
         let sender_account = &mut LocalAccount::new(sender_address, sender_key, sequence_number);
         let transaction =
             sender_account.sign_with_transaction_builder(transaction_factory.payload(
-                aptos_stdlib::encode_transfer_script_function(self.receiving_account, self.amount),
+                aptos_stdlib::encode_transfer_script_function(self.account, self.amount),
             ));
         client
             .submit_and_wait(&transaction)

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -36,19 +36,19 @@ impl InitTool {
         };
 
         // Select profile we're using
-        let mut profile_config =
-            if let Some(profile_config) = config.remove_profile(&self.profile.profile) {
-                profile_config
-            } else {
-                ProfileConfig::default()
-            };
-
-        if !prompt_yes(
-            &format!("Aptos already initialized for profile {}, do you want to overwrite the existing config?", self.profile.profile),
-        ) {
-            eprintln!("Exiting...");
-            return Ok(());
-        }
+        let mut profile_config = if let Some(profile_config) =
+            config.remove_profile(&self.profile.profile)
+        {
+            if !prompt_yes(
+                    &format!("Aptos already initialized for profile {}, do you want to overwrite the existing config?", self.profile.profile),
+                ) {
+                    eprintln!("Exiting...");
+                    return Ok(());
+                }
+            profile_config
+        } else {
+            ProfileConfig::default()
+        };
 
         eprintln!("Configuring for profile {}", self.profile.profile);
 

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -54,7 +54,7 @@ impl InitTool {
 
         // Rest Endpoint
         eprintln!(
-            "Enter your rest endpoint [Current: {} No input: {}]",
+            "Enter your rest endpoint [Current: {} | No input: {}]",
             profile_config
                 .rest_url
                 .unwrap_or_else(|| "None".to_string()),
@@ -75,7 +75,7 @@ impl InitTool {
 
         // Faucet Endpoint
         eprintln!(
-            "Enter your faucet endpoint [Current: {} No input: {}]",
+            "Enter your faucet endpoint [Current: {} | No input: {}]",
             profile_config
                 .faucet_url
                 .unwrap_or_else(|| "None".to_string()),
@@ -95,7 +95,7 @@ impl InitTool {
         profile_config.faucet_url = Some(faucet_url.to_string());
 
         // Private key
-        eprintln!("Enter your private key as a hex literal (0x...) [Current: {} No input: Generate new key (or keep one if present)]", profile_config.private_key.as_ref().map(|_| "Redacted").unwrap_or("None"));
+        eprintln!("Enter your private key as a hex literal (0x...) [Current: {} | No input: Generate new key (or keep one if present)]", profile_config.private_key.as_ref().map(|_| "Redacted").unwrap_or("None"));
         let input = read_line("Private key")?;
         let input = input.trim();
         let private_key = if input.is_empty() {

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -113,6 +113,8 @@ impl InitTool {
         let public_key = private_key.public_key();
         let address = account_address_from_public_key(&public_key);
         profile_config.private_key = Some(private_key);
+        profile_config.public_key = Some(public_key);
+        profile_config.account = Some(address);
 
         // Create account if it doesn't exist
         let client = aptos_rest_client::Client::new(rest_url);

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -69,6 +69,10 @@ pub struct CliConfig {
 pub struct ProfileConfig {
     /// Private key for commands.  TODO: Add vault functionality
     pub private_key: Option<Ed25519PrivateKey>,
+    /// Public key for commands
+    pub public_key: Option<Ed25519PublicKey>,
+    /// Account for commands
+    pub account: Option<AccountAddress>,
     /// URL for the Aptos rest endpoint
     pub rest_url: Option<String>,
     /// URL for the Faucet endpoint (if applicable)

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -32,6 +32,12 @@ pub type CliTypedResult<T> = Result<T, CliError>;
 
 #[derive(Debug, Error)]
 pub enum CliError {
+    #[error("Aborted command")]
+    AbortedError,
+    #[error("API error: {0}")]
+    ApiError(String),
+    #[error("Error (de)serializing '{0}': {1}")]
+    BCS(&'static str, #[source] bcs::Error),
     #[error("Invalid arguments: {0}")]
     CommandArgumentError(String),
     #[error("Unable to load config: {0} {1}")]
@@ -40,39 +46,33 @@ pub enum CliError {
     ConfigNotFoundError(String),
     #[error("Error accessing '{0}': {1}")]
     IO(String, #[source] std::io::Error),
-    #[error("Error (de)serializing '{0}': {1}")]
-    BCS(&'static str, #[source] bcs::Error),
-    #[error("Unable to parse '{0}': error: {1}")]
-    UnableToParse(&'static str, String),
-    #[error("Unable to read file '{0}', error: {1}")]
-    UnableToReadFile(String, String),
-    #[error("API error: {0}")]
-    ApiError(String),
-    #[error("Unexpected error: {0}")]
-    UnexpectedError(String),
-    #[error("Aborted command")]
-    AbortedError,
     #[error("Move compilation failed: {0}")]
     MoveCompilationError(String),
     #[error("Move unit tests failed: {0}")]
     MoveTestError(String),
+    #[error("Unable to parse '{0}': error: {1}")]
+    UnableToParse(&'static str, String),
+    #[error("Unable to read file '{0}', error: {1}")]
+    UnableToReadFile(String, String),
+    #[error("Unexpected error: {0}")]
+    UnexpectedError(String),
 }
 
 impl CliError {
     pub fn to_str(&self) -> &'static str {
         match self {
+            CliError::AbortedError => "AbortedError",
+            CliError::ApiError(_) => "ApiError",
+            CliError::BCS(_, _) => "BCS",
             CliError::CommandArgumentError(_) => "CommandArgumentError",
             CliError::ConfigLoadError(_, _) => "ConfigLoadError",
             CliError::ConfigNotFoundError(_) => "ConfigNotFoundError",
             CliError::IO(_, _) => "IO",
-            CliError::BCS(_, _) => "BCS",
-            CliError::UnableToParse(_, _) => "UnableToParse",
-            CliError::UnableToReadFile(_, _) => "UnableToReadFile",
-            CliError::ApiError(_) => "ApiError",
-            CliError::UnexpectedError(_) => "UnexpectedError",
-            CliError::AbortedError => "AbortedError",
             CliError::MoveCompilationError(_) => "MoveCompilationError",
             CliError::MoveTestError(_) => "MoveTestError",
+            CliError::UnableToParse(_, _) => "UnableToParse",
+            CliError::UnableToReadFile(_, _) => "UnableToReadFile",
+            CliError::UnexpectedError(_) => "UnexpectedError",
         }
     }
 }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -58,6 +58,25 @@ pub enum CliError {
     MoveTestError(String),
 }
 
+impl CliError {
+    pub fn to_str(&self) -> &'static str {
+        match self {
+            CliError::CommandArgumentError(_) => "CommandArgumentError",
+            CliError::ConfigLoadError(_, _) => "ConfigLoadError",
+            CliError::ConfigNotFoundError(_) => "ConfigNotFoundError",
+            CliError::IO(_, _) => "IO",
+            CliError::BCS(_, _) => "BCS",
+            CliError::UnableToParse(_, _) => "UnableToParse",
+            CliError::UnableToReadFile(_, _) => "UnableToReadFile",
+            CliError::ApiError(_) => "ApiError",
+            CliError::UnexpectedError(_) => "UnexpectedError",
+            CliError::AbortedError => "AbortedError",
+            CliError::MoveCompilationError(_) => "MoveCompilationError",
+            CliError::MoveTestError(_) => "MoveTestError",
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CliConfig {
     /// Map of profile configs

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -9,7 +9,7 @@ use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     x25519, PrivateKey, ValidCryptoMaterial, ValidCryptoMaterialStringExt,
 };
-use aptos_logger::{debug, info};
+use aptos_logger::debug;
 use aptos_rest_client::Client;
 use aptos_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
 use clap::{ArgEnum, Parser};
@@ -132,7 +132,7 @@ impl CliConfig {
                     aptos_folder, err
                 ))
             })?;
-            info!("Created .aptos/ folder");
+            debug!("Created .aptos/ folder");
         } else {
             debug!(".aptos/ folder already initialized");
         }

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -5,13 +5,18 @@ use crate::{
     common::types::{CliError, CliTypedResult},
     CliResult,
 };
+use aptos_telemetry::constants::APTOS_CLI_PUSH_METRICS;
 use move_core_types::account_address::AccountAddress;
 use serde::Serialize;
+use shadow_rs::shadow;
 use std::{
+    collections::HashMap,
     fs::File,
     io::Write,
     path::{Path, PathBuf},
 };
+
+shadow!(build);
 
 /// Prompts for confirmation until a yes or no is given explicitly
 /// TODO: Capture interrupts
@@ -35,13 +40,25 @@ pub fn prompt_yes(prompt: &str) -> bool {
 }
 
 /// Convert an empty response to Success
-pub fn to_common_success_result(result: CliTypedResult<()>) -> CliResult {
-    to_common_result(result.map(|()| "Success"))
+pub async fn to_common_success_result(command: &str, result: CliTypedResult<()>) -> CliResult {
+    to_common_result(command, result.map(|()| "Success")).await
 }
 
 /// For pretty printing outputs in JSON
-pub fn to_common_result<T: Serialize>(result: CliTypedResult<T>) -> CliResult {
+pub async fn to_common_result<T: Serialize>(command: &str, result: CliTypedResult<T>) -> CliResult {
     let is_err = result.is_err();
+    let error = if let Err(ref e) = result {
+        e.to_str()
+    } else {
+        "None"
+    };
+    let metrics = collect_metrics(command, !is_err, error);
+    aptos_telemetry::send_data(
+        APTOS_CLI_PUSH_METRICS.to_string(),
+        uuid::Uuid::new_v4().to_string(),
+        metrics,
+    )
+    .await;
     let result: ResultWrapper<T> = result.into();
     let string = serde_json::to_string_pretty(&result).unwrap();
     if is_err {
@@ -49,6 +66,48 @@ pub fn to_common_result<T: Serialize>(result: CliTypedResult<T>) -> CliResult {
     } else {
         Ok(string)
     }
+}
+
+/// Collect build and command metrics for better debugging of CLI
+fn collect_metrics(command: &str, successful: bool, error: &str) -> HashMap<String, String> {
+    let mut metrics = HashMap::new();
+    metrics.insert("Command".to_string(), command.to_string());
+    metrics.insert("Successful".to_string(), successful.to_string());
+    metrics.insert("Error".to_string(), error.to_string());
+    metrics.insert("Version".to_string(), build::VERSION.to_string());
+    metrics.insert("PkgVersion".to_string(), build::PKG_VERSION.to_string());
+    metrics.insert(
+        "ClapVersion".to_string(),
+        build::CLAP_LONG_VERSION.to_string(),
+    );
+    metrics.insert("Commit".to_string(), build::COMMIT_HASH.to_string());
+    metrics.insert("Branch".to_string(), build::BRANCH.to_string());
+    metrics.insert("Tag".to_string(), build::TAG.to_string());
+    metrics.insert("BUILD_OS".to_string(), build::BUILD_OS.to_string());
+    metrics.insert(
+        "BUILD_TARGET_OS".to_string(),
+        build::BUILD_TARGET.to_string(),
+    );
+    metrics.insert(
+        "BUILD_TARGET_ARCH".to_string(),
+        build::BUILD_TARGET_ARCH.to_string(),
+    );
+    metrics.insert(
+        "BUILD_RUST_CHANNEL".to_string(),
+        build::BUILD_RUST_CHANNEL.to_string(),
+    );
+    metrics.insert("BUILD_TIME".to_string(), build::BUILD_TIME.to_string());
+    metrics.insert("RUST_VERSION".to_string(), build::RUST_VERSION.to_string());
+    metrics.insert(
+        "RUST_TOOLCHAIN".to_string(),
+        build::RUST_CHANNEL.to_string(),
+    );
+    metrics.insert(
+        "CARGO_VERSION".to_string(),
+        build::CARGO_VERSION.to_string(),
+    );
+
+    metrics
 }
 
 /// A result wrapper for displaying either a correct execution result or an error.

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -29,7 +29,7 @@ impl Tool {
     pub async fn execute(self) -> CliResult {
         match self {
             Tool::Account(tool) => tool.execute().await,
-            Tool::Init(tool) => to_common_success_result(tool.execute().await),
+            Tool::Init(tool) => to_common_success_result("AptosInit", tool.execute().await).await,
             Tool::Move(tool) => tool.execute().await,
             Tool::Key(tool) => tool.execute().await,
         }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -51,10 +51,14 @@ pub enum MoveTool {
 impl MoveTool {
     pub async fn execute(self) -> CliResult {
         match self {
-            MoveTool::Compile(tool) => to_common_result(tool.execute().await),
-            MoveTool::Publish(tool) => to_common_result(tool.execute().await),
-            MoveTool::Run(tool) => to_common_result(tool.execute().await),
-            MoveTool::Test(tool) => to_common_result(tool.execute().await),
+            MoveTool::Compile(tool) => {
+                to_common_result("CompilePackage", tool.execute().await).await
+            }
+            MoveTool::Publish(tool) => {
+                to_common_result("PublishPackage", tool.execute().await).await
+            }
+            MoveTool::Run(tool) => to_common_result("RunFunction", tool.execute().await).await,
+            MoveTool::Test(tool) => to_common_result("TestPackage", tool.execute().await).await,
         }
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -69,7 +69,7 @@ pub struct CompilePackage {
 impl CompilePackage {
     pub async fn execute(self) -> CliTypedResult<Vec<String>> {
         let build_config = BuildConfig {
-            additional_named_addresses: self.move_options.named_addresses.clone(),
+            additional_named_addresses: self.move_options.named_addresses(),
             generate_docs: true,
             install_dir: self.move_options.output_dir.clone(),
             ..Default::default()
@@ -95,7 +95,7 @@ pub struct TestPackage {
 impl TestPackage {
     pub async fn execute(self) -> CliTypedResult<&'static str> {
         let config = BuildConfig {
-            additional_named_addresses: self.move_options.named_addresses.clone(),
+            additional_named_addresses: self.move_options.named_addresses(),
             test_mode: true,
             install_dir: self.move_options.output_dir.clone(),
             ..Default::default()
@@ -141,7 +141,7 @@ pub struct PublishPackage {
 impl PublishPackage {
     pub async fn execute(self) -> CliTypedResult<aptos_rest_client::Transaction> {
         let build_config = BuildConfig {
-            additional_named_addresses: self.move_options.named_addresses.clone(),
+            additional_named_addresses: self.move_options.named_addresses(),
             generate_abis: false,
             generate_docs: true,
             install_dir: self.move_options.output_dir.clone(),

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -9,7 +9,8 @@
 use crate::{
     common::{
         types::{
-            CliError, CliTypedResult, EncodingOptions, MovePackageDir, WriteTransactionOptions,
+            CliError, CliTypedResult, EncodingOptions, MovePackageDir, ProfileOptions,
+            WriteTransactionOptions,
         },
         utils::to_common_result,
     },
@@ -133,6 +134,8 @@ pub struct PublishPackage {
     move_options: MovePackageDir,
     #[clap(flatten)]
     write_options: WriteTransactionOptions,
+    #[clap(flatten)]
+    profile: ProfileOptions,
 }
 
 impl PublishPackage {
@@ -156,11 +159,11 @@ impl PublishPackage {
         let sender_key = self
             .write_options
             .private_key_options
-            .extract_private_key(self.encoding_options.encoding)?;
+            .extract_private_key(self.encoding_options.encoding, &self.profile.profile)?;
 
         submit_transaction(
-            self.write_options.rest_options.url()?,
-            self.write_options.chain_id().await?,
+            self.write_options.rest_options.url(&self.profile.profile)?,
+            self.write_options.chain_id(&self.profile.profile).await?,
             sender_key,
             compiled_payload,
             self.write_options.max_gas,
@@ -212,6 +215,8 @@ pub struct RunFunction {
     encoding_options: EncodingOptions,
     #[clap(flatten)]
     write_options: WriteTransactionOptions,
+    #[clap(flatten)]
+    profile: ProfileOptions,
     /// Function name as `<ADDRESS>::<MODULE_ID>::<FUNCTION_NAME>`
     ///
     /// Example: `0x842ed41fad9640a2ad08fdd7d3e4f7f505319aac7d67e1c0dd6a7cce8732c7e3::Message::set_message`
@@ -253,11 +258,11 @@ impl RunFunction {
         );
 
         submit_transaction(
-            self.write_options.rest_options.url()?,
-            self.write_options.chain_id().await?,
+            self.write_options.rest_options.url(&self.profile.profile)?,
+            self.write_options.chain_id(&self.profile.profile).await?,
             self.write_options
                 .private_key_options
-                .extract_private_key(self.encoding_options.encoding)?,
+                .extract_private_key(self.encoding_options.encoding, &self.profile.profile)?,
             TransactionPayload::ScriptFunction(script_function),
             self.write_options.max_gas,
         )

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -9,8 +9,8 @@
 use crate::{
     common::{
         types::{
-            CliError, CliTypedResult, EncodingOptions, MovePackageDir, ProfileOptions,
-            WriteTransactionOptions,
+            load_account_arg, CliError, CliTypedResult, EncodingOptions, MovePackageDir,
+            ProfileOptions, WriteTransactionOptions,
         },
         utils::to_common_result,
     },
@@ -366,10 +366,11 @@ fn parse_function_name(function_id: &str) -> CliTypedResult<FunctionId> {
                 .to_string(),
         ));
     }
-
-    let address = AccountAddress::from_hex_literal(ids.get(0).unwrap()).unwrap();
-    let module = Identifier::from_str(ids.get(1).unwrap()).unwrap();
-    let function_id = Identifier::from_str(ids.get(2).unwrap()).unwrap();
+    let address = load_account_arg(ids.get(0).unwrap())?;
+    let module = Identifier::from_str(ids.get(1).unwrap())
+        .map_err(|err| CliError::UnableToParse("Module Name", err.to_string()))?;
+    let function_id = Identifier::from_str(ids.get(2).unwrap())
+        .map_err(|err| CliError::UnableToParse("Function Name", err.to_string()))?;
     let module_id = ModuleId::new(address, module);
     Ok(FunctionId {
         module_id,

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -5,7 +5,7 @@ use crate::{
     common::{
         types::{
             CliError, CliTypedResult, EncodingOptions, EncodingType, ExtractPublicKey, KeyType,
-            PrivateKeyInputOptions, SaveFile,
+            PrivateKeyInputOptions, ProfileOptions, SaveFile,
         },
         utils::{append_file_extension, check_if_file_exists, to_common_result, write_to_file},
     },
@@ -52,6 +52,8 @@ pub struct ExtractPeer {
     output_file_options: SaveFile,
     #[clap(flatten)]
     encoding_options: EncodingOptions,
+    #[clap(flatten)]
+    profile: ProfileOptions,
 }
 
 impl ExtractPeer {
@@ -62,7 +64,7 @@ impl ExtractPeer {
         // Load key based on public or private
         let public_key = self
             .private_key_input_options
-            .extract_x25519_public_key(self.encoding_options.encoding)?;
+            .extract_x25519_public_key(self.encoding_options.encoding, &self.profile.profile)?;
 
         // Build peer info
         // TODO: Take in an address?

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -33,8 +33,8 @@ pub enum KeyTool {
 impl KeyTool {
     pub async fn execute(self) -> CliResult {
         match self {
-            KeyTool::Generate(tool) => to_common_result(tool.execute()),
-            KeyTool::ExtractPeer(tool) => to_common_result(tool.execute()),
+            KeyTool::Generate(tool) => to_common_result("GenerateKey", tool.execute()).await,
+            KeyTool::ExtractPeer(tool) => to_common_result("ExtracatPeer", tool.execute()).await,
         }
     }
 }


### PR DESCRIPTION
## Motivation

Account addresses are hard to deal with, so lets make it that they're profiles in the config.  The config is backwards incompatible with the previous one.

Now, AccountAddresses can be replaced with profile names, and can be short form 0x1, or skipping out on the 0x.  Additionally, the config now shows the public key and the address along with everything.

Documentation and message improvements I will do later with help from our new tech writer :)

Additionally, adds telemetry so we know how the CLI is being used in general.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
$ aptos init --profile Greg
Configuring for profile Greg
Enter your rest endpoint [Current: None No input: https://fullnode.devnet.aptoslabs.com]
http://localhost:8080
Enter your faucet endpoint [Current: None No input: https://faucet.devnet.aptoslabs.com]
http://localhost:8000
Enter your private key as a hex literal (0x...) [Current: None No input: Generate new key (or keep one if present)]

No key given, generating key...
Account 91617BF0BB0114492EEA544618BC88B085FF5CC7DC5C154DB1EC3CD7F48CDCB1 doesn't exist, creating it and funding it with 10000 coins
Aptos is now set up for account 91617BF0BB0114492EEA544618BC88B085FF5CC7DC5C154DB1EC3CD7F48CDCB1!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}

$ aptos init 
Aptos already initialized for profile default, do you want to overwrite the existing config? [yes/no] >
yes
Configuring for profile default
Enter your rest endpoint [Current: http://localhost:8080/ No input: https://fullnode.devnet.aptoslabs.com]
http://localhost:8080  
Enter your faucet endpoint [Current: http://localhost:8000/ No input: https://faucet.devnet.aptoslabs.com]
http://localhost:8000
Enter your private key as a hex literal (0x...) [Current: Redacted No input: Generate new key (or keep one if present)]

No key given, keeping existing key...
Aptos is now set up for account FB1277ADAA94B26B7557C77EA7A762F76E8234588DC561D9612513CD39D52EB5!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}
$ cat .aptos/config.yml 
---
profiles:
  default:
    private_key: "REDACTED"
    public_key: "0xd26e6be629b1afb6d33f736d78d70437019bcfa776b45d5091ee2c9fa0f36544"
    account: fb1277adaa94b26b7557c77ea7a762f76e8234588dc561d9612513cd39d52eb5
    rest_url: "http://localhost:8080/"
    faucet_url: "http://localhost:8000/"
  Greg:
    private_key: "REDACTED"
    public_key: "0x362d1fba7a4053ec88160f0372852829cab07eceff2d1f5596444b87b5282c41"
    account: 91617bf0bb0114492eea544618bc88b085ff5cc7dc5c154db1ec3cd7f48cdcb1
    rest_url: "http://localhost:8080/"
    faucet_url: "http://localhost:8000/"
    
$  aptos account list
{
  "Result": [
    {
      "counter": "3"
    },
    {
      "authentication_key": "0xfb1277adaa94b26b7557c77ea7a762f76e8234588dc561d9612513cd39d52eb5",
      "self_address": "0xfb1277adaa94b26b7557c77ea7a762f76e8234588dc561d9612513cd39d52eb5",
      "sequence_number": "103"
    },
...

$  aptos account list --profile default
{
  "Result": [
    {
      "counter": "3"
    },
    {
      "authentication_key": "0xfb1277adaa94b26b7557c77ea7a762f76e8234588dc561d9612513cd39d52eb5",
      "self_address": "0xfb1277adaa94b26b7557c77ea7a762f76e8234588dc561d9612513cd39d52eb5",
      "sequence_number": "103"
    },
...

$  aptos account list --account default
{
  "Result": [
    {
      "counter": "3"
    },
    {
      "authentication_key": "0xfb1277adaa94b26b7557c77ea7a762f76e8234588dc561d9612513cd39d52eb5",
      "self_address": "0xfb1277adaa94b26b7557c77ea7a762f76e8234588dc561d9612513cd39d52eb5",
      "sequence_number": "103"
    },
...

$ aptos account list --profile Greg
{
  "Result": [
    {
      "counter": "2"
    },
    {
      "authentication_key": "0x91617bf0bb0114492eea544618bc88b085ff5cc7dc5c154db1ec3cd7f48cdcb1",
      "self_address": "0x91617bf0bb0114492eea544618bc88b085ff5cc7dc5c154db1ec3cd7f48cdcb1",
      "sequence_number": "0"
    },

...

$ aptos move publish --package-dir /opt/git/aptos-core/aptos-move/move-examples --named-addresses HelloBlockchain=Greg --profile Greg
{
  "Result": {
    "type": "user_transaction",
    "version": "131432",
...

$ aptos move run --function-id default::Message::set_message --args string:hello! --profile Greg
{
  "Result": {
    "type": "user_transaction",

```

## Related PRs


