### PR TITLE
[CICD] Build DockerImages on Github Actions with self-hosted runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,26 +96,6 @@ jobs:
               done
               exit $ret
             fi
-  build-push-docker-rust-code:
-    executor: ubuntu-2xl
-    parameters:
-      image_target:
-        description: what value to pass to `IMAGE_TARGET=<value>` when running the docker/build-common.sh script which runs the Rust build.
-        type: string
-        default: NOT_PROVIDED
-    steps:
-      - checkout
-      - aws-ecr-setup
-      - run: echo $GITHUB_CONTAINER_REGISTRY_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
-      - run:
-          name: Build and Push
-          shell: /bin/bash
-          environment:
-            IMAGE_TARGET: << parameters.image_target >>
-          command: |
-            set -e
-            docker buildx create --use
-            docker/docker-bake-rust-all.sh
   build-push-community-platform:
     executor: ubuntu-medium
     steps:
@@ -124,7 +104,6 @@ jobs:
       - aws-ecr-setup
       - gcp-gcr/gcr-auth:
           registry-url: us-west1-docker.pkg.dev
-      - run: echo $GITHUB_CONTAINER_REGISTRY_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
       - run:
           name: Build or skip
           shell: /bin/bash
@@ -133,6 +112,7 @@ jobs:
             cd ecosystem/platform/server
             docker buildx create --use
             GIT_SHA1=${CIRCLE_SHA1} docker buildx bake --progress=plain --push -f ./docker-bake.hcl
+
   ecr-dockerhub-mirror:
     executor: ubuntu-medium
     parameters:
@@ -292,8 +272,8 @@ workflows:
     jobs:
       - build-push-community-platform:
           context:
-          - aws-dev
-          - gcp-global
+            - aws-dev
+            - gcp-global
 
   build-test-deploy:
     when:
@@ -315,34 +295,13 @@ workflows:
                 - canary
                 - devnet
                 - testnet
-      - build-push-docker-rust-code: &BuildPushRustRelease
-          name: build-push-rust-release-target
-          context: aws-dev
-          image_target: release
-      - build-push-docker-rust-code: &BuildPushRustTest
-          name: build-push-rust-test-target
-          context: aws-dev
-          image_target: test
-          filters:
-            branches:
-              only:
-                - main
-                - auto
-                - canary
-                - devnet
-                - testnet
-                - docker-caching ## remove this once https://github.com/aptos-labs/aptos-core/pull/741 is merged
       - ecosystem-test:
           context: aws-dev
           requires:
-            # - build-push-rust-release-target
-            # - build-push-rust-test-target
             - docker-build-push
       - forge-k8s-test:
           context: aws-dev
           requires:
-            # - build-push-rust-release-target
-            # - build-push-rust-test-target
             - docker-build-push
   ### on devnet branch update ###
   # Ensure the latest is built on the "devnet" branch, and mirror from ECR to Dockerhub
@@ -350,8 +309,6 @@ workflows:
     when:
       equal: [devnet, << pipeline.git.branch >>]
     jobs:
-      - build-push-docker-rust-code: *BuildPushRustRelease
-      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: devnet
@@ -361,8 +318,6 @@ workflows:
             - docker-aptoslabsbots
           addl_tag: devnet
           requires:
-            # - build-push-rust-release-target
-            # - build-push-rust-test-target
             - docker-build-push
   ### on testnet branch update ###
   # Ensure the latest is built on the "testnet" branch, and mirror from ECR to Dockerhub
@@ -370,8 +325,6 @@ workflows:
     when:
       equal: [testnet, << pipeline.git.branch >>]
     jobs:
-      - build-push-docker-rust-code: *BuildPushRustRelease
-      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: testnet
@@ -381,8 +334,6 @@ workflows:
             - docker-aptoslabsbots
           addl_tag: testnet
           requires:
-            # - build-push-rust-release-target
-            # - build-push-rust-test-target
             - docker-build-push
   ### on continuous_push scheduled pipeline ###
   # Build the latest on "main" branch
@@ -392,8 +343,6 @@ workflows:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - equal: ["continuous_push", << pipeline.schedule.name >>]
     jobs:
-      - build-push-docker-rust-code: *BuildPushRustRelease
-      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: main
@@ -405,8 +354,6 @@ workflows:
         - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
         - equal: ["nightly", << pipeline.schedule.name >>]
     jobs:
-      - build-push-docker-rust-code: *BuildPushRustRelease
-      - build-push-docker-rust-code: *BuildPushRustTest
       - docker-build-push:
           context: aws-dev
           addl_tag: main
@@ -417,8 +364,6 @@ workflows:
           addl_tag: main
           requires:
             - docker-build-push
-            # - build-push-rust-release-target
-            # - build-push-rust-test-target
 commands:
   dev-setup:
     steps:

--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,6 @@ terraform/
 
 clippy.toml
 .gitattributes
+
+# Ignore generated credentials from google-github-actions/auth as per https://github.com/google-github-actions/auth#prerequisites
+gha-creds-*.json

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,0 +1,115 @@
+name: "Build+Push Images"
+on: # build on main branch OR when a PR is labeled with `CICD:build-images`
+  pull_request:
+     types: [labeled, opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - auto
+      - canary
+      - devnet
+      - testnet
+
+# cancel redundant builds
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+  AWS_ECR_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+
+jobs:
+  RustImages:
+    if: ${{ github.event.label.name == 'CICD:build-images' || contains(github.event.pull_request.labels.*.name, 'CICD:build-images') }}
+    strategy:
+      matrix:
+        IMAGE_TARGET: [release, test]
+
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: auth
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v0"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v2
+        with:
+          registry: us-west1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: setup docker context for buildx
+        id: buildx-context
+        run: docker context create builders
+
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          endpoint: builders
+
+      - name: Build and Push Rust images
+        run: docker/docker-bake-rust-all.sh
+        env:
+          IMAGE_TARGET: ${{ matrix.IMAGE_TARGET }}
+
+  CommunityPlatform:
+    if: ${{ github.event.label.name == 'CICD:build-images' || contains(github.event.pull_request.labels.*.name, 'CICD:build-images') }}
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: auth
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v0"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v2
+        with:
+          registry: us-west1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Login to ECR
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: setup docker context for buildx
+        id: buildx-context
+        run: docker context create builders
+
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          endpoint: builders
+
+      - name: Build and Push Community Platform image
+        run: |
+          cd ecosystem/platform/server
+          GIT_SHA1=${GITHUB_SHA} docker buildx bake --progress=plain --push -f ./docker-bake.hcl

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -4,10 +4,17 @@
 
 variable "BUILD_DATE" {}
 
+variable "GITHUB_SHA" {}
+// this is the full GIT_SHA1 - let's use that as primary identifier going forward
+variable "GIT_SHA1" {
+  default = "${GITHUB_SHA}"
+}
 // this is the short GIT_SHA1 (8 chars). Tagging our docker images with that one is kinda deprecated and we might remove this in future.
-variable "GIT_REV" {}
-// this is the full GIT_SHA1 - let's use that as primary identify going forward
-variable "GIT_SHA1" {}
+variable "GIT_REV" {
+  default = substr("${GIT_SHA1}", 0, 8)
+}
+
+variable "GCP_DOCKER_ARTIFACT_REPO" {}
 
 variable "AWS_ECR_ACCOUNT_NUM" {}
 
@@ -127,19 +134,19 @@ target "forge" {
 
 function "generate_cache_from" {
   params = [target]
-  result = "type=registry,ref=${gh_image_cache}/${target}"
+  result = "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache"
 }
 
 function "generate_cache_to" {
   params = [target]
-  result = ["type=registry,ref=${gh_image_cache}/${target},mode=max"]
+  result = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache,mode=max"]
 }
 
 function "generate_tags" {
   params = [target]
   result = [
-    // "${ecr_base}/${target}:dev_${GIT_REV}",
-    // "${ecr_base}/${target}:${GIT_REV}",
+
+    "${GCP_DOCKER_ARTIFACT_REPO}/${target}:${GIT_SHA1}",
     "${ecr_base}/${target}:${GIT_SHA1}", // only tag with full GIT_SHA1 unless it turns out we really need any of the other variations
   ]
 }

--- a/ecosystem/platform/server/docker-bake.hcl
+++ b/ecosystem/platform/server/docker-bake.hcl
@@ -4,11 +4,10 @@
 
 
 variable "GIT_SHA1" {}
-variable "AWS_ECR_ACCOUNT_URL" {}
+variable "AWS_ECR_ACCOUNT_NUM" {}
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
-
-variable "gh_image_cache" {
-  default = "ghcr.io/aptos-labs/aptos-core/community-platform"
+variable "ecr_base" {
+  default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
 }
 
 group "default" {
@@ -20,10 +19,10 @@ group "default" {
 target "community-platform" {
   dockerfile = "Dockerfile"
   context    = "."
-  cache-from = ["type=registry,ref=${gh_image_cache}"]
-  cache-to   = ["type=registry,ref=${gh_image_cache},mode=max"]
+  cache-from = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache"]
+  cache-to   = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache,mode=max"]
   tags = [
-    "${AWS_ECR_ACCOUNT_URL}/aptos/community-platform:${GIT_SHA1}",
+    "${ecr_base}/community-platform:${GIT_SHA1}",
     "${GCP_DOCKER_ARTIFACT_REPO}/community-platform:${GIT_SHA1}",
   ]
 }


### PR DESCRIPTION
This PR moves the builds of the docker rust images and community platform from circleci to GitHub Actions on self-hosted runners. It also removes the dependency on Github Container Registry for caching and simply uses GCP Artifact registry for that instead (we already previously pushed images of community platform to GCP, but not the cache artifacts).
From what I've seen the rust docker images build in ~10 minutes on the self-hosted runners vs 15/16 minutes in CircleCI workers (in case of cache misses). In case of cache hits they finish both in circleci and Actions in less than a minute.

One nice feature this introduces:
By default the docker images get only build on our protected branches (main, auto, etc.) and not on PRs. However a user can apply the label `CICD:build-images` to the PR which will trigger the image building. This label (or any label) can only be added by a Repo committer (i.e. Aptos employees).

The supporting infrastructure for this PR is set up here https://github.com/aptos-labs/internal-ops/pull/216

For more context also see https://www.notion.so/aptoslabs/Migrate-to-GitHub-Actions-6080c8f24a02463396e118dc90f583eb