### PR TITLE
[config] Load network config and safety rules from genesis setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
 name = "aptos-config"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-crypto",
  "aptos-crypto-derive",
  "aptos-global-constants",

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.57"
 bcs = "0.1.3"
 get_if_addrs = { version = "0.5.3", default-features = false }
 mirai-annotations = "1.12.0"

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -162,11 +162,11 @@ impl WaypointConfig {
 
 #[derive(Deserialize, Serialize)]
 pub struct IdentityBlob {
-    account_address: AccountAddress,
-    account_key: Ed25519PrivateKey,
+    pub account_address: AccountAddress,
+    pub account_key: Ed25519PrivateKey,
     /// Optional consensus key.  Only used for validators
-    consensus_key: Option<Ed25519PrivateKey>,
-    network_key: x25519::PrivateKey,
+    pub consensus_key: Option<Ed25519PrivateKey>,
+    pub network_key: x25519::PrivateKey,
 }
 
 impl IdentityBlob {

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -42,6 +42,8 @@ mod test_config;
 pub use test_config::*;
 mod api_config;
 pub use api_config::*;
+use aptos_crypto::{ed25519::Ed25519PrivateKey, x25519};
+use aptos_types::account_address::AccountAddress;
 
 /// Represents a deprecated config that provides no field verification.
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
@@ -155,6 +157,26 @@ impl WaypointConfig {
             }
             _ => self.waypoint(),
         }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct IdentityBlob {
+    account_address: AccountAddress,
+    account_key: Ed25519PrivateKey,
+    /// Optional consensus key.  Only used for validators
+    consensus_key: Option<Ed25519PrivateKey>,
+    network_key: x25519::PrivateKey,
+}
+
+impl IdentityBlob {
+    pub fn from_file(path: &Path) -> anyhow::Result<IdentityBlob> {
+        Ok(serde_yaml::from_str(&fs::read_to_string(path)?)?)
+    }
+
+    pub fn to_file(&self, path: &Path) -> anyhow::Result<()> {
+        let mut file = File::open(path)?;
+        Ok(file.write_all(serde_yaml::to_string(self)?.as_bytes())?)
     }
 }
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    config::{Error, SecureBackend},
+    config::{Error, IdentityBlob, SecureBackend},
     keys::ConfigKey,
     network_id::NetworkId,
     utils,
@@ -148,6 +148,10 @@ impl NetworkConfig {
                     .expect("Unable to convert key");
                 Some(key)
             }
+            Identity::FromFile(config) => {
+                let identity_blob: IdentityBlob = IdentityBlob::from_file(&config.path).unwrap();
+                Some(identity_blob.network_key)
+            }
             Identity::None => None,
         };
         key.expect("identity key should be present")
@@ -212,6 +216,10 @@ impl NetworkConfig {
                     .value;
                 Some(peer_id)
             }
+            Identity::FromFile(config) => {
+                let identity_blob: IdentityBlob = IdentityBlob::from_file(&config.path).unwrap();
+                Some(identity_blob.account_address)
+            }
             Identity::None => None,
         }
         .expect("peer id should be present")
@@ -234,6 +242,7 @@ impl NetworkConfig {
                     config.peer_id = peer_id;
                 }
             }
+            Identity::FromFile(_) => (),
         };
     }
 
@@ -300,6 +309,7 @@ pub enum DiscoveryMethod {
 pub enum Identity {
     FromConfig(IdentityFromConfig),
     FromStorage(IdentityFromStorage),
+    FromFile(IdentityFromFile),
     None,
 }
 
@@ -315,6 +325,10 @@ impl Identity {
             key_name,
             peer_id_name,
         })
+    }
+
+    pub fn from_file(path: PathBuf) -> Self {
+        Identity::FromFile(IdentityFromFile { path })
     }
 }
 
@@ -334,6 +348,12 @@ pub struct IdentityFromStorage {
     pub backend: SecureBackend,
     pub key_name: String,
     pub peer_id_name: String,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct IdentityFromFile {
+    pub path: PathBuf,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -40,18 +40,20 @@ impl CliCommand<PathBuf> for GenerateKeys {
     async fn execute(self) -> CliTypedResult<PathBuf> {
         let account_key = key::GenerateKey::generate_ed25519_in_memory();
         let consensus_key = key::GenerateKey::generate_ed25519_in_memory();
-        let network_key = key::GenerateKey::generate_x25519_in_memory()?;
+        // Start network key based off of the account key, we can update it later
+        let network_key =
+            x25519::PrivateKey::from_ed25519_private_bytes(&account_key.to_bytes()).unwrap();
         let keys_file = self.output_dir.join(PRIVATE_KEYS_FILE);
 
         let account_address =
             AuthenticationKey::ed25519(&account_key.public_key()).derived_address();
+
         let config = KeysAndAccount {
             account_address,
             account_key,
             consensus_key,
             network_key,
         };
-
         write_to_file(
             keys_file.as_path(),
             "private_keys.yaml",


### PR DESCRIPTION
## Motivation

Make it simple to have 1 keyfile from genesis, with the genesis blob, and the waypoint.txt to set up a node.  I know the duplicate of waypoint information isn't great, but due to the way it's all built, I have to rework the entire config system to get around it, so this is a stopgap for now.  We really need to rethink how easy our config is since it has so many fields and is significantly nested in complicated ways.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

I tested starting up a node, and it runs with the below config.

```
$ cat validator.yml 
base:
  role: "validator"
  data_dir: "/home/greg/poc/data"
  waypoint:
    from_file: "/home/greg/poc/waypoint.txt"

consensus:
  safety_rules:
    service:
      type: "local"
    backend:
      type: "on_disk_storage"
      path: "/home/greg/poc/secure-data.json"
      namespace: ~
    initial_safety_rules_config:
      from_file:
        waypoint:
          from_file: "/home/greg/poc/waypoint.txt"
        identity_blob_path: "/home/greg/poc/private-keys.yml"

execution:
  genesis_file_location: "/home/greg/poc/genesis.blob"
  concurrency_level: 4

validator_network:
  discovery_method: "onchain"
  mutual_authentication: true
  identity:
    type: "from_file"
    path: "/home/greg/poc/private-keys.yml"

full_node_networks:
- network_id:
    private: "vfn"
  listen_address: "/ip4/0.0.0.0/tcp/6181"
  identity:
    type: "from_config"
    key: "b0f405a3e75516763c43a2ae1d70423699f34cd68fa9f8c6bb2d67aa87d0af69"
    peer_id: "00000000000000000000000000000000d58bc7bb154b38039bc9096ce04e1237"

api:
  enabled: true
  address: "0.0.0.0:8080"

```

Successfully makes progress on consensus:
```
2022-05-10T19:46:30.305973Z [consensus] INFO consensus/safety-rules/src/safety_rules.rs:139 {"event":"update","name":"one_chain_round","preferred_round":94}
2022-05-10T19:46:30.306047Z [consensus] INFO consensus/safety-rules/src/safety_rules.rs:147 {"event":"update","name":"preferred_round","preferred_round":93}
2022-05-10T19:46:30.307285Z [consensus] INFO consensus/safety-rules/src/safety_rules.rs:578 {"event":"success","name":"sign_proposal","round":95}
2022-05-10T19:46:30.309898Z [consensus] INFO consensus/src/round_manager.rs:532 {"block_hash":"5829ab89aed6dcde656decce91c646cb0005782f182d8faece4433990e669095","block_parent_hash":"1c9f3eab84bfcca7e377c41340cfdaa6085d795bfeb1b322d7cb737eaa0cf9a3","epoch":2,"event":"ReceiveProposal","remote_peer":"e886085df336eb521a7478f6faac66962df89543184cb2d0c8f6fa855718c9bd","round":95}
2022-05-10T19:46:30.337600Z [consensus] INFO consensus/safety-rules/src/safety_rules.rs:238 {"event":"update","last_voted_round":95,"name":"last_voted_round"}
2022-05-10T19:46:30.337657Z [consensus] INFO consensus/safety-rules/src/safety_rules.rs:139 {"event":"update","name":"one_chain_round","preferred_round":94}
2022-05-10T19:46:30.337684Z [consensus] INFO consensus/safety-rules/src/safety_rules.rs:147 {"event":"update","name":"preferred_round","preferred_round":93}
2022-05-10T19:46:30.339405Z [consensus] INFO consensus/safety-rules/src/safety_rules.rs:578 {"event":"success","name":"construct_and_sign_vote_two_chain","round":95}
2022-05-10T19:46:30.358548Z [consensus] INFO consensus/src/round_manager.rs:660 {"epoch":2,"event":"ReceiveVote","remote_peer":"e886085df336eb521a7478f6faac66962df89543184cb2d0c8f6fa855718c9bd","round":95,"vote":"Vote: [vote data: VoteData: [block id: 5829ab89, epoch: 2, round: 95, timestamp: 1652211989708831,parent_block_id: 1c9f3eab, parent_block_round: 94, parent_timestamp: 1652211989074699], author: e886085d, is_timeout: false, LedgerInfo: [commit_info: BlockInfo: [epoch: 2, round: 94, id: 1c9f3eab, executed_state_id: 41434355, version: 0, timestamp (us): 1652211989074699, next_epoch_state: None]]]","vote_epoch":2,"vote_id":"5829ab89aed6dcde656decce91c646cb0005782f182d8faece4433990e669095","vote_round":95,"vote_state":"414343554d554c41544f525f504c414345484f4c4445525f4841534800000000"}

```

## Related PRs

Built on https://github.com/aptos-labs/aptos-core/pull/892