### PR TITLE
trivial: hack around IDE bug

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -187,10 +187,7 @@ impl RocksdbPropertyReporter {
                 );
             }
             // report rocksdb properties each 10 seconds
-            #[cfg(not(test))]
-            const TIMEOUT_MS: u64 = 10000;
-            #[cfg(test)]
-            const TIMEOUT_MS: u64 = 10;
+            const TIMEOUT_MS: u64 = if cfg!(test) { 10 } else { 10000 };
 
             match recv.recv_timeout(Duration::from_millis(TIMEOUT_MS)) {
                 Ok(_) => break,

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -44,10 +44,7 @@ use storage_interface::DbReaderWriter;
 use structopt::StructOpt;
 use tokio::io::BufReader;
 
-#[cfg(not(test))]
-const BATCH_SIZE: usize = 10000;
-#[cfg(test)]
-const BATCH_SIZE: usize = 2;
+const BATCH_SIZE: usize = if cfg!(test) { 2 } else { 10000 };
 
 #[derive(StructOpt)]
 pub struct TransactionRestoreOpt {


### PR DESCRIPTION


## Motivation

CLion currently has difficalty indexing `#[cfg(not(test))]`, and this
gets around that

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y

## Test Plan
Now I can search for things around AptosDB in my IDE