### PR TITLE
[circleci] retry docker-compose testnet startup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,30 +418,35 @@ commands:
             echo 'export APTOS_NODE_URL="http://localhost:8080"' >> $BASH_ENV
             echo 'export APTOS_FAUCET_URL="http://localhost:8000"' >> $BASH_ENV
       - run:
-          name: Start local testnet docker-compose
+          name: Start local testnet docker-compose and verify up
           shell: /bin/bash
           working_directory: docker/compose/validator-testnet
           command: |
             export VALIDATOR_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/validator
             export FAUCET_IMAGE_REPO=${AWS_ECR_ACCOUNT_URL}/aptos/faucet
-            docker-compose up -d
-      - run:
-          name: Verify testnet docker-compose up
-          shell: /bin/bash
-          working_directory: docker/compose/validator-testnet
-          command: |
             DOCKER_COMPOSE_EXIT_CODE=1
-            for i in $(seq 60); do
-              curl -s -w "\n%{http_code}\n" localhost:8080 | tee >(tail -1 > validator_ret.txt)
-              curl -s -w "\n%{http_code}\n" -X POST 'localhost:8000/mint?pub_key=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d&amount=20000000' \
-                | tee >(tail -1 > faucet_ret.txt)
-              if [ "$(cat validator_ret.txt)" = "200" ] && [ "$(cat faucet_ret.txt)" = "200" ]; then
-                echo "Both validator and faucet healthy"
-                DOCKER_COMPOSE_EXIT_CODE=0
+
+            # try a total of 5 times (5 min timeout) to bring up a docker-compose testnet
+            for i in $(seq 1 5); do
+              docker-compose down || true # try bringing down ay existing testnets
+              docker-compose up -d
+              for j in $(seq 60); do
+                curl -s -w "\n%{http_code}\n" localhost:8080 | tee >(tail -1 > validator_ret.txt)
+                curl -s -w "\n%{http_code}\n" -X POST 'localhost:8000/mint?pub_key=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d&amount=20000000' \
+                  | tee >(tail -1 > faucet_ret.txt)
+                if [ "$(cat validator_ret.txt)" = "200" ] && [ "$(cat faucet_ret.txt)" = "200" ]; then
+                  echo "Both validator and faucet healthy"
+                  DOCKER_COMPOSE_EXIT_CODE=0
+                  break
+                fi
+                sleep 1
+              done
+              if [ "$DOCKER_COMPOSE_EXIT_CODE" = "0" ]; then
                 break
               fi
-              sleep 1
+              echo "DOCKER_COMPOSE_EXIT_CODE = $DOCKER_COMPOSE_EXIT_CODE, trying compose again..."
             done
+
             echo "export DOCKER_COMPOSE_EXIT_CODE=$DOCKER_COMPOSE_EXIT_CODE" >> $BASH_ENV
       - run:
           name: Check docker-compose resources

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,6 +214,17 @@ jobs:
               exit $FGI_EXIT_CODE
             fi
             exit 0
+  ecosystem-lint:
+    executor: ubuntu-medium
+    steps:
+      - ecosystem-setup
+      # install packages for examples
+      - run: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install
+      - run: cd ./ecosystem/typescript/sdk/examples/javascript && yarn install
+      # Run package build+lint + tests
+      - run: cd ./ecosystem/typescript/sdk && yarn install
+      - run: cd ./ecosystem/typescript/sdk && yarn lint
+      - run: cd ./ecosystem/typescript/sdk && yarn fmt:check
   ecosystem-test:
     executor: ubuntu-xl
     steps:
@@ -234,31 +245,9 @@ jobs:
               exit $DOCKER_COMPOSE_EXIT_CODE
             fi
             circleci-agent step halt
-      - dev-setup
-      - run:
-          name: Install Node + Yarn
-          command: |
-            # Set up Node
-            export NODE_VERSION=16.14.2
-            curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"
-            sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1
-            rm node.tar.xz
-            sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
-            # Set up Yarn
-            export PATH=~/.yarn/bin:$PATH
-            export YARN_VERSION=1.22.17
-            curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz"
-            sudo tar -xzf yarn.tar.gz -C /opt/
-            rm yarn.tar.gz
-            sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn
-            sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
-      # install packages for examples
-      - run: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install
-      - run: cd ./ecosystem/typescript/sdk/examples/javascript && yarn install
-      # Run package build+lint + tests
+      - ecosystem-setup
+      # Run package install, test, build
       - run: cd ./ecosystem/typescript/sdk && yarn install
-      - run: cd ./ecosystem/typescript/sdk && yarn lint
-      - run: cd ./ecosystem/typescript/sdk && yarn fmt:check
       - run: cd ./ecosystem/typescript/sdk && yarn test
       - run: cd ./ecosystem/typescript/sdk && yarn build
 
@@ -274,6 +263,7 @@ workflows:
       #      - build-benchmarks
       - e2e-test
       - lint
+      - ecosystem-lint
       - unit-test
       - docker-build-push:
           context: aws-dev
@@ -403,6 +393,26 @@ commands:
             # the images that exist in dockerhub org
             echo "export DOCKERHUB_ORG=aptoslab" >> $BASH_ENV
             echo "export DOCKERHUB_IMAGES=( validator forge init validator_tcb tools faucet )" >> $BASH_ENV
+  ecosystem-setup:
+    steps:
+      - checkout
+      - run:
+          name: Install Node + Yarn
+          command: |
+            # Set up Node
+            export NODE_VERSION=16.14.2
+            curl -L -o node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"
+            sudo tar -xJf node.tar.xz -C /usr/local --strip-components=1
+            rm node.tar.xz
+            sudo ln -s /usr/local/bin/node /usr/local/bin/nodejs
+            # Set up Yarn
+            export PATH=~/.yarn/bin:$PATH
+            export YARN_VERSION=1.22.17
+            curl -L -o yarn.tar.gz "https://yarnpkg.com/downloads/${YARN_VERSION}/yarn-v${YARN_VERSION}.tar.gz"
+            sudo tar -xzf yarn.tar.gz -C /opt/
+            rm yarn.tar.gz
+            sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn
+            sudo ln -s /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg
   docker-compose-setup:
     steps:
       - checkout

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -8,7 +8,7 @@ import { sleep } from "./util";
 import { AptosAccount } from "./aptos_account";
 import { Types } from "./types";
 import { Tables } from "./api/Tables";
-import { Address, AptosError, LedgerVersion, MoveModule } from "./api/data-contracts";
+import { AptosError } from "./api/data-contracts";
 
 export class RequestError extends Error {
   response?: AxiosResponse<any, Types.AptosError>;


### PR DESCRIPTION
Docker-compose networking is a bit flaky on CircleCI machines (tracking in a separate issue). Introduce some retry logic to the startup step, blocking for a maximum of 5 minutes.

Resolves https://github.com/aptos-labs/aptos-core/issues/788 for ecosystem tests. Forge improvements coming separately as well :) 

Test locally and by canary. To roll this out, we can enable `DOCKER_COMPOSE_BLOCKING` again, to start testing ecosystem stuff that relies on docker-compose.