### PR TITLE
[tf/helm][indexer] name resources with workspace override

### DIFF
--- a/terraform/helm/indexer/templates/indexer.yaml
+++ b/terraform/helm/indexer/templates/indexer.yaml
@@ -29,7 +29,7 @@ spec:
         - name: DATABASE_URI
           valueFrom:
             secretKeyRef:
-              name: indexer-credentials
+              name: {{ .Release.Name }}-credentials
               key: pg_db_uri
         image: {{ .Values.indexer.image.repo }}:{{ .Values.indexer.image.tag }}
         imagePullPolicy: {{ .Values.indexer.image.pullPolicy }}

--- a/terraform/modules/indexer/auth.tf
+++ b/terraform/modules/indexer/auth.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "indexer" {
 }
 
 resource "aws_iam_role" "indexer" {
-  name                 = "aptos-testnet-${terraform.workspace}-indexer"
+  name                 = "aptos-${local.workspace_name}-indexer"
   path                 = var.iam_path
   permissions_boundary = var.permissions_boundary_policy
   assume_role_policy   = data.aws_iam_policy_document.indexer-assume-role.json

--- a/terraform/modules/indexer/helm.tf
+++ b/terraform/modules/indexer/helm.tf
@@ -1,5 +1,5 @@
 resource "helm_release" "indexer" {
-  name        = "indexer"
+  name        = "indexer-${local.workspace_name}"
   chart       = "${path.module}/../../helm/indexer"
   max_history = 2
   wait        = false

--- a/terraform/modules/indexer/rds.tf
+++ b/terraform/modules/indexer/rds.tf
@@ -51,7 +51,7 @@ resource "aws_db_instance" "indexer" {
 
 resource "kubernetes_secret" "indexer_credentials" {
   metadata {
-    name      = "indexer-credentials"
+    name      = "${helm_release.indexer.name}-credentials"
     namespace = "default"
   }
 


### PR DESCRIPTION
Names all resources in the `indexer` Terraform module with the workspace override TF variable. This lets operators deploy multiple indexers on the same k8s namespace and IAM path