### PR TITLE
Fixing broken TokenClient SDK

### DIFF
--- a/ecosystem/typescript/sdk/src/api/Tables.ts
+++ b/ecosystem/typescript/sdk/src/api/Tables.ts
@@ -25,11 +25,11 @@ export class Tables<SecurityDataType = unknown> {
    * @tags state, table
    * @name GetTableItem
    * @summary Get table item by handle and key.
-   * @request POST:/tables/{table_handle}/items
+   * @request POST:/tables/{table_handle}/item
    */
   getTableItem = (tableHandle: string, data: TableItemRequest, params: RequestParams = {}) =>
     this.http.request<object, AptosError>({
-      path: `/tables/${tableHandle}/items`,
+      path: `/tables/${tableHandle}/item`,
       method: "POST",
       body: data,
       type: ContentType.Json,

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -2,11 +2,12 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 import { Accounts } from "./api/Accounts";
 import { Events } from "./api/Events";
 import { Transactions } from "./api/Transactions";
-import { HttpClient } from "./api/http-client";
+import { HttpClient, RequestParams } from "./api/http-client";
 import { HexString, MaybeHexString } from "./hex_string";
 import { sleep } from "./util";
 import { AptosAccount } from "./aptos_account";
 import { Types } from "./types";
+import { Tables } from "./api/Tables";
 
 export class RequestError extends Error {
   response?: AxiosResponse<any, Types.AptosError>;
@@ -46,6 +47,8 @@ export class AptosClient {
   // These are the different routes
   accounts: Accounts;
 
+  tables: Tables;
+
   events: Events;
 
   transactions: Transactions;
@@ -63,6 +66,7 @@ export class AptosClient {
 
     // Initialize routes
     this.accounts = new Accounts(this.client);
+    this.tables = new Tables(this.client);
     this.events = new Events(this.client);
     this.transactions = new Transactions(this.client);
   }
@@ -247,5 +251,14 @@ export class AptosClient {
         throw new Error(`Waiting for transaction ${txnHash} timed out!`);
       }
     }
+  }
+
+  async getTableItem(handle: string, data: Types.TableItemRequest, params?: RequestParams): Promise<any> {
+    const tableItem = await this.tables.getTableItem(
+      handle,
+      data,
+      params,
+    );
+    return tableItem;
   }
 }

--- a/ecosystem/typescript/sdk/src/token_client.test.ts
+++ b/ecosystem/typescript/sdk/src/token_client.test.ts
@@ -28,15 +28,19 @@ test(
 
     await tokenClient.createToken(
       alice,
-      "AliceCollection",
-      "AliceToken",
+      collection_name,
+      token_name,
       "Alice's simple token",
       1,
       "https://aptos.dev/img/nyan.jpeg",
     );
 
     // Transfer Token from Alice's Account to Bob's Account
-    const token_id = await tokenClient.getTokenId(alice.address().hex(), collection_name, token_name);
+    await tokenClient.getCollectionData(alice.address().hex(), collection_name);
+    await tokenClient.getTokenBalance(alice.address().hex(), collection_name, token_name);
+    await tokenClient.getTokenData(alice.address().hex(), collection_name, token_name);
+    await tokenClient.offerToken(alice, bob.address().hex(), alice.address().hex(), collection_name, token_name, 1);
+    await tokenClient.cancelTokenOffer(alice, bob.address().hex(), alice.address().hex(), collection_name, token_name);
     await tokenClient.offerToken(alice, bob.address().hex(), alice.address().hex(), collection_name, token_name, 1);
     await tokenClient.claimToken(bob, alice.address().hex(), alice.address().hex(), collection_name, token_name);
   },

--- a/ecosystem/typescript/sdk/src/token_client.ts
+++ b/ecosystem/typescript/sdk/src/token_client.ts
@@ -52,14 +52,13 @@ export class TokenClient {
   ): Promise<Types.HexEncodedBytes> {
     const payload: Types.TransactionPayload = {
       type: "script_function_payload",
-      function: "0x1::Token::create_limited_token_script",
+      function: "0x1::Token::create_unlimited_token_script",
       type_arguments: [],
       arguments: [
         Buffer.from(collectionName).toString("hex"),
         Buffer.from(name).toString("hex"),
         Buffer.from(description).toString("hex"),
         true,
-        supply.toString(),
         supply.toString(),
         Buffer.from(uri).toString("hex"),
       ],
@@ -129,7 +128,7 @@ export class TokenClient {
       function: "0x1::TokenTransfers::cancel_offer_script",
       type_arguments: [],
       arguments: [
-        sender,
+        receiver,
         creator,
         Buffer.from(collectionName).toString("hex"),
         Buffer.from(name).toString("hex"),
@@ -139,27 +138,75 @@ export class TokenClient {
     return transactionHash;
   }
 
-  // Retrieve the token's creation_num, which is useful for non-creator operations
-  async getTokenId(creator: MaybeHexString, collectionName: string, tokenName: string): Promise<number> {
-    const resources: Types.AccountResource[] = await this.aptosClient.getAccountResources(creator);
-    let collections: any[] = [];
-    let tokens = [];
+  async getCollectionData(
+    creator: MaybeHexString,
+    collectionName: string,
+  ): Promise<any> {
+    const resources = await this.aptosClient.getAccountResources(creator);
     const accountResource: { type: string; data: any } = resources.find((r) => r.type === "0x1::Token::Collections");
-    collections = accountResource.data.collections.data;
+    const { handle }: { handle: string } = accountResource.data.collections;
+    const getCollectionTableItemRequest: Types.TableItemRequest = {
+      key_type: "0x1::ASCII::String",
+      value_type: "0x1::Token::Collection",
+      key: collectionName,
+    };
+    // eslint-disable-next-line no-unused-vars
+    const collectionTable = await this.aptosClient.getTableItem(
+      handle,
+      getCollectionTableItemRequest,
+    );
+    return collectionTable;
+  }
 
-    for (let index = 0; index < collections.length; index += 1) {
-      if (collections[index].key === collectionName) {
-        tokens = collections[index].value.tokens.data;
-        break;
-      }
-    }
+  // Retrieve the token's creation_num, which is useful for non-creator operations
+  async getTokenData(creator: MaybeHexString, collectionName: string, tokenName: string): Promise<number> {
+    const collection: { type: string, data: any } = await this.aptosClient.getAccountResource(
+      creator,
+      "0x1::Token::Collections",
+    );
+    const { handle } = collection.data.token_data;
+    const tokenId = {
+      creator,
+      collection: collectionName,
+      name: tokenName,
+    };
 
-    for (let index = 0; index < tokens.length; index += 1) {
-      if (tokens[index].key === tokenName) {
-        return parseInt(tokens[index].value.id.creation_num, 10);
-      }
-    }
+    const getTokenTableItemRequest: Types.TableItemRequest = {
+      key_type: "0x1::Token::TokenId",
+      value_type: "0x1::Token::TokenData",
+      key: tokenId,
+    };
 
-    return null;
+    const tableItem = await this.aptosClient.getTableItem(
+      handle,
+      getTokenTableItemRequest,
+    );
+    return tableItem;
+  }
+
+  // Retrieve the token's creation_num, which is useful for non-creator operations
+  async getTokenBalance(creator: MaybeHexString, collectionName: string, tokenName: string): Promise<number> {
+    const tokenStore: { type: string, data: any } = await this.aptosClient.getAccountResource(
+      creator,
+      "0x1::Token::TokenStore",
+    );
+    const { handle } = tokenStore.data.tokens;
+    const tokenId = {
+      creator,
+      collection: collectionName,
+      name: tokenName,
+    };
+
+    const getTokenTableItemRequest: Types.TableItemRequest = {
+      key_type: "0x1::Token::TokenId",
+      value_type: "0x1::Token::Token",
+      key: tokenId,
+    };
+
+    const tableItem = await this.aptosClient.getTableItem(
+      handle,
+      getTokenTableItemRequest,
+    );
+    return tableItem;
   }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The TokenClient for the Typescript SDK was broken. Summary of the issues are listed below for future reference:
1. The Tables API was missing on the AptosClient and missing functions like `getTableItem` which is needed for getting collections and tokens. 
2. Tests were failing for the TokenClient because of incorrect payload arguments and incorrect url fetching. For example `create_limited_token_script` was being used where it should have been `create_unlimited_token_script`. Furthermore, `/tables/${tableHandle}/items` should have been `/tables/${tableHandle}/item` for fetching table items
3. Functions were outdated (ie. `getTokenId` was replaced with `getTokenBalance` and `getTokenData`)
4. TokenClient is now at 100% coverage. 

We should discuss ways to prevent this in the future as there are multiple potential points of failure and takes time to debug. A few suggestions:

1. Stronger type-checking on requests and responses from the sdk
2. Stronger error checking, more useful error messaging from the sdk
3. Ensuring CI/CD runs testing properly
4. Maybe we could create rust / typescript interface bindings for functions to ensure uniform behavior across all language implementations
5. Pass params as dictionaries (this is more explicit) and will remove confusion around ordering of params
```javascript
// instead of 
async getTokenBalance(creator: MaybeHexString, collectionName: string, tokenName: string) { ... }

// do this
interface GetTokenBalanceProps {
  creator: MaybeHexString;
  collectionName: string;
  tokenName: string;
}

async getTokenBalance({ 
  creator,
  collectionName, 
  tokenName 
}: GetTokenBalanceProps) { ... }
```

Will Run NPM Publish after PR is landed and merged

## Test Plan

Before

```bash
 PASS  src/util.test.ts
 PASS  src/hex_string.test.ts
 PASS  src/aptos_account.test.ts
 PASS  src/aptos_client.test.ts
 FAIL  src/token_client.test.ts (5.569 s)
 PASS  src/faucet_client.test.ts (7.333 s)
------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------|---------|----------|---------|---------|-------------------
All files         |   89.44 |    86.66 |   94.33 |   89.65 |                   
 aptos_account.ts |     100 |      100 |     100 |     100 |                   
 aptos_client.ts  |   97.53 |       90 |     100 |    97.5 | 232,247           
 faucet_client.ts |     100 |      100 |     100 |     100 |                   
 hex_string.ts    |     100 |      100 |     100 |     100 |                   
 token_client.ts  |   55.26 |        0 |   66.66 |   54.28 | 80-139,151-163    
 util.ts          |     100 |      100 |     100 |     100 |                   
------------------|---------|----------|---------|---------|-------------------
```

Now
```bash
 PASS  src/hex_string.test.ts
 PASS  src/aptos_account.test.ts
 PASS  src/util.test.ts
 PASS  src/aptos_client.test.ts
 PASS  src/faucet_client.test.ts (7.123 s)
 PASS  src/token_client.test.ts (15.559 s)
------------------|---------|----------|---------|---------|-------------------
File              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------------|---------|----------|---------|---------|-------------------
All files         |   99.46 |    96.42 |     100 |   99.45 |                   
 aptos_account.ts |     100 |      100 |     100 |     100 |                   
 aptos_client.ts  |   98.82 |       95 |     100 |    98.8 | 251               
 faucet_client.ts |     100 |      100 |     100 |     100 |                   
 hex_string.ts    |     100 |      100 |     100 |     100 |                   
 token_client.ts  |     100 |      100 |     100 |     100 |                   
 util.ts          |     100 |      100 |     100 |     100 |                   
------------------|---------|----------|---------|---------|-------------------

Test Suites: 6 passed, 6 total
Tests:       26 passed, 26 total
Snapshots:   0 total
Time:        16.09 s
Ran all test suites.
✨  Done in 16.95s.
```
