### PR TITLE
[docker][compose] use static IP rather than DNS

### DIFF
--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
     image: "${VALIDATOR_IMAGE_REPO:-aptoslab/validator}:${IMAGE_TAG:-devnet}"
     networks:
       shared:
+        ipv4_address:  172.16.1.10
     volumes:
       - type: volume
         source: aptos-shared
@@ -48,6 +49,7 @@ services:
       - validator
     networks:
       shared:
+        ipv4_address:  172.16.1.11
     volumes:
       - type: volume
         source: aptos-shared
@@ -65,7 +67,7 @@ services:
               --port 8000 \\
               --chain-id TESTING \\
               --mint-key-file-path /opt/aptos/var/mint.key \\
-              --server-url http://validator:8080
+              --server-url http://172.16.1.10:8080
             echo 'Faucet failed to run likely due to the Validator still starting. Will try again.'
           fi
         done


### PR DESCRIPTION
CircleCI runners sometimes have DNS issues with docker-compose. We saw this when we disabled the ecosystem-test workflow due to its flakiness. This PR changes the validator-testnet docker-compose to use static IP rather than using the onboard DNS for the faucet to talk to the validator.

Tested 120 times on CircleCI on sequential and parallel runners. https://github.com/aptos-labs/aptos-core/pull/683