### PR TITLE
[State Sync] Use optimistic fetch/single subscriptions for data streaming.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -187,7 +187,7 @@ impl Default for AptosDataClientConfig {
             max_num_in_flight_priority_polls: 10,
             max_num_in_flight_regular_polls: 10,
             response_timeout_ms: 5000,
-            summary_poll_interval_ms: 100,
+            summary_poll_interval_ms: 200,
         }
     }
 }

--- a/state-sync/aptos-data-client/src/aptosnet/state.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/state.rs
@@ -5,11 +5,16 @@ use crate::{
     aptosnet::logging::{LogEntry, LogEvent, LogSchema},
     AdvertisedData, GlobalDataSummary, OptimalChunkSizes, ResponseError,
 };
-use aptos_config::{config::StorageServiceConfig, network_id::PeerNetworkId};
+use aptos_config::{
+    config::{PeerRole, StorageServiceConfig},
+    network_id::PeerNetworkId,
+};
 use aptos_logger::debug;
+use network::application::storage::PeerMetadataStorage;
 use std::{
     cmp::min,
     collections::{HashMap, HashSet},
+    sync::Arc,
 };
 use storage_service_types::{StorageServerSummary, StorageServiceRequest};
 
@@ -103,15 +108,20 @@ pub(crate) struct PeerStates {
     peer_to_state: HashMap<PeerNetworkId, PeerState>,
     in_flight_priority_polls: HashSet<PeerNetworkId>, // The priority peers with in-flight polls
     in_flight_regular_polls: HashSet<PeerNetworkId>,  // The regular peers with in-flight polls
+    peer_metadata_storage: Arc<PeerMetadataStorage>,
 }
 
 impl PeerStates {
-    pub fn new(config: StorageServiceConfig) -> Self {
+    pub fn new(
+        config: StorageServiceConfig,
+        peer_metadata_storage: Arc<PeerMetadataStorage>,
+    ) -> Self {
         Self {
             config,
             peer_to_state: HashMap::new(),
             in_flight_priority_polls: HashSet::new(),
             in_flight_regular_polls: HashSet::new(),
+            peer_metadata_storage,
         }
     }
 
@@ -125,7 +135,12 @@ impl PeerStates {
         // Storage services can always respond to data advertisement requests.
         // We need this outer check, since we need to be able to send data summary
         // requests to new peers (who don't have a peer state yet).
-        if request.is_get_storage_server_summary() {
+        // Likewise, we can always send subscription requests to any peers and
+        // all peers should support versioning.
+        if request.is_get_storage_server_summary()
+            || request.is_data_subscription_request()
+            || matches!(request, StorageServiceRequest::GetServerProtocolVersion)
+        {
             return true;
         }
 
@@ -213,7 +228,27 @@ impl PeerStates {
     ///
     /// TODO(joshlind): make this less hacky using network topological awareness.
     pub fn is_priority_peer(&self, peer: &PeerNetworkId) -> bool {
-        peer.network_id().is_validator_network()
+        if peer.network_id().is_validator_network() {
+            return true;
+        }
+
+        let peer_role = self
+            .peer_metadata_storage
+            .read(*peer)
+            .map(|peer| peer.active_connection.role);
+        if let Some(peer_role) = peer_role {
+            if peer.network_id().is_vfn_network() {
+                match peer_role {
+                    PeerRole::Validator
+                    | PeerRole::ValidatorFullNode
+                    | PeerRole::PreferredUpstream
+                    | PeerRole::Upstream => return true,
+                    _ => return false,
+                }
+            }
+        }
+
+        false
     }
 
     /// Updates the storage summary for the given peer

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -33,9 +33,9 @@ use std::{
 use storage_service_client::{StorageServiceClient, StorageServiceNetworkSender};
 use storage_service_server::network::{NetworkRequest, ResponseSender};
 use storage_service_types::{
-    CompleteDataRange, DataSummary, ProtocolMetadata, StorageServerSummary, StorageServiceError,
-    StorageServiceMessage, StorageServiceRequest, StorageServiceResponse,
-    TransactionsWithProofRequest,
+    CompleteDataRange, DataSummary, NewTransactionsWithProofRequest, ProtocolMetadata,
+    StorageServerSummary, StorageServiceError, StorageServiceMessage, StorageServiceRequest,
+    StorageServiceResponse, TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
 };
 
 fn mock_ledger_info(version: Version) -> LedgerInfoWithSignatures {
@@ -60,7 +60,7 @@ fn mock_storage_summary(version: Version) -> StorageServerSummary {
             synced_ledger_info: Some(mock_ledger_info(version)),
             epoch_ending_ledger_infos: None,
             transactions: Some(CompleteDataRange::new(0, version).unwrap()),
-            transaction_outputs: None,
+            transaction_outputs: Some(CompleteDataRange::new(0, version).unwrap()),
             account_states: None,
         },
     }
@@ -616,6 +616,103 @@ async fn in_flight_error_handling() {
     // Verify we have no in-flight polls
     let num_in_flight_polls = get_num_in_flight_polls(client.clone(), true);
     assert_eq!(num_in_flight_polls, 0);
+}
+
+#[tokio::test]
+async fn prioritized_peer_request_selection() {
+    ::aptos_logger::Logger::init_for_testing();
+    let (mut mock_network, _, client, _) = MockNetwork::new(None);
+
+    // Ensure no peers can service the given request (we have no connections)
+    let server_version_request = StorageServiceRequest::GetServerProtocolVersion;
+    assert_matches!(
+        client.choose_peer_for_request(&server_version_request),
+        Err(Error::DataIsUnavailable(_))
+    );
+
+    // Add a regular peer and verify the peer is selected as the recipient
+    let regular_peer_1 = mock_network.add_peer(false);
+    assert_eq!(
+        client.choose_peer_for_request(&server_version_request),
+        Ok(regular_peer_1)
+    );
+
+    // Verify the peer is selected as the recipient for a subscription request
+    let new_transactions_request =
+        StorageServiceRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+            known_version: 1023,
+            known_epoch: 23,
+            include_events: false,
+        });
+    assert_eq!(
+        client.choose_peer_for_request(&new_transactions_request),
+        Ok(regular_peer_1)
+    );
+
+    // Add a priority peer and verify the peer is selected as the recipient
+    let priority_peer_1 = mock_network.add_peer(true);
+    assert_eq!(
+        client.choose_peer_for_request(&new_transactions_request),
+        Ok(priority_peer_1)
+    );
+
+    // Disconnect the priority peer and verify the regular peer is now chosen
+    mock_network.disconnect_peer(priority_peer_1);
+    assert_eq!(
+        client.choose_peer_for_request(&new_transactions_request),
+        Ok(regular_peer_1)
+    );
+
+    // Connect a new priority peer and verify it is now selected
+    let priority_peer_2 = mock_network.add_peer(true);
+    assert_eq!(
+        client.choose_peer_for_request(&new_transactions_request),
+        Ok(priority_peer_2)
+    );
+
+    // Request data that is not being advertised and verify we get an error
+    let output_data_request =
+        StorageServiceRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+            proof_version: 100,
+            start_version: 0,
+            end_version: 100,
+        });
+    assert_matches!(
+        client.choose_peer_for_request(&output_data_request),
+        Err(Error::DataIsUnavailable(_))
+    );
+
+    // Advertise the data for the regular peer and verify it is now selected
+    client.update_summary(regular_peer_1, mock_storage_summary(100));
+    assert_eq!(
+        client.choose_peer_for_request(&output_data_request),
+        Ok(regular_peer_1)
+    );
+
+    // Advertise the data for the priority peer and verify it is now selected
+    client.update_summary(priority_peer_2, mock_storage_summary(100));
+    assert_eq!(
+        client.choose_peer_for_request(&output_data_request),
+        Ok(priority_peer_2)
+    );
+
+    // Disconnect priority peer 2 and reconnect peer 1
+    mock_network.disconnect_peer(priority_peer_2);
+    mock_network.reconnect_peer(priority_peer_1);
+
+    // Request the data again and verify the regular peer is chosen
+    client.update_summary(regular_peer_1, mock_storage_summary(100));
+    assert_eq!(
+        client.choose_peer_for_request(&output_data_request),
+        Ok(regular_peer_1)
+    );
+
+    // Advertise the data for the priority peer and verify it is now selected
+    client.update_summary(priority_peer_1, mock_storage_summary(100));
+    assert_eq!(
+        client.choose_peer_for_request(&output_data_request),
+        Ok(priority_peer_1)
+    );
 }
 
 // 1. 2 peers

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -38,6 +38,8 @@ pub enum DataPayload {
 pub enum DataClientRequest {
     AccountsWithProof(AccountsWithProofRequest),
     EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest),
+    NewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest),
+    NewTransactionsWithProof(NewTransactionsWithProofRequest),
     NumberOfAccounts(NumberOfAccountsRequest),
     TransactionsWithProof(TransactionsWithProofRequest),
     TransactionOutputsWithProof(TransactionOutputsWithProofRequest),
@@ -49,6 +51,8 @@ impl DataClientRequest {
         match self {
             Self::AccountsWithProof(_) => "accounts_with_proof",
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
+            Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
+            Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
             Self::NumberOfAccounts(_) => "number_of_accounts",
             Self::TransactionsWithProof(_) => "transactions_with_proof",
             Self::TransactionOutputsWithProof(_) => "transaction_outputs_with_proof",
@@ -69,6 +73,21 @@ pub struct AccountsWithProofRequest {
 pub struct EpochEndingLedgerInfosRequest {
     pub start_epoch: Epoch,
     pub end_epoch: Epoch,
+}
+
+/// A client request for fetching new transactions with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NewTransactionsWithProofRequest {
+    pub known_version: Version,
+    pub known_epoch: Epoch,
+    pub include_events: bool,
+}
+
+/// A client request for fetching new transaction outputs with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NewTransactionOutputsWithProofRequest {
+    pub known_version: Version,
+    pub known_epoch: Epoch,
 }
 
 /// A client request for fetching the number of accounts at a version.

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -5,11 +5,13 @@ use crate::{
     data_notification::{
         AccountsWithProofRequest, DataClientRequest,
         DataClientRequest::{
-            AccountsWithProof, EpochEndingLedgerInfos, NumberOfAccounts,
-            TransactionOutputsWithProof, TransactionsWithProof,
+            AccountsWithProof, EpochEndingLedgerInfos, NewTransactionOutputsWithProof,
+            NewTransactionsWithProof, NumberOfAccounts, TransactionOutputsWithProof,
+            TransactionsWithProof,
         },
-        DataNotification, DataPayload, EpochEndingLedgerInfosRequest, NumberOfAccountsRequest,
-        TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
+        DataNotification, DataPayload, EpochEndingLedgerInfosRequest,
+        NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest,
+        NumberOfAccountsRequest, TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
     },
     error::Error,
     logging::{LogEntry, LogEvent, LogSchema},
@@ -275,6 +277,7 @@ impl DataStreamEngine for AccountsStreamEngine {
                 let data_notification = create_data_notification(
                     notification_id_generator,
                     client_response_payload,
+                    None,
                     self.clone().into(),
                 );
                 return Ok(Some(data_notification));
@@ -321,6 +324,9 @@ pub struct ContinuousTransactionStreamEngine {
     // True iff a request has been created to fetch an epoch ending ledger info
     pub end_of_epoch_requested: bool,
 
+    // True iff a request has been created to subscribe to data,
+    pub subscription_requested: bool,
+
     // The next version and epoch that we're waiting to send to the
     // client along the stream. All versions before this have been sent.
     pub next_stream_version_and_epoch: (Version, Epoch),
@@ -338,22 +344,32 @@ impl ContinuousTransactionStreamEngine {
     fn new(stream_request: &StreamRequest) -> Result<Self, Error> {
         match stream_request {
             StreamRequest::ContinuouslyStreamTransactions(request) => {
+                let (next_version, next_epoch) = Self::calculate_next_version_and_epoch(
+                    request.known_version,
+                    request.known_epoch,
+                )?;
                 Ok(ContinuousTransactionStreamEngine {
                     request: stream_request.clone(),
                     current_target_ledger_info: None,
                     end_of_epoch_requested: false,
-                    next_stream_version_and_epoch: (request.start_version, request.start_epoch),
-                    next_request_version_and_epoch: (request.start_version, request.start_epoch),
+                    subscription_requested: false,
+                    next_stream_version_and_epoch: (next_version, next_epoch),
+                    next_request_version_and_epoch: (next_version, next_epoch),
                     stream_is_complete: false,
                 })
             }
             StreamRequest::ContinuouslyStreamTransactionOutputs(request) => {
+                let (next_version, next_epoch) = Self::calculate_next_version_and_epoch(
+                    request.known_version,
+                    request.known_epoch,
+                )?;
                 Ok(ContinuousTransactionStreamEngine {
                     request: stream_request.clone(),
                     current_target_ledger_info: None,
                     end_of_epoch_requested: false,
-                    next_stream_version_and_epoch: (request.start_version, request.start_epoch),
-                    next_request_version_and_epoch: (request.start_version, request.start_epoch),
+                    subscription_requested: false,
+                    next_stream_version_and_epoch: (next_version, next_epoch),
+                    next_request_version_and_epoch: (next_version, next_epoch),
                     stream_is_complete: false,
                 })
             }
@@ -361,20 +377,30 @@ impl ContinuousTransactionStreamEngine {
         }
     }
 
+    fn calculate_next_version_and_epoch(
+        known_version: Version,
+        known_epoch: Epoch,
+    ) -> Result<(Version, Epoch), Error> {
+        let next_version = known_version
+            .checked_add(1)
+            .ok_or_else(|| Error::IntegerOverflow("Next version has overflown!".into()))?;
+        Ok((next_version, known_epoch))
+    }
+
     fn select_target_ledger_info(
         &self,
         advertised_data: &AdvertisedData,
-    ) -> Result<LedgerInfoWithSignatures, Error> {
+    ) -> Result<Option<LedgerInfoWithSignatures>, Error> {
         // Check if the stream has a final target ledger info
         match &self.request {
             StreamRequest::ContinuouslyStreamTransactions(request) => {
                 if let Some(target) = &request.target {
-                    return Ok(target.clone());
+                    return Ok(Some(target.clone()));
                 }
             }
             StreamRequest::ContinuouslyStreamTransactionOutputs(request) => {
                 if let Some(target) = &request.target {
-                    return Ok(target.clone());
+                    return Ok(Some(target.clone()));
                 }
             }
             request => invalid_stream_request!(request),
@@ -384,11 +410,9 @@ impl ContinuousTransactionStreamEngine {
         if let Some(highest_synced_ledger_info) = advertised_data.highest_synced_ledger_info() {
             let (next_request_version, _) = self.next_request_version_and_epoch;
             if next_request_version > highest_synced_ledger_info.ledger_info().version() {
-                Err(Error::NoDataToFetch(
-                    "We're already at the highest synced ledger info version!".into(),
-                ))
+                Ok(None) // We're already at the highest synced ledger info. There's no known target.
             } else {
-                Ok(highest_synced_ledger_info)
+                Ok(Some(highest_synced_ledger_info))
             }
         } else {
             Err(Error::DataIsUnavailable(
@@ -403,31 +427,156 @@ impl ContinuousTransactionStreamEngine {
             .expect("No current target ledger info found!")
     }
 
-    fn create_data_notification(
+    fn create_notification_for_continuous_data(
         &mut self,
-        request_end_version: Version,
+        request_start: Version,
+        request_end: Version,
         client_response_payload: ResponsePayload,
         notification_id_generator: Arc<U64IdGenerator>,
     ) -> Result<DataNotification, Error> {
-        // Create a new data notification
+        // Update the stream version
+        let target_ledger_info = self.get_target_ledger_info().clone();
+        self.update_stream_version_and_epoch(request_start, request_end, &target_ledger_info)?;
+
+        // Create the data notification
         let data_notification = create_data_notification(
             notification_id_generator,
             client_response_payload,
+            Some(target_ledger_info),
             self.clone().into(),
         );
-
-        // Update the target ledger info if we've hit it
-        if request_end_version == self.get_target_ledger_info().ledger_info().version() {
-            self.current_target_ledger_info = None;
-        }
-
         Ok(data_notification)
+    }
+
+    fn create_notification_for_subscription_data(
+        &mut self,
+        known_version: Version,
+        client_response_payload: ResponsePayload,
+        notification_id_generator: Arc<U64IdGenerator>,
+    ) -> Result<DataNotification, Error> {
+        // Calculate the first version
+        let first_version = known_version
+            .checked_add(1)
+            .ok_or_else(|| Error::IntegerOverflow("First version has overflown!".into()))?;
+        let (num_versions, target_ledger_info) = match &client_response_payload {
+            ResponsePayload::NewTransactionsWithProof((
+                transactions_with_proof,
+                target_ledger_info,
+            )) => (
+                transactions_with_proof.transactions.len(),
+                target_ledger_info.clone(),
+            ),
+            ResponsePayload::NewTransactionOutputsWithProof((
+                outputs_with_proof,
+                target_ledger_info,
+            )) => (
+                outputs_with_proof.transactions_and_outputs.len(),
+                target_ledger_info.clone(),
+            ),
+            response_payload => {
+                // TODO(joshlind): eventually we want to notify the data client of the bad response
+                return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                    "Expected new transactions or outputs but got: {:?}",
+                    response_payload
+                )));
+            }
+        };
+
+        // Calculate the last version
+        if num_versions == 0 {
+            // TODO(joshlind): eventually we want to notify the data client of the bad response
+            return Err(Error::AptosDataClientResponseIsInvalid(
+                "Received an empty transaction or output list!".into(),
+            ));
+        }
+        let last_version = known_version
+            .checked_add(num_versions as u64)
+            .ok_or_else(|| Error::IntegerOverflow("Last version has overflown!".into()))?;
+
+        // Update the request and stream versions
+        self.update_request_version_and_epoch(last_version, &target_ledger_info)?;
+        self.update_stream_version_and_epoch(first_version, last_version, &target_ledger_info)?;
+
+        // Create the data notification
+        let data_notification = create_data_notification(
+            notification_id_generator,
+            client_response_payload,
+            Some(target_ledger_info.clone()),
+            self.clone().into(),
+        );
+        Ok(data_notification)
+    }
+
+    fn create_subscription_request(&mut self) -> Result<DataClientRequest, Error> {
+        let (next_request_version, known_epoch) = self.next_request_version_and_epoch;
+        let known_version = next_request_version
+            .checked_sub(1)
+            .ok_or_else(|| Error::IntegerOverflow("Last version has overflown!".into()))?;
+
+        let data_client_request = match &self.request {
+            StreamRequest::ContinuouslyStreamTransactions(request) => {
+                DataClientRequest::NewTransactionsWithProof(NewTransactionsWithProofRequest {
+                    known_version,
+                    known_epoch,
+                    include_events: request.include_events,
+                })
+            }
+            StreamRequest::ContinuouslyStreamTransactionOutputs(_) => {
+                DataClientRequest::NewTransactionOutputsWithProof(
+                    NewTransactionOutputsWithProofRequest {
+                        known_version,
+                        known_epoch,
+                    },
+                )
+            }
+            request => invalid_stream_request!(request),
+        };
+        Ok(data_client_request)
+    }
+
+    fn handle_epoch_ending_response(
+        &mut self,
+        response_payload: ResponsePayload,
+    ) -> Result<(), Error> {
+        if let ResponsePayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos) = response_payload
+        {
+            match &epoch_ending_ledger_infos[..] {
+                [target_ledger_info] => {
+                    info!(
+                        (LogSchema::new(LogEntry::ReceivedDataResponse)
+                            .event(LogEvent::Success)
+                            .message(&format!(
+                                "Received an epoch ending ledger info for epoch: {:?}. \
+                                        Setting new target version: {:?}",
+                                target_ledger_info.ledger_info().epoch(),
+                                target_ledger_info.ledger_info().version()
+                            )))
+                    );
+                    self.current_target_ledger_info = Some(target_ledger_info.clone());
+                    Ok(())
+                }
+                response_payload => {
+                    // TODO(joshlind): eventually we want to notify the data client of the bad response
+                    return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                        "Received an incorrect number of epoch ending ledger infos. Response: {:?}",
+                        response_payload
+                    )));
+                }
+            }
+        } else {
+            // TODO(joshlind): eventually we want to notify the data client of the bad response
+            return Err(Error::AptosDataClientResponseIsInvalid(format!(
+                "Expected an epoch ending ledger response but got: {:?}",
+                response_payload
+            )));
+        }
     }
 
     fn update_stream_version_and_epoch(
         &mut self,
         request_start_version: Version,
         request_end_version: Version,
+        target_ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(), Error> {
         let (next_stream_version, mut next_stream_epoch) = self.next_stream_version_and_epoch;
         verify_client_request_indices(
@@ -435,6 +584,19 @@ impl ContinuousTransactionStreamEngine {
             request_start_version,
             request_end_version,
         );
+
+        // Update the next stream version and epoch
+        if request_end_version == target_ledger_info.ledger_info().version()
+            && target_ledger_info.ledger_info().ends_epoch()
+        {
+            next_stream_epoch = next_stream_epoch
+                .checked_add(1)
+                .ok_or_else(|| Error::IntegerOverflow("Next stream epoch has overflown!".into()))?;
+        }
+        let next_stream_version = request_end_version
+            .checked_add(1)
+            .ok_or_else(|| Error::IntegerOverflow("Next stream version has overflown!".into()))?;
+        self.next_stream_version_and_epoch = (next_stream_version, next_stream_epoch);
 
         // Check if the stream is now complete
         match &self.request {
@@ -455,18 +617,10 @@ impl ContinuousTransactionStreamEngine {
             request => invalid_stream_request!(request),
         };
 
-        // Update the next stream version and epoch
-        if request_end_version == self.get_target_ledger_info().ledger_info().version()
-            && self.get_target_ledger_info().ledger_info().ends_epoch()
-        {
-            next_stream_epoch = next_stream_epoch
-                .checked_add(1)
-                .ok_or_else(|| Error::IntegerOverflow("Next stream epoch has overflown!".into()))?;
+        // Update the current target ledger info if we've hit it
+        if request_end_version == target_ledger_info.ledger_info().version() {
+            self.current_target_ledger_info = None;
         }
-        let next_stream_version = request_end_version
-            .checked_add(1)
-            .ok_or_else(|| Error::IntegerOverflow("Next stream version has overflown!".into()))?;
-        self.next_stream_version_and_epoch = (next_stream_version, next_stream_epoch);
 
         Ok(())
     }
@@ -474,18 +628,20 @@ impl ContinuousTransactionStreamEngine {
     fn update_request_version_and_epoch(
         &mut self,
         request_end_version: Version,
+        target_ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(), Error> {
+        // Calculate the next request epoch
         let (_, mut next_request_epoch) = self.next_request_version_and_epoch;
-
-        // Update the next request version and epoch
-        if request_end_version == self.get_target_ledger_info().ledger_info().version()
-            && self.get_target_ledger_info().ledger_info().ends_epoch()
+        if request_end_version == target_ledger_info.ledger_info().version()
+            && target_ledger_info.ledger_info().ends_epoch()
         {
             // We've hit an epoch change
             next_request_epoch = next_request_epoch.checked_add(1).ok_or_else(|| {
                 Error::IntegerOverflow("Next request epoch has overflown!".into())
             })?;
         }
+
+        // Update the next request version and epoch
         let next_request_version = request_end_version
             .checked_add(1)
             .ok_or_else(|| Error::IntegerOverflow("Next request version has overflown!".into()))?;
@@ -497,13 +653,17 @@ impl ContinuousTransactionStreamEngine {
     fn update_request_tracking(
         &mut self,
         client_requests: &[DataClientRequest],
+        target_ledger_info: &LedgerInfoWithSignatures,
     ) -> Result<(), Error> {
         match &self.request {
             StreamRequest::ContinuouslyStreamTransactions(_) => {
                 for client_request in client_requests {
                     match client_request {
                         DataClientRequest::TransactionsWithProof(request) => {
-                            self.update_request_version_and_epoch(request.end_version)?;
+                            self.update_request_version_and_epoch(
+                                request.end_version,
+                                target_ledger_info,
+                            )?;
                         }
                         request => invalid_client_request!(request, self),
                     }
@@ -513,7 +673,10 @@ impl ContinuousTransactionStreamEngine {
                 for client_request in client_requests {
                     match client_request {
                         DataClientRequest::TransactionOutputsWithProof(request) => {
-                            self.update_request_version_and_epoch(request.end_version)?;
+                            self.update_request_version_and_epoch(
+                                request.end_version,
+                                target_ledger_info,
+                            )?;
                         }
                         request => invalid_client_request!(request, self),
                     }
@@ -532,75 +695,86 @@ impl DataStreamEngine for ContinuousTransactionStreamEngine {
         max_number_of_requests: u64,
         global_data_summary: &GlobalDataSummary,
     ) -> Result<Vec<DataClientRequest>, Error> {
-        if self.current_target_ledger_info.is_none() && self.end_of_epoch_requested {
-            return Ok(vec![]); // We are waiting for the epoch ending ledger info
+        if self.end_of_epoch_requested || self.subscription_requested {
+            return Ok(vec![]); // We are waiting for a blocking response type
         }
 
-        // If we don't have a syncing target, select one.
+        // If we don't have a syncing target, try to select one
         let (next_request_version, next_request_epoch) = self.next_request_version_and_epoch;
         if self.current_target_ledger_info.is_none() {
-            // Select a new ledger info from the advertised data
-            let target_ledger_info =
-                self.select_target_ledger_info(&global_data_summary.advertised_data)?;
-            if target_ledger_info.ledger_info().epoch() > next_request_epoch {
-                // There was an epoch change. Request an epoch ending ledger info.
-                info!(
-                    (LogSchema::new(LogEntry::AptosDataClient)
-                        .event(LogEvent::Pending)
-                        .message(&format!(
-                            "Requested an epoch ending ledger info for epoch: {:?}",
-                            next_request_epoch
-                        )))
-                );
-                self.end_of_epoch_requested = true;
-                return Ok(vec![DataClientRequest::EpochEndingLedgerInfos(
-                    EpochEndingLedgerInfosRequest {
-                        start_epoch: next_request_epoch,
-                        end_epoch: next_request_epoch,
-                    },
-                )]);
-            } else {
-                debug!(
-                    (LogSchema::new(LogEntry::ReceivedDataResponse)
-                        .event(LogEvent::Success)
-                        .message(&format!(
-                            "Setting new target ledger info. Version: {:?}, Epoch: {:?}",
-                            target_ledger_info.ledger_info().version(),
-                            target_ledger_info.ledger_info().epoch()
-                        )))
-                );
-                self.current_target_ledger_info = Some(target_ledger_info);
+            // Try to select a new ledger info from the advertised data
+            if let Some(target_ledger_info) =
+                self.select_target_ledger_info(&global_data_summary.advertised_data)?
+            {
+                if target_ledger_info.ledger_info().epoch() > next_request_epoch {
+                    // There was an epoch change. Request an epoch ending ledger info.
+                    info!(
+                        (LogSchema::new(LogEntry::AptosDataClient)
+                            .event(LogEvent::Pending)
+                            .message(&format!(
+                                "Requested an epoch ending ledger info for epoch: {:?}",
+                                next_request_epoch
+                            )))
+                    );
+                    self.end_of_epoch_requested = true;
+                    return Ok(vec![DataClientRequest::EpochEndingLedgerInfos(
+                        EpochEndingLedgerInfosRequest {
+                            start_epoch: next_request_epoch,
+                            end_epoch: next_request_epoch,
+                        },
+                    )]);
+                } else {
+                    debug!(
+                        (LogSchema::new(LogEntry::ReceivedDataResponse)
+                            .event(LogEvent::Success)
+                            .message(&format!(
+                                "Setting new target ledger info. Version: {:?}, Epoch: {:?}",
+                                target_ledger_info.ledger_info().version(),
+                                target_ledger_info.ledger_info().epoch()
+                            )))
+                    );
+                    self.current_target_ledger_info = Some(target_ledger_info);
+                }
             }
         }
 
-        // We have a target ledger info.
-        let target_ledger_info_version = self.get_target_ledger_info().ledger_info().version();
-        if next_request_version > target_ledger_info_version {
-            return Ok(vec![]); // Wait until all target notifications have been sent.
-        }
+        // Create the next set of data client requests
+        let maybe_target_ledger_info = self.current_target_ledger_info.clone();
+        let client_requests = if let Some(target_ledger_info) = maybe_target_ledger_info {
+            // Check if we're still waiting for stream notifications to be sent
+            if next_request_version > target_ledger_info.ledger_info().version() {
+                return Ok(vec![]);
+            }
 
-        // Create the client requests
-        let optimal_chunk_sizes = match &self.request {
-            StreamRequest::ContinuouslyStreamTransactions(_) => {
-                global_data_summary
-                    .optimal_chunk_sizes
-                    .transaction_chunk_size
-            }
-            StreamRequest::ContinuouslyStreamTransactionOutputs(_) => {
-                global_data_summary
-                    .optimal_chunk_sizes
-                    .transaction_output_chunk_size
-            }
-            request => invalid_stream_request!(request),
+            // Create the client requests for the target
+            let optimal_chunk_sizes = match &self.request {
+                StreamRequest::ContinuouslyStreamTransactions(_) => {
+                    global_data_summary
+                        .optimal_chunk_sizes
+                        .transaction_chunk_size
+                }
+                StreamRequest::ContinuouslyStreamTransactionOutputs(_) => {
+                    global_data_summary
+                        .optimal_chunk_sizes
+                        .transaction_output_chunk_size
+                }
+                request => invalid_stream_request!(request),
+            };
+            let client_requests = create_data_client_requests(
+                next_request_version,
+                target_ledger_info.ledger_info().version(),
+                max_number_of_requests,
+                optimal_chunk_sizes,
+                self.clone().into(),
+            )?;
+            self.update_request_tracking(&client_requests, &target_ledger_info)?;
+            client_requests
+        } else {
+            // We don't have a target, send a single subscription request
+            let subscription_request = self.create_subscription_request()?;
+            self.subscription_requested = true;
+            vec![subscription_request]
         };
-        let client_requests = create_data_client_requests(
-            next_request_version,
-            target_ledger_info_version,
-            max_number_of_requests,
-            optimal_chunk_sizes,
-            self.clone().into(),
-        )?;
-        self.update_request_tracking(&client_requests)?;
 
         Ok(client_requests)
     }
@@ -633,55 +807,45 @@ impl DataStreamEngine for ContinuousTransactionStreamEngine {
         client_response_payload: ResponsePayload,
         notification_id_generator: Arc<U64IdGenerator>,
     ) -> Result<Option<DataNotification>, Error> {
+        // We reset the pending requests to prevent malicious responses from blocking the streams
+        if self.end_of_epoch_requested {
+            self.end_of_epoch_requested = false;
+        } else if self.subscription_requested {
+            self.subscription_requested = false;
+        }
+
+        // Handle and transform the response
         match client_request {
             EpochEndingLedgerInfos(_) => {
-                if let ResponsePayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos) =
-                    client_response_payload
-                {
-                    match &epoch_ending_ledger_infos[..] {
-                        [target_ledger_info] => {
-                            info!(
-                                (LogSchema::new(LogEntry::ReceivedDataResponse)
-                                    .event(LogEvent::Success)
-                                    .message(&format!(
-                                        "Received an epoch ending ledger info for epoch: {:?}. \
-                                        Setting new target version: {:?}",
-                                        target_ledger_info.ledger_info().epoch(),
-                                        target_ledger_info.ledger_info().version()
-                                    )))
-                            );
-                            self.current_target_ledger_info = Some(target_ledger_info.clone());
-                        }
-                        response_payload => {
-                            // TODO(joshlind): notify the data client of the bad response
-                            debug!(
-                                (LogSchema::new(LogEntry::ReceivedDataResponse)
-                                    .event(LogEvent::Error)
-                                    .message(&format!("Received an incorrect number of epoch ending ledger infos. Response: {:?}", response_payload))
-                                ));
-                        }
-                    }
-                } else {
-                    // TODO(joshlind): notify the data client of the bad response
-                    debug!(
-                        (LogSchema::new(LogEntry::ReceivedDataResponse)
-                            .event(LogEvent::Error)
-                            .message(&format!(
-                                "Received an invalid epoch ending ledger response: {:?}",
-                                client_response_payload
-                            )))
-                    );
-                }
-                self.end_of_epoch_requested = false;
+                self.handle_epoch_ending_response(client_response_payload)?;
                 Ok(None)
             }
+            NewTransactionsWithProof(request) => match &self.request {
+                StreamRequest::ContinuouslyStreamTransactions(_) => {
+                    let data_notification = self.create_notification_for_subscription_data(
+                        request.known_version,
+                        client_response_payload,
+                        notification_id_generator,
+                    )?;
+                    Ok(Some(data_notification))
+                }
+                request => invalid_stream_request!(request),
+            },
+            NewTransactionOutputsWithProof(request) => match &self.request {
+                StreamRequest::ContinuouslyStreamTransactionOutputs(_) => {
+                    let data_notification = self.create_notification_for_subscription_data(
+                        request.known_version,
+                        client_response_payload,
+                        notification_id_generator,
+                    )?;
+                    Ok(Some(data_notification))
+                }
+                request => invalid_stream_request!(request),
+            },
             TransactionsWithProof(request) => match &self.request {
                 StreamRequest::ContinuouslyStreamTransactions(_) => {
-                    self.update_stream_version_and_epoch(
+                    let data_notification = self.create_notification_for_continuous_data(
                         request.start_version,
-                        request.end_version,
-                    )?;
-                    let data_notification = self.create_data_notification(
                         request.end_version,
                         client_response_payload,
                         notification_id_generator,
@@ -692,11 +856,8 @@ impl DataStreamEngine for ContinuousTransactionStreamEngine {
             },
             TransactionOutputsWithProof(request) => match &self.request {
                 StreamRequest::ContinuouslyStreamTransactionOutputs(_) => {
-                    self.update_stream_version_and_epoch(
+                    let data_notification = self.create_notification_for_continuous_data(
                         request.start_version,
-                        request.end_version,
-                    )?;
-                    let data_notification = self.create_data_notification(
                         request.end_version,
                         client_response_payload,
                         notification_id_generator,
@@ -849,6 +1010,7 @@ impl DataStreamEngine for EpochEndingStreamEngine {
                 let data_notification = create_data_notification(
                     notification_id_generator,
                     client_response_payload,
+                    None,
                     self.clone().into(),
                 );
                 Ok(Some(data_notification))
@@ -1051,6 +1213,7 @@ impl DataStreamEngine for TransactionStreamEngine {
         let data_notification = create_data_notification(
             notification_id_generator,
             client_response_payload,
+            None,
             self.clone().into(),
         );
         Ok(Some(data_notification))
@@ -1199,6 +1362,7 @@ fn create_data_client_request(
 fn create_data_notification(
     notification_id_generator: Arc<U64IdGenerator>,
     client_response: ResponsePayload,
+    target_ledger_info: Option<LedgerInfoWithSignatures>,
     stream_engine: StreamEngine,
 ) -> DataNotification {
     let notification_id = notification_id_generator.next();
@@ -1211,10 +1375,33 @@ fn create_data_notification(
         ResponsePayload::EpochEndingLedgerInfos(ledger_infos) => {
             DataPayload::EpochEndingLedgerInfos(ledger_infos)
         }
+        ResponsePayload::NewTransactionsWithProof((transactions_chunk, target_ledger_info)) => {
+            match stream_engine {
+                StreamEngine::ContinuousTransactionStreamEngine(_) => {
+                    DataPayload::ContinuousTransactionsWithProof(
+                        target_ledger_info,
+                        transactions_chunk,
+                    )
+                }
+                _ => invalid_response_type!(client_response_type),
+            }
+        }
+        ResponsePayload::NewTransactionOutputsWithProof((
+            transactions_output_chunk,
+            target_ledger_info,
+        )) => match stream_engine {
+            StreamEngine::ContinuousTransactionStreamEngine(_) => {
+                DataPayload::ContinuousTransactionOutputsWithProof(
+                    target_ledger_info,
+                    transactions_output_chunk,
+                )
+            }
+            _ => invalid_response_type!(client_response_type),
+        },
         ResponsePayload::TransactionsWithProof(transactions_chunk) => match stream_engine {
-            StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => {
+            StreamEngine::ContinuousTransactionStreamEngine(_) => {
                 DataPayload::ContinuousTransactionsWithProof(
-                    stream_engine.get_target_ledger_info().clone(),
+                    target_ledger_info.expect("A target ledger info is required!"),
                     transactions_chunk,
                 )
             }
@@ -1225,9 +1412,9 @@ fn create_data_notification(
         },
         ResponsePayload::TransactionOutputsWithProof(transactions_output_chunk) => {
             match stream_engine {
-                StreamEngine::ContinuousTransactionStreamEngine(stream_engine) => {
+                StreamEngine::ContinuousTransactionStreamEngine(_) => {
                     DataPayload::ContinuousTransactionOutputsWithProof(
-                        stream_engine.get_target_ledger_info().clone(),
+                        target_ledger_info.expect("A target ledger info is required!"),
                         transactions_output_chunk,
                     )
                 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -444,7 +444,7 @@ fn create_data_stream(
     };
 
     // Create a aptos data client mock and notification generator
-    let aptos_data_client = MockAptosDataClient::new();
+    let aptos_data_client = MockAptosDataClient::new(false);
     let notification_generator = Arc::new(U64IdGenerator::new());
 
     // Return the data stream and listener pair

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
@@ -145,15 +145,15 @@ fn test_continuously_stream_transactions() {
         new_streaming_service_client_listener_pair();
 
     // Note the request we expect to receive on the streaming service side
-    let request_start_version = 101;
-    let request_start_epoch = 2;
-    let request_include_events = false;
+    let known_version = 101;
+    let known_epoch = 2;
+    let include_events = false;
     let target = None;
     let expected_request =
         StreamRequest::ContinuouslyStreamTransactions(ContinuouslyStreamTransactionsRequest {
-            start_version: request_start_version,
-            start_epoch: request_start_epoch,
-            include_events: request_include_events,
+            known_version,
+            known_epoch,
+            include_events,
             target: target.clone(),
         });
 
@@ -162,9 +162,9 @@ fn test_continuously_stream_transactions() {
 
     // Send a continuous transaction stream request and verify we get a data stream listener
     let response = block_on(streaming_service_client.continuously_stream_transactions(
-        request_start_version,
-        request_start_epoch,
-        request_include_events,
+        known_version,
+        known_epoch,
+        include_events,
         target,
     ));
     assert_ok!(response);
@@ -182,8 +182,8 @@ fn test_continuously_stream_transaction_outputs() {
     let target = Some(create_ledger_info(1000, 10, true));
     let expected_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
         ContinuouslyStreamTransactionOutputsRequest {
-            start_version: request_start_version,
-            start_epoch: request_start_epoch,
+            known_version: request_start_version,
+            known_epoch: request_start_epoch,
             target: target.clone(),
         },
     );

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -19,7 +19,7 @@ use aptos_types::{
 use data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     data_stream::DataStreamListener,
-    streaming_client::{DataStreamingClient, NotificationFeedback},
+    streaming_client::{DataStreamingClient, Epoch, NotificationFeedback},
 };
 use std::{sync::Arc, time::Duration};
 use storage_interface::DbReader;
@@ -101,11 +101,6 @@ impl<
         // Fetch the highest epoch state (in storage)
         let highest_epoch_state = utils::fetch_latest_epoch_state(self.storage.clone())?;
 
-        // Start fetching data at highest_synced_version + 1
-        let next_version = highest_synced_version
-            .checked_add(1)
-            .ok_or_else(|| Error::IntegerOverflow("The next version has overflown!".into()))?;
-
         // Initialize a new active data stream
         let sync_request_target = consensus_sync_request
             .lock()
@@ -115,7 +110,7 @@ impl<
             ContinuousSyncingMode::ApplyTransactionOutputs => {
                 self.streaming_client
                     .continuously_stream_transaction_outputs(
-                        next_version,
+                        highest_synced_version,
                         highest_synced_epoch,
                         sync_request_target,
                     )
@@ -124,7 +119,7 @@ impl<
             ContinuousSyncingMode::ExecuteTransactions => {
                 self.streaming_client
                     .continuously_stream_transactions(
-                        next_version,
+                        highest_synced_version,
                         highest_synced_epoch,
                         false,
                         sync_request_target,
@@ -212,7 +207,7 @@ impl<
     }
 
     /// Returns the highest synced version and epoch in storage
-    fn get_highest_synced_version_and_epoch(&self) -> Result<(Version, Version), Error> {
+    fn get_highest_synced_version_and_epoch(&self) -> Result<(Version, Epoch), Error> {
         let highest_synced_version = utils::fetch_latest_synced_version(self.storage.clone())?;
         let highest_synced_epoch = utils::fetch_latest_epoch_state(self.storage.clone())?.epoch;
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
@@ -53,7 +53,7 @@ async fn test_critical_timeout() {
             .expect_continuously_stream_transaction_outputs()
             .times(1)
             .with(
-                eq(current_synced_version + 1),
+                eq(current_synced_version),
                 eq(current_synced_epoch),
                 eq(None),
             )
@@ -129,7 +129,7 @@ async fn test_data_stream_transactions() {
             .expect_continuously_stream_transactions()
             .times(1)
             .with(
-                eq(current_synced_version + 1),
+                eq(current_synced_version),
                 eq(current_synced_epoch),
                 eq(false),
                 eq(Some(target_ledger_info.clone())),
@@ -209,7 +209,7 @@ async fn test_data_stream_transaction_outputs() {
             .expect_continuously_stream_transaction_outputs()
             .times(1)
             .with(
-                eq(current_synced_version + 1),
+                eq(current_synced_version),
                 eq(current_synced_epoch),
                 eq(None),
             )

--- a/state-sync/storage-service/client/src/lib.rs
+++ b/state-sync/storage-service/client/src/lib.rs
@@ -70,6 +70,10 @@ impl StorageServiceClient {
             StorageServiceMessage::Request(_) => Err(Error::RpcError(RpcError::InvalidRpcResponse)),
         }
     }
+
+    pub fn get_peer_metadata_storage(&self) -> Arc<PeerMetadataStorage> {
+        self.peer_metadata.clone()
+    }
 }
 
 // TODO(philiphayes): not clear yet what value this trait is providing


### PR DESCRIPTION
Note: most of the code is just boilerplate and tests...

## Motivation

This PR adds the client side implementation of https://github.com/aptos-labs/aptos-core/pull/924, i.e., it updates the data streaming service to make optimistic fetch/subscription requests when the node appears to be synced to the highest known version. This helps reduce the end-to-end latency: a fullnode no longer needs to fetch data only after the poller has updated the advertised data view. Instead, the node will be notified about a single new data chunk once the peer has it.

The PR offers the following commits:
1. Update the Aptos Data Client to support optimistic fetch/subscription requests. Note: we also update the Aptos Data Client to favour sending requests to prioritized peers over regular peers. We currently use a hacky definition of "prioritized". But this will be updated with topology information later.
2. Update the Data Streaming Service to use optimistic fetch/subscription requests. These requests will only be made once the continuous data stream identifies that it is up-to-date with the highest known version according to the poller. In this case, a single subscription request will be sent. If the request times-out, the stream will either: (i) request the missing data according to the last polling information; or (ii) send another subscription request. Most of the code is just refactoring to handle this.
3. Add unit tests to ensure optimistic fetch/subscription requests are handled correctly. Here, we extend the mock advertised data to be lagging, i.e., not up-to-date with the data peers actually have. We also add a test for peer selection in the Aptos Data Client (related to 1 above).
4. Reduce the polling frequency to every 200ms. The average subscription request is handled in about 170ms (on `alden-net`). So, there's no point polling more frequently than that.

This PR is also deployed in `alden-net`, and the overall end-to-end latencies are now better than state sync v1 (this is with 50M+ versions and storage pruning running 🚀).

<img width="2526" alt="Screen Shot 2022-05-17 at 7 37 39 PM" src="https://user-images.githubusercontent.com/4578587/168929121-bed5a245-5182-45cd-8c4d-d075586dd0fb.png">

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The new and existing unit tests pass.

## Related PRs

None, but this PR relates to: https://github.com/aptos-labs/aptos-core/issues/245