### PR TITLE
Updated outdated versions

### DIFF
--- a/ecosystem/platform/client/package-lock.json
+++ b/ecosystem/platform/client/package-lock.json
@@ -16,15 +16,15 @@
         "@testing-library/react": "^13.1.1",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.4.1",
-        "@types/node": "^16.11.27",
+        "@types/node": "^16.11.32",
         "@types/react": "^18.0.5",
-        "@types/react-dom": "^18.0.1",
+        "@types/react-dom": "^18.0.3",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-ga4": "^1.4.1",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
-        "typescript": "^4.6.3",
+        "typescript": "^4.6.4",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -3356,9 +3356,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
-      "version": "16.11.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.29.tgz",
-      "integrity": "sha512-9dDdonLyPJQJ/kdOlDxAah+bTI+u2ccF3k62FErhquDuggoCX6piWez7j7o6yNE+rP2IRcZVQ6Tw4N0P38+rWA=="
+      "version": "16.11.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
+      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3401,9 +3401,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.2.tgz",
-      "integrity": "sha512-UxeS+Wtj5bvLRREz9tIgsK4ntCuLDo0EcAcACgw3E+9wE8ePDr9uQpq53MfcyxyIS55xJ+0B6mDS8c4qkkHLBg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.3.tgz",
+      "integrity": "sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -13594,9 +13594,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16977,9 +16977,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/node": {
-      "version": "16.11.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.29.tgz",
-      "integrity": "sha512-9dDdonLyPJQJ/kdOlDxAah+bTI+u2ccF3k62FErhquDuggoCX6piWez7j7o6yNE+rP2IRcZVQ6Tw4N0P38+rWA=="
+      "version": "16.11.32",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.32.tgz",
+      "integrity": "sha512-+fnfNvG5JQdC1uGZiTx+0QVtoOHcggy6+epx65JYroPGsE1uhp+vo5kioiGKsAkor6ocwHteU2EvO7N8vtOZtA=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -17022,9 +17022,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.2.tgz",
-      "integrity": "sha512-UxeS+Wtj5bvLRREz9tIgsK4ntCuLDo0EcAcACgw3E+9wE8ePDr9uQpq53MfcyxyIS55xJ+0B6mDS8c4qkkHLBg==",
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.3.tgz",
+      "integrity": "sha512-1RRW9kst+67gveJRYPxGmVy8eVJ05O43hg77G2j5m76/RFJtMbcfAs2viQ2UNsvvDg8F7OfQZx8qQcl6ymygaQ==",
       "requires": {
         "@types/react": "*"
       }
@@ -24359,9 +24359,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw=="
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/ecosystem/platform/client/package.json
+++ b/ecosystem/platform/client/package.json
@@ -11,15 +11,15 @@
     "@testing-library/react": "^13.1.1",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.4.1",
-    "@types/node": "^16.11.27",
+    "@types/node": "^16.11.32",
     "@types/react": "^18.0.5",
-    "@types/react-dom": "^18.0.1",
+    "@types/react-dom": "^18.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-ga4": "^1.4.1",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
-    "typescript": "^4.6.3",
+    "typescript": "^4.6.4",
     "web-vitals": "^2.1.4"
   },
   "scripts": {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)
**Updated outdated versions**

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
Yes.
(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)
**Signed and submitted**
## Test Plan
Changes should work. Updated versions. Everything looks fine on my end. Since I only updated outdated versions, there should be no issues.
The following updates were made:
upgrade typescript from 4.6.3 to 4.6.4.
* The recommended version is 1 version ahead of your current version.
* The recommended version was released 23 days ago, on 2022-04-28.

upgrade @types/react-dom from 18.0.2 to 18.0.3.
* The recommended version is 1 version ahead of your current version.
* The recommended version was released 23 days ago, on 2022-04-28.

@types/node from 16.11.29 to 16.11.32.
* The recommended version is 3 versions ahead of your current version.
* The recommended version was released 23 days ago, on 2022-04-28.
(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
