### PR TITLE
[Terraform] Disable backtraces for validators and fullnodes.

### DIFF
--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -82,7 +82,7 @@ spec:
           value: {{ .rust_log_remote }}
       {{- end }}
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "0"
         volumeMounts:
         - name: aptos-config
           mountPath: /opt/aptos/etc

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -78,7 +78,7 @@ spec:
           value: {{ .rust_log_remote }}
       {{- end }}
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "0"
         volumeMounts:
         - name: aptos-config
           mountPath: /opt/aptos/etc

--- a/terraform/helm/fullnode/templates/fullnode.yaml
+++ b/terraform/helm/fullnode/templates/fullnode.yaml
@@ -39,7 +39,7 @@ spec:
         - name: RUST_LOG_REMOTE
           value: {{ .Values.rust_log_remote }}
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "0"
         volumeMounts:
         - name: aptos-config
           mountPath: /opt/aptos/etc

--- a/terraform/helm/validator-lite/templates/validator.yaml
+++ b/terraform/helm/validator-lite/templates/validator.yaml
@@ -106,7 +106,7 @@ spec:
           value: {{ .rust_log_remote }}
       {{- end }}
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "0"
         volumeMounts:
         - name: aptos-config
           mountPath: /opt/aptos/etc

--- a/terraform/helm/validator/templates/fullnode.yaml
+++ b/terraform/helm/validator/templates/fullnode.yaml
@@ -91,7 +91,7 @@ spec:
           value: {{ .rust_log_remote }}
       {{- end }}
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "0"
         - name: STRUCT_LOG_TCP_ADDR
           value: '{{ include "aptos-validator.fullname" $ }}-logging:5044'
         volumeMounts:

--- a/terraform/helm/validator/templates/validator.yaml
+++ b/terraform/helm/validator/templates/validator.yaml
@@ -108,7 +108,7 @@ spec:
         - name: STRUCT_LOG_TCP_ADDR
           value: '{{ include "aptos-validator.fullname" . }}-logging:5044'
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "0"
         volumeMounts:
         - name: aptos-config
           mountPath: /opt/aptos/etc


### PR DESCRIPTION
## Motivation

We're still seeing backtraces in our logs. My gut feeling is that there's a direct crate dependency (or transitive) dependency that is adding backtraces to our errors when `RUST_BACKTRACE=1`. I've yet to find it, but I suspect it's still related to anyhow. This PR disables this env variable for validator and fullnode deployments.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manual deployment and verification in `alden-net`.

## Related PRs

None.
