### PR TITLE
[aptos-cli] Add shell completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "bcs",
  "cached-framework-packages",
  "clap 3.1.17",
+ "clap_complete",
  "executor",
  "framework",
  "hex",
@@ -1922,6 +1923,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da92e6facd8d73c22745a5d3cbb59bdf8e46e3235c923e516527d8e81eec14a4"
+dependencies = [
+ "clap 3.1.17",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2625,7 +2635,7 @@ dependencies = [
  "diesel_derives",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.1.43",
+ "num-traits 0.2.15",
  "pq-sys",
  "r2d2",
  "serde_json",
@@ -7206,7 +7216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0bccbcf40c8938196944a3da0e133e031a33f4d6b72db3bda3cc556e361905d"
 dependencies = [
  "lazy_static 1.4.0",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -8564,7 +8574,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -63,4 +63,53 @@ storage-interface = { path = "../../storage/storage-interface" }
 vm-genesis = { path = "../../aptos-move/vm-genesis" }
 
 [build-dependencies]
+clap_complete = "3.1.3"
+anyhow = "1.0.52"
+async-trait = "0.1.42"
+base64 = "0.13.0"
+clap = "3.1.8"
+hex = "0.4.3"
+itertools = "0.10.3"
+rand = "0.8.3"
+reqwest = { version = "0.11.2", features = ["blocking", "json"] }
+serde = "1.0.124"
+serde_json = "1.0.64"
+serde_yaml = "0.8.17"
 shadow-rs = "0.11.0"
+thiserror = "1.0.24"
+tempfile = "3.2.0"
+tokio = { version = "1.8.1", features = ["full"] }
+tokio-util = { version = "0.6.4", features = ["compat"] }
+toml = "0.5.9"
+uuid = { version = "0.8.2", features = ["v4", "serde"] }
+
+aptos-config = { path = "../../config" }
+aptos-crypto = { path = "../aptos-crypto" }
+aptos-logger = { path = "../aptos-logger" }
+aptos-management = { path = "../../config/management" }
+aptos-secure-storage = { path = "../../secure/storage" }
+aptos-github-client = { path = "../../secure/storage/github" }
+aptos-telemetry = { path = "../aptos-telemetry" }
+aptos-temppath = { path = "../aptos-temppath" }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
+aptos-types = { path = "../../types" }
+aptos-sdk = { path = "../../sdk" }
+aptos-rest-client = { path = "../../crates/aptos-rest-client"}
+aptos-vm = { path = "../../aptos-move/aptos-vm" }
+bcs = "0.1.2"
+short-hex-str = { path = "../short-hex-str" }
+cached-framework-packages =  { path = "../../aptos-move/framework/cached-packages" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-cli = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
+move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["testing"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["testing"] }
+framework = { path = '../../aptos-move/framework' }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+vm-genesis = { path = "../../aptos-move/vm-genesis" }
+storage-interface = { path = "../../storage/storage-interface" }
+aptosdb = { path = "../../storage/aptosdb" }
+executor = { path = "../../execution/executor" }

--- a/crates/aptos/build.rs
+++ b/crates/aptos/build.rs
@@ -1,6 +1,54 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::{Command, Subcommand};
+use clap_complete::{generate_to, shells::Bash, shells::Fish, shells::Zsh, shells::PowerShell};
+use std::env;
+
+include!("src/lib.rs");
+
 fn main() -> shadow_rs::SdResult<()> {
+
+    let outdir = match env::var_os("OUT_DIR") {
+        None => return Ok(()),
+        Some(outdir) => outdir,
+    };
+    let cmd = Command::new("aptos");
+    let mut cmd = Tool::augment_subcommands(cmd);
+    let path = generate_to(
+        Bash,
+        &mut cmd, // We need to specify what generator to use
+        "aptos",  // We need to specify the bin name manually
+        outdir.clone(),   // We need to specify where to write to
+    )?;
+
+    println!("cargo:warning=completion file is generated: {:?}", path);
+
+    let path = generate_to(
+        Fish,
+        &mut cmd, // We need to specify what generator to use
+        "aptos",  // We need to specify the bin name manually
+        outdir.clone(),   // We need to specify where to write to
+    )?;
+
+    println!("cargo:warning=completion file is generated: {:?}", path);
+
+    let path = generate_to(
+        PowerShell,
+        &mut cmd, // We need to specify what generator to use
+        "aptos",  // We need to specify the bin name manually
+        outdir.clone(),   // We need to specify where to write to
+    )?;
+
+    println!("cargo:warning=completion file is generated: {:?}", path);
+
+    let path = generate_to(
+        Zsh,
+        &mut cmd, // We need to specify what generator to use
+        "aptos",  // We need to specify the bin name manually
+        outdir,   // We need to specify where to write to
+    )?;
+
+    println!("cargo:warning=completion file is generated: {:?}", path);
     shadow_rs::new()
 }

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -17,7 +17,6 @@ use itertools::Itertools;
 use move_core_types::account_address::AccountAddress;
 use reqwest::Url;
 use serde::Serialize;
-use shadow_rs::shadow;
 use std::{
     collections::{BTreeMap, HashMap},
     env,
@@ -27,8 +26,6 @@ use std::{
     str::FromStr,
     time::{Duration, Instant},
 };
-
-shadow!(build);
 
 /// Prompts for confirmation until a yes or no is given explicitly
 pub fn prompt_yes(prompt: &str) -> bool {
@@ -100,38 +97,6 @@ fn collect_metrics(
     metrics.insert("Command".to_string(), command.to_string());
     metrics.insert("Successful".to_string(), successful.to_string());
     metrics.insert("Error".to_string(), error.to_string());
-    metrics.insert("Version".to_string(), build::VERSION.to_string());
-    metrics.insert("PkgVersion".to_string(), build::PKG_VERSION.to_string());
-    metrics.insert(
-        "ClapVersion".to_string(),
-        build::CLAP_LONG_VERSION.to_string(),
-    );
-    metrics.insert("Commit".to_string(), build::COMMIT_HASH.to_string());
-    metrics.insert("Branch".to_string(), build::BRANCH.to_string());
-    metrics.insert("Tag".to_string(), build::TAG.to_string());
-    metrics.insert("BUILD_OS".to_string(), build::BUILD_OS.to_string());
-    metrics.insert(
-        "BUILD_TARGET_OS".to_string(),
-        build::BUILD_TARGET.to_string(),
-    );
-    metrics.insert(
-        "BUILD_TARGET_ARCH".to_string(),
-        build::BUILD_TARGET_ARCH.to_string(),
-    );
-    metrics.insert(
-        "BUILD_RUST_CHANNEL".to_string(),
-        build::BUILD_RUST_CHANNEL.to_string(),
-    );
-    metrics.insert("BUILD_TIME".to_string(), build::BUILD_TIME.to_string());
-    metrics.insert("RUST_VERSION".to_string(), build::RUST_VERSION.to_string());
-    metrics.insert(
-        "RUST_TOOLCHAIN".to_string(),
-        build::RUST_CHANNEL.to_string(),
-    );
-    metrics.insert(
-        "CARGO_VERSION".to_string(),
-        build::CARGO_VERSION.to_string(),
-    );
 
     metrics
 }

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-#![forbid(unsafe_code)]
-
 pub mod account;
 pub mod common;
 pub mod config;


### PR DESCRIPTION
## Motivation

Builds shell completion at build time.  We can later add generate at runtime.  The process is for a user to source the bash completion, and then auto completes work.

The downside is I believe the compilation is a lot slower, so I might not do this in production.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally