### PR TITLE
[ecosystem] Add support for custom <title>.

### DIFF
--- a/ecosystem/platform/server/app/views/layouts/_application.html.erb
+++ b/ecosystem/platform/server/app/views/layouts/_application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Aptos Community Platform</title>
+    <title><%= content_for(:page_title) || 'Aptos Community Platform' %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/ecosystem/platform/server/app/views/leaderboard/it1.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it1.html.erb
@@ -1,6 +1,7 @@
+<% content_for(:page_title, 'AIT1 Validator Status') %>
 <div class="bg-neutral-900 text-white h-full">
   <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 md:px-8 py-12 sm:py-24">
-    <h2 class="text-6xl mb-4 font-display font-light">AIT1 Validator Status</h2>
+    <h2 class="text-6xl mb-4 font-display font-light"><%= content_for(:page_title) %></h2>
     <div class="mb-16">
       <%= render DividerComponent.new(scheme: :primary) %>
     </div>


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Views can set the `<title>` with `content_for(:page_title, 'some page title')`.

![image](https://user-images.githubusercontent.com/310773/170315794-79ef4a85-58fd-426e-9523-3c56f22f9cc6.png)

## Test Plan

Manual

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
