### PR TITLE
[storage] replace StateKeyAndValue with StateValue

### DIFF
--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -20,7 +20,7 @@ use aptos_types::{
         access_path_for_config, config_address, ConfigurationResource, OnChainConfig, ValidatorSet,
     },
     proof::SparseMerkleRangeProof,
-    state_store::{state_key::StateKey, state_value::StateKeyAndValue},
+    state_store::{state_key::StateKey, state_value::StateValue},
     test_helpers::transaction_test_helpers::block,
     transaction::{
         authenticator::AuthenticationKey, ChangeSet, Transaction, Version, WriteSetPayload,
@@ -196,7 +196,7 @@ fn get_configuration(db: &DbReaderWriter) -> ConfigurationResource {
 fn get_state_backup(
     db: &Arc<AptosDB>,
 ) -> (
-    Vec<(StateKey, StateKeyAndValue)>,
+    Vec<(StateKey, StateValue)>,
     SparseMerkleRangeProof,
     HashValue,
 ) {
@@ -224,7 +224,7 @@ fn get_state_backup(
 
 fn restore_state_to_db(
     db: &Arc<AptosDB>,
-    accounts: Vec<(StateKey, StateKeyAndValue)>,
+    accounts: Vec<(StateKey, StateValue)>,
     proof: SparseMerkleRangeProof,
     root_hash: HashValue,
     version: Version,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -17,7 +17,7 @@ use aptos_types::{
     proof::SparseMerkleRangeProof,
     state_store::{
         state_key::StateKey,
-        state_value::{StateKeyAndValue, StateValueChunkWithProof},
+        state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
         RawTransaction, Script, SignedTransaction, Transaction, TransactionListWithProof,
@@ -164,7 +164,7 @@ impl AptosDataClient for MockAptosDataClient {
         for _ in start_index..=end_index {
             account_blobs.push((
                 StateKey::Raw(HashValue::random().to_vec()),
-                StateKeyAndValue::new(StateKey::Raw(vec![]), vec![].into()),
+                StateValue::from(vec![]),
             ));
         }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -20,9 +20,7 @@ use aptos_types::{
     state_proof::StateProof,
     state_store::{
         state_key::StateKey,
-        state_value::{
-            StateKeyAndValue, StateValue, StateValueChunkWithProof, StateValueWithProof,
-        },
+        state_value::{StateValue, StateValueChunkWithProof, StateValueWithProof},
     },
     transaction::{
         AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
@@ -311,7 +309,7 @@ mock! {
             &self,
             version: Version,
             expected_root_hash: HashValue,
-        ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateKeyAndValue>>>;
+        ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>>;
 
         fn finalize_state_snapshot(
             &self,
@@ -335,8 +333,8 @@ mock! {
 // This automatically creates a MockSnapshotReceiver.
 mock! {
     pub SnapshotReceiver {}
-    impl StateSnapshotReceiver<StateKey, StateKeyAndValue> for SnapshotReceiver {
-        fn add_chunk(&mut self, chunk: Vec<(StateKey, StateKeyAndValue)>, proof: SparseMerkleRangeProof) -> Result<()>;
+    impl StateSnapshotReceiver<StateKey, StateValue> for SnapshotReceiver {
+        fn add_chunk(&mut self, chunk: Vec<(StateKey, StateValue)>, proof: SparseMerkleRangeProof) -> Result<()>;
 
         fn finish(self) -> Result<()>;
 

--- a/storage/aptosdb/src/backup/backup_handler.rs
+++ b/storage/aptosdb/src/backup/backup_handler.rs
@@ -18,7 +18,7 @@ use aptos_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
     proof::{SparseMerkleRangeProof, TransactionAccumulatorRangeProof, TransactionInfoWithProof},
-    state_store::{state_key::StateKey, state_value::StateKeyAndValue},
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{Transaction, TransactionInfo, Version},
 };
 use itertools::zip_eq;
@@ -103,7 +103,7 @@ impl BackupHandler {
     pub fn get_account_iter(
         &self,
         version: Version,
-    ) -> Result<Box<dyn Iterator<Item = Result<(StateKey, StateKeyAndValue)>> + Send + Sync>> {
+    ) -> Result<Box<dyn Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync>> {
         let store = Arc::clone(&self.state_store);
         let iterator =
             JellyfishMerkleIterator::new(Arc::clone(&store), version, HashValue::zero())?

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -12,7 +12,7 @@ use aptos_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
     proof::definition::LeafCount,
-    state_store::{state_key::StateKey, state_value::StateKeyAndValue},
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{Transaction, TransactionInfo, Version, PRE_GENESIS_VERSION},
 };
 use schemadb::DB;
@@ -53,7 +53,7 @@ impl RestoreHandler {
         &self,
         version: Version,
         expected_root_hash: HashValue,
-    ) -> Result<StateSnapshotRestore<StateKey, StateKeyAndValue>> {
+    ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         StateSnapshotRestore::new_overwrite(
             Arc::clone(&self.state_store),
             version,

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -66,9 +66,7 @@ use aptos_types::{
     state_store::{
         state_key::StateKey,
         state_key_prefix::StateKeyPrefix,
-        state_value::{
-            StateKeyAndValue, StateValue, StateValueChunkWithProof, StateValueWithProof,
-        },
+        state_value::{StateValue, StateValueChunkWithProof, StateValueWithProof},
     },
     transaction::{
         AccountTransactionsWithProof, Transaction, TransactionInfo, TransactionListWithProof,
@@ -1381,7 +1379,7 @@ impl DbWriter for AptosDB {
         &self,
         version: Version,
         expected_root_hash: HashValue,
-    ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateKeyAndValue>>> {
+    ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
         gauged_api("get_state_snapshot_receiver", || {
             self.state_store
                 .get_snapshot_receiver(version, expected_root_hash)

--- a/storage/aptosdb/src/schema/state_value/mod.rs
+++ b/storage/aptosdb/src/schema/state_value/mod.rs
@@ -7,19 +7,17 @@
 //! An Index Key in this data set has 2 pieces of information:
 //!     1. The state key
 //!     2. The version associated with the key
-//! The value associated with the key is the the serialized State Key and Value.
+//! The value associated with the key is the the serialized State Value.
 //!
 //! //! ```text
-//! |<-------- key -------->|<----- value ----->|
-//! |  state key  | version |  statekeyandvalue  |
+//! |<-------- key -------->|<-- value --->|
+//! |  state key  | version |  state value  |
 //! ```
 
 use crate::schema::{ensure_slice_len_gt, STATE_VALUE_CF_NAME};
 use anyhow::Result;
 use aptos_types::{
-    state_store::{
-        state_key::StateKey, state_key_prefix::StateKeyPrefix, state_value::StateKeyAndValue,
-    },
+    state_store::{state_key::StateKey, state_key_prefix::StateKeyPrefix, state_value::StateValue},
     transaction::Version,
 };
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -31,7 +29,7 @@ use std::{io::Write, mem::size_of};
 
 type Key = (StateKey, Version);
 
-define_schema!(StateValueSchema, Key, StateKeyAndValue, STATE_VALUE_CF_NAME);
+define_schema!(StateValueSchema, Key, StateValue, STATE_VALUE_CF_NAME);
 
 impl KeyCodec<StateValueSchema> for Key {
     fn encode_key(&self) -> Result<Vec<u8>> {
@@ -52,7 +50,7 @@ impl KeyCodec<StateValueSchema> for Key {
     }
 }
 
-impl ValueCodec<StateValueSchema> for StateKeyAndValue {
+impl ValueCodec<StateValueSchema> for StateValue {
     fn encode_value(&self) -> Result<Vec<u8>> {
         bcs::to_bytes(self).map_err(Into::into)
     }

--- a/storage/aptosdb/src/schema/state_value/test.rs
+++ b/storage/aptosdb/src/schema/state_value/test.rs
@@ -10,7 +10,7 @@ proptest! {
     fn test_encode_decode(
         state_key in any::<StateKey>(),
         version in any::<Version>(),
-        v in any::<StateKeyAndValue>(),
+        v in any::<StateValue>(),
     ) {
         assert_encode_decode::<StateValueSchema>(&(state_key, version), &v);
     }

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -499,7 +499,7 @@ proptest! {
                 .unwrap();
             let mut expected_values: Vec<_> = kvs[..=i]
                 .iter()
-                .map(|(key, value)| (key.clone(), StateKeyAndValue::new(key.clone(), value.clone())))
+                .map(|(key, value)| (key.clone(), value.clone()))
                 .collect();
             expected_values.sort_unstable_by_key(|item| item.0.hash());
             prop_assert_eq!(actual_values, expected_values);
@@ -538,7 +538,6 @@ proptest! {
             .clone()
             .into_iter()
             .take(batch1_size)
-            .map(|(key, value)| {let kv = StateKeyAndValue::new(key.clone(), value); (key, kv)})
             .collect();
         let rightmost_of_batch1 = batch1.last().map(|(key, _value)| key.hash()).unwrap();
         let proof_of_batch1 = store1
@@ -550,7 +549,6 @@ proptest! {
         let batch2: Vec<_> = ordered_input
             .into_iter()
             .skip(batch1_size)
-            .map(|(key, value)| {let kv = StateKeyAndValue::new(key.clone(), value); (key, kv)})
             .collect();
         let rightmost_of_batch2 = batch2.last().map(|(key, _value)| key.hash()).unwrap();
         let proof_of_batch2 = store1
@@ -637,7 +635,6 @@ proptest! {
         let batch1: Vec<_> = ordered_input
             .into_iter()
             .take(batch1_size)
-            .map(|(key, value)| (key, StateKeyAndValue::new(StateKey::Raw(vec![]), value)))
             .collect();
         let rightmost_of_batch1 = batch1.last().map(|(key, _value)| key.hash()).unwrap();
         let proof_of_batch1 = store1

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -613,15 +613,14 @@ pub fn put_transaction_info(db: &AptosDB, version: Version, txn_info: &Transacti
 }
 
 pub fn put_as_state_root(db: &AptosDB, version: Version, key: StateKey, value: StateValue) {
-    let state_value = StateKeyAndValue::new(key.clone(), value);
     db.db
         .put::<JellyfishMerkleNodeSchema>(
             &NodeKey::new_empty_path(version),
-            &Node::new_leaf(key.hash(), state_value.hash(), (key.clone(), version)),
+            &Node::new_leaf(key.hash(), value.hash(), (key.clone(), version)),
         )
         .unwrap();
     db.db
-        .put::<StateValueSchema>(&(key, version), &state_value)
+        .put::<StateValueSchema>(&(key, version), &value)
         .unwrap();
     db.state_store.set_latest_state_checkpoint_version(version);
 }

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
@@ -16,7 +16,7 @@ use aptos_logger::prelude::*;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::TransactionInfoWithProof,
-    state_store::{state_key::StateKey, state_value::StateKeyAndValue},
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
 use bytes::Bytes;
@@ -157,7 +157,7 @@ impl StateSnapshotBackupController {
     }
 
     fn parse_key(record: &Bytes) -> Result<HashValue> {
-        let (key, _): (StateKey, StateKeyAndValue) = bcs::from_bytes(record)?;
+        let (key, _): (StateKey, StateValue) = bcs::from_bytes(record)?;
         Ok(key.hash())
     }
 

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
@@ -25,7 +25,7 @@ use aptos_logger::prelude::*;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::TransactionInfoWithProof,
-    state_store::{state_key::StateKey, state_value::StateKeyAndValue},
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
 use std::sync::Arc;
@@ -148,7 +148,7 @@ impl StateSnapshotRestoreController {
     async fn read_state_value(
         &self,
         file_handle: FileHandle,
-    ) -> Result<Vec<(StateKey, StateKeyAndValue)>> {
+    ) -> Result<Vec<(StateKey, StateValue)>> {
         let mut file = self.storage.open_for_read(&file_handle).await?;
 
         let mut chunk = vec![];

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -15,10 +15,10 @@ use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_crypto::HashValue;
 use aptos_infallible::duration_since_epoch;
 use aptos_jellyfish_merkle::{
-    restore::StateSnapshotRestore, KVBatch, KVWriter, NodeBatch, TreeWriter,
+    restore::StateSnapshotRestore, KVBatch, NodeBatch, StateValueWriter, TreeWriter,
 };
 use aptos_types::{
-    state_store::{state_key::StateKey, state_value::StateKeyAndValue},
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
     waypoint::Waypoint,
 };
@@ -115,8 +115,8 @@ impl TreeWriter<StateKey> for MockStore {
     fn finish_version(&self, _version: Version) {}
 }
 
-impl KVWriter<StateKey, StateKeyAndValue> for MockStore {
-    fn write_kv_batch(&self, _kv_batch: &KVBatch<StateKey, StateKeyAndValue>) -> Result<()> {
+impl StateValueWriter<StateKey, StateValue> for MockStore {
+    fn write_kv_batch(&self, _kv_batch: &KVBatch<StateKey, StateValue>) -> Result<()> {
         Ok(())
     }
 }
@@ -140,7 +140,7 @@ impl RestoreRunMode {
         &self,
         version: Version,
         expected_root_hash: HashValue,
-    ) -> Result<StateSnapshotRestore<StateKey, StateKeyAndValue>> {
+    ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         match self {
             Self::Restore { restore_handler } => {
                 restore_handler.get_state_restore_receiver(version, expected_root_hash)

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -85,10 +85,7 @@ use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_types::{
     nibble::{nibble_path::NibblePath, Nibble, ROOT_NIBBLE_HEIGHT},
     proof::{SparseMerkleProof, SparseMerkleRangeProof},
-    state_store::{
-        state_key::StateKey,
-        state_value::{StateKeyAndValue, StateValue},
-    },
+    state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
 use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey, NodeType};
@@ -136,7 +133,7 @@ pub trait TreeWriter<K>: Send + Sync {
     fn finish_version(&self, version: Version);
 }
 
-pub trait KVWriter<K, V>: Send + Sync {
+pub trait StateValueWriter<K, V>: Send + Sync {
     /// Writes a kv batch into storage.
     fn write_kv_batch(&self, kv_batch: &KVBatch<K, V>) -> Result<()>;
 }
@@ -163,8 +160,6 @@ pub trait TestValue: Value + Arbitrary + std::fmt::Debug + Eq + PartialEq + 'sta
 impl Key for StateKey {}
 
 impl Value for StateValue {}
-
-impl Value for StateKeyAndValue {}
 
 #[cfg(any(test, feature = "fuzzing"))]
 impl TestKey for StateKey {}

--- a/storage/jellyfish-merkle/src/restore/restore_test.rs
+++ b/storage/jellyfish-merkle/src/restore/restore_test.rs
@@ -6,7 +6,8 @@ use crate::{
     node_type::{LeafNode, Node, NodeKey},
     restore::StateSnapshotRestore,
     test_helper::{init_mock_db, ValueBlob},
-    JellyfishMerkleTree, KVBatch, KVWriter, NodeBatch, TestKey, TestValue, TreeReader, TreeWriter,
+    JellyfishMerkleTree, KVBatch, NodeBatch, StateValueWriter, TestKey, TestValue, TreeReader,
+    TreeWriter,
 };
 use anyhow::Result;
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -39,7 +40,7 @@ where
     }
 }
 
-impl<K, V> KVWriter<K, V> for MockSnapshotStore<K, V>
+impl<K, V> StateValueWriter<K, V> for MockSnapshotStore<K, V>
 where
     K: TestKey,
     V: TestValue,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -22,9 +22,7 @@ use aptos_types::{
     state_store::{
         state_key::StateKey,
         state_key_prefix::StateKeyPrefix,
-        state_value::{
-            StateKeyAndValue, StateValue, StateValueChunkWithProof, StateValueWithProof,
-        },
+        state_value::{StateValue, StateValueChunkWithProof, StateValueWithProof},
     },
     transaction::{
         AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
@@ -632,7 +630,7 @@ pub trait DbWriter: Send + Sync {
         &self,
         version: Version,
         expected_root_hash: HashValue,
-    ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateKeyAndValue>>> {
+    ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
         unimplemented!()
     }
 

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -78,9 +78,9 @@ pub struct StateValueChunkWithProof {
     pub last_index: u64,      // The last hashed state index in chunk
     pub first_key: HashValue, // The first hashed state key in chunk
     pub last_key: HashValue,  // The last hashed state key in chunk
-    pub raw_values: Vec<(StateKey, StateKeyAndValue)>, // The hashed state key and and raw state key and value.
+    pub raw_values: Vec<(StateKey, StateValue)>, // The hashed state key and and raw state value.
     pub proof: SparseMerkleRangeProof, // The proof to ensure the chunk is in the hashed states
-    pub root_hash: HashValue,          // The root hash of the sparse merkle tree for this chunk
+    pub root_hash: HashValue, // The root hash of the sparse merkle tree for this chunk
 }
 
 impl StateValueChunkWithProof {
@@ -138,29 +138,6 @@ impl StateValueWithProof {
 
         self.proof
             .verify(ledger_info, version, state_key.hash(), self.value.as_ref())
-    }
-}
-
-#[derive(
-    Clone, Debug, CryptoHasher, Eq, PartialEq, Serialize, Deserialize, Ord, PartialOrd, Hash,
-)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
-pub struct StateKeyAndValue {
-    pub key: StateKey,
-    pub value: StateValue,
-}
-
-impl StateKeyAndValue {
-    pub fn new(key: StateKey, value: StateValue) -> Self {
-        Self { key, value }
-    }
-}
-
-impl CryptoHash for StateKeyAndValue {
-    type Hasher = StateKeyAndValueHasher;
-
-    fn hash(&self) -> HashValue {
-        self.value.hash
     }
 }
 


### PR DESCRIPTION
We don't need StateKeyAndValue anymore after we separate state_value out from JMT
