### PR TITLE
[telemetry] add metrics for node connectivity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,6 @@ dependencies = [
  "network",
  "network-builder",
  "rand 0.8.4",
- "regex",
  "state-sync-multiplexer",
  "state-sync-v1",
  "storage-client",
@@ -941,6 +940,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_json",
  "sysinfo",
+ "tokio",
  "uuid",
 ]
 
@@ -5312,6 +5312,7 @@ dependencies = [
  "aptos-metrics",
  "aptos-proptest-helpers",
  "aptos-rate-limiter",
+ "aptos-telemetry",
  "aptos-time-service",
  "aptos-types",
  "aptos-workspace-hack",

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -16,7 +16,6 @@ futures = "0.3.12"
 hex = "0.4.3"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 rand = "0.8.3"
-regex = "1.5.5"
 structopt = "0.3.21"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"

--- a/crates/aptos-metrics/src/metric_server.rs
+++ b/crates/aptos-metrics/src/metric_server.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    gather_metrics, json_encoder::JsonEncoder, json_metrics::get_json_metrics,
-    public_metrics::PUBLIC_METRICS, system_metrics::refresh_system_metrics, NUM_METRICS,
+    gather_metrics,
+    json_encoder::JsonEncoder,
+    json_metrics::get_json_metrics,
+    public_metrics::{PUBLIC_JSON_METRICS, PUBLIC_METRICS},
+    system_metrics::refresh_system_metrics,
+    NUM_METRICS,
 };
 use futures::future;
 use hyper::{
@@ -90,7 +94,7 @@ pub fn get_public_metrics() -> HashMap<String, String> {
 
 pub fn get_public_json_metrics() -> HashMap<&'static str, String> {
     let jmet = get_json_metrics();
-    whitelist_json_metrics(jmet, PUBLIC_METRICS)
+    whitelist_json_metrics(jmet, PUBLIC_JSON_METRICS)
 }
 
 // filtering metrics from the prometheus collections
@@ -167,7 +171,7 @@ async fn serve_public_metrics(req: Request<Body>) -> Result<Response<Body>, hype
         }
         (&Method::GET, "/json_metrics") => {
             let json_metrics = get_json_metrics();
-            let whitelist_json_metrics = whitelist_json_metrics(json_metrics, PUBLIC_METRICS);
+            let whitelist_json_metrics = whitelist_json_metrics(json_metrics, PUBLIC_JSON_METRICS);
             let encoded_metrics = serde_json::to_string(&whitelist_json_metrics).unwrap();
             *resp.body_mut() = Body::from(encoded_metrics);
         }

--- a/crates/aptos-metrics/src/public_metrics.rs
+++ b/crates/aptos-metrics/src/public_metrics.rs
@@ -2,16 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // A list of metrics which will be made public
-pub const PUBLIC_METRICS: &[&str] = &[
-    // aptos metrics
-    "aptos_connections",
-    "aptos_state_sync_version",
-    // binary metadata
+pub const PUBLIC_METRICS: &[&str] = &["aptos_connections"];
+
+pub const PUBLIC_JSON_METRICS: &[&str] = &[
+    // git revision of the build
     "revision",
     // system info
-    "system_name",
-    "system_kernel_version",
-    "system_os_version",
     "system_total_memory",
     "system_used_memory",
     "system_physical_core_count",

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -14,6 +14,7 @@ reqwest = { version = "0.11.10", features = ["json"] }
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = "1.0.81"
 sysinfo = "0.23.11"
+tokio = { version = "1.8.1" }
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
 aptos-logger = { path = "../../crates/aptos-logger" }

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -12,12 +12,27 @@ pub const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
 pub const HTTPBIN_URL: &str = "http://httpbin.org/ip";
 pub const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
 
+// Timeouts
+pub const NETWORK_PUSH_TIME_SECS: u64 = 30;
+pub const NODE_PUSH_TIME_SECS: u64 = 30;
+
 // Metrics events
-pub const APTOS_NODE_PUSH_METRICS: &str = "APTOS_NODE_PUSH_METRICS";
 pub const APTOS_CLI_PUSH_METRICS: &str = "APTOS_CLI_PUSH_METRICS";
+pub const APTOS_NETWORK_PUSH_METRICS: &str = "APTOS_NETWORK_PUSH_METRICS";
+pub const APTOS_NODE_PUSH_METRICS: &str = "APTOS_NODE_PUSH_METRICS";
 
 // Metrics names
-pub const IP_ADDR_METRIC: &str = "IP_ADDRESS";
+// Environment metrics
 pub const GIT_REV_METRIC: &str = "GIT_REV";
+pub const IP_ADDR_METRIC: &str = "IP_ADDRESS";
+
+// Node metrics
 pub const CHAIN_ID_METRIC: &str = "CHAIN_ID";
 pub const PEER_ID_METRIC: &str = "PEER_ID";
+pub const SYNCED_VERSION_METRIC: &str = "SYNCED_VERSION";
+
+// Network metrics
+pub const NETWORK_ID_METRIC: &str = "NETWORK_ID";
+pub const ORIGIN_METRIC: &str = "ORIGIN";
+pub const PEERS_CONNECTED_METRIC: &str = "PEERS_CONNECTED";
+pub const ROLE_METRIC: &str = "ROLE";

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -73,7 +73,7 @@ pub async fn to_common_result<T: Serialize>(
         "None"
     };
     let metrics = collect_metrics(command, !is_err, latency, error);
-    aptos_telemetry::send_data(
+    aptos_telemetry::send_env_data(
         APTOS_CLI_PUSH_METRICS.to_string(),
         uuid::Uuid::new_v4().to_string(),
         metrics,

--- a/devtools/x/build.rs
+++ b/devtools/x/build.rs
@@ -1,0 +1,7 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    // disables telemetry for all x commands by setting environment variable
+    println!("cargo:rustc-env=APTOS_TELEMETRY_DISABLE={}", 1);
+}

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -43,6 +43,7 @@ aptos-logger = { path = "../crates/aptos-logger" }
 aptos-metrics = { path = "../crates/aptos-metrics" }
 aptos-proptest-helpers = { path = "../crates/aptos-proptest-helpers", optional = true }
 aptos-rate-limiter = { path = "../crates/aptos-rate-limiter"}
+aptos-telemetry = { path = "../crates/aptos-telemetry" }
 aptos-time-service = { path = "../crates/aptos-time-service", features = ["async"] }
 aptos-types = { path = "../types" }
 aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }

--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -287,9 +287,9 @@ with open(f"{FORGE_OUTPUT_TEE}", 'r') as file:
         if 'test result: ok' in line:
             test_res = 'passed'
 
-        # attempt to get the error
-        if read_error_caused_by:
-            error_caused_by = line
+        # attempt to get the error as the first non-null line
+        if read_error_caused_by and line:
+            error_caused_by = line.strip()
             read_error_caused_by = False
         if 'Caused by:' in line:
             read_error_caused_by = True

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -261,7 +261,7 @@ pub fn run_forge<F: Factory>(
         }
         Err(e) => {
             eprintln!("Failed to run tests:\n{}", e);
-            process::exit(101); // Exit with a non-zero exit code if tests failed
+            Err(e)
         }
     }
 }


### PR DESCRIPTION
Instrument the network's connectivity_manager with `report_network_metrics`, which optionally reports metrics at a cadence.  It reports inbound and outbound peers separately. This will allow us to understand the network topology without having to crawl the network. 

Few improvements to telemetry system:
* split telemetry utilities into two functions `send_data` and `send_env_data`, the latter containing a superset of the former, along with environment data like build and system information
* disable telemetry during tests with build script in `x` to set the opt-out env var
* don't block on telemetry requests in various places

Few improvements to the metrics server:
* split `PUBLIC_METRICS` from `PUBLIC_JSON_METRICS`. it was confusing to use the same filter but on different types of metrics sources
* remove `aptos_state_sync_version` from public JSON metrics, instead choosing to get it directly into aptos-node telemetry

Note:
* Note that GA4 has a limit of 25 custom parameters per event, so the reporting logic chunks up payloads into the maximum size. Depending on the maximum number of peers, this could get quite large.

Test: run local node and see peer telemetry flow in. Also run on Forge and see no performance diff.