### PR TITLE
[Testnet] Disable SSv2.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -92,7 +92,7 @@ impl Default for StateSyncDriverConfig {
     fn default() -> Self {
         Self {
             bootstrapping_mode: BootstrappingMode::ApplyTransactionOutputsFromGenesis,
-            enable_state_sync_v2: true,
+            enable_state_sync_v2: false,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,

--- a/docker/compose/public_full_node/public_full_node.yaml
+++ b/docker/compose/public_full_node/public_full_node.yaml
@@ -9,7 +9,7 @@ base:
 
 state_sync:
   state_sync_driver:
-    enable_state_sync_v2: true
+    enable_state_sync_v2: false
 
 execution:
     # Path to a genesis transaction. Note, this must be paired with a waypoint. If you update your

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -13,7 +13,7 @@ fullnode_identity:
   # If not set, it will generate a random one on startup.
 
 fullnode_max_inbound_connections: 1000
-enable_state_sync_v2: true
+enable_state_sync_v2: false
 
 rust_log: info
 


### PR DESCRIPTION
## Motivation

In preparation for AIT1, this PR disables state sync v2 by default. This should help us reduce the noise on our first testnet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

None.

## Related PRs

None.
