### PR TITLE
[CP] Fix some flow issues + add authorizations admin view

### DIFF
--- a/ecosystem/platform/server/app/admin/authorizations.rb
+++ b/ecosystem/platform/server/app/admin/authorizations.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+ActiveAdmin.register Authorization do
+  menu priority: 3
+  actions :all, except: %i[destroy edit new]
+
+  permit_params :consensus_key
+  includes :user
+
+  index do
+    selectable_column
+    id_column
+
+    column :user
+    column :provider
+    column :uid
+    column :email
+    column :username
+    column :full_name
+    column(:profile_url) { |c| link_to 'view⇗', c.profile_url, target: '_blank' if c.profile_url.present? }
+    column :expires
+    column :expires_at
+    column :created_at
+    column :updated_at
+
+    actions
+  end
+
+  filter :provider
+  filter :uid
+  filter :email
+  filter :username
+  filter :full_name
+  filter :expires
+  filter :expires_at
+  filter :created_at
+  filter :updated_at
+
+  show do
+    default_main_content do
+      row :user
+    end
+  end
+end

--- a/ecosystem/platform/server/app/admin/users.rb
+++ b/ecosystem/platform/server/app/admin/users.rb
@@ -14,11 +14,11 @@ ActiveAdmin.register User do
     selectable_column
     id_column
     column :it1_profile
+    column :authorizations
     column 'External ID', :external_id
     column :email
     column :is_root
     column :kyc_exempt
-    column :providers
     column :current_sign_in_ip
     column 'Last Sign In', :current_sign_in_at
     column :sign_in_count
@@ -38,7 +38,7 @@ ActiveAdmin.register User do
 
   show do
     default_main_content do
-      row :providers
+      row :authorizations
       row :it1_profile
     end
   end

--- a/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
@@ -5,6 +5,7 @@
 class It1ProfilesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_it1_profile, only: %i[show edit update destroy]
+  before_action :ensure_confirmed!
   respond_to :html
 
   def show
@@ -42,7 +43,7 @@ class It1ProfilesController < ApplicationController
       log @it1_profile, 'created'
       validate_node(v, do_location: true)
       if @it1_profile.validator_verified?
-        redirect_to it1_path, notice: 'AIT1 application completed successfully: your node is verified!'
+        redirect_to it1_path, notice: 'AIT1 application completed successfully: your node is verified!' and return
       end
     end
     respond_with(@it1_profile)

--- a/ecosystem/platform/server/app/controllers/onboarding_controller.rb
+++ b/ecosystem/platform/server/app/controllers/onboarding_controller.rb
@@ -5,6 +5,7 @@
 
 class OnboardingController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_confirmed!, only: %i[kyc_redirect kyc_callback]
   before_action :set_oauth_data, except: :kyc_callback
   protect_from_forgery except: :kyc_callback
 
@@ -48,6 +49,7 @@ class OnboardingController < ApplicationController
       KYCCompleteJob.perform_now({ user_id: current_user.id, inquiry_id: })
       redirect_to it1_path, notice: 'Identity Verification completed successfully!'
     rescue KYCCompleteJobError => e
+      Sentry.capture_exception(e)
       redirect_to it1_path, error: 'Error; If you completed Identity Verification,'\
                                    " it may take some time to reflect. Error: #{e}"
     end

--- a/ecosystem/platform/server/app/controllers/welcome_controller.rb
+++ b/ecosystem/platform/server/app/controllers/welcome_controller.rb
@@ -6,6 +6,8 @@
 class WelcomeController < ApplicationController
   layout 'it1'
 
+  before_action :ensure_confirmed!, only: %i[it1]
+
   def index; end
 
   def it1

--- a/ecosystem/platform/server/app/helpers/node_helper.rb
+++ b/ecosystem/platform/server/app/helpers/node_helper.rb
@@ -73,6 +73,7 @@ module NodeHelper
       )
       LocationResult.new(true, nil, client.insights(@ip))
     rescue StandardError => e
+      Sentry.capture_exception(e)
       LocationResult.new(false, "Error: #{e}", nil)
     end
 
@@ -86,6 +87,7 @@ module NodeHelper
     rescue Net::OpenTimeout => e
       MetricsResult.new(false, nil, "Open timeout: #{e}")
     rescue StandardError => e
+      Sentry.capture_exception(e)
       MetricsResult.new(false, nil, "Error: #{e}")
     end
 

--- a/ecosystem/platform/server/app/jobs/kyc_complete_job.rb
+++ b/ecosystem/platform/server/app/jobs/kyc_complete_job.rb
@@ -10,13 +10,20 @@ class KYCCompleteJob < ApplicationJob
   # Ex args: { user_id: 32, inquiry_id=inq_syMMVRdEz7fswAa2hi }
   def perform(args)
     user = User.find(args[:user_id])
+    sentry_scope.set_user(id: user.id)
     inquiry_id = args[:inquiry_id]
+    sentry_scope.set_context(:inquiry_id, inquiry_id)
 
     client = PersonaHelper::PersonaClient.new
 
     inquiry = client.inquiry(inquiry_id)
 
     raise KYCCompleteJobError, "Could not get inquiry '#{inquiry_id}' for user ##{user.id}" unless inquiry.present?
+
+    reference_id = inquiry['data']&.[]('attributes')&.[]('reference_id')
+    unless user.external_id == reference_id
+      raise KYCCompleteJobError, "Inquiry '#{inquiry_id}' reference_id did not match expected user ##{user.id}"
+    end
 
     status = inquiry['data']&.[]('attributes')&.[]('status')
     raise KYCCompleteJobError, "Inquiry was not complete! Status: '#{status}'" unless status == 'completed'

--- a/ecosystem/platform/server/app/jobs/location_job.rb
+++ b/ecosystem/platform/server/app/jobs/location_job.rb
@@ -10,6 +10,9 @@ class LocationJob < ApplicationJob
   # Ex args: { it1_profile_id: 32 }
   def perform(args)
     it1_profile = It1Profile.find(args[:it1_profile_id])
+    sentry_scope.set_user(id: it1_profile.user_id)
+    sentry_scope.set_context(:it1_profile_id, it1_profile.id)
+    sentry_scope.set_context(:validator_address, it1_profile.validator_address)
 
     # pass zeroes as a hack here: we only need the validator address
     node_verifier = NodeHelper::NodeVerifier.new(it1_profile.validator_address, 0, 0)

--- a/ecosystem/platform/server/app/models/authorization.rb
+++ b/ecosystem/platform/server/app/models/authorization.rb
@@ -7,4 +7,8 @@ class Authorization < ApplicationRecord
   belongs_to :user, optional: true
 
   validates_uniqueness_of :uid, scope: [:provider]
+
+  def display_name
+    "#{provider} [#{full_name || username || email || uid}]"
+  end
 end

--- a/ecosystem/platform/server/app/models/user.rb
+++ b/ecosystem/platform/server/app/models/user.rb
@@ -61,11 +61,7 @@ class User < ApplicationRecord
   # end
 
   def kyc_complete?
-    kyc_status == 'completed'
-  end
-
-  def providers
-    authorizations.map(&:provider)
+    kyc_exempt? || kyc_status == 'completed'
   end
 
   def add_oauth_authorization(data)

--- a/ecosystem/platform/server/app/views/welcome/it1.html.erb
+++ b/ecosystem/platform/server/app/views/welcome/it1.html.erb
@@ -34,10 +34,10 @@
           <p class="mb-8 font-light">
           Identity must be verified by noon (PST) May 23 to get into the selection process.
           </p>
-          <% if current_user&.it1_profile&.validator_verified? %>
+          <% if current_user&.kyc_complete? %>
+            <div class="w-full bg-teal-400 text-neutral-800 block p-2 text-center font-mono uppercase text-lg rounded font-bold mt-auto cursor-not-allowed select-none">Verification Complete</div>
+          <% elsif current_user&.it1_profile&.validator_verified? %>
             <%= link_to "Verify", onboarding_kyc_redirect_path, class: "w-full bg-teal-400 text-neutral-800 block p-2 text-center font-mono uppercase text-lg rounded font-bold mt-auto" %>
-          <% else %>
-            <%= link_to "Verify", "#", class: "w-full bg-teal-400 text-neutral-800 block p-2 text-center font-mono uppercase text-lg rounded font-bold mt-auto" %>
           <% end %>
         </div>
       </div>

--- a/ecosystem/platform/server/config/routes.rb
+++ b/ecosystem/platform/server/config/routes.rb
@@ -15,9 +15,12 @@ Rails.application.routes.draw do
 
   namespace :api do
     # get ':provider/callback', to: 'sessions#create'
-
     get 'users/me', to: 'users#me'
     resources :users, only: %i[show update]
+  end
+
+  namespace :user do
+    root to: redirect('/it1') # creates user_root_path, where users go after confirming email
   end
 
   # KYC routes


### PR DESCRIPTION
- add authorizations admin view
- after email confirmation, redirect user to /it1
- don't let a user with an unconfirmed email: register a node, go through KYC
- show "Verification Complete" once KYC is complete
- if a user is KYC exempt, treat them as having already completed KYC
- fix a fun loophole where a clever user could replay a completed KYC callback (alliteration!)
- send all KYCCompleteJob failures to sentry for now
- set additional sentry context for jobs
