### PR TITLE
[aptos-cli] Add build size optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,6 +143,14 @@ default-members = [
 [profile.release]
 debug = true
 
+[profile.cli]
+inherits = "release"
+debug = false
+opt-level = "z"
+lto = true
+strip = true
+codegen-units = 1
+
 [profile.bench]
 debug = true
 

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -26,7 +26,7 @@ elif [ "$OS" == "Linux" ]; then
 fi
 
 echo "Building release $VERSION of $NAME for $OS-$ARCH"
-cargo build -p $CRATE_NAME --release
+cargo build -p $CRATE_NAME --profile cli
 
 EXIT_CODE=$?
 if [ "$EXIT_CODE" != "0" ]; then


### PR DESCRIPTION
## Motivation

Decrease size of CLI builds so that they don't grow too large.  We don't have to optimize for speed, just space in the CLI.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current release is built with this.  Took the Ubuntu CLI from 900MB to 100MB
