### PR TITLE
[Storage Service] Add LRU cache to storage service.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,6 +1163,7 @@ name = "aptos-workspace-hack"
 version = "0.1.0"
 dependencies = [
  "Inflector",
+ "ahash",
  "anyhow",
  "arrayvec",
  "backtrace",
@@ -2632,7 +2633,7 @@ dependencies = [
  "diesel_derives",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits 0.1.43",
  "pq-sys",
  "r2d2",
  "serde_json",
@@ -3652,6 +3653,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -4382,6 +4386,15 @@ checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
  "cfg-if 1.0.0",
  "serde 1.0.136",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32613e41de4c47ab04970c348ca7ae7382cf116625755af070b008a15516a889"
+dependencies = [
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -7781,6 +7794,8 @@ dependencies = [
  "channel",
  "claim",
  "futures",
+ "lru",
+ "mockall",
  "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f2e7585b1ed5bd2810163d6bdebafe5a388881d3)",
  "network",
  "once_cell",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -109,6 +109,7 @@ pub struct StorageServiceConfig {
     pub max_account_states_chunk_sizes: u64, // Max num of accounts per chunk
     pub max_concurrent_requests: u64,        // Max num of concurrent storage server tasks
     pub max_epoch_chunk_size: u64,           // Max num of epoch ending ledger infos per chunk
+    pub max_lru_cache_size: u64,             // Max num of items in the lru cache before eviction
     pub max_network_channel_size: u64,       // Max num of pending network messages
     pub max_transaction_chunk_size: u64,     // Max num of transactions per chunk
     pub max_transaction_output_chunk_size: u64, // Max num of transaction outputs per chunk
@@ -121,6 +122,7 @@ impl Default for StorageServiceConfig {
             max_account_states_chunk_sizes: 1000,
             max_concurrent_requests: 4000,
             max_epoch_chunk_size: 100,
+            max_lru_cache_size: 100,
             max_network_channel_size: 4000,
             max_transaction_chunk_size: 1000,
             max_transaction_output_chunk_size: 1000,

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 ### BEGIN HAKARI SECTION
 [dependencies]
 Inflector = { version = "0.11.4", features = ["heavyweight", "lazy_static", "regex"] }
+ahash = { version = "0.7.6", features = ["std"] }
 anyhow = { version = "1.0.57", features = ["backtrace", "std"] }
 arrayvec = { version = "0.5.2", features = ["array-sizes-33-128", "std"] }
 backtrace = { version = "0.3.58", features = ["addr2line", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
@@ -34,6 +35,7 @@ futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.17", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
 getrandom = { version = "0.2.6", default-features = false, features = ["std"] }
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14.18", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 indexmap = { version = "1.8.1", default-features = false, features = ["std"] }
@@ -66,6 +68,7 @@ zeroize = { version = "1.5.4", features = ["alloc", "zeroize_derive"] }
 
 [build-dependencies]
 Inflector = { version = "0.11.4", features = ["heavyweight", "lazy_static", "regex"] }
+ahash = { version = "0.7.6", features = ["std"] }
 anyhow = { version = "1.0.57", features = ["backtrace", "std"] }
 arrayvec = { version = "0.5.2", features = ["array-sizes-33-128", "std"] }
 backtrace = { version = "0.3.58", features = ["addr2line", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
@@ -89,6 +92,7 @@ futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.17", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "proc-macro-hack", "proc-macro-nested", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
 getrandom = { version = "0.2.6", default-features = false, features = ["std"] }
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14.18", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 indexmap = { version = "1.8.1", default-features = false, features = ["std"] }
@@ -119,17 +123,5 @@ tracing = { version = "0.1.34", features = ["attributes", "log", "std", "tracing
 tracing-core = { version = "0.1.26", features = ["lazy_static", "std"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 zeroize = { version = "1.5.4", features = ["alloc", "zeroize_derive"] }
-
-[target.x86_64-unknown-linux-gnu.dependencies]
-hashbrown = { version = "0.11.2", default-features = false, features = ["inline-more", "raw"] }
-
-[target.x86_64-unknown-linux-gnu.build-dependencies]
-hashbrown = { version = "0.11.2", default-features = false, features = ["inline-more", "raw"] }
-
-[target.x86_64-apple-darwin.dependencies]
-hashbrown = { version = "0.11.2", default-features = false, features = ["inline-more", "raw"] }
-
-[target.x86_64-apple-darwin.build-dependencies]
-hashbrown = { version = "0.11.2", default-features = false, features = ["inline-more", "raw"] }
 
 ### END HAKARI SECTION

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -578,6 +578,7 @@ async fn optimal_chunk_size_calculations() {
         max_account_states_chunk_sizes,
         max_concurrent_requests: 0,
         max_epoch_chunk_size,
+        max_lru_cache_size: 0,
         max_network_channel_size: 0,
         max_transaction_chunk_size,
         max_transaction_output_chunk_size,

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 bcs = "0.1.2"
 bytes = "1.0.1"
 futures = "0.3.12"
+lru = "0.7.5"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
@@ -34,6 +35,7 @@ storage-service-types = { path = "../types" }
 [dev-dependencies]
 anyhow = "1.0.52"
 claim = "0.5.0"
+mockall = "0.11.0"
 
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-time-service = { path = "../../../crates/aptos-time-service", features = ["async", "testing"] }

--- a/state-sync/storage-service/server/src/metrics.rs
+++ b/state-sync/storage-service/server/src/metrics.rs
@@ -7,6 +7,20 @@ use aptos_metrics::{
 use network::ProtocolId;
 use once_cell::sync::Lazy;
 
+/// Useful metric constants for the storage service
+pub const LRU_CACHE_HIT: &str = "lru_cache_hit";
+pub const LRU_CACHE_PROBE: &str = "lru_cache_probe";
+
+/// Counter for lru cache events in the storage service (server-side)
+pub static LRU_CACHE_EVENT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_storage_service_server_lru_cache",
+        "Counters for lru cache events in the storage server",
+        &["protocol", "event"]
+    )
+    .unwrap()
+});
+
 /// Counter for pending network events to the storage service (server-side)
 pub static PENDING_STORAGE_SERVER_NETWORK_EVENTS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -51,7 +51,7 @@ pub enum StorageServiceMessage {
 }
 
 /// A storage service request.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub enum StorageServiceRequest {
     GetAccountStatesChunkWithProof(AccountStatesChunkWithProofRequest), // Fetches a list of account states with a proof
     GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest), // Fetches a list of epoch ending ledger infos
@@ -229,7 +229,7 @@ impl TryFrom<StorageServiceResponse> for TransactionListWithProof {
 
 /// A storage service request for fetching a list of account states at a
 /// specified version.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct AccountStatesChunkWithProofRequest {
     pub version: u64,             // The version to fetch the account states at
     pub start_account_index: u64, // The account index to start fetching account states
@@ -238,7 +238,7 @@ pub struct AccountStatesChunkWithProofRequest {
 
 /// A storage service request for fetching a transaction output list with a
 /// corresponding proof.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct TransactionOutputsWithProofRequest {
     pub proof_version: u64, // The version the proof should be relative to
     pub start_version: u64, // The starting version of the transaction output list
@@ -247,7 +247,7 @@ pub struct TransactionOutputsWithProofRequest {
 
 /// A storage service request for fetching a transaction list with a
 /// corresponding proof.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct TransactionsWithProofRequest {
     pub proof_version: u64,   // The version the proof should be relative to
     pub start_version: u64,   // The starting version of the transaction list
@@ -256,7 +256,7 @@ pub struct TransactionsWithProofRequest {
 }
 
 /// A storage service request for fetching a list of epoch ending ledger infos.
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct EpochEndingLedgerInfoRequest {
     pub start_epoch: u64,
     pub expected_end_epoch: u64,


### PR DESCRIPTION
Note: this PR is only large because of the unit tests. Otherwise, it's pretty straightforward.

## Motivation

This PR adds a simple LRU cache to the storage service used by state sync v2. The hope is that frequently requested data chunks can be cached and we can reduce the load on the database. The cache hit percentage remains to be seen in practice (I've added metrics to help us track this).

The PR offers the following commits:
1. Add the LRU cache to the storage service (and metrics).
2. Add unit tests to ensure the LRU cache works as expected. To do this, I introduced mocking to the unit tests and updated all the unit tests to adopt the mocking approach. I've also added some checks to the unit tests to ensure additional functionality is being verified. Hence, the PR is a little large.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The new  and existing unit tests pass.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245