### PR TITLE
[helm][aptos-node] open up port 80 egress

### DIFF
--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -198,6 +198,10 @@ spec:
   - ports:
     - protocol: TCP
       port: 6180
+  # Aptos telemetry
+  - ports:
+    - protocol: TCP
+      port: 80
   # DNS
   - to:
     - namespaceSelector: {}


### PR DESCRIPTION
so we can send telemetry data from validator process