### PR TITLE
[aptos-cli] set restrictive permission bits for key files

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -6,7 +6,7 @@ use crate::{
         init::DEFAULT_REST_URL,
         utils::{
             check_if_file_exists, read_from_file, to_common_result, to_common_success_result,
-            write_to_file,
+            write_to_file, write_to_file_with_opts,
         },
     },
     genesis::git::from_yaml,
@@ -22,9 +22,12 @@ use async_trait::async_trait;
 use clap::{ArgEnum, Parser};
 use move_deps::move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::{
     collections::{BTreeMap, HashMap},
     fmt::Debug,
+    fs::OpenOptions,
     path::{Path, PathBuf},
     str::FromStr,
     time::Instant,
@@ -492,6 +495,14 @@ impl SaveFile {
     /// Save to the `output_file`
     pub fn save_to_file(&self, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
         write_to_file(self.output_file.as_path(), name, bytes)
+    }
+
+    /// Save to the `output_file` with restricted permissions (mode 0600)
+    pub fn save_to_file_confidential(&self, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
+        let mut opts = OpenOptions::new();
+        #[cfg(unix)]
+        opts.mode(0o600);
+        write_to_file_with_opts(self.output_file.as_path(), name, bytes, &mut opts)
     }
 }
 

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -21,7 +21,7 @@ use shadow_rs::shadow;
 use std::{
     collections::{BTreeMap, HashMap},
     env,
-    fs::File,
+    fs::OpenOptions,
     io::Write,
     path::{Path, PathBuf},
     str::FromStr,
@@ -195,7 +195,22 @@ pub fn read_from_file(path: &Path) -> CliTypedResult<Vec<u8>> {
 
 /// Write a `&[u8]` to a file
 pub fn write_to_file(path: &Path, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
-    let mut file = File::create(path).map_err(|e| CliError::IO(name.to_string(), e))?;
+    write_to_file_with_opts(path, name, bytes, &mut OpenOptions::new())
+}
+
+/// Write a `&[u8]` to a file with the given options
+pub fn write_to_file_with_opts(
+    path: &Path,
+    name: &str,
+    bytes: &[u8],
+    opts: &mut OpenOptions,
+) -> CliTypedResult<()> {
+    let mut file = opts
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| CliError::IO(name.to_string(), e))?;
     file.write_all(bytes)
         .map_err(|e| CliError::IO(name.to_string(), e))
 }

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -230,7 +230,7 @@ impl SaveKey {
         // Write private and public keys to files
         let public_key_file = self.public_key_file()?;
         self.file_options
-            .save_to_file(key_name, &encoded_private_key)?;
+            .save_to_file_confidential(key_name, &encoded_private_key)?;
         write_to_file(&public_key_file, key_name, &encoded_public_key)?;
 
         let mut map = HashMap::new();


### PR DESCRIPTION
## Motivation

The `aptos key generate` command creates private keys with default permission bits (`0666`).
On unix-like systems, this makes keys world-readable, i.e. any user on the system can access these private keys.

It is a widely accepted best practice to allow key files to only be read by the current user (i.e. permission bits `0600`).
Some tools like OpenSSH even refuse to work with keys that have too broad permission bits.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

Yea

## Test Plan

- Make Aptos CLI still compiles on Windows 
- Run `aptos key generate` on a Linux machine and make sure that the resulting file is not readable by group or world.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)

None