### PR TITLE
helm: add a network policy for validator rest api

### DIFF
--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -172,6 +172,11 @@ spec:
       port: 6180
     - protocol: TCP
       port: 9101
+  {{- if .Values.validator.exposeRestApi }}
+  # REST API from HAproxy
+    - protocol: TCP
+      port: 8080
+  {{- end }}
   - from:
     - podSelector:
         matchLabels:


### PR DESCRIPTION
We tried to install a AIT1 validator setup on GCP following the [instructions](https://aptos.dev/tutorials/validator-node/run-validator-node-using-gcp), but the validator REST API was not exposed.

I added the following to main.tf:

```
  helm_values = { validator: { exposeRestApi: true }}
```

But it was still not working. The reason was we were missing a network policy for haproxy to connect to the validator on port 8080. This PR fixes it: the API is now exposed on port 80 of the public IP assigned by GCP, whenever the helm value above is passed.

This should also work in Azure and AWS.

I don't know whether to submit to the testnet branch or the main branch, please provide guidance.

PS: please consider adding our validator 🏢MIDL.dev to the incentivized testnet program.

@sherry-x @rustielin 