### PR TITLE
[executor] log the first different txn_info and version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "aptos-types",
  "aptos-workspace-hack",
  "bcs",
+ "itertools",
  "scratchpad",
  "serde 1.0.136",
  "storage-interface",

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -11,10 +11,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.52"
+bcs = "0.1.2"
+itertools = "0.10.0"
 serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
 
-bcs = "0.1.2"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-state-view = { path = "../../storage/state-view" }


### PR DESCRIPTION
## Motivation

help debugging whenever the txn info check fails

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
Y
## Test Plan

in a devnet incident, getting
> ```2022-04-29T08:00:27.211870Z [state-sync-v1] ERROR state-sync/state-sync-v1/src/coordinator.rs:233 {"error":"ProcessInvalidChunk(\"Unexpected error: Execute and commit chunk failed: Transaction infos don't match. version: 31507, txn_info:TransactionInfo: [txn_hash: e2c90a60, state_root_hash: af59b104, event_root_hash: 41434355, gas_used: 10, recorded_status: EXECUTED], expected_txn_info:TransactionInfo: [txn_hash: e2c90a60, state_root_hash: 6787c9f4, event_root_hash: 41434355, gas_used: 2, recorded_status: MISCELLANEOUS_ERROR]\")","name":"process_chunk_message"}```
