### PR TITLE
[API] Read account resource directly from state store instead of creating account state

### DIFF
--- a/api/goldens/aptos_api__tests__accounts_test__test_get_core_account_data_not_found.json
+++ b/api/goldens/aptos_api__tests__accounts_test__test_get_core_account_data_not_found.json
@@ -1,5 +1,5 @@
 {
   "code": 404,
-  "message": "account not found by address(0xf) and ledger version(0)",
+  "message": "resource not found by address(0xf), struct tag(0x1::Account::Account) and ledger version(0)",
   "aptos_ledger_version": "0"
 }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -17,7 +17,11 @@ use aptos_types::{
 use storage_interface::{DbReader, Order};
 
 use anyhow::{ensure, format_err, Result};
-use aptos_types::{state_store::state_key_prefix::StateKeyPrefix, transaction::Version};
+use aptos_state_view::StateView;
+use aptos_types::{
+    state_store::{state_key::StateKey, state_key_prefix::StateKeyPrefix},
+    transaction::Version,
+};
 use aptos_vm::data_cache::{IntoMoveResolver, RemoteStorageOwned};
 use futures::{channel::oneshot, SinkExt};
 use std::{convert::Infallible, sync::Arc};
@@ -89,6 +93,12 @@ impl Context {
 
     pub fn get_latest_ledger_info_with_signatures(&self) -> Result<LedgerInfoWithSignatures> {
         self.db.get_latest_ledger_info()
+    }
+
+    pub fn get_state_value(&self, state_key: &StateKey, version: u64) -> Result<Option<Vec<u8>>> {
+        self.db
+            .state_view_at_version(Some(version))?
+            .get_state_value(state_key)
     }
 
     pub fn get_account_state(


### PR DESCRIPTION
## Motivation

An optimization to the API after fine-grained storage. Instead of creating `AccountState`, which reads all the resources of an account, we just read the `AccountResource`.
