### PR TITLE
[CICD] trigger docker build on specific branches by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,14 @@ workflows:
       - unit-test
       - docker-build-push:
           context: aws-dev
+          filters:
+            branches:
+              only:
+                - main
+                - auto
+                - canary
+                - devnet
+                - testnet
       - ecosystem-test:
           context: aws-dev
           requires:


### PR DESCRIPTION
to avoid AWS codebuild quota issues