### PR TITLE
[ecosystem] Don't put the error object in the flash message.

### DIFF
--- a/ecosystem/platform/server/app/controllers/onboarding_controller.rb
+++ b/ecosystem/platform/server/app/controllers/onboarding_controller.rb
@@ -52,8 +52,7 @@ class OnboardingController < ApplicationController
       redirect_to it1_path, notice: 'Identity Verification completed successfully!'
     rescue KYCCompleteJobError => e
       Sentry.capture_exception(e)
-      redirect_to it1_path, error: 'Error; If you completed Identity Verification,'\
-                                   " it may take some time to reflect. Error: #{e}"
+      redirect_to it1_path, error: 'Error; If you completed Identity Verification, it may take some time to reflect.'
     end
   end
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

I believe this is the source of a cookie overflow error in the `kyc_callback` route.

## Test Plan

I haven't been able to repro the cookie overflow, so this is untested.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
