### PR TITLE
[devtools] remove aggressive trailing whitespace linter

### DIFF
--- a/devtools/x/src/lint/whitespace.rs
+++ b/devtools/x/src/lint/whitespace.rs
@@ -75,15 +75,6 @@ impl<'cfg> ContentLinter for TrailingWhitespace<'cfg> {
             None => return Ok(RunStatus::Skipped(SkipReason::NonUtf8Content)),
         };
 
-        for (ln, line) in content.lines().enumerate().map(|(ln, line)| (ln + 1, line)) {
-            if line.trim_end() != line {
-                out.write(
-                    LintLevel::Error,
-                    format!("trailing whitespace at line {}", ln),
-                );
-            }
-        }
-
         if content
             .lines()
             .rev()


### PR DESCRIPTION
This removes the trailing whitespace check from xlint.
Having this rule in xlint is unnecessary and annoying, since xlint scans all files (incl. READMEs, .sh scripts etc.) and can't autoreformat unlike cargo xfmt and prettier, which is already ran as part of our CI pipeline anyways (I confirmed this behaviour my making some dummy whitespace changes in our repo).
So removing this check still guarantees we have no trailing whitespace in the languages that we enabled autoformatting (rust, JS/TS, Ruby) and avoids spurious additional CI cycles to fix trailing whitespaces and random README files etc.

In general I think we should strive to use language-aware / language ecosystem specific autoformatters instead of dumb non-auto unmaintained custom checks like the ones in x-lint.
