### PR TITLE
[Circle CI] Ensure that Cargo.toml files are sorted alphabetically!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ jobs:
       - run: cargo x lint
       - run: cargo xclippy --workspace --all-targets
       - run: cargo xfmt --check
+      # TODO(joshlind): turn this on for all workspace dependencies! We only do one now as a proof of concept.
+      - run: cargo sort --grouped --check state-sync/aptos-data-client/
   e2e-test:
     executor: ubuntu-2xl
     steps:
@@ -344,6 +346,7 @@ commands:
       - run: sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config --no-install-recommends --assume-yes
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
       - run: cat $HOME/.cargo/env >> $BASH_ENV
+      - run: cargo install cargo-sort
   deploy-setup:
     steps:
       - kubernetes/install-kubectl:

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -404,6 +404,12 @@ function install_cargo_guppy {
   fi
 }
 
+function install_cargo_sort {
+  if ! command -v cargo-sort &> /dev/null; then
+    cargo install cargo-sort
+  fi
+}
+
 function install_grcov {
   if ! command -v grcov &> /dev/null; then
     cargo install grcov --version="${GRCOV_VERSION}" --locked
@@ -865,6 +871,7 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
   rustup component add clippy
 
   install_cargo_guppy
+  install_cargo_sort
   install_sccache
   install_grcov
   install_postgres

--- a/state-sync/aptos-data-client/Cargo.toml
+++ b/state-sync/aptos-data-client/Cargo.toml
@@ -28,15 +28,15 @@ aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 network = { path = "../../network" }
 storage-service-client = { path = "../storage-service/client" }
-storage-service-types = { path = "../storage-service/types" }
 storage-service-server = { path = "../storage-service/server" }
+storage-service-types = { path = "../storage-service/types" }
 
 [dev-dependencies]
+bcs = "0.1.3"
 claim = "0.5.0"
 maplit = "1.0.2"
 tokio = { version = "1.8.1", features = ["rt", "macros"], default-features = false }
 
-bcs = "0.1.3"
-channel = { path = "../../crates/channel" }
 aptos-time-service = { path = "../../crates/aptos-time-service", features = ["async", "testing"] }
+channel = { path = "../../crates/channel" }
 network = { path = "../../network", features = ["fuzzing"] }


### PR DESCRIPTION
## Motivation

This PR updates Circle CI to ensure that Cargo.toml files are sorted alphabetically. If not, the lint checks will fail. 

We do this using the [`cargo-sort`](https://github.com/DevinR528/cargo-sort) crate. For example, to check that a specific crate Cargo.toml file is sorted correctly, you can run `cargo sort --grouped --check <directory of crate>`.

To automatically sort a crate, you can run the same command without `--check`. Note that we require the `--grouped` flag because we typically sort dependencies into two groups: (i) 3rd party external dependencies; and (ii) local crate dependencies.

Note: I have only enabled this check for one crate to show the proof of concept and avoid major merge conflicts in our PRs (we have a load (!) of unsorted Cargo.toml files). If we feel this makes sense, I'll gradually role it out 😄 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Ran the tool locally.

## Related PRs

None.