### PR TITLE
[docker] Copy all modules for Framework

### DIFF
--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -37,6 +37,7 @@ RUN mkdir -p /aptos-framework/move/build
 RUN mkdir -p /aptos-framework/move/modules
 COPY --from=builder /aptos/aptos-framework/releases/artifacts/current/build /aptos-framework/move/build
 RUN mv /aptos-framework/move/build/**/bytecode_modules/*.mv /aptos-framework/move/modules
+RUN mv /aptos-framework/move/build/**/bytecode_modules/dependencies/**/*.mv /aptos-framework/move/modules
 RUN rm -rf /aptos-framework/move/build
 
 FROM pre-prod as testing


### PR DESCRIPTION
### Motivation

The folder structure changed for Move compilation, which caused cached
packages to not include MoveStdLib.  Now, all paths should be copied over
without issue.  This caused Genesis to stop working in Forge.  Now we copy all the files over.


Folder structure changed from:
```
aptos-framework/releases/artifacts/current/build/AptosFramework/*.mv
aptos-framework/releases/artifacts/current/build/MoveStdLib/*.mv
```

to

```
aptos-framework/releases/artifacts/current/build/AptosFramework/*.mv
aptos-framework/releases/artifacts/current/build/AptosFramework/dependencies/MoveStdLib/*.mv
```

### Testing
Ran forge, and it successfully ran