### PR TITLE
[aptos-metrics] add state sync ver as public metric

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -413,7 +413,7 @@ async fn periodic_telemetry_dump(node_config: NodeConfig, db: DbReaderWriter) {
                 // Measurement Protocol params must be underscore or alphanumeric
                 // Prometheus metrics use {} to represent dimensions, so rename it
                 let met = get_public_metrics();
-                let re = Regex::new(r"[\{\}]").unwrap();
+                let re = Regex::new(r"[\{\}=]").unwrap();
                 for (k, v) in &met {
                     metrics_params.insert(re.replace_all(k, "_").to_string(), v.to_string());
                 }

--- a/crates/aptos-metrics/src/public_metrics.rs
+++ b/crates/aptos-metrics/src/public_metrics.rs
@@ -3,8 +3,12 @@
 
 // A list of metrics which will be made public
 pub const PUBLIC_METRICS: &[&str] = &[
+    // aptos metrics
     "aptos_connections",
+    "aptos_state_sync_version",
+    // binary metadata
     "revision",
+    // system info
     "system_name",
     "system_kernel_version",
     "system_os_version",


### PR DESCRIPTION
SEV followup for stuck state sync version: add `aptos_state_sync_version` as a public metric, which is used by the telemetry crate to push aptos-node metrics.

Test: compile and run aptos-node in test mode locally, and check telemetry data, filtering on `aptos_state_sync_version_type_synced_` (the normalized metric name)

![image](https://user-images.githubusercontent.com/12578616/166300310-08cb0792-0612-4020-b23f-fe21448240e7.png)



