### PR TITLE
[tf][testnet/validator] option for spot instance for EKS nodegroup

### DIFF
--- a/terraform/testnet/main.tf
+++ b/terraform/testnet/main.tf
@@ -40,6 +40,7 @@ module "validator" {
   k8s_admins         = var.k8s_admins
   ssh_pub_key        = var.ssh_pub_key
 
+  node_pool_capacity_type = var.node_pool_capacity_type
   max_node_pool_surge = var.enable_forge ? 2 : 1
   node_pool_sizes = var.validator_lite_mode ? {
     utilities  = var.num_utilities_instance > 0 ? var.num_utilities_instance : 3

--- a/terraform/testnet/variables.tf
+++ b/terraform/testnet/variables.tf
@@ -197,3 +197,8 @@ variable "coredns_min_replicas" {
   description = "Minimal replica numbers for core dns"
   default     = 2
 }
+
+variable "node_pool_capacity_type" {
+  description = "Type of capacity associated with the EKS Node Groups"
+  default     = "ON_DEMAND"
+}

--- a/terraform/validator/aws/cluster.tf
+++ b/terraform/validator/aws/cluster.tf
@@ -71,6 +71,8 @@ resource "aws_eks_node_group" "nodes" {
   subnet_ids      = [aws_subnet.private[0].id]
   tags            = local.default_tags
 
+  capacity_type = var.node_pool_capacity_type
+
   lifecycle {
     ignore_changes = [
       scaling_config[0].desired_size

--- a/terraform/validator/aws/variables.tf
+++ b/terraform/validator/aws/variables.tf
@@ -145,3 +145,8 @@ variable "workspace_name_override" {
   description = "If specified, overrides the usage of Terraform workspace for naming purposes"
   default     = ""
 }
+
+variable "node_pool_capacity_type" {
+  description = "Type of capacity associated with the EKS Node Groups"
+  default     = "ON_DEMAND"
+}


### PR DESCRIPTION
Spot instances for AWS Testnet and AWS Validator deployments, for workloads which can withstand being preempted. This is a naive attempt, as there are likely some instance type generalizations we can do on the launch template that will make nodes more available

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1042)
<!-- Reviewable:end -->
