### PR TITLE
[storage] TransactionStore::get_write_sets

### DIFF
--- a/storage/aptosdb/src/transaction_store/test.rs
+++ b/storage/aptosdb/src/transaction_store/test.rs
@@ -36,6 +36,7 @@ proptest! {
             store.put_write_set(ver as Version, ws, &mut cs).unwrap();
         }
         store.db.write_schemas(cs.batch).unwrap();
+        assert_eq!(store.get_write_sets(0, write_sets.len() as Version).unwrap(), write_sets);
 
         assert_eq!(store.get_first_txn_version().unwrap(), Some(0));
         assert_eq!(store.get_first_write_set_version().unwrap(), Some(0));


### PR DESCRIPTION

## Motivation

In preparation for per-block SMT update. (Gonna need write sets after latest checkpoint on start up).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y
## Test Plan
Unit test