### PR TITLE
[aptos-cli] Migrate config.yml to config.yaml

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -50,7 +50,7 @@ impl CliCommand<()> for InitTool {
     }
 
     async fn execute(self) -> CliTypedResult<()> {
-        let mut config = if CliConfig::config_exists()? {
+        let mut config = if CliConfig::config_exists() {
             CliConfig::load()?
         } else {
             CliConfig::default()


### PR DESCRIPTION
## Motivation

There seemed to be some bad UX around config.yml -> config.yaml.  Now this will migrate users between formats, as well as properly handle the file missing but the folder exists.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

```
$ ls .aptos
config.yml

$ aptos account list
{
  "Result": [
    {
      "counter": "2"
    },
...
}

$ aptos init
Aptos already initialized for profile default, do you want to overwrite the existing config? [yes/no] >
yes
Configuring for profile default
Enter your rest endpoint [Current: https://fullnode.devnet.aptoslabs.com/ | No input: https://fullnode.devnet.aptoslabs.com]

No rest url given, using https://fullnode.devnet.aptoslabs.com...
Enter your faucet endpoint [Current: https://faucet.devnet.aptoslabs.com/ | No input: https://faucet.devnet.aptoslabs.com]

No faucet url given, using https://faucet.devnet.aptoslabs.com...
Enter your private key as a hex literal (0x...) [Current: Redacted | No input: Generate new key (or keep one if present)]

No key given, keeping existing key...
Removing legacy config file config.yml
Aptos is now set up for account 43342F6844E95637DE217D528E53A9C5A8DE874D218564466152BB2015DAC7D5!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}

$ ls .aptos
config.yaml

```

