### PR TITLE
[ecosystem] Add :it1_node_registration_disabled feature flag.

### DIFF
--- a/ecosystem/platform/server/.rubocop.yml
+++ b/ecosystem/platform/server/.rubocop.yml
@@ -1,4 +1,6 @@
 AllCops:
+  Exclude:
+    - db/schema.rb
   NewCops: enable
 
 Metrics/MethodLength:

--- a/ecosystem/platform/server/Gemfile
+++ b/ecosystem/platform/server/Gemfile
@@ -82,6 +82,7 @@ gem 'recaptcha', '~> 5.10'
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# UI components
 gem 'view_component', '~> 2.54'
 
 # Monitoring
@@ -91,6 +92,10 @@ gem 'sentry-ruby'
 
 # State machines
 gem 'statesman', '~> 10.0'
+
+# Feature flags
+gem 'flipper', '~> 0.24.1'
+gem 'flipper-active_record', '~> 0.24.1'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/ecosystem/platform/server/Gemfile.lock
+++ b/ecosystem/platform/server/Gemfile.lock
@@ -149,6 +149,10 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    flipper (0.24.1)
+    flipper-active_record (0.24.1)
+      activerecord (>= 4.2, < 8)
+      flipper (~> 0.24.1)
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.7.0)
@@ -444,6 +448,8 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  flipper (~> 0.24.1)
+  flipper-active_record (~> 0.24.1)
   httparty
   jbuilder
   jsbundling-rails

--- a/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
@@ -4,8 +4,9 @@
 
 class It1ProfilesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_it1_profile, only: %i[show edit update destroy]
+  before_action :ensure_registration_enabled!
   before_action :ensure_confirmed!
+  before_action :set_it1_profile, only: %i[show edit update destroy]
   respond_to :html
 
   def show
@@ -123,5 +124,9 @@ class It1ProfilesController < ApplicationController
     params.fetch(:it1_profile, {}).permit(:consensus_key, :account_key, :network_key, :validator_address,
                                           :validator_port, :validator_api_port, :validator_metrics_port,
                                           :fullnode_address, :fullnode_port, :fullnode_network_key, :terms_accepted)
+  end
+
+  def ensure_registration_enabled!
+    redirect_to it1_path if Flipper.enabled?(:it1_node_registration_disabled, current_user)
   end
 end

--- a/ecosystem/platform/server/app/controllers/welcome_controller.rb
+++ b/ecosystem/platform/server/app/controllers/welcome_controller.rb
@@ -39,6 +39,7 @@ class WelcomeController < ApplicationController
     {
       name: :node_registration,
       completed:,
+      disabled: Flipper.enabled?(:it1_node_registration_disabled, current_user),
       href: completed ? edit_it1_profile_path(current_user.it1_profile) : new_it1_profile_path
     }
   end

--- a/ecosystem/platform/server/db/migrate/20220520172136_create_flipper_tables.rb
+++ b/ecosystem/platform/server/db/migrate/20220520172136_create_flipper_tables.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+class CreateFlipperTables < ActiveRecord::Migration[7.0]
+  def self.up
+    create_table :flipper_features do |t|
+      t.string :key, null: false
+      t.timestamps null: false
+    end
+    add_index :flipper_features, :key, unique: true
+
+    create_table :flipper_gates do |t|
+      t.string :feature_key, null: false
+      t.string :key, null: false
+      t.string :value
+      t.timestamps null: false
+    end
+    add_index :flipper_gates, %i[feature_key key value], unique: true
+  end
+
+  def self.down
+    drop_table :flipper_gates
+    drop_table :flipper_features
+  end
+end

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -1,7 +1,3 @@
-# frozen_string_literal: true
-
-# Copyright (c) Aptos
-# SPDX-License-Identifier: Apache-2.0
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -14,163 +10,179 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_220_513_141_301) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_20_172136) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'pgcrypto'
-  enable_extension 'plpgsql'
+  enable_extension "pgcrypto"
+  enable_extension "plpgsql"
 
-  create_table 'active_admin_comments', force: :cascade do |t|
-    t.string 'namespace'
-    t.text 'body'
-    t.string 'resource_type'
-    t.bigint 'resource_id'
-    t.string 'author_type'
-    t.bigint 'author_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[author_type author_id], name: 'index_active_admin_comments_on_author'
-    t.index ['namespace'], name: 'index_active_admin_comments_on_namespace'
-    t.index %w[resource_type resource_id], name: 'index_active_admin_comments_on_resource'
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string "namespace"
+    t.text "body"
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.string "author_type"
+    t.bigint "author_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author"
+    t.index ["namespace"], name: "index_active_admin_comments_on_namespace"
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource"
   end
 
-  create_table 'authorizations', force: :cascade do |t|
-    t.integer 'user_id'
-    t.string 'provider'
-    t.string 'uid'
-    t.string 'email'
-    t.string 'username'
-    t.string 'full_name'
-    t.text 'profile_url'
-    t.string 'token'
-    t.string 'secret'
-    t.string 'refresh_token'
-    t.boolean 'expires'
-    t.datetime 'expires_at', precision: nil
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[provider uid], name: 'index_authorizations_on_provider_and_uid'
-    t.index ['provider'], name: 'index_authorizations_on_provider'
-    t.index ['uid'], name: 'index_authorizations_on_uid'
-    t.index ['user_id'], name: 'index_authorizations_on_user_id'
+  create_table "authorizations", force: :cascade do |t|
+    t.integer "user_id"
+    t.string "provider"
+    t.string "uid"
+    t.string "email"
+    t.string "username"
+    t.string "full_name"
+    t.text "profile_url"
+    t.string "token"
+    t.string "secret"
+    t.string "refresh_token"
+    t.boolean "expires"
+    t.datetime "expires_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["provider", "uid"], name: "index_authorizations_on_provider_and_uid"
+    t.index ["provider"], name: "index_authorizations_on_provider"
+    t.index ["uid"], name: "index_authorizations_on_uid"
+    t.index ["user_id"], name: "index_authorizations_on_user_id"
   end
 
-  create_table 'delayed_jobs', force: :cascade do |t|
-    t.integer 'priority', default: 0, null: false
-    t.integer 'attempts', default: 0, null: false
-    t.text 'handler', null: false
-    t.text 'last_error'
-    t.datetime 'run_at'
-    t.datetime 'locked_at'
-    t.datetime 'failed_at'
-    t.string 'locked_by'
-    t.string 'queue'
-    t.datetime 'created_at'
-    t.datetime 'updated_at'
-    t.index %w[priority run_at], name: 'delayed_jobs_priority'
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
-  create_table 'it1_profiles', force: :cascade do |t|
-    t.bigint 'user_id', null: false
-    t.string 'consensus_key'
-    t.string 'account_key'
-    t.string 'network_key'
-    t.string 'validator_ip'
-    t.string 'validator_address'
-    t.integer 'validator_port'
-    t.integer 'validator_metrics_port'
-    t.integer 'validator_api_port'
-    t.boolean 'validator_verified', default: false
-    t.string 'fullnode_address'
-    t.integer 'fullnode_port'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.boolean 'terms_accepted', default: false
-    t.string 'fullnode_network_key'
-    t.index ['user_id'], name: 'index_it1_profiles_on_user_id'
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
   end
 
-  create_table 'locations', force: :cascade do |t|
-    t.string 'item_type', null: false
-    t.bigint 'item_id', null: false
-    t.integer 'accuracy_radius'
-    t.integer 'average_income'
-    t.float 'latitude'
-    t.float 'longitude'
-    t.integer 'metro_code'
-    t.integer 'population_density'
-    t.string 'time_zone'
-    t.boolean 'anonymous'
-    t.boolean 'anonymous_vpn'
-    t.integer 'autonomous_system_number'
-    t.string 'autonomous_system_organization'
-    t.string 'connection_type'
-    t.string 'domain'
-    t.boolean 'hosting_provider'
-    t.string 'ip_address'
-    t.string 'isp'
-    t.boolean 'legitimate_proxy'
-    t.string 'mobile_country_code'
-    t.string 'mobile_network_code'
-    t.string 'network'
-    t.string 'organization'
-    t.boolean 'public_proxy'
-    t.boolean 'residential_proxy'
-    t.float 'static_ip_score'
-    t.boolean 'tor_exit_node'
-    t.integer 'user_count'
-    t.string 'user_type'
-    t.string 'continent_code'
-    t.string 'continent_geoname_id'
-    t.string 'continent_name'
-    t.integer 'country_confidence'
-    t.string 'country_geoname_id'
-    t.string 'country_iso_code'
-    t.string 'country_name'
-    t.integer 'subdivision_confidence'
-    t.string 'subdivision_geoname_id'
-    t.string 'subdivision_iso_code'
-    t.string 'subdivision_name'
-    t.integer 'city_confidence'
-    t.string 'city_geoname_id'
-    t.string 'city_name'
-    t.integer 'postal_confidence'
-    t.string 'postal_code'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index %w[item_type item_id], name: 'index_locations_on_item'
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'username'
-    t.string 'email'
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.integer 'sign_in_count', default: 0, null: false
-    t.datetime 'current_sign_in_at'
-    t.datetime 'last_sign_in_at'
-    t.string 'current_sign_in_ip'
-    t.string 'last_sign_in_ip'
-    t.string 'confirmation_token'
-    t.datetime 'confirmed_at'
-    t.datetime 'confirmation_sent_at'
-    t.string 'unconfirmed_email'
-    t.boolean 'is_root', default: false, null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.boolean 'is_developer', default: false, null: false
-    t.boolean 'is_node_operator', default: false, null: false
-    t.string 'mainnet_address'
-    t.string 'kyc_status', default: 'not_started', null: false
-    t.uuid 'external_id', default: -> { 'gen_random_uuid()' }, null: false
-    t.boolean 'kyc_exempt', default: false
-    t.string 'completed_persona_inquiry_id'
-    t.index ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
-    t.index ['username'], name: 'index_users_on_username', unique: true
+  create_table "it1_profiles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "consensus_key"
+    t.string "account_key"
+    t.string "network_key"
+    t.string "validator_ip"
+    t.string "validator_address"
+    t.integer "validator_port"
+    t.integer "validator_metrics_port"
+    t.integer "validator_api_port"
+    t.boolean "validator_verified", default: false
+    t.string "fullnode_address"
+    t.integer "fullnode_port"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "terms_accepted", default: false
+    t.string "fullnode_network_key"
+    t.index ["user_id"], name: "index_it1_profiles_on_user_id"
   end
 
-  add_foreign_key 'it1_profiles', 'users'
+  create_table "locations", force: :cascade do |t|
+    t.string "item_type", null: false
+    t.bigint "item_id", null: false
+    t.integer "accuracy_radius"
+    t.integer "average_income"
+    t.float "latitude"
+    t.float "longitude"
+    t.integer "metro_code"
+    t.integer "population_density"
+    t.string "time_zone"
+    t.boolean "anonymous"
+    t.boolean "anonymous_vpn"
+    t.integer "autonomous_system_number"
+    t.string "autonomous_system_organization"
+    t.string "connection_type"
+    t.string "domain"
+    t.boolean "hosting_provider"
+    t.string "ip_address"
+    t.string "isp"
+    t.boolean "legitimate_proxy"
+    t.string "mobile_country_code"
+    t.string "mobile_network_code"
+    t.string "network"
+    t.string "organization"
+    t.boolean "public_proxy"
+    t.boolean "residential_proxy"
+    t.float "static_ip_score"
+    t.boolean "tor_exit_node"
+    t.integer "user_count"
+    t.string "user_type"
+    t.string "continent_code"
+    t.string "continent_geoname_id"
+    t.string "continent_name"
+    t.integer "country_confidence"
+    t.string "country_geoname_id"
+    t.string "country_iso_code"
+    t.string "country_name"
+    t.integer "subdivision_confidence"
+    t.string "subdivision_geoname_id"
+    t.string "subdivision_iso_code"
+    t.string "subdivision_name"
+    t.integer "city_confidence"
+    t.string "city_geoname_id"
+    t.string "city_name"
+    t.integer "postal_confidence"
+    t.string "postal_code"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_type", "item_id"], name: "index_locations_on_item"
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "username"
+    t.string "email"
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.boolean "is_root", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "is_developer", default: false, null: false
+    t.boolean "is_node_operator", default: false, null: false
+    t.string "mainnet_address"
+    t.string "kyc_status", default: "not_started", null: false
+    t.uuid "external_id", default: -> { "gen_random_uuid()" }, null: false
+    t.boolean "kyc_exempt", default: false
+    t.string "completed_persona_inquiry_id"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
+  end
+
+  add_foreign_key "it1_profiles", "users"
 end


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

```ruby
Flipper.enable(:it1_node_registration_disabled)
```

![image](https://user-images.githubusercontent.com/310773/169580938-895628df-46bc-4303-ad71-8799e2f1a13b.png)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

## Test Plan

Manual testing

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
