### PR TITLE
[API] fix spec

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -460,7 +460,7 @@ paths:
           $ref: '#/components/responses/404'
         "500":
           $ref: '#/components/responses/500'
-  /tables/{table_handle}/items:
+  /tables/{table_handle}/item:
     post:
       summary: Get table item by handle and key.
       description: |


### PR DESCRIPTION


## Motivation

/tables/{handle}/items -> /tables/{handle}/item

Caused the Typescript API to be generated wrong, and https://github.com/aptos-labs/aptos-core/pull/812 had to fix it manually.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y
## Test Plan

`make` in the API folder