### PR TITLE
[Storage][Pruner] Add tests for ensure DB APIs don't panic on pruning

### DIFF
--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -11,11 +11,16 @@ use aptos_types::{
     transaction::{SignedTransaction, Transaction},
 };
 
+use aptos_crypto::hash::CryptoHash;
+
+use crate::test_helper::arb_blocks_to_commit;
 use aptos_types::{
-    transaction::{TransactionInfo, Version},
+    ledger_info::LedgerInfoWithSignatures,
+    transaction::{TransactionInfo, TransactionToCommit, Version},
     write_set::WriteSet,
 };
 use proptest::{collection::vec, prelude::*};
+use storage_interface::{DbReader, DbWriter, Order};
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
@@ -27,17 +32,190 @@ proptest! {
             any::<SignedTransaction>().prop_map(Transaction::UserTransaction),
         ], 1..100,),
         txn_infos in vec(any::<TransactionInfo>(),100,),
-        step_size in 1usize..20,
-    ) {
-        verify_txn_store_pruner(txns, txn_infos, step_size)
+        step_size in 1usize..20,) {
+       verify_txn_store_pruner(txns, txn_infos, step_size)
     }
 
      #[test]
     fn test_write_set_pruner(
-        write_set in vec(any::<WriteSet>(), 100),
-        ) {
-            verify_write_set_pruner(write_set);
-        }
+        write_set in vec(any::<WriteSet>(), 100),) {
+         verify_write_set_pruner(write_set);
+    }
+
+    #[test]
+    fn test_no_panic_on_pruning(blocks in arb_blocks_to_commit()) {
+        verify_no_panic_on_pruning(blocks);
+    }
+}
+
+fn verify_no_panic_on_pruning(input: Vec<(Vec<TransactionToCommit>, LedgerInfoWithSignatures)>) {
+    let tmp_dir = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp_dir);
+
+    let mut transactions: Vec<TransactionToCommit> = vec![];
+
+    let transaction_store = &aptos_db.transaction_store;
+    let pruner = Pruner::new(
+        Arc::clone(&aptos_db.db),
+        StoragePrunerConfig {
+            state_store_prune_window: Some(0),
+            ledger_prune_window: Some(0),
+            pruning_batch_size: 1,
+        },
+        Arc::clone(transaction_store),
+        Arc::clone(&aptos_db.ledger_store),
+        Arc::clone(&aptos_db.event_store),
+    );
+
+    let mut next_ledger_version = 0;
+    for (_, (transactions_to_commit, ledger_info_with_sigs)) in input.iter().enumerate() {
+        transactions_to_commit
+            .iter()
+            .for_each(|x| transactions.push(x.clone()));
+        aptos_db
+            .save_transactions(
+                transactions_to_commit,
+                next_ledger_version, /* first_version */
+                Some(ledger_info_with_sigs),
+            )
+            .unwrap();
+        next_ledger_version += transactions_to_commit.len() as u64;
+    }
+
+    // start pruning write sets in batches of size 2 and verify transactions have been pruned from DB
+    for i in (0..=next_ledger_version).step_by(2) {
+        aptos_db
+            .get_transactions(i, 1, next_ledger_version - 1, true)
+            .unwrap();
+        pruner
+            .wake_and_wait(
+                i as u64, /* latest_version */
+                PrunerIndex::LedgerPrunerIndex as usize,
+            )
+            .unwrap();
+        verify_no_panic_for_apis(&aptos_db, i, next_ledger_version - 1, &transactions);
+    }
+}
+
+fn verify_no_panic_for_apis(
+    aptos_db: &AptosDB,
+    first_available_version: Version,
+    ledger_version: Version,
+    transactions: &[TransactionToCommit],
+) {
+    // Verify no panic for a particular version which has already been pruned
+    if first_available_version > 0 {
+        verify_no_panic_for_apis_for_not_present_version(
+            aptos_db,
+            first_available_version - 1,
+            ledger_version,
+            transactions,
+        );
+    }
+
+    // Verify no panic for a version which is present in the DB
+    if first_available_version <= ledger_version {
+        verify_no_panic_for_apis_for_present_version(
+            aptos_db,
+            first_available_version,
+            ledger_version,
+            transactions,
+        );
+    }
+}
+
+fn verify_no_panic_for_apis_for_present_version(
+    db: &AptosDB,
+    version: Version,
+    ledger_version: Version,
+    transactions: &[TransactionToCommit],
+) {
+    assert!(db
+        .get_transactions(version, 1, ledger_version, true)
+        .is_ok());
+
+    assert!(db
+        .get_transaction_by_hash(
+            transactions[version as usize].transaction().hash(),
+            ledger_version,
+            true,
+        )
+        .unwrap()
+        .is_some());
+
+    for event in transactions[version as usize].events() {
+        assert!(!db
+            .get_events(event.key(), version, Order::Ascending, 1)
+            .unwrap()
+            .is_empty());
+        assert!(!db
+            .get_events_with_proofs(event.key(), version, Order::Ascending, 1, None)
+            .unwrap()
+            .is_empty());
+        assert!(db
+            .get_event_by_version_with_proof(event.key(), version, version)
+            .unwrap()
+            .lower_bound_incl
+            .is_some());
+    }
+    assert!(db
+        .get_transaction_by_version(version, ledger_version, true)
+        .is_ok());
+    assert!(db.get_first_txn_version().is_ok());
+    assert!(db.get_first_write_set_version().is_ok());
+    assert!(db
+        .get_transaction_outputs(version, 10, ledger_version)
+        .is_ok());
+    assert!(db.get_block_timestamp(version).is_ok());
+    assert!(db.get_latest_version().is_ok());
+    assert!(db.get_latest_commit_metadata().is_ok());
+}
+
+fn verify_no_panic_for_apis_for_not_present_version(
+    db: &AptosDB,
+    version: Version,
+    ledger_version: Version,
+    transactions: &[TransactionToCommit],
+) {
+    assert!(db
+        .get_transactions(version, 10, ledger_version, true)
+        .is_err());
+
+    assert!(db
+        .get_transaction_by_hash(
+            transactions[version as usize].transaction().hash(),
+            ledger_version,
+            true,
+        )
+        .unwrap()
+        .is_none());
+
+    for event in transactions[version as usize].events() {
+        assert!(db
+            .get_events(event.key(), version, Order::Ascending, 1)
+            .unwrap()
+            .is_empty());
+        assert!(db
+            .get_events_with_proofs(event.key(), version, Order::Ascending, 1, None)
+            .unwrap()
+            .is_empty());
+        assert!(db
+            .get_event_by_version_with_proof(event.key(), version, version)
+            .unwrap()
+            .lower_bound_incl
+            .is_none());
+    }
+    assert!(db
+        .get_transaction_by_version(version, ledger_version, true)
+        .is_err());
+    assert!(db.get_first_txn_version().is_ok());
+    assert!(db.get_first_write_set_version().is_ok());
+    assert!(db
+        .get_transaction_outputs(version, 10, ledger_version)
+        .is_err());
+    assert!(db.get_block_timestamp(version).is_err());
+    assert!(db.get_latest_version().is_ok());
+    assert!(db.get_latest_commit_metadata().is_ok());
 }
 
 fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {


### PR DESCRIPTION
Adding tests to ensure DB critical APIs don't panic when ledger pruning is enabled. The following types of tests have been covered.

1. Ensure APIs don't panic when called for a version that was pruned
2. Ensure APIs don't panic when called for a version that was not pruned

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/987)
<!-- Reviewable:end -->
