### PR TITLE
[ecosystem] Enable caching in production.

### DIFF
--- a/ecosystem/platform/server/config/environments/production.rb
+++ b/ecosystem/platform/server/config/environments/production.rb
@@ -65,8 +65,8 @@ Rails.application.configure do
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 
-  # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # TODO: Use a different cache store in production.
+  config.cache_store = :memory_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :delayed


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Turn on caching in production (which is necessary to make the leaderboard fast). Use the `:memory_store` for now. Eventually we will switch to a redis-backed cache so that the cache can be shared between server processes.

## Test Plan

Manually tested with RAILS_ENV=production

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
