### PR TITLE
[aptos-cli] Add stake amounts to genesis tooling

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -241,7 +241,7 @@ fn create_and_initialize_validators(
         consensus_pubkeys.push(MoveValue::vector_u8(v.consensus_pubkey.clone()));
         validator_network_addresses.push(MoveValue::vector_u8(v.network_address.clone()));
         full_node_network_addresses.push(MoveValue::vector_u8(v.full_node_network_address.clone()));
-        staking_distribution.push(MoveValue::U64(1));
+        staking_distribution.push(MoveValue::U64(v.stake_amount));
     }
     exec_function(
         session,
@@ -365,6 +365,8 @@ pub struct Validator {
     pub network_address: Vec<u8>,
     /// `NetworkAddress` for the validator's full node
     pub full_node_network_address: Vec<u8>,
+    /// Amount to stake for consensus
+    pub stake_amount: u64,
 }
 
 pub struct TestValidator {
@@ -399,6 +401,7 @@ impl TestValidator {
             operator_auth_key,
             network_address,
             full_node_network_address,
+            stake_amount: 1,
         };
         Self { key, data }
     }

--- a/config/management/genesis/src/builder.rs
+++ b/config/management/genesis/src/builder.rs
@@ -135,6 +135,7 @@ impl<S: KVStorage> GenesisBuilder<S> {
                 operator_auth_key,
                 network_address,
                 full_node_network_address,
+                stake_amount: 1,
             })
         }
         Ok(validators)

--- a/crates/aptos/src/genesis/config.rs
+++ b/crates/aptos/src/genesis/config.rs
@@ -62,6 +62,8 @@ pub struct ValidatorConfiguration {
     pub validator_host: HostAndPort,
     /// Host for full node which can be an IP or a DNS name and is optional
     pub full_node_host: Option<HostAndPort>,
+    /// Stake amount for consensus
+    pub stake_amount: u64,
 }
 
 impl From<ValidatorConfiguration> for Validator {
@@ -87,6 +89,7 @@ impl From<ValidatorConfiguration> for Validator {
             full_node_network_address: bcs::to_bytes(&full_node_addresses).unwrap(),
             operator_auth_key: auth_key,
             auth_key,
+            stake_amount: config.stake_amount,
         }
     }
 }

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -61,6 +61,9 @@ pub struct SetValidatorConfiguration {
     /// Host and port pair for the fullnode e.g. 127.0.0.1:6180
     #[clap(long)]
     full_node_host: Option<HostAndPort>,
+    /// Stake amount for stake distribution
+    #[clap(long, default_value = "1")]
+    stake_amount: u64,
 }
 
 #[async_trait]
@@ -86,6 +89,7 @@ impl CliCommand<()> for SetValidatorConfiguration {
             network_key: network_key.public_key(),
             validator_host: self.validator_host,
             full_node_host: self.full_node_host,
+            stake_amount: self.stake_amount,
         };
 
         self.git_options


### PR DESCRIPTION


## Motivation

Now we can set amounts of stake for genesis tooling.  It should
be defaulting to 1.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
$ aptos genesis set-validator-configuration --local-repository-dir genesis --username greg --validator-host localhost:6180 --full-node-host localhost:6181
{
  "Result": "Success"
}

$ cat genesis/greg.yml
---
consensus_key: "0xe64b817e5e7aaf95b9223b3081881d041eb70cb4e894a567e4e4bcd34ea44ba5"
account_key: "0x39532eda53db28cfebd51e194198e656157afcafb2e19d0c8e70e00ca557c2ff"
network_key: "0xe86f5f014c732353cf2cfc7302432fedbfb78e650f1e06433e669ae069bcdb16"
validator_host:
  host: localhost
  port: 6180
full_node_host:
  host: localhost
  port: 6181
stake_amount: 1
```
