### PR TITLE
Disable turbolinks globally to fix recaptcha issues.

### DIFF
--- a/ecosystem/platform/server/app/views/layouts/_application.html.erb
+++ b/ecosystem/platform/server/app/views/layouts/_application.html.erb
@@ -15,7 +15,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="flex flex-col h-screen justify-between">
+  <body class="flex flex-col h-screen justify-between" data-turbo="false">
     <div class="flex flex-col flex-1">
       <%= render "layouts/header" unless @hide_header %>
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

With turbolinks enabled, recaptcha fails the first time the form is submitted. Disable recaptcha globally for now.

Before:

![recaptcha_turbo](https://user-images.githubusercontent.com/310773/168402280-612367fb-2ff2-43c9-9ab4-178cb131b83d.gif)

After:

![recaptcha_no_turbo](https://user-images.githubusercontent.com/310773/168402274-5b3f7b6f-543a-48b6-98ba-b89d3317c73a.gif)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

## Test Plan

Manual testing
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
