### PR TITLE
[aptos-cli] Add account address to genesis information

### DIFF
--- a/crates/aptos/src/genesis/config.rs
+++ b/crates/aptos/src/genesis/config.rs
@@ -12,6 +12,7 @@ use aptos_types::{
     network_address::{DnsName, NetworkAddress, Protocol},
     transaction::authenticator::AuthenticationKey,
 };
+use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
@@ -52,6 +53,8 @@ impl Layout {
 ///
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ValidatorConfiguration {
+    /// Account address
+    pub account_address: AccountAddress,
     /// Key used for signing in consensus
     pub consensus_key: Ed25519PublicKey,
     /// Key used for signing transactions with the account
@@ -66,8 +69,10 @@ pub struct ValidatorConfiguration {
     pub stake_amount: u64,
 }
 
-impl From<ValidatorConfiguration> for Validator {
-    fn from(config: ValidatorConfiguration) -> Self {
+impl TryFrom<ValidatorConfiguration> for Validator {
+    type Error = CliError;
+
+    fn try_from(config: ValidatorConfiguration) -> Result<Self, CliError> {
         let auth_key = AuthenticationKey::ed25519(&config.account_key);
         let validator_addresses = vec![config
             .validator_host
@@ -81,8 +86,15 @@ impl From<ValidatorConfiguration> for Validator {
             vec![]
         };
 
-        Validator {
-            address: auth_key.derived_address(),
+        let derived_address = auth_key.derived_address();
+        if config.account_address != derived_address {
+            return Err(CliError::CommandArgumentError(format!(
+                "AccountAddress {} does not match account key derived one {}",
+                config.account_address, derived_address
+            )));
+        }
+        Ok(Validator {
+            address: derived_address,
             consensus_pubkey: config.consensus_key.to_bytes().to_vec(),
             operator_address: auth_key.derived_address(),
             network_address: bcs::to_bytes(&validator_addresses).unwrap(),
@@ -90,7 +102,7 @@ impl From<ValidatorConfiguration> for Validator {
             operator_auth_key: auth_key,
             auth_key,
             stake_amount: config.stake_amount,
-        }
+        })
     }
 }
 

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -11,6 +11,7 @@ use crate::{
     CliCommand,
 };
 use aptos_crypto::{ed25519::Ed25519PrivateKey, x25519, PrivateKey};
+use aptos_types::transaction::authenticator::AuthenticationKey;
 use async_trait::async_trait;
 use clap::Parser;
 use std::path::PathBuf;
@@ -83,10 +84,17 @@ impl CliCommand<()> for SetValidatorConfiguration {
         let network_key: x25519::PrivateKey =
             EncodingType::Hex.load_key(NETWORK_KEY_FILE, &network_key_path)?;
 
+        let account_key = account_key.public_key();
+        let consensus_key = consensus_key.public_key();
+        let network_key = network_key.public_key();
+        let auth_key = AuthenticationKey::ed25519(&account_key);
+        let account_address = auth_key.derived_address();
+
         let credentials = ValidatorConfiguration {
-            consensus_key: consensus_key.public_key(),
-            account_key: account_key.public_key(),
-            network_key: network_key.public_key(),
+            account_address,
+            consensus_key,
+            account_key,
+            network_key,
             validator_host: self.validator_host,
             full_node_host: self.full_node_host,
             stake_amount: self.stake_amount,

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -24,7 +24,7 @@ use aptos_vm::AptosVM;
 use aptosdb::AptosDB;
 use async_trait::async_trait;
 use clap::Parser;
-use std::path::PathBuf;
+use std::{convert::TryInto, path::PathBuf};
 use storage_interface::DbReaderWriter;
 use vm_genesis::Validator;
 
@@ -106,7 +106,7 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
 
     let mut validators = Vec::new();
     for user in &layout.users {
-        validators.push(client.get::<ValidatorConfiguration>(user)?.into());
+        validators.push(client.get::<ValidatorConfiguration>(user)?.try_into()?);
     }
 
     let modules = client.get_modules("framework")?;


### PR DESCRIPTION
## Motivation

Account address wasn't easily derivable, so I've added it here.  If it's changed, it will not match the key, and fail with an error on genesis.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
$ aptos genesis set-validator-configuration --local-repository-dir genesis --username greg --validator-host localhost:6180 --full-node-host localhost:6181
{
  "Result": "Success"
}

$ cat genesis/greg.yml
---
account_address: 1c9fdc72bd45dc365d858febaf758c6a0e25b9fb7453f4530b630134665ccc3d
consensus_key: "0xe64b817e5e7aaf95b9223b3081881d041eb70cb4e894a567e4e4bcd34ea44ba5"
account_key: "0x39532eda53db28cfebd51e194198e656157afcafb2e19d0c8e70e00ca557c2ff"
network_key: "0xe86f5f014c732353cf2cfc7302432fedbfb78e650f1e06433e669ae069bcdb16"
validator_host:
  host: localhost
  port: 6180
full_node_host:
  host: localhost
  port: 6181
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
