### PR TITLE
[txn-emitter] configurable transaction expiration time

### DIFF
--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -45,6 +45,8 @@ struct Args {
     wait_millis: u64,
     #[structopt(long)]
     burst: bool,
+    #[structopt(long, default_value = "30")]
+    txn_expiration_time_secs: u64,
     #[structopt(long, default_value = "mint.key")]
     mint_file: String,
     /// Ed25519PrivateKey for minting coins
@@ -94,7 +96,9 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
     let mut emitter = TxnEmitter::new(
         &mut root_account,
         client,
-        TransactionFactory::new(cluster.chain_id).with_gas_unit_price(1),
+        TransactionFactory::new(cluster.chain_id)
+            .with_gas_unit_price(1)
+            .with_transaction_expiration_time(args.txn_expiration_time_secs),
         StdRng::from_seed(OsRng.gen()),
     );
     let mut emit_job_request =

--- a/terraform/testnet/testnet/templates/loadtest.yaml
+++ b/terraform/testnet/testnet/templates/loadtest.yaml
@@ -39,6 +39,7 @@ spec:
             - --duration={{ .config.duration }}
             - --accounts-per-client={{ .config.accounts_per_client }}
             - --workers-per-ac={{ .config.workers_per_ac }}
+            - --txn-expiration-time-secs={{ .config.txn_expiration_time_secs }}
             {{- if .config.enableBurst }}
             - --burst
             - --wait-millis={{ .config.waitMillis }}

--- a/terraform/testnet/testnet/values.yaml
+++ b/terraform/testnet/testnet/values.yaml
@@ -180,6 +180,7 @@ load_test:
     workers_per_ac: 64
     enableBurst: false
     waitMillis: 1000
+    txn_expiration_time_secs: 30
 
 # if enabled, faucet_test is synchronized with cluster_test traffic
 # to prevent race on mint account


### PR DESCRIPTION
## Motivation
Sometimes we want a large backlog of txns in the mempool, to see the max TPS.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
yes

## Test Plan

used on alden-net
