### PR TITLE
[ecosystem] Consolidate link styles into LinkComponent.

### DIFF
--- a/ecosystem/platform/server/app/components/link_component.rb
+++ b/ecosystem/platform/server/app/components/link_component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class LinkComponent < ViewComponent::Base
+  def initialize(**rest)
+    @rest = rest
+    @rest[:class] = [
+      'underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2',
+      @rest[:class]
+    ]
+  end
+
+  def call
+    content_tag :a, content, **@rest
+  end
+end

--- a/ecosystem/platform/server/app/views/it1_profiles/_form.html.erb
+++ b/ecosystem/platform/server/app/views/it1_profiles/_form.html.erb
@@ -105,7 +105,7 @@
       <div class="text-sm">
         <label class="flex gap-2 items-start cursor-pointer">
           <%= f.check_box :terms_accepted, required: true %>
-          <span class="leading-tight">I agree to the Aptos <a href="https://aptoslabs.com/terms-testnet/" class="underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2" target="_blank" rel="noopener noreferrer">Testnet Participation Terms of Use</a>.</span>
+          <span class="leading-tight">I agree to the Aptos <%= render(LinkComponent.new(href: 'https://aptoslabs.com/terms-testnet/', target: '_blank', rel: 'noopener noreferrer')) { 'Testnet Participation Terms of Use' } %>.</span>
         </label>
       </div>
     </div>

--- a/ecosystem/platform/server/app/views/onboarding/email_success.html.erb
+++ b/ecosystem/platform/server/app/views/onboarding/email_success.html.erb
@@ -8,6 +8,6 @@
   Please verify your email by clicking the link sent to your inbox.
   </p>
   <p class="mb-4 font-light">
-  If you have not received this email, please check your spam folder, or <%= link_to "click here", onboarding_email_path, class: "underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2" %> to send a new email.
+  If you have not received this email, please check your spam folder, or <%= render(LinkComponent.new(href: onboarding_email_path)) { "click here" } %> to send a new email.
   </p>
 </div>

--- a/ecosystem/platform/server/app/views/overview/index.html.erb
+++ b/ecosystem/platform/server/app/views/overview/index.html.erb
@@ -4,17 +4,17 @@
 
     <% if current_user.confirmed_at.nil? %>
       <p class="bg-gray-100 border border-gray-400 text-gray-700 px-4 py-3 rounded">
-      Your email has not yet been verified. Didn't receive a verification email? <%= link_to "Re-send verification email", onboarding_email_path, class: "underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2" %>
+      Your email has not yet been verified. Didn't receive a verification email? <%= render(LinkComponent.new(href: onboarding_email_path)) { "Re-send verification email" } %>
       </p>
     <% end %>
 
     <p class="bg-gray-100 border border-gray-400 text-gray-700 px-4 py-3 rounded">
       <% if current_user.it1_profile %>
         IT1 application received.
-        <%= link_to "Edit your application", edit_it1_profile_path(current_user.it1_profile), class: "underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2" %>
+        <%= render(LinkComponent.new(href: edit_it1_profile_path(current_user.it1_profile))) { "Edit your application" } %>
       <% else %>
         Registration for IT1 is open!
-        <%= link_to "Apply now", it1_path, class: "underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2" %>
+        <%= render(LinkComponent.new(href: it1_path)) { "Apply now" } %>
       <% end %>
     </p>
   </div>

--- a/ecosystem/platform/server/app/views/shared/_it1_intro.html.erb
+++ b/ecosystem/platform/server/app/views/shared/_it1_intro.html.erb
@@ -7,10 +7,10 @@ The Aptos community is coming together to build a secure, reliable, and decentra
 <ul class="flex flex-col gap-4 leading-tight">
   <li class="flex gap-2">
     <div class="text-teal-400">&rarr;</div>
-    <div>Read more <a href="https://medium.com/aptoslabs/aptos-incentivized-testnet-update-abcfcd94d54c" class="underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2">Aptos Incentivized Testnet 1 details</a>.</div>
+    <div>Read more <%= render(LinkComponent.new(href: 'https://medium.com/aptoslabs/aptos-incentivized-testnet-update-abcfcd94d54c')) { 'Aptos Incentivized Testnet 1 details' } %>.</div>
   </li>
   <li class="flex gap-2">
     <div class="text-teal-400">&rarr;</div>
-    <div>Please review the <a href="https://aptoslabs.com/terms-testnet/" class="underline decoration-teal-400 decoration-1 underline-offset-4 hover:decoration-2">Aptos Testnet Participation Terms of Use</a>.</div>
+    <div>Please review the <%= render(LinkComponent.new(href: 'https://aptoslabs.com/terms-testnet/')) { 'Aptos Testnet Participation Terms of Use' } %>.</div>
   </li>
 </ul>

--- a/ecosystem/platform/server/spec/components/link_component_spec.rb
+++ b/ecosystem/platform/server/spec/components/link_component_spec.rb
@@ -1,0 +1,17 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LinkComponent, type: :component do
+  pending "add some examples to (or delete) #{__FILE__}"
+
+  # it "renders something useful" do
+  #   expect(
+  #     render_inline(described_class.new(attr: "value")) { "Hello, components!" }.css("p").to_html
+  #   ).to include(
+  #     "Hello, components!"
+  #   )
+  # end
+end


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Reduce duplicated tailwind classes by creating a `LinkComponent`.

## Test Plan

Manually tested

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
