### PR TITLE
Improve aptos init

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -6,9 +6,9 @@ use crate::{
     common::{
         types::{
             account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
-            ProfileConfig, ProfileOptions,
+            ProfileConfig, ProfileOptions, PromptOptions,
         },
-        utils::prompt_yes,
+        utils::prompt_yes_with_override,
     },
     op::key::GenerateKey,
 };
@@ -28,6 +28,8 @@ const NUM_DEFAULT_COINS: u64 = 10000;
 pub struct InitTool {
     #[clap(flatten)]
     profile_options: ProfileOptions,
+    #[clap(flatten)]
+    prompt_options: PromptOptions,
 }
 
 #[async_trait]
@@ -47,12 +49,7 @@ impl CliCommand<()> for InitTool {
         let mut profile_config = if let Some(profile_config) =
             config.remove_profile(&self.profile_options.profile)
         {
-            if !prompt_yes(
-                    &format!("Aptos already initialized for profile {}, do you want to overwrite the existing config?", self.profile_options.profile),
-                ) {
-                    eprintln!("Exiting...");
-                    return Ok(());
-                }
+            prompt_yes_with_override(&format!("Aptos already initialized for profile {}, do you want to overwrite the existing config?", self.profile_options.profile), self.prompt_options)?;
             profile_config
         } else {
             ProfileConfig::default()

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -151,18 +151,21 @@ impl<T> From<CliTypedResult<T>> for ResultWrapper<T> {
 
 /// Checks if a file exists, being overridden by `PromptOptions`
 pub fn check_if_file_exists(file: &Path, prompt_options: PromptOptions) -> CliTypedResult<()> {
-    let exists = file.exists();
-    if (exists && prompt_options.assume_no)
-        || (exists
-            && !prompt_options.assume_yes
-            && !prompt_yes(
-                format!(
-                    "{:?} already exists, are you sure you want to overwrite it?",
-                    file.as_os_str()
-                )
-                .as_str(),
-            ))
-    {
+    if file.exists() {
+        prompt_yes_with_override(
+            &format!(
+                "{:?} already exists, are you sure you want to overwrite it?",
+                file.as_os_str(),
+            ),
+            prompt_options,
+        )?
+    }
+
+    Ok(())
+}
+
+pub fn prompt_yes_with_override(prompt: &str, prompt_options: PromptOptions) -> CliTypedResult<()> {
+    if prompt_options.assume_no || (!prompt_options.assume_yes && !prompt_yes(prompt)) {
         Err(CliError::AbortedError)
     } else {
         Ok(())


### PR DESCRIPTION

## Motivation

This allows for IDEs and automation built around the configuration (though it can also be built via the YAML file)/.
https://github.com/aptos-labs/aptos-core/issues/706

## Testing

```
$ aptos init --private-key-file key.pem --faucet-url https://faucet.devnet.aptoslabs.com --rest-url https://fullnode.devnet.aptoslabs.com --assume-yes --profile test
Configuring for profile test
Using command line argument for rest URL https://fullnode.devnet.aptoslabs.com/
Using command line argument for faucet URL https://faucet.devnet.aptoslabs.com/
Using command line argument for private key
Aptos is now set up for account ACE37F3A69B7886DFACFD5E54562F9E442C04B4A4DE547AA8A8EC312D22D93A1!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}
```
