### PR TITLE
[Bug] Create Account in CLI requires chain id when using faucet

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -10,7 +10,7 @@ use crate::common::{
     init::DEFAULT_FAUCET_URL,
     types::{
         account_address_from_public_key, CliConfig, CliError, CliTypedResult, EncodingOptions,
-        ExtractPublicKey, PublicKeyInputOptions, WriteTransactionOptions,
+        ExtractPublicKey, PublicKeyInputOptions,
     },
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
@@ -27,8 +27,6 @@ use reqwest::Url;
 pub struct CreateAccount {
     #[clap(flatten)]
     encoding_options: EncodingOptions,
-    #[clap(flatten)]
-    write_options: WriteTransactionOptions,
     #[clap(flatten)]
     public_key_options: PublicKeyInputOptions,
     /// Flag for using faucet to create the account

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -63,7 +63,6 @@ services:
             /opt/aptos/bin/aptos-faucet \\
               --address 0.0.0.0 \\
               --port 8000 \\
-              --chain-id TESTING \\
               --mint-key-file-path /opt/aptos/var/mint.key \\
               --server-url http://validator:8080
             echo 'Faucet failed to run likely due to the Validator still starting. Will try again.'

--- a/terraform/testnet/testnet/templates/faucet.yaml
+++ b/terraform/testnet/testnet/templates/faucet.yaml
@@ -48,7 +48,6 @@ spec:
         - "--address=0.0.0.0"
         - "--port=8080"
         - "--server-url=http://{{ include "testnet.fullname" . }}-jsonrpc"
-        - "--chain-id={{ .Values.genesis.chain_id | default .Values.genesis.era }}"
         - "--mint-key-file-path=/opt/aptos/etc/mint.key"
         ports:
         - name: http


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I have 3/4 changes done, not sure where to make a change in the aptos-faucet crate

## Test Plan

I have not installed aptos as I cant find reliable tutorials online. I plan on running the cli commands after all my changes and asking the community for help


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
