### PR TITLE
[aptos-cli] Add build script for CLI release and bump CLI version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "aptos-config",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################
+# Build and package a release for the CLI #
+#                                         #
+###########################################
+
+# Note: This must be run from the root of the aptos-core repository
+NAME='aptos-cli'
+CRATE_NAME='aptos'
+CARGO_PATH="crates/$CRATE_NAME/Cargo.toml"
+
+# Grab system information
+ARCH=`uname -m`
+OS=`uname -s`
+VERSION=`cat "$CARGO_PATH" | grep "^\w*version =" | sed 's/^.*=[ ]*"//g' | sed 's/".*$//g'`
+
+if [ "$OS" == "Darwin" ]; then
+  # Rename Darwin to MacOSX so it's less confusing
+  OS="MacOSX"
+elif [ "$OS" == "Linux" ]; then
+  # Get linux flavor
+  OS=`cat /etc/os-release | grep '^NAME=' | sed 's/^.*=//g' | sed 's/"//g'`
+fi
+
+echo "Building release $VERSION of $NAME for $OS-$ARCH"
+cargo build -p $CRATE_NAME --release
+
+EXIT_CODE=$?
+if [ "$EXIT_CODE" != "0" ]; then
+  echo "Build failed with exit code $EXIT_CODE"
+  exit $EXIT_CODE
+fi
+
+cd target/release/
+
+# Compress the CLI
+ZIP_NAME="$NAME-$VERSION-$OS-$ARCH.zip"
+
+echo "Zipping release: $ZIP_NAME"
+zip $ZIP_NAME $CRATE_NAME
+mv $ZIP_NAME ../..
+
+# TODO: Add installation instructions?


### PR DESCRIPTION
## Motivation

Script to build CLI release, and I bumped the CLI version for those users.  It's not the prettiest thing, but it does the job.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran locally, builds CLI and tested on Mac and Linux.  Windows doesn't build, because we have dependencies that don't work with it.

```
$ ./scripts/cli/build_cli_release.sh
Building release 0.1.1 of aptos-cli for MacOSX-x86_64
   Compiling aptos-metrics v0.1.0 (/opt/git/aptos-core/crates/aptos-metrics)
   Compiling scratchpad v0.1.0 (/opt/git/aptos-core/storage/scratchpad)
   Compiling aptos-vm v0.1.0 (/opt/git/aptos-core/aptos-move/aptos-vm)
   Compiling schemadb v0.1.0 (/opt/git/aptos-core/storage/schemadb)
   Compiling aptos-telemetry v0.1.0 (/opt/git/aptos-core/crates/aptos-telemetry)
   Compiling storage-interface v0.1.0 (/opt/git/aptos-core/storage/storage-interface)
   Compiling executor-types v0.1.0 (/opt/git/aptos-core/execution/executor-types)
   Compiling aptos-jellyfish-merkle v0.1.0 (/opt/git/aptos-core/storage/jellyfish-merkle)
   Compiling aptos-api-types v0.0.1 (/opt/git/aptos-core/api/types)
   Compiling vm-genesis v0.1.0 (/opt/git/aptos-core/aptos-move/vm-genesis)
   Compiling consensus-types v0.1.0 (/opt/git/aptos-core/consensus/consensus-types)
   Compiling aptosdb v0.1.0 (/opt/git/aptos-core/storage/aptosdb)
   Compiling aptos-rest-client v0.0.0 (/opt/git/aptos-core/crates/aptos-rest-client)
   Compiling executor v0.1.0 (/opt/git/aptos-core/execution/executor)
   Compiling aptos v0.1.1 (/opt/git/aptos-core/crates/aptos)
    Finished release [optimized + debuginfo] target(s) in 1m 59s
Zipping release: aptos-cli-0.1.1-MacOSX-x86_64.zip
  adding: aptos (deflated 69%)
```
