### PR TITLE
[Documentation] Fix typo in using-source-code.md

### DIFF
--- a/developer-docs-site/docs/tutorials/validator-node/using-source-code.md
+++ b/developer-docs-site/docs/tutorials/validator-node/using-source-code.md
@@ -115,7 +115,7 @@ With your development environment ready, now you can start to setup your Validat
     ```
     cargo run --release --package framework -- --package aptos-framework --output current
 
-    mkdir ~/WORKSPACE/framework
+    mkdir ~/$WORKSPACE/framework
 
     mv aptos-framework/releases/artifacts/current/build/**/bytecode_modules/*.mv ~/$WORKSPACE/framework/
     ```


### PR DESCRIPTION
As above. Few PRs (https://github.com/aptos-labs/aptos-core/pull/1009 and https://github.com/aptos-labs/aptos-core/pull/998) on this have been sent by the community but they have not signed the CLA.  Making this change on their behalf.