### PR TITLE
[CICD] set a time limit when waiting for dependent docker image build job

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Wait for images to have been built
+        timeout-minutes: 20
         uses: lewagon/wait-on-check-action@v1.0.0
         with:
           ref: ${{ github.ref }}


### PR DESCRIPTION
make sure this wait step doesn't run for hours when something in the dependent workflow goes horribly wrong