### PR TITLE
[CICD] introduce kodiak merge queue

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,0 +1,9 @@
+# config file for kodiak merge queue: https://kodiakhq.com/ . This intended to replace https://github.com/bors-rs/bors mid-term, but for a limited period we can support both.
+
+# to enqueue a PR into the kodiakhq, simply label with with `automerge`.
+
+version = 1
+
+[merge]
+
+method = "squash"

--- a/x.toml
+++ b/x.toml
@@ -243,7 +243,7 @@ root-members = [
 
 # CI-related files. TODO: maybe have separate rules for local and CI?
 [[determinator.path-rule]]
-globs = [".circleci/**/*", ".github/**/*", "codecov.yml"]
+globs = [".circleci/**/*", ".github/**/*", "codecov.yml", ".kodiak.toml"]
 mark-changed = "all"
 
 # Core devtools files.


### PR DESCRIPTION
This introduces https://kodiakhq.com/ which is part of what's suggested in https://www.notion.so/aptoslabs/Merge-Queue-bors-replacement-78453661a9a1471096ee09e0b382a4f3 . Not planning to get rid of bors in the next few weeks, but want to start using kodiakhq for some merges, esp my own to find its limits if any.