### PR TITLE
[telemetry] use chain_id as u8

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -414,7 +414,7 @@ async fn periodic_telemetry_dump(node_config: NodeConfig, db: DbReaderWriter) {
                 }
 
                 // get some data we do not currently have metrics for
-                let chain_id = fetch_chain_id(&db);
+                let chain_id = fetch_chain_id(&db).id(); // get the chain_id as its u8 id for consistency of schema
                 let peer_id = match node_config.peer_id() {
                     Some(p) => p.to_string(),
                     None => String::new()


### PR DESCRIPTION
Previously, we were just relying on the to_string for ChainId, which partially relies on the notion of "NamedChains" (e.g. Mainnet, Testnet, Devnet, etc.). So sometimes ChainId is a string, sometime it's an integer.

This normalizes that, so telemetry backend can have a consistent schema.

Before:

```
... "CHAIN_ID": "TESTING", "GIT_REV": "0336ebb43"} }] }
```

After:

```
... "CHAIN_ID": "4", "GIT_REV": "2bf40fdc6"} }] }
```