### PR TITLE
[Aptos Framework] Make Account::create_account_internal friend only

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/Account.move
+++ b/aptos-move/framework/aptos-framework/sources/Account.move
@@ -115,7 +115,7 @@ module AptosFramework::Account {
     /// can publish additional resources under `new_address`.
     /// The `_witness` guarantees that owner the registered caller of this function can call it.
     /// authentication key returned is `auth_key_prefix` | `fresh_address`.
-    public fun create_account_internal(
+    public(friend) fun create_account_internal(
         new_address: address,
     ): (signer, vector<u8>) {
         // there cannot be an Account resource under new_addr already.


### PR DESCRIPTION
## Motivation

Any module can currently call Account::create_account_internal because it's public. Since create_account_internal returns a signer, this is vulnerable to abuse as a malicious module can obtain signer for addresses that they might not have private keys for. Although there are no resources to steal (the account is just created), this can set up the legitimate account owner who has the private key for this account for potential attacks in the future.

Only the Genesis module currently calls Account::create_account_internal and Genesis is already a friend of Account.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Existing unit tests + manual tests.
