### PR TITLE
[helm][logging] disable blackhole sink

### DIFF
--- a/terraform/helm/logger/files/vector.toml
+++ b/terraform/helm/logger/files/vector.toml
@@ -25,11 +25,7 @@
   fields.owner = "{{ required "logger.name must be set" .Values.logger.name }}"
   fields.chain_name = "{{ required "chain.name must be set" .Values.chain.name }}"
 
-{{- if .Values.loggingToNull }}
-[sinks.null]
-  type = "blackhole"
-  inputs = ["add_fields"] # required
-{{- else }}
+{{- if .Values.loggingCentralHost }}
 [sinks.http_output]
   # General
   type = "http" # required

--- a/terraform/helm/logger/templates/logging.yaml
+++ b/terraform/helm/logger/templates/logging.yaml
@@ -9,7 +9,7 @@ data:
 {{ (tpl (.Files.Get "files/vector.toml") .) | indent 4 }}
 
 ---
-{{- if not .Values.loggingToNull }}
+{{- if .Values.loggingCentralHost }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -75,7 +75,7 @@ spec:
       - name: vector-config
         configMap:
           name: {{ include "aptos-logger.fullname" . }}-vector
-      {{- if not .Values.loggingToNull }}
+      {{- if .Values.loggingCentralHost }}
       - name: vector-secret
         secret:
           secretName: {{ include "aptos-logger.fullname" . }}-vector
@@ -111,7 +111,7 @@ spec:
         - name: vector-config
           mountPath: /etc/vector
           readOnly: true
-        {{- if not .Values.loggingToNull }}
+        {{- if .Values.loggingCentralHost }}
         - name: vector-secret
           mountPath: /etc/vector/cert
         {{- end }}

--- a/terraform/helm/logger/values.yaml
+++ b/terraform/helm/logger/values.yaml
@@ -36,4 +36,3 @@ loggingClientCert: ""
 loggingClientKey: ""
 loggingCA: ""
 loggingCentralHost: ""
-loggingToNull: true

--- a/terraform/helm/validator/files/vector.toml
+++ b/terraform/helm/validator/files/vector.toml
@@ -26,11 +26,7 @@
   fields.revision = "{{ .Values.imageTag }}"
   fields.chain_name = "{{ required "chain.name must be set" .Values.chain.name }}"
 
-{{- if .Values.loggingToNull }}
-[sinks.null]
-  type = "blackhole"
-  inputs = ["add_fields"] # required
-{{- else }}
+{{- if .Values.loggingCentralHost }}
 [sinks.http_output]
   # General
   type = "http" # required

--- a/terraform/helm/validator/templates/logging.yaml
+++ b/terraform/helm/validator/templates/logging.yaml
@@ -9,7 +9,7 @@ data:
 {{ (tpl (.Files.Get "files/vector.toml") .) | indent 4 }}
 
 ---
-{{- if not .Values.loggingToNull }}
+{{- if .Values.loggingCentralHost }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -76,7 +76,7 @@ spec:
       - name: vector-config
         configMap:
           name: {{ include "aptos-validator.fullname" . }}-vector
-      {{- if not .Values.loggingToNull }}
+      {{- if .Values.loggingCentralHost }}
       - name: vector-secret
         secret:
           secretName: {{ include "aptos-validator.fullname" . }}-vector
@@ -112,7 +112,7 @@ spec:
         - name: vector-config
           mountPath: /etc/vector
           readOnly: true
-        {{- if not $.Values.loggingToNull }}
+        {{- if $.Values.loggingCentralHost }}
         - name: vector-secret
           mountPath: /etc/vector/cert
         {{- end }}

--- a/terraform/helm/validator/values.yaml
+++ b/terraform/helm/validator/values.yaml
@@ -350,7 +350,6 @@ loggingClientCert:
 loggingClientKey:
 loggingCA:
 loggingCentralHost:
-loggingToNull: true
 
 # Used for testing purposes only!
 # Exposes the validator's REST API in addition to that of its VFN


### PR DESCRIPTION
Remove the `loggingToNull` value, as it's misleading when used with additional outputs: `.Values.logging.vector.outputs`. Instead, you can just leave the logging config blank, and not specify `.Values.logging.vector.outputs` or `.Values.loggingCentralHost`.
