### PR TITLE
[aptos-cli] Give proper outputs in genesis for failures in parsing

### DIFF
--- a/crates/aptos/src/genesis/config.rs
+++ b/crates/aptos/src/genesis/config.rs
@@ -73,6 +73,27 @@ pub struct ValidatorConfiguration {
     pub stake_amount: u64,
 }
 
+/// For better parsing error messages
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StringValidatorConfiguration {
+    /// Account address
+    pub account_address: String,
+    /// Key used for signing in consensus
+    pub consensus_key: String,
+    /// Key used for signing transactions with the account
+    pub account_key: String,
+    /// Public key used for validator network identity (same as account address)
+    pub validator_network_key: String,
+    /// Host for validator which can be an IP or a DNS name
+    pub validator_host: HostAndPort,
+    /// Public key used for full node network identity (same as account address)
+    pub full_node_network_key: Option<String>,
+    /// Host for full node which can be an IP or a DNS name and is optional
+    pub full_node_host: Option<HostAndPort>,
+    /// Stake amount for consensus
+    pub stake_amount: u64,
+}
+
 impl TryFrom<ValidatorConfiguration> for Validator {
     type Error = CliError;
 

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -14,7 +14,7 @@ use aptos_github_client::Client as GithubClient;
 use async_trait::async_trait;
 use clap::Parser;
 use serde::{de::DeserializeOwned, Serialize};
-use std::{io::Read, path::PathBuf, str::FromStr};
+use std::{fmt::Debug, io::Read, path::PathBuf, str::FromStr};
 
 pub const LAYOUT_NAME: &str = "layout";
 
@@ -137,7 +137,7 @@ impl Client {
     }
 
     /// Retrieves an object as a YAML encoded file from the appropriate storage
-    pub fn get<T: DeserializeOwned>(&self, name: &str) -> CliTypedResult<T> {
+    pub fn get<T: DeserializeOwned + Debug>(&self, name: &str) -> CliTypedResult<T> {
         match self {
             Client::Local(local_repository_path) => {
                 let path = local_repository_path.join(format!("{}.yaml", name));


### PR DESCRIPTION
## Motivation

Fix output so that it provides YAML in stderr when the inputs are not parsable.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
