### PR TITLE
[executor-benchmark] Various improvements 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,7 @@ dependencies = [
  "executor-types",
  "indicatif",
  "jemallocator",
+ "num_cpus",
  "rand 0.8.4",
  "rayon",
  "schemadb",

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -14,6 +14,7 @@ chrono = "0.4.19"
 criterion = "0.3.5"
 indicatif = "0.15.0"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+num_cpus = "1.13.1"
 rand = "0.8.3"
 rayon = "1.5.2"
 serde = "1.0.137"

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -37,7 +37,7 @@ pub fn run(
     println!("Initializing...");
 
     if db_dir.as_ref().exists() {
-        fs::remove_dir_all(db_dir.as_ref().join("aptosdb")).unwrap_or(());
+        panic!("data-dir exists already.");
     }
     // create if not exists
     fs::create_dir_all(db_dir.as_ref()).unwrap();

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -150,19 +150,18 @@ impl TransactionGenerator {
         accounts
     }
 
-    pub fn new_with_metafile<P: AsRef<Path>>(
+    pub fn new_with_existing_db<P: AsRef<Path>>(
         genesis_key: Ed25519PrivateKey,
         block_sender: mpsc::SyncSender<Vec<Transaction>>,
         db_dir: P,
+        version: Version,
     ) -> Self {
         let path = db_dir.as_ref().join(META_FILENAME);
         let mut file = File::open(&path).unwrap();
         let mut contents = vec![];
         file.read_to_end(&mut contents).unwrap();
         let test_case: TestCase = toml::from_slice(&contents).expect("Must exist.");
-        let num_accounts = match test_case {
-            TestCase::P2p(P2pTestCase { num_accounts }) => num_accounts,
-        };
+        let TestCase::P2p(P2pTestCase { num_accounts }) = test_case;
 
         let seed = [1u8; 32];
         let rng = StdRng::from_seed(seed);
@@ -173,7 +172,7 @@ impl TransactionGenerator {
             )),
             num_accounts,
             genesis_key,
-            version: 2 * num_accounts as Version,
+            version,
             rng,
             block_sender: Some(block_sender),
         }


### PR DESCRIPTION

## Motivation

1. don't overwrite db dir on create-db.
2. read latest version out of db on run-executor. (in preparation for issuing state checkpoint txns)
3. support setting VM concurrency level and defaults to num_cpus::get().

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y
## Test Plan
manually ran create-db and run-executor sub commands
