### PR TITLE
[ecosystem] Add a field for fullnode network key.

### DIFF
--- a/ecosystem/platform/server/app/admin/it1_profiles.rb
+++ b/ecosystem/platform/server/app/admin/it1_profiles.rb
@@ -25,6 +25,7 @@ ActiveAdmin.register It1Profile do
     column :validator_verified
     column :fullnode_address
     column :fullnode_port
+    column :fullnode_network_key
     column :created_at
     column :updated_at
     actions

--- a/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
@@ -110,6 +110,6 @@ class It1ProfilesController < ApplicationController
   def it1_profile_params
     params.fetch(:it1_profile, {}).permit(:consensus_key, :account_key, :network_key, :validator_address,
                                           :validator_port, :validator_api_port, :validator_metrics_port,
-                                          :fullnode_address, :fullnode_port, :terms_accepted)
+                                          :fullnode_address, :fullnode_port, :fullnode_network_key, :terms_accepted)
   end
 end

--- a/ecosystem/platform/server/app/models/it1_profile.rb
+++ b/ecosystem/platform/server/app/models/it1_profile.rb
@@ -21,6 +21,7 @@ class It1Profile < ApplicationRecord
   validates :validator_metrics_port, presence: true, numericality: { only_integer: true }
 
   validates :fullnode_port, numericality: { only_integer: true }, allow_nil: true
+  validates :fullnode_network_key, uniqueness: true, format: { with: /\A0x[a-f0-9]{64}\z/i }
 
   validates :terms_accepted, acceptance: true
 

--- a/ecosystem/platform/server/app/views/it1_profiles/_form.html.erb
+++ b/ecosystem/platform/server/app/views/it1_profiles/_form.html.erb
@@ -75,6 +75,11 @@
           <%= f.text_field :fullnode_address %>
           </p>
 
+          <p class="mb-4">
+          <%= f.label :fullnode_network_key, class: "font-mono uppercase block mb-2 text-lg" %>
+          <%= f.text_field :fullnode_network_key, pattern: '0x[a-f0-9]{64}' %>
+          </p>
+
           <div class="flex gap-8 md:gap-16 mb-4 items-end">
             <div class="flex-1">
               <%= f.label :fullnode_port, class: "font-mono uppercase block mb-2 text-lg" %>

--- a/ecosystem/platform/server/db/migrate/20220513141301_add_fullnode_network_key_to_it1_profile.rb
+++ b/ecosystem/platform/server/db/migrate/20220513141301_add_fullnode_network_key_to_it1_profile.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+class AddFullnodeNetworkKeyToIt1Profile < ActiveRecord::Migration[7.0]
+  def change
+    add_column :it1_profiles, :fullnode_network_key, :string, unique: true
+  end
+end

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -14,7 +14,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_220_512_031_021) do
+ActiveRecord::Schema[7.0].define(version: 20_220_513_141_301) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'pgcrypto'
   enable_extension 'plpgsql'
@@ -85,6 +85,7 @@ ActiveRecord::Schema[7.0].define(version: 20_220_512_031_021) do
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.boolean 'terms_accepted', default: false
+    t.string 'fullnode_network_key'
     t.index ['user_id'], name: 'index_it1_profiles_on_user_id'
   end
 

--- a/ecosystem/platform/server/spec/factories/it1_profiles.rb
+++ b/ecosystem/platform/server/spec/factories/it1_profiles.rb
@@ -13,5 +13,6 @@ FactoryBot.define do
     validator_metrics_port { 1 }
     fullnode_address { 'MyString' }
     fullnode_port { 1 }
+    fullnode_network_key { 'MyString' }
   end
 end


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We need another field for specifying the full node's network key.

![image](https://user-images.githubusercontent.com/310773/168304001-ad8a149d-c582-44f7-9b50-210b2fe86288.png)
## Test Plan

Manual testing

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
