### PR TITLE
Terraform script for Digital Ocean (localstorage)

### DIFF
--- a/terraform/fullnode/digital_ocean/.gitignore
+++ b/terraform/fullnode/digital_ocean/.gitignore
@@ -1,0 +1,3 @@
+*.tfstate
+*.tfstate.backup
+*.yml

--- a/terraform/fullnode/digital_ocean/.terraform.lock.hcl
+++ b/terraform/fullnode/digital_ocean/.terraform.lock.hcl
@@ -1,0 +1,82 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.19.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:XcLoKA2a1MR4foSFeFbJgCADRvsXtN9SyIiJX0fSGys=",
+    "zh:01cee85343dee2dfc01499e19ef4e56b0c9260eee0a47329231cf500c07b4386",
+    "zh:099eeddf9baf9c282430231da501a8b96b3fb28507ce3b78e3a185cc9d4b3860",
+    "zh:191e090e8553355d91842163737d71051aeb499c8ddb23d2e8aae9dab2f8a1a5",
+    "zh:25356abb47769270730b0ddb0a3eb89aec637395cdcb77c309d23e55839e4461",
+    "zh:28876afb75ba5367d20e508e05c7657f90922142ff80d8a81a4d68b3381adb86",
+    "zh:404a304e37c3dec8017318b16ab701553e5242dc2460211346a9dd39242709a6",
+    "zh:40f53111b01fc78fdc7a6ba47a80d51c9a45e77e5b7d7d5bcae3a0c6f58ffbdf",
+    "zh:48f212068234df3dcfe5544c96b10403b15a190203742756d7d0573ee0857c17",
+    "zh:5189fe4fffdbff5c280f6741f55b2de9cb2b8c653cda0b2339c28cd1e3bc7884",
+    "zh:a7d5840ca789a03a285c67d2838af4d8687c99f3e8fac4ce56fcd23802a66156",
+    "zh:c0bd3c4555e5d7e6c96d3add3ddd8e41aa0df9e4a4518ad3b7f1d726a4e0a9f4",
+    "zh:d70a903a6d75533aa4713e255c9c967ec453195f2209439981f015f203805a6e",
+    "zh:db8110736bd47f99213d72309ebb720718a80b15ddd46e34a8ee9b2125903079",
+    "zh:e2180f334506601e0a6af8863159cc719ce584fdb23bd45ddc120f33d22cec19",
+    "zh:eb515a24d231e7f1ef344b9b88fa2071f760ec34fbb47d80bbacdf7e35f3daca",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.5.1"
+  hashes = [
+    "h1:a9KwjqINdNy6IsEbkHUB1vwvYfy5OJ2VxFL9/NDFLoY=",
+    "zh:140b9748f0ad193a20d69e59d672f3c4eda8a56cede56a92f931bd3af020e2e9",
+    "zh:17ae319466ed6538ad49e011998bb86565fe0e97bc8b9ad7c8dda46a20f90669",
+    "zh:3a8bd723c21ba70e19f0395ed7096fc8e08bfc23366f1c3f06a9107eb37c572c",
+    "zh:3aae3b82adbe6dca52f1a1c8cf51575446e6b0f01f1b1f3b30de578c9af4a933",
+    "zh:3f65221f40148df57d2888e4f31ef3bf430b8c5af41de0db39a2b964e1826d7c",
+    "zh:650c74c4f46f5eb01df11d8392bdb7ebee3bba59ac0721000a6ad731ff0e61e2",
+    "zh:930fb8ab4cd6634472dfd6aa3123f109ef5b32cbe6ef7b4695fae6751353e83f",
+    "zh:ae57cd4b0be4b9ca252bc5d347bc925e35b0ed74d3dcdebf06c11362c1ac3436",
+    "zh:d15b1732a8602b6726eac22628b2f72f72d98b75b9c6aabceec9fd696fda696a",
+    "zh:d730ede1656bd193e2aea5302acec47c4905fe30b96f550196be4a0ed5f41936",
+    "zh:f010d4f9d8cd15936be4df12bf256cb2175ca1dedb728bd3a866c03d2ee7591f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.10.0"
+  hashes = [
+    "h1:v+xmcw54lMETOlhKPO61AlbxGB0OU8BphMfOO62e0Uo=",
+    "zh:0b011e77f02bc05194062c0a39f321a4f1bea0bae61787b0c1f5808f6efb2a26",
+    "zh:288ad46e240c5d1218909a9100ca8bd2197c8615558bbe7b393ba35877d5e4f0",
+    "zh:3e5554791ed103b6190efebe332fd3722796e6a59cf081f87ef1debb4e0b6ae3",
+    "zh:98e42cb48624be7eb2e16b5d8fc5044d7207943b6d13905bc3d3c006aa231cc7",
+    "zh:b1c800fd3971051d9deb4824f933e506ae288458e425be8ea449c9d40c7b0663",
+    "zh:bca1802585ecbc36bfcc700b6fa7c6ff96b2b8c4aca23c58df939a5002a05b4d",
+    "zh:c2f6bf46cd95d00f2bb1634afff92eeb269d27d83eea80b8cfceca1afdcd3033",
+    "zh:d2ccfbf3a9bf2ede8be6242c023173efd85a882cd3956a941f140c5718047412",
+    "zh:da19cd4a124f4ffc092e19f5b7a10ac4cce98db40cf855ea0d4a682f3df83a1f",
+    "zh:e3a2020453a86f80ad2b3f792e91a35fe272b907485a59c02d19269a1bdfe2fd",
+    "zh:f0659ca86e0dc0dd76b7f4497db8e58144ee9f0943b6d14dc57193d25ee22ced",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.2"
+  hashes = [
+    "h1:SjDyZXIUHEQzZe10VjhlhZq2a9kgQB6tmqJcpq2BeWg=",
+    "zh:027e4873c69da214e2fed131666d5de92089732a11d096b68257da54d30b6f9d",
+    "zh:0ba2216e16cfb72538d76a4c4945b4567a76f7edbfef926b1c5a08d7bba2a043",
+    "zh:1fee8f6aae1833c27caa96e156cf99a681b6f085e476d7e1b77d285e21d182c1",
+    "zh:2e8a3e72e877003df1c390a231e0d8e827eba9f788606e643f8e061218750360",
+    "zh:719008f9e262aa1523a6f9132adbe9eee93c648c2981f8359ce41a40e6425433",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9a70fdbe6ef955c4919a4519caca116f34c19c7ddedd77990fbe4f80fe66dc84",
+    "zh:abc412423d670cbb6264827fa80e1ffdc4a74aff3f19ba6a239dd87b85b15bec",
+    "zh:ae953a62c94d2a2a0822e5717fafc54e454af57bd6ed02cd301b9786765c1dd3",
+    "zh:be0910bdf46698560f9e86f51a4ff795c62c02f8dc82b2b1dab77a0b3a93f61e",
+    "zh:e58f9083b7971919b95f553227adaa7abe864fce976f0166cf4d65fc17257ff2",
+    "zh:ff4f77cbdbb22cc98182821c7ef84dce16298ab0e997d5c7fae97247f7a4bcb0",
+  ]
+}

--- a/terraform/fullnode/digital_ocean/cluster.tf
+++ b/terraform/fullnode/digital_ocean/cluster.tf
@@ -1,0 +1,12 @@
+resource "digitalocean_kubernetes_cluster" "aptos" {
+  name   = "aptos-${terraform.workspace}"
+  region = var.region
+  version = "1.22.8-do.1"
+
+  node_pool {
+    name       = "fullnodes"
+    size       = var.machine_type
+    node_count = var.num_fullnodes
+    tags            = ["fullnodes"]
+  }
+}

--- a/terraform/fullnode/digital_ocean/kubernetes.tf
+++ b/terraform/fullnode/digital_ocean/kubernetes.tf
@@ -1,0 +1,59 @@
+provider "kubernetes" {
+  host                   = "${digitalocean_kubernetes_cluster.aptos.endpoint}"
+  cluster_ca_certificate = base64decode(digitalocean_kubernetes_cluster.aptos.kube_config[0].cluster_ca_certificate)
+  token                  = digitalocean_kubernetes_cluster.aptos.kube_config[0].token
+}
+
+resource "kubernetes_namespace" "aptos" {
+  metadata {
+    name = var.k8s_namespace
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "${digitalocean_kubernetes_cluster.aptos.endpoint}"
+    cluster_ca_certificate = base64decode(digitalocean_kubernetes_cluster.aptos.kube_config[0].cluster_ca_certificate)
+    token                  = digitalocean_kubernetes_cluster.aptos.kube_config[0].token
+  }
+}
+
+resource "helm_release" "fullnode" {
+  count            = var.num_fullnodes
+  name             = "${terraform.workspace}${count.index}"
+  chart            = "${path.module}/../../helm/fullnode"
+  max_history      = 100
+  wait             = false
+  namespace        = var.k8s_namespace
+  create_namespace = true
+
+  values = [
+    jsonencode({
+      chain = {
+        era  = var.era
+      }
+      image = {
+        tag = var.image_tag
+      }
+      nodeSelector = {
+        "doks.digitalocean.com/node-pool" = digitalocean_kubernetes_cluster.aptos.node_pool[0].name
+      }
+      storageClass = {
+          class = "do-block-storage"
+      }
+      service = {
+        type = "LoadBalancer"
+      }
+      storage = {
+        size = "100Gi"
+      }
+    }),
+    jsonencode(var.fullnode_helm_values),
+    jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),
+  ]
+
+  set {
+    name  = "timestamp"
+    value = var.helm_force_update ? timestamp() : ""
+  }
+}

--- a/terraform/fullnode/digital_ocean/main.tf
+++ b/terraform/fullnode/digital_ocean/main.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "local" {}
+
+provider "digitalocean" {
+  token = var.do_token
+}

--- a/terraform/fullnode/digital_ocean/variables.tf
+++ b/terraform/fullnode/digital_ocean/variables.tf
@@ -1,0 +1,67 @@
+variable "helm_values" {
+  description = "Map of values to pass to Helm"
+  type        = any
+  default     = {}
+}
+
+variable "fullnode_helm_values" {
+  description = "Map of values to pass to public fullnode Helm"
+  type        = any
+  default     = {}
+}
+
+variable "do_token" {
+  type = string
+  description = "Digital Notion API token"
+}
+
+variable "region" {
+  description = "Digital Ocean region of nodes"
+  type        = string
+}
+
+variable "fullnode_helm_values_list" {
+  description = "List of values to pass to public fullnode, for setting different value per node. length(fullnode_helm_values_list) must equal var.num_fullnodes"
+  type        = any
+  default     = {}
+}
+
+variable "helm_force_update" {
+  description = "Force Terraform to update the Helm deployment"
+  default     = false
+}
+
+variable "k8s_namespace" {
+  default     = "aptos"
+  description = "Kubernetes namespace that the fullnode will be deployed into"
+}
+
+variable "k8s_api_sources" {
+  description = "List of CIDR subnets which can access the Kubernetes API endpoint"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "num_fullnodes" {
+  default     = 1
+  description = "Number of fullnodes"
+}
+
+variable "image_tag" {
+  default     = "devnet"
+  description = "Docker image tag to use for the fullnode"
+}
+
+variable "era" {
+  description = "Chain era, used to start a clean chain"
+  default     = 1
+}
+
+variable "chain_id" {
+  description = "aptos chain ID"
+  default     = "DEVNET"
+}
+
+variable "machine_type" {
+  description = "Machine type for running fullnode"
+  default     = "s-4vcpu-8gb"
+}


### PR DESCRIPTION
## Motivation
To make running fullnodes as accessible as possible it would make sense to have other options, especially ones that are not quite as expensive. One of those commonly used options is Digital Ocean. This terraform script provides an easy way to set up a single node terraform cluster on digital ocean. It uses the local machine storage instead of block storage (block storage script is coming soon). Let me know if this kind of contribution is welcome.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
[individual-cla (1).pdf](https://github.com/aptos-labs/aptos-core/files/8610679/individual-cla.1.pdf)


## Test Plan
Run it the same as the other terraform scripts. Just needs a Digital Ocean API access token.
>terraform init
>terraform apply
