### PR TITLE
[aptos-cli] Output Validator and VFN identity files for genesis

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -160,12 +160,19 @@ impl WaypointConfig {
     }
 }
 
+/// A single struct for reading / writing to a file for identity across config
 #[derive(Deserialize, Serialize)]
 pub struct IdentityBlob {
-    pub account_address: AccountAddress,
-    pub account_key: Ed25519PrivateKey,
+    /// Optional account address.  Used for validators and validator full nodes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_address: Option<AccountAddress>,
+    /// Optional account key.  Only used for validators
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_key: Option<Ed25519PrivateKey>,
     /// Optional consensus key.  Only used for validators
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub consensus_key: Option<Ed25519PrivateKey>,
+    /// Network private key.  Peer id is derived from this if account address is not present
     pub network_key: x25519::PrivateKey,
 }
 

--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -23,11 +23,11 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConfigKey<T: PrivateKey + Serialize> {
     #[serde(bound(deserialize = "T: Deserialize<'de>"))]
-    pub(crate) key: T,
+    key: T,
 }
 
 impl<T: DeserializeOwned + PrivateKey + Serialize> ConfigKey<T> {
-    pub(crate) fn new(key: T) -> Self {
+    pub fn new(key: T) -> Self {
         Self { key }
     }
 

--- a/consensus/safety-rules/src/safety_rules_manager.rs
+++ b/consensus/safety-rules/src/safety_rules_manager.rs
@@ -62,11 +62,15 @@ pub fn storage(config: &SafetyRulesConfig) -> PersistentSafetyStorage {
                 backend.try_into().expect("Unable to initialize storage");
             PersistentSafetyStorage::initialize(
                 internal_storage,
-                identity_blob.account_address,
+                identity_blob
+                    .account_address
+                    .expect("AccountAddress needed for safety rules"),
                 identity_blob
                     .consensus_key
                     .expect("Consensus key needed for safety rules"),
-                identity_blob.account_key,
+                identity_blob
+                    .account_key
+                    .expect("Account key needed for safety rules"),
                 waypoint,
                 config.enable_cached_safety_data,
             )

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -41,7 +41,7 @@ toml = "0.5.9"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
 aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../aptos-crypto" }
+aptos-crypto = { path = "../aptos-crypto", features = [] }
 aptos-github-client = { path = "../../secure/storage/github" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-management = { path = "../../config/management" }

--- a/crates/aptos/src/genesis/config.rs
+++ b/crates/aptos/src/genesis/config.rs
@@ -59,10 +59,12 @@ pub struct ValidatorConfiguration {
     pub consensus_key: Ed25519PublicKey,
     /// Key used for signing transactions with the account
     pub account_key: Ed25519PublicKey,
-    /// Public key used for network identity (same as account address)
-    pub network_key: x25519::PublicKey,
+    /// Public key used for validator network identity (same as account address)
+    pub validator_network_key: x25519::PublicKey,
     /// Host for validator which can be an IP or a DNS name
     pub validator_host: HostAndPort,
+    /// Public key used for full node network identity (same as account address)
+    pub full_node_network_key: x25519::PublicKey,
     /// Host for full node which can be an IP or a DNS name and is optional
     pub full_node_host: Option<HostAndPort>,
     /// Stake amount for consensus
@@ -76,11 +78,11 @@ impl TryFrom<ValidatorConfiguration> for Validator {
         let auth_key = AuthenticationKey::ed25519(&config.account_key);
         let validator_addresses = vec![config
             .validator_host
-            .as_network_address(config.network_key)
+            .as_network_address(config.validator_network_key)
             .unwrap()];
         let full_node_addresses = if let Some(full_node_host) = config.full_node_host {
             vec![full_node_host
-                .as_network_address(config.network_key)
+                .as_network_address(config.full_node_network_key)
                 .unwrap()]
         } else {
             vec![]

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     common::{
-        types::{CliError, CliTypedResult},
-        utils::{read_from_file, write_to_file},
+        types::{CliError, CliTypedResult, PromptOptions},
+        utils::{check_if_file_exists, read_from_file, write_to_file},
     },
     genesis::{
         config::{HostAndPort, ValidatorConfiguration},
@@ -13,6 +13,7 @@ use crate::{
     op::key,
     CliCommand,
 };
+use aptos_config::{config::IdentityBlob, keys::ConfigKey};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, x25519, PrivateKey};
 use aptos_types::transaction::authenticator::AuthenticationKey;
 use async_trait::async_trait;
@@ -22,39 +23,64 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 const PRIVATE_KEYS_FILE: &str = "private-keys.yaml";
+const VALIDATOR_FILE: &str = "validator-identity.yaml";
+const VFN_FILE: &str = "validator-full-node-identity.yaml";
 
 /// Generate account key, consensus key, and network key for a validator
 #[derive(Parser)]
 pub struct GenerateKeys {
+    #[clap(flatten)]
+    prompt_options: PromptOptions,
     /// Output path for the three keys
     #[clap(long, parse(from_os_str), default_value = ".")]
     output_dir: PathBuf,
 }
 
 #[async_trait]
-impl CliCommand<PathBuf> for GenerateKeys {
+impl CliCommand<Vec<PathBuf>> for GenerateKeys {
     fn command_name(&self) -> &'static str {
         "GenerateKeys"
     }
 
-    async fn execute(self) -> CliTypedResult<PathBuf> {
-        let account_key = key::GenerateKey::generate_ed25519_in_memory();
-        let consensus_key = key::GenerateKey::generate_ed25519_in_memory();
-        // Start network key based off of the account key, we can update it later
-        let network_key =
-            x25519::PrivateKey::from_ed25519_private_bytes(&account_key.to_bytes()).unwrap();
+    async fn execute(self) -> CliTypedResult<Vec<PathBuf>> {
         let keys_file = self.output_dir.join(PRIVATE_KEYS_FILE);
+        let validator_file = self.output_dir.join(VALIDATOR_FILE);
+        let vfn_file = self.output_dir.join(VFN_FILE);
+        check_if_file_exists(keys_file.as_path(), self.prompt_options)?;
+        check_if_file_exists(validator_file.as_path(), self.prompt_options)?;
+        check_if_file_exists(vfn_file.as_path(), self.prompt_options)?;
+
+        let account_key = ConfigKey::new(key::GenerateKey::generate_ed25519_in_memory());
+        let consensus_key = ConfigKey::new(key::GenerateKey::generate_ed25519_in_memory());
+        let validator_network_key = ConfigKey::new(key::GenerateKey::generate_x25519_in_memory()?);
+        let full_node_network_key = ConfigKey::new(key::GenerateKey::generate_x25519_in_memory()?);
 
         let account_address =
             AuthenticationKey::ed25519(&account_key.public_key()).derived_address();
 
-        let config = KeysAndAccount {
-            account_address,
-            account_key,
-            consensus_key,
-            network_key,
+        // Build these for use later as node identity
+        let validator_blob = IdentityBlob {
+            account_address: Some(account_address),
+            account_key: Some(account_key.private_key()),
+            consensus_key: Some(consensus_key.private_key()),
+            network_key: validator_network_key.private_key(),
+        };
+        let vfn_blob = IdentityBlob {
+            account_address: Some(account_address),
+            account_key: None,
+            consensus_key: None,
+            network_key: full_node_network_key.private_key(),
         };
 
+        let config = PrivateIdentity {
+            account_address,
+            account_key: account_key.private_key(),
+            consensus_key: consensus_key.private_key(),
+            full_node_network_key: full_node_network_key.private_key(),
+            validator_network_key: validator_network_key.private_key(),
+        };
+
+        // Create the directory if it doesn't exist
         if !self.output_dir.exists() || !self.output_dir.is_dir() {
             std::fs::create_dir(&self.output_dir)
                 .map_err(|e| CliError::IO(self.output_dir.to_str().unwrap().to_string(), e))?
@@ -62,19 +88,27 @@ impl CliCommand<PathBuf> for GenerateKeys {
 
         write_to_file(
             keys_file.as_path(),
-            "private_keys.yaml",
+            PRIVATE_KEYS_FILE,
             to_yaml(&config)?.as_bytes(),
         )?;
-        Ok(keys_file)
+        write_to_file(
+            validator_file.as_path(),
+            VALIDATOR_FILE,
+            to_yaml(&validator_blob)?.as_bytes(),
+        )?;
+        write_to_file(vfn_file.as_path(), VFN_FILE, to_yaml(&vfn_blob)?.as_bytes())?;
+        Ok(vec![keys_file, validator_file, vfn_file])
     }
 }
 
+/// Type for serializing private keys file
 #[derive(Deserialize, Serialize)]
-pub struct KeysAndAccount {
+pub struct PrivateIdentity {
     account_address: AccountAddress,
     account_key: Ed25519PrivateKey,
     consensus_key: Ed25519PrivateKey,
-    network_key: x25519::PrivateKey,
+    full_node_network_key: x25519::PrivateKey,
+    validator_network_key: x25519::PrivateKey,
 }
 
 /// Set ValidatorConfiguration for a single validator in the git repository
@@ -108,19 +142,21 @@ impl CliCommand<()> for SetValidatorConfiguration {
     async fn execute(self) -> CliTypedResult<()> {
         let private_keys_path = self.keys_dir.join(PRIVATE_KEYS_FILE);
         let bytes = read_from_file(private_keys_path.as_path())?;
-        let key_files: KeysAndAccount =
+        let key_files: PrivateIdentity =
             from_yaml(&String::from_utf8(bytes).map_err(CliError::from)?)?;
         let account_address = key_files.account_address;
         let account_key = key_files.account_key.public_key();
         let consensus_key = key_files.consensus_key.public_key();
-        let network_key = key_files.network_key.public_key();
+        let validator_network_key = key_files.validator_network_key.public_key();
+        let full_node_network_key = key_files.full_node_network_key.public_key();
 
         let credentials = ValidatorConfiguration {
             account_address,
             consensus_key,
             account_key,
-            network_key,
+            validator_network_key,
             validator_host: self.validator_host,
+            full_node_network_key,
             full_node_host: self.full_node_host,
             stake_amount: self.stake_amount,
         };


### PR DESCRIPTION
## Motivation

Lets make it simple, one file to startup a VFN, and one to start up a Validator.  Validator runners are suggested to keep all three files safe.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Generation:
```
$ aptos genesis generate-keys --assume-yes --output-dir node1
{ 
  "Result": [
    "node1/private-keys.yaml",
    "node1/validator-identity.yaml",
    "node1/validator-full-node-identity.yaml"
  ]
}
greg@apt:~/poc$ cat node1/validator-identity.yaml 
---
account_address: 6f8f7836cc79efa49478b89882136c3ca96a585ef18fefd9011db8adc218f0d9
account_key: "..."
consensus_key: "..."
network_key: "..."
greg@apt:~/poc$ cat node1/validator-full-node-identity.yaml 
---
account_address: 6f8f7836cc79efa49478b89882136c3ca96a585ef18fefd9011db8adc218f0d9
account_key: ~
consensus_key: ~
network_key: "..."
greg@apt:~/poc$ cat node1/private-keys.yaml 
---
account_address: 6f8f7836cc79efa49478b89882136c3ca96a585ef18fefd9011db8adc218f0d9
account_key: "..."
consensus_key: "..."
full_node_network_key: "..."
validator_network_key: "..."

```

Validator node config:
```
$ cat node1/node1.yml 
base:
  role: "validator"
  data_dir: "/home/greg/poc/node1/data"
  waypoint:
    from_file: "/home/greg/poc/waypoint.txt"

consensus:
  safety_rules:
    service:
      type: "local"
    backend:
      type: "on_disk_storage"
      path: "/home/greg/poc/node1/secure-data.json"
      namespace: ~
    initial_safety_rules_config:
      from_file:
        waypoint:
          from_file: "/home/greg/poc/waypoint.txt"
        identity_blob_path: "/home/greg/poc/node1/validator-identity.yaml"

execution:
  genesis_file_location: "/home/greg/poc/genesis.blob"
  concurrency_level: 1

validator_network:
  listen_address: "/ip4/0.0.0.0/tcp/6180"
  discovery_method: "onchain"
  mutual_authentication: true
  identity:
    type: "from_file"
    path: "/home/greg/poc/node1/validator-identity.yaml"


api:
  enabled: false
  address: "0.0.0.0:8080"

storage:
  address: "0.0.0.0:6181"
  backup_service_address: "0.0.0.0:6186"

debug_interface:
  admission_control_node_debug_port: 6191
  metrics_server_port: 9101
  public_metrics_server_port: 9102

full_node_networks:
- listen_address: "/ip4/0.0.0.0/tcp/7180"
  max_outbound_connections: 0
  identity:
    type: "from_file"
    path: "/home/greg/poc/node1/validator-identity.yaml"
  network_id:
    private: "vfn"
```

VFN node config:
```
$ cat vfn1/vfn1.yml 
base:
  data_dir: "/home/greg/poc/vfn1/data"
  role: "full_node"
  waypoint:
    from_file: "/home/greg/poc/waypoint.txt"

execution:
  genesis_file_location: "/home/greg/poc/genesis.blob"
  concurrency_level: 1

full_node_networks:
- listen_address: "/ip4/0.0.0.0/tcp/6183"
  discovery_method: "onchain"
  identity:
    type: "from_file"
    path: "/home/greg/poc/vfn1/validator-full-node-identity.yaml"
  network_id: "public"
- listen_address: "/ip4/0.0.0.0/tcp/9001"
  max_outbound_connections: 1
  network_id:
    private: "vfn"
  seeds:
    "f1e1189d54a64e8f41a033c23b9137d19c4ff9b738451e08242d990f282ed1ef":
      addresses:
        - "/ip4/127.0.0.1/tcp/7180/ln-noise-ik/0xf3e8377707d844d9ed04aad8926eb6364c733a9fe1177374e7a588a233a67e55/ln-handshake/0"
      keys: []
      role: "Validator"
api:
  enabled: true
  address: "0.0.0.0:9090"

storage:
  address: "0.0.0.0:9002"
  backup_service_address: "0.0.0.0:9003"

debug_interface:
  admission_control_node_debug_port: 9004
  metrics_server_port: 9005
  public_metrics_server_port: 9006
```

Mini testnet works:
```
2022-05-11T21:03:18.575387Z [network-vfn] INFO network/src/connectivity_manager/mod.rs:928 [full_node,vfn,9f378ead] Successfully connected to peer: f1e1189d at address: /ip4/127.0.0.1/tcp/7180/ln-noise-ik/0xf3e8377707d844d9ed04aad8926eb6364c733a9fe1177374e7a588a233a67e55/ln-handshake/0 {"network_address":"/ip4/127.0.0.1/tcp/7180/ln-noise-ik/0xf3e8377707d844d9ed04aad8926eb6364c7
33a9fe1177374e7a588a233a67e55/ln-handshake/0","network_context":{"role":"full_node","network_id":"vfn","peer_id":"9f378ead2ec819535a04519bc4add793370bd03cfb483479e4ff2864bad11951"},"remote_peer":"F1E1189D54A64E8F41A033C23B9137D19C4FF9B738451E08242D990F282ED1EF"}
```