### PR TITLE
[circleci] kubectl fix version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,8 @@ commands:
       - run: cat $HOME/.cargo/env >> $BASH_ENV
   deploy-setup:
     steps:
-      - kubernetes/install-kubectl
+      - kubernetes/install-kubectl:
+          kubectl-version: v1.23.4
       - run:
           name: Install Helm
           # https://helm.sh/docs/intro/install/#from-apt-debianubuntu

--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -273,8 +273,11 @@ test_res = 'failed'
 # perf report
 test_report = []
 read_lines = False
+read_error_caused_by = False
+error_caused_by = "Forge test failure"
 with open(f"{FORGE_OUTPUT_TEE}", 'r') as file:
     for line in file.readlines():
+        # get the json report
         if 'json-report-end' in line:
             read_lines = False
         if read_lines:
@@ -283,10 +286,23 @@ with open(f"{FORGE_OUTPUT_TEE}", 'r') as file:
             read_lines = True
         if 'test result: ok' in line:
             test_res = 'passed'
+
+        # attempt to get the error
+        if read_error_caused_by:
+            error_caused_by = line
+            read_error_caused_by = False
+        if 'Caused by:' in line:
+            read_error_caused_by = True
 if len(test_report) == 0:
-    # If Forge emits no report, return a generic error
+    # If Forge emits no report (during test setup), return a generic error
     test_report.append("{\"text\": \"Forge test runner is terminated\"}")
+
 temp_forge_report = json.loads(''.join(test_report))
+
+# If Forge emits a report but no text, attempt to return the failure
+if not temp_forge_report["text"]:
+    temp_forge_report["text"] = error_caused_by
+
 temp_forge_report["logs"] = LOGGING_LINK
 temp_forge_report["dashboard"] = DASHBOARD_LINK
 if args.report:


### PR DESCRIPTION
Seems to be version incompatibility with aws iam authenticator and kubectl version. 

```
error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
```

Digging deeper, saw that kubectl as installed via CircleCI orb are using the new 1.24.0 as of yesterday: https://kubernetes.io/blog/2022/05/03/kubernetes-1-24-release-announcement/, which seems to be incompatible. Downgrade this to 1.23.4

Test by writing canary https://github.com/aptos-labs/aptos-core/pull/796/commits/1bcfdea0dff89d1eb97563bb717bc808a64d1ff7, which just runs Forge. Forge job spins up right, so kubectl version fixed it: https://app.circleci.com/pipelines/github/aptos-labs/aptos-core/2791/workflows/63126a1b-2429-4eb7-9fc4-3b382dd1b2eb/jobs/13279

Also, while we're at it, attempt to return the crash error in Forge if the test runner emits an empty test report (happens when network spins up properly but tests fail before emitting report)