### PR TITLE
[Config] Disable SSv2.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -92,7 +92,7 @@ impl Default for StateSyncDriverConfig {
     fn default() -> Self {
         Self {
             bootstrapping_mode: BootstrappingMode::ApplyTransactionOutputsFromGenesis,
-            enable_state_sync_v2: true,
+            enable_state_sync_v2: false,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,


### PR DESCRIPTION
## Motivation

This PR disables SSv2 by default in the configs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Tes.

## Test Plan

None.

## Related PRs

None.
