### PR TITLE
[tf][indexer] option for RDS to be publicly accessible

### DIFF
--- a/terraform/modules/indexer/rds.tf
+++ b/terraform/modules/indexer/rds.tf
@@ -18,6 +18,18 @@ resource "aws_security_group" "indexer" {
   }
 }
 
+resource "aws_db_parameter_group" "indexer" {
+  name = "indexer-${local.workspace_name}"
+  # family parameter must correspond with the engine version of aws_db_instance.indexer
+  # aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"
+  family = var.db_parameter_group_family
+
+  parameter {
+    name  = "log_connections"
+    value = "1"
+  }
+}
+
 
 resource "aws_db_instance" "indexer" {
   identifier = "indexer-${local.workspace_name}"
@@ -33,20 +45,8 @@ resource "aws_db_instance" "indexer" {
   db_subnet_group_name   = aws_db_subnet_group.indexer.name
   vpc_security_group_ids = [aws_security_group.indexer.id]
   parameter_group_name   = aws_db_parameter_group.indexer.name
-  publicly_accessible    = false
+  publicly_accessible    = var.db_publicly_accessible
   skip_final_snapshot    = true
-}
-
-resource "aws_db_parameter_group" "indexer" {
-  name = "indexer-${local.workspace_name}"
-  # family parameter must correspond with the engine version of aws_db_instance.indexer
-  # aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"
-  family = var.db_parameter_group_family
-
-  parameter {
-    name  = "log_connections"
-    value = "1"
-  }
 }
 
 resource "kubernetes_secret" "indexer_credentials" {

--- a/terraform/modules/indexer/rds.tf
+++ b/terraform/modules/indexer/rds.tf
@@ -14,7 +14,7 @@ resource "aws_security_group" "indexer" {
     from_port   = 5432
     to_port     = 5432
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.db_sources_ipv4
   }
 }
 

--- a/terraform/modules/indexer/variables.tf
+++ b/terraform/modules/indexer/variables.tf
@@ -76,3 +76,8 @@ variable "db_parameter_group_family" {
   description = "Parameter group family name for the RDS DB. Must be compatible with the db_engine and db_engine_version. https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_WorkingWithDBInstanceParamGroups.html"
   default     = "postgres14"
 }
+
+variable "db_publicly_accessible" {
+  default     = false
+  description = "Determines if RDS instance is publicly accessible"
+}

--- a/terraform/modules/indexer/variables.tf
+++ b/terraform/modules/indexer/variables.tf
@@ -31,6 +31,11 @@ variable "vpc_id" {
   description = "VPC ID to create resources in"
 }
 
+variable "db_sources_ipv4" {
+  description = "List of CIDR subnets which can access the DB"
+  default     = ["0.0.0.0/0"]
+}
+
 variable "indexer_helm_values" {
   default = {}
 }

--- a/terraform/testnet/indexer.tf
+++ b/terraform/testnet/indexer.tf
@@ -11,10 +11,11 @@ module "indexer" {
 
   oidc_provider = module.validator.oidc_provider
 
-  subnet_ids = module.validator.aws_subnet_private.*.id
+  subnet_ids = var.indexer_db_publicly_accessible ? module.validator.aws_subnet_public.*.id : module.validator.aws_subnet_private.*.id
   vpc_id     = module.validator.vpc_id
 
-  db_password = var.indexer_db_password
+  db_password            = var.indexer_db_password
+  db_publicly_accessible = var.indexer_db_publicly_accessible
 
   indexer_helm_values = var.indexer_helm_values
 }

--- a/terraform/testnet/testnet/templates/service.yaml
+++ b/terraform/testnet/testnet/templates/service.yaml
@@ -48,7 +48,11 @@ metadata:
 spec:
   selector:
     app.kubernetes.io/part-of: aptos-validator
+{{- if .Values.validatorLite }}
+    app.kubernetes.io/name: validator
+{{- else }}
     app.kubernetes.io/name: haproxy
+{{- end }}
   ports:
   - port: 80
     targetPort: 8080

--- a/terraform/testnet/variables.tf
+++ b/terraform/testnet/variables.tf
@@ -56,7 +56,7 @@ variable "ssh_pub_key" {
 
 variable "validator_lite_mode" {
   description = "Run validator lite deployment"
-  default = false
+  default     = false
 }
 
 variable "num_validators" {
@@ -176,6 +176,11 @@ variable "enable_indexer" {
 variable "indexer_db_password" {
   description = "password for indexer RDS instance"
   default     = ""
+}
+
+variable "indexer_db_publicly_accessible" {
+  default     = false
+  description = "Determines if indexer RDS instance is publicly accessible"
 }
 
 variable "enable_k8s_metrics_server" {


### PR DESCRIPTION
New variable(s) to enable RDS to be publicly accessible, making it easier to plug into anlaytics tooling
* For testnet TF: `indexer_db_publicly_accessible` when `enable_indexer = true`, and will also determine which subnets to provision on
* For indexer TF: `db_publicly_accessible` 

Also, includes a small fix for testnet REST API when validator-lite is enabled