### PR TITLE
[circleci][forge] push circle build num to pgw to track failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
             FORGE_COMMENT=$(awk '{printf "%s\\n", $0}' forge_comment.txt)
 
             # TODO(rustielin): report cluster name
-            echo "forge_job_status $FGI_EXIT_CODE" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
+            echo "forge_job_status {FGI_EXIT_CODE=\"$FGI_EXIT_CODE\"} $CIRCLE_BUILD_NUM" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
 
             # post github comment on the PR
             curl -s -H "Authorization: token ${FORGE_GH_TOKEN}" \


### PR DESCRIPTION
To improve Forge observability, push the CircleCI build ID and job status to pushgateway. We can alert on count of `forge_job_status{FGI_EXIT_CODE!="0"}` over time. Swapped the Build ID and job status exit code for performance reasons