### PR TITLE
[Storage] Remove Accumulator consistency proof from state proof

### DIFF
--- a/consensus/src/persistent_liveness_storage.rs
+++ b/consensus/src/persistent_liveness_storage.rs
@@ -483,7 +483,7 @@ impl PersistentLivenessStorage for StorageWriteProxy {
     }
 
     fn retrieve_epoch_change_proof(&self, version: u64) -> Result<EpochChangeProof> {
-        let (_, proofs, _) = self
+        let (_, proofs) = self
             .aptos_db
             .get_state_proof(version)
             .map_err(DbError::from)?

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -168,14 +168,12 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         .commit_blocks(vec![block1_id], ledger_info_with_sigs)
         .unwrap();
 
-    let initial_accumulator = db.reader.get_accumulator_summary(0).unwrap();
     let state_proof = db.reader.get_state_proof(0).unwrap();
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let trusted_state =
-        match trusted_state.verify_and_ratchet(&state_proof, Some(&initial_accumulator)) {
-            Ok(TrustedStateChange::Epoch { new_state, .. }) => new_state,
-            _ => panic!("unexpected state change"),
-        };
+    let trusted_state = match trusted_state.verify_and_ratchet(&state_proof) {
+        Ok(TrustedStateChange::Epoch { new_state, .. }) => new_state,
+        _ => panic!("unexpected state change"),
+    };
     let current_version = state_proof.latest_ledger_info().version();
     assert_eq!(trusted_state.version(), 9);
 
@@ -354,9 +352,7 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         .unwrap();
 
     let state_proof = db.reader.get_state_proof(trusted_state.version()).unwrap();
-    let trusted_state_change = trusted_state
-        .verify_and_ratchet(&state_proof, None)
-        .unwrap();
+    let trusted_state_change = trusted_state.verify_and_ratchet(&state_proof).unwrap();
     assert!(matches!(
         trusted_state_change,
         TrustedStateChange::Version { .. }

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -73,18 +73,12 @@ fn test_empty_db() {
         waypoint
     );
 
-    let initial_accumulator = db_rw
-        .reader
-        .get_accumulator_summary(waypoint.version())
-        .unwrap();
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
     let state_proof = db_rw
         .reader
         .get_state_proof(trusted_state.version())
         .unwrap();
-    let trusted_state_change = trusted_state
-        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
-        .unwrap();
+    let trusted_state_change = trusted_state.verify_and_ratchet(&state_proof).unwrap();
     assert!(trusted_state_change.is_epoch_change());
 
     // `maybe_bootstrap()` does nothing on non-empty DB.
@@ -310,17 +304,11 @@ fn test_pre_genesis() {
     assert!(maybe_bootstrap::<AptosVM>(&db_rw, &genesis_txn, waypoint).unwrap());
 
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let initial_accumulator = db_rw
-        .reader
-        .get_accumulator_summary(trusted_state.version())
-        .unwrap();
     let state_proof = db_rw
         .reader
         .get_state_proof(trusted_state.version())
         .unwrap();
-    let trusted_state_change = trusted_state
-        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
-        .unwrap();
+    let trusted_state_change = trusted_state.verify_and_ratchet(&state_proof).unwrap();
     assert!(trusted_state_change.is_epoch_change());
 
     // Effect of bootstrapping reflected.
@@ -351,14 +339,8 @@ fn test_new_genesis() {
     assert_eq!(get_balance(&account2, &db), 2_000_000);
 
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let initial_accumulator = db
-        .reader
-        .get_accumulator_summary(trusted_state.version())
-        .unwrap();
     let state_proof = db.reader.get_state_proof(trusted_state.version()).unwrap();
-    let trusted_state_change = trusted_state
-        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
-        .unwrap();
+    let trusted_state_change = trusted_state.verify_and_ratchet(&state_proof).unwrap();
     assert!(trusted_state_change.is_epoch_change());
 
     // New genesis transaction: set validator set, bump epoch and overwrite account1 balance.
@@ -398,18 +380,11 @@ fn test_new_genesis() {
 
     // Client bootable from waypoint.
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let initial_accumulator = db
-        .reader
-        .get_accumulator_summary(trusted_state.version())
-        .unwrap();
     let state_proof = db.reader.get_state_proof(trusted_state.version()).unwrap();
-    let trusted_state_change = trusted_state
-        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
-        .unwrap();
+    let trusted_state_change = trusted_state.verify_and_ratchet(&state_proof).unwrap();
     assert!(trusted_state_change.is_epoch_change());
     let trusted_state = trusted_state_change.new_state().unwrap();
     assert_eq!(trusted_state.version(), 5);
-    assert!(state_proof.consistency_proof().is_empty());
 
     // Effect of bootstrapping reflected.
     assert_eq!(get_balance(&account1, &db), 1_000_000);

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -32,15 +32,9 @@ fn test_genesis() {
     let (_, db, _executor, waypoint) = create_db_and_executor(path.path(), &genesis);
 
     let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let initial_accumulator = db
-        .reader
-        .get_accumulator_summary(trusted_state.version())
-        .unwrap();
     let state_proof = db.reader.get_state_proof(trusted_state.version()).unwrap();
 
-    trusted_state
-        .verify_and_ratchet(&state_proof, Some(&initial_accumulator))
-        .unwrap();
+    trusted_state.verify_and_ratchet(&state_proof).unwrap();
     let li = state_proof.latest_ledger_info();
     assert_eq!(li.version(), 0);
 

--- a/types/src/state_proof.rs
+++ b/types/src/state_proof.rs
@@ -4,7 +4,6 @@
 use crate::{
     epoch_change::EpochChangeProof,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    proof::AccumulatorConsistencyProof,
 };
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -24,48 +23,25 @@ use serde::{Deserialize, Serialize};
 pub struct StateProof {
     latest_li_w_sigs: LedgerInfoWithSignatures,
     epoch_changes: EpochChangeProof,
-    consistency_proof: AccumulatorConsistencyProof,
 }
 
 impl StateProof {
     pub fn new(
         latest_li_w_sigs: LedgerInfoWithSignatures,
         epoch_changes: EpochChangeProof,
-        consistency_proof: AccumulatorConsistencyProof,
     ) -> Self {
         Self {
             latest_li_w_sigs,
             epoch_changes,
-            consistency_proof,
         }
     }
 
-    pub fn into_inner(
-        self,
-    ) -> (
-        LedgerInfoWithSignatures,
-        EpochChangeProof,
-        AccumulatorConsistencyProof,
-    ) {
-        (
-            self.latest_li_w_sigs,
-            self.epoch_changes,
-            self.consistency_proof,
-        )
+    pub fn into_inner(self) -> (LedgerInfoWithSignatures, EpochChangeProof) {
+        (self.latest_li_w_sigs, self.epoch_changes)
     }
 
-    pub fn as_inner(
-        &self,
-    ) -> (
-        &LedgerInfoWithSignatures,
-        &EpochChangeProof,
-        &AccumulatorConsistencyProof,
-    ) {
-        (
-            &self.latest_li_w_sigs,
-            &self.epoch_changes,
-            &self.consistency_proof,
-        )
+    pub fn as_inner(&self) -> (&LedgerInfoWithSignatures, &EpochChangeProof) {
+        (&self.latest_li_w_sigs, &self.epoch_changes)
     }
 
     #[inline]
@@ -81,11 +57,6 @@ impl StateProof {
     #[inline]
     pub fn epoch_changes(&self) -> &EpochChangeProof {
         &self.epoch_changes
-    }
-
-    #[inline]
-    pub fn consistency_proof(&self) -> &AccumulatorConsistencyProof {
-        &self.consistency_proof
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Accumulator consistency proof in state proof is not being used currently, hence this can be removed safely. We are doing this because this is blocking the transaction accumulator pruning.

