### PR TITLE
[aptos-cli] Make it so full node network key is not required for setting validator configuration

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -356,6 +356,15 @@ pub struct PromptOptions {
     pub assume_no: bool,
 }
 
+impl PromptOptions {
+    pub fn yes() -> Self {
+        Self {
+            assume_yes: true,
+            assume_no: false,
+        }
+    }
+}
+
 /// An insertable option for use with encodings.
 #[derive(Debug, Parser)]
 pub struct EncodingOptions {

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -23,10 +23,10 @@ pub const LAYOUT_NAME: &str = "layout";
 #[derive(Parser)]
 pub struct SetupGit {
     #[clap(flatten)]
-    git_options: GitOptions,
+    pub(crate) git_options: GitOptions,
     /// Path to `Layout` which defines where all the files are
     #[clap(long, parse(from_os_str))]
-    layout_file: PathBuf,
+    pub(crate) layout_file: PathBuf,
 }
 
 #[async_trait]
@@ -49,7 +49,7 @@ impl CliCommand<()> for SetupGit {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct GithubRepo {
     owner: String,
     repository: String,
@@ -71,20 +71,20 @@ impl FromStr for GithubRepo {
     }
 }
 
-#[derive(Clone, Parser)]
+#[derive(Clone, Default, Parser)]
 pub struct GitOptions {
     /// Github repository e.g. 'aptos-labs/aptos-core'
     #[clap(long)]
-    github_repository: Option<GithubRepo>,
+    pub(crate) github_repository: Option<GithubRepo>,
     /// Github repository branch e.g. main
     #[clap(long, default_value = "main")]
-    github_branch: String,
+    pub(crate) github_branch: String,
     /// Path to Github API token.  Token must have repo:* permissions
     #[clap(long, parse(from_os_str))]
-    github_token_file: Option<PathBuf>,
+    pub(crate) github_token_file: Option<PathBuf>,
     /// Path to local git repository
     #[clap(long, parse(from_os_str))]
-    local_repository_dir: Option<PathBuf>,
+    pub(crate) local_repository_dir: Option<PathBuf>,
 }
 
 impl GitOptions {

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -30,10 +30,10 @@ const VFN_FILE: &str = "validator-full-node-identity.yaml";
 #[derive(Parser)]
 pub struct GenerateKeys {
     #[clap(flatten)]
-    prompt_options: PromptOptions,
+    pub(crate) prompt_options: PromptOptions,
     /// Output path for the three keys
     #[clap(long, parse(from_os_str), default_value = ".")]
-    output_dir: PathBuf,
+    pub(crate) output_dir: PathBuf,
 }
 
 #[async_trait]
@@ -116,21 +116,21 @@ pub struct PrivateIdentity {
 pub struct SetValidatorConfiguration {
     /// Username
     #[clap(long)]
-    username: String,
+    pub(crate) username: String,
     #[clap(flatten)]
-    git_options: GitOptions,
+    pub(crate) git_options: GitOptions,
     /// Path to folder with account.key, consensus.key, and network.key
     #[clap(long, parse(from_os_str), default_value = ".")]
-    keys_dir: PathBuf,
+    pub(crate) keys_dir: PathBuf,
     /// Host and port pair for the validator e.g. 127.0.0.1:6180
     #[clap(long)]
-    validator_host: HostAndPort,
+    pub(crate) validator_host: HostAndPort,
     /// Host and port pair for the fullnode e.g. 127.0.0.1:6180
     #[clap(long)]
-    full_node_host: Option<HostAndPort>,
+    pub(crate) full_node_host: Option<HostAndPort>,
     /// Stake amount for stake distribution
     #[clap(long, default_value = "1")]
-    stake_amount: u64,
+    pub(crate) stake_amount: u64,
 }
 
 #[async_trait]

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -148,7 +148,12 @@ impl CliCommand<()> for SetValidatorConfiguration {
         let account_key = key_files.account_key.public_key();
         let consensus_key = key_files.consensus_key.public_key();
         let validator_network_key = key_files.validator_network_key.public_key();
-        let full_node_network_key = key_files.full_node_network_key.public_key();
+
+        let full_node_network_key = if self.full_node_host.is_some() {
+            Some(key_files.full_node_network_key.public_key())
+        } else {
+            None
+        };
 
         let credentials = ValidatorConfiguration {
             account_address,

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -4,6 +4,8 @@
 pub mod config;
 pub mod git;
 pub mod keys;
+#[cfg(test)]
+mod tests;
 
 use crate::{
     common::{

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -1,0 +1,165 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    common::{types::PromptOptions, utils::write_to_file},
+    genesis::{
+        config::{HostAndPort, Layout},
+        git::{GitOptions, SetupGit},
+        keys::{GenerateKeys, SetValidatorConfiguration},
+        GenerateGenesis,
+    },
+    op::key::GenerateKey,
+    CliCommand,
+};
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    PrivateKey,
+};
+use aptos_temppath::TempPath;
+use aptos_types::chain_id::ChainId;
+use move_deps::move_binary_format::access::ModuleAccess;
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+/// Test the E2E genesis flow since it doesn't require a node to run
+#[tokio::test]
+async fn test_genesis_e2e_flow() {
+    let user_a = "user_a".to_string();
+    let user_b = "user_b".to_string();
+    let chain_id = ChainId::test();
+
+    // First step is setup the local git repo
+    let root_private_key = GenerateKey::generate_ed25519_in_memory();
+    let git_options = setup_git_dir(
+        &root_private_key,
+        vec![user_a.clone(), user_b.clone()],
+        chain_id,
+    )
+    .await;
+
+    // Now create the two users
+    let user_a_dir = generate_keys().await;
+    add_public_keys(user_a, git_options.clone(), user_a_dir.path()).await;
+    let user_b_dir = generate_keys().await;
+    add_public_keys(user_b, git_options.clone(), user_b_dir.path()).await;
+
+    // Now generate genesis
+    let output_dir = TempPath::new();
+    output_dir.create_as_dir().unwrap();
+    let output_dir = PathBuf::from(output_dir.path());
+    generate_genesis(git_options, output_dir.clone()).await;
+
+    // TODO: Verify that these are good
+    let waypoint_file = output_dir.join("waypoint.txt");
+    assert!(waypoint_file.exists());
+    let genesis_file = output_dir.join("genesis.blob");
+    assert!(genesis_file.exists());
+}
+
+/// Generate genesis and waypoint
+async fn generate_genesis(git_options: GitOptions, output_dir: PathBuf) {
+    let command = GenerateGenesis {
+        prompt_options: PromptOptions::yes(),
+        git_options,
+        output_dir,
+    };
+    let _ = command.execute().await.unwrap();
+}
+
+/// Setup a temporary repo location and add all required pieces
+async fn setup_git_dir(
+    root_private_key: &Ed25519PrivateKey,
+    users: Vec<String>,
+    chain_id: ChainId,
+) -> GitOptions {
+    let git_options = git_options();
+    let layout_file = create_layout_file(root_private_key.public_key(), users, chain_id);
+    let layout_file = PathBuf::from(layout_file.path());
+    let setup_command = SetupGit {
+        git_options: git_options.clone(),
+        layout_file,
+    };
+
+    setup_command
+        .execute()
+        .await
+        .expect("Should not fail creating repo folder");
+
+    // Add framework
+    add_framework_to_dir(git_options.local_repository_dir.as_ref().unwrap().as_path());
+    git_options
+}
+
+/// Add framework modules to git directory
+fn add_framework_to_dir(git_dir: &Path) {
+    let framework_dir = git_dir.join("framework");
+    cached_framework_packages::modules_with_blobs().for_each(|(blob, module)| {
+        let module_name = module.name();
+        let file = framework_dir.join(format!("{}.mv", module_name));
+        write_to_file(file.as_path(), module_name.as_str(), blob).unwrap();
+    });
+}
+
+/// Local git options for testing
+fn git_options() -> GitOptions {
+    let temp_path = TempPath::new();
+    let path = PathBuf::from(temp_path.path());
+    GitOptions {
+        local_repository_dir: Some(path),
+        ..Default::default()
+    }
+}
+
+/// Create a layout file for the repo
+fn create_layout_file(
+    root_public_key: Ed25519PublicKey,
+    users: Vec<String>,
+    chain_id: ChainId,
+) -> TempPath {
+    let layout = Layout {
+        root_key: root_public_key,
+        users,
+        chain_id,
+    };
+    let file = TempPath::new();
+    file.create_as_file().unwrap();
+
+    write_to_file(
+        file.path(),
+        "Layout file",
+        serde_yaml::to_string(&layout).unwrap().as_bytes(),
+    )
+    .unwrap();
+    file
+}
+
+/// Generate keys for a "user"
+async fn generate_keys() -> TempPath {
+    let dir = TempPath::new();
+    dir.create_as_dir().unwrap();
+    let output_dir = PathBuf::from(dir.path());
+    let command = GenerateKeys {
+        prompt_options: PromptOptions::yes(),
+        output_dir,
+    };
+    let _ = command.execute().await.unwrap();
+
+    dir
+}
+
+/// Set validator configuration for a user
+async fn add_public_keys(username: String, git_options: GitOptions, keys_dir: &Path) {
+    let command = SetValidatorConfiguration {
+        username,
+        git_options,
+        keys_dir: PathBuf::from(keys_dir),
+        validator_host: HostAndPort::from_str("localhost:6180").unwrap(),
+        full_node_host: None,
+        stake_amount: 1,
+    };
+
+    command.execute().await.unwrap()
+}


### PR DESCRIPTION
## Motivation

Fixes a small bug so that full node network key is not required.  Additionally adds a simple E2E test.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

See test