### PR TITLE
[transaction-emitter] Make mint key able to be passed in as hex on cli

### DIFF
--- a/config/src/keys.rs
+++ b/config/src/keys.rs
@@ -12,7 +12,9 @@
 //! while ignored during serialization.
 //!
 
-use aptos_crypto::PrivateKey;
+use aptos_crypto::{
+    CryptoMaterialError, PrivateKey, ValidCryptoMaterial, ValidCryptoMaterialStringExt,
+};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// ConfigKey places a clonable wrapper around PrivateKeys for config purposes only. The only time
@@ -26,7 +28,7 @@ pub struct ConfigKey<T: PrivateKey + Serialize> {
     key: T,
 }
 
-impl<T: DeserializeOwned + PrivateKey + Serialize> ConfigKey<T> {
+impl<T: DeserializeOwned + PrivateKey + ValidCryptoMaterial + Serialize> ConfigKey<T> {
     pub fn new(key: T) -> Self {
         Self { key }
     }
@@ -37,6 +39,10 @@ impl<T: DeserializeOwned + PrivateKey + Serialize> ConfigKey<T> {
 
     pub fn public_key(&self) -> T::PublicKeyMaterial {
         aptos_crypto::PrivateKey::public_key(&self.key)
+    }
+
+    pub fn from_encoded_string(str: &str) -> Result<Self, CryptoMaterialError> {
+        Ok(Self::new(T::from_encoded_string(str)?))
     }
 }
 

--- a/crates/aptos-faucet/Cargo.toml
+++ b/crates/aptos-faucet/Cargo.toml
@@ -25,6 +25,7 @@ url = "2.2.2"
 warp = "0.3.2"
 
 aptos = { path = "../aptos" }
+aptos-config = { path = "../../config"}
 aptos-crypto = { path = "../aptos-crypto" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }

--- a/crates/transaction-emitter/src/cluster.rs
+++ b/crates/transaction-emitter/src/cluster.rs
@@ -5,9 +5,7 @@
 
 use crate::{instance::Instance, query_sequence_numbers};
 use anyhow::{format_err, Result};
-use aptos::common::types::EncodingType;
 use aptos_crypto::{
-    ed25519,
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
     Uniform,
@@ -18,7 +16,7 @@ use aptos_sdk::{
     types::{account_config::aptos_root_address, chain_id::ChainId, AccountKey, LocalAccount},
 };
 use rand::seq::SliceRandom;
-use std::{convert::TryFrom, path::Path};
+use std::convert::TryFrom;
 
 pub struct Cluster {
     instances: Vec<Instance>,
@@ -34,7 +32,7 @@ fn clone(key: &Ed25519PrivateKey) -> Ed25519PrivateKey {
 impl Cluster {
     pub fn from_host_port(
         peers: Vec<(String, u32, Option<u32>)>,
-        mint_file: &str,
+        mint_key: Ed25519PrivateKey,
         chain_id: ChainId,
         vasp: bool,
     ) -> Self {
@@ -53,11 +51,7 @@ impl Cluster {
         let mint_key_pair = if vasp {
             dummy_key_pair()
         } else {
-            KeyPair::from(
-                EncodingType::BCS
-                    .load_key::<ed25519::Ed25519PrivateKey>("mint key pair", Path::new(mint_file))
-                    .unwrap(),
-            )
+            KeyPair::from(mint_key)
         };
 
         Self {


### PR DESCRIPTION
## Motivation

So that we don't have to BCS encode the mint key, this will let us do it without BCS encoding (instead our more standard hex encoding).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Both faucet and txn emitter work:

```
$ cargo run -p aptos-faucet -- --server-url http://localhost:8080 --chain-id 4 --d
o-not-delegate --port 8081 --mint-key 0x...

$ curl -X POST 'http://localhost:8081/mint?amount=1000&address=0xacfd5e54562f9e442c04b4a4de547aa8a8ec312d22d93a1'
["39bd40795a8d004f31f1a8beb40338484d5f1bdaafb68da6778e1c212fb64a51"]

$ ./target/debug/transaction-emitter --emit-tx --peers localhost:8080 --mint-key 0x...
Will use 10 workers per endpoint with total 10 endpoint clients
Will create 15 accounts_per_client with total 150 accounts
Creating and minting faucet account
Root account current balances are 18446744070709550992, requested 1500000000 coins
Completed minting seed accounts, each with 1500000000 coins
Minting additional 150 accounts wtih 10000000 coins each
```