### PR TITLE
[Cargo.toml] Format all Cargo.toml files and enable the formatter.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,9 @@ jobs:
       - run: cargo x lint
       - run: cargo xclippy --workspace --all-targets
       - run: cargo xfmt --check
-      # TODO(joshlind): turn this on for all workspace dependencies! We only do one now as a proof of concept.
-      - run: cargo sort --grouped --check state-sync/aptos-data-client/
+      # Temporary workaround for unsorted hakari generated Cargo files (https://github.com/DevinR528/cargo-sort/issues/38).
+      - run: cargo sort --grouped crates/aptos-workspace-hack
+      - run: cargo sort --grouped --check --workspace
   e2e-test:
     executor: ubuntu-2xl
     steps:

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -17,6 +17,8 @@ fail = "0.5.0"
 futures = "0.3.12"
 hex = "0.4.3"
 hyper = "0.14.18"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 once_cell = "1.10.0"
 percent-encoding = "2.1.0"
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
@@ -24,28 +26,27 @@ serde_json = "1.0.81"
 tokio = { version = "1.8.1", features = ["full"] }
 warp = { version = "0.3.2", features = ["default", "tls"] }
 
+aptos-api-types = { path = "./types", package = "aptos-api-types" }
 aptos-config = { path = "../config" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-logger = { path = "../crates/aptos-logger" }
-aptos-mempool = { path = "../mempool"}
+aptos-mempool = { path = "../mempool" }
 aptos-metrics = { path = "../crates/aptos-metrics" }
 aptos-state-view = { path = "../storage/state-view" }
 aptos-types = { path = "../types" }
 aptos-vm = { path = "../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }
-aptos-api-types = { path = "./types", package = "aptos-api-types" }
 storage-interface = { path = "../storage/storage-interface" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 
 [dev-dependencies]
 goldenfile = "1.1.0"
+move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 rand = "0.8.3"
 regex = "1.5.5"
 reqwest = { version = "0.11.10", features = ["blocking", "json"], default_features = false }
 
 aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-genesis-tool = {path = "../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../config/management/genesis", features = ["testing"] }
 aptos-global-constants = { path = "../config/global-constants" }
 aptos-mempool = { path = "../mempool", features = ["fuzzing"] }
 aptos-sdk = { path = "../sdk" }
@@ -57,7 +58,6 @@ cached-framework-packages = { path = "../aptos-move/framework/cached-packages" }
 executor = { path = "../execution/executor" }
 executor-types = { path = "../execution/executor-types" }
 mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
-move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 vm-validator = { path = "../vm-validator" }
 
 [features]

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 anyhow = "1.0.57"
 bcs = "0.1.3"
 hex = "0.4.3"
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 serde = { version = "1.0.137", default-features = false }
 serde_json = "1.0.81"
 warp = { version = "0.3.2", features = ["default"] }
@@ -23,9 +26,6 @@ aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 
 [dev-dependencies]
 move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }

--- a/aptos-move/af-cli/Cargo.toml
+++ b/aptos-move/af-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap = "3.1.8"
 aptos-vm = { path = "../aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 cached-framework-packages =  { path = "../framework/cached-packages" }
-move-deps = { path = "../move-deps", features=["address32"] }
+move-deps = { path = "../move-deps", features = ["address32"] }
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/aptos-move/aptos-keygen/Cargo.toml
+++ b/aptos-move/aptos-keygen/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-rand = "0.8.3"
 hex = "0.4.3"
+rand = "0.8.3"
 
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-types = { path = "../../types" }

--- a/aptos-move/aptos-resource-viewer/Cargo.toml
+++ b/aptos-move/aptos-resource-viewer/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.57"
+
+aptos-types = { path = "../../types" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-aptos-types = { path = "../../types"  }
-move-deps = { path = "../move-deps", features=["address32"] }
-
-anyhow = "1.0.57"
+move-deps = { path = "../move-deps", features = ["address32"] }

--- a/aptos-move/aptos-transaction-benchmarks/Cargo.toml
+++ b/aptos-move/aptos-transaction-benchmarks/Cargo.toml
@@ -11,18 +11,17 @@ edition = "2018"
 
 [dependencies]
 criterion = "0.3.5"
-proptest = "1.0.0"
 criterion-cpu-time = "0.1.0"
 num_cpus = "1.13.1"
-
-aptos-types = { path = "../../types", features = ["fuzzing"] }
-language-e2e-tests = { path = "../e2e-tests" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-aptos-crypto = { path = "../../crates/aptos-crypto" }
-
+proptest = "1.0.0"
 read-write-set = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+
+aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-types = { path = "../../types", features = ["fuzzing"] }
 aptos-vm = { path = "../aptos-vm" }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+language-e2e-tests = { path = "../e2e-tests" }
 
 [[bench]]
 name = "transaction_benches"

--- a/aptos-move/aptos-validator-interface/Cargo.toml
+++ b/aptos-move/aptos-validator-interface/Cargo.toml
@@ -11,10 +11,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+
 aptos-config = { path = "../../config" }
-aptos-types = { path = "../../types" }
-aptosdb = { path = "../../storage/aptosdb" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-storage-interface = { path = "../../storage/storage-interface" }
 aptos-state-view = { path = "../../storage/state-view" }
+aptos-types = { path = "../../types" }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+aptosdb = { path = "../../storage/aptosdb" }
 move-deps = { path = "../move-deps" }
+storage-interface = { path = "../../storage/storage-interface" }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -14,24 +14,24 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 fail = "0.5.0"
 mirai-annotations = "1.12.0"
+num_cpus = "1.13.1"
 once_cell = "1.10.0"
 rayon = "1.5.2"
+serde = { version = "1.0.137", default-features = false }
+serde_json = "1.0.81"
 tracing = "0.1.34"
-num_cpus = "1.13.1"
 
-move-deps = { path = "../move-deps", features=["address32"] }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics = { path = "../../crates/aptos-metrics" }
-aptos-parallel-executor = {path = "../parallel-executor" }
+aptos-parallel-executor = { path = "../parallel-executor" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 framework =  { path = "../framework" }
+move-deps = { path = "../move-deps", features = ["address32"] }
 mvhashmap = { path = "../mvhashmap" }
-serde_json = "1.0.81"
-serde = { version = "1.0.137", default-features = false }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -41,5 +41,5 @@ aptos-types = { path = "../../types", features = ["fuzzing"] }
 [features]
 default = []
 mirai-contracts = []
-fuzzing = ["move-deps/fuzzing","move-deps/fuzzing"]
+fuzzing = ["move-deps/fuzzing", "move-deps/fuzzing"]
 failpoints = ["fail/failpoints", "move-deps/failpoints"]

--- a/aptos-move/e2e-tests/Cargo.toml
+++ b/aptos-move/e2e-tests/Cargo.toml
@@ -14,28 +14,23 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 goldenfile = "1.1.0"
 hex = "0.4.3"
+num_cpus = "1.13.1"
 once_cell = "1.10.0"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 rand = "0.8.3"
 serde = { version = "1.0.137", default-features = false }
-num_cpus = "1.13.1"
 
-## Move dependencies
-move-deps= { path = "../move-deps", features=["address32"] }
-
-## Aptos-Move dependencies
-aptos-keygen = { path = "../aptos-keygen" }
-aptos-vm = { path = "../aptos-vm" }
-aptos-writeset-generator = { path = "../writeset-transaction-generator" }
-cached-framework-packages = { path = "../framework/cached-packages" }
-vm-genesis = { path = "../vm-genesis" }
-
-## Other Aptos Dependencies
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
+aptos-keygen = { path = "../aptos-keygen" }
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types", features = ["fuzzing"] }
+aptos-vm = { path = "../aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+aptos-writeset-generator = { path = "../writeset-transaction-generator" }
+cached-framework-packages = { path = "../framework/cached-packages" }
+move-deps = { path = "../move-deps", features = ["address32"] }
+vm-genesis = { path = "../vm-genesis" }

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -12,24 +12,19 @@ publish = false
 [dependencies]
 proptest = "1.0.0"
 
-## Move dependencies
-move-deps = { path = "../move-deps", features=["address32"] }
-
-## Aptos-Move dependencies
+aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
 aptos-keygen = { path = "../aptos-keygen" }
+aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-parallel-executor = { path = "../parallel-executor" }
+aptos-state-view = { path = "../../storage/state-view" }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
+aptos-types = { path = "../../types", features = ["fuzzing"] }
 aptos-vm = { path = "../aptos-vm" }
-aptos-writeset-generator = { path = "../writeset-transaction-generator"}
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+aptos-writeset-generator = { path = "../writeset-transaction-generator" }
 cached-framework-packages =  { path = "../framework/cached-packages" }
 language-e2e-tests = { path = "../e2e-tests" }
-
-## Other dependencies
-aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
-aptos-types = { path = "../../types", features = ["fuzzing"] }
-aptos-transaction-builder = { path = "../../sdk/transaction-builder"}
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-state-view = { path = "../../storage/state-view" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+move-deps = { path = "../move-deps", features = ["address32"] }
 
 [features]
 default = ["aptos-transaction-builder/fuzzing"]

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -10,30 +10,30 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+anyhow = "1.0.57"
+bcs = "0.1.3"
+clap = "3.1.8"
+include_dir = "0.7.2"
+log = "0.4.17"
+once_cell = "1.10.0"
+rayon = "1.5.2"
+sha2 = "0.9.3"
+smallvec = "1.8.0"
+structopt = "0.3.21"
+tempfile = "3.3.0"
+
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+move-deps = { path = "../move-deps", features = ["address32"] }
 transaction-builder-generator = { path = "../transaction-builder-generator" }
-move-deps = { path = "../move-deps", features=["address32"] }
-
-bcs = "0.1.3"
-anyhow = "1.0.57"
-clap = "3.1.8"
-log = "0.4.17"
-rayon = "1.5.2"
-sha2 = "0.9.3"
-once_cell = "1.10.0"
-smallvec = "1.8.0"
-structopt = "0.3.21"
-include_dir = "0.7.2"
-tempfile = "3.3.0"
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
 dir-diff = "0.3.2"
 
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
-move-deps = { path = "../move-deps", features=["table-extension"] }
+move-deps = { path = "../move-deps", features = ["table-extension"] }
 
 [features]
 default = []

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -10,19 +10,19 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-aptos-types = { path = "../../../types" }
-aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
 bcs = "0.1.3"
-move-deps = { path = "../../move-deps", features=["address32"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 
+aptos-types = { path = "../../../types" }
+aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+move-deps = { path = "../../move-deps", features = ["address32"] }
 
 [build-dependencies]
-move-deps = { path = "../../move-deps" }
 framework = { path = ".." }
+move-deps = { path = "../../move-deps" }
 
 [features]
 default = []

--- a/aptos-move/genesis-viewer/Cargo.toml
+++ b/aptos-move/genesis-viewer/Cargo.toml
@@ -10,14 +10,14 @@ publish = false
 edition = "2018"
 
 [dependencies]
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["table-extension"] }
 structopt = "0.3.21"
 
-aptos-resource-viewer = { path = "../aptos-resource-viewer"}
+aptos-resource-viewer = { path = "../aptos-resource-viewer" }
 aptos-types = { path = "../../types" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 cached-framework-packages =  { path = "../framework/cached-packages" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["table-extension"] }
 vm-genesis = { path = "../vm-genesis" }

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -33,7 +33,7 @@ move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e758
 move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 read-write-set = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3"}
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 
 [features]
 default = []

--- a/aptos-move/move-examples/Cargo.toml
+++ b/aptos-move/move-examples/Cargo.toml
@@ -9,14 +9,15 @@ publish = false
 edition = "2018"
 
 [dependencies]
-aptos-vm = { path = "../aptos-vm" }
-aptos-types = {path = "../../types"}
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 clap = "3.1.8"
 move-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 move-stdlib = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["table-extension"] }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["table-extension"] }
+
+aptos-types = { path = "../../types" }
+aptos-vm = { path = "../aptos-vm" }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 
 [dev-dependencies]
 move-cli = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }

--- a/aptos-move/mvhashmap/Cargo.toml
+++ b/aptos-move/mvhashmap/Cargo.toml
@@ -9,14 +9,13 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-rayon = "1.5.2"
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+arc-swap = "1.5.0"
 crossbeam = "0.8.1"
 dashmap = "5.2.0"
-arc-swap = "1.5.0"
+rayon = "1.5.2"
+
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/aptos-move/parallel-executor/Cargo.toml
+++ b/aptos-move/parallel-executor/Cargo.toml
@@ -9,30 +9,27 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-mvhashmap = { path = "../mvhashmap" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-aptos-infallible = { path = "../../crates/aptos-infallible" }
-
 anyhow = "1.0.57"
+arc-swap = "1.5.0"
+criterion = { version = "0.3.5", optional = true }
+crossbeam = "0.8.1"
 crossbeam-queue = "0.3.5"
-rayon = "1.5.2"
 num_cpus = "1.13.1"
 once_cell = "1.10.0"
-crossbeam = "0.8.1"
-arc-swap = "1.5.0"
+proptest = { version = "1.0.0", optional = true }
+proptest-derive = { version = "0.3.0", optional = true }
+rayon = "1.5.2"
 
-criterion = { version = "0.3.5", optional = true}
-proptest = { version = "1.0.0", optional = true}
-proptest-derive = { version = "0.3.0", optional = true}
+aptos-infallible = { path = "../../crates/aptos-infallible" }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+mvhashmap = { path = "../mvhashmap" }
 
 [dev-dependencies]
 criterion = "0.3.5"
-rand = "0.8.3"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
+rand = "0.8.3"
 
 [features]
 fuzzing = ["criterion", "proptest", "proptest-derive"]

--- a/aptos-move/transaction-builder-generator/Cargo.toml
+++ b/aptos-move/transaction-builder-generator/Cargo.toml
@@ -14,15 +14,15 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 heck = "0.3.2"
 regex = "1.5.5"
+serde-generate = { git = "https://github.com/aptos-labs/serde-reflection" }
+serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection" }
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 textwrap = "0.15.0"
 
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-deps = { path = "../move-deps", features=["address32"] }
-serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection" }
-serde-generate = { git = "https://github.com/aptos-labs/serde-reflection" }
+move-deps = { path = "../move-deps", features = ["address32"] }
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/aptos-move/transaction-replay/Cargo.toml
+++ b/aptos-move/transaction-replay/Cargo.toml
@@ -14,24 +14,24 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 difference = "2.0.0"
 hex = "0.4.3"
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-cli = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 structopt = "0.3.21"
 
 aptos-resource-viewer = { path = "../aptos-resource-viewer" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 aptos-validator-interface = { path = "../aptos-validator-interface" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptos-vm = { path = "../aptos-vm" }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptosdb = { path = "../../storage/aptosdb" }
 cached-framework-packages =  { path = "../framework/cached-packages" }
 framework =  { path = "../framework" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3"}
-move-cli = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 
 [dev-dependencies]
 vm-genesis = { path = "../vm-genesis" }

--- a/aptos-move/vm-genesis/Cargo.toml
+++ b/aptos-move/vm-genesis/Cargo.toml
@@ -12,29 +12,30 @@ publish = false
 [dependencies]
 anyhow = "1.0.57"
 bcs = "0.1.3"
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 once_cell = "1.10.0"
 rand = "0.8.3"
+read-write-set = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-state-view = { path = "../../storage/state-view" }
-aptos-transaction-builder = { path = "../../sdk/transaction-builder"}
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-vm = { path = "../aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 cached-framework-packages =  { path = "../framework/cached-packages" }
 framework =  { path = "../framework" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3"}
-move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 
 [dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
+
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
 
 [features]

--- a/aptos-move/writeset-transaction-generator/Cargo.toml
+++ b/aptos-move/writeset-transaction-generator/Cargo.toml
@@ -9,30 +9,28 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = "1.0.57"
 bcs = "0.1.3"
 handlebars = "4.2.2"
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 serde = { version = "1.0.137", default-features = false }
 tempfile = "3.3.0"
 
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
-aptos-types = { path = "../../types" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-transaction-replay = { path = "../transaction-replay" }
+aptos-types = { path = "../../types" }
 aptos-vm = { path = "../aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptosdb = { path = "../../storage/aptosdb" }
 cached-framework-packages =  { path = "../framework/cached-packages" }
 framework =  { path = "../framework" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3"}
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -24,12 +24,13 @@ aptos-api = { path = "../api" }
 aptos-config = { path = "../config" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-data-client = { path = "../state-sync/aptos-data-client" }
-aptos-genesis-tool = {path = "../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../config/management/genesis", features = ["testing"] }
 aptos-infallible = { path = "../crates/aptos-infallible" }
 aptos-logger = { path = "../crates/aptos-logger" }
 aptos-mempool = { path = "../mempool" }
 aptos-metrics = { path = "../crates/aptos-metrics" }
 aptos-secure-storage = { path = "../secure/storage" }
+aptos-state-view = { path = "../storage/state-view" }
 aptos-telemetry = { path = "../crates/aptos-telemetry" }
 aptos-temppath = { path = "../crates/aptos-temppath" }
 aptos-time-service = { path = "../crates/aptos-time-service" }
@@ -37,7 +38,6 @@ aptos-types = { path = "../types" }
 aptos-vm = { path = "../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }
 aptosdb = { path = "../storage/aptosdb" }
-aptos-state-view = { path = "../storage/state-view" }
 backup-service = { path = "../storage/backup/backup-service" }
 cached-framework-packages = { path = "../aptos-move/framework/cached-packages" }
 consensus = { path = "../consensus" }
@@ -55,7 +55,7 @@ network-builder = { path = "../network/builder" }
 state-sync-multiplexer = { path = "../state-sync/state-sync-v2/state-sync-multiplexer" }
 state-sync-v1 = { path = "../state-sync/state-sync-v1" }
 storage-client = { path = "../storage/storage-client" }
-storage-interface= { path = "../storage/storage-interface" }
+storage-interface = { path = "../storage/storage-interface" }
 storage-service = { path = "../storage/storage-service" }
 storage-service-client = { path = "../state-sync/storage-service/client" }
 storage-service-server = { path = "../state-sync/storage-service/server" }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+bcs = "0.1.3"
 get_if_addrs = { version = "0.5.3", default-features = false }
 mirai-annotations = "1.12.0"
 rand = "0.8.3"
@@ -17,10 +18,9 @@ serde = { version = "1.0.137", features = ["rc"], default-features = false }
 serde_yaml = "0.8.24"
 thiserror = "1.0.31"
 
-bcs = "0.1.3"
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
-aptos-global-constants = { path = "./global-constants"}
+aptos-global-constants = { path = "./global-constants" }
 aptos-logger = { path = "../crates/aptos-logger" }
 aptos-secure-storage = { path = "../secure/storage" }
 aptos-temppath = { path = "../crates/aptos-temppath" }

--- a/config/management/Cargo.toml
+++ b/config/management/Cargo.toml
@@ -11,22 +11,22 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 hex = "0.4.3"
 serde = { version = "1.0.137", features = ["rc"], default-features = false }
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 thiserror = "1.0.31"
 
-bcs = "0.1.3"
-aptos-config = { path = ".."}
+aptos-config = { path = ".." }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-global-constants = { path = "../global-constants"}
+aptos-global-constants = { path = "../global-constants" }
 aptos-secure-storage = { path = "../../secure/storage" }
+aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptos-time-service = { path = "../../crates/aptos-time-service" }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-aptos-temppath = { path = "../../crates/aptos-temppath" }
-aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 
 [dev-dependencies]
 aptos-config = { path = "..", features = ["fuzzing"] }

--- a/config/management/genesis/Cargo.toml
+++ b/config/management/genesis/Cargo.toml
@@ -11,32 +11,31 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 rand = "0.8.3"
 serde = { version = "1.0.137", features = ["rc"], default-features = false }
 structopt = "0.3.21"
 toml = { version = "0.5.9", default-features = false }
 
-consensus-types = { path = "../../../consensus/consensus-types" }
-executor = { path = "../../../execution/executor" }
-bcs = "0.1.3"
-aptos-config = { path = "../.."}
+aptos-config = { path = "../.." }
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-global-constants = { path = "../../global-constants" }
 aptos-management = { path = ".." }
 aptos-secure-storage = { path = "../../../secure/storage" }
-aptos-types = { path = "../../../types" }
-aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
-aptos-temppath = { path = "../../../crates/aptos-temppath" }
-aptos-vm = { path = "../../../aptos-move/aptos-vm" }
-aptosdb = { path = "../../../storage/aptosdb" }
 aptos-state-view =  { path = "../../../storage/state-view" }
-
+aptos-temppath = { path = "../../../crates/aptos-temppath" }
+aptos-types = { path = "../../../types" }
+aptos-vm = { path = "../../../aptos-move/aptos-vm" }
+aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+aptosdb = { path = "../../../storage/aptosdb" }
 cached-framework-packages = { path = "../../../aptos-move/framework/cached-packages" }
+consensus-types = { path = "../../../consensus/consensus-types" }
+executor = { path = "../../../execution/executor" }
 storage-interface = { path = "../../../storage/storage-interface" }
 vm-genesis = { path = "../../../aptos-move/vm-genesis" }
 
 [dev-dependencies]
-aptos-config = { path = "../..", features = ["fuzzing"]}
+aptos-config = { path = "../..", features = ["fuzzing"] }
 
 [features]
 testing = []

--- a/config/management/operational/Cargo.toml
+++ b/config/management/operational/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 base64 = "0.13.0"
+bcs = "0.1.3"
 futures = "0.3.12"
 hex = "0.4.3"
 itertools = "0.10.3"
@@ -26,21 +27,20 @@ tokio-util = { version = "0.6.4", features = ["compat"] }
 toml = { version = "0.5.9", default-features = false }
 url = "2.2.2"
 
-bcs = "0.1.3"
-aptos-rest-client = { path = "../../../crates/aptos-rest-client" }
-aptos-config = { path = "../.."}
+aptos-config = { path = "../.." }
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-global-constants = { path = "../../global-constants" }
 aptos-infallible = { path = "../../../crates/aptos-infallible" }
 aptos-management = { path = ".." }
+aptos-rest-client = { path = "../../../crates/aptos-rest-client" }
 aptos-secure-storage = { path = "../../../secure/storage" }
+aptos-temppath = { path = "../../../crates/aptos-temppath" }
+aptos-transaction-builder = { path = "../../../sdk/transaction-builder" }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
-aptos-temppath = { path = "../../../crates/aptos-temppath" }
 fallible = { path = "../../../crates/fallible" }
 netcore = { path = "../../../network/netcore" }
 network = { path = "../../../network" }
-aptos-transaction-builder = { path = "../../../sdk/transaction-builder" }
 
 [features]
 testing = []

--- a/config/seed-peer-generator/Cargo.toml
+++ b/config/seed-peer-generator/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 hex = "0.4.3"
 rand = "0.8.3"
 serde_yaml = "0.8.24"
@@ -19,17 +20,16 @@ thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["full"] }
 url = "2.2.2"
 
-bcs = "0.1.3"
 aptos-config = { path = ".." }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 
 [dev-dependencies]
-aptos-types = {path = "../../types", features = ["fuzzing"]}
+aptos-types = { path = "../../types", features = ["fuzzing"] }
 
 [features]
 default = []

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 async-trait = "0.1.53"
+bcs = "0.1.3"
 byteorder = { version = "1.4.3", default-features = false }
 bytes = "1.1.0"
 fail = "0.5.0"
@@ -28,6 +29,17 @@ termion = { version = "1.5.6", default-features = false }
 thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["full"] }
 
+aptos-config = { path = "../config" }
+aptos-crypto = { path = "../crates/aptos-crypto" }
+aptos-infallible = { path = "../crates/aptos-infallible" }
+aptos-logger = { path = "../crates/aptos-logger" }
+aptos-mempool = { path = "../mempool" }
+aptos-metrics = { path = "../crates/aptos-metrics" }
+aptos-secure-storage = { path = "../secure/storage" }
+aptos-temppath = { path = "../crates/aptos-temppath" }
+aptos-types = { path = "../types" }
+aptos-vm = { path = "../aptos-move/aptos-vm" }
+aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }
 channel = { path = "../crates/channel" }
 consensus-notifications = { path = "../state-sync/inter-component/consensus-notifications" }
 consensus-types = { path = "consensus-types", default-features = false }
@@ -35,22 +47,10 @@ event-notifications = { path = "../state-sync/inter-component/event-notification
 executor = { path = "../execution/executor" }
 executor-types = { path = "../execution/executor-types" }
 fallible = { path = "../crates/fallible" }
-bcs = "0.1.3"
-aptos-config = { path = "../config" }
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-logger = { path = "../crates/aptos-logger" }
-aptos-mempool = { path = "../mempool" }
-aptos-metrics = { path = "../crates/aptos-metrics" }
-aptos-infallible = { path = "../crates/aptos-infallible" }
-aptos-secure-storage = { path = "../secure/storage" }
-aptos-temppath = { path = "../crates/aptos-temppath" }
-aptos-types = { path = "../types" }
-aptos-vm = { path = "../aptos-move/aptos-vm" }
-aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }
 network = { path = "../network" }
 safety-rules = { path = "safety-rules" }
-short-hex-str = { path = "../crates/short-hex-str" }
 schemadb = { path = "../storage/schemadb" }
+short-hex-str = { path = "../crates/short-hex-str" }
 storage-interface = { path = "../storage/storage-interface" }
 
 [dev-dependencies]
@@ -58,15 +58,15 @@ claim = "0.5.0"
 proptest = "1.0.0"
 tempfile = "3.3.0"
 
-consensus-types = { path = "consensus-types", default-features = false, features = ["fuzzing"] }
-executor-test-helpers = { path = "../execution/executor-test-helpers" }
 aptos-config = { path = "../config", features = ["fuzzing"] }
 aptos-mempool = { path = "../mempool", features = ["fuzzing"] }
+consensus-types = { path = "consensus-types", default-features = false, features = ["fuzzing"] }
+executor-test-helpers = { path = "../execution/executor-test-helpers" }
 network = { path = "../network", features = ["fuzzing"] }
 safety-rules = { path = "safety-rules", features = ["testing"] }
 vm-validator = { path = "../vm-validator" }
 
 [features]
 default = []
-fuzzing = [ "consensus-types/fuzzing", "aptos-config/fuzzing", "aptos-crypto/fuzzing", "aptos-mempool/fuzzing", "aptos-types/fuzzing", "safety-rules/testing"]
+fuzzing = ["consensus-types/fuzzing", "aptos-config/fuzzing", "aptos-crypto/fuzzing", "aptos-mempool/fuzzing", "aptos-types/fuzzing", "safety-rules/testing"]
 failpoints = ["fail/failpoints"]

--- a/consensus/consensus-types/Cargo.toml
+++ b/consensus/consensus-types/Cargo.toml
@@ -11,20 +11,19 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 itertools = "0.10.3"
 mirai-annotations = { version = "1.12.0", default-features = false }
 proptest = { version = "1.0.0", optional = true }
 serde = { version = "1.0.137", default-features = false }
 
-executor-types = { path = "../../execution/executor-types" }
-bcs = "0.1.3"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+executor-types = { path = "../../execution/executor-types" }
 short-hex-str = { path = "../../crates/short-hex-str" }
-
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/consensus/safety-rules/Cargo.toml
+++ b/consensus/safety-rules/Cargo.toml
@@ -11,14 +11,15 @@ edition = "2018"
 
 [dependencies]
 once_cell = "1.10.0"
-rand = { version = "0.8.3", default-features = false }
 proptest = { version = "1.0.0", optional = true }
+rand = { version = "0.8.3", default-features = false }
+serde = { version = "1.0.137", default-features = false }
+serde_json = "1.0.81"
+thiserror = "1.0.31"
 
-crash-handler = { path = "../../crates/crash-handler" }
-consensus-types = { path = "../consensus-types" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-global-constants = { path = "../../config/global-constants"}
+aptos-global-constants = { path = "../../config/global-constants" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers", optional = true }
@@ -29,20 +30,19 @@ aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptos-types = { path = "../../types" }
 aptos-vault-client = { path = "../../secure/storage/vault" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-serde = { version = "1.0.137", default-features = false }
-serde_json = "1.0.81"
-thiserror = "1.0.31"
+consensus-types = { path = "../consensus-types" }
+crash-handler = { path = "../../crates/crash-handler" }
 
 [dev-dependencies]
 criterion = "0.3.5"
-tempfile = "3.3.0"
 proptest = "1.0.0"
 rusty-fork = "0.3.0"
+tempfile = "3.3.0"
 
-consensus-types = { path = "../consensus-types", features = ["fuzzing"] }
 aptos-config = { path = "../../config", features = ["fuzzing"] }
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
 aptos-secure-storage = { path = "../../secure/storage", features = ["testing"] }
+consensus-types = { path = "../consensus-types", features = ["fuzzing"] }
 
 [[bench]]
 name = "safety_rules"

--- a/crates/aptos-bitvec/Cargo.toml
+++ b/crates/aptos-bitvec/Cargo.toml
@@ -10,11 +10,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 proptest = { version = "1.0.0", default-features = true, optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_bytes = "0.11.6"
+
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 
 [dev-dependencies]
 bcs = "0.1.3"

--- a/crates/aptos-crypto-derive/Cargo.toml
+++ b/crates/aptos-crypto-derive/Cargo.toml
@@ -13,9 +13,10 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-syn = { version = "1.0.92", features = ["derive"] }
-quote = "1.0.18"
 proc-macro2 = "1.0.38"
+quote = "1.0.18"
+syn = { version = "1.0.92", features = ["derive"] }
+
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -10,41 +10,42 @@ publish = ["crates-io"]
 edition = "2018"
 
 [dependencies]
+aes-gcm = "0.9.4"
 anyhow = "1.0.57"
+bcs = "0.1.3"
 bytes = "1.1.0"
 curve25519-dalek = { version = "3", default-features = false }
 digest = "0.9.0"
 ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek", rev = "44488e43b8d61fa8263b146f9a1beba5549f8b0e", features = ["std", "serde"] }
 hex = "0.4.3"
 hkdf = "0.10.0"
-once_cell = "1.10.0"
 mirai-annotations = "1.12.0"
+once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 rand = "0.8.0"
 rand_core = { version = "0.6.2", default-features = false }
 serde = { version = "1.0.137", features = ["derive"] }
-serde_bytes = "0.11.6"
 serde-name = "0.1.1"
+serde_bytes = "0.11.6"
 sha2 = "0.9.3"
 static_assertions = "1.1.0"
 thiserror = "1.0.31"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
 x25519-dalek = { version = "2.0.0-pre.1" }
-aes-gcm = "0.9.4"
+
 aptos-crypto-derive = { path = "../aptos-crypto-derive", version = "0.0.3" }
-bcs = "0.1.3"
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 
 [dev-dependencies]
 bitvec = "0.19.4"
 byteorder = "1.4.3"
+criterion = "0.3.5"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 ripemd160 = "0.9.1"
-criterion = "0.3.5"
-sha3 = "0.9.1"
 serde_json = "1.0.81"
+sha3 = "0.9.1"
 trybuild = "1.0.41"
 
 [features]

--- a/crates/aptos-log-derive/Cargo.toml
+++ b/crates/aptos-log-derive/Cargo.toml
@@ -13,7 +13,8 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
-syn = { version = "1.0.92", features = ["extra-traits"] }
-quote = "1.0.18"
 proc-macro2 = "1.0.38"
+quote = "1.0.18"
+syn = { version = "1.0.92", features = ["extra-traits"] }
+
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -16,12 +16,13 @@ backtrace = { version = "0.3.58", features = ["serde"] }
 chrono = "0.4.19"
 erased-serde = "0.3.13"
 hostname = "0.3.1"
-aptos-log-derive = { path = "../aptos-log-derive" }
-aptos-infallible = { path = "../aptos-infallible" }
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 once_cell = "1.10.0"
+prometheus = { version = "0.13.0", default-features = false }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-prometheus = { version = "0.13.0", default-features = false }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
+
+aptos-infallible = { path = "../aptos-infallible" }
+aptos-log-derive = { path = "../aptos-log-derive" }
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/aptos-metrics-core/Cargo.toml
+++ b/crates/aptos-metrics-core/Cargo.toml
@@ -10,5 +10,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 prometheus = { version = "0.13.0", default-features = false }
+
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/aptos-metrics/Cargo.toml
+++ b/crates/aptos-metrics/Cargo.toml
@@ -23,5 +23,5 @@ aptos-metrics-core = { path = "../aptos-metrics-core" }
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 
 [dev-dependencies]
-rusty-fork = "0.3.0"
 assert_approx_eq = "1.1.0"
+rusty-fork = "0.3.0"

--- a/crates/aptos-proptest-helpers/Cargo.toml
+++ b/crates/aptos-proptest-helpers/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 crossbeam = "0.8.1"
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
+
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/aptos-rate-limiter/Cargo.toml
+++ b/crates/aptos-rate-limiter/Cargo.toml
@@ -10,11 +10,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
-aptos-infallible = { path= "../../crates/aptos-infallible" }
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
-aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-metrics = { path = "../../crates/aptos-metrics" }
 futures = "0.3.12"
 pin-project = "1.0.10"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
+
+aptos-infallible = { path = "../../crates/aptos-infallible" }
+aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-metrics = { path = "../../crates/aptos-metrics" }
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -17,6 +17,7 @@ dpn = []
 anyhow = "1.0.57"
 bcs = "0.1.3"
 hex = "0.4.3"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 reqwest = { version = "0.11.10", features = ["json", "cookies"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
@@ -28,4 +29,3 @@ aptos-crypto = { path = "../aptos-crypto" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }

--- a/crates/aptos-retrier/Cargo.toml
+++ b/crates/aptos-retrier/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 tokio = { version = "1.8.1", features = ["time"] }
-aptos-logger = { path = "../../crates/aptos-logger"}
+
+aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/aptos-temppath/Cargo.toml
+++ b/crates/aptos-temppath/Cargo.toml
@@ -11,5 +11,6 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.3"
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 rand = "0.8.3"
+
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -14,17 +14,27 @@ build = "build.rs"
 anyhow = "1.0.57"
 async-trait = "0.1.53"
 base64 = "0.13.0"
+bcs = "0.1.3"
 clap = "3.1.8"
 hex = "0.4.3"
 itertools = "0.10.3"
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-cli = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["testing"] }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["testing"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 rand = "0.8.3"
 reqwest = { version = "0.11.10", features = ["blocking", "json"] }
 serde = "1.0.137"
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
 shadow-rs = "0.11.0"
-thiserror = "1.0.31"
 tempfile = "3.3.0"
+thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
 toml = "0.5.9"
@@ -32,33 +42,23 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
-aptosdb = { path = "../../storage/aptosdb" }
+aptos-github-client = { path = "../../secure/storage/github" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-management = { path = "../../config/management" }
+aptos-rest-client = { path = "../../crates/aptos-rest-client" }
+aptos-sdk = { path = "../../sdk" }
 aptos-secure-storage = { path = "../../secure/storage" }
-aptos-github-client = { path = "../../secure/storage/github" }
 aptos-telemetry = { path = "../aptos-telemetry" }
 aptos-temppath = { path = "../aptos-temppath" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
-aptos-sdk = { path = "../../sdk" }
-aptos-rest-client = { path = "../../crates/aptos-rest-client"}
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
-bcs = "0.1.3"
-executor = { path = "../../execution/executor" }
-short-hex-str = { path = "../short-hex-str" }
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }
+aptosdb = { path = "../../storage/aptosdb" }
 cached-framework-packages =  { path = "../../aptos-move/framework/cached-packages" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-cli = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["testing"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["testing"] }
+executor = { path = "../../execution/executor" }
 framework = { path = '../../aptos-move/framework' }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+short-hex-str = { path = "../short-hex-str" }
 storage-interface = { path = "../../storage/storage-interface" }
 vm-genesis = { path = "../../aptos-move/vm-genesis" }
 

--- a/crates/bounded-executor/Cargo.toml
+++ b/crates/bounded-executor/Cargo.toml
@@ -11,8 +11,9 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.12"
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 tokio = { version = "1.8.1", features = ["sync"] }
+
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 
 [dev-dependencies]
 tokio = { version = "1.8.1", features = ["full"] }

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -12,10 +12,12 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 futures = "0.3.12"
-aptos-metrics = { path = "../../crates/aptos-metrics" }
+
 aptos-infallible = { path = "../../crates/aptos-infallible" }
+aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 
 [dev-dependencies]
-aptos-types = { path = "../../types"  }
 tokio = { version = "1.8.1", features = ["full"] }
+
+aptos-types = { path = "../../types" }

--- a/crates/crash-handler/Cargo.toml
+++ b/crates/crash-handler/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 backtrace = "0.3.58"
+serde = { version = "1.0.137", features = ["derive"] }
 toml = "0.5.9"
 
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }
-serde = { version = "1.0.137", features = ["derive"] }

--- a/crates/fallible/Cargo.toml
+++ b/crates/fallible/Cargo.toml
@@ -11,4 +11,5 @@ edition = "2018"
 
 [dependencies]
 thiserror = "1.0.31"
+
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/num-variants/Cargo.toml
+++ b/crates/num-variants/Cargo.toml
@@ -9,12 +9,12 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-
 [lib]
 proc-macro = true
 
 [dependencies]
-syn = "1.0.92"
-quote = "1.0.18"
 proc-macro2 = "1.0.38"
+quote = "1.0.18"
+syn = "1.0.92"
+
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/proxy/Cargo.toml
+++ b/crates/proxy/Cargo.toml
@@ -11,4 +11,5 @@ edition = "2018"
 
 [dependencies]
 ipnet = "2.5.0"
+
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/crates/short-hex-str/Cargo.toml
+++ b/crates/short-hex-str/Cargo.toml
@@ -14,6 +14,7 @@ mirai-annotations = "1.12.0"
 serde = { version = "1.0.137", default-features = false }
 static_assertions = "1.1.0"
 thiserror = "1.0.31"
+
 aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 
 [dev-dependencies]

--- a/crates/transaction-emitter/Cargo.toml
+++ b/crates/transaction-emitter/Cargo.toml
@@ -21,10 +21,10 @@ termion = "1.5.6"
 tokio = { version = "1.8.1", features = ["full"] }
 
 aptos = { path = "../aptos" }
-aptos-rest-client = { path = "../aptos-rest-client"}
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
 aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-rest-client = { path = "../aptos-rest-client" }
 aptos-sdk = { path = "../../sdk" }
-aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }

--- a/devtools/x-core/Cargo.toml
+++ b/devtools/x-core/Cargo.toml
@@ -12,11 +12,11 @@ camino = { version = "1.0.3", features = ["serde1"] }
 debug-ignore = "1.0.1"
 determinator = "0.8.0"
 guppy = "0.13.0"
-indoc = "1.0.3"
 hakari = { version = "0.9.0", features = ["cli-support"] }
 hex = "0.4.3"
+indoc = "1.0.3"
 log = "0.4.17"
-toml = "0.5.9"
 once_cell = "1.10.0"
 ouroboros = "0.9.2"
 serde = { version = "1.0.137", features = ["derive"] }
+toml = "0.5.9"

--- a/devtools/x-lint/Cargo.toml
+++ b/devtools/x-lint/Cargo.toml
@@ -11,4 +11,5 @@ license = "Apache-2.0"
 camino = "1.0.3"
 guppy = "0.13.0"
 hakari = "0.9.0"
+
 x-core = { path = "../x-core" }

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -8,25 +8,26 @@ publish = false
 license = "Apache-2.0"
 
 [dependencies]
+anyhow = "1.0.57"
 camino = "1.0.3"
+chrono = "0.4.19"
+colored-diff = "0.2.2"
 determinator = "0.8.0"
+env_logger = "0.8.3"
+globset = "0.4.6"
+guppy = { version = "0.13.0", features = ["summaries"] }
+hakari = "0.9.0"
+indexmap = "1.6.2"
+indoc = "1.0.3"
+log = "0.4.17"
+nextest-runner = "0.4.0"
+rayon = "1.5.2"
+regex = "1.5.5"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 structopt = "0.3.21"
-anyhow = "1.0.57"
-colored-diff = "0.2.2"
-guppy = { version = "0.13.0", features = ["summaries"] }
-hakari = "0.9.0"
-indoc = "1.0.3"
-toml = "0.5.9"
-env_logger = "0.8.3"
-log = "0.4.17"
-chrono = "0.4.19"
-globset = "0.4.6"
-regex = "1.5.5"
-rayon = "1.5.2"
-nextest-runner = "0.4.0"
-indexmap = "1.6.2"
 supports-color = "1.3.0"
+toml = "0.5.9"
+
 x-core = { path = "../x-core" }
 x-lint = { path = "../x-lint" }

--- a/ecosystem/indexer/Cargo.toml
+++ b/ecosystem/indexer/Cargo.toml
@@ -23,11 +23,10 @@ serde_json = "1.0.81"
 tokio = { version = "1.8.1", features = ["full", "time"] }
 url = "2.2.2"
 
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
-
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 
 [[bin]]
 name = "aptos-indexer"

--- a/execution/db-bootstrapper/Cargo.toml
+++ b/execution/db-bootstrapper/Cargo.toml
@@ -11,15 +11,15 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 structopt = "0.3.21"
 
-executor = { path = "../executor" }
-bcs = "0.1.3"
-aptosdb = { path = "../../storage/aptosdb" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptos-types = { path = "../../types" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+aptosdb = { path = "../../storage/aptosdb" }
+executor = { path = "../executor" }
 storage-interface = { path = "../../storage/storage-interface" }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-criterion = "0.3.5"
 chrono = "0.4.19"
+criterion = "0.3.5"
 indicatif = "0.15.0"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 rand = "0.8.3"
@@ -20,25 +20,25 @@ serde = "1.0.137"
 structopt = "0.3.21"
 toml = "0.5.9"
 
-aptosdb = { path = "../../storage/aptosdb" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../../config/management/genesis", features = ["testing"] }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-jellyfish-merkle = { path = "../../storage/jellyfish-merkle" }
 aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-sdk = { path = "../../sdk" }
 aptos-secure-push-metrics = { path = "../../secure/push-metrics" }
+aptos-state-view = { path = "../../storage/state-view" }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
-aptos-vm= { path = "../../aptos-move/aptos-vm" }
+aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+aptosdb = { path = "../../storage/aptosdb" }
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
 schemadb = { path = "../../storage/schemadb" }
 storage-client = { path = "../../storage/storage-client" }
 storage-interface = { path = "../../storage/storage-interface" }
-aptos-state-view = { path = "../../storage/state-view" }
-aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
-aptos-sdk = { path = "../../sdk" }
 
 [dev-dependencies]
 aptos-temppath = { path = "../../crates/aptos-temppath" }

--- a/execution/executor-test-helpers/Cargo.toml
+++ b/execution/executor-test-helpers/Cargo.toml
@@ -11,21 +11,21 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+move-core-types = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e", version = "0.0.4", features = ["address32"] }
 rand = "0.8.3"
 
-executor = { path = "../executor" }
-executor-types = { path = "../executor-types" }
-aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
-aptos-state-view = { path = "../../storage/state-view" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e", version = "0.0.4", features=["address32"] }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../../config/management/genesis", features = ["testing"] }
+aptos-state-view = { path = "../../storage/state-view" }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types", features = ["fuzzing"] }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
+executor = { path = "../executor" }
+executor-types = { path = "../executor-types" }
 storage-interface = { path = "../../storage/storage-interface" }
 storage-service = { path = "../../storage/storage-service" }
-aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 vm-genesis = { path = "../../aptos-move/vm-genesis" }

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -11,39 +11,39 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 fail = "0.5.0"
 itertools = { version = "0.10.0", default-features = false }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 once_cell = "1.10.0"
 serde = { version = "1.0.137", features = ["derive"] }
 
-consensus-types = { path = "../../consensus/consensus-types"}
-executor-types = { path = "../executor-types" }
-bcs = "0.1.3"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics = { path = "../../crates/aptos-metrics" }
-aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+consensus-types = { path = "../../consensus/consensus-types" }
+executor-types = { path = "../executor-types" }
 scratchpad = { path = "../../storage/scratchpad" }
 storage-interface = { path = "../../storage/storage-interface" }
 
 [dev-dependencies]
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 proptest = "1.0.0"
 rand = "0.8.3"
 
-executor-test-helpers = { path = "../executor-test-helpers" }
 aptos-config = { path = "../../config" }
-aptos-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../../config/management/genesis", features = ["testing"] }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
-aptosdb = { path = "../../storage/aptosdb" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-storage-interface = { path = "../../storage/storage-interface", features=["fuzzing"] }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
+aptosdb = { path = "../../storage/aptosdb" }
+executor-test-helpers = { path = "../executor-test-helpers" }
+storage-interface = { path = "../../storage/storage-interface", features = ["fuzzing"] }
 vm-genesis = { path = "../../aptos-move/vm-genesis" }
 
 [features]

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -12,40 +12,39 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 async-trait = "0.1.53"
+bcs = "0.1.3"
 fail = "0.5.0"
 futures = "0.3.12"
 itertools = "0.10.0"
+mirai-annotations = "1.12.0"
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
+rand = "0.8.3"
 rayon = "1.5.2"
 serde = { version = "1.0.137", default-features = false }
+serde_json = "1.0.81"
 thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
-bounded-executor = { path = "../crates/bounded-executor" }
-channel = { path = "../crates/channel" }
-bcs = "0.1.3"
 aptos-config = { path = "../config" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
+aptos-infallible = { path = "../crates/aptos-infallible" }
 aptos-logger = { path = "../crates/aptos-logger" }
 aptos-metrics = { path = "../crates/aptos-metrics" }
-aptos-infallible = { path = "../crates/aptos-infallible" }
 aptos-proptest-helpers = { path = "../crates/aptos-proptest-helpers", optional = true }
 aptos-types = { path = "../types" }
 aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }
+bounded-executor = { path = "../crates/bounded-executor" }
+channel = { path = "../crates/channel" }
 event-notifications = { path = "../state-sync/inter-component/event-notifications" }
-mirai-annotations = "1.12.0"
 mempool-notifications = { path = "../state-sync/inter-component/mempool-notifications" }
-network = { path = "../network" }
-rand = "0.8.3"
 netcore = { path = "../network/netcore" }
-serde_json = "1.0.81"
+network = { path = "../network" }
 short-hex-str = { path = "../crates/short-hex-str" }
 storage-interface = { path = "../storage/storage-interface" }
-vm-validator = { path = "../vm-validator" }
-
 storage-service = { path = "../storage/storage-service", optional = true }
+vm-validator = { path = "../vm-validator" }
 
 [dev-dependencies]
 enum_dispatch = "0.3.8"

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 async-trait = "0.1.53"
+bcs = "0.1.3"
 bytes = { version = "1.0.1", features = ["serde"] }
 futures = "0.3.12"
 futures-util = "0.3.12"
@@ -31,9 +32,6 @@ tokio-retry = "0.3.0"
 tokio-stream = "0.1.4"
 tokio-util = { version = "0.6.4", features = ["compat", "codec"] }
 
-bitvec = { path = "../crates/aptos-bitvec", package = "aptos-bitvec" }
-channel = { path = "../crates/channel" }
-bcs = "0.1.3"
 aptos-config = { path = "../config" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
@@ -42,17 +40,26 @@ aptos-infallible = { path = "../crates/aptos-infallible" }
 aptos-logger = { path = "../crates/aptos-logger" }
 aptos-metrics = { path = "../crates/aptos-metrics" }
 aptos-proptest-helpers = { path = "../crates/aptos-proptest-helpers", optional = true }
-aptos-rate-limiter = { path = "../crates/aptos-rate-limiter"}
+aptos-rate-limiter = { path = "../crates/aptos-rate-limiter" }
 aptos-telemetry = { path = "../crates/aptos-telemetry" }
 aptos-time-service = { path = "../crates/aptos-time-service", features = ["async"] }
 aptos-types = { path = "../types" }
 aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }
+bitvec = { path = "../crates/aptos-bitvec", package = "aptos-bitvec" }
+channel = { path = "../crates/channel" }
 memsocket = { path = "./memsocket", optional = true }
 netcore = { path = "./netcore" }
 num-variants = { path = "../crates/num-variants" }
 short-hex-str = { path = "../crates/short-hex-str" }
 
 [dev-dependencies]
+criterion = "0.3.5"
+maplit = "1.0.2"
+proptest = { version = "1.0.0", default-features = true }
+proptest-derive = { version = "0.3.0" }
+rand_core = "0.6.2"
+serial_test = "0.6.0"
+
 aptos-config = { path = "../config", features = ["testing"] }
 aptos-proptest-helpers = { path = "../crates/aptos-proptest-helpers" }
 aptos-time-service = { path = "../crates/aptos-time-service", features = ["async", "testing"] }
@@ -60,14 +67,7 @@ aptos-types = { path = "../types", features = ["fuzzing"] }
 bitvec = { path = "../crates/aptos-bitvec", package = "aptos-bitvec", features = ["fuzzing"] }
 memsocket = { path = "./memsocket" }
 netcore = { path = "./netcore", features = ["testing"] }
-network-builder = {path = "./builder"}
-
-criterion = "0.3.5"
-maplit = "1.0.2"
-proptest = { version = "1.0.0", default-features = true }
-proptest-derive = { version = "0.3.0" }
-rand_core = "0.6.2"
-serial_test = "0.6.0"
+network-builder = { path = "./builder" }
 
 [features]
 default = []

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -8,18 +8,16 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 async-trait = "0.1.53"
+bcs = "0.1.3"
 futures = "0.3.12"
 rand = "0.8.3"
 serde = { version = "1.0.137", default-features = false }
 tokio = { version = "1.8.1", features = ["full"] }
 
-channel = { path = "../../crates/channel" }
-bcs = "0.1.3"
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
@@ -28,6 +26,7 @@ aptos-secure-storage = { path = "../../secure/storage" }
 aptos-time-service = { path = "../../crates/aptos-time-service", features = ["async"] }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+channel = { path = "../../crates/channel" }
 event-notifications = { path = "../../state-sync/inter-component/event-notifications" }
 netcore = { path = "../netcore" }
 network = { path = "../." }

--- a/network/discovery/Cargo.toml
+++ b/network/discovery/Cargo.toml
@@ -11,28 +11,29 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 futures = "0.3.12"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 once_cell = "1.10.0"
 serde_yaml = "0.8.24"
 tokio = { version = "1.8.1", features = ["full"] }
 
-channel = {path = "../../crates/channel"}
-bcs = "0.1.3"
-event-notifications = { path = "../../state-sync/inter-component/event-notifications" }
-aptos-config = { path = "../../config"}
-aptos-crypto = {path = "../../crates/aptos-crypto"}
-aptos-logger = {path = "../../crates/aptos-logger"}
-aptos-metrics = {path = "../../crates/aptos-metrics"}
-aptos-time-service = {path = "../../crates/aptos-time-service"}
+aptos-config = { path = "../../config" }
+aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-secure-storage = { path = "../../secure/storage" }
-aptos-types = {path = "../../types"}
+aptos-time-service = { path = "../../crates/aptos-time-service" }
+aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-network = {path = "../../network"}
+channel = { path = "../../crates/channel" }
+event-notifications = { path = "../../state-sync/inter-component/event-notifications" }
+network = { path = "../../network" }
 short-hex-str = { path = "../../crates/short-hex-str" }
 
 [dev-dependencies]
-aptos-config = { path = "../../config", features = ["testing"]}
+rand = "0.8.3"
+
+aptos-config = { path = "../../config", features = ["testing"] }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
 netcore = { path = "../netcore", features = ["fuzzing"] }
-rand = "0.8.3"

--- a/network/memsocket/Cargo.toml
+++ b/network/memsocket/Cargo.toml
@@ -10,9 +10,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.12"
 bytes = "1.1.0"
+futures = "0.3.12"
 once_cell = "1.10.0"
+
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 

--- a/network/netcore/Cargo.toml
+++ b/network/netcore/Cargo.toml
@@ -17,8 +17,9 @@ serde = { version = "1.0.137", default-features = false }
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-util = { version = "0.6.4", features = ["compat"] }
 url = { version = "2.2.2" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+
 aptos-types = { path = "../../types" }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 memsocket = { path = "../memsocket", optional = true }
 proxy = { path = "../../crates/proxy" }
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 
 [dependencies]
 bcs = "0.1.3"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 rand_core = "0.6.2"
 serde = { version = "1.0.137", features = ["derive"] }
 
 aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-types = { path = "../types" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 aptos-transaction-builder = { path = "./transaction-builder" }
+aptos-types = { path = "../types" }
 aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }

--- a/sdk/transaction-builder/Cargo.toml
+++ b/sdk/transaction-builder/Cargo.toml
@@ -11,19 +11,19 @@ edition = "2018"
 
 [dependencies]
 bcs = "0.1.3"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 once_cell = "1.10.0"
-
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-aptos-types = { path = "../../types" }
 proptest-derive = { version = "0.3.0", optional = true }
+
+aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-cached-framework-packages = {path = "../../aptos-move/framework/cached-packages" }
+cached-framework-packages = { path = "../../aptos-move/framework/cached-packages" }
 
 [dev-dependencies]
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing", "address32"] }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing", "address32"] }
 
 [features]
 default = []
-fuzzing = [ "proptest-derive", "cached-framework-packages/fuzzing", "move-core-types/fuzzing"]
+fuzzing = ["proptest-derive", "cached-framework-packages/fuzzing", "move-core-types/fuzzing"]

--- a/secure/push-metrics/Cargo.toml
+++ b/secure/push-metrics/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 ureq = { version = "1.5.4", features = ["json", "native-tls"], default-features = false }
+
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }

--- a/secure/storage/Cargo.toml
+++ b/secure/storage/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13.0"
+bcs = "0.1.3"
 chrono = "0.4.19"
 enum_dispatch = "0.3.8"
 rand = "0.8.3"
@@ -18,7 +19,6 @@ serde = { version = "1.0.137", features = ["rc"], default-features = false }
 serde_json = "1.0.81"
 thiserror = "1.0.31"
 
-bcs = "0.1.3"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-github-client = { path = "github" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
@@ -29,9 +29,10 @@ aptos-vault-client = { path = "vault" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 
 [dev-dependencies]
+rand = "0.8.3"
+
 aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
-rand = "0.8.3"
 
 [features]
 fuzzing = ["aptos-crypto/fuzzing"]

--- a/secure/storage/github/Cargo.toml
+++ b/secure/storage/github/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = "1.0.81"
 thiserror = "1.0.31"
 ureq = { version = "1.5.4", features = ["json", "native-tls"], default-features = false }
+
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
 proxy = { path = "../../../crates/proxy" }
 

--- a/secure/storage/vault/Cargo.toml
+++ b/secure/storage/vault/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2018"
 [dependencies]
 base64 = "0.13.0"
 chrono = "0.4.19"
+native-tls = "0.2.7"
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
-native-tls = "0.2.7"
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = "1.0.81"
 thiserror = "1.0.31"

--- a/state-sync/inter-component/consensus-notifications/Cargo.toml
+++ b/state-sync/inter-component/consensus-notifications/Cargo.toml
@@ -23,4 +23,4 @@ aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
 [dev-dependencies]
 claim = "0.5.0"
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }

--- a/state-sync/inter-component/event-notifications/Cargo.toml
+++ b/state-sync/inter-component/event-notifications/Cargo.toml
@@ -15,23 +15,22 @@ futures = "0.3.12"
 serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 
-channel = { path = "../../../crates/channel" }
 aptos-id-generator = { path = "../../../crates/aptos-id-generator" }
 aptos-infallible = { path = "../../../crates/aptos-infallible" }
+aptos-state-view = { path = "../../../storage/state-view" }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+channel = { path = "../../../crates/channel" }
 storage-interface = { path = "../../../storage/storage-interface" }
-aptos-state-view = { path = "../../../storage/state-view" }
-
 
 [dev-dependencies]
 bcs = "0.1.3"
 claim = "0.5.0"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-temppath = { path = "../../../crates/aptos-temppath" }
 aptos-vm = { path = "../../../aptos-move/aptos-vm" }
 aptosdb = { path = "../../../storage/aptosdb" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 vm-genesis = { path = "../../../aptos-move/vm-genesis", features = ["fuzzing"] }

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1.53"
 bcs = "0.1.3"
+channel = { path = "../../crates/channel" }
 fail = "0.5.0"
 futures = "0.3.12"
 itertools = { version = "0.10.0", default-features = false }
@@ -23,13 +24,11 @@ thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
-consensus-notifications = { path = "../inter-component/consensus-notifications" }
-channel = { path = "../../crates/channel" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
-aptos-mempool = { path = "../../mempool"}
+aptos-mempool = { path = "../../mempool" }
 aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers", optional = true }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
@@ -37,12 +36,13 @@ aptos-types = { path = "../../types" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptosdb = { path = "../../storage/aptosdb", optional = true }
+consensus-notifications = { path = "../inter-component/consensus-notifications" }
 event-notifications = { path = "../../state-sync/inter-component/event-notifications" }
 executor = { path = "../../execution/executor" }
 executor-test-helpers = { path = "../../execution/executor-test-helpers", optional = true }
 executor-types = { path = "../../execution/executor-types" }
-memsocket = { path = "../../network/memsocket", optional = true }
 mempool-notifications = { path = "../inter-component/mempool-notifications" }
+memsocket = { path = "../../network/memsocket", optional = true }
 netcore = { path = "../../network/netcore" }
 network = { path = "../../network" }
 short-hex-str = { path = "../../crates/short-hex-str" }
@@ -52,22 +52,22 @@ vm-genesis = { path = "../../aptos-move/vm-genesis", optional = true }
 [dev-dependencies]
 bytes = "1.1.0"
 claim = "0.5.0"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 proptest = "1.0.0"
 
-channel = { path = "../../crates/channel" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../../config/management/genesis", features = ["testing"] }
 aptos-mempool = { path = "../../mempool", features = ["fuzzing"] }
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
+aptos-time-service = { path = "../../crates/aptos-time-service", features = ["testing"] }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptosdb = { path = "../../storage/aptosdb" }
+channel = { path = "../../crates/channel" }
 executor-test-helpers = { path = "../../execution/executor-test-helpers" }
 memsocket = { path = "../../network/memsocket" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 network = { path = "../../network", features = ["fuzzing", "testing"] }
-network-builder = { path  = "../../network/builder" }
+network-builder = { path = "../../network/builder" }
 storage-service = { path = "../../storage/storage-service" }
-aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
-aptos-time-service = { path = "../../crates/aptos-time-service", features = ["testing"] }
 vm-genesis = { path = "../../aptos-move/vm-genesis", features = ["fuzzing"] }
 
 [features]

--- a/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
+++ b/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
@@ -19,7 +19,6 @@ thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
-channel = { path = "../../../crates/channel" }
 aptos-config = { path = "../../../config" }
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-data-client = { path = "../../aptos-data-client" }
@@ -29,6 +28,7 @@ aptos-logger = { path = "../../../crates/aptos-logger" }
 aptos-metrics = { path = "../../../crates/aptos-metrics" }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+channel = { path = "../../../crates/channel" }
 network = { path = "../../../network" }
 short-hex-str = { path = "../../../crates/short-hex-str" }
 

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -17,8 +17,6 @@ thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 
-consensus-notifications = { path = "../../inter-component/consensus-notifications" }
-data-streaming-service = { path = "../data-streaming-service" }
 aptos-config = { path = "../../../config" }
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-data-client = { path = "../../aptos-data-client" }
@@ -27,6 +25,8 @@ aptos-logger = { path = "../../../crates/aptos-logger" }
 aptos-metrics = { path = "../../../crates/aptos-metrics" }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+consensus-notifications = { path = "../../inter-component/consensus-notifications" }
+data-streaming-service = { path = "../data-streaming-service" }
 event-notifications = { path = "../../inter-component/event-notifications" }
 executor = { path = "../../../execution/executor" }
 executor-types = { path = "../../../execution/executor-types" }
@@ -39,15 +39,15 @@ async-trait = "0.1.53"
 bcs = "0.1.3"
 claim = "0.5.0"
 mockall = "0.11.0"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 
-channel = { path = "../../../crates/channel" }
-aptosdb = { path = "../../../storage/aptosdb" }
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-temppath = { path = "../../../crates/aptos-temppath" }
 aptos-time-service = { path = "../../../crates/aptos-time-service", features = ["async", "testing"] }
 aptos-vm = { path = "../../../aptos-move/aptos-vm" }
+aptosdb = { path = "../../../storage/aptosdb" }
+channel = { path = "../../../crates/channel" }
 executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 network = { path = "../../../network", features = ["fuzzing"] }
 storage-service-client = { path = "../../storage-service/client" }
 storage-service-types = { path = "../../storage-service/types" }

--- a/state-sync/state-sync-v2/state-sync-multiplexer/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 futures = "0.3.12"
 tokio = { version = "1.8.1", features = ["full"] }
 
-consensus-notifications = { path = "../../../state-sync/inter-component/consensus-notifications" }
-data-streaming-service = { path = "../data-streaming-service" }
 aptos-config = { path = "../../../config" }
 aptos-data-client = { path = "../../aptos-data-client" }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+consensus-notifications = { path = "../../../state-sync/inter-component/consensus-notifications" }
+data-streaming-service = { path = "../data-streaming-service" }
 event-notifications = { path = "../../../state-sync/inter-component/event-notifications" }
 executor-types = { path = "../../../execution/executor-types" }
 mempool-notifications = { path = "../../../state-sync/inter-component/mempool-notifications" }
@@ -29,7 +29,7 @@ storage-interface = { path = "../../../storage/storage-interface" }
 
 [dev-dependencies]
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
-aptos-genesis-tool = {path = "../../../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../../../config/management/genesis", features = ["testing"] }
 aptos-infallible = { path = "../../../crates/aptos-infallible" }
 aptos-temppath = { path = "../../../crates/aptos-temppath" }
 aptos-time-service = { path = "../../../crates/aptos-time-service", features = ["async", "testing"] }

--- a/state-sync/storage-service/client/Cargo.toml
+++ b/state-sync/storage-service/client/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 async-trait = "0.1.53"
 thiserror = "1.0.31"
 
-channel = { path = "../../../crates/channel" }
 aptos-config = { path = "../../../config" }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+channel = { path = "../../../crates/channel" }
 network = { path = "../../../network" }
 storage-service-types = { path = "../types" }

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -19,15 +19,15 @@ serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 tokio = { version = "1.8.1", features = ["rt", "macros"], default-features = false }
 
-bounded-executor = { path = "../../../crates/bounded-executor" }
-channel = { path = "../../../crates/channel" }
 aptos-config = { path = "../../../config" }
-aptos-logger = { path = "../../../crates/aptos-logger" }
 aptos-infallible = { path = "../../../crates/aptos-infallible" }
+aptos-logger = { path = "../../../crates/aptos-logger" }
 aptos-metrics = { path = "../../../crates/aptos-metrics" }
 aptos-time-service = { path = "../../../crates/aptos-time-service", features = ["async"] }
 aptos-types = { path = "../../../types" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
+bounded-executor = { path = "../../../crates/bounded-executor" }
+channel = { path = "../../../crates/channel" }
 network = { path = "../../../network" }
 storage-interface = { path = "../../../storage/storage-interface" }
 storage-service-types = { path = "../types" }
@@ -36,9 +36,9 @@ storage-service-types = { path = "../types" }
 anyhow = "1.0.57"
 claim = "0.5.0"
 mockall = "0.11.0"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-time-service = { path = "../../../crates/aptos-time-service", features = ["async", "testing"] }
 aptos-types = { path = "../../../types" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 storage-interface = { path = "../../../storage/storage-interface" }

--- a/storage/accumulator/Cargo.toml
+++ b/storage/accumulator/Cargo.toml
@@ -11,15 +11,16 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
-aptos-crypto = { path = "../../crates/aptos-crypto" }
 mirai-annotations = "1.12.0"
-aptos-types = { path = "../../types" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 proptest = { version = "1.0.0", optional = true }
 
+aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-types = { path = "../../types" }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+
 [dev-dependencies]
-rand = "0.8.3"
 proptest = "1.0.0"
+rand = "0.8.3"
 
 aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
 

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -15,6 +15,7 @@ arc-swap = "1.5.0"
 bcs = "0.1.3"
 byteorder = "1.4.3"
 itertools = "0.10.0"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 once_cell = "1.10.0"
@@ -35,7 +36,6 @@ aptos-temppath = { path = "../../crates/aptos-temppath", optional = true }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 executor-types = { path = "../../execution/executor-types", optional = true }
-move-core-types = {git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"]}
 num-variants = { path = "../../crates/num-variants" }
 schemadb = { path = "../schemadb" }
 scratchpad = { path = "../scratchpad", optional = true }

--- a/storage/backup/backup-cli/Cargo.toml
+++ b/storage/backup/backup-cli/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 async-trait = "0.1.53"
+bcs = "0.1.3"
 bytes = "1.1.0"
 futures = "0.3.12"
 itertools = "0.10.0"
@@ -23,19 +24,15 @@ reqwest = { version = "0.11.10", features = ["stream"], default-features = false
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 structopt = "0.3.21"
-toml = "0.5.9"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 tokio-util = { version = "0.6.4", features = ["compat"] }
+toml = "0.5.9"
 
-executor = { path = "../../../execution/executor" }
-executor-test-helpers = { path = "../../../execution/executor-test-helpers", optional = true }
-executor-types = { path = "../../../execution/executor-types" }
-aptos-jellyfish-merkle = { path = "../../jellyfish-merkle" }
-bcs = "0.1.3"
 aptos-config = { path = "../../../config" }
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-infallible = { path = "../../../crates/aptos-infallible" }
+aptos-jellyfish-merkle = { path = "../../jellyfish-merkle" }
 aptos-logger = { path = "../../../crates/aptos-logger" }
 aptos-secure-push-metrics = { path = "../../../secure/push-metrics" }
 aptos-temppath = { path = "../../../crates/aptos-temppath" }
@@ -43,17 +40,20 @@ aptos-types = { path = "../../../types" }
 aptos-vm = { path = "../../../aptos-move/aptos-vm" }
 aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
 aptosdb = { path = "../../aptosdb" }
+executor = { path = "../../../execution/executor" }
+executor-test-helpers = { path = "../../../execution/executor-test-helpers", optional = true }
+executor-types = { path = "../../../execution/executor-types" }
 storage-interface = { path = "../../storage-interface" }
 
 [dev-dependencies]
 proptest = "1.0.0"
 warp = "0.3.2"
 
-backup-service = { path = "../backup-service" }
-executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
-aptosdb = { path = "../../aptosdb", features = ["fuzzing"] }
 aptos-config = { path = "../../../config" }
 aptos-proptest-helpers = { path = "../../../crates/aptos-proptest-helpers" }
+aptosdb = { path = "../../aptosdb", features = ["fuzzing"] }
+backup-service = { path = "../backup-service" }
+executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
 storage-interface = { path = "../../storage-interface" }
 
 [features]

--- a/storage/backup/backup-service/Cargo.toml
+++ b/storage/backup/backup-service/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 bytes = "1.1.0"
 hyper = "0.14.18"
 once_cell = "1.10.0"
@@ -17,7 +18,6 @@ serde = { version = "1.0.137", default-features = false }
 tokio = { version = "1.8.1", features = ["full"] }
 warp = "0.3.2"
 
-bcs = "0.1.3"
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-logger = { path = "../../../crates/aptos-logger" }
 aptos-metrics = { path = "../../../crates/aptos-metrics" }
@@ -27,11 +27,11 @@ aptosdb = { path = "../../aptosdb" }
 storage-interface = { path = "../../storage-interface" }
 
 [dev-dependencies]
-aptosdb = { path = "../../aptosdb", features = ["fuzzing"] }
+reqwest = { version = "0.11.10", features = ["blocking", "json"], default_features = false }
+
 aptos-config = { path = "../../../config" }
 aptos-temppath = { path = "../../../crates/aptos-temppath" }
-
-reqwest = { version = "0.11.10", features = ["blocking", "json"], default_features = false }
+aptosdb = { path = "../../aptosdb", features = ["fuzzing"] }
 
 [features]
 fuzzing = ["aptosdb/fuzzing"]

--- a/storage/jellyfish-merkle/Cargo.toml
+++ b/storage/jellyfish-merkle/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 byteorder = "1.4.3"
 itertools = { version = "0.10.0", default-features = false }
 mirai-annotations = "1.12.0"
@@ -22,7 +23,6 @@ proptest-derive = { version = "0.3.0", optional = true }
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.31"
 
-bcs = "0.1.3"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
@@ -32,9 +32,9 @@ aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 storage-interface = { path = "../storage-interface" }
 
 [dev-dependencies]
-rand = "0.8.3"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
+rand = "0.8.3"
 
 aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
 aptos-types = { path = "../../types", features = ["fuzzing"] }

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 once_cell = "1.10.0"
-proptest = {version = "1.0.0", optional = true}
+proptest = { version = "1.0.0", optional = true }
 
 aptos-config = { path = "../../config" }
 aptos-logger = { path = "../../crates/aptos-logger" }
@@ -27,6 +27,7 @@ features = ["lz4"]
 [dev-dependencies]
 byteorder = "1.4.3"
 proptest = "1.0.0"
+
 aptos-temppath = { path = "../../crates/aptos-temppath" }
 
 [features]

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -23,13 +23,12 @@ aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 
-
 [dev-dependencies]
 bitvec = "0.19.4"
 criterion = "0.3.5"
-rand = "0.8.3"
 once_cell = "1.10.0"
 proptest = "1.0.0"
+rand = "0.8.3"
 
 aptos-types = { path = "../../types", features = ["fuzzing"] }
 storage-interface = { path = "../storage-interface" }

--- a/storage/state-view/Cargo.toml
+++ b/storage/state-view/Cargo.toml
@@ -11,16 +11,15 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
-aptos-crypto = { path = "../../crates/aptos-crypto" }
+bcs = "0.1.3"
+move-core-types = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e", version = "0.0.4", features = ["address32"] }
+serde = { version = "1.0.137", default-features = false }
+serde_bytes = "0.11.6"
+serde_json = "1.0.81"
 
+aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-
-serde = { version = "1.0.137", default-features = false }
-serde_json = "1.0.81"
-serde_bytes = "0.11.6"
-bcs = "0.1.3"
-move-core-types = { git = "https://github.com/move-language/move", rev = "1b6b7513dcc1a5c866f178ca5c1e74beb2ce181e", version = "0.0.4", features=["address32"] }
 
 [features]
 default = []

--- a/storage/storage-client/Cargo.toml
+++ b/storage/storage-client/Cargo.toml
@@ -11,12 +11,12 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 serde = "1.0.137"
 
-bcs = "0.1.3"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
+aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -11,18 +11,18 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+parking_lot = "0.12.0"
 serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
-parking_lot = "0.12.0"
 
-bcs = "0.1.3"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-state-view = { path = "../state-view" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 scratchpad = { path = "../scratchpad" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 
 [features]
 default = []

--- a/storage/storage-service/Cargo.toml
+++ b/storage/storage-service/Cargo.toml
@@ -11,27 +11,28 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
-
 bcs = "0.1.3"
+rand = { version = "0.8.3", optional = true }
+
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptosdb = { path = "../aptosdb" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-secure-net = { path = "../../secure/net" }
-storage-interface = { path = "../storage-interface" }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-rand = { version = "0.8.3", optional = true }
+aptosdb = { path = "../aptosdb" }
 storage-client = { path = "../storage-client", optional = true }
+storage-interface = { path = "../storage-interface" }
 
 [dev-dependencies]
 itertools = "0.10.0"
-aptosdb = { path = "../aptosdb", features = ["fuzzing"] }
-aptos-temppath = { path = "../../crates/aptos-temppath" }
 proptest = "1.0.0"
+
+aptos-temppath = { path = "../../crates/aptos-temppath" }
+aptosdb = { path = "../aptosdb", features = ["fuzzing"] }
 storage-client = { path = "../storage-client" }
 
 [features]
 default = []
-fuzzing = [ "aptosdb/fuzzing", "rand"]
+fuzzing = ["aptosdb/fuzzing", "rand"]

--- a/testsuite/aptos-fuzzer/Cargo.toml
+++ b/testsuite/aptos-fuzzer/Cargo.toml
@@ -9,50 +9,46 @@ license = "Apache-2.0"
 publish = false
 edition = "2018"
 
-# common dependencies
 [dependencies]
 anyhow = "1.0.57"
+bcs = "0.1.3"
 byteorder = { version = "1.4.3", default-features = false }
 hex = "0.4.3"
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing", "address32"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing"] }
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", default-features = false }
 proptest-derive = { version = "0.3.0", default-features = false }
+rand = "0.8.3"
 rusty-fork = { version = "0.3.0", default-features = false }
 sha-1 = { version = "0.10.0", default-features = false }
 structopt = "0.3.21"
-rand = "0.8.3"
 
-bcs = "0.1.3"
-aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
-aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-
-# List out modules with data structures being fuzzed here.
 accumulator = { path = "../../storage/accumulator", features = ["fuzzing"] }
+aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
+aptos-jellyfish-merkle = { path = "../../storage/jellyfish-merkle", features = ["fuzzing"] }
+aptos-mempool = { path = "../../mempool" }
+aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
+aptos-types = { path = "../../types", features = ["fuzzing"] }
+aptos-vault-client = { path = "../../secure/storage/vault", features = ["fuzzing"] }
+aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
 consensus = { path = "../../consensus", features = ["fuzzing"] }
 consensus-types = { path = "../../consensus/consensus-types", features = ["fuzzing"] }
 executor = { path = "../../execution/executor", features = ["fuzzing"] }
 executor-types = { path = "../../execution/executor-types", features = ["fuzzing"] }
 language-e2e-tests = { path = "../../aptos-move/e2e-tests" }
-aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"]}
-aptos-jellyfish-merkle = { path = "../../storage/jellyfish-merkle", features = ["fuzzing"] }
-aptos-mempool = { path = "../../mempool" }
-aptos-types = { path = "../../types", features = ["fuzzing"] }
-aptos-vault-client = { path = "../../secure/storage/vault", features = ["fuzzing"] }
-aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing"] }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing", "address32"] }
 network = { path = "../../network", features = ["fuzzing"] }
-safety-rules = { path = "../../consensus/safety-rules", features = ["fuzzing", "testing"]  }
-scratchpad = { path = "../../storage/scratchpad", features = ["fuzzing"]}
-state-sync-v1 = { path = "../../state-sync/state-sync-v1", features = ["fuzzing", "aptosdb"]  }
+safety-rules = { path = "../../consensus/safety-rules", features = ["fuzzing", "testing"] }
+scratchpad = { path = "../../storage/scratchpad", features = ["fuzzing"] }
+state-sync-v1 = { path = "../../state-sync/state-sync-v1", features = ["fuzzing", "aptosdb"] }
 storage-interface = { path = "../../storage/storage-interface" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing"] }
 
 [dev-dependencies]
+datatest-stable = "0.1.1"
 rusty-fork = "0.3.0"
 stats_alloc = "0.1.8"
-
-datatest-stable = "0.1.1"
 
 [[test]]
 harness = false

--- a/testsuite/aptos-fuzzer/fuzz/Cargo.toml
+++ b/testsuite/aptos-fuzzer/fuzz/Cargo.toml
@@ -14,11 +14,10 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "=0.3.2"
-aptos-fuzzer = { path = ".." }
-aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
 once_cell = "1.10.0"
 
-# Prevent this from interfering with workspaces
+aptos-fuzzer = { path = ".." }
+aptos-workspace-hack = { path = "../../../crates/aptos-workspace-hack" }
 
 [[bin]]
 name = "fuzz_runner"

--- a/testsuite/forge-cli/Cargo.toml
+++ b/testsuite/forge-cli/Cargo.toml
@@ -11,15 +11,16 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.53"
-aptos-sdk = { path = "../../sdk" }
-aptos-rest-client = { path = "../../crates/aptos-rest-client"}
-forge = { path = "../forge" }
 structopt = "0.3.21"
 tokio = { version = "1.8.1", features = ["full"] }
-testcases = { path = "../testcases" }
 url = "2.2.2"
+
+aptos-rest-client = { path = "../../crates/aptos-rest-client" }
+aptos-sdk = { path = "../../sdk" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 cached-framework-packages = { path = "../../aptos-move/framework/cached-packages" }
+forge = { path = "../forge" }
+testcases = { path = "../testcases" }
 
 [[bin]]
 name = "forge"

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -34,15 +34,15 @@ termcolor = "1.1.2"
 tokio = { version = "1.8.1", features = ["full"] }
 url = "2.2.2"
 
-debug-interface = { path = "../../crates/debug-interface" }
 aptos-config = { path = "../../config" }
 aptos-genesis-tool = { path = "../../config/management/genesis" }
 aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-retrier = { path = "../../crates/aptos-retrier" }
 aptos-sdk = { path = "../../sdk" }
-aptos-rest-client = { path = "../../crates/aptos-rest-client"}
 aptos-secure-storage = { path = "../../secure/storage" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 cached-framework-packages = { path = "../../aptos-move/framework/cached-packages" }
+debug-interface = { path = "../../crates/debug-interface" }
 transaction-emitter = { path = "../../crates/transaction-emitter" }

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -10,22 +10,22 @@ publish = false
 edition = "2018"
 
 [dependencies]
+bcs = "0.1.3"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing", "address32"] }
 rand = "0.8.3"
 serde = { version = "1.0.137", features = ["derive"] }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection" }
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 
-consensus = { path = "../../consensus", features=["fuzzing"] }
-consensus-types = { path = "../../consensus/consensus-types", features=["fuzzing"] }
-bcs = "0.1.3"
 aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../../crates/aptos-crypto", features=["fuzzing"] }
-aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive"}
-aptos-types = { path = "../../types", features=["fuzzing"] }
+aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
+aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
+aptos-types = { path = "../../types", features = ["fuzzing"] }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+consensus = { path = "../../consensus", features = ["fuzzing"] }
+consensus-types = { path = "../../consensus/consensus-types", features = ["fuzzing"] }
 network = { path = "../../network" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["fuzzing", "address32"] }
 
 [[bin]]
 name = "compute"

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -14,10 +14,15 @@ anyhow = "1.0.57"
 async-trait = "0.1.53"
 bcs = "0.1.3"
 diesel = { version = "1.4.8", features = ["chrono", "postgres", "r2d2", "numeric", "serde_json"] }
+hex = "0.4.3"
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 proptest = "1.0.0"
-tokio = { version = "1.8.1", features = ["full"] }
 reqwest = { version = "0.11.10", features = ["json"] }
 serde_json = "1.0.81"
+tokio = { version = "1.8.1", features = ["full"] }
 
 aptos = { path = "../../crates/aptos" }
 aptos-config = { path = "../../config" }
@@ -31,34 +36,28 @@ aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 cached-framework-packages =  { path = "../../aptos-move/framework/cached-packages" }
 forge = { path = "../forge" }
-hex = "0.4.3"
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-move-package = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
-
 
 [dev-dependencies]
 base64 = "0.13.0"
+futures = "0.3.12"
 once_cell = "1.10.0"
 rand = "0.8.3"
 regex = "1.5.5"
 serde_yaml = "0.8.24"
-futures = "0.3.12"
 
-backup-cli = { path = "../../storage/backup/backup-cli" }
-debug-interface = { path = "../../crates/debug-interface" }
-aptos-genesis-tool = {path = "../../config/management/genesis", features = ["testing"] }
+aptos-genesis-tool = { path = "../../config/management/genesis", features = ["testing"] }
 aptos-global-constants = { path = "../../config/global-constants" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-management = { path = "../../config/management", features = ["testing"] }
-aptos-operational-tool = {path = "../../config/management/operational", features = ["testing"] }
+aptos-operational-tool = { path = "../../config/management/operational", features = ["testing"] }
 aptos-secure-storage = { path = "../../secure/storage", features = ["testing"] }
 aptos-time-service = { path = "../../crates/aptos-time-service", features = ["testing"] }
+aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-vault-client = { path = "../../secure/storage/vault", features = ["fuzzing"] }
 aptos-writeset-generator = { path = "../../aptos-move/writeset-transaction-generator" }
-aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
+backup-cli = { path = "../../storage/backup/backup-cli" }
+debug-interface = { path = "../../crates/debug-interface" }
 
 [[test]]
 name = "forge"

--- a/testsuite/testcases/Cargo.toml
+++ b/testsuite/testcases/Cargo.toml
@@ -11,14 +11,15 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
-aptos-sdk = { path = "../../sdk" }
-aptos-operational-tool = {path = "../../config/management/operational", features = ["testing"] }
-aptos-rest-client = { path = "../../crates/aptos-rest-client"}
-forge = { path = "../forge" }
 rand = "0.8.3"
 tokio = { version = "1.8.1", features = ["full"] }
+
 aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-operational-tool = { path = "../../config/management/operational", features = ["testing"] }
+aptos-rest-client = { path = "../../crates/aptos-rest-client" }
+aptos-sdk = { path = "../../sdk" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+forge = { path = "../forge" }
 
 [[test]]
 name = "forge-local-compatibility"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -12,37 +12,37 @@ edition = "2018"
 [dependencies]
 aes-gcm = "0.9.4"
 anyhow = "1.0.57"
+bcs = "0.1.3"
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 hex = "0.4.3"
 itertools = { version = "0.10.3", default-features = false }
-once_cell = "1.10.0"
 mirai-annotations = "1.12.0"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
+move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 num-derive = "0.3.3"
 num-traits = "0.2.15"
+once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", default-features = false, optional = true }
 rand = "0.8.3"
 serde = { version = "1.0.137", default-features = false }
-serde_json = "1.0.81"
 serde_bytes = "0.11.6"
+serde_json = "1.0.81"
 thiserror = "1.0.31"
 tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"] }
 
-bcs = "0.1.3"
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
-move-read-write-set-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3" }
 aptos-workspace-hack = { path = "../crates/aptos-workspace-hack" }
 
 [dev-dependencies]
-regex = "1.5.5"
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing","address32"] }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
+regex = "1.5.5"
 serde_json = "1.0.81"
 
 aptos-crypto = { path = "../crates/aptos-crypto", features = ["fuzzing"] }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["fuzzing","address32"] }
 
 [features]
 default = []

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.57"
 fail = "0.5.0"
+
 aptos-state-view = { path = "../storage/state-view" }
 aptos-types = { path = "../types" }
 aptos-vm = { path = "../aptos-move/aptos-vm" }
@@ -20,17 +21,17 @@ executor = { path = "../execution/executor" }
 storage-interface = { path = "../storage/storage-interface" }
 
 [dev-dependencies]
+move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features = ["address32"] }
 rand = "0.8.3"
 
-executor-test-helpers = { path = "../execution/executor-test-helpers" }
 aptos-crypto = { path = "../crates/aptos-crypto", features = ["fuzzing"] }
 aptos-temppath = { path = "../crates/aptos-temppath" }
 aptos-transaction-builder = { path = "../sdk/transaction-builder" }
 aptos-types = { path = "../types", features = ["fuzzing"] }
 aptos-vm = { path = "../aptos-move/aptos-vm" }
 aptosdb = { path = "../storage/aptosdb", features = ["fuzzing"] }
+executor-test-helpers = { path = "../execution/executor-test-helpers" }
 vm-genesis = { path = "../aptos-move/vm-genesis" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "f2e7585b1ed5bd2810163d6bdebafe5a388881d3", features=["address32"] }
 
 [features]
 default = []


### PR DESCRIPTION
## Motivation

Following on from https://github.com/aptos-labs/aptos-core/pull/869, this PR formats all `Cargo.toml` files and enables the lint checker for all crates. A couple notes:
1. Each `Cargo.toml` dependency section is split up into: (i) 3rd party external crates; and (ii) local crates.
2. We disable the lint checker for the `aptos-workspace-hack` given that the generated output is not always alphabetical.
3. The linter will enforce alphabetical ordering, spacing of files, etc. but it will not enforce property (1) above. Developers can add 3rd party crates to the local crates group and vice versa. This is something we're expecting reviewers to look out for 😄 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manual verification.

## Related PRs

None.
