### PR TITLE
[CICD] modernize+simplify docker build and enable caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,6 @@ jobs:
       - run: sudo apt-get install shellcheck --assume-yes --no-install-recommends
       - run: shellcheck scripts/dev_setup.sh
       - run: shellcheck scripts/dockerhub_prune.sh
-      - run: shellcheck docker/build_push.sh
-      - run: shellcheck docker/docker_republish.sh
       - run: shellcheck scripts/weekly-dep-report.sh
       - run: cargo x lint
       - run: cargo xclippy --workspace --all-targets
@@ -97,6 +95,26 @@ jobs:
               done
               exit $ret
             fi
+  build-push-docker-rust-code:
+    executor: ubuntu-2xl
+    parameters:
+      image_target:
+        description: what value to pass to `IMAGE_TARGET=<value>` when running the docker/build-common.sh script which runs the Rust build.
+        type: string
+        default: NOT_PROVIDED
+    steps:
+      - checkout
+      - aws-ecr-setup
+      - run: echo $GITHUB_CONTAINER_REGISTRY_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
+      - run:
+          name: Build and Push
+          shell: /bin/bash
+          environment:
+            IMAGE_TARGET: << parameters.image_target >>
+          command: |
+            set -e
+            docker buildx create --use
+            docker/docker-bake-rust-all.sh
   build-push-community-platform:
     executor: ubuntu-medium
     steps:
@@ -296,13 +314,34 @@ workflows:
                 - canary
                 - devnet
                 - testnet
+      - build-push-docker-rust-code: &BuildPushRustRelease
+          name: build-push-rust-release-target
+          context: aws-dev
+          image_target: release
+      - build-push-docker-rust-code: &BuildPushRustTest
+          name: build-push-rust-test-target
+          context: aws-dev
+          image_target: test
+          filters:
+            branches:
+              only:
+                - main
+                - auto
+                - canary
+                - devnet
+                - testnet
+                - docker-caching ## remove this once https://github.com/aptos-labs/aptos-core/pull/741 is merged
       - ecosystem-test:
           context: aws-dev
           requires:
+            # - build-push-rust-release-target
+            # - build-push-rust-test-target
             - docker-build-push
       - forge-k8s-test:
           context: aws-dev
           requires:
+            # - build-push-rust-release-target
+            # - build-push-rust-test-target
             - docker-build-push
   ### on devnet branch update ###
   # Ensure the latest is built on the "devnet" branch, and mirror from ECR to Dockerhub
@@ -310,6 +349,8 @@ workflows:
     when:
       equal: [devnet, << pipeline.git.branch >>]
     jobs:
+      - build-push-docker-rust-code: *BuildPushRustRelease
+      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: devnet
@@ -319,6 +360,8 @@ workflows:
             - docker-aptoslabsbots
           addl_tag: devnet
           requires:
+            # - build-push-rust-release-target
+            # - build-push-rust-test-target
             - docker-build-push
   ### on testnet branch update ###
   # Ensure the latest is built on the "testnet" branch, and mirror from ECR to Dockerhub
@@ -326,6 +369,8 @@ workflows:
     when:
       equal: [testnet, << pipeline.git.branch >>]
     jobs:
+      - build-push-docker-rust-code: *BuildPushRustRelease
+      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: testnet
@@ -335,6 +380,8 @@ workflows:
             - docker-aptoslabsbots
           addl_tag: testnet
           requires:
+            # - build-push-rust-release-target
+            # - build-push-rust-test-target
             - docker-build-push
   ### on continuous_push scheduled pipeline ###
   # Build the latest on "main" branch
@@ -344,6 +391,8 @@ workflows:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - equal: ["continuous_push", << pipeline.schedule.name >>]
     jobs:
+      - build-push-docker-rust-code: *BuildPushRustRelease
+      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: main
@@ -355,6 +404,8 @@ workflows:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - equal: ["nightly", << pipeline.schedule.name >>]
     jobs:
+      - build-push-docker-rust-code: *BuildPushRustRelease
+      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: main
@@ -365,6 +416,8 @@ workflows:
           addl_tag: main
           requires:
             - docker-build-push
+            # - build-push-rust-release-target
+            # - build-push-rust-test-target
 commands:
   dev-setup:
     steps:

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,31 @@
+# list of files to ignore from docker's perspective
+# The more we can exclude the higher likelihood we can reuse cached layers
+
+.assets/
+.circleci/
+.config/
+.github/
+.idea/
+.lintrules/
+developer-docs-site/
+docker/
+!docker/validator/install-tools.sh
+!docker/build-common.sh
+!docker/tools/boto.cfg
+documentation/
+ecosystem/
+!ecosystem/indexer/
+scripts/
+target/
+terraform/
+
 *~
 *.swp
 **/.terraform/
-target/
+**/*.md
+**/*.MD
 **/*Dockerfile
-docker/update_or_build.sh
+.git/
+
+clippy.toml
+.gitattributes

--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -3,11 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
-#either release or test
-if [ -z "$IMAGE_TARGETS" ]; then
-  IMAGE_TARGETS="all"
-fi
-
 # This is a common compilation scripts across different docker file
 # It unifies RUSFLAGS, compilation flags (like --release) and set of binary crates to compile in common docker layer
 
@@ -20,9 +15,14 @@ export CARGO_PROFILE_RELEASE_LTO=thin # override lto setting to turn on thin-LTO
 # Can't use ${CARGO} because of https://github.com/rust-lang/rustup/issues/2647 and
 # https://github.com/env-logger-rs/env_logger/issues/190.
 # TODO: consider using ${CARGO} once upstream issues are fixed.
-cargo x generate-workspace-hack --mode disable
+# cargo x generate-workspace-hack --mode disable
 
-if [ "$IMAGE_TARGETS" = "release" ] || [ "$IMAGE_TARGETS" = "all" ]; then
+if [ "$IMAGE_TARGET" != "release" ] && [ "$IMAGE_TARGET" != "test" ]; then
+  echo "Error: IMAGE_TARGET must one of: release,test but received: $IMAGE_TARGET"
+  exit -1
+fi
+
+if [ "$IMAGE_TARGET" = "release" ]; then
   # Build release binaries (TODO: use x to run this?)
   cargo build --release \
           -p aptos-genesis-tool \
@@ -40,15 +40,10 @@ if [ "$IMAGE_TARGETS" = "release" ] || [ "$IMAGE_TARGETS" = "all" ]; then
   # Build our core modules!
   cargo run --package framework -- --package aptos-framework --output current
 
-  # Build and overwrite the aptos-node binary with feature failpoints if $ENABLE_FAILPOINTS is configured
-  if [ "$ENABLE_FAILPOINTS" = "1" ]; then
-    echo "Building aptos-node with failpoints feature"
-    (cd aptos-node && cargo build --release --features failpoints "$@")
-  fi
 fi
 
 
-if [ "$IMAGE_TARGETS" = "test" ] || [ "$IMAGE_TARGETS" = "all"  ]; then
+if [ "$IMAGE_TARGET" = "test" ]; then
   # These non-release binaries are built separately to avoid feature unification issues
   cargo build --release \
           -p aptos-faucet \

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -1,0 +1,145 @@
+# This is a docker bake file in HCL syntax.
+# It provides a high-level mechenanism to build multiple dockerfiles in one shot.
+# Check https://crazymax.dev/docker-allhands2-buildx-bake and https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition for an intro.
+
+variable "BUILD_DATE" {}
+
+// this is the short GIT_SHA1 (8 chars). Tagging our docker images with that one is kinda deprecated and we might remove this in future.
+variable "GIT_REV" {}
+// this is the full GIT_SHA1 - let's use that as primary identify going forward
+variable "GIT_SHA1" {}
+
+variable "AWS_ECR_ACCOUNT_NUM" {}
+
+variable "ecr_base" {
+  default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
+}
+
+variable "gh_image_cache" {
+  default = "ghcr.io/aptos-labs/aptos-core"
+}
+
+# images with IMAGE_TARGET=release for rust build
+group "release" {
+  targets = [
+    "validator",
+    "indexer",
+    "safety-rules",
+    "tools",
+    "init",
+    "txn-emitter",
+  ]
+}
+
+# images with IMAGE_TARGET=test for rust build
+group "test" {
+  targets = [
+    "faucet",
+    "forge",
+  ]
+}
+
+target "_common" {
+  dockerfile = "docker/rust-all.Dockerfile"
+  context    = "."
+  cache-from = [
+    // need to repeat all images here until https://github.com/docker/buildx/issues/934 is resolved
+    generate_cache_from("validator"),
+    generate_cache_from("indexer"),
+    generate_cache_from("validator_tcb"),
+    generate_cache_from("tools"),
+    generate_cache_from("init"),
+    generate_cache_from("txn-emitter"),
+    generate_cache_from("faucet"),
+    generate_cache_from("forge"),
+  ]
+  labels = {
+    "org.label-schema.schema-version" = "1.0",
+    "org.label-schema.build-date"     = "${BUILD_DATE}"
+    "org.label-schema.vcs-ref"        = "${GIT_REV}"
+  }
+  args = {
+    IMAGE_TARGET = "release"
+  }
+}
+
+target "validator" {
+  inherits = ["_common"]
+  target   = "validator"
+  cache-to = generate_cache_to("validator")
+  tags     = generate_tags("validator")
+}
+
+target "indexer" {
+  inherits = ["_common"]
+  target   = "indexer"
+  cache-to = generate_cache_to("indexer")
+  tags     = generate_tags("indexer")
+}
+
+target "safety-rules" {
+  inherits = ["_common"]
+  target   = "safety-rules"
+  cache-to = generate_cache_to("validator_tcb")
+  tags     = generate_tags("validator_tcb")
+}
+
+target "tools" {
+  inherits = ["_common"]
+  target   = "tools"
+  cache-to = generate_cache_to("tools")
+  tags     = generate_tags("tools")
+}
+
+target "init" {
+  inherits = ["_common"]
+  target   = "init"
+  cache-to = generate_cache_to("init")
+  tags     = generate_tags("init")
+}
+
+target "txn-emitter" {
+  inherits = ["_common"]
+  target   = "txn-emitter"
+  cache-to = generate_cache_to("txn-emitter")
+  tags     = generate_tags("txn-emitter")
+}
+
+target "faucet" {
+  inherits = ["_common"]
+  target   = "faucet"
+  cache-to = generate_cache_to("faucet")
+  tags     = generate_tags("faucet")
+  args = {
+    IMAGE_TARGET = "test"
+  }
+}
+
+target "forge" {
+  inherits = ["_common"]
+  target   = "forge"
+  cache-to = generate_cache_to("forge")
+  tags     = generate_tags("forge")
+  args = {
+    IMAGE_TARGET = "test"
+  }
+}
+
+function "generate_cache_from" {
+  params = [target]
+  result = "type=registry,ref=${gh_image_cache}/${target}"
+}
+
+function "generate_cache_to" {
+  params = [target]
+  result = ["type=registry,ref=${gh_image_cache}/${target},mode=max"]
+}
+
+function "generate_tags" {
+  params = [target]
+  result = [
+    // "${ecr_base}/${target}:dev_${GIT_REV}",
+    // "${ecr_base}/${target}:${GIT_REV}",
+    "${ecr_base}/${target}:${GIT_SHA1}", // only tag with full GIT_SHA1 unless it turns out we really need any of the other variations
+  ]
+}

--- a/docker/docker-bake-rust-all.sh
+++ b/docker/docker-bake-rust-all.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+# This script docker bake to build all the rust-based docker images
+# You need to execute this from the repository root as working directory
+# E.g. docker/docker-bake-rust-all.sh
+
+set -e
+
+## TODO(christian): add `--progress=plain` as soon as circleci supports a docker version that includes https://github.com/moby/buildkit/pull/2763
+export GIT_REV=$(git rev-parse --short=8 HEAD)
+export GIT_SHA1=$(git rev-parse HEAD)
+export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+docker buildx bake --push --file docker/docker-bake-rust-all.hcl $IMAGE_TARGET

--- a/docker/faucet/Dockerfile
+++ b/docker/faucet/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="test" ./docker/build-common.sh
+RUN IMAGE_TARGET="test" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS pre-test

--- a/docker/forge/Dockerfile
+++ b/docker/forge/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="test" ./docker/build-common.sh
+RUN IMAGE_TARGET="test" ./docker/build-common.sh
 
 FROM debian-base
 

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="release" ./docker/build-common.sh
+RUN IMAGE_TARGET="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS pre-prod

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="release" ./docker/build-common.sh
+RUN IMAGE_TARGET="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS pre-prod

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -1,0 +1,189 @@
+#syntax=docker/dockerfile:1.4
+
+FROM debian:buster-20220228@sha256:fd510d85d7e0691ca551fe08e8a2516a86c7f24601a940a299b5fe5cdd22c03a AS debian-base
+
+
+### Build Rust code as base for everything else ###
+
+FROM debian-base AS builder
+
+# To use http/https proxy while building, use:
+# docker build --build-arg https_proxy=http://fwdproxy:8080 --build-arg http_proxy=http://fwdproxy:8080
+
+RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /aptos
+COPY --link rust-toolchain /aptos/rust-toolchain
+RUN rustup install $(cat rust-toolchain)
+
+COPY --link . /aptos
+
+# must be: release|test depending on the target - required
+ARG IMAGE_TARGET
+
+RUN IMAGE_TARGET="${IMAGE_TARGET}" \
+    ./docker/build-common.sh
+
+### Validator Image ###
+FROM debian-base AS validator
+
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*
+
+### Needed to run debugging tools like perf
+RUN apt-get update && apt-get install -y linux-tools-4.19 sudo procps
+
+RUN addgroup --system --gid 6180 aptos && adduser --system --ingroup aptos --no-create-home --uid 6180 aptos
+
+RUN mkdir -p /opt/aptos/bin /opt/aptos/etc
+COPY --link --from=builder /aptos/target/release/aptos-node /opt/aptos/bin
+COPY --link --from=builder /aptos/target/release/db-backup /opt/aptos/bin
+COPY --link --from=builder /aptos/target/release/db-bootstrapper /opt/aptos/bin
+COPY --link --from=builder /aptos/target/release/db-restore /opt/aptos/bin
+
+# Admission control
+EXPOSE 8000
+# Validator network
+EXPOSE 6180
+# Metrics
+EXPOSE 9101
+# Backup
+EXPOSE 6186
+
+# Capture backtrace on error
+ENV RUST_BACKTRACE 1
+
+
+
+### Indexer Image ###
+
+FROM debian-base AS indexer
+
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates net-tools tcpdump iproute2 netcat libpq-dev \
+&& apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/aptos/bin
+COPY --from=builder /aptos/target/release/aptos-indexer /usr/local/bin
+
+
+### Safety Rules Image ###
+
+FROM debian-base AS safety-rules
+
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN addgroup --system --gid 6180 aptos && adduser --system --ingroup aptos --no-create-home --uid 6180 aptos
+
+RUN mkdir -p /opt/aptos/bin /opt/aptos/etc /opt/aptos/data
+
+COPY --from=builder /aptos/target/release/safety-rules /opt/aptos/bin
+
+ENV RUST_BACKTRACE 1
+
+
+### Tools Image ###
+FROM debian-base AS tools
+
+RUN echo "deb http://deb.debian.org/debian bullseye main" > /etc/apt/sources.list.d/bullseye.list && \
+    echo "Package: *\nPin: release n=bullseye\nPin-Priority: 50" > /etc/apt/preferences.d/bullseye
+
+RUN apt-get update && \
+    apt-get --no-install-recommends --yes install wget curl libssl1.1 ca-certificates socat python3-botocore/bullseye awscli/bullseye && \
+    apt-get clean && \
+    rm -r /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/local/bin/python
+COPY docker/tools/boto.cfg /etc
+
+RUN cd /usr/local/bin && wget https://azcopyvnext.azureedge.net/release20210226/azcopy_linux_amd64_10.9.0.tar.gz -O- | tar --gzip --wildcards --extract '*/azcopy' --strip-components=1 --no-same-owner && chmod +x azcopy
+RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O- | tar --gzip --directory /opt --extract && ln -s /opt/gsutil/gsutil /usr/local/bin
+
+COPY --from=builder /aptos/target/release/aptos-genesis-tool /usr/local/bin
+COPY --from=builder /aptos/target/release/aptos-operational-tool /usr/local/bin
+COPY --from=builder /aptos/target/release/db-bootstrapper /usr/local/bin
+COPY --from=builder /aptos/target/release/db-backup /usr/local/bin
+COPY --from=builder /aptos/target/release/db-backup-verify /usr/local/bin
+COPY --from=builder /aptos/target/release/db-restore /usr/local/bin
+COPY --from=builder /aptos/target/release/aptos-transaction-replay /usr/local/bin
+
+### Get Aptos Move modules bytecodes for genesis ceremony
+RUN mkdir -p /aptos-framework/move/build
+RUN mkdir -p /aptos-framework/move/modules
+COPY --from=builder /aptos/aptos-framework/releases/artifacts/current/build /aptos-framework/move/build
+RUN mv /aptos-framework/move/build/**/bytecode_modules/*.mv /aptos-framework/move/modules
+RUN rm -rf /aptos-framework/move/build
+
+
+
+### Init / Genesis Image ###
+### TODO(christian|rusty|sherry): This image is appears to be a subset of the tools image. We can probably get rid of this in favor for the tools image.
+
+FROM debian-base AS init
+
+RUN apt-get update && apt-get -y install libssl1.1 ca-certificates wget busybox gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
+RUN cd /usr/local/bin && wget "https://releases.hashicorp.com/vault/1.5.0/vault_1.5.0_linux_amd64.zip" -O- | busybox unzip - && chmod +x vault
+
+RUN mkdir -p /opt/aptos/bin
+COPY --from=builder /aptos/target/release/aptos-genesis-tool /usr/local/bin
+COPY --from=builder /aptos/target/release/aptos-operational-tool /usr/local/bin
+
+### Get Aptos Move modules bytecodes for genesis ceremony
+RUN mkdir -p /aptos-framework/move/build
+RUN mkdir -p /aptos-framework/move/modules
+COPY --from=builder /aptos/aptos-framework/releases/artifacts/current/build /aptos-framework/move/build
+RUN mv /aptos-framework/move/build/**/bytecode_modules/*.mv /aptos-framework/move/modules
+RUN rm -rf /aptos-framework/move/build
+
+
+
+### Transaction Emitter Image ###
+FROM debian-base AS txn-emitter
+
+RUN apt-get update && apt-get -y install libssl1.1 ca-certificates wget busybox gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/aptos/bin
+COPY --from=builder /aptos/target/release/transaction-emitter /usr/local/bin
+
+
+
+### Faucet Image ###
+FROM debian-base AS faucet
+
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates nano net-tools tcpdump iproute2 netcat \
+    && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/aptos/bin  /aptos/client/data/wallet/
+
+COPY --from=builder /aptos/target/release/aptos-faucet /opt/aptos/bin
+
+#install needed tools
+RUN apt-get update && apt-get install -y procps
+
+# Mint proxy listening address
+EXPOSE 8000
+
+
+
+### Forge Image ###
+
+FROM debian-base as forge
+
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates openssh-client wget busybox git unzip awscli && apt-get clean && rm -r /var/lib/apt/lists/*
+
+RUN mkdir /aptos
+COPY rust-toolchain /aptos/rust-toolchain
+
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
+RUN cd /usr/local/bin && wget "https://releases.hashicorp.com/vault/1.5.0/vault_1.5.0_linux_amd64.zip" -O- | busybox unzip - && chmod +x vault
+RUN cd /usr/local/bin && wget "https://get.helm.sh/helm-v3.8.0-linux-amd64.tar.gz" -O- | busybox tar -zxvf - && mv linux-amd64/helm . && chmod +x helm
+ENV PATH "$PATH:/root/bin"
+
+RUN helm plugin install https://github.com/hypnoglow/helm-s3.git --version 0.10.0
+
+RUN mkdir /etc/forge
+WORKDIR /etc/forge
+COPY --from=builder /aptos/target/release/forge /usr/local/bin/forge
+ENTRYPOINT ["forge"]

--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="release" ./docker/build-common.sh
+RUN IMAGE_TARGET="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS prod

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="release" ./docker/build-common.sh
+RUN IMAGE_TARGET="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS prod

--- a/docker/txn-emitter/Dockerfile
+++ b/docker/txn-emitter/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="release" ./docker/build-common.sh
+RUN IMAGE_TARGET="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS pre-prod

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -19,7 +19,7 @@ FROM toolchain AS builder
 ARG ENABLE_FAILPOINTS
 COPY . /aptos
 
-RUN IMAGE_TARGETS="release" ./docker/build-common.sh
+RUN IMAGE_TARGET="release" ./docker/build-common.sh
 
 ### Production Image ###
 FROM debian-base AS prod

--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -137,7 +137,19 @@ TAG = args.tag
 BASE_TAG = args.base_image_tag
 REPORT = args.report
 if not args.tag:
-    if args.pr:  # codebuild using a PR
+    if args.pr:
+
+        # Retain this after https://github.com/aptos-labs/aptos-core/pull/741 is found to be stable enough
+        output = subprocess.check_output(
+            [f"curl https://api.github.com/repos/aptos-labs/aptos-core/pulls/{args.pr}"],
+            shell=True,
+            stderr=subprocess.DEVNULL
+        )
+        parsed_pr = json.loads(output)
+        TAG = print(parsed_pr['head']['sha'])
+
+        # Delete all the aws codebuild stuff after https://github.com/aptos-labs/aptos-core/pull/741 is found to be stable enough
+
         ret = subprocess.call(
             ["aws", "codebuild", "list-projects"], stdout=subprocess.DEVNULL
         )


### PR DESCRIPTION
This modernizes and simplifies the docker build step in a few ways:
- gets rid of some duplication in the rust-based docker build files and unifies them into a single multi-stage Dockerfile which is built via docker bake (https://docs.docker.com/engine/reference/commandline/buildx_bake/) . This has the advantage that the rust build step is reused between multiple builds, we need less resources and 2 build workers suffice (previously we had 8 seperate ones)
- adds some basic docker layer caching via buildkit. We push cache manifests to github's container registry since AWS ECR (https://github.com/aws/containers-roadmap/issues/876) doesn't support it, but the actual image layers are still pushed to AWS ECR.
- gets rid of AWS Codebuild. Instead we build in CircleCI directly
- gets rid of a plethora of bash helper scripts and whatnot

Benefits:
- Less code and overall more simplicity
- Less resource consumption
- In cases where none of the rust code has changed, we should usually get a cache hit and reuse the Rust artifacts from previous builds. Note that this is not perfect and may not work in all circumstances - there is some potential for improvement. The way for example https://github.com/GoogleContainerTools/kaniko reuses cache layers leads to a more fine grained cache reuse compared to just using docker, but there were some other limitations with kaniko and it's a bit slower for uncached builds.

What this not solve:
From what I've seen this doesn't substantially speed up the builds if some of the Rust code actually has changed unfortunately. To do so we probably need to investigate sscache or cachepot a bit more.
