### PR TITLE
[docs] remove clutter in display of run validator of testnet on Azure

### DIFF
--- a/developer-docs-site/docs/tutorials/validator-node/using-azure.md
+++ b/developer-docs-site/docs/tutorials/validator-node/using-azure.md
@@ -52,7 +52,6 @@ Install pre-requisites if needed:
     }
   }
 
-
   module "aptos-node" {
     # download Terraform module from aptos-labs/aptos-core repo
     source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/azure?ref=main"


### PR DESCRIPTION
## Motivation

UI is displayed incorrectly for paragraphs that need to be formatted as code.

<img width="2032" alt="Screen Shot 2022-05-15 at 10 27 21 AM" src="https://user-images.githubusercontent.com/12815768/168455950-51263e57-ea07-4926-aed1-9ddbe641ba18.png">

Fixed:

<img width="2032" alt="Screen Shot 2022-05-15 at 11 03 51 AM" src="https://user-images.githubusercontent.com/12815768/168456769-374e8e33-d013-4d60-b4b8-c1e1b019efe7.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes. 