### PR TITLE
[telemetry] use http

### DIFF
--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -10,7 +10,7 @@ pub const APTOS_GA_MEASUREMENT_ID: &str = "G-ZX4L6WPCFZ";
 pub const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
 
 pub const HTTPBIN_URL: &str = "http://httpbin.org/ip";
-pub const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
+pub const GA4_URL: &str = "http://www.google-analytics.com/mp/collect";
 
 // Timeouts
 pub const NETWORK_PUSH_TIME_SECS: u64 = 30;


### PR DESCRIPTION
Use HTTP so as not to block on cert issues, esp from complex container setups