### PR TITLE
[storage] VerifiedStateView gets persisted checkpoint from reader Instead of requiring it as a parameter to the constructor

### DIFF
--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -359,31 +359,29 @@ impl ExecutedTrees {
 
     pub fn verified_state_view(
         &self,
-        persisted_view: &Self,
         id: StateViewId,
         reader: Arc<dyn DbReader>,
-    ) -> CachedStateView {
+    ) -> Result<CachedStateView> {
         CachedStateView::new(
             id,
-            persisted_view.state.checkpoint_version,
-            persisted_view.state.checkpoint_root_hash(),
+            reader.clone(),
+            self.transaction_accumulator.num_leaves(),
             self.state.current.clone(),
-            Arc::new(SyncProofFetcher::new(reader.clone())),
+            Arc::new(SyncProofFetcher::new(reader)),
         )
     }
 
     pub fn state_view(
         &self,
-        persisted_view: &Self,
         id: StateViewId,
         reader: Arc<dyn DbReader>,
-    ) -> CachedStateView {
+    ) -> Result<CachedStateView> {
         CachedStateView::new(
             id,
-            persisted_view.state.checkpoint_version,
-            persisted_view.state.checkpoint_root_hash(),
+            reader.clone(),
+            self.transaction_accumulator.num_leaves(),
             self.state.current.clone(),
-            Arc::new(NoProofFetcher::new(reader.clone())),
+            Arc::new(NoProofFetcher::new(reader)),
         )
     }
 }

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -93,10 +93,9 @@ where
             );
             let _timer = APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
             let state_view = parent_view.verified_state_view(
-                &committed_block.output.result_view,
                 StateViewId::BlockExecution { block_id },
                 self.db.reader.clone(),
-            );
+            )?;
 
             let chunk_output = {
                 let _timer = APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS.start_timer();

--- a/execution/executor/src/components/in_memory_state_calculator.rs
+++ b/execution/executor/src/components/in_memory_state_calculator.rs
@@ -60,11 +60,11 @@ impl IntoLedgerView for TreeState {
             );
             let checkpoint_state_view = CachedStateView::new(
                 StateViewId::Miscellaneous,
-                self.state_checkpoint_version,
-                self.state_checkpoint_hash,
+                db.clone(),
+                self.num_transactions,
                 checkpoint_state.checkpoint.clone(),
                 Arc::new(SyncProofFetcher::new(db.clone())),
-            );
+            )?;
             let write_sets = db.get_write_sets(checkpoint_next_version, self.num_transactions)?;
             checkpoint_state_view.prime_cache_by_write_set(&write_sets)?;
             let state_cache = checkpoint_state_view.into_state_cache();

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -112,7 +112,7 @@ pub fn calculate_genesis<V: VMExecutor>(
     let genesis_version = tree_state.num_transactions;
     let base_view = tree_state.into_ledger_view(&db.reader)?;
     let base_state_view =
-        base_view.verified_state_view(&base_view, StateViewId::Miscellaneous, db.reader.clone());
+        base_view.verified_state_view(StateViewId::Miscellaneous, db.reader.clone())?;
 
     let epoch = if genesis_version == 0 {
         GENESIS_EPOCH
@@ -132,11 +132,9 @@ pub fn calculate_genesis<V: VMExecutor>(
         // TODO(aldenhu): fix existing tests before using real timestamp and check on-chain epoch.
         GENESIS_TIMESTAMP_USECS
     } else {
-        let state_view = output.result_view.verified_state_view(
-            &base_view,
-            StateViewId::Miscellaneous,
-            db.reader.clone(),
-        );
+        let state_view = output
+            .result_view
+            .verified_state_view(StateViewId::Miscellaneous, db.reader.clone())?;
         let next_epoch = epoch
             .checked_add(1)
             .ok_or_else(|| format_err!("integer overflow occurred"))?;

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -390,11 +390,9 @@ fn apply_transaction_by_writeset(
         )))
         .collect();
 
-    let state_view = ledger_view.verified_state_view(
-        &ledger_view,
-        StateViewId::Miscellaneous,
-        db.reader.clone(),
-    );
+    let state_view = ledger_view
+        .verified_state_view(StateViewId::Miscellaneous, db.reader.clone())
+        .unwrap();
 
     let chunk_output =
         ChunkOutput::by_transaction_output(transactions_and_outputs, state_view).unwrap();
@@ -534,11 +532,9 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
     for txn in transactions {
         let out = ChunkOutput::by_transaction_execution::<MockVM>(
             vec![txn],
-            ledger_view.verified_state_view(
-                &ledger_view,
-                StateViewId::Miscellaneous,
-                db.reader.clone(),
-            ),
+            ledger_view
+                .verified_state_view(StateViewId::Miscellaneous, db.reader.clone())
+                .unwrap(),
         )
         .unwrap();
         let (executed, _, _) = out.apply_to_ledger(&ledger_view).unwrap();

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -28,7 +28,7 @@ fn put_value_set(
         .put_value_sets(vec![&value_set], version, &mut cs)
         .unwrap();
     db.write_schemas(cs.batch).unwrap();
-    state_store.set_latest_state_checkpoint_version(version);
+    state_store.set_latest_checkpoint(version, root);
 
     root
 }

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -37,7 +37,7 @@ fn put_value_set(
         .put_value_sets(vec![&value_set], version, &mut cs)
         .unwrap();
     state_store.db.write_schemas(cs.batch).unwrap();
-    state_store.set_latest_state_checkpoint_version(version);
+    state_store.set_latest_checkpoint(version, root);
     root
 }
 
@@ -677,13 +677,13 @@ fn update_store(
         let mut cs = ChangeSet::new();
         let value_state_set: HashMap<_, _> = std::iter::once((key, value)).collect();
         let version = first_version + i as Version;
-        store
+        let root_hashes = store
             .merklize_value_sets(vec![&value_state_set], None, version, &mut cs)
             .unwrap();
         store
             .put_value_sets(vec![&value_state_set], version, &mut cs)
             .unwrap();
         store.db.write_schemas(cs.batch).unwrap();
-        store.set_latest_state_checkpoint_version(version);
+        store.set_latest_checkpoint(version, root_hashes[0]);
     }
 }

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -617,16 +617,15 @@ pub fn put_transaction_info(db: &AptosDB, version: Version, txn_info: &Transacti
 }
 
 pub fn put_as_state_root(db: &AptosDB, version: Version, key: StateKey, value: StateValue) {
+    let leaf_node = Node::new_leaf(key.hash(), value.hash(), (key.clone(), version));
     db.db
-        .put::<JellyfishMerkleNodeSchema>(
-            &NodeKey::new_empty_path(version),
-            &Node::new_leaf(key.hash(), value.hash(), (key.clone(), version)),
-        )
+        .put::<JellyfishMerkleNodeSchema>(&NodeKey::new_empty_path(version), &leaf_node)
         .unwrap();
     db.db
         .put::<StateValueSchema>(&(key, version), &value)
         .unwrap();
-    db.state_store.set_latest_state_checkpoint_version(version);
+    db.state_store
+        .set_latest_checkpoint(version, leaf_node.hash());
 }
 
 pub fn test_sync_transactions_impl(

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -112,7 +112,7 @@ impl TreeWriter<StateKey> for MockStore {
         Ok(())
     }
 
-    fn finish_version(&self, _version: Version) {}
+    fn finish_version(&self, _version: Version, _root_hash: HashValue) {}
 }
 
 impl StateValueWriter<StateKey, StateValue> for MockStore {

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -131,7 +131,7 @@ pub trait TreeWriter<K>: Send + Sync {
     fn write_node_batch(&self, node_batch: &NodeBatch<K>) -> Result<()>;
 
     /// Inform underlying store that a latest version is complete and readable.
-    fn finish_version(&self, version: Version);
+    fn finish_version(&self, version: Version, root_hash: HashValue);
 }
 
 pub trait StateValueWriter<K, V>: Send + Sync {

--- a/storage/jellyfish-merkle/src/mock_tree_store.rs
+++ b/storage/jellyfish-merkle/src/mock_tree_store.rs
@@ -6,6 +6,7 @@ use crate::{
     NodeBatch, StaleNodeIndex, TreeReader, TreeUpdateBatch, TreeWriter,
 };
 use anyhow::{bail, ensure, Result};
+use aptos_crypto::HashValue;
 use aptos_infallible::RwLock;
 use aptos_types::transaction::Version;
 use std::collections::{hash_map::Entry, BTreeSet, HashMap};
@@ -65,7 +66,7 @@ where
         Ok(())
     }
 
-    fn finish_version(&self, _version: Version) {}
+    fn finish_version(&self, _version: Version, _root_hash: HashValue) {}
 }
 
 impl<K> MockTreeStore<K>

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -680,7 +680,8 @@ where
 
         self.freeze(0);
         self.store.write_node_batch(&self.frozen_nodes)?;
-        self.store.finish_version(self.version);
+        self.store
+            .finish_version(self.version, self.expected_root_hash);
         Ok(())
     }
 }

--- a/storage/jellyfish-merkle/src/restore/restore_test.rs
+++ b/storage/jellyfish-merkle/src/restore/restore_test.rs
@@ -76,7 +76,7 @@ where
         self.tree_store.write_node_batch(node_batch)
     }
 
-    fn finish_version(&self, _version: Version) {}
+    fn finish_version(&self, _version: Version, _root_hash: HashValue) {}
 }
 
 fn init_mock_store<V>(kvs: &BTreeMap<V, V>) -> (MockSnapshotStore<V, V>, Version)

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -392,7 +392,15 @@ pub trait DbReader: Send + Sync {
     }
 
     /// Returns the latest state checkpoint version if any.
-    fn get_latest_state_checkpoint_version(&self) -> Result<Option<Version>> {
+    fn get_latest_state_checkpoint(&self) -> Result<Option<(Version, HashValue)>> {
+        unimplemented!()
+    }
+
+    /// Returns the latest state checkpoint strictly before `next_version` if any.
+    fn get_state_checkpoint_before(
+        &self,
+        next_version: Version,
+    ) -> Result<Option<(Version, HashValue)>> {
         unimplemented!()
     }
 
@@ -619,8 +627,9 @@ impl MoveStorage for &dyn DbReader {
     }
 
     fn fetch_latest_state_checkpoint_version(&self) -> Result<Version> {
-        self.get_latest_state_checkpoint_version()?
+        self.get_latest_state_checkpoint()?
             .ok_or_else(|| format_err!("[MoveStorage] Latest state checkpoint not found."))
+            .map(|(v, _)| v)
     }
 }
 

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -5,6 +5,7 @@
 
 use crate::{DbReader, DbWriter};
 use anyhow::{anyhow, Result};
+use aptos_crypto::HashValue;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
@@ -36,9 +37,9 @@ impl DbReader for MockDbReaderWriter {
         Ok(Some(1))
     }
 
-    fn get_latest_state_checkpoint_version(&self) -> Result<Option<Version>> {
+    fn get_latest_state_checkpoint(&self) -> Result<Option<(Version, HashValue)>> {
         // return a dummy version for tests
-        Ok(Some(1))
+        Ok(Some((1, HashValue::zero())))
     }
 
     fn get_state_value_by_version(

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -45,7 +45,7 @@ impl LatestDbStateCheckpointView for Arc<dyn DbReader> {
     fn latest_state_checkpoint_view(&self) -> Result<DbStateView> {
         Ok(DbStateView {
             db: self.clone(),
-            version: self.get_latest_state_checkpoint_version()?,
+            version: self.get_latest_state_checkpoint()?.map(|(v, _)| v),
         })
     }
 }

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -42,13 +42,14 @@ fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> CachedStateView {
         .into_ledger_view(db_reader)
         .expect("Should not fail.");
 
-    ledger_view.state_view(
-        &ledger_view,
-        StateViewId::TransactionValidation {
-            base_version: ledger_view.version().expect("Must be bootstrapped."),
-        },
-        db_reader.clone(),
-    )
+    ledger_view
+        .state_view(
+            StateViewId::TransactionValidation {
+                base_version: ledger_view.version().expect("Must be bootstrapped."),
+            },
+            db_reader.clone(),
+        )
+        .expect("failed to get latest state view.")
 }
 
 pub struct VMValidator {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation


So that it's easier to make persisting state checkpoints asynchronous --
the execution and comission threads don't need to track explicitly the
latest persisted state checkpoint.

We do still need to make sure all speculative SMTs haven't yet been
dropped after the latest persisted checkpoint -- this unfortunately
becomes implicit after this change.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

existing coverage