### PR TITLE
[web-wallet] PostMessage migration and production layout

### DIFF
--- a/ecosystem/web-wallet/public/contentscript.ts
+++ b/ecosystem/web-wallet/public/contentscript.ts
@@ -21,7 +21,7 @@ window.addEventListener('message', function (event) {
     // contentscript -> background
     chrome.runtime.sendMessage(event.data, function (response) {
       // contentscript -> inpage
-      window.postMessage( { responseMethod: event.data.method, id: event.data.id, response })
+      window.postMessage({ responseMethod: event.data.method, id: event.data.id, response })
     })
   }
 })

--- a/ecosystem/web-wallet/public/contentscript.ts
+++ b/ecosystem/web-wallet/public/contentscript.ts
@@ -14,3 +14,14 @@ function injectScript () {
 }
 
 injectScript()
+
+// inpage -> contentscript
+window.addEventListener('message', function (event) {
+  if (event.data.method) {
+    // contentscript -> background
+    chrome.runtime.sendMessage(event.data, function (response) {
+      // contentscript -> inpage
+      window.postMessage( { responseMethod: event.data.method, id: event.data.id, response })
+    })
+  }
+})

--- a/ecosystem/web-wallet/public/inpage.js
+++ b/ecosystem/web-wallet/public/inpage.js
@@ -1,31 +1,49 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-const extensionId = 'jmmhmakollmjgkjgnbeppkccgddmjnib'
-
 class Web3 {
+  requestId;
+
+  constructor() {
+    this.requestId = 0
+  }
+
   account () {
+    const id = this.requestId++
     return new Promise(function (resolve, reject) {
-      chrome.runtime.sendMessage(extensionId, { method: 'getAccountAddress' }, function (response) {
-        if (response.address) {
-          resolve(response.address)
-        } else {
-          reject(response.error ?? 'Error')
+      const method = 'getAccountAddress'
+      window.postMessage({ method, id })
+      window.addEventListener('message', function handler (event) {
+        if (event.data.responseMethod === method
+            && event.data.id === id ) {
+          const response = event.data.response
+          this.removeEventListener('message', handler);
+          if (response.address) {
+            resolve(response.address)
+          } else {
+            reject(response.error ?? 'Error')
+          }
         }
-        return true
       })
     })
   }
 
-  signTransaction (transaction, completion) {
+  signTransaction (transaction) {
+    const id = this.requestId++
     return new Promise(function (resolve, reject) {
-      chrome.runtime.sendMessage(extensionId, { method: 'signTransaction', transaction }, function (response) {
-        if (response.transaction) {
-          resolve(response.transaction)
-        } else {
-          reject(response.error ?? 'Error')
+      const method = 'signTransaction'
+      window.postMessage({ method, transaction, id})
+      window.addEventListener('message', function handler (event) {
+        if (event.data.responseMethod === method
+            && event.data.id === id ) {
+          const response = event.data.response
+          this.removeEventListener('message', handler);
+          if (response.transaction) {
+            resolve(response.transaction)
+          } else {
+            reject(response.error ?? 'Error')
+          }
         }
-        return true
       })
     })
   }

--- a/ecosystem/web-wallet/public/inpage.js
+++ b/ecosystem/web-wallet/public/inpage.js
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class Web3 {
-  requestId;
+  requestId
 
-  constructor() {
+  constructor () {
     this.requestId = 0
   }
 
@@ -14,10 +14,10 @@ class Web3 {
       const method = 'getAccountAddress'
       window.postMessage({ method, id })
       window.addEventListener('message', function handler (event) {
-        if (event.data.responseMethod === method
-            && event.data.id === id ) {
+        if (event.data.responseMethod === method &&
+            event.data.id === id) {
           const response = event.data.response
-          this.removeEventListener('message', handler);
+          this.removeEventListener('message', handler)
           if (response.address) {
             resolve(response.address)
           } else {
@@ -32,12 +32,12 @@ class Web3 {
     const id = this.requestId++
     return new Promise(function (resolve, reject) {
       const method = 'signTransaction'
-      window.postMessage({ method, transaction, id})
+      window.postMessage({ method, transaction, id })
       window.addEventListener('message', function handler (event) {
-        if (event.data.responseMethod === method
-            && event.data.id === id ) {
+        if (event.data.responseMethod === method &&
+            event.data.id === id) {
           const response = event.data.response
-          this.removeEventListener('message', handler);
+          this.removeEventListener('message', handler)
           if (response.transaction) {
             resolve(response.transaction)
           } else {

--- a/ecosystem/web-wallet/public/manifest.json
+++ b/ecosystem/web-wallet/public/manifest.json
@@ -18,9 +18,5 @@
   "background": {
     "scripts": ["background.ts"],
     "persistent": true
-  },
-  "externally_connectable": {
-    "matches": ["http://localhost/*"],
-    "ids": ["*"]
   }
 }

--- a/ecosystem/web-wallet/src/background.ts
+++ b/ecosystem/web-wallet/src/background.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosAccount, AptosClient, Types } from 'aptos'
-import { devnetNodeUrl } from './constants'
+import { DEVNET_NODE_URL } from './constants'
 import { MessageMethod } from './types'
 import { getAptosAccountState } from './utils/account'
 
-chrome.runtime.onMessageExternal.addListener(async function (request, _sender, sendResponse) {
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   const account = getAptosAccountState()
   if (account === undefined) {
     sendResponse({ error: 'No Accounts' })
@@ -20,11 +20,13 @@ chrome.runtime.onMessageExternal.addListener(async function (request, _sender, s
       signTransaction(account, request.transaction, sendResponse)
       break;
     default:
-      throw(request.method + ' method is not supported')
+      // method not handled
+      break;
   }
+  return true
 })
 
-function getAccountAddress( account: AptosAccount, sendResponse: (response?: any) => void) {
+function getAccountAddress (account: AptosAccount, sendResponse: (response?: any) => void) {
   if (account.address()) {
     sendResponse({ address: account.address().hex() })
   } else {
@@ -33,7 +35,7 @@ function getAccountAddress( account: AptosAccount, sendResponse: (response?: any
 }
 
 async function signTransaction (account: AptosAccount, transaction: Types.UserTransactionRequest, sendResponse: (response?: any) => void) {
-  const client = new AptosClient(devnetNodeUrl)
+  const client = new AptosClient(DEVNET_NODE_URL)
   const message = await client.createSigningMessage(transaction)
   const signatureHex = account.signHexString(message.substring(2))
   const transactionSignature = {

--- a/ecosystem/web-wallet/src/background.ts
+++ b/ecosystem/web-wallet/src/background.ts
@@ -15,13 +15,13 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   switch (request.method) {
     case MessageMethod.GET_ACCOUNT_ADDRESS:
       getAccountAddress(account, sendResponse)
-      break;
+      break
     case MessageMethod.SIGN_TRANSACTION:
       signTransaction(account, request.transaction, sendResponse)
-      break;
+      break
     default:
       // method not handled
-      break;
+      break
   }
   return true
 })

--- a/ecosystem/web-wallet/src/components/WithSimulatedExtensionContainer.tsx
+++ b/ecosystem/web-wallet/src/components/WithSimulatedExtensionContainer.tsx
@@ -46,47 +46,56 @@ function withSimulatedExtensionContainer<T> (Component: ComponentType<T>) {
       setSimulatedDimensions(fullscreenDimensions)
     }
 
-    return (
-      <VStack w="100vw" h="100vh" spacing={0}>
-        <Flex
-          flexDirection="row-reverse"
-          w="100%"
-          py={4}
-          bgColor={secondaryHeaderBgColor[colorMode]}
-        >
-          <HStack spacing={4} pr={4}>
-            <Button onClick={changeDimensionsToExtension}>
-              Extension
-            </Button>
-            <Button onClick={changeDimensionsToFullscreen}>
-              Full screen
-            </Button>
-            <IconButton
-              aria-label='dark mode'
-              icon={colorMode === 'dark' ? <SunIcon /> : <MoonIcon />}
-              onClick={() => setColorMode((colorMode === 'dark') ? 'light' : 'dark')}
-            />
-          </HStack>
-        </Flex>
-        <Center
-          w="100%"
-          h="100%"
-          bgColor={secondaryFlexBgColor[colorMode]}
-        >
+    if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
+      return (
+        <VStack w="100vw" h="100vh" spacing={0}>
+          <Flex
+              flexDirection="row-reverse"
+              w="100%"
+              py={4}
+              bgColor={secondaryHeaderBgColor[colorMode]}
+            >
+              <HStack spacing={4} pr={4}>
+                <Button onClick={changeDimensionsToExtension}>
+                  Extension
+                </Button>
+                <Button onClick={changeDimensionsToFullscreen}>
+                  Full screen
+                </Button>
+                <IconButton
+                  aria-label='dark mode'
+                  icon={colorMode === 'dark' ? <SunIcon /> : <MoonIcon />}
+                  onClick={() => setColorMode((colorMode === 'dark') ? 'light' : 'dark')}
+                />
+              </HStack>
+            </Flex>
           <Center
-            maxW={simulatedDimensions[0]}
-            maxH={simulatedDimensions[1]}
-            w={simulatedDimensions[0]}
-            h={simulatedDimensions[1]}
-            borderRadius=".5rem"
-            overflow="auto"
-            boxShadow={isFullScreen ? undefined : boxShadow}
+            w="100%"
+            h="100%"
+            bgColor={secondaryFlexBgColor[colorMode]}
           >
-            <Component {...hocProps} />
+            <Center
+              maxW={simulatedDimensions[0]}
+              maxH={simulatedDimensions[1]}
+              w={simulatedDimensions[0]}
+              h={simulatedDimensions[1]}
+              borderRadius=".5rem"
+              overflow="auto"
+              boxShadow={isFullScreen ? undefined : boxShadow}
+            >
+              <Component {...hocProps} />
+            </Center>
           </Center>
-        </Center>
-      </VStack>
-    )
+        </VStack>
+      )
+    } else {
+      setColorMode('dark')
+      return (
+        <VStack w="100vw" h="100vh" spacing={0}>
+          <Component {...hocProps} />
+        </VStack>
+      )
+    }
   }
   HOC.displayName = 'withSimulatedExtensionContainerHOC'
   return HOC

--- a/ecosystem/web-wallet/src/pages/Login.tsx
+++ b/ecosystem/web-wallet/src/pages/Login.tsx
@@ -84,7 +84,7 @@ function Login () {
           </Box>
         </Center>
         <Heading textAlign="center">Wallet</Heading>
-        <Text textAlign="center" pb={8} color={secondaryTextColor[colorMode]}>The official Aptos crypto wallet</Text>
+        <Text textAlign="center" pb={8} color={secondaryTextColor[colorMode]}>An Aptos crypto wallet</Text>
         <form onSubmit={handleSubmit(onSubmit)}>
           <VStack spacing={4}>
             <Center minW="100%" px={4}>


### PR DESCRIPTION
## Motivation
Using postMessage:
runtime.sendMessage was great buttttttt we had to define what hosts could use the extension and also provide a extension id which would change in development. postMessage between the injected script and the contentscript does not require any permissions so it will be better for the upcoming hackathon. It's not super pretty though so I filed a task (#805) to make this better, there are a bunch of things I already tried that didn't work so I'll fill out that issue more when I have time.

Layout in production mode:
When we build the app for extension we don't want to have the "extension"/"fullscreen" options.


## Test Plan

<img width="376" alt="Screen Shot 2022-05-04 at 8 45 53 PM" src="https://user-images.githubusercontent.com/19931667/166862456-2beb3ec6-1e7a-40e4-9d3a-d56534e3cb38.png">

