### PR TITLE
[Aptos Data Client] Prioritize peer polling.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -121,10 +121,10 @@ impl Default for StorageServiceConfig {
             max_account_states_chunk_sizes: 1000,
             max_concurrent_requests: 4000,
             max_epoch_chunk_size: 100,
-            max_network_channel_size: 1000,
+            max_network_channel_size: 4000,
             max_transaction_chunk_size: 1000,
             max_transaction_output_chunk_size: 1000,
-            storage_summary_refresh_interval_ms: 100,
+            storage_summary_refresh_interval_ms: 50,
         }
     }
 }
@@ -158,7 +158,7 @@ pub struct DataStreamingServiceConfig {
 impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
-            global_summary_refresh_interval_ms: 100,
+            global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: 1,
             max_data_stream_channel_sizes: 1000,
             max_request_retry: 3,


### PR DESCRIPTION
## Motivation

This PR improves the polling mechanism of the Aptos Data Client. Specifically, we poll peers we consider to be prioritized more frequently, where prioritization is based on peers who are upstream and more likely to have new data. Prioritization is currently hard coded based on if the network is the validator network (meaning validators and VFNs will prioritize validators when polling). This needs to be generalized with network topology awareness.

The implications of prioritized peer polling is that end-to-end mempool latency is reduced for state sync:

- Baseline SSv1:
    - Validators: 500-550 ms.
    - VFNs: 650-800 ms.
- SSv2 without this optimization:
    - Validators: 450 ms.
    - VFNs: 1100-1300 ms.
- SSv2 with this optimization:
    - Validators: 350 ms.
    - VFNs: 800-900 ms.

This optimization dropped the latency 300-400ms for VFNs (e.g., see https://github.com/aptos-labs/aptos-core/issues/697). Validators are 150-200 ms faster now because we have multithreading. The regression is only 150-250 ms for VFNs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Unit tests have been added/updated.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245