### PR TITLE
[CICD] fix COPY command in docker image builds

### DIFF
--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -38,10 +38,10 @@ RUN apt-get update && apt-get install -y linux-tools-4.19 sudo procps
 RUN addgroup --system --gid 6180 aptos && adduser --system --ingroup aptos --no-create-home --uid 6180 aptos
 
 RUN mkdir -p /opt/aptos/bin /opt/aptos/etc
-COPY --link --from=builder /aptos/target/release/aptos-node /opt/aptos/bin
-COPY --link --from=builder /aptos/target/release/db-backup /opt/aptos/bin
-COPY --link --from=builder /aptos/target/release/db-bootstrapper /opt/aptos/bin
-COPY --link --from=builder /aptos/target/release/db-restore /opt/aptos/bin
+COPY --link --from=builder /aptos/target/release/aptos-node /opt/aptos/bin/
+COPY --link --from=builder /aptos/target/release/db-backup /opt/aptos/bin/
+COPY --link --from=builder /aptos/target/release/db-bootstrapper /opt/aptos/bin/
+COPY --link --from=builder /aptos/target/release/db-restore /opt/aptos/bin/
 
 # Admission control
 EXPOSE 8000
@@ -65,7 +65,7 @@ RUN apt-get update && apt-get install -y libssl1.1 ca-certificates net-tools tcp
 && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/aptos/bin
-COPY --from=builder /aptos/target/release/aptos-indexer /usr/local/bin
+COPY --from=builder /aptos/target/release/aptos-indexer /usr/local/bin/
 
 
 ### Safety Rules Image ###
@@ -78,7 +78,7 @@ RUN addgroup --system --gid 6180 aptos && adduser --system --ingroup aptos --no-
 
 RUN mkdir -p /opt/aptos/bin /opt/aptos/etc /opt/aptos/data
 
-COPY --from=builder /aptos/target/release/safety-rules /opt/aptos/bin
+COPY --from=builder /aptos/target/release/safety-rules /opt/aptos/bin/
 
 ENV RUST_BACKTRACE 1
 
@@ -100,13 +100,13 @@ COPY docker/tools/boto.cfg /etc
 RUN cd /usr/local/bin && wget https://azcopyvnext.azureedge.net/release20210226/azcopy_linux_amd64_10.9.0.tar.gz -O- | tar --gzip --wildcards --extract '*/azcopy' --strip-components=1 --no-same-owner && chmod +x azcopy
 RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O- | tar --gzip --directory /opt --extract && ln -s /opt/gsutil/gsutil /usr/local/bin
 
-COPY --from=builder /aptos/target/release/aptos-genesis-tool /usr/local/bin
-COPY --from=builder /aptos/target/release/aptos-operational-tool /usr/local/bin
-COPY --from=builder /aptos/target/release/db-bootstrapper /usr/local/bin
-COPY --from=builder /aptos/target/release/db-backup /usr/local/bin
-COPY --from=builder /aptos/target/release/db-backup-verify /usr/local/bin
-COPY --from=builder /aptos/target/release/db-restore /usr/local/bin
-COPY --from=builder /aptos/target/release/aptos-transaction-replay /usr/local/bin
+COPY --from=builder /aptos/target/release/aptos-genesis-tool /usr/local/bin/
+COPY --from=builder /aptos/target/release/aptos-operational-tool /usr/local/bin/
+COPY --from=builder /aptos/target/release/db-bootstrapper /usr/local/bin/
+COPY --from=builder /aptos/target/release/db-backup /usr/local/bin/
+COPY --from=builder /aptos/target/release/db-backup-verify /usr/local/bin/
+COPY --from=builder /aptos/target/release/db-restore /usr/local/bin/
+COPY --from=builder /aptos/target/release/aptos-transaction-replay /usr/local/bin/
 
 ### Get Aptos Move modules bytecodes for genesis ceremony
 RUN mkdir -p /aptos-framework/move/build
@@ -127,8 +127,8 @@ RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release
 RUN cd /usr/local/bin && wget "https://releases.hashicorp.com/vault/1.5.0/vault_1.5.0_linux_amd64.zip" -O- | busybox unzip - && chmod +x vault
 
 RUN mkdir -p /opt/aptos/bin
-COPY --from=builder /aptos/target/release/aptos-genesis-tool /usr/local/bin
-COPY --from=builder /aptos/target/release/aptos-operational-tool /usr/local/bin
+COPY --from=builder /aptos/target/release/aptos-genesis-tool /usr/local/bin/
+COPY --from=builder /aptos/target/release/aptos-operational-tool /usr/local/bin/
 
 ### Get Aptos Move modules bytecodes for genesis ceremony
 RUN mkdir -p /aptos-framework/move/build
@@ -145,7 +145,7 @@ FROM debian-base AS txn-emitter
 RUN apt-get update && apt-get -y install libssl1.1 ca-certificates wget busybox gettext-base && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN mkdir -p /opt/aptos/bin
-COPY --from=builder /aptos/target/release/transaction-emitter /usr/local/bin
+COPY --from=builder /aptos/target/release/transaction-emitter /usr/local/bin/
 
 
 
@@ -157,7 +157,7 @@ RUN apt-get update && apt-get install -y libssl1.1 ca-certificates nano net-tool
 
 RUN mkdir -p /opt/aptos/bin  /aptos/client/data/wallet/
 
-COPY --from=builder /aptos/target/release/aptos-faucet /opt/aptos/bin
+COPY --from=builder /aptos/target/release/aptos-faucet /opt/aptos/bin/
 
 #install needed tools
 RUN apt-get update && apt-get install -y procps


### PR DESCRIPTION
This fixes our newer docker image builds.

Previously we had multiple statement like this:
```
COPY --link --from=builder /aptos/target/release/aptos-node /opt/aptos/bin
COPY --link --from=builder /aptos/target/release/db-backup /opt/aptos/bin
```
which actually resulted in the `aptos-node`  and `db-backup` binaries being copied into the image as binary named `bin` (plus overriding each other).
What we really want is to copy the binary `aptos-node` and `db-backup` _into_ the `bin` _directory_ . E.g. the result should be:
- `/opt/aptos/bin/aptos-node`
- `/opt/aptos/bin/db-backup`

So this fixes this. by changing above COPY commands to:

```
COPY --link --from=builder /aptos/target/release/aptos-node /opt/aptos/bin/
COPY --link --from=builder /aptos/target/release/db-backup /opt/aptos/bin/
```

It appears that previous docker versions were interpreting:
`COPY --link --from=builder /aptos/target/release/aptos-node /opt/aptos/bin` differently (and kind of in a funny way that is inconsistent of how bash's `cp` command works), which is why this was working previously.

### Test Plan

- I let the CI pipeline build the images (via CICD:build-images)
- Pulled the built images via `dive  us-west1-docker.pkg.dev/aptos-global/aptos-internal/validator:aa88f24c401a7bdc63a4d8cc3e0c7db74992c558` and inspected its contents to verify that the aptos-node binary etc. are in `/opt/aptos/bin`