### PR TITLE
[gitignore] ignore emacs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,9 @@ target-out-docker
 *.swp
 *.swo
 
+# Emacs backup files
+*~
+\#*\#
+
 # Aptos CLI files
 .aptos/


### PR DESCRIPTION
## Motivation

Ignore tmp/backup files of emacs in .gitignore

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

