### PR TITLE
Update README.md for installing dependencies before compiling

### DIFF
--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -23,7 +23,15 @@ source $HOME/.cargo/env
 1. Install dependencies before compiling:
    1. For Debian or Ubuntu: `sudo apt install build-essential pkg-config openssl libssl-dev libclang-dev`.
    2. For RHEL or Centos: `sudo yum install pkgconfig openssl openssl-devel clang`.
-   3. For others: please manually install `pkg-config` `openssl`, `libssl` and `libclang`.
+   3. For others: please manually install `pkg-config` `openssl`, `libssl` and `libclang`:
+      - `pkg-config`:
+         - Download and unzip the source code at https://pkgconfig.freedesktop.org/releases/
+         - `./configure --prefix=/usr/local/pkg_config/0_29_2 --with-internal-glib`
+         - `sudo make && sudo make install` 
+      - `openssl` and `libssl`:
+         - Check https://wiki.openssl.org/index.php/Compilation_and_Installation for full instructions.
+      - `libclang`:
+         - Check https://clang.llvm.org/get_started.html for full instructions.
 2. Install the `aptos` CLI tool by running the below command.  You can run this command from any directory.  The `aptos`
    CLI tool will be installed into your `CARGO_HOME`, usually `~/.cargo`:
 ```bash

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -20,12 +20,16 @@ You will need the `cargo` package manager to install the `aptos` CLI tool.  Foll
 source $HOME/.cargo/env
 ```
 ### Install the `aptos` CLI
-1. Install the `aptos` CLI tool by running the below command.  You can run this command from any directory.  The `aptos`
+1. Install dependencies before compiling:
+   1. For Debian or Ubuntu: `sudo apt install build-essential pkg-config openssl libssl-dev libclang-dev`.
+   2. For RHEL or Centos: `sudo yum install pkgconfig openssl openssl-devel clang`.
+   3. For others: please manually install `pkg-config` `openssl`, `libssl` and `libclang`.
+3. Install the `aptos` CLI tool by running the below command.  You can run this command from any directory.  The `aptos`
    CLI tool will be installed into your `CARGO_HOME`, usually `~/.cargo`:
 ```bash
 cargo install --git https://github.com/aptos-labs/aptos-core.git aptos --tag aptos-cli-latest
 ```
-2. Confirm that the `aptos` CLI tool is installed successfully by running the below command.  The terminal will display
+3. Confirm that the `aptos` CLI tool is installed successfully by running the below command.  The terminal will display
    the path to the `aptos` CLI's location.
 ```bash
 which aptos

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -27,7 +27,7 @@ source $HOME/.cargo/env
       - `pkg-config`:
          - Download and unzip the source code at https://pkgconfig.freedesktop.org/releases/
          - `./configure --prefix=/usr/local/pkg_config/0_29_2 --with-internal-glib`
-         - `sudo make && sudo make install` 
+         - `sudo make && sudo make install`
       - `openssl` and `libssl`:
          - Check https://wiki.openssl.org/index.php/Compilation_and_Installation for full instructions.
       - `libclang`:

--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -24,7 +24,7 @@ source $HOME/.cargo/env
    1. For Debian or Ubuntu: `sudo apt install build-essential pkg-config openssl libssl-dev libclang-dev`.
    2. For RHEL or Centos: `sudo yum install pkgconfig openssl openssl-devel clang`.
    3. For others: please manually install `pkg-config` `openssl`, `libssl` and `libclang`.
-3. Install the `aptos` CLI tool by running the below command.  You can run this command from any directory.  The `aptos`
+2. Install the `aptos` CLI tool by running the below command.  You can run this command from any directory.  The `aptos`
    CLI tool will be installed into your `CARGO_HOME`, usually `~/.cargo`:
 ```bash
 cargo install --git https://github.com/aptos-labs/aptos-core.git aptos --tag aptos-cli-latest


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Some libraries are missing during compiling the `aptos` from the source code, and there is no instruction on how to install them. I think it would be helpful to mention it in the `README.md`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

Submitted to cla@aptoslabs.com

## Test Plan

No test plan for the documentation update.

## Related PRs

N/A
