### PR TITLE
[ecosystem] center dialog to page & prevent autofocus on close button…

### DIFF
--- a/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
+++ b/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
@@ -48,6 +48,7 @@ dialog.fixed {
   position: fixed;
   top: 50%;
   transform: translate(0, -50%);
+  margin: 0 auto;
 }
 
 dialog::backdrop {

--- a/ecosystem/platform/server/app/components/dialog_component.rb
+++ b/ecosystem/platform/server/app/components/dialog_component.rb
@@ -12,7 +12,7 @@ class DialogComponent < ViewComponent::Base
   def initialize(**rest)
     @rest = rest
     @rest[:class] = [
-      'rounded-xl border-none bg-neutral-900 text-white p-8 w-96',
+      'rounded-xl border-none bg-neutral-900 text-white p-8 w-96 fixed',
       @rest[:class]
     ]
 

--- a/ecosystem/platform/server/app/views/welcome/index.html.erb
+++ b/ecosystem/platform/server/app/views/welcome/index.html.erb
@@ -14,7 +14,7 @@
         Sign up
       <% end %>
       <%= dialog.with_body do %>
-        <div class="flex flex-col gap-3">
+        <div class="flex flex-col gap-3 outline-none" autofocus tabindex="-1">
           <%= render LoginButtonComponent.new(provider: :github, size: :large, class: 'w-full') %>
           <%= render LoginButtonComponent.new(provider: :discord, size: :large, class: 'w-full') %>
         </div>


### PR DESCRIPTION
## Motivation

Address issue with **Sign Up** `<dialog>` appearing out of viewport on Safari mobile, correct vertical centering by removing top and bottom margins and disable autofocusing close button on Safari. 

## Test Plan

Manual review in Safari mobile:

### Before:

`<dialog>` content out of view when clicking the **Sign Up** button
![image](https://user-images.githubusercontent.com/98909677/171347151-3e085488-1341-4f0a-b404-479057235d41.png)

Must scroll up to view `<dialog>` content, also getting blue focus on close button:
![image](https://user-images.githubusercontent.com/98909677/171347316-e5d09108-ff4c-4406-ae7b-f98cbeab075f.png)

### After:

![image](https://user-images.githubusercontent.com/98909677/171347518-062718a3-861e-4660-93dc-5e194023957e.png)


