### PR TITLE
[CLI] "$ aptos move compile" - Added default value "current directory" for "--package-dir"

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -468,7 +468,7 @@ impl WriteTransactionOptions {
 #[derive(Debug, Parser)]
 pub struct MovePackageDir {
     /// Path to a move package (the folder with a Move.toml file)
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, parse(from_os_str), default_value = ".")]
     pub package_dir: PathBuf,
     /// Path to save the compiled move package
     ///


### PR DESCRIPTION
Added default value **current directory** for **--package-dir**: 
```bash
aptos move compile 
```

@gregnazario please check