### PR TITLE
Generate ABIs in 'aptos move compile' command

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -162,6 +162,7 @@ impl CliCommand<Vec<String>> for CompilePackage {
     async fn execute(self) -> CliTypedResult<Vec<String>> {
         let build_config = BuildConfig {
             additional_named_addresses: self.move_options.named_addresses(),
+            generate_abis: true,
             generate_docs: true,
             install_dir: self.move_options.output_dir.clone(),
             ..Default::default()


### PR DESCRIPTION
## Motivation

ABIs are useful for frontends and other tools.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

n/a

## Related PRs

n/a