### PR TITLE
[helm][testnet/forge] disable validator_network rotation at re-genesis

### DIFF
--- a/terraform/testnet/testnet/templates/genesis.yaml
+++ b/terraform/testnet/testnet/templates/genesis.yaml
@@ -97,7 +97,8 @@ spec:
             export VAULT_TOKEN="root"
             VAULT_BACKEND="backend=vault;server=$VAULT_ADDR;token=/tmp/vault.token"
             {{- end }}
-            vault write -f "/transit/keys/val${N}__validator_network/rotate"
+            # XXX: disables key rotation at re-genesis to keep from hitting managed backend key size limits
+            # vault write -f "/transit/keys/val${N}__validator_network/rotate"
             aptos-genesis-tool owner-key --validator-backend "$VAULT_BACKEND;namespace=val$N" --shared-backend "$FILE_BACKEND;namespace=val$N"
             aptos-genesis-tool operator-key --validator-backend "$VAULT_BACKEND;namespace=val$N" --shared-backend "$FILE_BACKEND;namespace=val$N"
             {{- if .Values.service.fullnode.enableOnchainDiscovery }}


### PR DESCRIPTION
We've run Forge 1000s of times, and that's caused the validator_network keys to build up after each key rotation. This is now hitting DynamoDB's key limit size. Disable validator_network key rotation at re-genesis. This shouldn't affect much as few folks are running full k8s testnet and never in a "production" way.

Test by running Forge on `forge-1`, which was failing due to DynamoDB storage error on rotation:

```
$ ./scripts/fgi/run -W forge-1 --tag dev_61b76654 --suite land_blocking
...
"text": "all up : 1290 TPS, 3410 ms latency, 5250 ms p99 latency,no expired txns"
``