### PR TITLE
Devnet: Added a fix to Indexer that fixes the problem 'unsupported Unicode escape sequence' when Indexer insert into DB event or changes(resource)

### DIFF
--- a/ecosystem/indexer/src/models/events.rs
+++ b/ecosystem/indexer/src/models/events.rs
@@ -23,6 +23,13 @@ pub struct Event {
 
 impl Event {
     pub fn from_event(transaction_hash: String, event: &APIEvent) -> Self {
+        let mut _data = event.data.clone();
+        let from_message = serde_json::to_string(&_data["from_message"]).unwrap();
+        let to_message = serde_json::to_string(&_data["from_message"]).unwrap();
+
+        _data["from_message"] = serde_json::Value::from(from_message.trim_matches(char::from(0)).replace("\\u0000", ""));
+        _data["to_message"] = serde_json::Value::from(to_message.trim_matches(char::from(0)).replace("\\u0000", ""));
+        
         Event {
             transaction_hash,
             key: event.key.to_string(),

--- a/ecosystem/indexer/src/models/write_set_changes.rs
+++ b/ecosystem/indexer/src/models/write_set_changes.rs
@@ -93,15 +93,22 @@ impl WriteSetChange {
                 address,
                 state_key_hash,
                 data,
-            } => WriteSetChange {
-                transaction_hash,
-                hash: state_key_hash.clone(),
-                type_: write_set_change.type_str().to_string(),
-                address: address.to_string(),
-                module: Default::default(),
-                resource: Default::default(),
-                data: serde_json::to_value(data).unwrap(),
-                inserted_at: chrono::Utc::now().naive_utc(),
+            } => {
+                let _data = &data;
+                let mut _json = serde_json::to_value(_data).unwrap();
+                let str = serde_json::to_string(&_json["data"]["message"]).unwrap();
+                _json["data"]["message"] = serde_json::Value::from(str.trim_matches(char::from(0)).replace("\\u0000", ""));
+
+                WriteSetChange {
+                    transaction_hash,
+                    hash: state_key_hash.clone(),
+                    type_: write_set_change.type_str().to_string(),
+                    address: address.to_string(),
+                    module: Default::default(),
+                    resource: Default::default(),
+                    data: _json,
+                    inserted_at: chrono::Utc::now().naive_utc(),
+                }
             },
             APIWriteSetChange::WriteTableItem {
                 state_key_hash,


### PR DESCRIPTION
## Motivation

The main problem:
```
2022-05-06T05:45:06.164926Z [tokio-runtime-worker] WARN ecosystem/indexer/src/database.rs:38 Error running query: DatabaseError(__Unknown, "unsupported Unicode escape sequence")
INSERT INTO "events" ("transaction_hash", "key", "sequence_number", "type", "data", "inserted_at") VALUES ($1, $2, $3, $4, $5, $6) ON CONFLICT DO NOTHING -- binds: 

["0x117b393271edea6da45bfa1a2d4387ffbd7fdb178f10eee6178c2521e0146221", "0x02000000000000002a0e66fde889cebf0401e676bb9bfa073e03caa9c009c66b739c30d24dccad81", 0, "0x2a0e66fde889cebf0401e676bb9bfa073e03caa9c009c66b739c30d24dccad81::Message::MessageChangeEvent", Object({"from_message": String("he\u{0}\u{0} w\u{7} d!"), "to_message": String("he\u{0}\u{0} w\u{7} d!")}), 2022-05-06T14:03:32.596190953]

thread 'tokio-runtime-worker' panicked at 'Error inserting row into database: DatabaseError(__Unknown, "unsupported Unicode escape sequence")', ecosystem/indexer/src/default_processor.rs:61:6
```
This fix solves this problem for Events and Changes (resource).