### PR TITLE
Add stubs for transaction native functions

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/Transaction.move
+++ b/aptos-move/framework/aptos-framework/sources/Transaction.move
@@ -1,7 +1,7 @@
 /// Native Move functions for transaction metadata and scheduling
 module AptosFramework::Transaction {
 
-    use Std::Option::Option;
+    use AptosFramework::TypeInfo
     use Std::ASCII::String;
 
     /// Return the version number of the distributed database,
@@ -10,23 +10,19 @@ module AptosFramework::Transaction {
     /// [Versioned database](https://aptos.dev/basics/basics-txns-states#versioned-database)
     public native fun version_number(): u64;
 
-    /// Initialize a recurring transaction for a public script function
-    /// that takes no arguments, to execute at the end of every `n`th
-    /// block
-    public(script) native fun init_schedule(
+    /// Schedule transaction for the epilogue of a block, delaying by
+    /// `delay` blocks. A `delay` of 0 schedules a transaction during
+    /// the epilogue of the current block, and can only be called from a
+    /// non-epilogue transaction. Calling during the epilogue requires
+    /// a `delay` of at least 1, corresponding to a transaction
+    /// scheduled during the epilogue of the next block.
+    public(script) native fun schedule(
         account: &signer,
         script_address: address,
         script_module_name: String,
         script_function_name: String,
-        n: u64,
-    );
-
-    /// Cancel the recurring schedule for a transaction previously
-    /// authorized by `account`
-    public(script) native fun cancel_schedule(
-        account: &signer,
-        script_address: address,
-        script_module_name: String,
-        script_function_name: String,
+        type_arguments: &vector<TypeInfo>,
+        arguments: &vector<String>,
+        delay: u64,
     );
 }

--- a/aptos-move/framework/aptos-framework/sources/Transaction.move
+++ b/aptos-move/framework/aptos-framework/sources/Transaction.move
@@ -1,0 +1,32 @@
+/// Native Move functions for transaction metadata and scheduling
+module AptosFramework::Transaction {
+
+    use Std::Option::Option;
+    use Std::ASCII::String;
+
+    /// Return the version number of the distributed database,
+    /// corresponding to the number of transactions the system will have
+    /// executed upon the conclusion of the current one. Reference:
+    /// [Versioned database](https://aptos.dev/basics/basics-txns-states#versioned-database)
+    public native fun version_number(): u64;
+
+    /// Initialize a recurring transaction for a public script function
+    /// that takes no arguments, to execute at the end of every `n`th
+    /// block
+    public(script) native fun init_schedule(
+        account: &signer,
+        script_address: address,
+        script_module_name: String,
+        script_function_name: String,
+        n: u64,
+    );
+
+    /// Cancel the recurring schedule for a transaction previously
+    /// authorized by `account`
+    public(script) native fun cancel_schedule(
+        account: &signer,
+        script_address: address,
+        script_module_name: String,
+        script_function_name: String,
+    );
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

The proposed native functions enable the functionality described during a previous call with core Aptos developers, namely a parallelized matching engine for a central limit order book. The code changes in this pull request are only stubs, designed to initiate a conversation about future development.

The proposed native function `AptosFramework::Transaction::version_number` returns the Aptos ledger version number during transaction execution, which allows for chronological re-sequencing of data structures within Move, when they have been written to non-overlapping locations in memory. Through Block-STM's optimistic concurrency, non-overlapping write sets execute in parallel, and if the data structure in each write set can be marked with the version number as proposed through this native function, then it is possible for a matching engine to determine chronology for data structures that were written, for example, to queues that were designed to take in orders in parallel.

The second proposed native function `AptosFramework::Transaction::init_schedule` initializes a regular schedule for transaction execution of a public script function, authorized by the signing account. This is basically a transaction scheduler that enables a matching engine on a central limit order book to be invoked on a regular interval, for example through a simple trigger function of the form `Orderbook::Match::match`. Without a transaction scheduler, the matching engine would require external inputs to initiate dispersement of funds, analagous to "crank turners" on the Serum DEX from Solana.

The third proposed native function, `AptosFramework::Transaction::cancel_schedule` ends the recurring schedule for a public script function that had been initialized per above.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, I have, and I have signed a CLA

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/910)
<!-- Reviewable:end -->
