### PR TITLE
[scratchpad] new_node_hashes_since()

### DIFF
--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 arc-swap = "1.2.0"
-bitvec = {version = "0.19.4", optional = true}
+bitvec = { version = "0.19.4" }
 itertools = "0.10.0"
 once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
@@ -25,7 +25,6 @@ aptos-workspace-hack = { version = "0.1", path = "../../crates/aptos-workspace-h
 
 
 [dev-dependencies]
-bitvec = "0.19.4"
 criterion = "0.3.4"
 rand = "0.8.3"
 once_cell = "1.7.2"
@@ -35,8 +34,8 @@ aptos-types = { path = "../../types", features = ["fuzzing"] }
 storage-interface = { path = "../storage-interface" }
 
 [features]
-fuzzing = ["bitvec", "aptos-types/fuzzing", "proptest"]
-bench = ["bitvec", "proptest"]
+fuzzing = ["aptos-types/fuzzing", "proptest"]
+bench = ["proptest"]
 
 [[bench]]
 name = "sparse_merkle"

--- a/types/src/nibble/nibble_path/mod.rs
+++ b/types/src/nibble/nibble_path/mod.rs
@@ -211,6 +211,15 @@ impl NibblePath {
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
+
+    pub fn truncate(&mut self, len: usize) {
+        assert!(len <= self.num_nibbles);
+        self.num_nibbles = len;
+        self.bytes.truncate((len + 1) / 2);
+        if len % 2 != 0 {
+            *self.bytes.last_mut().expect("must exist.") &= 0xf0;
+        }
+    }
 }
 
 pub trait Peekable: Iterator {


### PR DESCRIPTION


## Motivation
Get newly created node hashes by traversing the diff on top of a base
generation, instead of looking up the tree by updated leaves. This is
more efficient.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y
## Test Plan
existing coverage