### PR TITLE
[aptos-cli] Fix CLI instructions to use tag

### DIFF
--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -23,7 +23,7 @@ source $HOME/.cargo/env
 1. Install the `aptos` CLI tool by running the below command.  You can run this command from any directory.  The `aptos`
    CLI tool will be installed into your `CARGO_HOME`, usually `~/.cargo`:
 ```bash
-cargo install --git https://github.com/aptos-labs/aptos-core.git aptos
+cargo install --git https://github.com/aptos-labs/aptos-core.git aptos --tag aptos-cli-latest
 ```
 2. Confirm that the `aptos` CLI tool is installed successfully by running the below command.  The terminal will display
    the path to the `aptos` CLI's location.


### PR DESCRIPTION
## Motivation

To remove confusion against main vs a release, I've added tagging for the cargo instructions

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
