### PR TITLE
[Storage] Use gauged api to measure missing database calls.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -285,7 +285,7 @@ mock! {
             chunk_size: usize,
         ) -> Result<StateValueChunkWithProof>;
 
-        fn get_state_prune_window(&self) -> Option<usize>;
+        fn get_state_prune_window(&self) -> Result<Option<usize>>;
     }
 }
 

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -454,6 +454,7 @@ impl StorageReader {
         let pruning_window = self
             .storage
             .get_state_prune_window()
+            .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?
             .map(|window| window as u64);
         if let Some(pruning_window) = pruning_window {
             if latest_version > pruning_window {

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -766,8 +766,8 @@ impl DbReader for MockDbReader {
         Ok(account_states_chunk_with_proof)
     }
 
-    fn get_state_prune_window(&self) -> Option<usize> {
-        Some(STATE_PRUNE_WINDOW as usize)
+    fn get_state_prune_window(&self) -> Result<Option<usize>> {
+        Ok(Some(STATE_PRUNE_WINDOW as usize))
     }
 }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -510,7 +510,7 @@ pub trait DbReader: Send + Sync {
     }
 
     /// Get the state prune window config value.
-    fn get_state_prune_window(&self) -> Option<usize> {
+    fn get_state_prune_window(&self) -> Result<Option<usize>> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
## Motivation

This PR updates 3 DbReader calls to use the `gauged_api`. These were previously missed. It would be good to see how long these calls actually take.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

None.

## Related PRs

None.
