### PR TITLE
Changing expiration timestamp to 10 seconds from now

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -149,8 +149,8 @@ export class AptosClient {
       max_gas_amount: "1000",
       gas_unit_price: "1",
       gas_currency_code: "XUS",
-      // Unix timestamp, in seconds + 10 minutes
-      expiration_timestamp_secs: (Math.floor(Date.now() / 1000) + 600).toString(),
+      // Unix timestamp, in seconds + 10 seconds
+      expiration_timestamp_secs: (Math.floor(Date.now() / 1000) + 10).toString(),
       payload,
       ...(options || {}),
     };


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is related to a bug on how transactions are discarded.

Steps to repro:
1. Send an amount to another address such that amount + gas > balance. For example account balance = 1000, transfer amount = 999
2. Submit transaction and wait
3. Returns: Waiting for transaction 0xa888e02ca4e774e25a00752bfb518f1c63976f6064b78e8d94e46c9d668e989b timed out!
4. When you try to submit another transaction, it sends back
```json
{
  "code": 400,
  "message": "transaction is rejected: InvalidUpdate - Transaction already in mempool"
}
```
```json
{
  "signature": {
    "type": "ed25519_signature",
    "public_key": "0xde7b6f1d5998aa3ea4a49ff2305fe994e3a0a4fa438dba95bceac4fd5b33246e",
    "signature": "0x7d8962d66c4360ab9c479b29176bd30c45a39bd4679440df9adcb3b12278be6b792895bf68f9c67fefb33381a52539ffd16c1810e3edaf300d3f0d8fb373b40d"
  },
  "sender": "0x43dd16f52fe5c24644333e7fecc9d5f4d11725cfe62d50b662c2aa1d3505e655",
  "sequence_number": "1",
  "max_gas_amount": "1000",
  "gas_unit_price": "1",
  "gas_currency_code": "XUS",
  "expiration_timestamp_secs": "1651790489",
  "payload": {
    "type": "script_function_payload",
    "function": "0x1::TestCoin::transfer",
    "type_arguments": [],
    "arguments": [
      "0xc49fadd94d749b527f6e100f0526d2af836d0cc9c187d1d86a34af18ebd6acd4",
      "5113"
    ]
  }
}
```

Current hypothesis is that transaction is executed and fails, but because it is not committed to the ledger, mempool does not discard the transaction until the expiration time has exceeded. For some reason though, it doesn't charge gas for the transaction. Ideal behavior is that the transaction simply fails at execution, gas is charged, failed transaction is added to the ledger, this is propogated through state sync, and then mempool purges that transaction. For the time being, I'm changing the default expiration to 10 seconds instead of 10 minutes

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

N/A
