### PR TITLE
[State Sync] Reset chunk executor on consensus/state sync switches.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -89,6 +89,10 @@ pub trait StorageSynchronizerInterface {
         notification_id: NotificationId,
         account_states_with_proof: StateValueChunkWithProof,
     ) -> Result<(), Error>;
+
+    /// Resets the chunk executor. This is required to support continuous
+    /// interaction between consensus and state sync.
+    fn reset_chunk_executor(&mut self) -> Result<(), Error>;
 }
 
 /// The implementation of the `StorageSynchronizerInterface` used by state sync
@@ -305,6 +309,15 @@ impl<ChunkExecutor: ChunkExecutorTrait + 'static> StorageSynchronizerInterface
             increment_pending_data_chunks(self.pending_data_chunks.clone());
             Ok(())
         }
+    }
+
+    fn reset_chunk_executor(&mut self) -> Result<(), Error> {
+        self.chunk_executor.reset().map_err(|error| {
+            Error::UnexpectedError(format!(
+                "Failed to reset the chunk executor! Error: {:?}",
+                error
+            ))
+        })
     }
 }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
@@ -107,7 +107,7 @@ async fn test_critical_timeout() {
 }
 
 #[tokio::test]
-async fn test_data_stream_transactions() {
+async fn test_data_stream_transactions_with_target() {
     // Create test data
     let current_synced_epoch = 5;
     let current_synced_version = 234;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -99,6 +99,9 @@ pub fn create_ready_storage_synchronizer() -> MockStorageSynchronizer {
     mock_storage_synchronizer
         .expect_pending_storage_data()
         .return_const(false);
+    mock_storage_synchronizer
+        .expect_reset_chunk_executor()
+        .return_const(Ok(()));
 
     mock_storage_synchronizer
 }
@@ -428,6 +431,8 @@ mock! {
             notification_id: NotificationId,
             account_states_with_proof: StateValueChunkWithProof,
         ) -> Result<(), crate::error::Error>;
+
+        fn reset_chunk_executor(&mut self) -> Result<(), crate::error::Error>;
     }
     impl Clone for StorageSynchronizer {
         fn clone(&self) -> Self;


### PR DESCRIPTION
## Motivation

This PR updates state sync to reset the chunk executor whenever consensus sends a sync request target. This ensures that the chunk executor is synchronized with wherever consensus left off (it's possible that we've switched between state sync and consensus multiple times).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The unit tests have been updated.

## Related PRs

None.
