### PR TITLE
[Storage] Refactor verified state view to support different types of proof fetcher

### DIFF
--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -92,7 +92,7 @@ where
                 "execute_block"
             );
             let _timer = APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
-            let state_view = parent_view.state_view(
+            let state_view = parent_view.verified_state_view(
                 &committed_block.output.result_view,
                 StateViewId::BlockExecution { block_id },
                 self.db.reader.clone(),

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -31,7 +31,7 @@ use executor_types::{
 };
 use fail::fail_point;
 use std::{marker::PhantomData, sync::Arc};
-use storage_interface::{verified_state_view::VerifiedStateView, DbReaderWriter};
+use storage_interface::{cached_state_view::CachedStateView, DbReaderWriter};
 
 pub struct ChunkExecutor<V> {
     db: DbReaderWriter,
@@ -62,8 +62,8 @@ impl<V> ChunkExecutor<V> {
         &self,
         latest_view: &ExecutedTrees,
         persisted_view: &ExecutedTrees,
-    ) -> VerifiedStateView {
-        latest_view.state_view(
+    ) -> CachedStateView {
+        latest_view.verified_state_view(
             persisted_view,
             StateViewId::ChunkExecution {
                 first_version: latest_view.txn_accumulator().num_leaves(),

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -12,7 +12,7 @@ use aptos_vm::VMExecutor;
 use executor_types::{ExecutedChunk, ExecutedTrees};
 use fail::fail_point;
 use std::collections::HashSet;
-use storage_interface::verified_state_view::{StateCache, VerifiedStateView};
+use storage_interface::cached_state_view::{CachedStateView, StateCache};
 
 pub struct ChunkOutput {
     /// Input transactions.
@@ -28,7 +28,7 @@ pub struct ChunkOutput {
 impl ChunkOutput {
     pub fn by_transaction_execution<V: VMExecutor>(
         transactions: Vec<Transaction>,
-        state_view: VerifiedStateView,
+        state_view: CachedStateView,
     ) -> Result<Self> {
         let transaction_outputs = V::execute_block(transactions.clone(), &state_view)?;
 
@@ -41,7 +41,7 @@ impl ChunkOutput {
 
     pub fn by_transaction_output(
         transactions_and_outputs: Vec<(Transaction, TransactionOutput)>,
-        state_view: VerifiedStateView,
+        state_view: CachedStateView,
     ) -> Result<Self> {
         let (transactions, transaction_outputs): (Vec<_>, Vec<_>) =
             transactions_and_outputs.into_iter().unzip();

--- a/execution/executor/src/components/in_memory_state_calculator.rs
+++ b/execution/executor/src/components/in_memory_state_calculator.rs
@@ -25,8 +25,9 @@ use std::{
     sync::Arc,
 };
 use storage_interface::{
+    cached_state_view::{CachedStateView, StateCache},
     in_memory_state::InMemoryState,
-    verified_state_view::{StateCache, VerifiedStateView},
+    sync_proof_fetcher::SyncProofFetcher,
     DbReader, TreeState,
 };
 
@@ -57,12 +58,12 @@ impl IntoLedgerView for TreeState {
                 checkpoint_next_version,
                 self.num_transactions,
             );
-            let checkpoint_state_view = VerifiedStateView::new(
+            let checkpoint_state_view = CachedStateView::new(
                 StateViewId::Miscellaneous,
-                db.clone(),
                 self.state_checkpoint_version,
                 self.state_checkpoint_hash,
                 checkpoint_state.checkpoint.clone(),
+                Arc::new(SyncProofFetcher::new(db.clone())),
             );
             let write_sets = db.get_write_sets(checkpoint_next_version, self.num_transactions)?;
             checkpoint_state_view.prime_cache_by_write_set(&write_sets)?;

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -390,8 +390,11 @@ fn apply_transaction_by_writeset(
         )))
         .collect();
 
-    let state_view =
-        ledger_view.state_view(&ledger_view, StateViewId::Miscellaneous, db.reader.clone());
+    let state_view = ledger_view.verified_state_view(
+        &ledger_view,
+        StateViewId::Miscellaneous,
+        db.reader.clone(),
+    );
 
     let chunk_output =
         ChunkOutput::by_transaction_output(transactions_and_outputs, state_view).unwrap();
@@ -531,7 +534,11 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
     for txn in transactions {
         let out = ChunkOutput::by_transaction_execution::<MockVM>(
             vec![txn],
-            ledger_view.state_view(&ledger_view, StateViewId::Miscellaneous, db.reader.clone()),
+            ledger_view.verified_state_view(
+                &ledger_view,
+                StateViewId::Miscellaneous,
+                db.reader.clone(),
+            ),
         )
         .unwrap();
         let (executed, _, _) = out.apply_to_ledger(&ledger_view).unwrap();

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1088,6 +1088,17 @@ impl DbReader for AptosDB {
         })
     }
 
+    fn get_state_value_by_version(
+        &self,
+        state_store_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<StateValue>> {
+        gauged_api("get_state_value_at_version", || {
+            self.state_store
+                .get_value_by_version(state_store_key, version)
+        })
+    }
+
     fn get_latest_tree_state(&self) -> Result<TreeState> {
         gauged_api("get_latest_tree_state", || {
             let latest_version = self

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -194,7 +194,6 @@ impl StateStore {
     /// Get the state value given the state key and root hash of state Merkle tree by using the
     /// state value index. Only used for testing for now but should replace the
     /// `get_value_with_proof_by_version` call for VM execution to fetch the value without proof.
-    #[cfg(test)]
     pub fn get_value_by_version(
         &self,
         state_key: &StateKey,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -34,11 +34,14 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
+pub mod cached_state_view;
 pub mod in_memory_state;
 #[cfg(any(feature = "testing", feature = "fuzzing"))]
 pub mod mock;
+pub mod no_proof_fetcher;
+pub mod proof_fetcher;
 pub mod state_view;
-pub mod verified_state_view;
+pub mod sync_proof_fetcher;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StartupInfo {
@@ -462,7 +465,7 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// Gets an account state by account address, out of the ledger state indicated by the state
+    /// Gets a state value by state key along with the proof, out of the ledger state indicated by the state
     /// Merkle tree root with a sparse merkle proof proving state tree root.
     /// See [AptosDB::get_account_state_with_proof_by_version].
     ///
@@ -475,6 +478,21 @@ pub trait DbReader: Send + Sync {
         state_key: &StateKey,
         version: Version,
     ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
+        unimplemented!()
+    }
+
+    /// Gets a state value by state key, out of the ledger state indicated by the version
+    /// See [AptosDB::get_account_state_with_proof_by_version].
+    ///
+    /// [AptosDB::get_account_state_with_proof_by_version]:
+    /// ../aptosdb/struct.AptosDB.html#method.get_account_state_with_proof_by_version
+    ///
+    /// This is used by aptos core (executor) internally.
+    fn get_state_value_by_version(
+        &self,
+        state_store_key: &StateKey,
+        version: Version,
+    ) -> Result<Option<StateValue>> {
         unimplemented!()
     }
 

--- a/storage/storage-interface/src/no_proof_fetcher.rs
+++ b/storage/storage-interface/src/no_proof_fetcher.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{proof_fetcher::ProofFetcher, DbReader};
+use aptos_crypto::HashValue;
+use aptos_types::{
+    proof::SparseMerkleProof,
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use std::{collections::HashMap, sync::Arc};
+
+/// An implementation of proof fetcher, which just reads the state value without fetching the proof.
+/// This can be useful for mempool validation, when we don't need to fetch the proof.
+pub struct NoProofFetcher {
+    reader: Arc<dyn DbReader>,
+}
+
+impl NoProofFetcher {
+    pub fn new(reader: Arc<dyn DbReader>) -> Self {
+        Self { reader }
+    }
+}
+
+impl ProofFetcher for NoProofFetcher {
+    fn fetch_state_value_and_proof(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> anyhow::Result<(Option<StateValue>, Option<SparseMerkleProof>)> {
+        Ok((
+            self.reader.get_state_value_by_version(state_key, version)?,
+            None,
+        ))
+    }
+
+    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProof> {
+        unimplemented!()
+    }
+}

--- a/storage/storage-interface/src/proof_fetcher.rs
+++ b/storage/storage-interface/src/proof_fetcher.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::HashValue;
+use aptos_types::{
+    proof::SparseMerkleProof,
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use std::collections::HashMap;
+
+/// Defines the trait for fetching proof from the DB
+pub trait ProofFetcher: Sync + Send {
+    /// API to fetch the state value along with proof
+    fn fetch_state_value_and_proof(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> anyhow::Result<(Option<StateValue>, Option<SparseMerkleProof>)>;
+
+    /// API to return all the proofs fetched by the proof fetcher so far.
+    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProof>;
+}

--- a/storage/storage-interface/src/sync_proof_fetcher.rs
+++ b/storage/storage-interface/src/sync_proof_fetcher.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{proof_fetcher::ProofFetcher, DbReader};
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_types::{
+    proof::SparseMerkleProof,
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use parking_lot::RwLock;
+use std::{collections::HashMap, sync::Arc};
+
+/// An implementation of proof fetcher, which synchronously fetches proofs from the underlying persistent
+/// storage.
+pub struct SyncProofFetcher {
+    reader: Arc<dyn DbReader>,
+    state_proof_cache: RwLock<HashMap<HashValue, SparseMerkleProof>>,
+}
+
+impl SyncProofFetcher {
+    pub fn new(reader: Arc<dyn DbReader>) -> Self {
+        Self {
+            reader,
+            state_proof_cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl ProofFetcher for SyncProofFetcher {
+    fn fetch_state_value_and_proof(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> anyhow::Result<(Option<StateValue>, Option<SparseMerkleProof>)> {
+        let (state_value, proof) = self
+            .reader
+            .get_state_value_with_proof_by_version(state_key, version)?;
+        // multiple threads may enter this code, and another thread might add
+        // an address before this one. Thus the insertion might return a None here.
+        self.state_proof_cache
+            .write()
+            .insert(state_key.hash(), proof.clone());
+
+        Ok((state_value, Some(proof)))
+    }
+
+    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProof> {
+        self.state_proof_cache
+            .read()
+            .iter()
+            .map(|(x, y)| (*x, y.clone()))
+            .collect()
+    }
+}

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -15,7 +15,7 @@ use executor::components::in_memory_state_calculator::IntoLedgerView;
 use fail::fail_point;
 use std::sync::Arc;
 use storage_interface::{
-    state_view::LatestDbStateCheckpointView, verified_state_view::VerifiedStateView, DbReader,
+    cached_state_view::CachedStateView, state_view::LatestDbStateCheckpointView, DbReader,
 };
 
 #[cfg(test)]
@@ -35,7 +35,7 @@ pub trait TransactionValidation: Send + Sync + Clone {
     fn notify_commit(&mut self);
 }
 
-fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> VerifiedStateView {
+fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> CachedStateView {
     let ledger_view = db_reader
         .get_latest_tree_state()
         .expect("Should not fail.")
@@ -53,7 +53,7 @@ fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> VerifiedStateView {
 
 pub struct VMValidator {
     db_reader: Arc<dyn DbReader>,
-    cached_state_view: VerifiedStateView,
+    cached_state_view: CachedStateView,
     vm: AptosVM,
 }
 


### PR DESCRIPTION
## Motivation

This is a preparation for supporting async proof fetching in the state view.  Following changes are included 
1. A `ProofFetcher` trait has been introduced, which supports synchronous proof fetching and no proof fetching. In the next PR, we will introduce async proof fetcher.  
2. Change the mempool validation to no proof fetcher - proof fetching is not needed because we don't need to calculate the merkle proof for validation and we trust the local storage.
3. Rename `VerifiedStateView` -> `CachedStateView` as it can support no proof fetching as well.

