### PR TITLE
Update Transfer Flow, refactoring using react-query

### DIFF
--- a/ecosystem/web-wallet/src/core/components/BoringAvatar.tsx
+++ b/ecosystem/web-wallet/src/core/components/BoringAvatar.tsx
@@ -1,0 +1,58 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import React from 'react';
+
+interface BoringAvatarProps {
+  type?: 'beam' | 'marble'
+}
+
+/**
+ * @see https://boringavatars.com/
+ */
+export function GraceHopperBoringAvatar({
+  type = 'beam',
+}: BoringAvatarProps) {
+  const marble = (
+    <svg viewBox="0 0 80 80" fill="none" role="img" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
+      <title>Grace Hopper</title>
+      <mask id="mask__marble" maskUnits="userSpaceOnUse" x="0" y="0" width="80" height="80"><rect width="80" height="80" rx="160" fill="#FFFFFF" /></mask>
+      <g mask="url(#mask__marble)">
+        <rect width="80" height="80" fill="#efb0a9" />
+        <path filter="url(#prefix__filter0_f)" d="M32.414 59.35L50.376 70.5H72.5v-71H33.728L26.5 13.381l19.057 27.08L32.414 59.35z" fill="#bda0a2" transform="translate(0 0) rotate(-88 40 40) scale(1.2)" />
+        <path filter="url(#prefix__filter0_f)" d="M22.216 24L0 46.75l14.108 38.129L78 86l-3.081-59.276-22.378 4.005 12.972 20.186-23.35 27.395L22.215 24z" fill="#ffe6db" transform="translate(4 4) rotate(132 40 40) scale(1.2)" style={{ mixBlendMode: 'overlay' }} />
+      </g>
+      <defs>
+        <filter id="prefix__filter0_f" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feGaussianBlur stdDeviation="7" result="effect1_foregroundBlur" />
+        </filter>
+      </defs>
+    </svg>
+  );
+
+  const beam = (
+    <svg viewBox="0 0 36 36" fill="none" role="img" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
+      <title>Grace Hopper</title>
+      <mask id="mask__beam" maskUnits="userSpaceOnUse" x="0" y="0" width="36" height="36"><rect width="36" height="36" rx="72" fill="#FFFFFF" /></mask>
+      <g mask="url(#mask__beam)">
+        <rect width="36" height="36" fill="#d1eaee" />
+        <rect x="0" y="0" width="36" height="36" transform="translate(0 8) rotate(44 18 18) scale(1.2)" fill="#efb0a9" rx="36" />
+        <g transform="translate(-4 4) rotate(-4 18 18)">
+          <path d="M13,21 a1,0.75 0 0,0 10,0" fill="#000000" />
+          <rect x="10" y="14" width="1.5" height="2" rx="1" stroke="none" fill="#000000" />
+          <rect x="24" y="14" width="1.5" height="2" rx="1" stroke="none" fill="#000000" />
+        </g>
+      </g>
+    </svg>
+  );
+
+  switch (type) {
+    case 'marble': return marble;
+    case 'beam': return beam;
+    default: return beam;
+  }
+}
+
+export default GraceHopperBoringAvatar;

--- a/ecosystem/web-wallet/src/core/components/CreateNFTModal.tsx
+++ b/ecosystem/web-wallet/src/core/components/CreateNFTModal.tsx
@@ -24,7 +24,6 @@ import { useMutation, useQueryClient } from 'react-query';
 import React from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import useWalletState from 'core/hooks/useWalletState';
-import { Inputs } from 'pages/Wallet';
 import { secondaryTextColor } from 'pages/Login';
 import { NODE_URL } from 'core/constants';
 import { AptosAccountState } from 'core/types';
@@ -32,14 +31,14 @@ import { AptosAccountState } from 'core/types';
 // eslint-disable-next-line global-require
 window.Buffer = window.Buffer || require('buffer').Buffer;
 
-const defaultRequestErrorAttributes = {
+export const defaultRequestErrorAttributes = {
   config: {},
   headers: {},
   status: 400,
   statusText: 'Move abort',
 };
 
-interface RaiseForErrorProps {
+export interface RaiseForErrorProps {
   vmStatus: string
 }
 
@@ -135,7 +134,7 @@ export default function CreateNFTModal() {
 
   const errorMessage = error?.response?.data?.message;
 
-  const onSubmit: SubmitHandler<Inputs> = async (_data, event) => {
+  const onSubmit: SubmitHandler<Record<string, any>> = async (_data, event) => {
     event?.preventDefault();
     await createTokenAndCollectionOnClick();
     await queryClient.refetchQueries(['gallery-items']);

--- a/ecosystem/web-wallet/src/core/components/TransferDrawer.tsx
+++ b/ecosystem/web-wallet/src/core/components/TransferDrawer.tsx
@@ -1,0 +1,289 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  Flex,
+  Grid,
+  Input,
+  InputGroup,
+  InputRightAddon,
+  SimpleGrid,
+  Tag,
+  Text,
+  useColorMode,
+  useDisclosure,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import React, { useMemo, useRef } from 'react';
+import { IoIosSend } from 'react-icons/io';
+import useWalletState from 'core/hooks/useWalletState';
+import {
+  accountExists,
+  getAccountResources,
+  getTestCoinTokenBalanceFromAccountResources,
+  getToAddressAccountExists,
+} from 'core/queries/account';
+import { submitTestCoinTransferTransaction } from 'core/mutations/transaction';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { getUserTransaction } from 'core/queries/transaction';
+import { ExternalLinkIcon } from '@chakra-ui/icons';
+import {
+  NODE_URL,
+  secondaryErrorMessageColor, STATIC_GAS_AMOUNT,
+} from 'core/constants';
+import numeral from 'numeral';
+import { GraceHopperBoringAvatar } from 'core/components/BoringAvatar';
+import { secondaryTextColor } from '../../pages/Login';
+
+export const secondaryDividerColor = {
+  dark: 'whiteAlpha.300',
+  light: 'gray.200',
+};
+
+function TransferDrawer() {
+  const { colorMode } = useColorMode();
+  const { aptosAccount } = useWalletState();
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const {
+    formState: { errors }, handleSubmit, register, setError, watch,
+  } = useForm();
+  const addressInputRef = useRef<HTMLInputElement>();
+  const { isOpen, onClose, onOpen } = useDisclosure();
+  const {
+    isLoading: isTransferLoading,
+    mutateAsync: submitSendTransaction,
+  } = useMutation(submitTestCoinTransferTransaction, {
+    onSettled: async (txnHash) => {
+      if (!txnHash) {
+        return;
+      }
+      queryClient.invalidateQueries('getAccountResources');
+      const txn = await getUserTransaction({ txnHashOrVersion: txnHash });
+      const amount = (txn?.payload)
+        ? (txn.payload as { arguments: string[] }).arguments[1]
+        : undefined;
+      toast({
+        description: (txn?.success) ? `Amount transferred: ${amount}, gas consumed: ${txn?.gas_used}` : `Transfer failed, gas consumed: ${txn?.gas_used}`,
+        duration: 5000,
+        isClosable: true,
+        status: (txn?.success) ? 'success' : 'error',
+        title: `Transaction ${txn?.success ? 'success' : 'error'}`,
+        variant: 'solid',
+      });
+    },
+  });
+
+  const transferAmount: string | undefined | null = watch('transferAmount');
+  const transferAmountNumeral = numeral(transferAmount).format('0,0');
+
+  const {
+    onChange: addressOnChange,
+    ref: toAddressRef,
+    ...toAddressRest
+  } = { ...register('toAddress') };
+  const toAddress: string | undefined | null = watch('toAddress');
+  const explorerAddress = `https://explorer.devnet.aptos.dev/account/${toAddress}`;
+  const { data: toAddressAccountExists } = useQuery(
+    ['getToAddressAccountExists', { aptosAccount, toAddress }],
+    getToAddressAccountExists,
+  );
+
+  const onSubmit: SubmitHandler<Record<string, any>> = async (data, event) => {
+    event?.preventDefault();
+    if (toAddress && aptosAccount && transferAmount) {
+      const toAccountExists = await accountExists({ address: toAddress });
+      if (!toAccountExists) {
+        setError('toAddress', { message: 'Invalid account address', type: 'custom' });
+        return;
+      }
+      const fromAccountResources = await getAccountResources({
+        address: aptosAccount.address().hex(),
+        nodeUrl: NODE_URL,
+      });
+      const tokenBalance = getTestCoinTokenBalanceFromAccountResources({
+        accountResources: fromAccountResources,
+      });
+      if (Number(transferAmount) >= Number(tokenBalance) - STATIC_GAS_AMOUNT) {
+        setError('toAddress', { message: 'Insufficient balance', type: 'custom' });
+        return;
+      }
+      await submitSendTransaction({
+        amount: transferAmount,
+        fromAccount: aptosAccount,
+        onClose,
+        toAddress,
+      });
+    }
+  };
+
+  const toAddressStatus = useMemo(() => {
+    if (!toAddress) {
+      return 'Please enter an address';
+    } if (toAddressAccountExists && toAddress) {
+      return toAddress;
+    }
+    return 'Invalid address';
+  }, [toAddressAccountExists, toAddress]);
+  return (
+    <>
+      <Button
+        isLoading={isTransferLoading}
+        isDisabled={isTransferLoading}
+        leftIcon={<IoIosSend />}
+        onClick={onOpen}
+      >
+        Send
+      </Button>
+      <Drawer
+        size="xl"
+        onClose={onClose}
+        isOpen={isOpen}
+        placement="bottom"
+        initialFocusRef={(addressInputRef as React.RefObject<HTMLInputElement>)}
+      >
+        <DrawerOverlay />
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <DrawerContent>
+            <DrawerHeader borderBottomWidth="1px">
+              <Grid templateColumns="32px 1fr" gap={4} maxW="100%">
+                <Box pt={1}>
+                  <Box width="32px">
+                    <GraceHopperBoringAvatar type={(toAddressAccountExists) ? 'beam' : 'marble'} />
+                  </Box>
+                </Box>
+                <VStack boxSizing="border-box" spacing={0} alignItems="flex-start" width="100%" maxW="100%">
+                  <Text
+                    fontSize="md"
+                    noOfLines={1}
+                    maxW="280px"
+                  >
+                    {toAddressStatus}
+                  </Text>
+                  {toAddressAccountExists ? (
+                    <Button
+                      color={secondaryTextColor[colorMode]}
+                      fontSize="sm"
+                      fontWeight={400}
+                      height="24px"
+                      as="a"
+                      target="_blank"
+                      rightIcon={<ExternalLinkIcon />}
+                      variant="unstyled"
+                      cursor="pointer"
+                      href={explorerAddress}
+                    >
+                      View on explorer
+                    </Button>
+                  ) : (
+                    <Button
+                      color={secondaryTextColor[colorMode]}
+                      fontSize="sm"
+                      fontWeight={400}
+                      height="24px"
+                      variant="unstyled"
+                      cursor="default"
+                    >
+                      Account not found
+                    </Button>
+                  )}
+                </VStack>
+              </Grid>
+            </DrawerHeader>
+            <DrawerBody px={0}>
+              <VStack spacing={4}>
+                <VStack
+                  py={10}
+                >
+                  <Text color={secondaryTextColor[colorMode]}>Send</Text>
+                  <Text
+                    fontSize="5xl"
+                    fontWeight={600}
+                    noOfLines={1}
+                    maxW="250px"
+                  >
+                    {transferAmountNumeral}
+                  </Text>
+                  <Tag
+                    borderRadius="full"
+                    variant="solid"
+                  >
+                    coins
+                  </Tag>
+                </VStack>
+                <VStack
+                  borderTopWidth="1px"
+                  borderTopColor={secondaryDividerColor[colorMode]}
+                  pt={4}
+                  px={6}
+                  width="100%"
+                >
+                  <InputGroup>
+                    <Input
+                      variant="filled"
+                      placeholder="To address"
+                      required
+                      maxLength={70}
+                      minLength={60}
+                      onChange={addressOnChange}
+                      autoComplete="off"
+                      ref={(e) => {
+                        toAddressRef(e);
+                        addressInputRef.current = e || undefined;
+                      }}
+                      {...toAddressRest}
+                    />
+                  </InputGroup>
+                  <InputGroup>
+                    <Input
+                      type="number"
+                      variant="filled"
+                      placeholder="Transfer amount"
+                      min={0}
+                      required
+                      {...register('transferAmount')}
+                    />
+                    <InputRightAddon>
+                      coins
+                    </InputRightAddon>
+                  </InputGroup>
+                  <Flex overflowY="auto" maxH="100px">
+                    <Text
+                      fontSize="xs"
+                      color={secondaryErrorMessageColor[colorMode]}
+                      wordBreak="break-word"
+                    >
+                      {errors?.toAddress?.message}
+                    </Text>
+                  </Flex>
+                </VStack>
+              </VStack>
+            </DrawerBody>
+            <DrawerFooter borderTopColor={secondaryDividerColor[colorMode]} borderTopWidth="1px">
+              <SimpleGrid spacing={4} width="100%" columns={2}>
+                <Button colorScheme="teal" isLoading={isTransferLoading} isDisabled={isTransferLoading} type="submit">
+                  Submit
+                </Button>
+                <Button onClick={onClose} isDisabled={isTransferLoading}>
+                  Cancel
+                </Button>
+              </SimpleGrid>
+            </DrawerFooter>
+          </DrawerContent>
+        </form>
+      </Drawer>
+    </>
+  );
+}
+
+export default TransferDrawer;

--- a/ecosystem/web-wallet/src/core/components/WalletAccountBalance.tsx
+++ b/ecosystem/web-wallet/src/core/components/WalletAccountBalance.tsx
@@ -1,0 +1,33 @@
+import {
+  Heading, Text, useColorMode, VStack,
+} from '@chakra-ui/react';
+import React from 'react';
+import { seconaryAddressFontColor } from 'core/components/WalletHeader';
+import { getAccountResources, getTestCoinTokenBalanceFromAccountResources } from 'core/queries/account';
+import { useQuery } from 'react-query';
+import useWalletState from 'core/hooks/useWalletState';
+import numeral from 'numeral';
+
+function WalletAccountBalance() {
+  const { colorMode } = useColorMode();
+  const { aptosAccount } = useWalletState();
+  const {
+    data: accountResources,
+  } = useQuery(
+    'getAccountResources',
+    () => getAccountResources({ address: aptosAccount?.address() }),
+    { refetchInterval: 2000 },
+  );
+
+  const tokenBalance = getTestCoinTokenBalanceFromAccountResources({ accountResources });
+  const tokenBalanceString = numeral(tokenBalance).format('0,0.0000');
+
+  return (
+    <VStack>
+      <Text fontSize="sm" color={seconaryAddressFontColor[colorMode]}>Account balance</Text>
+      <Heading>{tokenBalanceString}</Heading>
+    </VStack>
+  );
+}
+
+export default WalletAccountBalance;

--- a/ecosystem/web-wallet/src/core/constants.ts
+++ b/ecosystem/web-wallet/src/core/constants.ts
@@ -3,6 +3,7 @@
 
 export const KEY_LENGTH: number = 64;
 export const WALLET_STATE_LOCAL_STORAGE_KEY = 'aptosWalletState';
+export const WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY = 'aptosWalletNetworkState';
 
 export const STATIC_GAS_AMOUNT = 150;
 

--- a/ecosystem/web-wallet/src/core/hooks/useWalletState.ts
+++ b/ecosystem/web-wallet/src/core/hooks/useWalletState.ts
@@ -4,8 +4,9 @@
 import { useState, useCallback } from 'react';
 import constate from 'constate';
 import { getAptosAccountState, getLocalStorageState } from 'core/utils/account';
-import { WALLET_STATE_LOCAL_STORAGE_KEY } from 'core/constants';
+import { WALLET_STATE_LOCAL_STORAGE_KEY, WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY } from 'core/constants';
 import { AptosAccountState, LocalStorageState } from 'core/types';
+import { AptosNetwork, getLocalStorageNetworkState } from 'core/utils/network';
 
 const defaultValue: LocalStorageState = {
   aptosAccountObject: undefined,
@@ -21,6 +22,9 @@ export default function useWalletState() {
   );
 
   const [aptosAccount, setAptosAccount] = useState<AptosAccountState>(() => getAptosAccountState());
+  const [aptosNetwork, setAptosNetwork] = useState<AptosNetwork | null>(
+    () => getLocalStorageNetworkState(),
+  );
 
   const updateWalletState = useCallback(({ aptosAccountState }: UpdateWalletStateProps) => {
     try {
@@ -34,6 +38,16 @@ export default function useWalletState() {
     }
   }, []);
 
+  const updateNetworkState = useCallback((network: AptosNetwork) => {
+    try {
+      setAptosNetwork(network);
+      window.localStorage.setItem(WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY, network);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  }, []);
+
   const signOut = useCallback(() => {
     setAptosAccount(undefined);
     setLocalStorageState({ aptosAccountObject: undefined });
@@ -41,7 +55,12 @@ export default function useWalletState() {
   }, []);
 
   return {
-    aptosAccount, signOut, updateWalletState, walletState: localStorageState,
+    aptosAccount,
+    aptosNetwork,
+    signOut,
+    updateNetworkState,
+    updateWalletState,
+    walletState: localStorageState,
   };
 }
 

--- a/ecosystem/web-wallet/src/core/mutations/transaction.ts
+++ b/ecosystem/web-wallet/src/core/mutations/transaction.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AptosAccount, AptosClient, MaybeHexString, Types,
+} from 'aptos';
+import { NODE_URL } from 'core/constants';
+import {
+  type GetTestCoinTokenBalanceFromAccountResourcesProps,
+} from 'core/queries/account';
+
+export interface SubmitTransactionProps {
+  fromAccount: AptosAccount;
+  nodeUrl?: string;
+  payload: Types.TransactionPayload,
+}
+
+export const submitTransaction = async ({
+  fromAccount,
+  nodeUrl = NODE_URL,
+  payload,
+}: SubmitTransactionProps) => {
+  const client = new AptosClient(nodeUrl);
+  const txnRequest = await client.generateTransaction(fromAccount.address(), payload);
+  const signedTxn = await client.signTransaction(fromAccount, txnRequest);
+  const transactionRes = await client.submitTransaction(signedTxn);
+  await client.waitForTransaction(transactionRes.hash);
+  return transactionRes.hash;
+};
+
+export interface TestCoinTransferTransactionPayload {
+  amount: string | number;
+  toAddress: MaybeHexString;
+}
+
+export type SendTestCoinTransactionProps = Omit<SubmitTransactionProps & TestCoinTransferTransactionPayload, 'payload'>;
+
+export const sendTestCoinTransaction = async ({
+  amount,
+  fromAccount,
+  nodeUrl = NODE_URL,
+  toAddress,
+}: SendTestCoinTransactionProps) => {
+  const payload: Types.TransactionPayload = {
+    arguments: [toAddress, `${amount}`],
+    function: '0x1::Coin::transfer',
+    type: 'script_function_payload',
+    type_arguments: ['0x1::TestCoin::TestCoin'],
+  };
+  const txnHash = await submitTransaction({
+    fromAccount,
+    nodeUrl,
+    payload,
+  });
+  return txnHash;
+};
+
+export const TransferResult = Object.freeze({
+  AmountOverLimit: 'Amount is over limit',
+  AmountWithGasOverLimit: 'Amount with gas is over limit',
+  IncorrectPayload: 'Incorrect transaction payload',
+  Success: 'Transaction executed successfully',
+  UndefinedAccount: 'Account does not exist',
+} as const);
+
+export type SubmitTestCoinTransferTransactionProps = Omit<
+TestCoinTransferTransactionPayload &
+SendTestCoinTransactionProps &
+GetTestCoinTokenBalanceFromAccountResourcesProps & {
+  onClose: () => void
+},
+'accountResources'
+>;
+
+export const submitTestCoinTransferTransaction = async ({
+  amount,
+  fromAccount,
+  onClose,
+  toAddress,
+}: SubmitTestCoinTransferTransactionProps) => {
+  const txnHash = await sendTestCoinTransaction({
+    amount,
+    fromAccount,
+    toAddress,
+  });
+  onClose();
+  return txnHash;
+};

--- a/ecosystem/web-wallet/src/core/queries/account.ts
+++ b/ecosystem/web-wallet/src/core/queries/account.ts
@@ -1,0 +1,97 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  AptosClient, MaybeHexString, Types,
+} from 'aptos';
+import { NODE_URL } from 'core/constants';
+import { AptosAccountState } from 'core/types';
+
+export interface GetAccountResourcesProps {
+  address?: MaybeHexString;
+  nodeUrl?: string;
+}
+
+export const getAccountResources = async ({
+  nodeUrl = NODE_URL,
+  address,
+}: GetAccountResourcesProps) => {
+  const client = new AptosClient(nodeUrl);
+  return (address) ? (client.getAccountResources(address)) : undefined;
+};
+
+export const getAccountBalanceFromAccountResources = (
+  accountResources: Types.AccountResource[] | undefined,
+): Number => {
+  if (accountResources) {
+    const accountResource = (accountResources) ? accountResources?.find((r) => r.type === '0x1::Coin::CoinStore<0x1::TestCoin::TestCoin>') : undefined;
+    const tokenBalance = (accountResource)
+      ? (accountResource.data as { coin: { value: string } }).coin.value
+      : undefined;
+    return Number(tokenBalance);
+  }
+  return -1;
+};
+
+export interface GetResourceFromAccountResources {
+  accountResources: Types.AccountResource[] | undefined;
+  resource: string
+}
+
+export const getResourceFromAccountResources = ({
+  accountResources,
+  resource,
+}: GetResourceFromAccountResources) => ((accountResources)
+  ? accountResources?.find((r) => r.type === resource)
+  : undefined);
+
+export type GetTestCoinTokenBalanceFromAccountResourcesProps = Omit<GetResourceFromAccountResources, 'resource'>;
+
+export const getTestCoinTokenBalanceFromAccountResources = ({
+  accountResources,
+}: GetTestCoinTokenBalanceFromAccountResourcesProps) => {
+  const testCoinResource = getResourceFromAccountResources({
+    accountResources,
+    resource: '0x1::Coin::CoinStore<0x1::TestCoin::TestCoin>',
+  });
+  const tokenBalance = (testCoinResource)
+    ? (testCoinResource.data as { coin: { value: string } }).coin.value
+    : undefined;
+  return tokenBalance;
+};
+
+export const accountExists = async ({
+  nodeUrl = NODE_URL,
+  address,
+}: GetAccountResourcesProps) => {
+  const client = new AptosClient(nodeUrl);
+  try {
+    if (address) {
+      const account = await client.getAccount(address);
+      return !!(account);
+    }
+  } catch (err) {
+    return false;
+  }
+  return false;
+};
+
+interface GetToAddressAccountExistsProps {
+  queryKey: (string | {
+    aptosAccount: AptosAccountState;
+    toAddress?: MaybeHexString | null;
+  })[]
+}
+
+export const getToAddressAccountExists = async (
+  { queryKey }: GetToAddressAccountExistsProps,
+) => {
+  const [, paramsObject] = queryKey;
+  if (typeof paramsObject === 'string') return false;
+  const { aptosAccount, toAddress } = paramsObject;
+  if (toAddress && aptosAccount) {
+    const doesAccountExist = await accountExists({ address: toAddress });
+    return doesAccountExist;
+  }
+  return false;
+};

--- a/ecosystem/web-wallet/src/core/queries/faucet.ts
+++ b/ecosystem/web-wallet/src/core/queries/faucet.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import { FaucetClient } from 'aptos';
+import { FAUCET_URL, NODE_URL } from 'core/constants';
+
+export interface FundAccountWithFaucetProps {
+  address: string;
+  faucetUrl?: string;
+  nodeUrl?: string;
+}
+
+export const fundAccountWithFaucet = async ({
+  nodeUrl = NODE_URL,
+  faucetUrl = FAUCET_URL,
+  address,
+}: FundAccountWithFaucetProps): Promise<void> => {
+  const faucetClient = new FaucetClient(nodeUrl, faucetUrl);
+  await faucetClient.fundAccount(address, 5000);
+};

--- a/ecosystem/web-wallet/src/core/queries/transaction.ts
+++ b/ecosystem/web-wallet/src/core/queries/transaction.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import { AptosClient } from 'aptos';
+import { NODE_URL } from 'core/constants';
+
+export interface GetTransactionProps {
+  nodeUrl?: string,
+  txnHashOrVersion?: string;
+}
+
+export const getTransaction = async ({
+  txnHashOrVersion,
+  nodeUrl = NODE_URL,
+}: GetTransactionProps) => {
+  const aptosClient = new AptosClient(nodeUrl);
+  if (txnHashOrVersion) {
+    const txn = await aptosClient.getTransaction(txnHashOrVersion);
+    return txn;
+  }
+  return undefined;
+};
+
+export const getUserTransaction = async ({
+  txnHashOrVersion,
+  nodeUrl = NODE_URL,
+}: GetTransactionProps) => {
+  const aptosClient = new AptosClient(nodeUrl);
+  if (txnHashOrVersion) {
+    const txn = await aptosClient.getTransaction(txnHashOrVersion);
+    if ('events' in txn && 'signature' in txn) {
+      return txn;
+    }
+  }
+  return undefined;
+};

--- a/ecosystem/web-wallet/src/core/utils/network.ts
+++ b/ecosystem/web-wallet/src/core/utils/network.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import { WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY } from 'core/constants';
+
+export type AptosNetwork = 'http://0.0.0.0:8080' | 'https://fullnode.devnet.aptoslabs.com';
+
+export function getLocalStorageNetworkState(): AptosNetwork | null {
+  // Get network from local storage by key
+  return (window.localStorage.getItem(
+    WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY,
+  ) as AptosNetwork | null);
+}

--- a/ecosystem/web-wallet/src/pages/Login.tsx
+++ b/ecosystem/web-wallet/src/pages/Login.tsx
@@ -26,9 +26,7 @@ import useWalletState from 'core/hooks/useWalletState';
 import { AptosWhiteLogo, AptosBlackLogo } from 'core/components/AptosLogo';
 import withSimulatedExtensionContainer from 'core/components/WithSimulatedExtensionContainer';
 import { secondaryBgColor, secondaryErrorMessageColor } from 'core/constants';
-import { getAccountResources } from './Wallet';
-
-type Inputs = Record<string, any>;
+import { getAccountResources } from 'core/queries/account';
 
 export const secondaryTextColor = {
   dark: 'gray.400',
@@ -38,13 +36,13 @@ export const secondaryTextColor = {
 function Login() {
   const { colorMode } = useColorMode();
   const { aptosAccount, updateWalletState } = useWalletState();
+  const navigate = useNavigate();
   const {
     formState: { errors }, handleSubmit, register, setError, watch,
   } = useForm();
   const key: string = watch('privateKey');
-  const navigate = useNavigate();
 
-  const onSubmit: SubmitHandler<Inputs> = async (data, event) => {
+  const onSubmit: SubmitHandler<Record<string, any>> = async (data, event) => {
     event?.preventDefault();
     try {
       const nonHexKey = (key.startsWith('0x')) ? key.substring(2) : key;

--- a/ecosystem/web-wallet/src/pages/Wallet.tsx
+++ b/ecosystem/web-wallet/src/pages/Wallet.tsx
@@ -1,243 +1,55 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
 import {
   Button,
-  Flex,
-  Heading,
   HStack,
-  Input,
-  InputGroup,
-  InputRightAddon,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverContent,
-  PopoverTrigger as OrigPopoverTrigger,
-  Text,
-  useColorMode,
-  useDisclosure,
-  useToast,
   VStack,
 } from '@chakra-ui/react';
-import { SubmitHandler, useForm } from 'react-hook-form';
-import React, { useEffect, useState } from 'react';
-import {
-  AptosAccount, AptosClient, FaucetClient, Types,
-} from 'aptos';
-import { AccountResource } from 'aptos/src/api/data-contracts';
+import React, { useCallback } from 'react';
 import { FaFaucet } from 'react-icons/fa';
-import { IoIosSend } from 'react-icons/io';
-import numeral from 'numeral';
 import useWalletState from 'core/hooks/useWalletState';
 import withSimulatedExtensionContainer from 'core/components/WithSimulatedExtensionContainer';
-import { seconaryAddressFontColor } from 'core/components/WalletHeader';
 import WalletLayout from 'core/layouts/WalletLayout';
-import {
-  FAUCET_URL,
-  NODE_URL,
-  secondaryErrorMessageColor,
-  STATIC_GAS_AMOUNT,
-} from '../core/constants';
-
-/**
- * TODO: Will be fixed in upcoming Chakra-UI 2.0.0
- * @see https://github.com/chakra-ui/chakra-ui/issues/5896
- */
-export const PopoverTrigger: React.FC<{ children: React.ReactNode }> = OrigPopoverTrigger;
-
-interface GetAccountResourcesProps {
-  address?: string;
-  nodeUrl?: string;
-}
-
-export const getAccountResources = async ({
-  nodeUrl = NODE_URL,
-  address,
-}: GetAccountResourcesProps) => {
-  const client = new AptosClient(nodeUrl);
-  if (address) {
-    const accountResources = await client.getAccountResources(
-      address,
-    );
-    return accountResources;
-  }
-  return undefined;
-};
-
-export type Inputs = Record<string, any>;
-
-interface SubmitTransactionProps {
-  amount: string;
-  fromAddress: AptosAccount;
-  nodeUrl?: string;
-  toAddress: string;
-}
-
-interface FundWithFaucetProps {
-  address?: string;
-  faucetUrl?: string;
-  nodeUrl?: string;
-}
-
-const fundWithFaucet = async ({
-  nodeUrl = NODE_URL,
-  faucetUrl = FAUCET_URL,
-  address,
-}: FundWithFaucetProps): Promise<void> => {
-  const faucetClient = new FaucetClient(nodeUrl, faucetUrl);
-  if (address) {
-    await faucetClient.fundAccount(address, 5000);
-  }
-};
-
-const TransferResult = Object.freeze({
-  AmountOverLimit: 'Amount is over limit',
-  AmountWithGasOverLimit: 'Amount with gas is over limit',
-  IncorrectPayload: 'Incorrect transaction payload',
-  Success: 'Transaction executed successfully',
-  UndefinedAccount: 'Account does not exist',
-} as const);
-
-const submitTransaction = async ({
-  toAddress,
-  fromAddress,
-  amount,
-  nodeUrl = NODE_URL,
-}: SubmitTransactionProps) => {
-  const client = new AptosClient(nodeUrl);
-  const payload: Types.TransactionPayload = {
-    arguments: [toAddress, `${amount}`],
-    function: '0x1::Coin::transfer',
-    type: 'script_function_payload',
-    type_arguments: ['0x1::TestCoin::TestCoin'],
-  };
-  const txnRequest = await client.generateTransaction(fromAddress.address(), payload);
-  const signedTxn = await client.signTransaction(fromAddress, txnRequest);
-  const transactionRes = await client.submitTransaction(signedTxn);
-  await client.waitForTransaction(transactionRes.hash);
-};
-
-const getAccountBalanceFromAccountResources = (
-  accountResources: Types.AccountResource[] | undefined,
-): Number => {
-  if (accountResources) {
-    const accountResource = (accountResources) ? accountResources?.find((r) => r.type === '0x1::Coin::CoinStore<0x1::TestCoin::TestCoin>') : undefined;
-    const tokenBalance = (accountResource)
-      ? (accountResource.data as { coin: { value: string } }).coin.value
-      : undefined;
-    return Number(tokenBalance);
-  }
-  return -1;
-};
+import { fundAccountWithFaucet } from 'core/queries/faucet';
+import { useMutation, useQueryClient } from 'react-query';
+import WalletAccountBalance from 'core/components/WalletAccountBalance';
+import TransferDrawer from 'core/components/TransferDrawer';
 
 function Wallet() {
-  const { colorMode } = useColorMode();
   const { aptosAccount } = useWalletState();
+  const queryClient = useQueryClient();
+
   const {
-    formState: { errors }, handleSubmit, register, setError, watch,
-  } = useForm();
-  const { isOpen, onClose, onOpen } = useDisclosure();
-  const [
-    accountResources,
-    setAccountResources,
-  ] = useState<AccountResource[] | undefined>(undefined);
-  const [refreshState, setRefreshState] = useState(true);
-  const [isFaucetLoading, setIsFaucetLoading] = useState(false);
-  const [isTransferLoading, setIsTransferLoading] = useState(false);
-  const [lastBalance, setLastBalance] = useState<number>(-1);
-  const [lastTransferAmount, setLastTransferAmount] = useState<number>(-1);
-  const [
-    lastTransactionStatus,
-    setLastTransactionStatus,
-  ] = useState<string>(TransferResult.Success);
-  const toast = useToast();
+    isLoading: isFaucetLoading,
+    mutateAsync: fundWithFaucet,
+  } = useMutation(fundAccountWithFaucet, {
+    onSettled: () => {
+      queryClient.invalidateQueries('getAccountResources');
+    },
+  });
 
   const address = aptosAccount?.address().hex();
-  const accountResource = (accountResources)
-    ? accountResources?.find((r) => r.type === '0x1::Coin::CoinStore<0x1::TestCoin::TestCoin>')
-    : undefined;
-  const tokenBalance = (accountResource)
-    ? (accountResource.data as { coin: { value: string } }).coin.value
-    : undefined;
-  const tokenBalanceString = numeral(tokenBalance).format('0,0.0000');
-  const toAddress: string | undefined | null = watch('toAddress');
-  const transferAmount: string | undefined | null = watch('transferAmount');
 
-  const onSubmit: SubmitHandler<Inputs> = async (data, event) => {
-    event?.preventDefault();
-    if (toAddress && aptosAccount && transferAmount) {
-      setIsTransferLoading(true);
-      setLastBalance(Number(tokenBalance));
-      setLastTransferAmount(Number(transferAmount));
-      try {
-        // TODO: awaiting Zekun's changes, @see PR #821
-        if (Number(transferAmount) >= Number(tokenBalance) - STATIC_GAS_AMOUNT) {
-          setLastTransactionStatus(TransferResult.AmountWithGasOverLimit);
-          throw new Error(TransferResult.AmountOverLimit);
-        }
-        const accountResponse = await getAccountResources({
-          address: toAddress,
-          nodeUrl: NODE_URL,
-        });
-        if (!accountResponse) {
-          setLastTransactionStatus(TransferResult.UndefinedAccount);
-          throw new Error(TransferResult.UndefinedAccount);
-        }
-        await submitTransaction({
-          amount: transferAmount,
-          fromAddress: aptosAccount,
-          toAddress,
-        });
-        setLastTransactionStatus(TransferResult.Success);
-        setRefreshState(!refreshState);
-        onClose();
-      } catch (e) {
-        const err = (e as Error).message;
-        if (err !== TransferResult.IncorrectPayload && err !== TransferResult.Success) {
-          setIsTransferLoading(false);
-        }
-        setLastTransactionStatus(err);
-        setError('toAddress', { message: err, type: 'custom' });
-        setRefreshState(!refreshState);
-      }
+  const faucetOnClick = async () => {
+    if (address) {
+      await fundWithFaucet({ address });
     }
   };
 
-  const faucetOnClick = async () => {
-    setIsFaucetLoading(true);
-    await fundWithFaucet({ address });
-    setRefreshState(!refreshState);
-    setIsFaucetLoading(false);
-  };
-
-  useEffect(() => {
-    getAccountResources({ address })?.then((data) => {
-      if (
-        isTransferLoading
-        && (lastTransactionStatus === TransferResult.Success
-          || lastTransactionStatus === TransferResult.IncorrectPayload)
-      ) {
-        const newTokenBalance = getAccountBalanceFromAccountResources(data);
-        toast({
-          description: `${lastTransactionStatus}. Amount transferred: ${lastTransferAmount}, gas consumed: ${lastBalance - lastTransferAmount - Number(newTokenBalance)}`,
-          duration: 7000,
-          isClosable: true,
-          status: (lastTransactionStatus === TransferResult.Success) ? 'success' : 'error',
-          title: (lastTransactionStatus === TransferResult.Success) ? 'Transaction succeeded' : 'Transaction failed',
-        });
-      }
-      setIsTransferLoading(false);
-      const tempAccountResources = data;
-      setAccountResources(tempAccountResources);
-    });
-  }, [refreshState]);
+  const toAddressOnChange = useCallback(async (event: {
+    target: any;
+    type?: any;
+  }) => {
+    // toAddressOnChange(event);
+    queryClient.invalidateQueries('getToAddressAccountExists');
+  }, []);
 
   return (
     <WalletLayout>
       <VStack width="100%" paddingTop={8}>
-        <Text fontSize="sm" color={seconaryAddressFontColor[colorMode]}>Account balance</Text>
-        <Heading>{tokenBalanceString}</Heading>
+        <WalletAccountBalance />
         <HStack spacing={4}>
           <Button
             isLoading={isFaucetLoading}
@@ -247,65 +59,7 @@ function Wallet() {
           >
             Faucet
           </Button>
-          <Popover
-            isOpen={isOpen}
-            onOpen={onOpen}
-            onClose={onClose}
-          >
-            <PopoverTrigger>
-              <Button
-                isLoading={isTransferLoading}
-                isDisabled={isTransferLoading}
-                leftIcon={<IoIosSend />}
-              >
-                Send
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent>
-              <PopoverArrow />
-              <PopoverBody>
-                <form onSubmit={handleSubmit(onSubmit)}>
-                  <VStack spacing={4}>
-                    <InputGroup>
-                      <Input
-                        variant="filled"
-                        placeholder="To address"
-                        required
-                        maxLength={70}
-                        minLength={60}
-                        {...register('toAddress')}
-                      />
-                    </InputGroup>
-                    <InputGroup>
-                      <Input
-                        type="number"
-                        variant="filled"
-                        placeholder="Transfer amount"
-                        min={0}
-                        required
-                        {...register('transferAmount')}
-                      />
-                      <InputRightAddon>
-                        tokens
-                      </InputRightAddon>
-                    </InputGroup>
-                    <Flex overflowY="auto" maxH="100px">
-                      <Text
-                        fontSize="xs"
-                        color={secondaryErrorMessageColor[colorMode]}
-                        wordBreak="break-word"
-                      >
-                        {(errors?.toAddress?.message)}
-                      </Text>
-                    </Flex>
-                    <Button isDisabled={isTransferLoading} type="submit">
-                      Submit
-                    </Button>
-                  </VStack>
-                </form>
-              </PopoverBody>
-            </PopoverContent>
-          </Popover>
+          <TransferDrawer />
         </HStack>
       </VStack>
     </WalletLayout>


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

https://user-images.githubusercontent.com/31301117/169892395-d048a52b-b14d-45ce-9585-799e6c38e6fb.mov

## Motivation

Sorry for the large diff

Refactoring our mutations and queries to use `react-query`. This helps limit re-renders or excessive API calls. 

Summary of changes

- [x] Changed UI Flow for Transfer, now opens a transfer drawer, you're able to view the account your transferring to on explorer if its a valid account
- [x] Created mutations and queries folder as a centralized place for accessing functions
- [x] Refactoring to use queries and mutations instead of useEffect on `Wallet.tsx`, 
- [x] Created Wallet Network context with localstorage so wallet users can swap between their local testnet and devnet on wallet

Future tasks:
- [ ] Add debounce to getAccount queries on input change (maybe make a query 1500ms after they're done with changes)
- [ ] Refactor to use `react-query` for `Login.tsx` in a future PR
- [ ] Add Account balance to the drawer below the input fields in a future PR
- [ ] Create a flow in settings to switch between networks

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

## Test Plan

```
yarn run lint:fix && yarn build
# also compiles and works as an extension in chrome
```




