### PR TITLE
[storage] Lazy StateDB prototype in executor-benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "schemadb",
+ "scratchpad",
  "serde 1.0.137",
  "storage-client",
  "storage-interface",

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -38,6 +38,7 @@ aptosdb = { path = "../../storage/aptosdb" }
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
 schemadb = { path = "../../storage/schemadb" }
+scratchpad = { path = "../../storage/scratchpad" }
 storage-client = { path = "../../storage/storage-client" }
 storage-interface = { path = "../../storage/storage-interface" }
 

--- a/execution/executor-benchmark/benches/executor_benchmark.rs
+++ b/execution/executor-benchmark/benches/executor_benchmark.rs
@@ -23,7 +23,7 @@ pub const INITIAL_BALANCE: u64 = 1000000;
 fn executor_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {
     let (config, genesis_key) = aptos_genesis_tool::test_config();
 
-    let (_db, executor) = init_db_and_executor(&config);
+    let (_r, _w, executor) = init_db_and_executor(&config);
     let parent_block_id = executor.committed_block_id();
     let executor = Arc::new(executor);
 

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -62,7 +62,7 @@ pub fn run(
     let executor_2 = executor.clone();
     let genesis_block_id = executor.committed_block_id();
     let (block_sender, block_receiver) = mpsc::sync_channel(3 /* bound */);
-    let (commit_sender, commit_receiver) = mpsc::sync_channel(3 /* bound */);
+    let (commit_sender, commit_receiver) = mpsc::sync_channel(100 /* bound */);
 
     // Set a progressing bar
     // Spawn threads to run transaction generator, executor and committer separately.
@@ -97,7 +97,7 @@ pub fn run(
     let commit_thread = std::thread::Builder::new()
         .name("txn_committer".to_string())
         .spawn(move || {
-            let mut committer = TransactionCommitter::new(executor_2, 0, commit_receiver);
+            let mut committer = TransactionCommitter::new(executor_2, 0, commit_receiver, None);
             committer.run();
         })
         .expect("Failed to spawn transaction committer thread.");

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -75,6 +75,9 @@ enum Command {
             about = "Verify sequence number of all the accounts after execution finishes"
         )]
         verify: bool,
+
+        #[structopt(long, about = "commit state synchronously")]
+        sync_state_commit: bool,
     },
 }
 
@@ -113,6 +116,7 @@ fn main() {
             data_dir,
             checkpoint_dir,
             verify,
+            sync_state_commit,
         } => {
             aptos_logger::Logger::new().init();
             executor_benchmark::run_benchmark(
@@ -121,6 +125,7 @@ fn main() {
                 data_dir,
                 checkpoint_dir,
                 verify,
+                sync_state_commit,
             );
         }
     }

--- a/execution/executor-benchmark/src/state_committer.rs
+++ b/execution/executor-benchmark/src/state_committer.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_logger::info;
+use aptos_types::{
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use scratchpad::SparseMerkleTree;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{mpsc, Arc},
+};
+use storage_interface::DbWriter;
+
+const NUM_COMMITTED_SMTS_TO_CACHE: usize = 10;
+const NUM_COMMITS_TO_BATCH: usize = 20;
+
+pub struct StateCommitter {
+    commit_receiver: mpsc::Receiver<(
+        Version,
+        SparseMerkleTree<StateValue>,
+        Vec<HashMap<StateKey, StateValue>>,
+    )>,
+    db: Arc<dyn DbWriter>,
+}
+
+impl StateCommitter {
+    pub fn new(
+        commit_receiver: mpsc::Receiver<(
+            Version,
+            SparseMerkleTree<StateValue>,
+            Vec<HashMap<StateKey, StateValue>>,
+        )>,
+        db: Arc<dyn DbWriter>,
+    ) -> Self {
+        Self {
+            commit_receiver,
+            db,
+        }
+    }
+
+    pub fn run(self, base_smt: SparseMerkleTree<StateValue>) {
+        // keep some recently committed SMTs in mem as a naive cache
+        let mut cache_queue = VecDeque::with_capacity(NUM_COMMITTED_SMTS_TO_CACHE);
+        cache_queue.push_back(base_smt.clone());
+        // information wrt the next commit
+        let mut version_to_commit;
+        let mut smt_to_commit;
+        let mut state_updates_to_commit = HashMap::new();
+        let mut num_pending_commits = 0;
+        let mut committed_smt = base_smt;
+
+        while let Ok((version, smt, state_updates)) = self.commit_receiver.recv() {
+            version_to_commit = version;
+            smt_to_commit = smt;
+            state_updates_to_commit.extend(state_updates.into_iter().flatten());
+            num_pending_commits += 1;
+
+            if num_pending_commits >= NUM_COMMITS_TO_BATCH {
+                let mut to_commit = HashMap::new();
+                std::mem::swap(&mut to_commit, &mut state_updates_to_commit);
+                let node_hashes = smt_to_commit
+                    .clone()
+                    .freeze()
+                    .new_node_hashes_since(&committed_smt.freeze());
+
+                self.db
+                    .merklize_state(to_commit, node_hashes, version_to_commit)
+                    .unwrap();
+                info!(version = version_to_commit, "State committed.");
+                num_pending_commits = 0;
+                committed_smt = smt_to_commit.clone();
+                if cache_queue.len() >= NUM_COMMITTED_SMTS_TO_CACHE {
+                    cache_queue.pop_front();
+                }
+                cache_queue.push_back(smt_to_commit);
+            }
+        }
+    }
+}

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -120,7 +120,7 @@ pub trait BlockExecutorTrait: Send + Sync {
         Option<(
             Version,
             SparseMerkleTree<StateValue>,
-            Vec<Vec<(HashValue, (HashValue, StateKey))>>,
+            Vec<HashMap<StateKey, StateValue>>,
         )>,
         Error,
     > {

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -28,7 +28,7 @@ use aptos_types::{
     },
     write_set::WriteSet,
 };
-use scratchpad::ProofRead;
+use scratchpad::{ProofRead, SparseMerkleTree};
 use serde::{Deserialize, Serialize};
 use std::{cmp::max, collections::HashMap, sync::Arc};
 use storage_interface::DbReader;
@@ -111,6 +111,21 @@ pub trait BlockExecutorTrait: Send + Sync {
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
     ) -> Result<(), Error>;
+
+    fn commit_blocks_no_state_merklize(
+        &self,
+        _block_ids: Vec<HashValue>,
+        _ledger_info_with_sigs: LedgerInfoWithSignatures,
+    ) -> Result<
+        Option<(
+            Version,
+            SparseMerkleTree<StateValue>,
+            Vec<Vec<(HashValue, (HashValue, StateKey))>>,
+        )>,
+        Error,
+    > {
+        unimplemented!()
+    }
 }
 
 pub trait TransactionReplayer: Send {

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -97,6 +97,7 @@ impl<V> ChunkExecutor<V> {
                 &txns_to_commit,
                 base_view.txn_accumulator().num_leaves(),
                 ledger_info,
+                true,
             )?;
         }
 

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -15,7 +15,7 @@ use aptos_crypto::{
     hash::{CryptoHash, EventAccumulatorHasher},
     HashValue,
 };
-use aptos_logger::error;
+use aptos_logger::{debug, error};
 use aptos_types::{
     contract_event::ContractEvent,
     nibble::nibble_path::NibblePath,
@@ -131,7 +131,12 @@ impl ApplyChunkOutput {
             .map(|(t, o)| {
                 // In case a new status other than Retry, Keep and Discard is added:
                 if !matches!(o.status(), TransactionStatus::Discard(_)) {
-                    error!("Status other than Retry, Keep or Discard; Transaction discarded.");
+                    error!(
+                        status = o.status(),
+                        "Status other than Retry, Keep or Discard; Transaction discarded."
+                    );
+                } else {
+                    debug!(status = o.status(), "Discarded transaction.",)
                 }
                 // VM shouldn't have output anything for discarded transactions, log if it did.
                 if !o.write_set().is_empty() || !o.events().is_empty() {

--- a/execution/executor/src/components/block_tree/mod.rs
+++ b/execution/executor/src/components/block_tree/mod.rs
@@ -14,9 +14,12 @@ use anyhow::{anyhow, ensure, Result};
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_logger::{debug, info};
-use aptos_types::{ledger_info::LedgerInfo, proof::definition::LeafCount};
+use aptos_types::{
+    ledger_info::LedgerInfo, proof::definition::LeafCount, state_store::state_value::StateValue,
+};
 use consensus_types::block::Block as ConsensusBlock;
 use executor_types::{Error, ExecutedChunk};
+use scratchpad::SparseMerkleTree;
 use std::{
     collections::{hash_map::Entry, HashMap},
     sync::{Arc, Weak},
@@ -226,7 +229,7 @@ impl BlockTree {
         block_lookup.fetch_or_add_block(id, ExecutedChunk::new_empty(result_view), None)
     }
 
-    pub fn prune(&self, ledger_info: &LedgerInfo) -> Result<()> {
+    pub fn prune(&self, ledger_info: &LedgerInfo) -> Result<SparseMerkleTree<StateValue>> {
         let committed_block_id = ledger_info.consensus_block_id();
         let last_committed_block = self.get_block(committed_block_id)?;
 
@@ -251,8 +254,10 @@ impl BlockTree {
             last_committed_block
         };
 
+        let root_smt = root.output.result_view.state().current.clone();
+
         *self.root.lock() = root;
-        Ok(())
+        Ok(root_smt)
     }
 
     pub fn add_block(

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -93,6 +93,7 @@ impl GenesisCommitter {
             &self.output.transactions_to_commit()?,
             self.output.result_view.txn_accumulator().version(),
             self.output.ledger_info.as_ref(),
+            true,
         )?;
         info!("Genesis commited.");
         // DB bootstrapped, avoid anything that could fail after this.

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -87,6 +87,7 @@ impl DbWriter for FakeDb {
         _txns_to_commit: &[TransactionToCommit],
         _first_version: Version,
         _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        _merklize_state: bool,
     ) -> Result<()> {
         Ok(())
     }

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -404,6 +404,7 @@ fn apply_transaction_by_writeset(
             &executed.transactions_to_commit().unwrap(),
             ledger_view.txn_accumulator().num_leaves(),
             None,
+            true,
         )
         .unwrap();
 }
@@ -543,6 +544,7 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
                 &executed.transactions_to_commit().unwrap(),
                 ledger_view.txn_accumulator().num_leaves(),
                 None,
+                true,
             )
             .unwrap();
         ledger_view = executed.result_view;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -317,6 +317,7 @@ mock! {
             txns_to_commit: &[TransactionToCommit],
             first_version: Version,
             ledger_info_with_sigs: Option<&'a LedgerInfoWithSignatures>,
+            merklize_state: bool,
         ) -> Result<()>;
 
         fn delete_genesis(&self) -> Result<()>;

--- a/storage/aptosdb/src/backup/test.rs
+++ b/storage/aptosdb/src/backup/test.rs
@@ -17,7 +17,7 @@ proptest! {
 
         let mut cur_ver = 0;
         for (txns_to_commit, ledger_info_with_sigs) in input.iter() {
-            db.save_transactions(txns_to_commit, cur_ver, Some(ledger_info_with_sigs))
+            db.save_transactions(txns_to_commit, cur_ver, Some(ledger_info_with_sigs), true)
                 .unwrap();
             cur_ver += txns_to_commit.len() as u64;
         }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -87,7 +87,10 @@ use std::{
     thread::JoinHandle,
     time::{Duration, Instant},
 };
-use storage_interface::{DbReader, DbWriter, Order, StartupInfo, StateSnapshotReceiver, TreeState};
+use storage_interface::{
+    jmt_update_ref_sets, jmt_update_sets, DbReader, DbWriter, Order, StartupInfo,
+    StateSnapshotReceiver, TreeState,
+};
 
 const MAX_LIMIT: u64 = 5000;
 
@@ -604,6 +607,7 @@ impl AptosDB {
                 .iter()
                 .map(|txn_to_commit| txn_to_commit.state_updates())
                 .collect::<Vec<_>>();
+            let jmt_update_sets = jmt_update_sets(&state_updates_vec);
             // find the last version with state tree updates -- that's the latest state checkpoint
             let latest_state_checkpoint_index = state_updates_vec
                 .iter()
@@ -614,7 +618,7 @@ impl AptosDB {
                 .map(|txn_to_commit| txn_to_commit.jf_node_hashes())
                 .collect::<Option<Vec<_>>>();
             let root_hashes = self.state_store.merklize_value_sets(
-                state_updates_vec.clone(),
+                jmt_update_ref_sets(&jmt_update_sets),
                 node_hashes,
                 first_version,
                 cs,

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -35,6 +35,14 @@ pub static LATEST_TXN_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static LATEST_STATE_CHECKPOINT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_storage_latest_state_checkpoint_version",
+        "Aptos storage latest state checkpoint version"
+    )
+    .unwrap()
+});
+
 pub static LEDGER_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "aptos_storage_ledger_version",

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
 use aptos_types::state_store::{state_key::StateKey, state_value::StateValue};
+use storage_interface::{jmt_update_ref_sets, jmt_update_sets};
 
 use crate::{change_set::ChangeSet, pruner::*, state_store::StateStore, AptosDB};
 
@@ -20,9 +21,15 @@ fn put_value_set(
         .iter()
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect();
+    let jmt_update_sets = jmt_update_sets(&[&value_set]);
 
     let root = state_store
-        .merklize_value_sets(vec![&value_set], None, version, &mut cs)
+        .merklize_value_sets(
+            jmt_update_ref_sets(&jmt_update_sets),
+            None,
+            version,
+            &mut cs,
+        )
         .unwrap()[0];
     state_store
         .put_value_sets(vec![&value_set], version, &mut cs)

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -261,29 +261,14 @@ impl StateStore {
     /// hashes for each write set.
     pub fn merklize_value_sets(
         &self,
-        value_state_sets: Vec<&HashMap<StateKey, StateValue>>,
+        value_sets: Vec<Vec<(HashValue, &(HashValue, StateKey))>>,
         node_hashes: Option<Vec<&HashMap<NibblePath, HashValue>>>,
         first_version: Version,
         cs: &mut ChangeSet,
     ) -> Result<Vec<HashValue>> {
-        let value_sets: Vec<Vec<_>> = value_state_sets
-            .iter()
-            .map(|value_set| {
-                value_set
-                    .iter()
-                    .map(|(key, value)| (key.hash(), (value.hash(), key.clone())))
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-
-        let value_sets_ref = value_sets
-            .iter()
-            .map(|value_set| value_set.iter().map(|(x, y)| (*x, y)).collect::<Vec<_>>())
-            .collect::<Vec<_>>();
-
         let (new_root_hash_vec, tree_update_batch) = JellyfishMerkleTree::new(self)
             .batch_put_value_sets(
-                value_sets_ref,
+                value_sets,
                 node_hashes,
                 self.find_latest_persisted_version_less_than(first_version)?,
                 first_version,

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -13,7 +13,7 @@ use aptos_temppath::TempPath;
 use aptos_types::{
     access_path::AccessPath, account_address::AccountAddress, state_store::state_key::StateKeyTag,
 };
-use storage_interface::StateSnapshotReceiver;
+use storage_interface::{jmt_update_ref_sets, jmt_update_sets, StateSnapshotReceiver};
 
 use crate::{pruner, AptosDB};
 
@@ -29,9 +29,15 @@ fn put_value_set(
         .iter()
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect();
+    let jmt_update_sets = jmt_update_sets(&[&value_set]);
 
     let root = state_store
-        .merklize_value_sets(vec![&value_set], None, version, &mut cs)
+        .merklize_value_sets(
+            jmt_update_ref_sets(&jmt_update_sets),
+            None,
+            version,
+            &mut cs,
+        )
         .unwrap()[0];
     state_store
         .put_value_sets(vec![&value_set], version, &mut cs)
@@ -675,10 +681,16 @@ fn update_store(
 ) {
     for (i, (key, value)) in input.enumerate() {
         let mut cs = ChangeSet::new();
-        let value_state_set: HashMap<_, _> = std::iter::once((key, value)).collect();
+        let value_state_set = vec![(key, value)].into_iter().collect();
+        let jmt_update_sets = jmt_update_sets(&[&value_state_set]);
         let version = first_version + i as Version;
         let root_hashes = store
-            .merklize_value_sets(vec![&value_state_set], None, version, &mut cs)
+            .merklize_value_sets(
+                jmt_update_ref_sets(&jmt_update_sets),
+                None,
+                version,
+                &mut cs,
+            )
             .unwrap();
         store
             .put_value_sets(vec![&value_state_set], version, &mut cs)

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -162,6 +162,7 @@ pub fn test_save_blocks_impl(input: Vec<(Vec<TransactionToCommit>, LedgerInfoWit
             txns_to_commit,
             cur_ver, /* first_version */
             Some(ledger_info_with_sigs),
+            true,
         )
         .unwrap();
 
@@ -644,6 +645,7 @@ pub fn test_sync_transactions_impl(
                 &txns_to_commit[..batch1_len],
                 cur_ver, /* first_version */
                 None,
+                true,
             )
             .unwrap();
         }
@@ -651,6 +653,7 @@ pub fn test_sync_transactions_impl(
             &txns_to_commit[batch1_len..],
             cur_ver + batch1_len as u64, /* first_version */
             Some(ledger_info_with_sigs),
+            true,
         )
         .unwrap();
 

--- a/storage/backup/backup-cli/src/utils/test_utils.rs
+++ b/storage/backup/backup-cli/src/utils/test_utils.rs
@@ -34,6 +34,7 @@ pub fn tmp_db_with_random_content() -> (
             txns_to_commit,
             cur_ver, /* first_version */
             Some(ledger_info_with_sigs),
+            true,
         )
         .unwrap();
         cur_ver += txns_to_commit.len() as u64;

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -516,6 +516,6 @@ impl DB {
 /// selectively turning this off for some non-critical writes to improve performance.
 fn default_write_options() -> rocksdb::WriteOptions {
     let mut opts = rocksdb::WriteOptions::default();
-    opts.set_sync(true);
+    // opts.set_sync(true);
     opts
 }

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -70,6 +70,7 @@ impl StorageClient {
         txns_to_commit: Vec<TransactionToCommit>,
         first_version: Version,
         ledger_info_with_sigs: Option<LedgerInfoWithSignatures>,
+        _merklize_state: bool,
     ) -> std::result::Result<(), Error> {
         self.request(StorageRequest::SaveTransactionsRequest(Box::new(
             SaveTransactionsRequest::new(txns_to_commit, first_version, ledger_info_with_sigs),
@@ -97,12 +98,14 @@ impl DbWriter for StorageClient {
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        merklize_state: bool,
     ) -> Result<()> {
         Ok(Self::save_transactions(
             self,
             txns_to_commit.to_vec(),
             first_version,
             ledger_info_with_sigs.cloned(),
+            merklize_state,
         )?)
     }
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -16,6 +16,7 @@ use aptos_types::{
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     move_resource::MoveStorage,
+    nibble::nibble_path::NibblePath,
     on_chain_config::{access_path_for_config, ConfigID},
     proof::{
         definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof,
@@ -683,6 +684,15 @@ pub trait DbWriter: Send + Sync {
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         merklize_state: bool,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn merklize_state(
+        &self,
+        state_updates: HashMap<StateKey, StateValue>,
+        node_hashes: HashMap<NibblePath, HashValue>,
+        version: Version,
     ) -> Result<()> {
         unimplemented!()
     }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -682,6 +682,7 @@ pub trait DbWriter: Send + Sync {
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        merklize_state: bool,
     ) -> Result<()> {
         unimplemented!()
     }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, format_err, Result};
-use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
+use aptos_crypto::{
+    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    HashValue,
+};
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -763,4 +766,27 @@ impl SaveTransactionsRequest {
             ledger_info_with_signatures,
         }
     }
+}
+
+pub fn jmt_update_sets(
+    state_update_sets: &[&HashMap<StateKey, StateValue>],
+) -> Vec<Vec<(HashValue, (HashValue, StateKey))>> {
+    state_update_sets
+        .iter()
+        .map(|updates| {
+            updates
+                .iter()
+                .map(|(k, v)| (k.hash(), (v.hash(), k.clone())))
+                .collect()
+        })
+        .collect()
+}
+
+pub fn jmt_update_ref_sets(
+    jmt_update_sets: &[Vec<(HashValue, (HashValue, StateKey))>],
+) -> Vec<Vec<(HashValue, &(HashValue, StateKey))>> {
+    jmt_update_sets
+        .iter()
+        .map(|vec| vec.iter().map(|(x, y)| (*x, y)).collect())
+        .collect()
 }

--- a/storage/storage-service/src/lib.rs
+++ b/storage/storage-service/src/lib.rs
@@ -72,6 +72,7 @@ impl StorageService {
             &req.txns_to_commit,
             req.first_version,
             req.ledger_info_with_signatures.as_ref(),
+            true,
         )?)
     }
 

--- a/storage/storage-service/src/storage_service_test.rs
+++ b/storage/storage-service/src/storage_service_test.rs
@@ -46,6 +46,7 @@ proptest! {
                 txns_to_commit.clone(),
                 version, /* first_version */
                 Some(ledger_info_with_sigs.clone()),
+                true,
             ).unwrap();
             version += txns_to_commit.len() as u64;
             let mut account_states = HashMap::new();

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1137,6 +1137,10 @@ impl TransactionToCommit {
         &self.state_updates
     }
 
+    pub fn into_state_updates(self) -> HashMap<StateKey, StateValue> {
+        self.state_updates
+    }
+
     pub fn jf_node_hashes(&self) -> Option<&HashMap<NibblePath, HashValue>> {
         self.jf_node_hashes.as_ref()
     }


### PR DESCRIPTION

## Motivation

By making state commission asynchronous and less frequent, we expect higher throughput overall.
This demos the ability in executor-benchmark.

With a 1 million accounts DB we observe 3.5x throughput increase (12k vs 3.5k TPS).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
y
## Test Plan

```
 cargo run --release -p executor-benchmark -- --block-size 10000 --concurrency-level 32 create-db --data-dir ~/work/data/per-block/1M --num-accounts 1000000
```


```
cargo run --release -p executor-benchmark -- --block-size 10000 --concurrency-level 32 run-executor --data-dir ~/work/data/per-block/1M --blocks 1000 --checkpoint-dir ~/work/tmp/cp  --sync-state-commit
```

```
cargo run --release -p executor-benchmark -- --block-size 10000 --concurrency-level 32 run-executor --data-dir ~/work/data/per-block/1M --blocks 1000 --checkpoint-dir ~/work/tmp/cp  
```

