### PR TITLE
[tf][aptos-node] logging and monitoring consistency across clouds

### DIFF
--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -157,7 +157,7 @@ variable "workspace_name_override" {
 }
 
 variable "enable_logger" {
-  description = "Enable logger pod"
+  description = "Enable logger helm chart"
   default     = false
 }
 
@@ -168,7 +168,7 @@ variable "logger_helm_values" {
 }
 
 variable "enable_monitoring" {
-  description = "Enable logger pod"
+  description = "Enable monitoring helm chart"
   default     = false
 }
 

--- a/terraform/aptos-node/azure/kubernetes.tf
+++ b/terraform/aptos-node/azure/kubernetes.tf
@@ -65,3 +65,64 @@ resource "helm_release" "validator" {
     value = var.helm_force_update ? timestamp() : ""
   }
 }
+
+resource "helm_release" "logger" {
+  count       = var.enable_logger ? 1 : 0
+  name        = "${terraform.workspace}-log"
+  chart       = "${path.module}/../../helm/logger"
+  max_history = 10
+  wait        = false
+
+  values = [
+    jsonencode({
+      logger = {
+        name = "aptos-logger"
+      }
+      chain = {
+        name = var.chain_name
+      }
+      serviceAccount = {
+        create = false
+        name = "${terraform.workspace}-aptos-node-validator"
+      }
+    }),
+    jsonencode(var.logger_helm_values),
+  ]
+
+  set {
+    name  = "timestamp"
+    value = timestamp()
+  }
+}
+
+resource "helm_release" "monitoring" {
+  count       = var.enable_monitoring ? 1 : 0
+  name        = "${terraform.workspace}-mon"
+  chart       = "${path.module}/../../helm/monitoring"
+  max_history = 10
+  wait        = false
+
+  values = [
+    jsonencode({
+      chain = {
+        name = var.chain_name
+      }
+      validator = {
+        name = var.validator_name
+      }
+      monitoring = {
+        prometheus = {
+          storage = {
+            class = "default"
+          }
+        }
+      }
+    }),
+    jsonencode(var.monitoring_helm_values),
+  ]
+
+  set {
+    name  = "timestamp"
+    value = timestamp()
+  }
+}

--- a/terraform/aptos-node/azure/variables.tf
+++ b/terraform/aptos-node/azure/variables.tf
@@ -106,3 +106,25 @@ variable "validator_instance_num" {
   description = "Number of instances used for validator and fullnodes"
   default     = 2
 }
+
+variable "enable_logger" {
+  description = "Enable logger helm chart"
+  default     = false
+}
+
+variable "logger_helm_values" {
+  description = "Map of values to pass to logger Helm"
+  type        = any
+  default     = {}
+}
+
+variable "enable_monitoring" {
+  description = "Enable monitoring helm chart"
+  default     = false
+}
+
+variable "monitoring_helm_values" {
+  description = "Map of values to pass to monitoring Helm"
+  type        = any
+  default     = {}
+}

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -106,7 +106,7 @@ variable "validator_instance_num" {
 }
 
 variable "enable_logger" {
-  description = "Enable logger pod"
+  description = "Enable logger helm chart"
   default     = false
 }
 
@@ -117,7 +117,7 @@ variable "logger_helm_values" {
 }
 
 variable "enable_monitoring" {
-  description = "Enable logger pod"
+  description = "Enable monitoring helm chart"
   default     = false
 }
 


### PR DESCRIPTION
Fix typo in `enable_monitoring` TF var and make it and `enable_logging` more descriptive.
Also do the same for Azure, which was missing the option to install the helm charts. Didn't deploy it, but validated it with `terraform init -backend=false && terraform validate`. Paths and vars all line up