### PR TITLE
[aptos-cli] Move init to config subcommand

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -22,6 +22,8 @@ pub const DEFAULT_FAUCET_URL: &str = "https://faucet.devnet.aptoslabs.com";
 const NUM_DEFAULT_COINS: u64 = 10000;
 
 /// Tool to initialize current directory for the aptos tool
+///
+/// Configuration will be pushed into .aptos/config.yaml
 #[derive(Debug, Parser)]
 pub struct InitTool {
     #[clap(flatten)]

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::{CliCommand, CliResult};
+use clap::Parser;
+
+/// Tool for configuration of the CLI tool
+///
+#[derive(Parser)]
+pub enum ConfigTool {
+    Init(crate::common::init::InitTool),
+}
+
+impl ConfigTool {
+    pub async fn execute(self) -> CliResult {
+        match self {
+            ConfigTool::Init(tool) => tool.execute_serialized_success().await,
+        }
+    }
+}

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod account;
 pub mod common;
+pub mod config;
 pub mod move_tool;
 pub mod op;
 
@@ -18,6 +19,8 @@ use clap::Parser;
 pub enum Tool {
     #[clap(subcommand)]
     Account(account::AccountTool),
+    #[clap(subcommand)]
+    Config(config::ConfigTool),
     Init(common::init::InitTool),
     #[clap(subcommand)]
     Move(move_tool::MoveTool),
@@ -29,6 +32,8 @@ impl Tool {
     pub async fn execute(self) -> CliResult {
         match self {
             Tool::Account(tool) => tool.execute().await,
+            Tool::Config(tool) => tool.execute().await,
+            // TODO: Replace entirely with config init
             Tool::Init(tool) => tool.execute_serialized_success().await,
             Tool::Move(tool) => tool.execute().await,
             Tool::Key(tool) => tool.execute().await,


### PR DESCRIPTION

## Motivation

After several conversations, it was clear that it wasn't clear that `aptos init` was initializing configuration.  That led me to think that we should approach it similarly to a CLI like `git` which has a `config` command separately.  We can think about displaying and manipulation at a later time.

This subcommand will let us do something closer to git where you
can list or edit the config in the future via commands.  The original
aptos init command is kept for now, but it's the same command.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

yes

### Testing
```
$ aptos help
aptos 0.1.0
Aptos Labs <opensource@aptoslabs.com>
CLI tool for interacting with the Aptos blockchain and nodes

USAGE:
    aptos <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    account    CLI tool for interacting with accounts
    config     Tool for configuration of CLI tool
    help       Print this message or the help of the given subcommand(s)
    init       Tool to initialize current directory for the aptos tool
    key        CLI tool for generating, inspecting, and interacting with keys
    move       CLI tool for performing Move tasks

$ aptos config help
aptos-config 0.1.0
Tool for configuration of CLI tool

USAGE:
    aptos config <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    help    Print this message or the help of the given subcommand(s)
    init    Tool to initialize current directory for the aptos tool

$ aptos config init
Configuring for profile default
Enter your rest endpoint [Current: None | No input: https://fullnode.devnet.aptoslabs.com]

No rest url given, using https://fullnode.devnet.aptoslabs.com...
Enter your faucet endpoint [Current: None | No input: https://faucet.devnet.aptoslabs.com]

No faucet url given, using https://faucet.devnet.aptoslabs.com...
Enter your private key as a hex literal (0x...) [Current: None | No input: Generate new key (or keep one if present)]

No key given, generating key...
Account D0B0278B5A2CAAFD0FF678AFA3EB3F19E626E72AC3530042BC41D27C026E41E1 doesn't exist, creating it and funding it with 10000 coins

Aptos is now set up for account D0B0278B5A2CAAFD0FF678AFA3EB3F19E626E72AC3530042BC41D27C026E41E1!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}```