### PR TITLE
fix bug re-run test

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -470,7 +470,7 @@ impl WriteTransactionOptions {
 }
 
 /// Options for compiling a move package dir
-#[derive(Debug, Parser)]
+#[derive(Debug, Parser, Clone)]
 pub struct MovePackageDir {
     /// Path to a move package (the folder with a Move.toml file)
     #[clap(long, parse(from_os_str), default_value = ".")]

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -172,6 +172,12 @@ impl CliCommand<Vec<String>> for CompilePackage {
     }
 }
 
+impl From<MovePackageDir> for CompilePackage {
+    fn from(move_options: MovePackageDir) -> Self {
+        CompilePackage { move_options }
+    }
+}
+
 /// Run Move unit tests against a package path
 #[derive(Parser)]
 pub struct TestPackage {
@@ -186,6 +192,12 @@ impl CliCommand<&'static str> for TestPackage {
     }
 
     async fn execute(self) -> CliTypedResult<&'static str> {
+        // Compile the package before running the test
+        // This is added to fix the error with test re-run
+        CompilePackage::from(self.move_options.clone())
+            .execute()
+            .await?;
+
         let config = BuildConfig {
             additional_named_addresses: self.move_options.named_addresses(),
             test_mode: true,


### PR DESCRIPTION
You can reproduce the error if you run the command several times in a row:
``` bash
aptos move test --package-dir <project/dir>
```
Output:
> **CACHED** MoveStdlib
> **BUILDING** test_project_simple
> thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: No such file or directory './build/MoveStdlib/sources/OptionTests.move'', .../.cargo/git/checkouts/move-0639dd674f581c30/1b6b751/language/tools/move-cli/src/package/cli.rs:510:83

Re-created PR https://github.com/aptos-labs/aptos-core/pull/722

@gregnazario please check. Test "Move" project was sent in Slack.