### PR TITLE
[aptos-cli] Add fund command to add coins to an existing command

### DIFF
--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::{
+    types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions},
+    utils::fund_account,
+};
+use aptos_types::account_address::AccountAddress;
+use async_trait::async_trait;
+use clap::Parser;
+
+/// Command to fund an account with tokens from a faucet
+///
+#[derive(Debug, Parser)]
+pub struct FundAccount {
+    #[clap(flatten)]
+    profile_options: ProfileOptions,
+    /// Address to create account for
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    account: AccountAddress,
+    #[clap(flatten)]
+    faucet_options: FaucetOptions,
+    /// Coins to fund when using the faucet
+    #[clap(long, default_value = "10000")]
+    num_coins: u64,
+}
+
+#[async_trait]
+impl CliCommand<String> for FundAccount {
+    fn command_name(&self) -> &'static str {
+        "FundAccount"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        fund_account(
+            self.faucet_options
+                .faucet_url(&self.profile_options.profile)?,
+            self.num_coins,
+            self.account,
+        )
+        .await
+        .map(|_| format!("Added {} coins to account {}", self.num_coins, self.account))
+    }
+}

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -5,6 +5,7 @@ use crate::common::types::{CliCommand, CliResult};
 use clap::Subcommand;
 
 pub mod create;
+pub mod fund;
 pub mod list;
 pub mod transfer;
 
@@ -13,6 +14,7 @@ pub mod transfer;
 #[derive(Debug, Subcommand)]
 pub enum AccountTool {
     Create(create::CreateAccount),
+    Fund(fund::FundAccount),
     List(list::ListAccount),
     Transfer(transfer::TransferCoins),
 }
@@ -21,6 +23,7 @@ impl AccountTool {
     pub async fn execute(self) -> CliResult {
         match self {
             AccountTool::Create(tool) => tool.execute_serialized().await,
+            AccountTool::Fund(tool) => tool.execute_serialized().await,
             AccountTool::List(tool) => tool.execute_serialized().await,
             AccountTool::Transfer(tool) => tool.execute_serialized().await,
         }

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    account::create::CreateAccount,
     common::{
         types::{
             account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
             EncodingOptions, PrivateKeyInputOptions, ProfileConfig, ProfileOptions, PromptOptions,
         },
-        utils::{prompt_yes_with_override, read_line},
+        utils::{fund_account, prompt_yes_with_override, read_line},
     },
     op::key::GenerateKey,
 };
@@ -157,8 +156,7 @@ impl CliCommand<()> for InitTool {
                 "Account {} doesn't exist, creating it and funding it with {} coins",
                 address, NUM_DEFAULT_COINS
             );
-            CreateAccount::create_account_with_faucet(faucet_url, NUM_DEFAULT_COINS, address)
-                .await?;
+            fund_account(faucet_url, NUM_DEFAULT_COINS, address).await?;
         }
 
         // Ensure the loaded config has profiles setup for a possible empty file

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -331,3 +331,27 @@ pub fn read_line(input_name: &'static str) -> CliTypedResult<String> {
 
     Ok(input_buf)
 }
+
+/// Fund account (and possibly create it) from a faucet
+pub async fn fund_account(
+    faucet_url: Url,
+    num_coins: u64,
+    address: AccountAddress,
+) -> CliTypedResult<()> {
+    let response = reqwest::Client::new()
+        .post(format!(
+            "{}mint?amount={}&auth_key={}",
+            faucet_url, num_coins, address
+        ))
+        .send()
+        .await
+        .map_err(|err| CliError::ApiError(err.to_string()))?;
+    if response.status() == 200 {
+        Ok(())
+    } else {
+        Err(CliError::ApiError(format!(
+            "Faucet issue: {}",
+            response.status()
+        )))
+    }
+}


### PR DESCRIPTION
## Motivation

I can get more coins now without having to go through the create flow

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Related Issue

https://github.com/aptos-labs/aptos-core/issues/852