### PR TITLE
[terraform] Add VULTR (vultr.com) terraform setup for a fullnode on k8s.

### DIFF
--- a/terraform/fullnode/vultr/.terraform.lock.hcl
+++ b/terraform/fullnode/vultr/.terraform.lock.hcl
@@ -1,0 +1,83 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version = "2.5.1"
+  hashes = [
+    "h1:a9KwjqINdNy6IsEbkHUB1vwvYfy5OJ2VxFL9/NDFLoY=",
+    "zh:140b9748f0ad193a20d69e59d672f3c4eda8a56cede56a92f931bd3af020e2e9",
+    "zh:17ae319466ed6538ad49e011998bb86565fe0e97bc8b9ad7c8dda46a20f90669",
+    "zh:3a8bd723c21ba70e19f0395ed7096fc8e08bfc23366f1c3f06a9107eb37c572c",
+    "zh:3aae3b82adbe6dca52f1a1c8cf51575446e6b0f01f1b1f3b30de578c9af4a933",
+    "zh:3f65221f40148df57d2888e4f31ef3bf430b8c5af41de0db39a2b964e1826d7c",
+    "zh:650c74c4f46f5eb01df11d8392bdb7ebee3bba59ac0721000a6ad731ff0e61e2",
+    "zh:930fb8ab4cd6634472dfd6aa3123f109ef5b32cbe6ef7b4695fae6751353e83f",
+    "zh:ae57cd4b0be4b9ca252bc5d347bc925e35b0ed74d3dcdebf06c11362c1ac3436",
+    "zh:d15b1732a8602b6726eac22628b2f72f72d98b75b9c6aabceec9fd696fda696a",
+    "zh:d730ede1656bd193e2aea5302acec47c4905fe30b96f550196be4a0ed5f41936",
+    "zh:f010d4f9d8cd15936be4df12bf256cb2175ca1dedb728bd3a866c03d2ee7591f",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.11.0"
+  hashes = [
+    "h1:T65SZhN/tQgsAsHe/G5PCgpjofi+aTKPZ+nZg6WOJpc=",
+    "zh:143a19dd0ea3b07fc5e3d9231f3c2d01f92894385c98a67327de74c76c715843",
+    "zh:1fc757d209e09c3cf7848e4274daa32408c07743698fbed10ee52a4a479b62b6",
+    "zh:22dfebd0685749c51a8f765d51a1090a259778960ac1cd4f32021a325b2b9b72",
+    "zh:3039b3b76e870cd8fc404cf75a29c66b171c6ba9b6182e131b6ae2ca648ec7c0",
+    "zh:3af0a15562fcab4b5684b18802e0239371b2b8ff9197ed069ff4827f795a002b",
+    "zh:50aaf20336d1296a73315adb66f7687f75bd5c6b1f93a894b95c75cc142810ec",
+    "zh:682064fabff895ec351860b4fe0321290bbbb17c2a410b62c9bea0039400650e",
+    "zh:70ac914d5830b3371a2679d8f77cc20c419a6e12925145afae6c977c8eb90934",
+    "zh:710aa02cccf7b0f3fb50880d6d2a7a8b8c9435248666616844ba71f74648cddc",
+    "zh:88e418118cd5afbdec4984944c7ab36950bf48e8d3e09e090232e55eecfb470b",
+    "zh:9cef159377bf23fa331f8724fdc6ce27ad39a217a4bae6df3b1ca408fc643da6",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.2"
+  hashes = [
+    "h1:SjDyZXIUHEQzZe10VjhlhZq2a9kgQB6tmqJcpq2BeWg=",
+    "zh:027e4873c69da214e2fed131666d5de92089732a11d096b68257da54d30b6f9d",
+    "zh:0ba2216e16cfb72538d76a4c4945b4567a76f7edbfef926b1c5a08d7bba2a043",
+    "zh:1fee8f6aae1833c27caa96e156cf99a681b6f085e476d7e1b77d285e21d182c1",
+    "zh:2e8a3e72e877003df1c390a231e0d8e827eba9f788606e643f8e061218750360",
+    "zh:719008f9e262aa1523a6f9132adbe9eee93c648c2981f8359ce41a40e6425433",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9a70fdbe6ef955c4919a4519caca116f34c19c7ddedd77990fbe4f80fe66dc84",
+    "zh:abc412423d670cbb6264827fa80e1ffdc4a74aff3f19ba6a239dd87b85b15bec",
+    "zh:ae953a62c94d2a2a0822e5717fafc54e454af57bd6ed02cd301b9786765c1dd3",
+    "zh:be0910bdf46698560f9e86f51a4ff795c62c02f8dc82b2b1dab77a0b3a93f61e",
+    "zh:e58f9083b7971919b95f553227adaa7abe864fce976f0166cf4d65fc17257ff2",
+    "zh:ff4f77cbdbb22cc98182821c7ef84dce16298ab0e997d5c7fae97247f7a4bcb0",
+  ]
+}
+
+provider "registry.terraform.io/vultr/vultr" {
+  version     = "2.10.1"
+  constraints = "2.10.1"
+  hashes = [
+    "h1:GGS/xnIJT7m2QAV3saTpCrPbiKjqDGiSWbY6bxRz0ms=",
+    "zh:0d1f8297a122f5f3a30fbba80a8838ec973f83e4350a0266db4ae54bba1c8959",
+    "zh:1191630f282be80d1ba52e9d98420c5badf0ab0b199086dc58a86f0b3bbfdbd9",
+    "zh:1730887e32b3ff58ca7c80510c02e47e488ca6a1f35e2efb15c8ff0e1a069a85",
+    "zh:1adf730a80d3b8239103e9bef07fea16c81a417d5f72d87f4d78c0783442776f",
+    "zh:3f204c86f8acd8641936690804b016a7a5a11dbae2c69eac22f6fde268742f72",
+    "zh:403213a0f747aab0b2d3f57867abbaaf46f7b793e42fc542c88022712969f7f2",
+    "zh:6614e81988346f3a77dfac18d5979570bc4e511c479f0f6896329521df19b932",
+    "zh:7006b442c78e103f1d1a1ac058daa935f1a10c1e4c841a7778cc6b5dab89afdf",
+    "zh:8e2b236764927263b5b95bacdde7a522dc6fc26cc688c16ec3188402c6e94252",
+    "zh:b4c0b0b76f6c700e4c9e6ab0d32317694bb0afac0d87d4bdb99247bb47d6f190",
+    "zh:b57875af655d03294ae58edc31261fef458c80b2d68a28c9475c3954b5c8595e",
+    "zh:bd42311a444e38c719ebcd9b705d019110b961504df6e7dbccd1ad144c8ffc0e",
+    "zh:c5a590054e47b40d671d70494937b6fd76874cbee574a2c386f75b64a09e95e0",
+    "zh:cd86bf98dca59cc9ca5e4e7690e4032142acca3d59d9494a465731c1990e7ca7",
+    "zh:fddd5f58f87242e6535230d3daf1af312722a19050ca23af661db922da22fd63",
+    "zh:fee19a1d66a479b03099bbc26a80d047ec8fbd794f01f43af6c7c35c655bac44",
+  ]
+}

--- a/terraform/fullnode/vultr/README.md
+++ b/terraform/fullnode/vultr/README.md
@@ -1,0 +1,67 @@
+Aptos Fullnodes VULTR (https://www.vultr.com/) Deployment
+==============================
+
+This directory contains Terraform configs to deploy a public fullnode on VULTR.
+
+These instructions assume that you have a functioning VULTR account. 
+The default configuration will create a single node cluster with 4CPU/8GB and a automatically allocate and bind a persistant block storage (SSD) using VULTR-CSI (https://github.com/vultr/vultr-csi)
+
+
+1. Install pre-requisites if needed:
+
+   * Terraform 1.1.7: https://www.terraform.io/downloads.html
+   * Docker: https://www.docker.com/products/docker-desktop
+   * Kubernetes cli: https://kubernetes.io/docs/tasks/tools/
+   
+   Once you have a VULTR account, log into VULTR, go into ACCOUNT -> API and obtain your Personal Access Token.
+   Configure the Access Control to whitelist the IP of the machine where you will run Terraform from.
+
+
+2. Clone the aptos-core repo and go to the terraform vultr folder.
+
+         $ git clone https://github.com/aptos-labs/aptos-core.git
+
+         $ cd aptos-core/terraform/fullnode/vultr
+
+3. Change the cluster Name in `cluster.tf`
+
+4. Configure cluster properties in `variables.tf`. 
+
+    The most important variable is `api_key`, make sure you use the API key obtained in step 1. It will create a 1 machine with 4CPU/8GB in Frankfurt per default.
+
+5. Apply the configuration with (it might take a while)
+        
+        $ terraform apply
+
+6. Configure your Kubernetes client:
+
+    Log in your VULTR account. Go to Products -> Kubernetes. Press  the 3 dots on the right side and choose "Manage".
+    Press Download Configuration, it will download a YAML containing the access config to your cluster.
+
+        $ export KUBECONFIG=~/vke...yaml
+
+7. Check that your fullnode pods are now running (this may take a few minutes):
+
+        $ kubectl get pods -n aptos
+
+8. Get your fullnode IP:
+
+        $ kubectl get svc -o custom-columns=IP:status.loadBalancer.ingress -n aptos
+
+9. Check REST API, make sure the ledge version is increasing.
+
+        $ curl http://<IP>
+
+10. To verify the correctness of your FullNode, as outlined in the documentation (https://aptos.dev/tutorials/run-a-fullnode/#verify-the-correctness-of-your-fullnode), you will need to set up a port-forwarding mechanism directly to the aptos pod in one ssh terminal and test it in another ssh terminal
+
+   * Set up the port-forwarding to the aptos-fullnode pod.  Use `kubectl get pods -n aptos` to get the name of the pod
+
+         $ kubectl port-forward -n aptos <pod-name> 9101:9101
+
+   * Open a new ssh terminal.  Execute the following curl calls to verify the correctness
+
+         $ curl -v http://0:9101/metrics 2> /dev/null | grep "aptos_state_sync_version{type=\"synced\"}"
+
+         $ curl -v http://0:9101/metrics 2> /dev/null | grep "aptos_connections{direction=\"outbound\""
+
+   * Exit port-forwarding when you are done by entering control-c in the terminal

--- a/terraform/fullnode/vultr/README.md
+++ b/terraform/fullnode/vultr/README.md
@@ -23,36 +23,46 @@ The default configuration will create a single node cluster with 4CPU/8GB and a 
 
          $ cd aptos-core/terraform/fullnode/vultr
 
-3. Change the cluster Name in `cluster.tf`
+3. Create a working directory for your configuration.  Copy the files you will change so it does not interfere with the cloned repo:
 
-4. Configure cluster properties in `variables.tf`. 
+   * Choose a workspace name e.g. `devnet`. Note: this defines terraform workspace name, which in turn is used to form resource names.
+
+         $ export WORKSPACE=devnet
+
+   * Create a directory for the workspace
+
+         $ mkdir -p ~/$WORKSPACE         
+
+4. Change the cluster Name in `cluster.tf`
+
+5. Configure cluster properties in `variables.tf`. 
 
     The most important variable is `api_key`, make sure you use the API key obtained in step 1. It will create a 1 machine with 4CPU/8GB in Frankfurt per default.
 
-5. Apply the configuration with (it might take a while)
+6. Apply the configuration with (it might take a while)
         
         $ terraform apply
 
-6. Configure your Kubernetes client:
+7. Configure your Kubernetes client:
 
     Log in your VULTR account. Go to Products -> Kubernetes. Press  the 3 dots on the right side and choose "Manage".
     Press Download Configuration, it will download a YAML containing the access config to your cluster.
 
         $ export KUBECONFIG=~/vke...yaml
 
-7. Check that your fullnode pods are now running (this may take a few minutes):
+8. Check that your fullnode pods are now running (this may take a few minutes):
 
         $ kubectl get pods -n aptos
 
-8. Get your fullnode IP:
+9. Get your fullnode IP:
 
         $ kubectl get svc -o custom-columns=IP:status.loadBalancer.ingress -n aptos
 
-9. Check REST API, make sure the ledge version is increasing.
+10. Check REST API, make sure the ledge version is increasing.
 
         $ curl http://<IP>
 
-10. To verify the correctness of your FullNode, as outlined in the documentation (https://aptos.dev/tutorials/run-a-fullnode/#verify-the-correctness-of-your-fullnode), you will need to set up a port-forwarding mechanism directly to the aptos pod in one ssh terminal and test it in another ssh terminal
+11. To verify the correctness of your FullNode, as outlined in the documentation (https://aptos.dev/tutorials/run-a-fullnode/#verify-the-correctness-of-your-fullnode), you will need to set up a port-forwarding mechanism directly to the aptos pod in one ssh terminal and test it in another ssh terminal
 
    * Set up the port-forwarding to the aptos-fullnode pod.  Use `kubectl get pods -n aptos` to get the name of the pod
 

--- a/terraform/fullnode/vultr/cluster.tf
+++ b/terraform/fullnode/vultr/cluster.tf
@@ -1,0 +1,16 @@
+resource "vultr_kubernetes" "k8" {
+  region  = var.fullnode_region
+  label   = "aptos-devnet"
+  version = "v1.23.5+3"
+
+  node_pools {
+    node_quantity = var.num_fullnodes
+    plan          = var.machine_type
+    label         = "aptos-fullnode"
+  }
+}
+
+resource "local_file" "kube_config" {
+  content  = base64decode(vultr_kubernetes.k8.kube_config)
+  filename = "${path.module}/vultr_kube_config.yml"
+}

--- a/terraform/fullnode/vultr/cluster.tf
+++ b/terraform/fullnode/vultr/cluster.tf
@@ -1,6 +1,6 @@
 resource "vultr_kubernetes" "k8" {
   region  = var.fullnode_region
-  label   = "aptos-devnet"
+  label   = "aptos-${terraform.workspace}"
   version = "v1.23.5+3"
 
   node_pools {

--- a/terraform/fullnode/vultr/kubernetes.tf
+++ b/terraform/fullnode/vultr/kubernetes.tf
@@ -1,0 +1,64 @@
+provider "kubernetes" {
+  config_path = local_file.kube_config.filename
+}
+
+resource "kubernetes_namespace" "aptos" {
+  metadata {
+    name = var.k8s_namespace
+  }
+}
+
+resource "kubernetes_storage_class" "ssd" {
+  metadata {
+    name = "ssd"
+  }
+  storage_provisioner = "block.csi.vultr.com"
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    block_type = "high_perf"
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = local_file.kube_config.filename
+  }
+}
+
+resource "helm_release" "fullnode" {
+  count            = var.num_fullnodes
+  name             = "${terraform.workspace}${count.index}"
+  chart            = "${path.module}/../../helm/fullnode"
+  max_history      = 100
+  wait             = false
+  namespace        = var.k8s_namespace
+  create_namespace = true
+
+  values = [
+    jsonencode({
+      chain = {
+        era = var.era
+      }
+      image = {
+        tag = var.image_tag
+      }
+      nodeSelector = {
+        "vke.vultr.com/node-pool" = "node"
+      }
+      storage = {
+        class = kubernetes_storage_class.ssd.metadata[0].name
+      }
+      service = {
+        type = "LoadBalancer"
+      }
+    }),
+    jsonencode(var.fullnode_helm_values),
+    jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),
+  ]
+
+  set {
+    name  = "timestamp"
+    value = var.helm_force_update ? timestamp() : ""
+  }
+}
+

--- a/terraform/fullnode/vultr/kubernetes.tf
+++ b/terraform/fullnode/vultr/kubernetes.tf
@@ -43,7 +43,7 @@ resource "helm_release" "fullnode" {
         tag = var.image_tag
       }
       nodeSelector = {
-        "vke.vultr.com/node-pool" = "node"
+        "vke.vultr.com/node-pool" = "aptos-fullnode"
       }
       storage = {
         class = kubernetes_storage_class.ssd.metadata[0].name

--- a/terraform/fullnode/vultr/main.tf
+++ b/terraform/fullnode/vultr/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    vultr = {
+      source  = "vultr/vultr"
+      version = "2.10.1"
+    }
+  }
+}
+
+provider "local" {}
+
+provider "vultr" {
+  api_key     = var.api_key
+  rate_limit  = 700
+  retry_limit = 3
+}

--- a/terraform/fullnode/vultr/variables.tf
+++ b/terraform/fullnode/vultr/variables.tf
@@ -1,0 +1,67 @@
+variable "helm_values" {
+  description = "Map of values to pass to Helm"
+  type        = any
+  default     = {}
+}
+
+variable "fullnode_helm_values" {
+  description = "Map of values to pass to public fullnode Helm"
+  type        = any
+  default     = {}
+}
+
+variable "fullnode_helm_values_list" {
+  description = "List of values to pass to public fullnode, for setting different value per node. length(fullnode_helm_values_list) must equal var.num_fullnodes"
+  type        = any
+  default     = {}
+}
+
+variable "helm_force_update" {
+  description = "Force Terraform to update the Helm deployment"
+  default     = false
+}
+
+variable "k8s_namespace" {
+  default     = "aptos"
+  description = "Kubernetes namespace that the fullnode will be deployed into"
+}
+
+variable "k8s_api_sources" {
+  description = "List of CIDR subnets which can access the Kubernetes API endpoint"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "num_fullnodes" {
+  default     = 1
+  description = "Number of fullnodes"
+}
+
+variable "image_tag" {
+  default     = "devnet"
+  description = "Docker image tag to use for the fullnode"
+}
+
+variable "era" {
+  description = "Chain era, used to start a clean chain"
+  default     = 1
+}
+
+variable "chain_id" {
+  description = "aptos chain ID"
+  default     = "DEVNET"
+}
+
+variable "machine_type" {
+  description = "Machine type for running fullnode. All configurations can be obtained at https://www.vultr.com/api/#tag/plans"
+  default     = "vc2-4c-8gb"
+}
+
+variable "api_key" {
+  description = "API Key, can be obtained at https://my.vultr.com/settings/#settingsapi"
+  default     = ""
+}
+
+variable "fullnode_region" {
+  description = "Geographical region for the node location. All 25 regions can be obtained at https://api.vultr.com/v2/regions"
+  default     = "fra"
+}


### PR DESCRIPTION

## Motivation

Extending the collection of Terraform scripts to just another hoster. VULTR (vultr.com). 
It is quite inexpensive and should reduce the barrier of running a fullnode.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

YES

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

Done.

## Test Plan

Tested within my own setup. 