### PR TITLE
[Ecosystem] [3/3] Add token metadata to indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,9 @@ dependencies = [
  "diesel_migrations",
  "futures",
  "once_cell",
+ "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "serde 1.0.137",
  "serde_json",
  "tokio",
@@ -6524,6 +6527,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -6539,6 +6543,53 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69539cea4148dce683bec9dc95be3f0397a9bb2c248a49c8296a9d21659a8cdd"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "http",
+ "reqwest",
+ "serde 1.0.137",
+ "task-local-extensions",
+ "thiserror",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce246a729eaa6aff5e215aee42845bf5fed9893cc6cd51aeeb712f34e04dd9f3"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "http",
+ "hyper",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "task-local-extensions",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "retry-policies"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f9e19b18c6cdd796cc70aea8a9ea5ee7b813be611c6589e3624fcdbfd05f9d"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -7869,6 +7920,15 @@ dependencies = [
  "guppy-workspace-hack",
  "serde 1.0.137",
  "target-lexicon",
+]
+
+[[package]]
+name = "task-local-extensions"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36794203e10c86e5998179e260869d156e0674f02d5451b4a3fb9fd86d02aaab"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -43,7 +43,7 @@ parking_lot = { version = "0.12.0", features = ["send_guard"] }
 rand = { version = "0.8.5", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 regex = { version = "1.5.5", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-syntax = { version = "0.6.25", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
+reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "mime_guess", "multipart", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["timeout", "wait-timeout"] }
 serde = { version = "1.0.137", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
 serde_json = { version = "1.0.81", features = ["indexmap", "preserve_order", "std"] }
@@ -89,7 +89,7 @@ parking_lot = { version = "0.12.0", features = ["send_guard"] }
 rand = { version = "0.8.5", features = ["alloc", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"] }
 regex = { version = "1.5.5", features = ["aho-corasick", "memchr", "perf", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
 regex-syntax = { version = "0.6.25", features = ["unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"] }
-reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
+reqwest = { version = "0.11.10", features = ["__tls", "blocking", "cookie_crate", "cookie_store", "cookies", "default-tls", "hyper-tls", "json", "mime_guess", "multipart", "native-tls-crate", "proc-macro-hack", "serde_json", "stream", "tokio-native-tls", "tokio-util"] }
 rusty-fork = { version = "0.3.0", features = ["timeout", "wait-timeout"] }
 serde = { version = "1.0.137", features = ["alloc", "derive", "rc", "serde_derive", "std"] }
 serde_json = { version = "1.0.81", features = ["indexmap", "preserve_order", "std"] }

--- a/ecosystem/indexer/Cargo.toml
+++ b/ecosystem/indexer/Cargo.toml
@@ -18,6 +18,9 @@ diesel = { version = "1.4.8", features = ["chrono", "postgres", "r2d2", "numeric
 diesel_migrations = { version = "1.4.0", features = ["postgres"] }
 futures = "0.3.21"
 once_cell = "1.10.0"
+reqwest = { version = "0.11.10", features = ["json", "cookies"] }
+reqwest-middleware = {version = "0.1.6"}
+reqwest-retry = { version = "0.1.5" }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 tokio = { version = "1.18.2", features = ["full", "time"] }

--- a/ecosystem/indexer/migrations/2022-05-30-173317_metadatas/down.sql
+++ b/ecosystem/indexer/migrations/2022-05-30-173317_metadatas/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+drop table if exists metadatas;

--- a/ecosystem/indexer/migrations/2022-05-30-173317_metadatas/up.sql
+++ b/ecosystem/indexer/migrations/2022-05-30-173317_metadatas/up.sql
@@ -1,0 +1,19 @@
+-- Your SQL goes here
+CREATE TABLE metadatas
+(
+    token_id VARCHAR NOT NULL,
+    name VARCHAR,
+    symbol VARCHAR,
+    seller_fee_basis_points BIGINT,
+    description VARCHAR,
+    image VARCHAR NOT NULL,
+    external_url VARCHAR,
+    animation_url VARCHAR,
+    attributes jsonb,
+    properties jsonb,
+
+    last_updated_at TIMESTAMP NOT NULL,
+    inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- Constraints
+    PRIMARY KEY (token_id)
+);

--- a/ecosystem/indexer/src/indexer/metadata_fetcher.rs
+++ b/ecosystem/indexer/src/indexer/metadata_fetcher.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::models::metadata::TokenMetaFromURI;
+use anyhow::Result;
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+
+pub enum UriType {
+    ARWEAVE { uri: String },
+    IPFS { uri: String },
+    UNKNOWN { uri: String },
+}
+
+pub fn get_type(uri: String) -> UriType {
+    if uri.contains("IPFS/") {
+        UriType::IPFS { uri }
+    } else if uri.contains("arweave.net/") {
+        UriType::ARWEAVE { uri }
+    } else {
+        UriType::UNKNOWN { uri }
+    }
+}
+
+pub struct MetaDataFetcher {
+    restclient: ClientWithMiddleware,
+}
+
+impl MetaDataFetcher {
+    pub fn new() -> Self {
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+        MetaDataFetcher {
+            restclient: ClientBuilder::new(reqwest::Client::new())
+                .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+                .build(),
+        }
+    }
+
+    async fn read_http_uri(&self, uri: String) -> Result<serde_json::Value> {
+        let resp = self
+            .restclient
+            .get(uri)
+            .send()
+            .await?
+            .json::<serde_json::Value>()
+            .await?;
+        Ok(resp)
+    }
+
+    fn parse_json(&self, value: serde_json::Value) -> Result<TokenMetaFromURI> {
+        Ok(serde_json::value::from_value::<TokenMetaFromURI>(value)?)
+    }
+
+    pub async fn get_metadata(&self, uri: String) -> Option<TokenMetaFromURI> {
+        match get_type(uri) {
+            UriType::ARWEAVE { uri } => match self.read_http_uri(uri).await {
+                Ok(value) => self.parse_json(value).ok(),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}

--- a/ecosystem/indexer/src/indexer/mod.rs
+++ b/ecosystem/indexer/src/indexer/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod errors;
 pub mod fetcher;
+pub mod metadata_fetcher;
 pub mod processing_result;
 pub mod tailer;
 pub mod transaction_processor;

--- a/ecosystem/indexer/src/main.rs
+++ b/ecosystem/indexer/src/main.rs
@@ -53,9 +53,11 @@ struct IndexerArgs {
     /// Set to 0 to disable.
     #[clap(long, default_value_t = 1000)]
     emit_every: usize,
-}
 
-const INTERNAL_TESTING_TOKEN_PROCESSOR: bool = true;
+    /// whether run indexer to get token data
+    #[clap(long)]
+    index_token_data: bool,
+}
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
@@ -75,7 +77,7 @@ async fn main() -> std::io::Result<()> {
 
     let pg_transaction_processor = DefaultTransactionProcessor::new(conn_pool.clone());
     tailer.add_processor(Arc::new(pg_transaction_processor));
-    if !INTERNAL_TESTING_TOKEN_PROCESSOR {
+    if args.index_token_data {
         let token_transaction_processor = TokenTransactionProcessor::new(conn_pool.clone());
         tailer.add_processor(Arc::new(token_transaction_processor));
     }

--- a/ecosystem/indexer/src/models/metadata.rs
+++ b/ecosystem/indexer/src/models/metadata.rs
@@ -1,0 +1,59 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::schema::metadatas;
+use serde::{Deserialize, Serialize};
+
+#[derive(Associations, Debug, Identifiable, Insertable, Queryable, Serialize, Clone)]
+#[diesel(table_name = "metadata")]
+#[primary_key(token_id)]
+pub struct Metadata {
+    pub token_id: String,
+    pub name: Option<String>,
+    pub symbol: Option<String>,
+    pub seller_fee_basis_points: Option<i64>,
+    pub description: Option<String>,
+    pub image: String,
+    pub external_url: Option<String>,
+    pub animation_url: Option<String>,
+    pub attributes: Option<serde_json::Value>,
+    pub properties: Option<serde_json::Value>,
+    pub last_updated_at: chrono::NaiveDateTime,
+    pub inserted_at: chrono::NaiveDateTime,
+}
+
+impl Metadata {
+    pub fn from_token_uri_meta(token_uri: TokenMetaFromURI, token_id_str: String) -> Option<Self> {
+        if token_uri.image.is_some() {
+            Some(Self {
+                token_id: token_id_str,
+                name: token_uri.name,
+                symbol: token_uri.symbol,
+                seller_fee_basis_points: token_uri.seller_fee_basis_points,
+                description: token_uri.description,
+                image: token_uri.image.unwrap(),
+                external_url: token_uri.external_url,
+                animation_url: token_uri.animation_url,
+                attributes: token_uri.attributes,
+                properties: token_uri.properties,
+                last_updated_at: chrono::Utc::now().naive_utc(),
+                inserted_at: chrono::Utc::now().naive_utc(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TokenMetaFromURI {
+    pub name: Option<String>,
+    pub symbol: Option<String>,
+    pub seller_fee_basis_points: Option<i64>,
+    pub description: Option<String>,
+    pub image: Option<String>,
+    pub external_url: Option<String>,
+    pub animation_url: Option<String>,
+    pub attributes: Option<serde_json::Value>,
+    pub properties: Option<serde_json::Value>,
+}

--- a/ecosystem/indexer/src/models/mod.rs
+++ b/ecosystem/indexer/src/models/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod collection;
 pub mod events;
+pub mod metadata;
 pub mod ownership;
 pub mod processor_statuses;
 pub mod token;

--- a/ecosystem/indexer/src/schema.rs
+++ b/ecosystem/indexer/src/schema.rs
@@ -40,6 +40,23 @@ table! {
 }
 
 table! {
+    metadatas (token_id) {
+        token_id -> Varchar,
+        name -> Nullable<Varchar>,
+        symbol -> Nullable<Varchar>,
+        seller_fee_basis_points -> Nullable<Int8>,
+        description -> Nullable<Varchar>,
+        image -> Varchar,
+        external_url -> Nullable<Varchar>,
+        animation_url -> Nullable<Varchar>,
+        attributes -> Nullable<Jsonb>,
+        properties -> Nullable<Jsonb>,
+        last_updated_at -> Timestamp,
+        inserted_at -> Timestamp,
+    }
+}
+
+table! {
     ownerships (token_id, owner) {
         token_id -> Varchar,
         owner -> Varchar,
@@ -138,6 +155,7 @@ allow_tables_to_appear_in_same_query!(
     block_metadata_transactions,
     collections,
     events,
+    metadatas,
     ownerships,
     processor_statuses,
     token_activities,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

1. fetch arweave URI and parse the json to store the metadata in DB
2. add a arg to indexer cli to turn on/off the token indexer. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
Yes

## Test Plan

Token metadata uri https://xdc7mlwypvsqdrbp3fq2jywgiapdod5fck733ilywdvo3slng3uq.arweave.net/uMX2Lth9ZQHEL9lhpOLGQB43D6USv72heLDq7cltNuk

The token metadata data is stored at DB as expected.
<img width="1539" alt="Screen Shot 2022-05-30 at 4 41 57 PM" src="https://user-images.githubusercontent.com/1082769/171068557-3de9c091-f25b-417a-abf5-2d75495cbb5c.png">


