### PR TITLE
[docker] Add restart policy to auto start container(s)

### DIFF
--- a/docker/compose/aptos-node/docker-compose-fullnode.yaml
+++ b/docker/compose/aptos-node/docker-compose-fullnode.yaml
@@ -24,6 +24,7 @@ services:
         source: ./validator-full-node-identity.yaml
         target: /opt/aptos/genesis/validator-full-node-identity.yaml
     command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
+    restart: unless-stopped
     ports:
       - "6182:6182"
       - "80:8080"

--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -24,6 +24,7 @@ services:
         source: ./validator-identity.yaml
         target: /opt/aptos/genesis/validator-identity.yaml
     command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/validator.yaml"]
+    restart: unless-stopped
     ports:
       - "6180:6180"
       - "6181:6181"


### PR DESCRIPTION
## Motivation

Some time the host machine need to reboot to update, apply patch... Then when it boots up again, we may forget to start the container. Then I think we may want to add restart policy to the compose file.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, I did.

## Test Plan

Not really need, it will work as it has been.

If we need to test, just reboot the host machine then check the container(s).

## Related PRs

https://github.com/aptos-labs/aptos-core/pull/1008 (CLA was signed and sent since this PR.)