### PR TITLE
[aptos-cli] Bump version

### DIFF
--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -34,7 +34,7 @@ if [ "$EXIT_CODE" != "0" ]; then
   exit $EXIT_CODE
 fi
 
-cd target/release/
+cd target/cli/
 
 # Compress the CLI
 ZIP_NAME="$NAME-$VERSION-$OS-$ARCH.zip"


### PR DESCRIPTION
CLI is not compatible with AIT1 framework, so we're bumping the version.

Related to: https://github.com/aptos-labs/aptos-core/issues/1108