### PR TITLE
CICD: fix github action job to trigger on protected branches without the CICD label

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -25,7 +25,8 @@ permissions:
 
 jobs:
   RustImages:
-    if: ${{ github.event.label.name == 'CICD:build-images' || contains(github.event.pull_request.labels.*.name, 'CICD:build-images') }}
+    # trigger only for push events (on protected branches as defined above) OR on PR events with the "CICD:build-images" label.
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CICD:build-images') }}
     strategy:
       matrix:
         IMAGE_TARGET: [release, test]
@@ -72,7 +73,7 @@ jobs:
           IMAGE_TARGET: ${{ matrix.IMAGE_TARGET }}
 
   CommunityPlatform:
-    if: ${{ github.event.label.name == 'CICD:build-images' || contains(github.event.pull_request.labels.*.name, 'CICD:build-images') }}
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'CICD:build-images') }}
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Previously this was only triggering on PRs that have the CICD:build-images label applied. With this change this will trigger on _any_ commit on protected branches like main, auto etc, which was the original intention of #1077 