### PR TITLE
[CICD] migrate more pipelines from circeci to github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,22 +96,6 @@ jobs:
               done
               exit $ret
             fi
-  build-push-community-platform:
-    executor: ubuntu-medium
-    steps:
-      - checkout
-      - aws-setup
-      - aws-ecr-setup
-      - gcp-gcr/gcr-auth:
-          registry-url: us-west1-docker.pkg.dev
-      - run:
-          name: Build or skip
-          shell: /bin/bash
-          command: |
-            set -e
-            cd ecosystem/platform/server
-            docker buildx create --use
-            GIT_SHA1=${CIRCLE_SHA1} docker buildx bake --progress=plain --push -f ./docker-bake.hcl
 
   ecr-dockerhub-mirror:
     executor: ubuntu-medium
@@ -268,13 +252,6 @@ workflows:
   # Build the PR binaries and run various tests
   # Build the Docker images and run Forge tests
 
-  build-push-community-platform:
-    jobs:
-      - build-push-community-platform:
-          context:
-            - aws-dev
-            - gcp-global
-
   build-test-deploy:
     when:
       not:
@@ -333,35 +310,6 @@ workflows:
             - aws-dev
             - docker-aptoslabsbots
           addl_tag: testnet
-          requires:
-            - docker-build-push
-  ### on continuous_push scheduled pipeline ###
-  # Build the latest on "main" branch
-  continuous-push:
-    when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ["continuous_push", << pipeline.schedule.name >>]
-    jobs:
-      - docker-build-push:
-          context: aws-dev
-          addl_tag: main
-  ### on nightly scheduled pipeline ###
-  # Ensure the latest on "main" branch is built, and mirror from ECR to Dockerhub
-  nightly:
-    when:
-      and:
-        - equal: [scheduled_pipeline, << pipeline.trigger_source >>]
-        - equal: ["nightly", << pipeline.schedule.name >>]
-    jobs:
-      - docker-build-push:
-          context: aws-dev
-          addl_tag: main
-      - ecr-dockerhub-mirror:
-          context:
-            - aws-dev
-            - docker-aptoslabsbots
-          addl_tag: main
           requires:
             - docker-build-push
 commands:

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,7 +1,7 @@
 name: "Build+Push Images"
 on: # build on main branch OR when a PR is labeled with `CICD:build-images`
   pull_request:
-     types: [labeled, opened, synchronize, reopened]
+    types: [labeled, opened, synchronize, reopened]
   push:
     branches:
       - main

--- a/.github/workflows/copy-image-to-dockerhub-nightly.yaml
+++ b/.github/workflows/copy-image-to-dockerhub-nightly.yaml
@@ -1,0 +1,57 @@
+on:
+  schedule:
+    # mon-fri at 9am PST (16:00 UTC).
+    - cron: "0 16 * * 1-5"
+
+env:
+  GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+
+jobs:
+  CopyImagesToDockerHub:
+    strategy:
+      matrix:
+        IMAGE_NAME: [validator, forge, init, validator_tcb, tools, faucet, txn-emitter, indexer]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: auth
+        name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v0"
+        with:
+          create_credentials_file: false
+          token_format: "access_token"
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Login to Google Artifact Registry
+        uses: docker/login-action@v2
+        with:
+          registry: us-west1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+
+      - name: Compute 8-char SHA1
+        id: vars
+        run: echo "::set-output name=short_sha1::$(git rev-parse --short=8 HEAD)"
+
+      - name: Push Images to Dockerhub
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ${{ GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ GITHUB_SHA }}
+          dst: |
+            docker.io/aptoslab/${{matrix.IMAGE_NAME}}:nightly
+            docker.io/aptoslab/${{matrix.IMAGE_NAME}}:nightly_${{ steps.vars.outputs.short_sha1 }}
+            docker.io/aptoslabs/${{matrix.IMAGE_NAME}}:nightly
+            docker.io/aptoslabs/${{matrix.IMAGE_NAME}}:nightly_${{ steps.vars.outputs.short_sha1 }}

--- a/x.toml
+++ b/x.toml
@@ -130,6 +130,8 @@ whitespace-exceptions = [
     "**/*.errmap",
     "**/*.abi",
     "terraform/**/*",
+    "**/*.yaml",
+    "**/*.yml",
 ]
 
 license-exceptions = [


### PR DESCRIPTION
This PR:
- removes community platform build from circleci - has been build already over a week on github actions reliably
- removes continuous push build from circleci - I don't think this is needed since we build and push every image on main anyways, so this would just lead to duplicate jobs
- migrates the nightly circleci pipeline to github actions. I made a few changes in the tagging scheme so it's instead of `main_<short_sha1>` tagged with `nightly_<short_sha1>` which is more common imo.