### PR TITLE
Merge authorizations if they belong to another user.

### DIFF
--- a/ecosystem/platform/server/app/models/user.rb
+++ b/ecosystem/platform/server/app/models/user.rb
@@ -29,7 +29,18 @@ class User < ApplicationRecord
 
     # returning users
     authorization = Authorization.find_by(provider: auth.provider, uid: auth.uid)
-    return authorization.user if authorization
+    if authorization
+      if current_user && current_user.id != authorization.user.id &&
+         current_user.created_at < authorization.user.created_at
+        # A different User is associated with this authorization. Merge the
+        # authorization into current_user if current_user is older than the
+        # associated User.
+        authorization.user = current_user
+        authorization.save!
+      end
+
+      return authorization.user
+    end
 
     # if user is already logged in, add new oauth to existing user
     if current_user


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We don't currently handle the case where two OAuth authorizations belong to two separate accounts. This PR will merge the authorization into the original account in this scenario.

Starting from an empty database:

Before (you get logged in as the Discord user#2):

https://user-images.githubusercontent.com/310773/169355575-f4150452-7b20-4743-a691-f9f97259e61c.mp4

After (you stay logged in as the Github user#1 and the Discord authorization is linked to the Github user#1):

https://user-images.githubusercontent.com/310773/169355667-3e88a0a5-6409-4daf-960f-485e249a0367.mp4


## Test Plan

Manual

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
