### PR TITLE
[telemetry] enable metrics and on networkpolicy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics",
  "aptos-workspace-hack",
+ "once_cell",
  "reqwest",
  "serde 1.0.137",
  "serde_json",

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+once_cell = "1.10.0"
 reqwest = { version = "0.11.10", features = ["json"] }
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = "1.0.81"

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -9,8 +9,10 @@
 pub const APTOS_GA_MEASUREMENT_ID: &str = "G-ZX4L6WPCFZ";
 pub const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
 
-pub const HTTPBIN_URL: &str = "http://httpbin.org/ip";
-pub const GA4_URL: &str = "http://www.google-analytics.com/mp/collect";
+pub const HTTPBIN_URL: &str = "https://httpbin.org/ip";
+// measurement protocol requires HTTPS
+// https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#transport
+pub const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
 
 // Timeouts
 pub const NETWORK_PUSH_TIME_SECS: u64 = 30;

--- a/docker/faucet/Dockerfile
+++ b/docker/faucet/Dockerfile
@@ -24,7 +24,7 @@ RUN IMAGE_TARGETS="test" ./docker/build-common.sh
 ### Production Image ###
 FROM debian-base AS pre-test
 
-RUN apt-get update && apt-get install -y libssl1.1 nano net-tools tcpdump iproute2 netcat \
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates nano net-tools tcpdump iproute2 netcat \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/aptos/bin  /aptos/client/data/wallet/

--- a/docker/forge/Dockerfile
+++ b/docker/forge/Dockerfile
@@ -23,7 +23,7 @@ RUN IMAGE_TARGETS="test" ./docker/build-common.sh
 
 FROM debian-base
 
-RUN apt-get update && apt-get install -y libssl1.1 openssh-client wget busybox git unzip awscli && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates openssh-client wget busybox git unzip awscli && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN mkdir /aptos
 COPY rust-toolchain /aptos/rust-toolchain

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -24,7 +24,7 @@ RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 ### Production Image ###
 FROM debian-base AS pre-prod
 
-RUN apt-get update && apt-get install -y libssl1.1 net-tools tcpdump iproute2 netcat libpq-dev \
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates net-tools tcpdump iproute2 netcat libpq-dev \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/aptos/bin

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -24,7 +24,7 @@ RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 ### Production Image ###
 FROM debian-base AS pre-prod
 
-RUN apt-get update && apt-get -y install libssl1.1 wget busybox gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install libssl1.1 ca-certificates wget busybox gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
 RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 RUN cd /usr/local/bin && wget "https://releases.hashicorp.com/vault/1.5.0/vault_1.5.0_linux_amd64.zip" -O- | busybox unzip - && chmod +x vault
 

--- a/docker/safety-rules/Dockerfile
+++ b/docker/safety-rules/Dockerfile
@@ -24,7 +24,7 @@ RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 ### Production Image ###
 FROM debian-base AS prod
 
-RUN apt-get update && apt-get install -y libssl1.1 && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN addgroup --system --gid 6180 aptos && adduser --system --ingroup aptos --no-create-home --uid 6180 aptos
 

--- a/docker/txn-emitter/Dockerfile
+++ b/docker/txn-emitter/Dockerfile
@@ -24,7 +24,7 @@ RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 ### Production Image ###
 FROM debian-base AS pre-prod
 
-RUN apt-get update && apt-get -y install libssl1.1 wget busybox gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get -y install libssl1.1 ca-certificates wget busybox gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/aptos/bin
 COPY --from=builder /aptos/target/release/transaction-emitter /usr/local/bin

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -24,7 +24,7 @@ RUN IMAGE_TARGETS="release" ./docker/build-common.sh
 ### Production Image ###
 FROM debian-base AS prod
 
-RUN apt-get update && apt-get install -y libssl1.1 && apt-get clean && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*
 
 ### Needed to run debugging tools like perf
 RUN apt-get update && apt-get install -y linux-tools-4.19 sudo procps

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -198,13 +198,14 @@ spec:
   - ports:
     - protocol: TCP
       port: 6180
-  # Aptos telemetry
-  - ports:
-    - protocol: TCP
-      port: 80
   # DNS
   - to:
     - namespaceSelector: {}
     ports:
     - protocol: UDP
       port: 53
+  # Enable HTTPS telemetry
+  - ports:
+    - protocol: TCP
+      port: 443
+

--- a/terraform/helm/validator/templates/validator.yaml
+++ b/terraform/helm/validator/templates/validator.yaml
@@ -297,3 +297,7 @@ spec:
     ports:
     - protocol: UDP
       port: 53
+  # Enable HTTPS telemetry
+  - ports:
+    - protocol: TCP
+      port: 443


### PR DESCRIPTION
add some prometheus metrics for operators to track their telemetry status and add NetworkPolicy for egress HTTPS

also install `ca-certificates` on docker images, since that's preventing HTTPS telemetry calls from containers