### PR TITLE
[API] enable "preserve_order" feature on serde_json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "reqwest",
  "rusty-fork",
  "serde 1.0.137",
+ "serde_json",
  "sha-1 0.10.0",
  "standback",
  "syn 1.0.95",
@@ -1807,9 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
+checksum = "bf6b561dcf059c85bbe388e0a7b0a1469acb3934cc0cfa148613a830629e3049"
 dependencies = [
  "glob",
  "libc",
@@ -2536,7 +2537,7 @@ dependencies = [
  "diesel_derives",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.1.43",
  "pq-sys",
  "r2d2",
  "serde_json",
@@ -3534,16 +3535,16 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "handlebars"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d6a30320f094710245150395bc763ad23128d6a1ebbad7594dc4164b62c56b"
+checksum = "d113a9853e5accd30f43003560b5563ffbb007e3f325e8b103fa0d0029c6e6df"
 dependencies = [
  "log",
  "pest",
  "pest_derive",
- "quick-error 2.0.1",
  "serde 1.0.137",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -6817,12 +6818,12 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static 1.4.0",
- "winapi 0.3.9",
+ "windows-sys",
 ]
 
 [[package]]
@@ -7133,7 +7134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static 1.4.0",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -8495,7 +8496,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,7 +20,7 @@ hyper = "0.14.18"
 once_cell = "1.10.0"
 percent-encoding = "2.1.0"
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
-serde_json = "1.0.81"
+serde_json = { version = "1.0.81", features = ["preserve_order"] }
 tokio = { version = "1.8.1", features = ["full"] }
 warp = { version = "0.3.2", features = ["default", "tls"] }
 

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -46,6 +46,7 @@ regex-syntax = { version = "0.6.25", features = ["unicode", "unicode-age", "unic
 reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["timeout", "wait-timeout"] }
 serde = { version = "1.0.137", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
+serde_json = { version = "1.0.81", features = ["indexmap", "preserve_order", "std"] }
 sha-1 = { version = "0.10.0", features = ["std"] }
 tokio = { version = "1.18.2", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros"] }
 tokio-util = { version = "0.6.10", features = ["codec", "compat", "futures-io", "io"] }
@@ -91,6 +92,7 @@ regex-syntax = { version = "0.6.25", features = ["unicode", "unicode-age", "unic
 reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["timeout", "wait-timeout"] }
 serde = { version = "1.0.137", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
+serde_json = { version = "1.0.81", features = ["indexmap", "preserve_order", "std"] }
 sha-1 = { version = "0.10.0", features = ["std"] }
 syn = { version = "1.0.95", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit", "visit-mut"] }
 tokio = { version = "1.18.2", features = ["bytes", "fs", "full", "io-std", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "test-util", "time", "tokio-macros"] }


### PR DESCRIPTION
## Motivation

Somehow we start seeing different ordering of fields on different
platforms, and that fails the goldenfile based tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y

## Test Plan
existing coverage