### PR TITLE
[ecosystem] Add selected to It1Profile and a flag to end IT1 registration.

### DIFF
--- a/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it1_profiles_controller.rb
@@ -127,6 +127,7 @@ class It1ProfilesController < ApplicationController
   end
 
   def ensure_registration_enabled!
-    redirect_to it1_path if Flipper.enabled?(:it1_node_registration_disabled, current_user)
+    redirect_to it1_path if Flipper.enabled?(:it1_node_registration_disabled,
+                                             current_user) || Flipper.enabled?(:it1_registration_closed, current_user)
   end
 end

--- a/ecosystem/platform/server/app/controllers/onboarding_controller.rb
+++ b/ecosystem/platform/server/app/controllers/onboarding_controller.rb
@@ -7,6 +7,7 @@ class OnboardingController < ApplicationController
   before_action :authenticate_user!, except: %i[kyc_callback]
   before_action :ensure_discord!, only: %i[kyc_redirect]
   before_action :ensure_confirmed!, only: %i[kyc_redirect]
+  before_action :ensure_it1_registration_open!, only: %i[kyc_callback kyc_redirect]
   before_action :set_oauth_data, except: %i[kyc_callback]
   protect_from_forgery except: :kyc_callback
 
@@ -95,5 +96,9 @@ class OnboardingController < ApplicationController
   def set_oauth_data
     @oauth_username = current_user.authorizations.pluck(:username).first
     @oauth_email = current_user.authorizations.pluck(:email).first
+  end
+
+  def ensure_it1_registration_open!
+    redirect_to root_url if Flipper.enabled?(:it1_registration_closed, current_user)
   end
 end

--- a/ecosystem/platform/server/app/controllers/welcome_controller.rb
+++ b/ecosystem/platform/server/app/controllers/welcome_controller.rb
@@ -14,6 +14,7 @@ class WelcomeController < ApplicationController
 
   def it1
     redirect_to root_path unless user_signed_in?
+    @it1_registration_closed = Flipper.enabled?(:it1_registration_closed, current_user)
     @steps = [
       connect_discord_step,
       node_registration_step,
@@ -21,6 +22,7 @@ class WelcomeController < ApplicationController
     ].map { |h| OpenStruct.new(**h) }
     first_incomplete = @steps.index { |step| !step.completed }
     @steps[first_incomplete + 1..].each { |step| step.disabled = true } if first_incomplete
+    @steps.each { |step| step.disabled = true } if @it1_registration_closed
   end
 
   private

--- a/ecosystem/platform/server/app/views/welcome/it1.html.erb
+++ b/ecosystem/platform/server/app/views/welcome/it1.html.erb
@@ -6,6 +6,17 @@
 
     <%= render "layouts/flash" %>
 
+    <% if @it1_registration_closed && current_user.it1_profile %>
+      <h2 class="font-mono text-3xl mb-12">
+        <% if current_user.it1_profile.selected %>
+          <div>Congratulations!</div>
+          <div>Your node was selected!</div>
+        <% else %>
+          Sorry, your node was not selected.
+        <% end %>
+      </h2>
+    <% end %>
+
     <div class="flex flex-col lg:flex-row gap-8" data-controller="shake">
       <% @steps.each_with_index do |step, i| %>
         <div data-action="<%= step.disabled ? 'click->shake#shake' : '' %>" data-target="<%= !step.disabled && !step.completed ? 'shake.content' : '' %>" class="bg-neutral-800 rounded-md flex flex-col flex-1 <%= step.disabled ? 'cursor-not-allowed select-none opacity-50' : '' %>">

--- a/ecosystem/platform/server/db/migrate/20220520193550_add_selected_to_it1_profile.rb
+++ b/ecosystem/platform/server/db/migrate/20220520193550_add_selected_to_it1_profile.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+class AddSelectedToIt1Profile < ActiveRecord::Migration[7.0]
+  def change
+    add_column :it1_profiles, :selected, :boolean, default: false, null: false,
+                                                   comment: 'Whether this node is selected for participation in IT1.'
+  end
+end

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_20_172136) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_20_193550) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -98,6 +98,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_20_172136) do
     t.datetime "updated_at", null: false
     t.boolean "terms_accepted", default: false
     t.string "fullnode_network_key"
+    t.boolean "selected", default: false, null: false, comment: "Whether this node is selected for participation in IT1."
     t.index ["user_id"], name: "index_it1_profiles_on_user_id"
   end
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

```ruby
Flipper.enable(:it1_registration_closed)
```

This will display a page that indicates whether the node was selected for participation or not (`It1Profile.selected`). It also closes Persona verification.

`It1Profile.selected` will need to be set for the selected nodes prior to enabling the `:it1_registration_closed` flag.

`it1_profile.selected`:

![image](https://user-images.githubusercontent.com/310773/169603556-2eaa7b7f-4895-49ef-a91f-24376b01330b.png)

`!it1_profile.selected`:

![image](https://user-images.githubusercontent.com/310773/169603638-65de0bb8-c1c3-4e91-808b-00409c358189.png)


## Test Plan

Manual
## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
