### PR TITLE
[Aptos Data Client] Update in-flight polls despite server-side errors.

### DIFF
--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -40,7 +40,7 @@ use storage_service_types::{
     StorageServiceRequest, StorageServiceResponse, TransactionOutputsWithProofRequest,
     TransactionsWithProofRequest,
 };
-use tokio::runtime::Handle;
+use tokio::{runtime::Handle, task::JoinHandle};
 
 mod logging;
 mod metrics;
@@ -621,7 +621,11 @@ fn update_in_flight_metrics(label: &str, num_in_flight_polls: u64) {
 }
 
 /// Spawns a dedicated poller for the given peer.
-fn poll_peer(data_client: AptosNetDataClient, peer: PeerNetworkId, runtime: Option<Handle>) {
+pub(crate) fn poll_peer(
+    data_client: AptosNetDataClient,
+    peer: PeerNetworkId,
+    runtime: Option<Handle>,
+) -> JoinHandle<()> {
     // Create the poller for the peer
     let poller = async move {
         // Mark the in-flight poll as started
@@ -642,6 +646,9 @@ fn poll_peer(data_client: AptosNetDataClient, peer: PeerNetworkId, runtime: Opti
             .map(Response::into_payload);
         drop(timer);
 
+        // Mark the in-flight poll as now complete
+        data_client.in_flight_request_complete(&peer);
+
         // Check the storage summary response
         let storage_summary = match result {
             Ok(storage_summary) => storage_summary,
@@ -660,9 +667,6 @@ fn poll_peer(data_client: AptosNetDataClient, peer: PeerNetworkId, runtime: Opti
         // Update the global storage summary and the summary for the peer
         data_client.update_summary(peer, storage_summary);
         data_client.update_global_summary_cache();
-
-        // Mark the in-flight poll as now complete
-        data_client.in_flight_request_complete(&peer);
 
         // Log the new global data summary and update the metrics
         sample!(
@@ -688,7 +692,7 @@ fn poll_peer(data_client: AptosNetDataClient, peer: PeerNetworkId, runtime: Opti
         runtime.spawn(poller)
     } else {
         tokio::spawn(poller)
-    };
+    }
 }
 
 /// Updates the advertised data metrics using the given global


### PR DESCRIPTION
## Motivation

This PR is a small follow-up from https://github.com/aptos-labs/aptos-core/pull/811, where we added support for tracking in-flight peer polls. There's a small edge-case where we were not marking the in-flight request as terminated if we get an error response from the server. Instead, we should always mark in-flight requests as complete. I've updated the code and added a test 😄 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The new unit test passes.

## Related PRs

None.
