### PR TITLE
[ecosystem] Add latest_reported_timestamp to default sort.

### DIFF
--- a/ecosystem/platform/server/app/controllers/leaderboard_controller.rb
+++ b/ecosystem/platform/server/app/controllers/leaderboard_controller.rb
@@ -9,7 +9,7 @@ class LeaderboardController < ApplicationController
 
   def it1
     expires_in 1.minute, public: true
-    default_sort = [[:participation, -1], [:liveness, -1]]
+    default_sort = [[:participation, -1], [:liveness, -1], [:latest_reported_timestamp, -1]]
     @metrics = Rails.cache.fetch(:it1_leaderboard, expires_in: 1.minute) do
       response = HTTParty.get(ENV.fetch('LEADERBOARD_IT1_URL'))
       metrics = JSON.parse(response.body).map do |metric|


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Use latest_reported_timestamp as a tiebreaker when participation and liveness are equal.

![image](https://user-images.githubusercontent.com/310773/170122419-c2d74e85-80c7-44f3-9244-594bcffecb88.png)

## Test Plan

Manual

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
