### PR TITLE
[Storage] Remove test compilation from the PrunerIndex.

### DIFF
--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -63,7 +63,7 @@ pub(crate) struct Pruner {
 }
 
 pub enum PrunerIndex {
-    #[cfg(test)]
+    #[allow(dead_code)]
     StateStorePrunerIndex,
     LedgerPrunerIndex,
 }


### PR DESCRIPTION
## Motivation

This PR removes a conditional test compilation flag from the `PrunerIndex`. The issue is that `get_first_txn_version` and `get_first_write_set_version` are returning the least readable version for the account state pruner and not the ledger pruner. The `PrunerIndex` is used to index into the pruners to fetch the correct least readable versions, but with `#[cfg(test)]` above the `StateStorePrunerIndex`, it means that `LedgerPrunerIndex` is resolving to 0 in production code, and thus reading the state pruner index when we want to read the ledger pruner index.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Tested manually in alden-net.

## Related PRs

None.
