### PR TITLE
[CLI] "$ aptos move test" added "--filter"

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -179,7 +179,7 @@ pub struct TestPackage {
     move_options: MovePackageDir,
 
     /// A filter string to determine which unit tests to run
-    #[clap(name = "filter", short = 'f', long = "filter")]
+    #[clap(long)]
     pub filter: Option<String>,
 }
 

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -177,6 +177,10 @@ impl CliCommand<Vec<String>> for CompilePackage {
 pub struct TestPackage {
     #[clap(flatten)]
     move_options: MovePackageDir,
+
+    /// A filter string to determine which unit tests to run
+    #[clap(name = "filter", short = 'f', long = "filter")]
+    pub filter: Option<String>,
 }
 
 #[async_trait]
@@ -195,7 +199,10 @@ impl CliCommand<&'static str> for TestPackage {
         let result = move_cli::package::cli::run_move_unit_tests(
             self.move_options.package_dir.as_path(),
             config,
-            UnitTestingConfig::default_with_bound(Some(100_000)),
+            UnitTestingConfig {
+                filter: self.filter,
+                ..UnitTestingConfig::default_with_bound(Some(100_000))
+            },
             aptos_natives(),
             false,
         )


### PR DESCRIPTION
"--filter" parameter has been added to the "aptos move test" so that only one unit tests can be run

```bash
aptos move test --package-dir <project/dir> --filter <NameOfTestModule>
```

- [x] Re-created PR - https://github.com/aptos-labs/aptos-core/pull/723
- [x] removed short = 'f'

@gregnazario please check