### PR TITLE
[Storage][Pruner] Various fixes for ledger pruning to enable in prod

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -99,7 +99,7 @@ impl Default for StorageConfig {
             storage_pruner_config: StoragePrunerConfig {
                 state_store_prune_window: Some(1_000_000),
                 ledger_prune_window: Some(10_000_000),
-                pruning_batch_size: 10_000,
+                pruning_batch_size: 500,
             },
             data_dir: PathBuf::from("/opt/aptos/data"),
             // Default read/write/connection timeout, in milliseconds

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -14,9 +14,7 @@ use aptos_jellyfish_merkle::metrics::{
     APTOS_JELLYFISH_STORAGE_READS,
 };
 use aptos_vm::AptosVM;
-use aptosdb::{
-    metrics::APTOS_STORAGE_ROCKSDB_PROPERTIES, schema::JELLYFISH_MERKLE_NODE_CF_NAME, AptosDB,
-};
+use aptosdb::{metrics::ROCKSDB_PROPERTIES, schema::JELLYFISH_MERKLE_NODE_CF_NAME, AptosDB};
 use executor::{
     block_executor::BlockExecutor,
     db_bootstrapper::{generate_waypoint, maybe_bootstrap},
@@ -113,13 +111,13 @@ pub fn run(
     generator.write_meta(&db_dir);
 
     db.update_rocksdb_properties().unwrap();
-    let db_size = APTOS_STORAGE_ROCKSDB_PROPERTIES
+    let db_size = ROCKSDB_PROPERTIES
         .with_label_values(&[
             JELLYFISH_MERKLE_NODE_CF_NAME,
             "aptos_rocksdb_live_sst_files_size_bytes",
         ])
         .get();
-    let data_size = APTOS_STORAGE_ROCKSDB_PROPERTIES
+    let data_size = ROCKSDB_PROPERTIES
         .with_label_values(&[
             JELLYFISH_MERKLE_NODE_CF_NAME,
             "aptos_rocksdb_total-sst-files-size",

--- a/execution/executor-benchmark/src/transaction_committer.rs
+++ b/execution/executor-benchmark/src/transaction_committer.rs
@@ -9,7 +9,7 @@ use aptos_types::{
     transaction::Version,
 };
 use aptos_vm::AptosVM;
-use aptosdb::metrics::APTOS_STORAGE_API_LATENCY_SECONDS;
+use aptosdb::metrics::API_LATENCY_SECONDS;
 use executor::{
     block_executor::BlockExecutor,
     metrics::{
@@ -119,7 +119,7 @@ fn report_block(
             APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum(),
             APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.get_sample_sum() - APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.get_sample_sum(),
             APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.get_sample_sum(),
-            APTOS_STORAGE_API_LATENCY_SECONDS.get_metric_with_label_values(&["save_transactions", "Ok"]).expect("must exist.").get_sample_sum(),
+            API_LATENCY_SECONDS.get_metric_with_label_values(&["save_transactions", "Ok"]).expect("must exist.").get_sample_sum(),
         );
     const NANOS_PER_SEC: f64 = 1_000_000_000.0;
     info!(
@@ -130,7 +130,7 @@ fn report_block(
                 / total_versions,
             APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.get_sample_sum() * NANOS_PER_SEC
                 / total_versions,
-            APTOS_STORAGE_API_LATENCY_SECONDS.get_metric_with_label_values(&["save_transactions", "Ok"]).expect("must exist.").get_sample_sum() * NANOS_PER_SEC
+            API_LATENCY_SECONDS.get_metric_with_label_values(&["save_transactions", "Ok"]).expect("must exist.").get_sample_sum() * NANOS_PER_SEC
                 / total_versions,
         );
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -173,10 +173,6 @@ mock! {
             fetch_events: bool,
         ) -> Result<TransactionWithProof>;
 
-        fn get_first_txn_version(&self) -> Result<Option<Version>>;
-
-        fn get_first_write_set_version(&self) -> Result<Option<Version>>;
-
         fn get_transaction_outputs(
             &self,
             start_version: Version,

--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     get_first_seq_num_and_limit, schema::jellyfish_merkle_node::JellyfishMerkleNodeSchema,
-    test_helper, test_helper::arb_blocks_to_commit, AptosDB, APTOS_STORAGE_ROCKSDB_PROPERTIES,
+    test_helper, test_helper::arb_blocks_to_commit, AptosDB, ROCKSDB_PROPERTIES,
 };
 use aptos_crypto::{
     hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
@@ -129,7 +129,7 @@ fn test_get_latest_tree_state() {
 #[test]
 fn test_rocksdb_properties_reporter() {
     fn get_metric() -> i64 {
-        APTOS_STORAGE_ROCKSDB_PROPERTIES
+        ROCKSDB_PROPERTIES
             .get_metric_with_label_values(&[
                 "transaction_info",
                 "aptos_rocksdb_is-file-deletions-enabled",

--- a/storage/aptosdb/src/ledger_counters/mod.rs
+++ b/storage/aptosdb/src/ledger_counters/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::metrics::APTOS_STORAGE_LEDGER;
+use crate::metrics::LEDGER_COUNTER;
 use num_derive::ToPrimitive;
 use num_traits::ToPrimitive;
 use num_variants::NumVariants;
@@ -145,7 +145,7 @@ impl LedgerCounters {
     /// Bump Prometheus counters.
     pub fn bump_op_counters(&self) {
         for counter in &LedgerCounter::VARIANTS {
-            APTOS_STORAGE_LEDGER
+            LEDGER_COUNTER
                 .with_label_values(&[counter.name()])
                 .set(self.get(*counter) as i64);
         }

--- a/storage/aptosdb/src/ledger_store/mod.rs
+++ b/storage/aptosdb/src/ledger_store/mod.rs
@@ -370,13 +370,15 @@ impl LedgerStore {
     }
 
     /// Prune the ledger counters stored in DB in the range [being, end)
-    pub fn prune_ledger_couners(
+    pub fn prune_ledger_counters(
         &self,
         begin: Version,
         end: Version,
         db_batch: &mut SchemaBatch,
     ) -> anyhow::Result<()> {
-        db_batch.delete_range::<LedgerCountersSchema>(&begin, &end)?;
+        for version in begin..end {
+            db_batch.delete::<LedgerCountersSchema>(&version)?;
+        }
         Ok(())
     }
 }

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -7,7 +7,7 @@ use aptos_metrics::{
 };
 use once_cell::sync::Lazy;
 
-pub static APTOS_STORAGE_LEDGER: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub static LEDGER_COUNTER: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
         "aptos_storage_ledger",
@@ -19,7 +19,7 @@ pub static APTOS_STORAGE_LEDGER: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static APTOS_STORAGE_COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
+pub static COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_storage_committed_txns",
         "Aptos storage committed transactions"
@@ -27,7 +27,7 @@ pub static APTOS_STORAGE_COMMITTED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static APTOS_STORAGE_LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+pub static LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "aptos_storage_latest_transaction_version",
         "Aptos storage latest transaction version"
@@ -35,7 +35,7 @@ pub static APTOS_STORAGE_LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static APTOS_STORAGE_LEDGER_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+pub static LEDGER_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "aptos_storage_ledger_version",
         "Version in the latest saved ledger info."
@@ -43,7 +43,7 @@ pub static APTOS_STORAGE_LEDGER_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static APTOS_STORAGE_NEXT_BLOCK_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
+pub static NEXT_BLOCK_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "aptos_storage_next_block_epoch",
         "ledger_info.next_block_epoch() for the latest saved ledger info."
@@ -51,20 +51,28 @@ pub static APTOS_STORAGE_NEXT_BLOCK_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static APTOS_STORAGE_LATEST_ACCOUNT_COUNT: Lazy<IntGauge> = Lazy::new(|| {
+pub static STATE_ITEM_COUNT: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_storage_latest_account_count",
-        "Total number of account in the StateDB at the latest version."
+        "aptos_storage_state_item_count",
+        "Total number of entries in the StateDB at the latest version."
     )
     .unwrap()
 });
 
-pub static APTOS_STORAGE_PRUNE_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!("aptos_storage_prune_window", "Aptos storage prune window").unwrap()
+pub static PRUNER_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        // metric name
+        "aptos_storage_prune_window",
+        // metric description
+        "Aptos storage prune window",
+        // metric labels (dimensions)
+        &["pruner_name",]
+    )
+    .unwrap()
 });
 
 /// DB pruner least readable versions
-pub static APTOS_PRUNER_LEAST_READABLE_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub static PRUNER_LEAST_READABLE_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
         "aptos_pruner_least_readable_version",
@@ -76,7 +84,10 @@ pub static APTOS_PRUNER_LEAST_READABLE_VERSION: Lazy<IntGaugeVec> = Lazy::new(||
     .unwrap()
 });
 
-pub static APTOS_STORAGE_API_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+pub static PRUNER_BATCH_SIZE: Lazy<IntGauge> =
+    Lazy::new(|| register_int_gauge!("pruner_batch_size", "Aptos pruner batch size").unwrap());
+
+pub static API_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
         "aptos_storage_api_latency_seconds",
@@ -88,7 +99,7 @@ pub static APTOS_STORAGE_API_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| 
     .unwrap()
 });
 
-pub static APTOS_STORAGE_OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+pub static OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         // metric name
         "aptos_storage_other_timers_seconds",
@@ -101,7 +112,7 @@ pub static APTOS_STORAGE_OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(||
 });
 
 /// Rocksdb metrics
-pub static APTOS_STORAGE_ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
+pub static ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(
         // metric name
         "aptos_rocksdb_properties",

--- a/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
@@ -1,10 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 use crate::{pruner::db_sub_pruner::DBSubPruner, EventStore};
-use aptos_types::{contract_event::ContractEvent, event::EventKey, transaction::Version};
-use itertools::Itertools;
 use schemadb::SchemaBatch;
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 pub struct EventStorePruner {
     event_store: Arc<EventStore>,
@@ -17,31 +15,8 @@ impl DBSubPruner for EventStorePruner {
         least_readable_version: u64,
         target_version: u64,
     ) -> anyhow::Result<()> {
-        let candidate_events =
-            self.get_pruning_candidate_events(least_readable_version, target_version)?;
-
-        let event_keys: HashSet<EventKey> =
-            candidate_events.iter().map(|event| *event.key()).collect();
-
-        self.event_store.prune_events_by_version(
-            event_keys,
-            least_readable_version,
-            target_version,
-            db_batch,
-        )?;
-
         self.event_store
-            .prune_events_by_key(&candidate_events, db_batch)?;
-
-        self.event_store.prune_event_accumulator(
-            least_readable_version,
-            target_version,
-            db_batch,
-        )?;
-
-        self.event_store
-            .prune_event_schema(least_readable_version, target_version, db_batch)?;
-
+            .prune_events(least_readable_version, target_version, db_batch)?;
         Ok(())
     }
 }
@@ -49,16 +24,5 @@ impl DBSubPruner for EventStorePruner {
 impl EventStorePruner {
     pub(in crate::pruner) fn new(event_store: Arc<EventStore>) -> Self {
         EventStorePruner { event_store }
-    }
-
-    fn get_pruning_candidate_events(
-        &self,
-        start: Version,
-        end: Version,
-    ) -> anyhow::Result<Vec<ContractEvent>> {
-        self.event_store
-            .get_events_by_version_iter(start, (end - start) as usize)?
-            .flatten_ok()
-            .collect()
     }
 }

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_counter_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_counter_pruner.rs
@@ -16,8 +16,11 @@ impl DBSubPruner for LedgerCounterPruner {
         least_readable_version: u64,
         target_version: u64,
     ) -> anyhow::Result<()> {
-        self.ledger_store
-            .prune_ledger_couners(least_readable_version, target_version, db_batch)?;
+        self.ledger_store.prune_ledger_counters(
+            least_readable_version,
+            target_version,
+            db_batch,
+        )?;
         Ok(())
     }
 }

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -127,6 +127,7 @@ fn verify_txn_store_pruner(
             )
             .unwrap();
         // ensure that all transaction up to i * 2 has been pruned
+        assert_eq!(*pruner.last_version_sent_to_pruners.lock(), i as u64);
         for j in 0..i {
             verify_txn_not_in_store(transaction_store, &txns, j as u64, ledger_version);
         }

--- a/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
@@ -18,6 +18,7 @@ impl DBSubPruner for TransactionStorePruner {
     ) -> anyhow::Result<()> {
         // Current target version  might be less than the target version to ensure we don't prune
         // more than max_version in one go.
+
         let candidate_transactions =
             self.get_pruning_candidate_transactions(least_readable_version, target_version)?;
         self.transaction_store

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -267,7 +267,9 @@ impl TransactionStore {
         end: Version,
         db_batch: &mut SchemaBatch,
     ) -> anyhow::Result<()> {
-        db_batch.delete_range::<TransactionSchema>(&begin, &end)?;
+        for version in begin..end {
+            db_batch.delete::<TransactionSchema>(&version)?;
+        }
         Ok(())
     }
 
@@ -278,7 +280,9 @@ impl TransactionStore {
         end: Version,
         db_batch: &mut SchemaBatch,
     ) -> anyhow::Result<()> {
-        db_batch.delete_range::<TransactionInfoSchema>(&begin, &end)?;
+        for version in begin..end {
+            db_batch.delete::<TransactionInfoSchema>(&version)?;
+        }
         Ok(())
     }
 
@@ -289,7 +293,9 @@ impl TransactionStore {
         end: Version,
         db_batch: &mut SchemaBatch,
     ) -> anyhow::Result<()> {
-        db_batch.delete_range::<WriteSetSchema>(&begin, &end)?;
+        for version in begin..end {
+            db_batch.delete::<WriteSetSchema>(&version)?;
+        }
         Ok(())
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -525,6 +525,11 @@ pub trait DbReader: Send + Sync {
     fn get_state_prune_window(&self) -> Result<Option<usize>> {
         unimplemented!()
     }
+
+    /// Get the ledger prune window config value.
+    fn get_ledger_prune_window(&self) -> Result<Option<usize>> {
+        unimplemented!()
+    }
 }
 
 impl MoveStorage for &dyn DbReader {


### PR DESCRIPTION
Following fixes are included for ledge pruning to 
1.  Pruner batching implementation had a bug where the `last_version_sent_to_pruner` was not updated, so batching was not working. 
2. Switch from range_delete to point delete for ledger pruning - range delete implementation is sub-optimal and leads to higher latency for point `get` queries. See https://rocksdb.org/blog/2018/11/21/delete-range.html for reference.
3. Remove unnecessary DB call `get_first_txn_version` in state-sync to get range of txn and write-set version - given we already know the latest version, we can just substract the pruning window to get the range of available txn version - assuming pruning is enabled.
4. Expose more metrics for the ledger pruner window.

There are still some more minor cleanups I have planned for the pruner, which will be done in a followup PR.