### PR TITLE
[CICD] optimize docker layer caching

### DIFF
--- a/docker/docker-bake-rust-all.sh
+++ b/docker/docker-bake-rust-all.sh
@@ -12,4 +12,5 @@ set -e
 export GIT_REV=$(git rev-parse --short=8 HEAD)
 export GIT_SHA1=$(git rev-parse HEAD)
 export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 docker buildx bake --push --file docker/docker-bake-rust-all.hcl $IMAGE_TARGET


### PR DESCRIPTION
This PR optimizes the Docker layer caching in the following way:
Previously all docker builds were pushing a cache manifest to `<registry>/<image_name>:cache` . This meant that effectively there was only one actively used cache shared by all branches/builds and that the cache manifest would be overridden by whomever pushed last. Effectively this meant a PR on `my_feature_branch` could override the cache created by `main`, which is undesirable if a PR did not make any code change with respect to `main`.

With this change, builds push a branch specific cache manifest to `:cache-<current_branch>`.
Builds will pull cache manifests from 2 places: `:cache-<current_branch>` and `:cache-main` .
This allows PRs to always leverage the `main` cache and on top of that a branch-specific local cache.
This should drastically increase the cache hit ratio.
