### PR TITLE
[circleci] remove slack push and use pgw

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ orbs:
   aws-ecr: circleci/aws-ecr@7.3.0
   gcp-gcr: circleci/gcp-gcr@0.15.0
   kubernetes: circleci/kubernetes@1.3.0
-  slack: circleci/slack@4.9.3
 
 executors:
   ubuntu-medium:
@@ -209,24 +208,14 @@ jobs:
             # replace all newlines
             FORGE_COMMENT=$(awk '{printf "%s\\n", $0}' forge_comment.txt)
 
+            # TODO(rustielin): report cluster name
+            echo "forge_job_status $FGI_EXIT_CODE" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
+
             # post github comment on the PR
             curl -s -H "Authorization: token ${FORGE_GH_TOKEN}" \
             -X POST -d "{\"body\": \"${FORGE_COMMENT}\"}" \
             "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${PR_NUMBER}/comments"
             exit 0
-      - slack/notify:
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "[fgi($FGI_EXIT_CODE)] <$CIRCLE_BUILD_URL|Forge run> for $IMAGE_TAG: `$FORGE_REPORT_TXT`"
-                  }
-                }
-              ]
-            }
       - run:
           name: Check Forge status
           shell: /bin/bash


### PR DESCRIPTION
Remove slack notification since it fails when Forge gives it a multiline or empty report string. Instead, push the job status to prometheus push gateway