### PR TITLE
[State Sync] Add new unit tests for driver.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -3,28 +3,34 @@
 
 use crate::{
     driver_factory::DriverFactory,
-    tests::utils::{create_ledger_info_at_version, create_transaction},
+    tests::utils::{
+        create_event, create_ledger_info_at_version, create_transaction,
+        verify_mempool_and_event_notification,
+    },
 };
 use aptos_config::config::{NodeConfig, RoleType};
 use aptos_data_client::aptosnet::AptosNetDataClient;
 use aptos_infallible::RwLock;
 use aptos_time_service::TimeService;
 use aptos_types::{
+    event::EventKey,
     move_resource::MoveStorage,
-    on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
+    on_chain_config::{new_epoch_event_key, ON_CHAIN_CONFIG_REGISTRY},
     transaction::{Transaction, WriteSetPayload},
     waypoint::Waypoint,
 };
 use aptos_vm::AptosVM;
 use aptosdb::AptosDB;
-use claim::assert_err;
+use claim::{assert_err, assert_none};
 use consensus_notifications::{ConsensusNotificationSender, ConsensusNotifier};
 use data_streaming_service::streaming_client::new_streaming_service_client_listener_pair;
 use event_notifications::{
-    EventNotificationSender, EventSubscriptionService, ReconfigNotificationListener,
+    EventNotificationListener, EventNotificationSender, EventSubscriptionService,
+    ReconfigNotificationListener,
 };
 use executor::chunk_executor::ChunkExecutor;
 use executor_test_helpers::bootstrap_genesis;
+use futures::{FutureExt, StreamExt};
 use mempool_notifications::MempoolNotificationListener;
 use network::application::{interface::MultiNetworkSender, storage::PeerMetadataStorage};
 use std::{collections::HashMap, sync::Arc};
@@ -33,10 +39,20 @@ use storage_service_client::StorageServiceClient;
 
 // TODO(joshlind): extend these tests to cover more functionality!
 
+#[tokio::test(flavor = "multi_thread")]
+async fn test_auto_bootstrapping() {
+    // Create a driver for a validator with a waypoint at version 0
+    let (validator_driver, _, _, _, _) = create_validator_driver(None).await;
+
+    // Wait until the validator is bootstrapped (auto-bootstrapping should occur)
+    let driver_client = validator_driver.create_driver_client();
+    driver_client.notify_once_bootstrapped().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_consensus_commit_notification() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _) = create_full_node_driver();
+    let (_full_node_driver, consensus_notifier, _, _, _) = create_full_node_driver(None).await;
 
     // Verify that full nodes can't process commit notifications
     let result = consensus_notifier
@@ -45,7 +61,7 @@ async fn test_consensus_commit_notification() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _) = create_validator_driver();
+    let (_validator_driver, consensus_notifier, _, _, _) = create_validator_driver(None).await;
 
     // Send a new commit notification and verify the node isn't bootstrapped
     let result = consensus_notifier
@@ -55,9 +71,100 @@ async fn test_consensus_commit_notification() {
 }
 
 #[tokio::test]
+async fn test_mempool_commit_notifications() {
+    // Create a driver for a validator with a waypoint at version 0
+    let subscription_event_key = EventKey::random();
+    let (validator_driver, consensus_notifier, mut mempool_listener, _, mut event_listener) =
+        create_validator_driver(Some(vec![subscription_event_key])).await;
+
+    // Wait until the validator is bootstrapped
+    let driver_client = validator_driver.create_driver_client();
+    driver_client.notify_once_bootstrapped().await.unwrap();
+
+    // Create commit data for testing
+    let transactions = vec![create_transaction(), create_transaction()];
+    let events = vec![
+        create_event(Some(subscription_event_key)),
+        create_event(Some(subscription_event_key)),
+    ];
+
+    // Send a new consensus commit notification to the driver
+    let committed_transactions = transactions.clone();
+    let committed_events = events.clone();
+    let join_handle = tokio::spawn(async move {
+        consensus_notifier
+            .notify_new_commit(committed_transactions, committed_events)
+            .await
+            .unwrap();
+    });
+
+    // Verify mempool is notified and that the event listener is notified
+    verify_mempool_and_event_notification(
+        Some(&mut event_listener),
+        &mut mempool_listener,
+        transactions,
+        events,
+    )
+    .await;
+
+    // Ensure the consensus notification is acknowledged
+    join_handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn test_reconfiguration_notifications() {
+    // Create a driver for a validator with a waypoint at version 0
+    let (validator_driver, consensus_notifier, mut mempool_listener, mut reconfig_listener, _) =
+        create_validator_driver(None).await;
+
+    // Wait until the validator is bootstrapped
+    let driver_client = validator_driver.create_driver_client();
+    driver_client.notify_once_bootstrapped().await.unwrap();
+
+    // Test different events
+    let reconfiguration_event = new_epoch_event_key();
+    for event_key in [
+        EventKey::random(),
+        reconfiguration_event,
+        EventKey::random(),
+        reconfiguration_event,
+    ] {
+        // Create commit data for testing
+        let transactions = vec![create_transaction(), create_transaction()];
+        let events = vec![create_event(Some(event_key))];
+
+        // Send a new consensus commit notification to the driver
+        let committed_transactions = transactions.clone();
+        let committed_events = events.clone();
+        let consensus_notifier = consensus_notifier.clone();
+        let join_handle = tokio::spawn(async move {
+            consensus_notifier
+                .notify_new_commit(committed_transactions, committed_events)
+                .await
+                .unwrap();
+        });
+
+        // Verify mempool is notified
+        verify_mempool_and_event_notification(None, &mut mempool_listener, transactions, events)
+            .await;
+
+        // Verify the reconfiguration listener is notified if a reconfiguration occurred
+        if event_key == reconfiguration_event {
+            let reconfig_notification = reconfig_listener.select_next_some().await;
+            assert_eq!(reconfig_notification.version, 0);
+        } else {
+            assert_none!(reconfig_listener.select_next_some().now_or_never());
+        }
+
+        // Ensure the consensus notification is acknowledged
+        join_handle.await.unwrap();
+    }
+}
+
+#[tokio::test]
 async fn test_consensus_sync_request() {
     // Create a driver for a full node
-    let (_full_node_driver, consensus_notifier, _, _) = create_full_node_driver();
+    let (_full_node_driver, consensus_notifier, _, _, _) = create_full_node_driver(None).await;
 
     // Verify that full nodes can't process sync requests
     let result = consensus_notifier
@@ -66,7 +173,7 @@ async fn test_consensus_sync_request() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _) = create_validator_driver();
+    let (_validator_driver, consensus_notifier, _, _, _) = create_validator_driver(None).await;
 
     // Send a new sync request and verify the node isn't bootstrapped
     let result = consensus_notifier
@@ -76,40 +183,48 @@ async fn test_consensus_sync_request() {
 }
 
 /// Creates a state sync driver for a validator node
-pub fn create_validator_driver() -> (
-    DriverFactory,
-    ConsensusNotifier,
-    MempoolNotificationListener,
-    ReconfigNotificationListener,
-) {
-    let mut node_config = NodeConfig::default();
-    node_config.base.role = RoleType::Validator;
-
-    create_driver_for_tests(node_config, Waypoint::default())
-}
-
-/// Creates a state sync driver for a full node
-pub fn create_full_node_driver() -> (
-    DriverFactory,
-    ConsensusNotifier,
-    MempoolNotificationListener,
-    ReconfigNotificationListener,
-) {
-    let mut node_config = NodeConfig::default();
-    node_config.base.role = RoleType::FullNode;
-
-    create_driver_for_tests(node_config, Waypoint::default())
-}
-
-/// Creates a state sync driver using the given node config and waypoint
-fn create_driver_for_tests(
-    node_config: NodeConfig,
-    waypoint: Waypoint,
+async fn create_validator_driver(
+    event_key_subscriptions: Option<Vec<EventKey>>,
 ) -> (
     DriverFactory,
     ConsensusNotifier,
     MempoolNotificationListener,
     ReconfigNotificationListener,
+    EventNotificationListener,
+) {
+    let mut node_config = NodeConfig::default();
+    node_config.base.role = RoleType::Validator;
+
+    create_driver_for_tests(node_config, Waypoint::default(), event_key_subscriptions).await
+}
+
+/// Creates a state sync driver for a full node
+async fn create_full_node_driver(
+    event_key_subscriptions: Option<Vec<EventKey>>,
+) -> (
+    DriverFactory,
+    ConsensusNotifier,
+    MempoolNotificationListener,
+    ReconfigNotificationListener,
+    EventNotificationListener,
+) {
+    let mut node_config = NodeConfig::default();
+    node_config.base.role = RoleType::FullNode;
+
+    create_driver_for_tests(node_config, Waypoint::default(), event_key_subscriptions).await
+}
+
+/// Creates a state sync driver using the given node config and waypoint
+async fn create_driver_for_tests(
+    node_config: NodeConfig,
+    waypoint: Waypoint,
+    event_key_subscriptions: Option<Vec<EventKey>>,
+) -> (
+    DriverFactory,
+    ConsensusNotifier,
+    MempoolNotificationListener,
+    ReconfigNotificationListener,
+    EventNotificationListener,
 ) {
     // Create test aptos database
     let db_path = aptos_temppath::TempPath::new();
@@ -121,23 +236,31 @@ fn create_driver_for_tests(
     let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
     bootstrap_genesis::<AptosVM>(&db_rw, &genesis_txn).unwrap();
 
-    // Create the event subscription service and notify initial configs
+    // Create the event subscription service and subscribe to events and reconfigurations
     let storage: Arc<dyn DbReader> = db;
     let synced_version = (&*storage).fetch_latest_state_checkpoint_version().unwrap();
     let mut event_subscription_service = EventSubscriptionService::new(
         ON_CHAIN_CONFIG_REGISTRY,
         Arc::new(RwLock::new(db_rw.clone())),
     );
-    let reconfiguration_subscriber = event_subscription_service
+    let mut reconfiguration_subscriber = event_subscription_service
         .subscribe_to_reconfigurations()
         .unwrap();
+    let event_key_subscriptions =
+        event_key_subscriptions.unwrap_or_else(|| vec![EventKey::random()]);
+    let event_subscriber = event_subscription_service
+        .subscribe_to_events(event_key_subscriptions)
+        .unwrap();
+
+    // Notify subscribers of the initial configs
     event_subscription_service
         .notify_initial_configs(synced_version)
         .unwrap();
+    reconfiguration_subscriber.select_next_some().await;
 
     // Create consensus and mempool notifiers and listeners
     let (consensus_notifier, consensus_listener) =
-        consensus_notifications::new_consensus_notifier_listener_pair(1000);
+        consensus_notifications::new_consensus_notifier_listener_pair(5000);
     let (mempool_notifier, mempool_listener) =
         mempool_notifications::new_mempool_notifier_listener_pair();
 
@@ -179,5 +302,6 @@ fn create_driver_for_tests(
         consensus_notifier,
         mempool_listener,
         reconfiguration_subscriber,
+        event_subscriber,
     )
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -16,7 +16,7 @@ use crate::{
         utils::{
             create_epoch_ending_ledger_info, create_event, create_output_list_with_proof,
             create_startup_info, create_state_value_chunk_with_proof, create_transaction,
-            create_transaction_list_with_proof,
+            create_transaction_list_with_proof, verify_mempool_and_event_notification,
         },
     },
 };
@@ -24,15 +24,14 @@ use anyhow::format_err;
 use aptos_config::config::StateSyncDriverConfig;
 use aptos_infallible::{Mutex, RwLock};
 use aptos_types::{
-    contract_event::ContractEvent, ledger_info::LedgerInfoWithSignatures,
-    on_chain_config::ON_CHAIN_CONFIG_REGISTRY, transaction::Transaction,
+    ledger_info::LedgerInfoWithSignatures, on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
 };
 use claim::assert_matches;
 use data_streaming_service::data_notification::NotificationId;
-use event_notifications::{EventNotificationListener, EventSubscriptionService};
+use event_notifications::EventSubscriptionService;
 use executor_types::ChunkCommitNotification;
 use futures::StreamExt;
-use mempool_notifications::{CommittedTransaction, MempoolNotificationListener};
+use mempool_notifications::MempoolNotificationListener;
 use mockall::predicate::{always, eq};
 use std::{sync::Arc, time::Duration};
 use storage_interface::DbReaderWriter;
@@ -42,7 +41,7 @@ use tokio::task::JoinHandle;
 async fn test_apply_transaction_outputs() {
     // Create test data
     let transaction_to_commit = create_transaction();
-    let event_to_commit = create_event();
+    let event_to_commit = create_event(None);
 
     // Setup the mock executor
     let mut chunk_executor = create_mock_executor();
@@ -164,7 +163,7 @@ async fn test_commit_chunk_error() {
 async fn test_execute_transactions() {
     // Create test data
     let transaction_to_commit = create_transaction();
-    let event_to_commit = create_event();
+    let event_to_commit = create_event(None);
 
     // Setup the mock executor
     let mut chunk_executor = create_mock_executor();
@@ -622,36 +621,6 @@ async fn verify_account_commit_notification(
         committed_accounts.committed_transaction,
         expected_committed_transactions
     );
-}
-
-/// Verifies that mempool is notified about the committed transactions and
-/// verifies that the event listener is notified about the committed
-/// events (if it exists).
-async fn verify_mempool_and_event_notification(
-    event_listener: Option<&mut EventNotificationListener>,
-    mempool_notification_listener: &mut MempoolNotificationListener,
-    expected_transactions: Vec<Transaction>,
-    expected_events: Vec<ContractEvent>,
-) {
-    // Verify mempool is notified and ack the notification
-    let mempool_notification = mempool_notification_listener.select_next_some().await;
-    let committed_transactions: Vec<CommittedTransaction> = expected_transactions
-        .into_iter()
-        .map(|txn| CommittedTransaction {
-            sender: txn.as_signed_user_txn().unwrap().sender(),
-            sequence_number: 0,
-        })
-        .collect();
-    assert_eq!(mempool_notification.transactions, committed_transactions);
-    mempool_notification_listener
-        .ack_commit_notification(mempool_notification)
-        .unwrap();
-
-    // Verify the event listener is notified about the specified event
-    if let Some(event_listener) = event_listener {
-        let event_notification = event_listener.select_next_some().await;
-        assert_eq!(event_notification.subscribed_events, expected_events);
-    }
 }
 
 /// Verifies that the expected error notification is received by the listener

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -32,6 +32,9 @@ use channel::{aptos_channel, aptos_channel::Sender, message_queues::QueueStyle};
 use data_streaming_service::{
     data_notification::DataNotification, data_stream::DataStreamListener, streaming_client::Epoch,
 };
+use event_notifications::EventNotificationListener;
+use futures::StreamExt;
+use mempool_notifications::{CommittedTransaction, MempoolNotificationListener};
 use move_deps::move_core_types::language_storage::TypeTag;
 use std::collections::BTreeMap;
 use storage_interface::{StartupInfo, TreeState};
@@ -53,13 +56,9 @@ pub fn create_epoch_ending_ledger_info() -> LedgerInfoWithSignatures {
 }
 
 /// Creates a single test event
-pub fn create_event() -> ContractEvent {
-    ContractEvent::new(
-        EventKey::random(),
-        0,
-        TypeTag::Bool,
-        bcs::to_bytes(&0).unwrap(),
-    )
+pub fn create_event(event_key: Option<EventKey>) -> ContractEvent {
+    let event_key = event_key.unwrap_or_else(EventKey::random);
+    ContractEvent::new(event_key, 0, TypeTag::Bool, bcs::to_bytes(&0).unwrap())
 }
 
 /// Creates a test driver configuration for full nodes
@@ -232,8 +231,36 @@ pub fn create_transaction_list_with_proof() -> TransactionListWithProof {
 pub fn create_transaction_output() -> TransactionOutput {
     TransactionOutput::new(
         WriteSet::default(),
-        vec![create_event()],
+        vec![create_event(None)],
         0,
         TransactionStatus::Keep(ExecutionStatus::Success),
     )
+}
+
+/// Verifies that mempool is notified about the committed transactions and
+/// verifies that the event listener is notified about the committed
+/// events (if it exists).
+pub async fn verify_mempool_and_event_notification(
+    event_listener: Option<&mut EventNotificationListener>,
+    mempool_notification_listener: &mut MempoolNotificationListener,
+    expected_transactions: Vec<Transaction>,
+    expected_events: Vec<ContractEvent>,
+) {
+    // Verify mempool is notified and ack the notification
+    let mempool_notification = mempool_notification_listener.select_next_some().await;
+    let committed_transactions: Vec<CommittedTransaction> = expected_transactions
+        .into_iter()
+        .map(|txn| CommittedTransaction {
+            sender: txn.as_signed_user_txn().unwrap().sender(),
+            sequence_number: 0,
+        })
+        .collect();
+    assert_eq!(mempool_notification.transactions, committed_transactions);
+    let _ = mempool_notification_listener.ack_commit_notification(mempool_notification);
+
+    // Verify the event listener is notified about the specified events
+    if let Some(event_listener) = event_listener {
+        let event_notification = event_listener.select_next_some().await;
+        assert_eq!(event_notification.subscribed_events, expected_events);
+    }
 }


### PR DESCRIPTION
## Motivation

This PR adds several new unit tests to the state sync driver. Nothing super critical (we already test this functionality in the smoke tests, but unit tests are much easier to debug) 😄 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New unit tests have been added.

## Related PRs

None.
