### PR TITLE
[Backtraces] Remove backtrace support from anyhow through feature unification.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,8 +1102,6 @@ dependencies = [
 name = "aptos-workspace-hack"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "backtrace",
  "byteorder",
  "bytes",
  "cc",
@@ -1140,7 +1138,6 @@ dependencies = [
  "reqwest",
  "rusty-fork",
  "serde 1.0.137",
- "serde_json",
  "sha-1 0.10.0",
  "standback",
  "syn 1.0.92",
@@ -2539,7 +2536,7 @@ dependencies = [
  "diesel_derives",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.1.43",
+ "num-traits 0.2.15",
  "pq-sys",
  "r2d2",
  "serde_json",

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -11,8 +11,6 @@ edition = "2018"
 
 ### BEGIN HAKARI SECTION
 [dependencies]
-anyhow = { version = "1.0.57", features = ["backtrace", "std"] }
-backtrace = { version = "0.3.58", features = ["addr2line", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
 byteorder = { version = "1.4.3", features = ["std"] }
 bytes = { version = "1.1.0", features = ["serde", "std"] }
 chrono = { version = "0.4.19", features = ["clock", "libc", "oldtime", "serde", "std", "time", "winapi"] }
@@ -48,9 +46,7 @@ regex-syntax = { version = "0.6.25", features = ["unicode", "unicode-age", "unic
 reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["timeout", "wait-timeout"] }
 serde = { version = "1.0.137", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.81", features = ["indexmap", "preserve_order", "std"] }
 sha-1 = { version = "0.10.0", features = ["std"] }
-standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio = { version = "1.18.1", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros"] }
 tokio-util = { version = "0.6.9", features = ["codec", "compat", "futures-io", "io"] }
 toml = { version = "0.5.9" }
@@ -59,8 +55,6 @@ tracing-core = { version = "0.1.26", features = ["lazy_static", "std"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 
 [build-dependencies]
-anyhow = { version = "1.0.57", features = ["backtrace", "std"] }
-backtrace = { version = "0.3.58", features = ["addr2line", "gimli-symbolize", "miniz_oxide", "object", "serde", "std"] }
 byteorder = { version = "1.4.3", features = ["std"] }
 bytes = { version = "1.1.0", features = ["serde", "std"] }
 cc = { version = "1.0.73", default-features = false, features = ["jobserver", "parallel"] }
@@ -97,9 +91,7 @@ regex-syntax = { version = "0.6.25", features = ["unicode", "unicode-age", "unic
 reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["timeout", "wait-timeout"] }
 serde = { version = "1.0.137", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.81", features = ["indexmap", "preserve_order", "std"] }
 sha-1 = { version = "0.10.0", features = ["std"] }
-standback = { version = "0.2.17", default-features = false, features = ["std"] }
 syn = { version = "1.0.92", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 tokio = { version = "1.18.1", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros"] }
 tokio-util = { version = "0.6.9", features = ["codec", "compat", "futures-io", "io"] }
@@ -107,5 +99,17 @@ toml = { version = "0.5.9" }
 tracing = { version = "0.1.34", features = ["attributes", "log", "std", "tracing-attributes"] }
 tracing-core = { version = "0.1.26", features = ["lazy_static", "std"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+standback = { version = "0.2.17", default-features = false, features = ["std"] }
+
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+standback = { version = "0.2.17", default-features = false, features = ["std"] }
+
+[target.x86_64-apple-darwin.dependencies]
+standback = { version = "0.2.17", default-features = false, features = ["std"] }
+
+[target.x86_64-apple-darwin.build-dependencies]
+standback = { version = "0.2.17", default-features = false, features = ["std"] }
 
 ### END HAKARI SECTION

--- a/x.toml
+++ b/x.toml
@@ -74,6 +74,10 @@ workspace-members = [
 
     # Don't consider since it includes excluded move crates
     "move-deps",
+
+    # Don't include these since they contain test features that we don't want in production.
+    "forge",
+    "transaction-emitter",
 ]
 
 [hakari.final-excludes]


### PR DESCRIPTION
## Motivation

This PR removes the backtraces being added to the anyhow logs when `RUST_BACKTRACE=1` (e.g., see: https://docs.rs/anyhow/latest/anyhow/).  I think there might be an issue with feature unification in our codebase. The only crates that pull in the `backtrace` feature are the transaction emitter and forge. But, both of these are marked as test-only in `x.toml`. So, I'd assume the workspace hack would ignore them (maybe not?).

Anyway, this updates `x.toml` to ignore these dependencies from hakari.

@sherry-x, if you'd like to disable the backtraces (without cherry-picking this PR), remove `RUST_BACKTRACE=1` from the deployments. I think it might be these lines (blind guess)?
- Fullnodes: https://github.com/aptos-labs/aptos-core/blob/429da28119517a7ab53a92a8f953b04f497894bc/terraform/helm/fullnode/templates/fullnode.yaml#L41
- VFNs: https://github.com/aptos-labs/aptos-core/blob/9cec3804dc823dccf4e8faa404757ea124e792fd/terraform/helm/validator/templates/fullnode.yaml#L93
- Validators: https://github.com/aptos-labs/aptos-core/blob/9cec3804dc823dccf4e8faa404757ea124e792fd/terraform/helm/validator/templates/validator.yaml#L110

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Verification manually seems to remove the backtraces from the logs I'm seeing locally.

## Related PRs

None.