### PR TITLE
[aptos-cli] Ensure all private information is not open to all users

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -6,7 +6,7 @@ use crate::{
         init::DEFAULT_REST_URL,
         utils::{
             check_if_file_exists, read_from_file, to_common_result, to_common_success_result,
-            write_to_file, write_to_file_with_opts,
+            write_to_file, write_to_file_with_opts, write_to_user_only_file,
         },
     },
     genesis::git::from_yaml,
@@ -224,7 +224,7 @@ impl CliConfig {
         let config_bytes = serde_yaml::to_string(&self).map_err(|err| {
             CliError::UnexpectedError(format!("Failed to serialize config {}", err))
         })?;
-        write_to_file(&config_file, CONFIG_FILE, config_bytes.as_bytes())?;
+        write_to_user_only_file(&config_file, CONFIG_FILE, config_bytes.as_bytes())?;
 
         // As a cleanup, delete the old if it exists
         let legacy_config_file = aptos_folder.join(LEGACY_CONFIG_FILE);

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -23,6 +23,7 @@ use std::{
     env,
     fs::OpenOptions,
     io::Write,
+    os::unix::fs::OpenOptionsExt,
     path::{Path, PathBuf},
     str::FromStr,
     time::{Duration, Instant},
@@ -196,6 +197,14 @@ pub fn read_from_file(path: &Path) -> CliTypedResult<Vec<u8>> {
 /// Write a `&[u8]` to a file
 pub fn write_to_file(path: &Path, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
     write_to_file_with_opts(path, name, bytes, &mut OpenOptions::new())
+}
+
+/// Write a User only read / write file
+pub fn write_to_user_only_file(path: &Path, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
+    let mut opts = OpenOptions::new();
+    #[cfg(unix)]
+    opts.mode(0o600);
+    write_to_file_with_opts(path, name, bytes, &mut opts)
 }
 
 /// Write a `&[u8]` to a file with the given options

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -4,7 +4,7 @@
 use crate::{
     common::{
         types::{CliError, CliTypedResult, PromptOptions},
-        utils::{check_if_file_exists, read_from_file, write_to_file},
+        utils::{check_if_file_exists, read_from_file, write_to_user_only_file},
     },
     genesis::{
         config::{HostAndPort, ValidatorConfiguration},
@@ -86,17 +86,17 @@ impl CliCommand<Vec<PathBuf>> for GenerateKeys {
                 .map_err(|e| CliError::IO(self.output_dir.to_str().unwrap().to_string(), e))?
         };
 
-        write_to_file(
+        write_to_user_only_file(
             keys_file.as_path(),
             PRIVATE_KEYS_FILE,
             to_yaml(&config)?.as_bytes(),
         )?;
-        write_to_file(
+        write_to_user_only_file(
             validator_file.as_path(),
             VALIDATOR_FILE,
             to_yaml(&validator_blob)?.as_bytes(),
         )?;
-        write_to_file(vfn_file.as_path(), VFN_FILE, to_yaml(&vfn_blob)?.as_bytes())?;
+        write_to_user_only_file(vfn_file.as_path(), VFN_FILE, to_yaml(&vfn_blob)?.as_bytes())?;
         Ok(vec![keys_file, validator_file, vfn_file])
     }
 }


### PR DESCRIPTION
Files are now properly saved with 0600 unix permissions unless they
contain public information.
