### PR TITLE
[Storage] Avoid DB call for get_first_txn API

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -815,14 +815,24 @@ impl DbReader for AptosDB {
     /// Get the first version that txn starts existent.
     fn get_first_txn_version(&self) -> Result<Option<Version>> {
         gauged_api("get_first_txn_version", || {
-            self.transaction_store.get_first_txn_version()
+            if let Some(pruner) = self.pruner.as_ref() {
+                // If pruning is enabled, we can get the least readable version from the pruner.
+                Ok(Some(pruner.get_least_readable_ledger_version()))
+            } else {
+                self.transaction_store.get_first_txn_version()
+            }
         })
     }
 
     /// Get the first version that write set starts existent.
     fn get_first_write_set_version(&self) -> Result<Option<Version>> {
         gauged_api("get_first_write_set_version", || {
-            self.transaction_store.get_first_write_set_version()
+            if let Some(pruner) = self.pruner.as_ref() {
+                // If pruning is enabled, we can get the least readable version from the pruner.
+                Ok(Some(pruner.get_least_readable_ledger_version()))
+            } else {
+                self.transaction_store.get_first_write_set_version()
+            }
         })
     }
 

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -100,7 +100,7 @@ impl LedgerPruner {
         event_store: Arc<EventStore>,
         ledger_store: Arc<LedgerStore>,
     ) -> Self {
-        LedgerPruner {
+        let pruner = LedgerPruner {
             db,
             target_version: AtomicVersion::new(0),
             least_readable_version: AtomicVersion::new(0),
@@ -110,6 +110,8 @@ impl LedgerPruner {
             )),
             event_store_pruner: Arc::new(EventStorePruner::new(event_store)),
             write_set_pruner: Arc::new(WriteSetPruner::new(transaction_store)),
-        }
+        };
+        pruner.initialize();
+        pruner
     }
 }

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -109,13 +109,15 @@ impl StateStorePruner {
         index_min_nonpurged_version: Version,
         index_purged_at: Instant,
     ) -> Self {
-        StateStorePruner {
+        let pruner = StateStorePruner {
             db,
             index_min_nonpurged_version: AtomicVersion::new(index_min_nonpurged_version),
             index_purged_at: Mutex::new(index_purged_at),
             target_version: AtomicVersion::new(0),
             least_readable_version: AtomicVersion::new(0),
-        }
+        };
+        pruner.initialize();
+        pruner
     }
 
     /// Purge the stale node index so that after restart not too much already pruned stuff is dealt

--- a/storage/aptosdb/src/pruner/worker.rs
+++ b/storage/aptosdb/src/pruner/worker.rs
@@ -51,9 +51,6 @@ impl Worker {
     }
 
     pub(crate) fn work(mut self) {
-        for db_pruner in &self.db_pruners {
-            db_pruner.lock().initialize();
-        }
         while self.receive_commands() {
             // Process a reasonably small batch of work before trying to receive commands again,
             // in case `Command::Quit` is received (that's when we should quit.)


### PR DESCRIPTION
## Motivation

With ledger pruning enabled, seeking to the first txn becomes very expensive call. Instead of doing a DB call, we could simply use the value cached in the pruner. Another related change we need to do in the pruner is initializing them synchronously in the caller thread, so that the `least_readable_version` from the pruner is initialized.


## Test Plan

Existing tests

