### PR TITLE
[Wallet] Add connection methods

### DIFF
--- a/ecosystem/web-wallet/package.json
+++ b/ecosystem/web-wallet/package.json
@@ -36,7 +36,8 @@
     "build": "yarn run lint:fix && yarn run build:app && yarn run build:bg",
     "build:tauri": "yarn tauri build --target aarch64-apple-darwin",
     "build:app": "INLINE_RUNTIME_CHUNK=false react-scripts build",
-    "build:bg": "webpack --mode production ./src/background.js --output-path ./build --output-filename background.js",
+    "build:bg": "webpack --mode production ./src/scripts/background.js --output-path ./build --output-filename background.js",
+    "build:inpage": "webpack --mode production ./src/scripts/inpage.js --output-path ./build --output-filename inpage.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },

--- a/ecosystem/web-wallet/src/core/types.ts
+++ b/ecosystem/web-wallet/src/core/types.ts
@@ -12,7 +12,10 @@ export interface LocalStorageState {
 }
 
 export const MessageMethod = Object.freeze({
+  CONNECT: 'connect',
+  DISCONNECT: 'disconnect',
   GET_ACCOUNT_ADDRESS: 'getAccountAddress',
+  IS_CONNECTED: 'is_connected',
   SIGN_TRANSACTION: 'signTransaction',
 } as const);
 

--- a/ecosystem/web-wallet/src/scripts/background.js
+++ b/ecosystem/web-wallet/src/scripts/background.js
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosClient } from 'aptos'
-import { DEVNET_NODE_URL } from './core/constants'
-import { MessageMethod } from './core/types'
-import { getAptosAccountState } from './core/utils/account'
+import { DEVNET_NODE_URL } from '../core/constants'
+import { MessageMethod } from '../core/types'
+import { getAptosAccountState } from '../core/utils/account'
 
 chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
   const account = getAptosAccountState()

--- a/ecosystem/web-wallet/src/scripts/background.js
+++ b/ecosystem/web-wallet/src/scripts/background.js
@@ -12,18 +12,42 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
     sendResponse({ error: 'No Accounts' })
     return
   }
+
   switch (request.method) {
+    case MessageMethod.CONNECT:
+      connect(account, sendResponse)
+      break
+    case MessageMethod.DISCONNECT:
+      disconnect()
+      break
+    case MessageMethod.IS_CONNECTED:
+      isConnected(sendResponse)
+      break
     case MessageMethod.GET_ACCOUNT_ADDRESS:
       getAccountAddress(account, sendResponse)
       break
     case MessageMethod.SIGN_TRANSACTION:
-      signTransaction(account, request.transaction, sendResponse)
+      signTransaction(account, request.args.transaction, sendResponse)
       break
     default:
       throw new Error(request.method + ' method is not supported')
   }
   return true
 })
+
+function connect (account, sendResponse) {
+  // todo: register caller for permission checking purposes
+  getAccountAddress(account, sendResponse)
+}
+
+function disconnect () {
+  // todo: unregister caller
+}
+
+function isConnected (sendResponse) {
+  // todo: send boolean response based on registered caller
+  sendResponse(true)
+}
 
 function getAccountAddress (account, sendResponse) {
   if (account.address()) {

--- a/ecosystem/web-wallet/src/scripts/inpage.js
+++ b/ecosystem/web-wallet/src/scripts/inpage.js
@@ -10,31 +10,30 @@ class Web3 {
     this.requestId = 0
   }
 
+  connect () {
+    return this._message(MessageMethod.CONNECT, {})
+  }
+
+  disconnect () {
+    return this._message(MessageMethod.DISCONNECT, {})
+  }
+
+  isConnected () {
+    return this._message(MessageMethod.IS_CONNECTED, {})
+  }
+
   account () {
-    const id = this.requestId++
-    return new Promise(function (resolve, reject) {
-      const method = MessageMethod.GET_ACCOUNT_ADDRESS
-      window.postMessage({ method, id })
-      window.addEventListener('message', function handler (event) {
-        if (event.data.responseMethod === method &&
-            event.data.id === id) {
-          const response = event.data.response
-          this.removeEventListener('message', handler)
-          if (response.address) {
-            resolve(response.address)
-          } else {
-            reject(response.error ?? 'Error')
-          }
-        }
-      })
-    })
+    return this._message(MessageMethod.GET_ACCOUNT_ADDRESS, {})
   }
 
   signAndSubmitTransaction (transaction) {
+    return this._message(MessageMethod.SIGN_TRANSACTION, { transaction })
+  }
+
+  _message(method, args) {
     const id = this.requestId++
     return new Promise(function (resolve, reject) {
-      const method = MessageMethod.SIGN_TRANSACTION
-      window.postMessage({ method, transaction, id })
+      window.postMessage({ method, args, id })
       window.addEventListener('message', function handler (event) {
         if (event.data.responseMethod === method &&
             event.data.id === id) {

--- a/ecosystem/web-wallet/src/scripts/inpage.js
+++ b/ecosystem/web-wallet/src/scripts/inpage.js
@@ -1,6 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+import { MessageMethod } from '../core/types'
+
 class Web3 {
   requestId
 
@@ -11,7 +13,7 @@ class Web3 {
   account () {
     const id = this.requestId++
     return new Promise(function (resolve, reject) {
-      const method = 'getAccountAddress'
+      const method = MessageMethod.GET_ACCOUNT_ADDRESS
       window.postMessage({ method, id })
       window.addEventListener('message', function handler (event) {
         if (event.data.responseMethod === method &&
@@ -31,7 +33,7 @@ class Web3 {
   signAndSubmitTransaction (transaction) {
     const id = this.requestId++
     return new Promise(function (resolve, reject) {
-      const method = 'signTransaction'
+      const method = MessageMethod.SIGN_TRANSACTION
       window.postMessage({ method, transaction, id })
       window.addEventListener('message', function handler (event) {
         if (event.data.responseMethod === method &&


### PR DESCRIPTION
## Motivation

Currently working on making our dapp api be more "official". My branch was getting large trying to also add permissions and user prompts, so I'm breaking it up and getting the basic api in so that is can be used in partner connections.

After looking at how a few different wallets handle wallet connection this seems like basically the standard, and any dapp will be very familiar with integrating with this api.

A dapp first needs to establish a `connection` and then they can start making requests for signing and so forth. Obviously this diff doesn't have those permissions so it's always returning true, but I'm working on it!

A lot more on the way :)

## Test Plan

```
const response = await (window as any).aptos.connect();
console.log(`RESPONSE: ${response.address}`);
```

`RESPONSE: 0xf104b577cf4e41869b5eef29a9408e9666259482cb2f03dd7514216a4d1dcfa4`
