### PR TITLE
[Executor-benchmark] Various optimizations to reduce DB creation time by 2.5x

### DIFF
--- a/execution/executor-benchmark/benches/executor_benchmark.rs
+++ b/execution/executor-benchmark/benches/executor_benchmark.rs
@@ -10,6 +10,7 @@ use executor_types::BlockExecutorTrait;
 use std::sync::Arc;
 
 pub const NUM_ACCOUNTS: usize = 1000;
+pub const NUM_SEED_ACCOUNTS: usize = 5;
 pub const SMALL_BLOCK_SIZE: usize = 500;
 pub const MEDIUM_BLOCK_SIZE: usize = 1000;
 pub const LARGE_BLOCK_SIZE: usize = 1000;
@@ -26,15 +27,22 @@ fn executor_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {
     let parent_block_id = executor.committed_block_id();
     let executor = Arc::new(executor);
 
-    let mut generator = TransactionGenerator::new(genesis_key, NUM_ACCOUNTS);
+    let mut generator = TransactionGenerator::new(genesis_key, NUM_ACCOUNTS, NUM_SEED_ACCOUNTS);
     let (commit_tx, _commit_rx) = std::sync::mpsc::sync_channel(50 /* bound */);
 
     let mut executor = TransactionExecutor::new(executor, parent_block_id, 0, Some(commit_tx));
-    let txns = generator.gen_account_creations(SMALL_BLOCK_SIZE);
+
+    let txns = generator.create_seed_accounts(SMALL_BLOCK_SIZE);
     for txn_block in txns {
         executor.execute_block(txn_block);
     }
-    let txns = generator.gen_mint_transactions(INITIAL_BALANCE, SMALL_BLOCK_SIZE);
+
+    let txns = generator.mint_seed_accounts(INITIAL_BALANCE * 10_000, SMALL_BLOCK_SIZE);
+    for txn_block in txns {
+        executor.execute_block(txn_block);
+    }
+
+    let txns = generator.create_and_fund_accounts(INITIAL_BALANCE, SMALL_BLOCK_SIZE);
     for txn_block in txns {
         executor.execute_block(txn_block);
     }

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -69,8 +69,13 @@ pub fn run(
     let gen_thread = std::thread::Builder::new()
         .name("txn_generator".to_string())
         .spawn(move || {
-            let mut generator =
-                TransactionGenerator::new_with_sender(genesis_key, num_accounts, block_sender);
+            let seed_accounts = (num_accounts / 1000).max(1);
+            let mut generator = TransactionGenerator::new_with_sender(
+                genesis_key,
+                num_accounts,
+                seed_accounts,
+                block_sender,
+            );
             generator.run_mint(init_account_balance, block_size);
             generator
         })

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -18,6 +18,7 @@ use aptos_types::{
 use chrono::Local;
 use indicatif::{ProgressBar, ProgressStyle};
 use rand::{rngs::StdRng, SeedableRng};
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
@@ -71,6 +72,11 @@ pub struct TransactionGenerator {
     /// so generated transactions are guaranteed to be successfully executed.
     accounts_cache: Vec<AccountData>,
 
+    /// The current state of seed accounts. The purpose of the seed accounts to parallelize the
+    /// account creation and minting process so that they are not blocked on sequence number of
+    /// a single root account.
+    seed_accounts_cache: Vec<AccountData>,
+
     /// Total number of accounts in the DB
     num_accounts: usize,
 
@@ -89,27 +95,39 @@ pub struct TransactionGenerator {
 }
 
 impl TransactionGenerator {
-    pub fn new(genesis_key: Ed25519PrivateKey, num_accounts: usize) -> Self {
-        Self::new_impl(genesis_key, num_accounts, None)
+    pub fn new(
+        genesis_key: Ed25519PrivateKey,
+        num_accounts: usize,
+        num_seed_accounts: usize,
+    ) -> Self {
+        Self::new_impl(genesis_key, num_accounts, num_seed_accounts, None)
     }
 
     pub fn new_with_sender(
         genesis_key: Ed25519PrivateKey,
         num_accounts: usize,
+        num_seed_accounts: usize,
         block_sender: mpsc::SyncSender<Vec<Transaction>>,
     ) -> Self {
-        Self::new_impl(genesis_key, num_accounts, Some(block_sender))
+        Self::new_impl(
+            genesis_key,
+            num_accounts,
+            num_seed_accounts,
+            Some(block_sender),
+        )
     }
 
     fn new_impl(
         genesis_key: Ed25519PrivateKey,
         num_accounts: usize,
+        num_seed_accounts: usize,
         block_sender: Option<mpsc::SyncSender<Vec<Transaction>>>,
     ) -> Self {
         let seed = [1u8; 32];
         let rng = StdRng::from_seed(seed);
         Self {
-            accounts_cache: Self::gen_account_cache(num_accounts),
+            seed_accounts_cache: Self::gen_account_cache(num_seed_accounts, true),
+            accounts_cache: Self::gen_account_cache(num_accounts, false),
             num_accounts,
             genesis_key,
             version: 0,
@@ -118,13 +136,21 @@ impl TransactionGenerator {
         }
     }
 
-    fn gen_account_cache(num_accounts: usize) -> Vec<AccountData> {
+    fn gen_account_cache(num_accounts: usize, seed_account: bool) -> Vec<AccountData> {
         let start = Instant::now();
-        let seed = [1u8; 32];
+        let seed = if seed_account { [1u8; 32] } else { [2u8; 32] };
         let mut rng = StdRng::from_seed(seed);
 
         let mut accounts = Vec::with_capacity(num_accounts);
-        println!("[{}] Generating {} accounts.", now_fmt!(), num_accounts);
+        if seed_account {
+            println!(
+                "[{}] Generating {} seed accounts.",
+                now_fmt!(),
+                num_accounts
+            );
+        } else {
+            println!("[{}] Generating {} accounts.", now_fmt!(), num_accounts);
+        }
         let bar = get_progress_bar(num_accounts);
         for _i in 0..num_accounts {
             let private_key = Ed25519PrivateKey::generate(&mut rng);
@@ -142,11 +168,19 @@ impl TransactionGenerator {
         bar.finish();
         println!("[{}] done.", now_fmt!());
 
-        info!(
-            num_accounts_generated = num_accounts,
-            time_ms = %start.elapsed().as_millis(),
-            "Account cache generation finished.",
-        );
+        if seed_account {
+            info!(
+                num_accounts_generated = num_accounts,
+                time_ms = %start.elapsed().as_millis(),
+                "Seed Account cache generation finished.",
+            );
+        } else {
+            info!(
+                num_accounts_generated = num_accounts,
+                time_ms = %start.elapsed().as_millis(),
+                "Account cache generation finished.",
+            );
+        }
         accounts
     }
 
@@ -165,11 +199,13 @@ impl TransactionGenerator {
 
         let seed = [1u8; 32];
         let rng = StdRng::from_seed(seed);
+        let num_seed_accounts = (num_accounts / 1000).max(1);
         Self {
-            accounts_cache: Self::gen_account_cache(std::cmp::min(
-                num_accounts,
-                MAX_ACCOUNTS_INVOLVED_IN_P2P,
-            )),
+            seed_accounts_cache: Self::gen_account_cache(num_seed_accounts, true),
+            accounts_cache: Self::gen_account_cache(
+                std::cmp::min(num_accounts, MAX_ACCOUNTS_INVOLVED_IN_P2P),
+                false,
+            ),
             num_accounts,
             genesis_key,
             version,
@@ -195,8 +231,11 @@ impl TransactionGenerator {
 
     pub fn run_mint(&mut self, init_account_balance: u64, block_size: usize) {
         assert!(self.block_sender.is_some());
-        self.gen_account_creations(block_size);
-        self.gen_mint_transactions(init_account_balance, block_size);
+        self.create_seed_accounts(block_size);
+        // Ensure that seed accounts have enough balance to transfer money to at least 1000 account with
+        // balance init_account_balance.
+        self.mint_seed_accounts(init_account_balance * 10_000, block_size);
+        self.create_and_fund_accounts(init_account_balance, block_size);
     }
 
     pub fn run_transfer(&mut self, block_size: usize, num_transfer_blocks: usize) {
@@ -211,17 +250,17 @@ impl TransactionGenerator {
             .with_max_gas_amount(1000)
     }
 
-    pub fn gen_account_creations(&mut self, block_size: usize) -> Vec<Vec<Transaction>> {
+    pub fn create_seed_accounts(&mut self, block_size: usize) -> Vec<Vec<Transaction>> {
         let root_address = aptos_root_address();
         let mut txn_block = vec![];
 
         println!(
-            "[{}] Generating {} account creation txns.",
+            "[{}] Generating {} seed account creation txns.",
             now_fmt!(),
-            self.accounts_cache.len(),
+            self.seed_accounts_cache.len(),
         );
-        let bar = get_progress_bar(self.accounts_cache.len());
-        for (i, block) in self.accounts_cache.chunks(block_size).enumerate() {
+        let bar = get_progress_bar(self.seed_accounts_cache.len());
+        for (i, block) in self.seed_accounts_cache.chunks(block_size).enumerate() {
             let mut transactions = Vec::with_capacity(block_size);
             for (j, account) in block.iter().enumerate() {
                 let txn = create_transaction(
@@ -248,26 +287,76 @@ impl TransactionGenerator {
         txn_block
     }
 
-    /// Generates transactions that allocate `init_account_balance` to every account.
-    pub fn gen_mint_transactions(
+    /// Generates transactions that creates a set of accounts and fund them from the seed accounts.
+    pub fn create_and_fund_accounts(
         &mut self,
         init_account_balance: u64,
+        block_size: usize,
+    ) -> Vec<Vec<Transaction>> {
+        let mut txn_block = vec![];
+
+        println!(
+            "[{}] Generating {} account creation txns.",
+            now_fmt!(),
+            self.accounts_cache.len(),
+        );
+        let bar = get_progress_bar(self.accounts_cache.len());
+        for (_, block) in self.accounts_cache.chunks(block_size).enumerate() {
+            let mut transactions = Vec::with_capacity(block_size);
+            for (_, account) in block.iter().enumerate() {
+                let seed_index =
+                    rand::seq::index::sample(&mut self.rng, self.seed_accounts_cache.len(), 1)
+                        .index(0);
+                let seed_account = &self.seed_accounts_cache[seed_index];
+                let txn = create_transaction(
+                    &seed_account.private_key,
+                    seed_account.public_key.clone(),
+                    Self::transaction_factory()
+                        .create_and_fund_user_account(&account.public_key, init_account_balance)
+                        .sender(seed_account.address)
+                        .sequence_number(seed_account.sequence_number)
+                        .build(),
+                );
+                self.seed_accounts_cache[seed_index].sequence_number += 1;
+                transactions.push(txn);
+            }
+            self.version += transactions.len() as Version;
+            if let Some(sender) = &self.block_sender {
+                sender.send(transactions).unwrap();
+            } else {
+                txn_block.push(transactions);
+            }
+            bar.inc(block_size as u64);
+        }
+        bar.finish();
+        println!("[{}] done.", now_fmt!());
+        txn_block
+    }
+
+    /// Generates transactions that allocate `init_account_balance` to every account.
+    pub fn mint_seed_accounts(
+        &mut self,
+        seed_account_balance: u64,
         block_size: usize,
     ) -> Vec<Vec<Transaction>> {
         let root_address = aptos_root_address();
         let mut txn_block = vec![];
 
-        let total_accounts = self.accounts_cache.len();
-        println!("[{}] Generating {} mint txns.", now_fmt!(), total_accounts,);
+        let total_accounts = self.seed_accounts_cache.len();
+        println!(
+            "[{}] Generating {} mint txns for seed accounts.",
+            now_fmt!(),
+            total_accounts,
+        );
         let bar = get_progress_bar(total_accounts);
-        for (i, block) in self.accounts_cache.chunks(block_size).enumerate() {
+        for (i, block) in self.seed_accounts_cache.chunks(block_size).enumerate() {
             let mut transactions = Vec::with_capacity(block_size);
             for (j, account) in block.iter().enumerate() {
                 let txn = create_transaction(
                     &self.genesis_key,
                     self.genesis_key.public_key(),
                     Self::transaction_factory()
-                        .mint(account.address, init_account_balance)
+                        .mint(account.address, seed_account_balance)
                         .sender(root_address)
                         .sequence_number((total_accounts + i * block_size + j) as u64)
                         .build(),
@@ -336,7 +425,7 @@ impl TransactionGenerator {
             self.accounts_cache.len(),
         );
         let bar = get_progress_bar(self.accounts_cache.len());
-        for account in &self.accounts_cache {
+        self.accounts_cache.par_iter().for_each(|account| {
             let address = account.address;
             let db_state_view = db.latest_state_view().unwrap();
             let address_account_view = db_state_view.as_account_with_state_view(&address);
@@ -349,7 +438,7 @@ impl TransactionGenerator {
                 account.sequence_number
             );
             bar.inc(1);
-        }
+        });
         bar.finish();
         println!("[{}] done.", now_fmt!());
     }

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -136,6 +136,18 @@ impl TransactionFactory {
         ))
     }
 
+    pub fn create_and_fund_user_account(
+        &self,
+        public_key: &Ed25519PublicKey,
+        amount: u64,
+    ) -> TransactionBuilder {
+        let preimage = AuthenticationKeyPreimage::ed25519(public_key);
+        self.payload(aptos_stdlib::encode_account_utils_create_and_fund_account(
+            AuthenticationKey::from_preimage(&preimage).derived_address(),
+            amount,
+        ))
+    }
+
     pub fn transfer(&self, to: AccountAddress, amount: u64) -> TransactionBuilder {
         self.payload(aptos_stdlib::encode_test_coin_transfer(to, amount))
     }


### PR DESCRIPTION
Optimizations to reduce the DB creation time during the local executor benchmark run

1. Use a number of seed accounts (number of accounts/1000) to speed up the account creation process. This way we can parallelize the transactions instead of blocking on sequence number of the root account.
2. Use `create_and_fund` API to create and fund the accounts instead of doing that in 2 transactions.
3. Parallelize the sequence number verification process.

Ran the DB creation tool locally and observed 2.5x Speed up for DB of size 1M.

Command ran -

```
gtime cargo run --release -p executor-benchmark -- --block-size 10000 create-db  --data-dir /tmp/data_test_4 --num-accounts 1000000
```

Without the change, time taken is 17:28.40
With this change, time taken is 6:53.96
