### PR TITLE
Account::create_and_fund_account()

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/AccountUtils.move
+++ b/aptos-move/framework/aptos-framework/sources/AccountUtils.move
@@ -1,0 +1,10 @@
+module AptosFramework::AccountUtils {
+    use AptosFramework::Account;
+    use AptosFramework::Coin;
+    use AptosFramework::TestCoin::TestCoin;
+
+    public(script) fun create_and_fund_account(funder: &signer, account: address, amount: u64) {
+        Account::create_account(account);
+        Coin::transfer<TestCoin>(funder, account, amount);
+    }
+}

--- a/testsuite/smoke-test/src/aptos/account_creation.rs
+++ b/testsuite/smoke-test/src/aptos/account_creation.rs
@@ -24,13 +24,26 @@ impl AptosTest for AccountCreation {
             accounts.push(local_account);
         }
         // created by user account
-        for mut account in accounts {
+        for account in &mut accounts {
             let new_account = ctx.random_account();
             let txn =
                 account.sign_with_transaction_builder(ctx.aptos_transaction_factory().payload(
                     aptos_stdlib::encode_account_create_account(new_account.address()),
                 ));
             ctx.client().submit_and_wait(&txn).await?;
+        }
+        // create and fund
+        for mut account in accounts {
+            let new_account = ctx.random_account();
+            let txn =
+                account.sign_with_transaction_builder(ctx.aptos_transaction_factory().payload(
+                    aptos_stdlib::encode_account_utils_create_and_fund_account(
+                        new_account.address(),
+                        5000,
+                    ),
+                ));
+            ctx.client().submit_and_wait(&txn).await?;
+            assert_eq!(ctx.get_balance(new_account.address()).await.unwrap(), 5000);
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation

So the executor-benchmark can use one less transaction for creating one test account.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

y

## Test Plan
smoke test
