### PR TITLE
[CICD] add github workflow to build and release aptos CLI

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -1,0 +1,68 @@
+# This defines a workflow to build and release a new version of the aptos CLI.
+# In order to trigger it go to the Actions Tab of the Repo, click "Release CLI" and then "Run Workflow".
+
+name: "Release CLI"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        type: string
+        required: true
+        description: "The release tag to create. E.g. `aptos-cli-v0.2.3` :"
+      source_git_ref_override:
+        type: string
+        required: false
+        description: "GIT_SHA1_OVERRIDE: Use this to override the Git SHA1, branch or tag to build the binaries from. Defaults to the workflow Git REV, but can be different than that:"
+
+jobs:
+  build-linux-binary:
+    name: "Build Linux binary"
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh
+      - name: Upload Binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cli-builds
+          path: aptos-cli-*.zip
+
+  build-os-x-binary:
+    name: "Build OS X binary"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh
+      - name: Upload Binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cli-builds
+          path: aptos-cli-*.zip
+
+  release-binaries:
+    name: "Release binaries"
+    needs:
+      - build-linux-binary
+      - build-os-x-binary
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: cli-builds
+
+      - name: Create GitHub Release
+        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ github.event.inputs.release_tag }}"
+          prerelease: false
+          files: |
+            aptos-cli-*.zip

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -8,6 +8,9 @@
 ###########################################
 
 # Note: This must be run from the root of the aptos-core repository
+
+set -e
+
 NAME='aptos-cli'
 CRATE_NAME='aptos'
 CARGO_PATH="crates/$CRATE_NAME/Cargo.toml"
@@ -27,12 +30,6 @@ fi
 
 echo "Building release $VERSION of $NAME for $OS-$ARCH"
 cargo build -p $CRATE_NAME --profile cli
-
-EXIT_CODE=$?
-if [ "$EXIT_CODE" != "0" ]; then
-  echo "Build failed with exit code $EXIT_CODE"
-  exit $EXIT_CODE
-fi
 
 cd target/cli/
 


### PR DESCRIPTION
In order to trigger the workflow you have to go here and trigger it manually:
<img width="1283" alt="image" src="https://user-images.githubusercontent.com/1221897/169923270-237b1f4f-2b9e-47ca-892a-be64638b2a67.png">

(the workflow will only become visible in this menu after this PR is merged to main)