### PR TITLE
[Aptos Framework] Add a new RegisterEvent emitted during registering CoinStore for an account and a Typescript example for creating/minting a new coin

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/TypeInfo.move
+++ b/aptos-move/framework/aptos-framework/sources/TypeInfo.move
@@ -1,5 +1,5 @@
 module AptosFramework::TypeInfo {
-    struct TypeInfo has copy, drop {
+    struct TypeInfo has copy, drop, store {
         account_address: address,
         module_name: vector<u8>,
         struct_name: vector<u8>,

--- a/aptos-move/move-examples/coin/Move.toml
+++ b/aptos-move/move-examples/coin/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Examples"
+version = "0.0.0"
+
+[addresses]
+MoonCoinType = "_"

--- a/aptos-move/move-examples/coin/sources/MoonCoinType.move
+++ b/aptos-move/move-examples/coin/sources/MoonCoinType.move
@@ -1,0 +1,3 @@
+module MoonCoinType::MoonCoin {
+    struct MoonCoin {}
+}

--- a/developer-docs-site/static/examples/typescript/coin.ts
+++ b/developer-docs-site/static/examples/typescript/coin.ts
@@ -1,0 +1,142 @@
+// Copyright (c) The Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import assert from "assert";
+import fs from "fs";
+import { Account, RestClient, TESTNET_URL, FAUCET_URL, FaucetClient } from "./first_transaction";
+
+const readline = require("readline").createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+class CoinClient extends RestClient {
+
+  /** Publishes a new module to the blockchain within the specified account */
+  async publishModule(accountFrom: Account, moduleHex: string): Promise<string> {
+    const payload = {
+      "type": "module_bundle_payload",
+      "modules": [
+        {"bytecode": `0x${moduleHex}`},
+      ],
+    };
+    return await this.executeTransactionWithPayload(accountFrom, payload);
+  }
+  
+  /** Initializes the new coin */
+  async initializeCoin(accountFrom: Account, coinTypeAddress: string): Promise<string> {
+    let payload: { function: string; arguments: any[]; type: string; type_arguments: any[] } = {
+      type: "script_function_payload",
+      function: `0x1::Coin::initialize`,
+      type_arguments: [
+        `0x${coinTypeAddress}::MoonCoin::MoonCoin`,
+      ],
+      arguments: [
+        Buffer.from("Moon Coin", "utf-8").toString("hex"),
+        "18",
+        false,
+      ]
+    };
+    return await this.executeTransactionWithPayload(accountFrom, payload);
+  }
+
+  /** Receiver needs to register the coin before they can receive it */
+  async registerCoin(coinReceiver: Account, coinTypeAddress: string): Promise<string> {
+    let payload: { function: string; arguments: string[]; type: string; type_arguments: any[] };
+    payload = {
+      "type": "script_function_payload",
+      "function": `0x1::Coin::register`,
+      "type_arguments": [
+        `0x${coinTypeAddress}::MoonCoin::MoonCoin`,
+      ],
+      "arguments": []
+    };
+    return await this.executeTransactionWithPayload(coinReceiver, payload);
+  }
+
+  /** Mints the newly created coin to a specified receiver address */
+  async mintCoin(
+    coinOwner: Account,
+    coinTypeAddress: string,
+    receiverAddress: string,
+    amount: number,
+  ): Promise<string> {
+    let payload: { function: string; arguments: string[]; type: string; type_arguments: any[] };
+    payload = {
+      "type": "script_function_payload",
+      "function": `0x1::Coin::mint`,
+      "type_arguments": [
+        `0x${coinTypeAddress}::MoonCoin::MoonCoin`,
+      ],
+      "arguments": [
+        receiverAddress,
+        amount.toString(),
+      ]
+    };
+    return await this.executeTransactionWithPayload(coinOwner, payload);
+  }
+
+  /** Return the balance of the newly created coin */
+  async getBalance(accountAddress: string, coinTypeAddress: string): Promise<string> {
+    const resource = await this.accountResource(
+      accountAddress,
+      `0x1::Coin::CoinStore<0x${coinTypeAddress}::MoonCoin::MoonCoin>`,
+    );
+    if (resource == null) {
+      return null;
+    } else {
+      return resource["data"]["coin"]["value"]
+    }
+  }
+}
+
+/** run our demo! */
+async function main() {
+  assert(process.argv.length == 3, "Expecting an argument that points to the helloblockchain module");
+
+  const restClient = new CoinClient(TESTNET_URL);
+  const faucetClient = new FaucetClient(FAUCET_URL, restClient);
+
+  // Create two accounts, Alice and Bob, and fund Alice but not Bob
+  const alice = new Account();
+  const bob = new Account();
+
+  console.log("\n=== Addresses ===");
+  console.log(`Alice: ${alice.address()}`);
+  console.log(`Bob: ${bob.address()}`);
+
+  await faucetClient.fundAccount(alice.address(), 10_000_000);
+  await faucetClient.fundAccount(bob.address(), 10_000_000);
+
+  await new Promise<void>(resolve => {
+    readline.question("Update the CoinType module with Alice's address, build, copy to the provided path, and press enter.", () => {
+      resolve();
+      readline.close();
+    });
+  });
+  const modulePath = process.argv[2];
+  const moduleHex = fs.readFileSync(modulePath).toString("hex");
+
+  console.log("Publishing...");
+
+  let txHash = await restClient.publishModule(alice, moduleHex);
+  await restClient.waitForTransaction(txHash);
+
+  console.log("Alice will initialize the new coin");
+  txHash = await restClient.initializeCoin(alice, alice.address());
+  await restClient.waitForTransaction(txHash);
+
+  console.log("Bob registers the newly created coin so he can receive it from Alice");
+  txHash = await restClient.registerCoin(bob, alice.address());
+  await restClient.waitForTransaction(txHash);
+  console.log(`Bob's initial balance: ${await restClient.getBalance(bob.address(), alice.address())}`);
+
+  console.log("Alice mints Bob some of the new coin");
+  txHash = await restClient.mintCoin(alice, alice.address(), bob.address(), 100);
+  await restClient.waitForTransaction(txHash);
+  console.log(`Bob's new balance: ${await restClient.getBalance(bob.address(), alice.address())}`);
+}
+
+if (require.main === module) {
+  main().then((resp) => console.log(resp));
+}

--- a/developer-docs-site/static/examples/typescript/first_transaction.ts
+++ b/developer-docs-site/static/examples/typescript/first_transaction.ts
@@ -122,7 +122,7 @@ export class RestClient {
   }
 
   /** Submits a signed transaction to the blockchain. */
-  async submitTransaction(accountFrom: Account, txnRequest: TxnRequest): Promise<Record<string, any>> {
+  async submitTransaction(txnRequest: TxnRequest): Promise<Record<string, any>> {
     const response = await fetch(`${this.url}/transactions`, {
       method: "POST",
       headers: {"Content-Type": "application/json"},
@@ -132,6 +132,13 @@ export class RestClient {
       assert(response.status == 202, (await response.text()) + " - " + JSON.stringify(txnRequest));
     }
     return await response.json();
+  }
+
+  async executeTransactionWithPayload(accountFrom: Account, payload: Record<string, any>): Promise<string> {
+    const txnRequest = await this.generateTransaction(accountFrom.address(), payload);
+    const signedTxn = await this.signTransaction(accountFrom, txnRequest);
+    const res = await this.submitTransaction(signedTxn);
+    return res["hash"];
   }
 
   async transactionPending(txnHash: string): Promise<boolean> {

--- a/developer-docs-site/static/examples/typescript/package.json
+++ b/developer-docs-site/static/examples/typescript/package.json
@@ -10,8 +10,9 @@
   "license": "Apache-2.0",
   "scripts": {
     "first": "node --loader ts-node/esm first_transaction.ts",
+    "first_nft": "node --loader ts-node/esm first_nft.ts",
     "hello_blockchain": "node --loader ts-node/esm hello_blockchain.ts",
-    "first_nft": "node --loader ts-node/esm first_nft.ts"
+    "coin": "node --loader ts-node/esm coin.ts"
   },
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
## Motivation

Introduce a RegisterEvent so users can easily track when an account registers to receive a new coin type. We can also use this construct in the future to introduce another event for tracking when an account creates a new coin type (InitializeEvent).

## Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Local network testing: initialize a new coin type, register to receive it and check that the receiver account has the right register events.

Screenshot of loading the register_events:
Url used: http://127.0.0.1:8080/accounts/7124fec8a655e01d0fc849f4d2222b796e57d7015983f7c81f676edfc10c0dc1/events/0x1::Coin::CoinEvents/register_events

<img width="1815" alt="image" src="https://user-images.githubusercontent.com/105028215/167660534-fedc8f18-406e-44d9-8de7-d88730332016.png">

I'll update the tutorial later to show how a coin can be created/minted.