### PR TITLE
[Storage] Returns better error message when the requested version of data is pruned.

### DIFF
--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -130,8 +130,12 @@ impl Pruner {
         self.ledger_prune_window
     }
 
+    pub fn get_min_readable_version_by_pruner_index(&self, pruner_index: PrunerIndex) -> Version {
+        self.min_readable_version.lock()[pruner_index as usize]
+    }
+
     pub fn get_min_readable_ledger_version(&self) -> Version {
-        self.min_readable_version.lock()[LedgerPrunerIndex as usize]
+        self.get_min_readable_version_by_pruner_index(LedgerPrunerIndex)
     }
     /// Sends pruning command to the worker thread when necessary.
     pub fn maybe_wake_pruner(&self, latest_version: Version) {
@@ -194,6 +198,12 @@ impl Pruner {
             anyhow::bail!("Timeout waiting for pruner worker.");
         }
         Ok(())
+    }
+
+    /// (For tests only.) Updates the minimal readable version kept by pruner.
+    #[cfg(test)]
+    pub fn testonly_update_min_version(&mut self, version: &[Version]) {
+        self.min_readable_version = Arc::new(Mutex::new(version.to_vec()));
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

https://github.com/aptos-labs/aptos-core/issues/1168

Add checks in some storage APIs to early return with a more clear error message when the requested data version is pruned.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

y

## Test Plan

Unit tests.

## Related PRs

N/A
