### PR TITLE
[storage] reverse version ordering in state_value cf

### DIFF
--- a/storage/aptosdb/src/schema/state_value/mod.rs
+++ b/storage/aptosdb/src/schema/state_value/mod.rs
@@ -35,7 +35,7 @@ impl KeyCodec<StateValueSchema> for Key {
     fn encode_key(&self) -> Result<Vec<u8>> {
         let mut encoded = vec![];
         encoded.write_all(&self.0.encode()?)?;
-        encoded.write_u64::<BigEndian>(self.1)?;
+        encoded.write_u64::<BigEndian>(!self.1)?;
         Ok(encoded)
     }
 
@@ -45,7 +45,7 @@ impl KeyCodec<StateValueSchema> for Key {
         ensure_slice_len_gt(data, VERSION_SIZE)?;
         let state_key_len = data.len() - VERSION_SIZE;
         let state_key: StateKey = StateKey::decode(&data[..state_key_len])?;
-        let version = (&data[state_key_len..]).read_u64::<BigEndian>()?;
+        let version = !(&data[state_key_len..]).read_u64::<BigEndian>()?;
         Ok((state_key, version))
     }
 }


### PR DESCRIPTION
## Motivation

using `seek()` is more performant than my stupid `seek_for_prev`.
So we just reverse `version` in the encoding to indirectly reverse the ordering in this cf. Basically after this change, the ordering would be like:

abc/def       <---- seek the prefix goes here.
abc/def | 5
abc/def | 3   <---- seek("abc/def", 4) goes here.
abc/def | 1
abc/def | 0  
abc/deg
abc/deg | 8

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

ut


