### PR TITLE
[CI] Avoid building `cargo sort` for all pipelines.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
       - run: cargo x lint
       - run: cargo xclippy --workspace --all-targets
       - run: cargo xfmt --check
+      - run: cargo install cargo-sort
       # Temporary workaround for unsorted hakari generated Cargo files (https://github.com/DevinR528/cargo-sort/issues/38).
       - run: cargo sort --grouped crates/aptos-workspace-hack
       - run: cargo sort --grouped --check --workspace
@@ -47,7 +48,7 @@ jobs:
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
       - run: echo "export RUST_BACKTRACE=full" >> $BASH_ENV
       - run: echo "export INDEXER_DATABASE_URL=postgresql://postgres@localhost/postgres" >> $BASH_ENV
-      # --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries
+      # --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
       - run: cargo nextest --nextest-profile ci --partition hash:1/1 --package smoke-test --test-threads 6 --retries 3
   unit-test:
     executor: ubuntu-2xl
@@ -426,7 +427,6 @@ commands:
       - run: sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config --no-install-recommends --assume-yes
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
       - run: cat $HOME/.cargo/env >> $BASH_ENV
-      - run: cargo install cargo-sort
   deploy-setup:
     steps:
       - kubernetes/install-kubectl:


### PR DESCRIPTION
## Motivation

This PR updates the circleci script to avoid building `cargo sort` for all steps (i.e., linting, unit tests and e2e tests). Instead, we only need to build it for linting. This should reduce the other pipelines by ~1 minute each.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

CI/CD.

## Related PRs

None.
