### PR TITLE
[State Sync] Clean up some logs and add metrics.

### DIFF
--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -136,7 +136,7 @@ pub async fn send_data(event_name: String, user_id: String, event_params: HashMa
             Ok(res) => {
                 let status_code = res.status().as_u16();
                 if status_code > 200 && status_code < 299 {
-                    info!("Sent telemetry event {}", event_name.as_str());
+                    debug!("Sent telemetry event {}", event_name.as_str());
                     debug!("Sent telemetry data {:?}", &metrics_dump);
                     APTOS_TELEMETRY_SUCCESS
                         .with_label_values(&[event_name.as_str()])

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -59,23 +59,22 @@ pub trait ChunkExecutorTrait: Send + Sync {
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> anyhow::Result<()>;
 
-    /// Commit a previously executed chunk. Returns a vector of reconfiguration
-    /// events in the chunk and the transactions that were committed.
-    fn commit_chunk(&self) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
+    /// Commit a previously executed chunk. Returns a chunk commit notification.
+    fn commit_chunk(&self) -> Result<ChunkCommitNotification>;
 
     fn execute_and_commit_chunk(
         &self,
         txn_list_with_proof: TransactionListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
+    ) -> Result<ChunkCommitNotification>;
 
     fn apply_and_commit_chunk(
         &self,
         txn_output_list_with_proof: TransactionOutputListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
+    ) -> Result<ChunkCommitNotification>;
 
     /// Resets the chunk executor by synchronizing state with storage.
     fn reset(&self) -> Result<()>;
@@ -119,6 +118,13 @@ pub trait TransactionReplayer: Send {
     ) -> Result<()>;
 
     fn commit(&self) -> Result<Arc<ExecutedChunk>>;
+}
+
+/// A structure that holds relevant information about a chunk that was committed.
+pub struct ChunkCommitNotification {
+    pub committed_events: Vec<ContractEvent>,
+    pub committed_transactions: Vec<Transaction>,
+    pub reconfiguration_occurred: bool,
 }
 
 /// A structure that summarizes the result of the execution needed for consensus to agree on.

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -111,7 +111,7 @@ impl<C: ChunkExecutorTrait> ExecutorProxyTrait for ExecutorProxy<C> {
     ) -> Result<(), Error> {
         // track chunk execution time
         let timer = counters::EXECUTE_CHUNK_DURATION.start_timer();
-        let (events, _) = self
+        let commit_notification = self
             .chunk_executor
             .execute_and_commit_chunk(
                 txn_list_with_proof,
@@ -122,7 +122,7 @@ impl<C: ChunkExecutorTrait> ExecutorProxyTrait for ExecutorProxy<C> {
                 Error::UnexpectedError(format!("Execute and commit chunk failed: {}", error))
             })?;
         timer.stop_and_record();
-        if let Err(e) = self.publish_event_notifications(events) {
+        if let Err(e) = self.publish_event_notifications(commit_notification.committed_events) {
             error!(
                 LogSchema::event_log(LogEntry::Reconfig, LogEvent::Fail).error(&e),
                 "Failed to publish reconfig updates in execute_chunk"

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -283,11 +283,13 @@ impl<
         &self,
         consensus_commit_notification: &ConsensusCommitNotification,
     ) {
+        // Update the driver metrics
         metrics::increment_counter(
             &metrics::DRIVER_COUNTERS,
             metrics::DRIVER_CONSENSUS_COMMIT_NOTIFICATION,
         );
 
+        // Update the synced versions
         let operations = [
             metrics::StorageSynchronizerOperations::ExecutedTransactions,
             metrics::StorageSynchronizerOperations::Synced,
@@ -297,6 +299,18 @@ impl<
                 &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
                 operation.get_label(),
                 consensus_commit_notification.transactions.len() as u64,
+            );
+        }
+
+        // Update the synced epoch
+        if !consensus_commit_notification
+            .reconfiguration_events
+            .is_empty()
+        {
+            metrics::increment_gauge(
+                &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+                metrics::StorageSynchronizerOperations::SyncedEpoch.get_label(),
+                1,
             );
         }
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -34,7 +34,7 @@ use tokio::time::{interval, Duration};
 use tokio_stream::wrappers::IntervalStream;
 
 // Useful constants for the driver
-const DRIVER_ERROR_LOG_FREQ_SECS: u64 = 1;
+const DRIVER_ERROR_LOG_FREQ_SECS: u64 = 3;
 
 /// The configuration of the state sync driver
 #[derive(Clone)]

--- a/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
@@ -16,6 +16,7 @@ pub enum StorageSynchronizerOperations {
     ExecutedTransactions,      // Executed a chunk of transactions.
     Synced,                    // Wrote a chunk of transactions and outputs to storage.
     SyncedAccounts,            // Wrote a chunk of accounts to storage.
+    SyncedEpoch, // Wrote a chunk of transactions and outputs to storage that resulted in a new epoch.
 }
 
 impl StorageSynchronizerOperations {
@@ -27,6 +28,7 @@ impl StorageSynchronizerOperations {
             StorageSynchronizerOperations::ExecutedTransactions => "executed_transactions",
             StorageSynchronizerOperations::Synced => "synced",
             StorageSynchronizerOperations::SyncedAccounts => "synced_accounts",
+            StorageSynchronizerOperations::SyncedEpoch => "synced_epoch",
         }
     }
 }


### PR DESCRIPTION
## Motivation

This PR offers some small cleanups to the state sync logs and adds new metrics to track epoch changes.

The PR offers the following commits:
1. Add sampling around stream request errors (to prevent log spamming when streams can't be created).
2. Add a state sync metric to track epoch changes.
3. Reduce the log frequency of driver errors and cleanup a small telemetry log.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manual verification.

## Related PRs

None.