### PR TITLE
[storage] clean some state related API

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -20,7 +20,7 @@ use aptos_types::{
     state_proof::StateProof,
     state_store::{
         state_key::StateKey,
-        state_value::{StateValue, StateValueChunkWithProof, StateValueWithProof},
+        state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
         AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
@@ -255,13 +255,6 @@ mock! {
         ) -> Result<StateProof>;
 
         fn get_state_proof(&self, known_version: u64) -> Result<StateProof>;
-
-        fn get_state_value_with_proof(
-            &self,
-            state_key: StateKey,
-            version: Version,
-            ledger_version: Version,
-        ) -> Result<StateValueWithProof>;
 
         fn get_state_value_with_proof_by_version(
             &self,

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -24,7 +24,7 @@ use aptos_types::{
     state_proof::StateProof,
     state_store::{
         state_key::StateKey,
-        state_value::{StateValue, StateValueChunkWithProof, StateValueWithProof},
+        state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
         AccountTransactionsWithProof, ExecutionStatus, RawTransaction, Script, SignedTransaction,
@@ -1533,13 +1533,6 @@ mock! {
         ) -> Result<StateProof>;
 
         fn get_state_proof(&self, known_version: u64) -> Result<StateProof>;
-
-        fn get_state_value_with_proof(
-            &self,
-            state_key: StateKey,
-            version: Version,
-            ledger_version: Version,
-        ) -> Result<StateValueWithProof>;
 
         fn get_state_value_with_proof_by_version(
             &self,

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -580,12 +580,16 @@ pub fn verify_committed_transactions(
 
         // Fetch and verify account states.
         for (state_key, state_value) in txn_to_commit.state_updates() {
-            let state_value_with_proof = db
-                .get_state_value_with_proof(state_key.clone(), cur_ver, ledger_version)
+            let (state_value_in_db, proof) = db
+                .get_state_value_with_proof_by_version(state_key, cur_ver)
                 .unwrap();
-            assert_eq!(state_value_with_proof.value, Some(state_value.clone()));
-            state_value_with_proof
-                .verify(ledger_info, cur_ver, state_key.clone())
+            assert_eq!(state_value_in_db, Some(state_value.clone()));
+            proof
+                .verify(
+                    txn_info.state_checkpoint_hash().unwrap(),
+                    state_key.hash(),
+                    state_value_in_db.as_ref(),
+                )
                 .unwrap();
         }
 

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -9,15 +9,14 @@ use aptos_logger::warn;
 use aptos_secure_net::NetworkClient;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    proof::SparseMerkleProof,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{TransactionToCommit, Version},
 };
 use serde::de::DeserializeOwned;
 use std::net::SocketAddr;
 use storage_interface::{
-    DbReader, DbWriter, Error, GetStateValueWithProofByVersionRequest, SaveTransactionsRequest,
-    StartupInfo, StorageRequest,
+    DbReader, DbWriter, Error, GetStateValueByVersionRequest, SaveTransactionsRequest, StartupInfo,
+    StorageRequest,
 };
 
 pub struct StorageClient {
@@ -52,17 +51,14 @@ impl StorageClient {
         bcs::from_bytes(&result)?
     }
 
-    pub fn get_state_value_with_proof_by_version(
+    pub fn get_state_value_by_version(
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> std::result::Result<(Option<StateValue>, SparseMerkleProof), Error> {
-        self.request(StorageRequest::GetStateValueWithProofByVersionRequest(
-            Box::new(GetStateValueWithProofByVersionRequest::new(
-                state_key.clone(),
-                version,
-            )),
-        ))
+    ) -> std::result::Result<Option<StateValue>, Error> {
+        self.request(StorageRequest::GetStateValueByVersionRequest(Box::new(
+            GetStateValueByVersionRequest::new(state_key.clone(), version),
+        )))
     }
 
     pub fn get_startup_info(&self) -> std::result::Result<Option<StartupInfo>, Error> {
@@ -82,14 +78,12 @@ impl StorageClient {
 }
 
 impl DbReader for StorageClient {
-    fn get_state_value_with_proof_by_version(
+    fn get_state_value_by_version(
         &self,
         state_key: &StateKey,
         version: u64,
-    ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
-        Ok(Self::get_state_value_with_proof_by_version(
-            self, state_key, version,
-        )?)
+    ) -> Result<Option<StateValue>> {
+        Ok(Self::get_state_value_by_version(self, state_key, version)?)
     }
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -22,7 +22,7 @@ use aptos_types::{
     state_store::{
         state_key::StateKey,
         state_key_prefix::StateKeyPrefix,
-        state_value::{StateValue, StateValueChunkWithProof, StateValueWithProof},
+        state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
         AccountTransactionsWithProof, TransactionInfo, TransactionListWithProof,
@@ -454,14 +454,16 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// Returns the account state corresponding to the given version and account address with proof
-    /// based on `ledger_version`
-    fn get_state_value_with_proof(
+    /// Gets an account state by account address.
+    /// See [AptosDB::get_state_value_by_version].
+    ///
+    /// [AptosDB::get_state_value_by_version]:
+    /// ../aptosdb/struct.AptosDB.html#method.get_state_value_by_version
+    fn get_state_value_by_version(
         &self,
-        state_key: StateKey,
+        state_key: &StateKey,
         version: Version,
-        ledger_version: Version,
-    ) -> Result<StateValueWithProof> {
+    ) -> Result<Option<StateValue>> {
         unimplemented!()
     }
 
@@ -478,21 +480,6 @@ pub trait DbReader: Send + Sync {
         state_key: &StateKey,
         version: Version,
     ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
-        unimplemented!()
-    }
-
-    /// Gets a state value by state key, out of the ledger state indicated by the version
-    /// See [AptosDB::get_account_state_with_proof_by_version].
-    ///
-    /// [AptosDB::get_account_state_with_proof_by_version]:
-    /// ../aptosdb/struct.AptosDB.html#method.get_account_state_with_proof_by_version
-    ///
-    /// This is used by aptos core (executor) internally.
-    fn get_state_value_by_version(
-        &self,
-        state_store_key: &StateKey,
-        version: Version,
-    ) -> Result<Option<StateValue>> {
         unimplemented!()
     }
 
@@ -726,13 +713,13 @@ impl DbReaderWriter {
 /// Network types for storage service
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum StorageRequest {
-    GetStateValueWithProofByVersionRequest(Box<GetStateValueWithProofByVersionRequest>),
+    GetStateValueByVersionRequest(Box<GetStateValueByVersionRequest>),
     GetStartupInfoRequest,
     SaveTransactionsRequest(Box<SaveTransactionsRequest>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
-pub struct GetStateValueWithProofByVersionRequest {
+pub struct GetStateValueByVersionRequest {
     /// The access key for the resource
     pub state_key: StateKey,
 
@@ -740,7 +727,7 @@ pub struct GetStateValueWithProofByVersionRequest {
     pub version: Version,
 }
 
-impl GetStateValueWithProofByVersionRequest {
+impl GetStateValueByVersionRequest {
     /// Constructor.
     pub fn new(state_key: StateKey, version: Version) -> Self {
         Self { state_key, version }

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -9,7 +9,6 @@ use aptos_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
     account_state::AccountState,
-    proof::SparseMerkleProof,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
@@ -42,16 +41,13 @@ impl DbReader for MockDbReaderWriter {
         Ok(Some(1))
     }
 
-    fn get_state_value_with_proof_by_version(
+    fn get_state_value_by_version(
         &self,
         state_key: &StateKey,
         _: Version,
-    ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
+    ) -> Result<Option<StateValue>> {
         // dummy proof which is not used
-        Ok((
-            self.get_latest_state_value(state_key.clone()).unwrap(),
-            SparseMerkleProof::new(None, vec![]),
-        ))
+        Ok(self.get_latest_state_value(state_key.clone()).unwrap())
     }
 }
 

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -16,8 +16,8 @@ impl DbStateView {
     fn get(&self, key: &StateKey) -> Result<Option<Vec<u8>>> {
         if let Some(version) = self.version {
             self.db
-                .get_state_value_with_proof_by_version(key, version)
-                .map(|(value_opt, _proof)| {
+                .get_state_value_by_version(key, version)
+                .map(|value_opt| {
                     // Hack: `v.maybe_bytes == None` represents deleted value, deemed non-existent
                     value_opt.and_then(|value| value.maybe_bytes)
                 })

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use aptos_config::config::NodeConfig;
 use aptos_logger::prelude::*;
 use aptos_secure_net::NetworkServer;
-use aptos_types::{proof::SparseMerkleProof, state_store::state_value::StateValue};
+use aptos_types::state_store::state_value::StateValue;
 use aptosdb::AptosDB;
 use std::{
     sync::Arc,
@@ -38,8 +38,8 @@ impl StorageService {
     fn handle_message(&self, input_message: Vec<u8>) -> Result<Vec<u8>, Error> {
         let input = bcs::from_bytes(&input_message)?;
         let output = match input {
-            storage_interface::StorageRequest::GetStateValueWithProofByVersionRequest(req) => {
-                bcs::to_bytes(&self.get_account_state_with_proof_by_version(&req))
+            storage_interface::StorageRequest::GetStateValueByVersionRequest(req) => {
+                bcs::to_bytes(&self.get_account_state_by_version(&req))
             }
             storage_interface::StorageRequest::GetStartupInfoRequest => {
                 bcs::to_bytes(&self.get_startup_info())
@@ -51,13 +51,13 @@ impl StorageService {
         Ok(output?)
     }
 
-    fn get_account_state_with_proof_by_version(
+    fn get_account_state_by_version(
         &self,
-        req: &storage_interface::GetStateValueWithProofByVersionRequest,
-    ) -> Result<(Option<StateValue>, SparseMerkleProof), Error> {
+        req: &storage_interface::GetStateValueByVersionRequest,
+    ) -> Result<Option<StateValue>, Error> {
         Ok(self
             .db
-            .get_state_value_with_proof_by_version(&req.state_key, req.version)?)
+            .get_state_value_by_version(&req.state_key, req.version)?)
     }
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>, Error> {

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -68,18 +68,10 @@ proptest! {
 
             let account_states_returned = account_states
                 .keys()
-                .map(|address| client.get_state_value_with_proof_by_version(address, version - 1).unwrap())
+                .map(|address| client.get_state_value_by_version(address, version - 1).unwrap())
                 .collect::<Vec<_>>();
-            let startup_info = client.get_startup_info().unwrap().unwrap();
-            for ((address, blob), state_with_proof) in zip_eq(account_states, account_states_returned) {
-                 prop_assert_eq!(&Some(blob), &state_with_proof.0);
-                 prop_assert!(state_with_proof.1
-                     .verify(
-                         startup_info.committed_tree_state.state_checkpoint_hash,
-                         address.hash(),
-                         state_with_proof.0.as_ref()
-                     )
-                     .is_ok());
+            for ((_address, blob), state) in zip_eq(account_states, account_states_returned) {
+                 prop_assert_eq!(&Some(blob), &state);
             }
         }
     }

--- a/testsuite/aptos-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/aptos-fuzzer/src/fuzz_targets.rs
@@ -37,7 +37,6 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(proof::SparseMerkleProofFuzzer::default()),
         Box::new(proof::TestAccumulatorRangeProofFuzzer::default()),
         Box::new(proof::TransactionInfoWithProofFuzzer::default()),
-        Box::new(proof::AccountStateProofFuzzer::default()),
         Box::new(proof::EventProofFuzzer::default()),
         Box::new(proof::TransactionInfoListWithProofFuzzer::default()),
         // Network

--- a/testsuite/aptos-fuzzer/src/fuzz_targets/proof.rs
+++ b/testsuite/aptos-fuzzer/src/fuzz_targets/proof.rs
@@ -7,8 +7,8 @@ use aptos_proptest_helpers::ValueGenerator;
 use aptos_types::{
     ledger_info::LedgerInfo,
     proof::{
-        EventProof, SparseMerkleProof, StateStoreValueProof, TestAccumulatorProof,
-        TestAccumulatorRangeProof, TransactionInfoListWithProof, TransactionInfoWithProof,
+        EventProof, SparseMerkleProof, TestAccumulatorProof, TestAccumulatorRangeProof,
+        TransactionInfoListWithProof, TransactionInfoWithProof,
     },
     state_store::state_value::StateValue,
     transaction::Version,
@@ -136,38 +136,6 @@ impl FuzzTargetImpl for TransactionInfoWithProofFuzzer {
         let _res = input
             .proof
             .verify(&input.ledger_info, input.transaction_version);
-    }
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct AccountStateProofFuzzer;
-
-#[derive(Debug, Arbitrary)]
-struct AccountStateProofFuzzerInput {
-    proof: StateStoreValueProof,
-    ledger_info: LedgerInfo,
-    state_version: Version,
-    state_key_hash: HashValue,
-    state_value: Option<StateValue>,
-}
-
-impl FuzzTargetImpl for AccountStateProofFuzzer {
-    fn description(&self) -> &'static str {
-        "Proof: AccountStateProof"
-    }
-
-    fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(corpus_from_strategy(any::<AccountStateProofFuzzerInput>()))
-    }
-
-    fn fuzz(&self, data: &[u8]) {
-        let input = fuzz_data_to_value(data, any::<AccountStateProofFuzzerInput>());
-        let _res = input.proof.verify(
-            &input.ledger_info,
-            input.state_version,
-            input.state_key_hash,
-            input.state_value.as_ref(),
-        );
     }
 }
 

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -31,9 +31,8 @@ use std::marker::PhantomData;
 pub use self::definition::{
     AccumulatorConsistencyProof, AccumulatorExtensionProof, AccumulatorProof,
     AccumulatorRangeProof, EventAccumulatorProof, EventProof, SparseMerkleProof,
-    SparseMerkleRangeProof, StateStoreValueProof, TransactionAccumulatorProof,
-    TransactionAccumulatorRangeProof, TransactionAccumulatorSummary, TransactionInfoListWithProof,
-    TransactionInfoWithProof,
+    SparseMerkleRangeProof, TransactionAccumulatorProof, TransactionAccumulatorRangeProof,
+    TransactionAccumulatorSummary, TransactionInfoListWithProof, TransactionInfoWithProof,
 };
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/proof/unit_tests/proof_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_conversion_test.rs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::proof::{
-    definition::{
-        EventProof, StateStoreValueProof, TransactionInfoListWithProof, TransactionInfoWithProof,
-    },
+    definition::{EventProof, TransactionInfoListWithProof, TransactionInfoWithProof},
     AccumulatorConsistencyProof, SparseMerkleRangeProof, TestAccumulatorProof,
     TestAccumulatorRangeProof,
 };
@@ -56,13 +54,6 @@ proptest! {
     fn test_transaction_proof_bcs_roundtrip(proof in any::<TransactionInfoWithProof>()) {
         assert_canonical_encode_decode(proof);
     }
-
-
-    #[test]
-    fn test_account_state_proof_bcs_roundtrip(proof in any::<StateStoreValueProof>()) {
-        assert_canonical_encode_decode(proof);
-    }
-
 
     #[test]
     fn test_event_proof_bcs_roundtrip(proof in any::<EventProof>()) {

--- a/types/src/proof/unit_tests/proof_test.rs
+++ b/types/src/proof/unit_tests/proof_test.rs
@@ -10,7 +10,7 @@ use crate::{
     event::EventKey,
     ledger_info::LedgerInfo,
     proof::{
-        definition::{EventProof, StateStoreValueProof, MAX_ACCUMULATOR_PROOF_DEPTH},
+        definition::{EventProof, MAX_ACCUMULATOR_PROOF_DEPTH},
         AccumulatorExtensionProof, AccumulatorRangeProof, EventAccumulatorInternalNode,
         EventAccumulatorProof, SparseMerkleInternalNode, SparseMerkleLeafNode,
         TestAccumulatorInternalNode, TestAccumulatorProof, TransactionAccumulatorInternalNode,
@@ -422,46 +422,6 @@ fn test_verify_state_store_resource_and_event() {
 
     let ledger_info_to_transaction_info_proof =
         TransactionAccumulatorProof::new(vec![*ACCUMULATOR_PLACEHOLDER_HASH, internal_a_hash]);
-    let transaction_info_to_account_proof = SparseMerkleProof::new(
-        Some(leaf2),
-        vec![leaf3_hash, leaf1_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH],
-    );
-    let account_state_proof = StateStoreValueProof::new(
-        TransactionInfoWithProof::new(
-            ledger_info_to_transaction_info_proof.clone(),
-            txn_info2.clone(),
-        ),
-        transaction_info_to_account_proof,
-    );
-
-    // Prove that account at `key2` has value `value2`.
-    assert!(account_state_proof
-        .verify(
-            &ledger_info,
-            /* state_version = */ 2,
-            key2,
-            Some(&blob2),
-        )
-        .is_ok());
-    // Use the same proof to prove that `non_existing_key` doesn't exist.
-    assert!(account_state_proof
-        .verify(
-            &ledger_info,
-            /* state_version = */ 2,
-            non_existing_key,
-            None,
-        )
-        .is_ok());
-
-    let bad_blob2 = b"3".to_vec().into();
-    assert!(account_state_proof
-        .verify(
-            &ledger_info,
-            /* state_version = */ 2,
-            key2,
-            Some(&bad_blob2),
-        )
-        .is_err());
 
     let transaction_info_to_event_proof = EventAccumulatorProof::new(vec![event1_hash]);
     let event_proof = EventProof::new(

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -1,13 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    ledger_info::LedgerInfo,
-    proof::{SparseMerkleRangeProof, StateStoreValueProof},
-    state_store::state_key::StateKey,
-    transaction::Version,
-};
-use anyhow::ensure;
+use crate::{proof::SparseMerkleRangeProof, state_store::state_key::StateKey};
 use aptos_crypto::{
     hash::{CryptoHash, CryptoHasher, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
@@ -91,53 +85,6 @@ impl StateValueChunkWithProof {
         right_siblings
             .iter()
             .all(|sibling| *sibling == *SPARSE_MERKLE_PLACEHOLDER_HASH)
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
-pub struct StateValueWithProof {
-    /// The transaction version at which this account state is seen.
-    pub version: Version,
-    /// Value represents the value in state store. If this field is not set, it
-    /// means the key does not exist.
-    pub value: Option<StateValue>,
-    /// The proof the client can use to authenticate the value.
-    pub proof: StateStoreValueProof,
-}
-
-impl StateValueWithProof {
-    /// Constructor.
-    pub fn new(version: Version, value: Option<StateValue>, proof: StateStoreValueProof) -> Self {
-        Self {
-            version,
-            value,
-            proof,
-        }
-    }
-
-    /// Verifies the state store value with the proof, both carried by `self`.
-    ///
-    /// Two things are ensured if no error is raised:
-    ///   1. This value exists in the ledger represented by `ledger_info`.
-    ///   2. It belongs to state_key and is seen at the time the transaction at version
-    /// `state_version` is just committed. To make sure this is the latest state, pass in
-    /// `ledger_info.version()` as `state_version`.
-    pub fn verify(
-        &self,
-        ledger_info: &LedgerInfo,
-        version: Version,
-        state_key: StateKey,
-    ) -> anyhow::Result<()> {
-        ensure!(
-            self.version == version,
-            "State version ({}) is not expected ({}).",
-            self.version,
-            version,
-        );
-
-        self.proof
-            .verify(ledger_info, version, state_key.hash(), self.value.as_ref())
     }
 }
 


### PR DESCRIPTION
## Motivation

Delete unused APIs and change some callsites to call `get_state_value_by_version` instead of `get_state_value_with_proof_by_version`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

ut


