### PR TITLE
Step number incorrect for username creation

### DIFF
--- a/developer-docs-site/docs/tutorials/validator-node/using-aws.md
+++ b/developer-docs-site/docs/tutorials/validator-node/using-aws.md
@@ -144,7 +144,7 @@ This will download all the terraform dependencies for you, in the `.terraform` f
     ---
     root_key: "0x5243ca72b0766d9e9cbf2debf6153443b01a1e0e6d086c7ea206eaf6f8043956"
     users:
-      - <username you created in step 5>
+      - <username you created in step 11>
     chain_id: 23
     ```
 


### PR DESCRIPTION
in the aws validator guide, you create your username in step 11 not step 5 as stated. 

## Motivation
The validator documentation is incorrect.

