### PR TITLE
[Storage][API] Switch to non-proof reading DB APIs

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -664,10 +664,7 @@ impl DbReader for AptosDB {
         gauged_api("get_latest_state_value", || {
             let ledger_info_with_sigs = self.ledger_store.get_latest_ledger_info()?;
             let version = ledger_info_with_sigs.ledger_info().version();
-            let (blob, _proof) = self
-                .state_store
-                .get_value_with_proof_by_version(&state_key, version)?;
-            Ok(blob)
+            self.state_store.get_value_by_version(&state_key, version)
         })
     }
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1032,6 +1032,17 @@ impl DbReader for AptosDB {
         })
     }
 
+    fn get_state_value_by_version(
+        &self,
+        state_store_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<StateValue>> {
+        gauged_api("get_state_value_by_version", || {
+            self.state_store
+                .get_value_by_version(state_store_key, version)
+        })
+    }
+
     fn get_latest_tree_state(&self) -> Result<TreeState> {
         gauged_api("get_latest_tree_state", || {
             let tree_state = match self.ledger_store.get_latest_transaction_info_option()? {

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -196,7 +196,6 @@ impl StateStore {
     /// Get the state value given the state key and root hash of state Merkle tree by using the
     /// state value index. Only used for testing for now but should replace the
     /// `get_value_with_proof_by_version` call for VM execution to fetch the value without proof.
-    #[cfg(test)]
     pub fn get_value_by_version(
         &self,
         state_key: &StateKey,
@@ -221,7 +220,6 @@ impl StateStore {
 
     /// Returns the value index in the form of number of nibbles for given pair of state key and version
     /// which can be used to index into the JMT leaf.
-    #[cfg(test)]
     fn get_jmt_leaf_node_key(
         &self,
         state_key: &StateKey,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -427,7 +427,7 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    // Gets an account state by account address, out of the ledger state indicated by the state
+    // Gets a state value and corresponding proof for a state key for the ledger state indicated by the state
     // Merkle tree root with a sparse merkle proof proving state tree root.
     // See [`AptosDB::get_account_state_with_proof_by_version`].
     //
@@ -440,6 +440,15 @@ pub trait DbReader: Send + Sync {
         state_key: &StateKey,
         version: Version,
     ) -> Result<(Option<StateValue>, SparseMerkleProof<StateValue>)> {
+        unimplemented!()
+    }
+    /// Returns the state value for a state key without reading the corresponding proof from the DB.
+    /// This is useful for clients, which don't care about the state proof.
+    fn get_state_value_by_version(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<StateValue>> {
         unimplemented!()
     }
 

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -48,6 +48,14 @@ impl DbReader for MockDbReaderWriter {
             SparseMerkleProof::new(None, vec![]),
         ))
     }
+
+    fn get_state_value_by_version(
+        &self,
+        state_key: &StateKey,
+        _: Version,
+    ) -> Result<Option<StateValue>> {
+        Ok(self.get_latest_state_value(state_key.clone()).unwrap())
+    }
 }
 
 fn get_mock_account_state() -> AccountState {

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -16,8 +16,8 @@ impl DbStateView {
     fn get(&self, key: &StateKey) -> Result<Option<Vec<u8>>> {
         if let Some(version) = self.version {
             self.db
-                .get_state_value_with_proof_by_version(key, version)
-                .map(|(value_opt, _proof)| {
+                .get_state_value_by_version(key, version)
+                .map(|value_opt| {
                     // Hack: `v.maybe_bytes == None` represents deleted value, deemed non-existent
                     value_opt.and_then(|value| value.maybe_bytes)
                 })


### PR DESCRIPTION
## Motivation

Previously we used to read proofs for all APIs because there was no way to read a value without reading the proofs. Now that we have DB index enabled for the value, we can switch to non-proof reading APIs wherever applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/923)
<!-- Reviewable:end -->
