### PR TITLE
[consensus] extend the number of events leader reputation seeks

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -98,6 +98,15 @@ pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+/// The number of block events the LeaderReputation uses
+pub static LEADER_REPUTATION_WINDOW_SIZE: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_leader_reputation_window_size",
+        "Total number of new block events in the current reputation window"
+    )
+    .unwrap()
+});
+
 //////////////////////
 // RoundState COUNTERS
 //////////////////////

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -186,6 +186,7 @@ impl EpochManager {
             ConsensusProposerType::LeaderReputation(heuristic_config) => {
                 let backend = Box::new(AptosDBBackend::new(
                     proposers.len(),
+                    onchain_config.leader_reputation_exclude_round() + 10,
                     self.storage.aptos_db(),
                 ));
                 let heuristic = Box::new(ActiveInactiveHeuristic::new(


### PR DESCRIPTION
It's oversight from the decoupled execution that we don't seek further enough to have all required block events.

The target round is current round - exclude_round (was 4 before decoupled execution), and the seek length is window_size + 10.
it ends up being the case that all events we fetch have higher round than the target round and being filtered out.

This commit takes the exclude_round into consideration when seeking events so hopefully it can get enough events back.

