### PR TITLE
[terraform] improvements for Vultr module

### DIFF
--- a/terraform/fullnode/vultr/cluster.tf
+++ b/terraform/fullnode/vultr/cluster.tf
@@ -9,8 +9,3 @@ resource "vultr_kubernetes" "k8" {
     label         = "aptos-fullnode"
   }
 }
-
-resource "local_file" "kube_config" {
-  content  = base64decode(vultr_kubernetes.k8.kube_config)
-  filename = "${path.module}/vultr_kube_config.yml"
-}

--- a/terraform/fullnode/vultr/main.tf
+++ b/terraform/fullnode/vultr/main.tf
@@ -7,8 +7,6 @@ terraform {
   }
 }
 
-provider "local" {}
-
 provider "vultr" {
   api_key     = var.api_key
   rate_limit  = 700

--- a/terraform/fullnode/vultr/variables.tf
+++ b/terraform/fullnode/vultr/variables.tf
@@ -65,3 +65,9 @@ variable "fullnode_region" {
   description = "Geographical region for the node location. All 25 regions can be obtained at https://api.vultr.com/v2/regions"
   default     = "fra"
 }
+
+
+variable "block_storage_class" {
+  description = "Either vultr-block-storage for high_perf/ssd, vultr-block-storage-hdd for storage_opt/hdd. high_perf is not available in all regions!"
+  default = "vultr-block-storage"
+}


### PR DESCRIPTION
## Motivation
This PR removes the dependency on the local kubeconfig file which does not work in ephemeral environments such as TF cloud. Also removes the unnecessary storage class and instead allows passing it in, which is useful as there are two types and only one is broadly available across all regions. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
yes & submitted in previous PR
