### PR TITLE
[Safety rules] Use rusty fork to avoid metrics collision.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6835,6 +6835,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "rand 0.8.4",
+ "rusty-fork",
  "serde 1.0.136",
  "serde_json",
  "tempfile",

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0.24"
 criterion = "0.3.4"
 tempfile = "3.2.0"
 proptest = "1.0.0"
+rusty-fork = "0.3.0"
 
 consensus-types = { path = "../consensus-types", features = ["fuzzing"] }
 aptos-config = { path = "../../config", features = ["fuzzing"] }

--- a/consensus/safety-rules/src/persistent_safety_storage.rs
+++ b/consensus/safety-rules/src/persistent_safety_storage.rs
@@ -201,22 +201,27 @@ mod tests {
         block_info::BlockInfo, epoch_state::EpochState, ledger_info::LedgerInfo,
         transaction::Version, validator_signer::ValidatorSigner, waypoint::Waypoint,
     };
+    use rusty_fork::rusty_fork_test;
 
-    #[test]
-    fn test_counters() {
-        let consensus_private_key = ValidatorSigner::from_int(0).private_key().clone();
-        let storage = Storage::from(InMemoryStorage::new());
-        let mut safety_storage = PersistentSafetyStorage::initialize(
-            storage,
-            Author::random(),
-            consensus_private_key,
-            Ed25519PrivateKey::generate_for_testing(),
-            Waypoint::default(),
-            true,
-        );
-        // they both touch the global counters, running it serially to prevent race condition.
-        test_safety_data_counters(&mut safety_storage);
-        test_waypoint_counters(&mut safety_storage);
+    // Metrics are globally instantiated. We use rusty_fork to prevent concurrent tests
+    // from interfering with the metrics while we run this test.
+    rusty_fork_test! {
+        #[test]
+        fn test_counters() {
+            let consensus_private_key = ValidatorSigner::from_int(0).private_key().clone();
+            let storage = Storage::from(InMemoryStorage::new());
+            let mut safety_storage = PersistentSafetyStorage::initialize(
+                storage,
+                Author::random(),
+                consensus_private_key,
+                Ed25519PrivateKey::generate_for_testing(),
+                Waypoint::default(),
+                true,
+            );
+            // they both touch the global counters, running it serially to prevent race condition.
+            test_safety_data_counters(&mut safety_storage);
+            test_waypoint_counters(&mut safety_storage);
+        }
     }
 
     fn test_safety_data_counters(safety_storage: &mut PersistentSafetyStorage) {


### PR DESCRIPTION
## Motivation

The `test_counters` test verifies that the metrics are updated correctly. Unfortunately, metrics are global, so when multiple unit tests run at the same time, they may interfere. To avoid this, we use rusty_fork (https://github.com/altsysrq/rusty-fork) to fork this test into a new process so that the global counter is not shared. Hopefully, this should fix the flakiness.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Run locally.

## Related PRs

None.
