### PR TITLE
[Aptos Data Client] Favor sending subscription requests to priority peers.

### DIFF
--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -608,6 +608,9 @@ impl DataSummaryPoller {
             // Wait for next round before polling
             ticker.next().await;
 
+            // Update the global storage summary
+            self.data_client.update_global_summary_cache();
+
             // Fetch the prioritized and regular peers to poll (if any)
             let prioritized_peer = self.try_fetch_peer(true);
             let regular_peer = self.fetch_regular_peer(prioritized_peer.is_none());
@@ -735,9 +738,8 @@ pub(crate) fn poll_peer(
             }
         };
 
-        // Update the global storage summary and the summary for the peer
+        // Update the summary for the peer
         data_client.update_summary(peer, storage_summary);
-        data_client.update_global_summary_cache();
 
         // Log the new global data summary and update the metrics
         sample!(

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -928,10 +928,12 @@ async fn bad_peer_is_eventually_added_back() {
         }
     });
 
-    // Advance time so the poller sends a data summary request.
-    tokio::task::yield_now().await;
+    // Advance time so the poller sends data summary requests.
     let summary_poll_interval = Duration::from_millis(1_000);
-    mock_time.advance_async(summary_poll_interval).await;
+    for _ in 0..2 {
+        tokio::task::yield_now().await;
+        mock_time.advance_async(summary_poll_interval).await;
+    }
 
     // Initially this request range is serviceable by this peer.
     let global_summary = client.get_global_data_summary();


### PR DESCRIPTION
## Motivation

This PR is a small follow-up from https://github.com/aptos-labs/aptos-core/pull/1046. It offers two small changes (in separate commits):
1. When handling storage service requests, we send requests to any peers that can service them except for the case of subscription and storage summary requests, where we favor priority peers over regular peers (to help ensure latency is decreased).
2. We move calculation of the overall aggregate summary out of the poller and into the main loop. This makes more sense semantically, i.e., each poller should only update the data for the peer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

None.

## Test Plan

The existing unit tests have been updated to handle both cases.

## Related PRs

None.
