### PR TITLE
[aptos-cli] Add smoke tests to Aptos CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3060,6 +3060,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "aptos-config",
+ "aptos-faucet",
  "aptos-genesis-tool",
  "aptos-logger",
  "aptos-rest-client",
@@ -7391,6 +7392,7 @@ dependencies = [
  "aptos",
  "aptos-config",
  "aptos-crypto",
+ "aptos-faucet",
  "aptos-genesis-tool",
  "aptos-global-constants",
  "aptos-indexer",

--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -29,10 +29,124 @@ use aptos_sdk::{
 use futures::lock::Mutex;
 use reqwest::StatusCode;
 use std::{convert::Infallible, fmt, sync::Arc};
+use std::path::Path;
 use url::Url;
 use warp::{http, Filter, Rejection, Reply};
+use aptos::common::types::EncodingType;
+use aptos_config::keys::ConfigKey;
+use aptos_crypto::ed25519::Ed25519PrivateKey;
+use aptos_sdk::types::account_address::AccountAddress;
+use aptos_sdk::types::account_config::aptos_root_address;
+use structopt::StructOpt;
 
 pub mod mint;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+name = "Aptos Faucet",
+author = "Aptos",
+about = "Aptos Testnet utility service for creating test accounts and minting test coins"
+)]
+pub struct FaucetArgs {
+    /// Faucet service listen address
+    #[structopt(short = "a", long, default_value = "127.0.0.1")]
+    pub address: String,
+    /// Faucet service listen port
+    #[structopt(short = "p", long, default_value = "80")]
+    pub port: u16,
+    /// Aptos fullnode/validator server URL
+    #[structopt(short = "s", long, default_value = "https://testnet.aptoslabs.com/")]
+    pub server_url: String,
+    /// Path to the private key for creating test account and minting coins.
+    /// To keep Testnet simple, we used one private key for aptos root account
+    /// To manually generate a keypair, use generate-key:
+    /// `cargo run -p generate-keypair -- -o <output_file_path>`
+    #[structopt(short = "m", long, default_value = "/opt/aptos/etc/mint.key")]
+    pub mint_key_file_path: String,
+    /// Ed25519PrivateKey for minting coins
+    #[structopt(long, parse(try_from_str = ConfigKey::from_encoded_string))]
+    pub mint_key: Option<ConfigKey<Ed25519PrivateKey>>,
+    /// Address of the account to send transactions from.
+    /// On Testnet, for example, this is a550c18.
+    /// If not present, the mint key's address is used
+    #[structopt(short = "t", long, parse(try_from_str = AccountAddress::from_hex_literal))]
+    pub mint_account_address: Option<AccountAddress>,
+    /// Chain ID of the network this client is connecting to.
+    /// For mainnet: "MAINNET" or 1, testnet: "TESTNET" or 2, devnet: "DEVNET" or 3,
+    /// local swarm: "TESTING" or 4
+    /// Note: Chain ID of 0 is not allowed; Use number if chain id is not predefined.
+    #[structopt(short = "c", long, default_value = "2")]
+    pub chain_id: ChainId,
+    /// Maximum amount of coins to mint.
+    #[structopt(long)]
+    pub maximum_amount: Option<u64>,
+    #[structopt(long)]
+    pub do_not_delegate: bool,
+}
+
+impl FaucetArgs {
+    pub async fn run(self) {
+        let address: std::net::SocketAddr = format!("{}:{}", self.address, self.port)
+            .parse()
+            .expect("invalid address or port number");
+
+        info!(
+        "[faucet]: chain id: {}, server url: {} . Limit: {:?}",
+        self.chain_id,
+        self.server_url.as_str(),
+        self.maximum_amount,
+    );
+
+        let key = if let Some(key) = self.mint_key {
+            key.private_key()
+        } else {
+            EncodingType::BCS
+                .load_key::<Ed25519PrivateKey>("mint key", Path::new(&self.mint_key_file_path))
+                .unwrap()
+        };
+
+        let faucet_address: AccountAddress =
+            self.mint_account_address.unwrap_or_else(aptos_root_address);
+        let faucet_account = LocalAccount::new(faucet_address, key, 0);
+
+        // Do not use maximum amount on delegation, this allows the new delegated faucet to
+        // mint a lot for themselves!
+        let maximum_amount = if self.do_not_delegate {
+            self.maximum_amount
+        } else {
+            None
+        };
+
+        let service = Arc::new(Service::new(
+            self.server_url.clone(),
+            self.chain_id,
+            faucet_account,
+            maximum_amount,
+        ));
+
+        let actual_service = if self.do_not_delegate {
+            service
+        } else {
+            delegate_mint_account(
+                service,
+                self.server_url,
+                self.chain_id,
+                self.maximum_amount,
+            )
+                .await
+        };
+
+        info!(
+        "[faucet]: running on: {}. Minting from {}",
+        address,
+        actual_service.faucet_account.lock().await.address()
+    );
+        warp::serve(routes(actual_service))
+            .run(address)
+            .await;
+    }
+}
+
 
 pub struct Service {
     pub faucet_account: Mutex<LocalAccount>,

--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -1,123 +1,15 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos::common::types::EncodingType;
-use aptos_config::keys::ConfigKey;
-use aptos_crypto::ed25519::Ed25519PrivateKey;
-use aptos_logger::info;
-use aptos_sdk::types::{
-    account_address::AccountAddress, account_config::aptos_root_address, chain_id::ChainId,
-    LocalAccount,
-};
-use std::{path::Path, sync::Arc};
 use structopt::StructOpt;
+use aptos_faucet::FaucetArgs;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Aptos Faucet",
-    author = "Aptos",
-    about = "Aptos Testnet utility service for creating test accounts and minting test coins"
-)]
-struct Args {
-    /// Faucet service listen address
-    #[structopt(short = "a", long, default_value = "127.0.0.1")]
-    pub address: String,
-    /// Faucet service listen port
-    #[structopt(short = "p", long, default_value = "80")]
-    pub port: u16,
-    /// Aptos fullnode/validator server URL
-    #[structopt(short = "s", long, default_value = "https://testnet.aptoslabs.com/")]
-    pub server_url: String,
-    /// Path to the private key for creating test account and minting coins.
-    /// To keep Testnet simple, we used one private key for aptos root account
-    /// To manually generate a keypair, use generate-key:
-    /// `cargo run -p generate-keypair -- -o <output_file_path>`
-    #[structopt(short = "m", long, default_value = "/opt/aptos/etc/mint.key")]
-    pub mint_key_file_path: String,
-    /// Ed25519PrivateKey for minting coins
-    #[structopt(long, parse(try_from_str = ConfigKey::from_encoded_string))]
-    pub mint_key: Option<ConfigKey<Ed25519PrivateKey>>,
-    /// Address of the account to send transactions from.
-    /// On Testnet, for example, this is a550c18.
-    /// If not present, the mint key's address is used
-    #[structopt(short = "t", long, parse(try_from_str = AccountAddress::from_hex_literal))]
-    pub mint_account_address: Option<AccountAddress>,
-    /// Chain ID of the network this client is connecting to.
-    /// For mainnet: "MAINNET" or 1, testnet: "TESTNET" or 2, devnet: "DEVNET" or 3,
-    /// local swarm: "TESTING" or 4
-    /// Note: Chain ID of 0 is not allowed; Use number if chain id is not predefined.
-    #[structopt(short = "c", long, default_value = "2")]
-    pub chain_id: ChainId,
-    /// Maximum amount of coins to mint.
-    #[structopt(long)]
-    pub maximum_amount: Option<u64>,
-    #[structopt(long)]
-    pub do_not_delegate: bool,
-}
 
 #[tokio::main]
 async fn main() {
-    let args: Args = Args::from_args();
     aptos_logger::Logger::new().init();
-
-    let address: std::net::SocketAddr = format!("{}:{}", args.address, args.port)
-        .parse()
-        .expect("invalid address or port number");
-
-    info!(
-        "[faucet]: chain id: {}, server url: {} . Limit: {:?}",
-        args.chain_id,
-        args.server_url.as_str(),
-        args.maximum_amount,
-    );
-
-    let key = if let Some(key) = args.mint_key {
-        key.private_key()
-    } else {
-        EncodingType::BCS
-            .load_key::<Ed25519PrivateKey>("mint key", Path::new(&args.mint_key_file_path))
-            .unwrap()
-    };
-
-    let faucet_address: AccountAddress =
-        args.mint_account_address.unwrap_or_else(aptos_root_address);
-    let faucet_account = LocalAccount::new(faucet_address, key, 0);
-
-    // Do not use maximum amount on delegation, this allows the new delegated faucet to
-    // mint a lot for themselves!
-    let maximum_amount = if args.do_not_delegate {
-        args.maximum_amount
-    } else {
-        None
-    };
-
-    let service = Arc::new(aptos_faucet::Service::new(
-        args.server_url.clone(),
-        args.chain_id,
-        faucet_account,
-        maximum_amount,
-    ));
-
-    let actual_service = if args.do_not_delegate {
-        service
-    } else {
-        aptos_faucet::delegate_mint_account(
-            service,
-            args.server_url,
-            args.chain_id,
-            args.maximum_amount,
-        )
-        .await
-    };
-
-    info!(
-        "[faucet]: running on: {}. Minting from {}",
-        address,
-        actual_service.faucet_account.lock().await.address()
-    );
-    warp::serve(aptos_faucet::routes(actual_service))
-        .run(address)
-        .await;
+    let args: FaucetArgs = FaucetArgs::from_args();
+    args.run().await
 }
 
 #[cfg(test)]

--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -1,9 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use structopt::StructOpt;
 use aptos_faucet::FaucetArgs;
-
+use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() {

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -13,27 +13,29 @@ use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
 use clap::Parser;
 
+pub const DEFAULT_FUNDED_COINS: u64 = 10000;
+
 /// Command to create a new account on-chain
 ///
 #[derive(Debug, Parser)]
 pub struct CreateAccount {
     #[clap(flatten)]
-    encoding_options: EncodingOptions,
+    pub(crate) encoding_options: EncodingOptions,
     #[clap(flatten)]
-    write_options: WriteTransactionOptions,
+    pub(crate) write_options: WriteTransactionOptions,
     #[clap(flatten)]
-    profile_options: ProfileOptions,
+    pub(crate) profile_options: ProfileOptions,
     /// Address to create account for
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
-    account: AccountAddress,
+    pub(crate) account: AccountAddress,
     /// Flag for using faucet to create the account
     #[clap(long)]
-    use_faucet: bool,
+    pub(crate) use_faucet: bool,
     #[clap(flatten)]
-    faucet_options: FaucetOptions,
+    pub(crate) faucet_options: FaucetOptions,
     /// Initial coins to fund when using the faucet
-    #[clap(long, default_value = "10000")]
-    initial_coins: u64,
+    #[clap(long, default_value_t = DEFAULT_FUNDED_COINS)]
+    pub(crate) initial_coins: u64,
 }
 
 #[async_trait]

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -1,9 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::{
-    types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions},
-    utils::fund_account,
+use crate::{
+    account::create::DEFAULT_FUNDED_COINS,
+    common::{
+        types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions},
+        utils::fund_account,
+    },
 };
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
@@ -14,15 +17,15 @@ use clap::Parser;
 #[derive(Debug, Parser)]
 pub struct FundAccount {
     #[clap(flatten)]
-    profile_options: ProfileOptions,
+    pub(crate) profile_options: ProfileOptions,
     /// Address to create account for
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
-    account: AccountAddress,
+    pub(crate) account: AccountAddress,
     #[clap(flatten)]
-    faucet_options: FaucetOptions,
+    pub(crate) faucet_options: FaucetOptions,
     /// Coins to fund when using the faucet
-    #[clap(long, default_value = "10000")]
-    num_coins: u64,
+    #[clap(long, default_value_t = DEFAULT_FUNDED_COINS)]
+    pub(crate) num_coins: u64,
 }
 
 #[async_trait]

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -9,13 +9,27 @@ use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
 use clap::{ArgEnum, Parser};
 use serde_json::json;
-use std::str::FromStr;
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 
 #[derive(ArgEnum, Clone, Copy, Debug)]
-enum ListQuery {
+pub enum ListQuery {
     Balance,
     Modules,
     Resources,
+}
+
+impl Display for ListQuery {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            ListQuery::Balance => "balance",
+            ListQuery::Modules => "modules",
+            ListQuery::Resources => "resources",
+        };
+        write!(f, "{}", str)
+    }
 }
 
 impl FromStr for ListQuery {
@@ -36,19 +50,19 @@ impl FromStr for ListQuery {
 #[derive(Debug, Parser)]
 pub struct ListAccount {
     #[clap(flatten)]
-    rest_options: RestOptions,
+    pub(crate) rest_options: RestOptions,
 
     #[clap(flatten)]
-    profile_options: ProfileOptions,
+    pub(crate) profile_options: ProfileOptions,
 
     /// Address of account you want to list resources/modules for
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
-    account: Option<AccountAddress>,
+    pub(crate) account: Option<AccountAddress>,
 
     /// Type of items to list: resources, modules. (Defaults to 'resources').
     /// TODO: add options like --tokens --nfts etc
-    #[clap(long, default_value = "resources")]
-    query: ListQuery,
+    #[clap(long, default_value_t = ListQuery::Resources)]
+    pub(crate) query: ListQuery,
 }
 
 #[async_trait]

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -18,21 +18,21 @@ use std::collections::BTreeMap;
 #[derive(Debug, Parser)]
 pub struct TransferCoins {
     #[clap(flatten)]
-    write_options: WriteTransactionOptions,
+    pub(crate) write_options: WriteTransactionOptions,
 
     #[clap(flatten)]
-    encoding_options: EncodingOptions,
+    pub(crate) encoding_options: EncodingOptions,
 
     #[clap(flatten)]
-    profile_options: ProfileOptions,
+    pub(crate) profile_options: ProfileOptions,
 
     /// Address of account you want to send coins to
     #[clap(long, parse(try_from_str = crate::common::types::load_account_arg))]
-    account: AccountAddress,
+    pub(crate) account: AccountAddress,
 
     /// Amount of coins to transfer
     #[clap(long)]
-    amount: u64,
+    pub(crate) amount: u64,
 }
 
 #[async_trait]
@@ -68,12 +68,12 @@ const SUPPORTED_COINS: [&str; 1] = ["0x1::Coin::CoinStore<0x1::TestCoin::TestCoi
 /// A shortened transaction output
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct TransferSummary {
-    gas_used: Option<u64>,
-    balance_changes: BTreeMap<AccountAddress, serde_json::Value>,
-    sender: Option<AccountAddress>,
-    success: bool,
-    version: Option<u64>,
-    vm_status: String,
+    pub gas_used: Option<u64>,
+    pub balance_changes: BTreeMap<AccountAddress, serde_json::Value>,
+    pub sender: Option<AccountAddress>,
+    pub success: bool,
+    pub version: Option<u64>,
+    pub vm_status: String,
 }
 
 impl From<Transaction> for TransferSummary {

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -33,13 +33,13 @@ pub struct InitTool {
     #[clap(long)]
     pub faucet_url: Option<Url>,
     #[clap(flatten)]
-    private_key_options: PrivateKeyInputOptions,
+    pub(crate) private_key_options: PrivateKeyInputOptions,
     #[clap(flatten)]
-    profile_options: ProfileOptions,
+    pub(crate) profile_options: ProfileOptions,
     #[clap(flatten)]
-    prompt_options: PromptOptions,
+    pub(crate) prompt_options: PromptOptions,
     #[clap(flatten)]
-    encoding_options: EncodingOptions,
+    pub(crate) encoding_options: EncodingOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -129,7 +129,7 @@ pub struct SetValidatorConfiguration {
     #[clap(long)]
     pub(crate) full_node_host: Option<HostAndPort>,
     /// Stake amount for stake distribution
-    #[clap(long, default_value = "1")]
+    #[clap(long, default_value_t = 1)]
     pub(crate) stake_amount: u64,
 }
 

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -9,7 +9,6 @@ pub mod config;
 pub mod genesis;
 pub mod move_tool;
 pub mod op;
-#[cfg(test)]
 pub mod test;
 
 use crate::common::types::{CliCommand, CliResult};

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -9,6 +9,8 @@ pub mod config;
 pub mod genesis;
 pub mod move_tool;
 pub mod op;
+#[cfg(test)]
+pub mod test;
 
 use crate::common::types::{CliCommand, CliResult};
 use clap::Parser;

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -101,7 +101,7 @@ impl CliCommand<HashMap<AccountAddress, Peer>> for ExtractPeer {
 #[derive(Debug, Parser)]
 pub struct GenerateKey {
     /// Key type: `x25519` or `ed25519`
-    #[clap(long, default_value = "ed25519")]
+    #[clap(long, default_value_t = KeyType::Ed25519)]
     key_type: KeyType,
     #[clap(flatten)]
     save_params: SaveKey,

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -1,0 +1,188 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    account::{
+        create::{CreateAccount, DEFAULT_FUNDED_COINS},
+        fund::FundAccount,
+        list::{ListAccount, ListQuery},
+        transfer::{TransferCoins, TransferSummary},
+    },
+    common::{
+        init::{InitTool, DEFAULT_FAUCET_URL, DEFAULT_REST_URL},
+        types::{
+            CliConfig, CliTypedResult, EncodingOptions, PrivateKeyInputOptions, ProfileOptions,
+            PromptOptions,
+        },
+    },
+    op::key::GenerateKey,
+    CliCommand,
+};
+use aptos_crypto::ed25519::Ed25519PrivateKey;
+use aptos_sdk::move_types::account_address::AccountAddress;
+use reqwest::Url;
+use serde_json::Value;
+use std::str::FromStr;
+
+/// A framework for testing the CLI
+pub struct CliTestFramework {
+    endpoint: Url,
+    faucet_endpoint: Url,
+}
+
+impl CliTestFramework {
+    pub async fn new(endpoint: Url, faucet_endpoint: Url, num_accounts: usize) -> CliTestFramework {
+        let framework = CliTestFramework {
+            endpoint,
+            faucet_endpoint,
+        };
+
+        // TODO: Make this allow a passed in random seed
+        for i in 0..num_accounts {
+            let private_key = GenerateKey::generate_ed25519_in_memory();
+
+            // For now use, the config files to handle accounts
+            framework
+                .init(i, &private_key)
+                .await
+                .expect("Expected init command to succeed");
+        }
+
+        framework
+    }
+
+    pub async fn create_account(&self, index: usize) -> CliTypedResult<String> {
+        CreateAccount {
+            encoding_options: Default::default(),
+            write_options: Default::default(),
+            profile_options: profile(index),
+            account: account_id(index),
+            use_faucet: true,
+            faucet_options: Default::default(),
+            initial_coins: 0,
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn fund_account(&self, index: usize) -> CliTypedResult<String> {
+        FundAccount {
+            profile_options: profile(index),
+            account: account_id(index),
+            faucet_options: Default::default(),
+            num_coins: DEFAULT_FUNDED_COINS,
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn list_account(&self, index: usize, query: ListQuery) -> CliTypedResult<Vec<Value>> {
+        ListAccount {
+            rest_options: Default::default(),
+            profile_options: profile(index),
+            account: Some(account_id(index)),
+            query,
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn transfer_coins(
+        &self,
+        sender_index: usize,
+        receiver_index: usize,
+        amount: u64,
+    ) -> CliTypedResult<TransferSummary> {
+        let receiver_account = account_id(receiver_index);
+
+        TransferCoins {
+            write_options: Default::default(),
+            encoding_options: Default::default(),
+            profile_options: profile(sender_index),
+            account: receiver_account,
+            amount,
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn init(&self, index: usize, private_key: &Ed25519PrivateKey) -> CliTypedResult<()> {
+        InitTool {
+            rest_url: Some(self.endpoint.clone()),
+            faucet_url: Some(self.faucet_endpoint.clone()),
+            private_key_options: private_key_options(private_key),
+            profile_options: profile(index),
+            prompt_options: PromptOptions::yes(),
+            encoding_options: EncodingOptions::default(),
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn account_balance(&self, index: usize) -> u64 {
+        u64::from_str(
+            self.list_account(index, ListQuery::Balance)
+                .await
+                .unwrap()
+                .get(0)
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("coin")
+                .unwrap()
+                .as_object()
+                .unwrap()
+                .get("value")
+                .unwrap()
+                .as_str()
+                .unwrap(),
+        )
+        .unwrap()
+    }
+}
+
+fn account_id(index: usize) -> AccountAddress {
+    let profile = CliConfig::load_profile(&index.to_string())
+        .expect("Must select account in bounds")
+        .expect("Expected to already be initialized");
+    profile.account.expect("Expected to have account address")
+}
+
+fn profile(index: usize) -> ProfileOptions {
+    ProfileOptions {
+        profile: index.to_string(),
+    }
+}
+
+fn private_key_options(private_key: &Ed25519PrivateKey) -> PrivateKeyInputOptions {
+    PrivateKeyInputOptions::from_private_key(private_key)
+        .expect("Must serialize private key to hex")
+}
+
+// Ignore test because we don't want to be dependent on testnet
+#[tokio::test]
+#[ignore]
+async fn test_flow() {
+    let framework = CliTestFramework::new(
+        DEFAULT_REST_URL.parse().unwrap(),
+        DEFAULT_FAUCET_URL.parse().unwrap(),
+        2,
+    )
+    .await;
+
+    assert_eq!(DEFAULT_FUNDED_COINS, framework.account_balance(0).await);
+    assert_eq!(DEFAULT_FUNDED_COINS, framework.account_balance(1).await);
+
+    let transfer_amount = 100;
+
+    let response = framework
+        .transfer_coins(0, 1, transfer_amount)
+        .await
+        .unwrap();
+    let expected_sender_amount =
+        DEFAULT_FUNDED_COINS - response.gas_used.unwrap() - transfer_amount;
+    let expected_receiver_amount = DEFAULT_FUNDED_COINS + transfer_amount;
+
+    assert_eq!(expected_sender_amount, framework.account_balance(0).await);
+    assert_eq!(expected_receiver_amount, framework.account_balance(1).await);
+}

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { version = "1.18.2", features = ["full"] }
 url = "2.2.2"
 
 aptos-config = { path = "../../config" }
+aptos-faucet = { path = "../../crates/aptos-faucet" }
 aptos-genesis-tool = { path = "../../config/management/genesis" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -6,11 +6,14 @@ use crate::{
     Validator, Version,
 };
 use anyhow::{anyhow, bail, Result};
-use aptos_config::config::NodeConfig;
+use aptos_config::{config::NodeConfig, keys::ConfigKey};
 use aptos_genesis_tool::{fullnode_builder::FullnodeConfig, validator_builder::ValidatorBuilder};
-use aptos_sdk::types::{
-    chain_id::ChainId, transaction::Transaction, waypoint::Waypoint, AccountKey, LocalAccount,
-    PeerId,
+use aptos_sdk::{
+    crypto::ed25519::Ed25519PrivateKey,
+    types::{
+        chain_id::ChainId, transaction::Transaction, waypoint::Waypoint, AccountKey, LocalAccount,
+        PeerId,
+    },
 };
 use std::{
     collections::HashMap,
@@ -173,10 +176,10 @@ impl LocalSwarmBuilder {
                 Ok((node.peer_id(), node))
             })
             .collect::<Result<HashMap<_, _>>>()?;
-
+        let root_key = ConfigKey::new(root_keys.root_key);
         let root_account = LocalAccount::new(
             aptos_sdk::types::account_config::aptos_root_address(),
-            AccountKey::from_private_key(root_keys.root_key),
+            AccountKey::from_private_key(root_key.private_key()),
             0,
         );
 
@@ -190,6 +193,7 @@ impl LocalSwarmBuilder {
             dir,
             root_account,
             chain_id: ChainId::test(),
+            root_key,
         })
     }
 }
@@ -205,6 +209,7 @@ pub struct LocalSwarm {
     dir: SwarmDirectory,
     root_account: LocalAccount,
     chain_id: ChainId,
+    root_key: ConfigKey<Ed25519PrivateKey>,
 }
 
 impl LocalSwarm {
@@ -336,6 +341,10 @@ impl LocalSwarm {
         self.fullnodes.insert(peer_id, fullnode);
 
         Ok(peer_id)
+    }
+
+    pub fn root_key(&self) -> Ed25519PrivateKey {
+        self.root_key.private_key()
     }
 
     pub fn chain_id(&self) -> ChainId {

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.18.2", features = ["full"] }
 aptos = { path = "../../crates/aptos" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-faucet = { path = "../../crates/aptos-faucet" }
 aptos-indexer = { path = "../../ecosystem/indexer" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-sdk = { path = "../../sdk" }

--- a/testsuite/smoke-test/src/aptos_cli.rs
+++ b/testsuite/smoke-test/src/aptos_cli.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
+use aptos_config::keys::ConfigKey;
+use aptos_crypto::ed25519::Ed25519PrivateKey;
+use aptos_faucet::FaucetArgs;
+use aptos_types::{account_config::aptos_root_address, chain_id::ChainId};
+use forge::{LocalSwarm, Node};
+use tokio::task::JoinHandle;
+
+pub async fn setup_test(num_nodes: usize) -> (LocalSwarm, CliTestFramework) {
+    let swarm = new_local_swarm_with_aptos(num_nodes).await;
+    let chain_id = swarm.chain_id();
+    let validator = swarm.validators().next().unwrap();
+    let root_key = swarm.root_key();
+    let _ = launch_faucet(validator.rest_api_endpoint(), root_key, chain_id);
+
+    // Connect the operator tool to the node's JSON RPC API
+    let tool = CliTestFramework::new(
+        validator.rest_api_endpoint(),
+        "http://localhost:9996".parse().unwrap(),
+        2,
+    )
+    .await;
+
+    (swarm, tool)
+}
+
+fn launch_faucet(
+    endpoint: reqwest::Url,
+    mint_key: Ed25519PrivateKey,
+    chain_id: ChainId,
+) -> JoinHandle<()> {
+    let faucet = FaucetArgs {
+        address: "127.0.0.1".to_string(),
+        port: 9996,
+        server_url: endpoint.to_string(),
+        mint_key_file_path: "".to_string(),
+        mint_key: Some(ConfigKey::new(mint_key)),
+        mint_account_address: Some(aptos_root_address()),
+        chain_id,
+        maximum_amount: None,
+        do_not_delegate: true,
+    };
+    tokio::spawn(faucet.run())
+}
+
+#[tokio::test]
+async fn test_account_flow() {
+    let (_swarm, cli) = setup_test(1).await;
+
+    assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(0).await.unwrap());
+    assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(1).await.unwrap());
+
+    // Transfer an amount between the accounts
+    let transfer_amount = 100;
+    let response = cli.transfer_coins(0, 1, transfer_amount).await.unwrap();
+    let expected_sender_amount =
+        DEFAULT_FUNDED_COINS - response.gas_used.unwrap() - transfer_amount;
+    let expected_receiver_amount = DEFAULT_FUNDED_COINS + transfer_amount;
+
+    assert_eq!(
+        expected_sender_amount,
+        cli.wait_for_balance(0, expected_sender_amount)
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        expected_receiver_amount,
+        cli.wait_for_balance(1, expected_receiver_amount)
+            .await
+            .unwrap()
+    );
+
+    // Wait for faucet amount to be updated
+    let expected_sender_amount = expected_sender_amount + DEFAULT_FUNDED_COINS;
+    let _ = cli.fund_account(0).await.unwrap();
+    assert_eq!(
+        expected_sender_amount,
+        cli.wait_for_balance(0, expected_sender_amount)
+            .await
+            .unwrap()
+    );
+}

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -11,6 +11,8 @@ pub mod transaction;
 
 // Converted to local Forge backend
 #[cfg(test)]
+mod aptos_cli;
+#[cfg(test)]
 mod client;
 #[cfg(test)]
 mod consensus;


### PR DESCRIPTION
## Motivation

So we can ensure that the Aptos CLI continues to work properly.

This only does the account commands, and will come back and do the rest soon.  Genesis should be replaced in forge with this tool entirely.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See tests