### PR TITLE
[rustdoc] Cleanup all warnings from cargo doc

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 /// Port selected RocksDB options for tuning underlying rocksdb instance of AptosDB.
-/// see https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h
+/// see <https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h>
 /// for detailed explanations.
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/consensus/src/consensusdb/schema/single_entry/mod.rs
+++ b/consensus/src/consensusdb/schema/single_entry/mod.rs
@@ -5,7 +5,9 @@
 //!
 //! There will be only one row in this column family for each type of data.
 //! The key will be a serialized enum type designating the data type and should not have any meaning
-//! and be used. ```text
+//! and be used.
+//!
+//! ```text
 //! |<-------key------->|<-----value----->|
 //! | single entry key  | raw value bytes |
 //! ```

--- a/crates/aptos-crypto/src/traits.rs
+++ b/crates/aptos-crypto/src/traits.rs
@@ -3,8 +3,7 @@
 
 //! This module provides a generic set of traits for dealing with cryptographic primitives.
 //!
-//! For examples on how to use these traits, see the implementations of the [`ed25519`] or
-//! [`bls12381`] modules.
+//! For examples on how to use these traits, see the implementations of the [`crate::ed25519`]
 
 use crate::hash::{CryptoHash, CryptoHasher};
 use anyhow::Result;

--- a/crates/aptos-id-generator/src/lib.rs
+++ b/crates/aptos-id-generator/src/lib.rs
@@ -20,12 +20,12 @@ pub struct U32IdGenerator {
 }
 
 impl U32IdGenerator {
-    /// Creates a new [`InOrderIdGenerator`] initialized to `0`
+    /// Creates a new [`U32IdGenerator`] initialized to `0`
     pub const fn new() -> Self {
         Self::new_with_value(0)
     }
 
-    /// Creates a new [`InOrderIdGenerator`] with an `initial_value`
+    /// Creates a new [`U32IdGenerator`] with an `initial_value`
     pub const fn new_with_value(initial_value: u32) -> Self {
         Self {
             inner: AtomicU32::new(initial_value),
@@ -47,12 +47,12 @@ pub struct U64IdGenerator {
 }
 
 impl U64IdGenerator {
-    /// Creates a new [`InOrderIdGenerator`] initialized to `0`
+    /// Creates a new [`U64IdGenerator`] initialized to `0`
     pub const fn new() -> Self {
         Self::new_with_value(0)
     }
 
-    /// Creates a new [`InOrderIdGenerator`] with an `initial_value`
+    /// Creates a new [`U64IdGenerator`] with an `initial_value`
     pub const fn new_with_value(initial_value: u64) -> Self {
         Self {
             inner: AtomicU64::new(initial_value),

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -511,7 +511,7 @@ impl SaveFile {
 pub struct RestOptions {
     /// URL to a fullnode on the network
     ///
-    /// Defaults to https://fullnode.devnet.aptoslabs.com
+    /// Defaults to <https://fullnode.devnet.aptoslabs.com>
     #[clap(long, parse(try_from_str))]
     pub url: Option<reqwest::Url>,
 }

--- a/crates/channel/src/lib.rs
+++ b/crates/channel/src/lib.rs
@@ -5,10 +5,10 @@
 
 //! Provides an mpsc (multi-producer single-consumer) channel wrapped in an
 //! [`IntGauge`](aptos_metrics::IntGauge) that counts the number of currently
-//! queued items. While there is only one [`channel::Receiver`], there can be
-//! many [`channel::Sender`]s, which are also cheap to clone.
+//! queued items. While there is only one [`Receiver`], there can be
+//! many [`Sender`]s, which are also cheap to clone.
 //!
-//! This channel differs from our other channel implementation, [`channel::aptos_channel`],
+//! This channel differs from our other channel implementation, [`aptos_channel`],
 //! in that it is just a single queue (vs. different queues for different keys)
 //! with backpressure (senders will block if the queue is full instead of evicting
 //! another item in the queue) that only implements FIFO (vs. LIFO or KLAST).

--- a/crates/fallible/src/copy_from_slice.rs
+++ b/crates/fallible/src/copy_from_slice.rs
@@ -3,7 +3,7 @@
 
 use thiserror::Error;
 
-/// A fallible wrapper around [`std::vec::Vec::copy_from_slice`]
+/// A fallible wrapper around `copy_from_slice`
 pub fn copy_slice_to_vec<T>(slice: &[T], vec: &mut [T]) -> Result<(), CopySliceError>
 where
     T: Copy,

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -134,7 +134,7 @@ pub struct StateComputeResult {
     /// transaction accumulator root hash is identified as `state_id` in Consensus.
     root_hash: HashValue,
     /// Represents the roots of all the full subtrees from left to right in this accumulator
-    /// after the execution. For details, please see [`InMemoryAccumulator`](accumulator::InMemoryAccumulator).
+    /// after the execution. For details, please see [`InMemoryAccumulator`](aptos_types::proof::accumulator::InMemoryAccumulator).
     frozen_subtree_roots: Vec<HashValue>,
 
     /// The frozen subtrees roots of the parent block,

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -321,9 +321,9 @@ impl NetworkBuilder {
         self.peer_manager_builder.listen_address()
     }
 
-    /// Add a [`ConnectivityManager`] to the network.
+    /// Add a [`network::connectivity_manager::ConnectivityManager`] to the network.
     ///
-    /// [`ConnectivityManager`] is responsible for ensuring that we are connected
+    /// [`network::connectivity_manager::ConnectivityManager`] is responsible for ensuring that we are connected
     /// to a node iff. it is an eligible node and maintaining persistent
     /// connections with all eligible nodes. A list of eligible nodes is received
     /// at initialization, and updates are received on changes to system membership.

--- a/network/netcore/src/transport/proxy_protocol.rs
+++ b/network/netcore/src/transport/proxy_protocol.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! # An implementation of ProxyProtocol for HAProxy
-//! https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+//! <https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt>
 //!
 //! ## Limitations
 //! - Only supports ProxyProtocol V2

--- a/secure/storage/github/src/lib.rs
+++ b/secure/storage/github/src/lib.rs
@@ -58,7 +58,7 @@ impl From<serde_json::Error> for Error {
 }
 
 /// Client provides a client around the restful interface to GitHub API version 3. Learn more
-/// here: https://developer.github.com/v3
+/// here: <https://developer.github.com/v3>
 ///
 /// This is not intended for securely storing private data, though perhaps it could with a private
 /// repository. The tooling is intended to be used to exchange data in an authenticated fashion

--- a/secure/storage/src/vault.rs
+++ b/secure/storage/src/vault.rs
@@ -28,7 +28,7 @@ const TRANSIT_NAMESPACE_SEPARATOR: &str = "__";
 /// version currently matches the behavior of OnDiskStorage and InMemoryStorage. In the future,
 /// Vault will be able to create keys, sign messages, and handle permissions across different
 /// services. The specific vault service leveraged herein is called KV (Key Value) Secrets Engine -
-/// Version 2 (https://www.vaultproject.io/api/secret/kv/kv-v2.html). So while Secure Storage
+/// Version 2 (<https://www.vaultproject.io/api/secret/kv/kv-v2.html>). So while Secure Storage
 /// calls pointers to data keys, Vault has actually a secret that contains multiple key value
 /// pairs.
 pub struct VaultStorage {

--- a/secure/storage/vault/src/lib.rs
+++ b/secure/storage/vault/src/lib.rs
@@ -97,7 +97,7 @@ impl From<serde_json::Error> for Error {
 }
 
 /// Client provides a client around the restful interface to a Vault servce. Learn more
-/// here: https://www.vaultproject.io/api-docs/
+/// here: <https://www.vaultproject.io/api-docs/>
 ///
 /// A brief overview of Vault:
 ///

--- a/state-sync/state-sync-v1/src/chunk_request.rs
+++ b/state-sync/state-sync-v1/src/chunk_request.rs
@@ -12,7 +12,7 @@ pub enum TargetType {
     /// The response is built relative to the target (or end of epoch).
     /// **DEPRECATED**: `TargetLedgerInfo` is only required for backward compatibility. State sync
     /// avoids sending these target types and instead uses `HighestAvailable` below. This message
-    /// will be removed on the next breaking release: https://github.com/aptos-labs/aptos-core/issues/8013
+    /// will be removed on the next breaking release: <https://github.com/aptos-labs/aptos-core/issues/8013>
     TargetLedgerInfo(LedgerInfoWithSignatures),
     /// The response is built relative to the highest available LedgerInfo (or end of epoch).
     /// The value specifies the timeout in ms to wait for an available response.

--- a/state-sync/state-sync-v1/src/chunk_response.rs
+++ b/state-sync/state-sync-v1/src/chunk_response.rs
@@ -17,7 +17,7 @@ pub enum ResponseLedgerInfo {
     /// local trusted validator set.
     /// **DEPRECATED**: `VerifiableLedgerInfo` is only required for backward compatibility. State
     /// sync avoids sending these response types and instead uses `ProgressiveLedgerInfo` below.
-    /// This message will be removed on the next breaking release: https://github.com/aptos-labs/aptos-core/issues/8013
+    /// This message will be removed on the next breaking release: <https://github.com/aptos-labs/aptos-core/issues/8013>
     VerifiableLedgerInfo(LedgerInfoWithSignatures),
     /// A response to `TargetType::HighestAvailable` chunk request type.
     ProgressiveLedgerInfo {

--- a/storage/aptosdb/src/schema/state_value_index/mod.rs
+++ b/storage/aptosdb/src/schema/state_value_index/mod.rs
@@ -11,7 +11,7 @@
 //! version can give us access to the JMT leaf associated with corresponding key and version
 //!
 //!
-//! //! ```text
+//! ```text
 //! |<---------key--------> |<-----value----->|
 //! |  state_key, version  |   num of nibbles |
 //! ```

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -270,7 +270,7 @@ impl DB {
     /// Open db as secondary.
     /// This allows to read the DB in another process while it's already opened for read / write in
     /// one (e.g. a Node)
-    /// https://github.com/facebook/rocksdb/blob/493f425e77043cc35ea2d89ee3c4ec0274c700cb/include/rocksdb/db.h#L176-L222
+    /// <https://github.com/facebook/rocksdb/blob/493f425e77043cc35ea2d89ee3c4ec0274c700cb/include/rocksdb/db.h#L176-L222>
     pub fn open_as_secondary<P: AsRef<Path>>(
         primary_path: P,
         secondary_path: P,
@@ -377,7 +377,7 @@ impl DB {
     /// Delete all keys in range [begin, end).
     ///
     /// `SK` has to be an explicit type parameter since
-    /// https://github.com/rust-lang/rust/issues/44721
+    /// <https://github.com/rust-lang/rust/issues/44721>
     pub fn range_delete<S, SK>(&self, begin: &SK, end: &SK) -> Result<()>
     where
         S: Schema,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -213,9 +213,9 @@ pub enum Order {
 /// expected of an Aptos DB
 #[allow(unused_variables)]
 pub trait DbReader: Send + Sync {
-    /// See [`AptosDB::get_epoch_ending_ledger_infos`].
+    /// See [AptosDB::get_epoch_ending_ledger_infos].
     ///
-    /// [`AptosDB::get_epoch_ending_ledger_infos`]:
+    /// [AptosDB::get_epoch_ending_ledger_infos]:
     /// ../aptosdb/struct.AptosDB.html#method.get_epoch_ending_ledger_infos
     fn get_epoch_ending_ledger_infos(
         &self,
@@ -225,9 +225,9 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_transactions`].
+    /// See [AptosDB::get_transactions].
     ///
-    /// [`AptosDB::get_transactions`]: ../aptosdb/struct.AptosDB.html#method.get_transactions
+    /// [AptosDB::get_transactions]: ../aptosdb/struct.AptosDB.html#method.get_transactions
     fn get_transactions(
         &self,
         start_version: Version,
@@ -238,9 +238,9 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_transaction_by_hash`].
+    /// See [AptosDB::get_transaction_by_hash].
     ///
-    /// [`AptosDB::get_transaction_by_hash`]: ../aptosdb/struct.AptosDB.html#method.get_transaction_by_hash
+    /// [AptosDB::get_transaction_by_hash]: ../aptosdb/struct.AptosDB.html#method.get_transaction_by_hash
     fn get_transaction_by_hash(
         &self,
         hash: HashValue,
@@ -250,9 +250,9 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_transaction_by_version`].
+    /// See [AptosDB::get_transaction_by_version].
     ///
-    /// [`AptosDB::get_transaction_by_version`]: ../aptosdb/struct.AptosDB.html#method.get_transaction_by_version
+    /// [AptosDB::get_transaction_by_version]: ../aptosdb/struct.AptosDB.html#method.get_transaction_by_version
     fn get_transaction_by_version(
         &self,
         version: Version,
@@ -262,23 +262,23 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_txn_set_version`].
+    /// See [AptosDB::get_first_txn_version].
     ///
-    /// [`AptosDB::get_first_txn_version`]: ../aptosdb/struct.AptosDB.html#method.get_first_txn_version
+    /// [AptosDB::get_first_txn_version]: ../aptosdb/struct.AptosDB.html#method.get_first_txn_version
     fn get_first_txn_version(&self) -> Result<Option<Version>> {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_first_write_set_version`].
+    /// See [AptosDB::get_first_write_set_version].
     ///
-    /// [`AptosDB::get_first_write_set_version`]: ../aptosdb/struct.AptosDB.html#method.get_first_write_set_version
+    /// [AptosDB::get_first_write_set_version]: ../aptosdb/struct.AptosDB.html#method.get_first_write_set_version
     fn get_first_write_set_version(&self) -> Result<Option<Version>> {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_transaction_outputs`].
+    /// See [AptosDB::get_transaction_outputs].
     ///
-    /// [`AptosDB::get_transaction_outputs`]: ../aptosdb/struct.AptosDB.html#method.get_transaction_outputs
+    /// [AptosDB::get_transaction_outputs]: ../aptosdb/struct.AptosDB.html#method.get_transaction_outputs
     fn get_transaction_outputs(
         &self,
         start_version: Version,
@@ -322,16 +322,16 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_block_timestamp`].
+    /// See [AptosDB::get_block_timestamp].
     ///
-    /// [`AptosDB::get_block_timestamp`]:
+    /// [AptosDB::get_block_timestamp]:
     /// ../aptosdb/struct.AptosDB.html#method.get_block_timestamp
     fn get_block_timestamp(&self, version: u64) -> Result<u64> {
         unimplemented!()
     }
 
-    /// Returns the [`NewBlockEvent`] for the block containing the requested
-    /// `version` and proof that the block actually contains the `version`.
+    /// Returns the [`aptos_types::account_config::events::new_block::NewBlockEvent`] for the block
+    /// containing the requested `version` and proof that the block actually contains the `version`.
     fn get_event_by_version_with_proof(
         &self,
         event_key: &EventKey,
@@ -342,7 +342,7 @@ pub trait DbReader: Send + Sync {
     }
 
     /// Gets the version of the last transaction committed before timestamp,
-    /// a commited block at or after the required timestamp must exist (otherwise it's possible
+    /// a committed block at or after the required timestamp must exist (otherwise it's possible
     /// the next block committed as a timestamp smaller than the one in the request).
     fn get_last_version_before_timestamp(
         &self,
@@ -352,9 +352,9 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// See [`AptosDB::get_latest_account_state`].
+    /// See [AptosDB::get_latest_account_state].
     ///
-    /// [`AptosDB::get_latest_account_state`]:
+    /// [AptosDB::get_latest_account_state]:
     /// ../aptosdb/struct.AptosDB.html#method.get_latest_account_state
     fn get_latest_state_value(&self, state_key: StateKey) -> Result<Option<StateValue>> {
         unimplemented!()
@@ -402,9 +402,9 @@ pub trait DbReader: Send + Sync {
     }
 
     /// Gets information needed from storage during the main node startup.
-    /// See [`AptosDB::get_startup_info`].
+    /// See [AptosDB::get_startup_info].
     ///
-    /// [`AptosDB::get_startup_info`]:
+    /// [AptosDB::get_startup_info]:
     /// ../aptosdb/struct.AptosDB.html#method.get_startup_info
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         unimplemented!()
@@ -463,14 +463,14 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    // Gets an account state by account address, out of the ledger state indicated by the state
-    // Merkle tree root with a sparse merkle proof proving state tree root.
-    // See [`AptosDB::get_account_state_with_proof_by_version`].
-    //
-    // [`AptosDB::get_account_state_with_proof_by_version`]:
-    // ../aptosdb/struct.AptosDB.html#method.get_account_state_with_proof_by_version
-    //
-    // This is used by aptos core (executor) internally.
+    /// Gets an account state by account address, out of the ledger state indicated by the state
+    /// Merkle tree root with a sparse merkle proof proving state tree root.
+    /// See [AptosDB::get_account_state_with_proof_by_version].
+    ///
+    /// [AptosDB::get_account_state_with_proof_by_version]:
+    /// ../aptosdb/struct.AptosDB.html#method.get_account_state_with_proof_by_version
+    ///
+    /// This is used by aptos core (executor) internally.
     fn get_state_value_with_proof_by_version(
         &self,
         state_key: &StateKey,

--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -147,7 +147,7 @@ where
     }
 
     /// Appends a list of new subtrees to the existing accumulator. This is similar to
-    /// [`append`](Accumulator::append) except that the new leaves themselves are not known and
+    /// [`append`](InMemoryAccumulator::append) except that the new leaves themselves are not known and
     /// they are represented by `subtrees`. As an example, given the following accumulator that
     /// currently has 10 leaves, the frozen subtree roots and the new subtrees are annotated below.
     /// Note that in this case `subtrees[0]` represents two new leaves `A` and `B`, `subtrees[1]`

--- a/types/src/proof/definition.rs
+++ b/types/src/proof/definition.rs
@@ -368,7 +368,7 @@ impl TransactionAccumulatorSummary {
 /// the client can verify that it can indeed obtain the new root hash by appending these new
 /// leaves, it can be convinced that the two accumulators are consistent.
 ///
-/// See [`crate::proof::accumulator::Accumulator::append_subtrees`] for more details.
+/// See [`crate::proof::accumulator::InMemoryAccumulator::append_subtrees`] for more details.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct AccumulatorConsistencyProof {
     /// The subtrees representing the newly appended leaves.

--- a/types/src/proof/position/mod.rs
+++ b/types/src/proof/position/mod.rs
@@ -388,7 +388,7 @@ impl Iterator for FrozenSubTreeIterator {
 /// positions of required subtrees if we want to append these subtrees to the existing accumulator
 /// to generate a bigger one of size `new_num_leaves`.
 ///
-/// See [`crate::proof::accumulator::Accumulator::append_subtrees`] for more details.
+/// See [`crate::proof::accumulator::InMemoryAccumulator::append_subtrees`] for more details.
 pub struct FrozenSubtreeSiblingIterator {
     current_num_leaves: LeafCount,
     remaining_new_leaves: LeafCount,

--- a/types/src/trusted_state.rs
+++ b/types/src/trusted_state.rs
@@ -104,7 +104,7 @@ impl TrustedState {
 
     /// Verify and ratchet forward our trusted state using an [`EpochChangeProof`]
     /// (that moves us into the latest epoch), a [`LedgerInfoWithSignatures`]
-    /// inside that epoch, and an [`AccumulatorConsistencyProof`] from our current
+    /// inside that epoch, and an [`crate::proof::AccumulatorConsistencyProof`] from our current
     /// version to that last verifiable ledger info.
     ///
     /// If our current trusted state doesn't have an accumulator summary yet


### PR DESCRIPTION
To turn back on the doc builds, I wanted to fix all warnings so that
the build is clean.  Afterwards, we can update the `gh-pages` branch to update the rustdocs accordingly.