### PR TITLE
[Documentation] Using regenerated search public API keys for Algolia.

### DIFF
--- a/developer-docs-site/docusaurus.config.js
+++ b/developer-docs-site/docusaurus.config.js
@@ -128,7 +128,7 @@ const config = {
       },
       algolia: {
         appId: 'HM7UY0NMLG',
-        apiKey: 'ab185b9077070c3e02dce2e381a3f81b',
+        apiKey: '63c5819714b74e64977337e61a1e3ae6',
         indexName: 'aptos',
         contextualSearch: true,
         debug: false,


### PR DESCRIPTION
cc: @davidiw 