### PR TITLE
[ecosystem] Emit JSON logs in production.

### DIFF
--- a/ecosystem/platform/server/Gemfile
+++ b/ecosystem/platform/server/Gemfile
@@ -88,6 +88,7 @@ gem 'tailwindcss-rails', '~> 2.0'
 # Monitoring
 gem 'sentry-rails'
 gem 'sentry-ruby'
+gem 'lograge', '~> 0.12.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/ecosystem/platform/server/Gemfile.lock
+++ b/ecosystem/platform/server/Gemfile.lock
@@ -458,8 +458,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kaminari
-  maxmind-geoip2
   lograge (~> 0.12.0)
+  maxmind-geoip2
   omniauth
   omniauth-discord
   omniauth-github

--- a/ecosystem/platform/server/Gemfile.lock
+++ b/ecosystem/platform/server/Gemfile.lock
@@ -204,6 +204,11 @@ GEM
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
+    lograge (0.12.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -323,6 +328,8 @@ GEM
     regexp_parser (2.3.1)
     reline (0.3.1)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -452,6 +459,7 @@ DEPENDENCIES
   jbuilder
   kaminari
   maxmind-geoip2
+  lograge (~> 0.12.0)
   omniauth
   omniauth-discord
   omniauth-github

--- a/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
@@ -39,6 +39,7 @@ class It1ProfilesController < ApplicationController
     end
 
     if @it1_profile.save
+      log @it1_profile, 'created'
       validate_node(v, do_location: true)
       if @it1_profile.validator_verified?
         redirect_to it1_path, notice: 'AIT1 application completed successfully: your node is verified!'
@@ -64,6 +65,7 @@ class It1ProfilesController < ApplicationController
 
     ip_changed = @it1_profile.validator_ip_changed?
     if @it1_profile.update(it1_profile_params)
+      log @it1_profile, 'updated'
       if @it1_profile.validator_verified? && !@it1_profile.needs_revalidation?
         redirect_to it1_path,
                     notice: 'AIT1 node information updated' and return

--- a/ecosystem/platform/server/app/controllers/onboarding_controller.rb
+++ b/ecosystem/platform/server/app/controllers/onboarding_controller.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
-# frozen_string_literal: true
 
 class OnboardingController < ApplicationController
   before_action :authenticate_user!
@@ -13,6 +14,7 @@ class OnboardingController < ApplicationController
 
     email_params = params.require(:user).permit(:email, :username)
     if verify_recaptcha(model: current_user) && current_user.update(email_params)
+      log current_user, 'email updated'
       current_user.send_confirmation_instructions
       redirect_to onboarding_email_path, notice: "Verification email sent to #{email_params[:email]}"
     else

--- a/ecosystem/platform/server/config/initializers/lograge.rb
+++ b/ecosystem/platform/server/config/initializers/lograge.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+Rails.application.configure do
+  config.lograge.enabled = !Rails.env.development? || ENV.fetch('LOGRAGE_IN_DEVELOPMENT', nil) == 'true'
+
+  config.lograge.custom_options = lambda do |event|
+    result = {}
+    result[:time] = Time.now.to_i
+    result[:request_id] = event.payload[:request_id]
+    result[:user_id] = event.payload[:user_id] if event.payload[:user_id].present?
+    result
+  end
+end

--- a/ecosystem/platform/server/config/initializers/lograge.rb
+++ b/ecosystem/platform/server/config/initializers/lograge.rb
@@ -5,10 +5,11 @@
 
 Rails.application.configure do
   config.lograge.enabled = !Rails.env.development? || ENV.fetch('LOGRAGE_IN_DEVELOPMENT', nil) == 'true'
+  config.lograge.formatter = Lograge::Formatters::Json.new
 
   config.lograge.custom_options = lambda do |event|
     result = {}
-    result[:time] = Time.now.to_i
+    result[:time] = Time.now.to_f
     result[:request_id] = event.payload[:request_id]
     result[:user_id] = event.payload[:user_id] if event.payload[:user_id].present?
     result

--- a/ecosystem/platform/server/lib/logging/logs.rb
+++ b/ecosystem/platform/server/lib/logging/logs.rb
@@ -9,28 +9,28 @@ module Logging
     USER_ID_KEY = 'user_id'
 
     def log(message_or_object, message = nil)
-      result = []
-      result << "time=#{Time.now.to_i}"
-      result << "class=#{self.class}"
+      result = {}
+
+      result[:time] = Time.now.to_f
+      result[:class] = self.class
 
       request_id = Thread.current.thread_variable_get(REQUEST_ID_KEY)
-      result << "request_id=#{request_id}"
+      result[:request_id] = request_id
 
       user_id = Thread.current.thread_variable_get(USER_ID_KEY)
-      result << "user_id=#{user_id}" if user_id.present?
+      result[:user_id] = user_id if user_id.present?
 
       if message.nil?
         message = message_or_object
       else
         object = message_or_object
-        result << "object_class=#{object.class}"
-        result << "object_id=#{object.id}" if object.respond_to?(:id)
+        result[:object_class] = object.class
+        result[:object_id] = object.id if object.respond_to?(:id)
       end
 
-      message = message.gsub('"', '\"')
-      result << "message=\"#{message}\""
+      result[:message] = message
 
-      Rails.logger.info(result.join(' '))
+      Rails.logger.info(result.to_json)
     end
   end
 end

--- a/ecosystem/platform/server/lib/logging/logs.rb
+++ b/ecosystem/platform/server/lib/logging/logs.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+module Logging
+  module Logs
+    REQUEST_ID_KEY = 'request_id'
+    USER_ID_KEY = 'user_id'
+
+    def log(message_or_object, message = nil)
+      result = []
+      result << "time=#{Time.now.to_i}"
+      result << "class=#{self.class}"
+
+      request_id = Thread.current.thread_variable_get(REQUEST_ID_KEY)
+      result << "request_id=#{request_id}"
+
+      user_id = Thread.current.thread_variable_get(USER_ID_KEY)
+      result << "user_id=#{user_id}" if user_id.present?
+
+      if message.nil?
+        message = message_or_object
+      else
+        object = message_or_object
+        result << "object_class=#{object.class}"
+        result << "object_id=#{object.id}" if object.respond_to?(:id)
+      end
+
+      message = message.gsub('"', '\"')
+      result << "message=\"#{message}\""
+
+      Rails.logger.info(result.join(' '))
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Adds `lograge` to emit JSON logs (all on one line) in production/test environments. Also adds the `request_id` and `user_id` (if present) to aid request tracing. Adds a `Logging::Logs.log()` method which automatically emits `object_class` and `object_id` if present.

Example HTTP request log:

```
{"method":"POST","path":"/onboarding/email","format":"html","controller":"OnboardingController","action":"email_update","status":302,"duration":296.65,"view":0.0,"db":2.11,"location":"http://localhost:3001/onboarding/email","time":1652308730.7250135,"request_id":"83daae2f-c9a0-4a79-aa5b-4e6286d8fc4a","user_id":2}
```

Example `Logging::Logs.log()` log

```
{"time":1652308730.5666764,"class":"OnboardingController","request_id":"83daae2f-c9a0-4a79-aa5b-4e6286d8fc4a","user_id":2,"object_class":"User","object_id":2,"message":"email updated"}
```

## Test Plan

Manual testing with `LOGRAGE_IN_DEVELOPMENT=true`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
