### PR TITLE
[aptos-cli] Add assume-no prompt option

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -282,11 +282,14 @@ impl FromStr for EncodingType {
 }
 
 /// An insertable option for use with prompts.
-#[derive(Debug, Parser)]
+#[derive(Clone, Copy, Debug, Parser)]
 pub struct PromptOptions {
     /// Assume yes for all yes/no prompts
-    #[clap(long)]
+    #[clap(long, group = "prompt_options")]
     pub assume_yes: bool,
+    /// Assume no for all yes/no prompts
+    #[clap(long, group = "prompt_options")]
+    pub assume_no: bool,
 }
 
 /// An insertable option for use with encodings.
@@ -407,7 +410,7 @@ pub struct SaveFile {
 impl SaveFile {
     /// Check if the key file exists already
     pub fn check_file(&self) -> CliTypedResult<()> {
-        check_if_file_exists(self.output_file.as_path(), self.prompt_options.assume_yes)
+        check_if_file_exists(self.output_file.as_path(), self.prompt_options)
     }
 
     /// Save to the `output_file`

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::types::{CliError, CliTypedResult},
+    common::types::{CliError, CliTypedResult, PromptOptions},
     CliResult,
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey};
@@ -149,17 +149,19 @@ impl<T> From<CliTypedResult<T>> for ResultWrapper<T> {
     }
 }
 
-/// Checks if a file exists, being overridden by `--assume-yes`
-pub fn check_if_file_exists(file: &Path, assume_yes: bool) -> CliTypedResult<()> {
-    if file.exists()
-        && !assume_yes
-        && !prompt_yes(
-            format!(
-                "{:?} already exists, are you sure you want to overwrite it?",
-                file.as_os_str()
-            )
-            .as_str(),
-        )
+/// Checks if a file exists, being overridden by `PromptOptions`
+pub fn check_if_file_exists(file: &Path, prompt_options: PromptOptions) -> CliTypedResult<()> {
+    let exists = file.exists();
+    if (exists && prompt_options.assume_no)
+        || (exists
+            && !prompt_options.assume_yes
+            && !prompt_yes(
+                format!(
+                    "{:?} already exists, are you sure you want to overwrite it?",
+                    file.as_os_str()
+                )
+                .as_str(),
+            ))
     {
         Err(CliError::AbortedError)
     } else {

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -89,7 +89,7 @@ impl CliCommand<()> for InitPackage {
 
     async fn execute(self) -> CliTypedResult<()> {
         let move_toml = self.package_dir.join(SourcePackageLayout::Manifest.path());
-        check_if_file_exists(move_toml.as_path(), self.prompt_options.assume_yes)?;
+        check_if_file_exists(move_toml.as_path(), self.prompt_options)?;
         create_dir_all(self.package_dir.join(SourcePackageLayout::Sources.path())).map_err(
             |err| {
                 CliError::IO(

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -212,10 +212,7 @@ impl SaveKey {
     pub fn check_key_file(&self) -> CliTypedResult<()> {
         // Check if file already exists
         self.file_options.check_file()?;
-        check_if_file_exists(
-            &self.public_key_file()?,
-            self.file_options.prompt_options.assume_yes,
-        )
+        check_if_file_exists(&self.public_key_file()?, self.file_options.prompt_options)
     }
 
     /// Saves a key to a file encoded in a string


### PR DESCRIPTION
## Motivation

I've kept the interactive prompts to keep people from shooting themselves in the foot by overwriting important keys.  However, for automation purposes, there is now an `--assume-no` to go with `--assume-yes` to cancel if it already exists.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
$ aptos key generate --output-file test.key
{
  "Result": {
    "PrivateKey Path": "test.key",
    "PublicKey Path": "test.key.pub"
  }
}

$ aptos key generate --output-file test.key --assume-no
{
  "Error": "Aborted command"
}

$ aptos key generate --output-file test.key --assume-yes
{
  "Result": {
    "PublicKey Path": "test.key.pub",
    "PrivateKey Path": "test.key"
  }
}

$ aptos key generate --output-file test.key
"test.key" already exists, are you sure you want to overwrite it? [yes/no] >
yes
"test.key.pub" already exists, are you sure you want to overwrite it? [yes/no] >
yes
{
  "Result": {
    "PublicKey Path": "test.key.pub",
    "PrivateKey Path": "test.key"
  }
}

$ aptos key generate --output-file test.key --assume-yes --assume-no
error: The argument '--assume-yes' cannot be used with '--assume-no'

USAGE:
    aptos key generate --output-file <OUTPUT_FILE> --output-file <OUTPUT_FILE> --assume-yes

```
