### PR TITLE
[storage] split aptosdb into ledger_db and state_merkle_db

### DIFF
--- a/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
@@ -6,7 +6,7 @@ use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Transaction, waypoint::Waypoint};
 use aptos_vm::AptosVM;
-use aptosdb::AptosDB;
+use aptosdb::{AptosDB, LEDGER_DB_NAME, STATE_MERKLE_DB_NAME};
 use executor::db_bootstrapper::calculate_genesis;
 use std::{
     fs::File,
@@ -60,7 +60,8 @@ fn main() -> Result<()> {
         tmpdir = TempPath::new();
         AptosDB::open_as_secondary(
             opt.db_dir.as_path(),
-            tmpdir.path(),
+            &tmpdir.as_ref().to_path_buf().join(LEDGER_DB_NAME),
+            &tmpdir.as_ref().to_path_buf().join(STATE_MERKLE_DB_NAME),
             RocksdbConfig::default(),
         )
     }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -50,7 +50,7 @@ pub fn run_benchmark(
 ) {
     // Create rocksdb checkpoint.
     if checkpoint_dir.as_ref().exists() {
-        fs::remove_dir_all(checkpoint_dir.as_ref().join("aptosdb")).unwrap_or(());
+        fs::remove_dir_all(checkpoint_dir.as_ref()).unwrap_or(());
     }
     std::fs::create_dir_all(checkpoint_dir.as_ref()).unwrap();
 
@@ -61,7 +61,7 @@ pub fn run_benchmark(
         RocksdbConfig::default(),
     )
     .expect("db open failure.")
-    .create_checkpoint(checkpoint_dir.as_ref().join("aptosdb"))
+    .create_checkpoint(checkpoint_dir.as_ref())
     .expect("db checkpoint creation fails.");
 
     let (mut config, genesis_key) = aptos_genesis_tool::test_config();

--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -82,15 +82,13 @@ fn test_error_if_version_is_pruned() {
     let tmp_dir = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp_dir);
     let mut pruner = Pruner::new(
-        Arc::clone(&aptos_db.db),
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
             pruning_batch_size: 1,
         },
-        Arc::clone(&aptos_db.transaction_store),
-        Arc::clone(&aptos_db.ledger_store),
-        Arc::clone(&aptos_db.event_store),
     );
     pruner.testonly_update_min_version(&[5, 10]);
     let pruner = Some(pruner);

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -22,7 +22,7 @@ use storage_interface::{DbReader, TreeState};
 /// Provides functionalities for AptosDB data restore.
 #[derive(Clone)]
 pub struct RestoreHandler {
-    db: Arc<DB>,
+    ledger_db: Arc<DB>,
     pub aptosdb: Arc<AptosDB>,
     ledger_store: Arc<LedgerStore>,
     transaction_store: Arc<TransactionStore>,
@@ -32,7 +32,7 @@ pub struct RestoreHandler {
 
 impl RestoreHandler {
     pub(crate) fn new(
-        db: Arc<DB>,
+        ledger_db: Arc<DB>,
         aptosdb: Arc<AptosDB>,
         ledger_store: Arc<LedgerStore>,
         transaction_store: Arc<TransactionStore>,
@@ -40,7 +40,7 @@ impl RestoreHandler {
         event_store: Arc<EventStore>,
     ) -> Self {
         Self {
-            db,
+            ledger_db,
             aptosdb,
             ledger_store,
             transaction_store,
@@ -62,7 +62,11 @@ impl RestoreHandler {
     }
 
     pub fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()> {
-        restore_utils::save_ledger_infos(self.db.clone(), self.ledger_store.clone(), ledger_infos)
+        restore_utils::save_ledger_infos(
+            self.ledger_db.clone(),
+            self.ledger_store.clone(),
+            ledger_infos,
+        )
     }
 
     pub fn confirm_or_save_frozen_subtrees(
@@ -70,7 +74,11 @@ impl RestoreHandler {
         num_leaves: LeafCount,
         frozen_subtrees: &[HashValue],
     ) -> Result<()> {
-        restore_utils::confirm_or_save_frozen_subtrees(self.db.clone(), num_leaves, frozen_subtrees)
+        restore_utils::confirm_or_save_frozen_subtrees(
+            self.ledger_db.clone(),
+            num_leaves,
+            frozen_subtrees,
+        )
     }
 
     pub fn save_transactions(
@@ -81,7 +89,7 @@ impl RestoreHandler {
         events: &[Vec<ContractEvent>],
     ) -> Result<()> {
         restore_utils::save_transactions(
-            self.db.clone(),
+            self.ledger_db.clone(),
             self.ledger_store.clone(),
             self.transaction_store.clone(),
             self.event_store.clone(),

--- a/storage/aptosdb/src/event_store/test.rs
+++ b/storage/aptosdb/src/event_store/test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::AptosDB;
+use crate::{AptosDB, EventStore};
 use aptos_crypto::hash::ACCUMULATOR_PLACEHOLDER_HASH;
 use aptos_proptest_helpers::Index;
 use aptos_temppath::TempPath;

--- a/storage/aptosdb/src/ledger_store/ledger_info_test.rs
+++ b/storage/aptosdb/src/ledger_store/ledger_info_test.rs
@@ -133,5 +133,5 @@ fn put_transaction_infos(db: &AptosDB, txn_infos: &[TransactionInfo]) {
     db.ledger_store
         .put_transaction_infos(0, txn_infos, &mut cs)
         .unwrap();
-    db.db.write_schemas(cs.batch).unwrap()
+    db.ledger_db.write_schemas(cs.batch).unwrap()
 }

--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -38,7 +38,11 @@ pub trait DBPruner {
 
     /// Performs the actual pruning, a target version is passed, which is the target the pruner
     /// tries to prune.
-    fn prune(&self, db_batch: &mut SchemaBatch, max_versions: u64) -> anyhow::Result<Version>;
+    fn prune(
+        &self,
+        ledger_db_batch: &mut SchemaBatch,
+        max_versions: u64,
+    ) -> anyhow::Result<Version>;
 
     /// Initializes the least readable version stored in underlying DB storage
     fn initialize_min_readable_version(&self) -> anyhow::Result<Version>;

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -50,15 +50,13 @@ fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {
     let num_write_sets = write_sets.len();
 
     let pruner = Pruner::new(
-        Arc::clone(&aptos_db.db),
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
             pruning_batch_size: 1,
         },
-        Arc::clone(transaction_store),
-        Arc::clone(&aptos_db.ledger_store),
-        Arc::clone(&aptos_db.event_store),
     );
 
     // write sets
@@ -68,7 +66,7 @@ fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {
             .put_write_set(ver as Version, ws, &mut cs)
             .unwrap();
     }
-    aptos_db.db.write_schemas(cs.batch).unwrap();
+    aptos_db.ledger_db.write_schemas(cs.batch).unwrap();
     // start pruning write sets in batches of size 2 and verify transactions have been pruned from DB
     for i in (0..=num_write_sets).step_by(2) {
         pruner
@@ -97,19 +95,17 @@ fn verify_txn_store_pruner(
     let tmp_dir = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp_dir);
     let transaction_store = &aptos_db.transaction_store;
-    let ledger_store = LedgerStore::new(Arc::clone(&aptos_db.db));
+    let ledger_store = LedgerStore::new(Arc::clone(&aptos_db.ledger_db));
     let num_transaction = txns.len();
 
     let pruner = Pruner::new(
-        Arc::clone(&aptos_db.db),
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
             pruning_batch_size: 1,
         },
-        Arc::clone(transaction_store),
-        Arc::clone(&aptos_db.ledger_store),
-        Arc::clone(&aptos_db.event_store),
     );
 
     let ledger_version = num_transaction as Version - 1;
@@ -209,7 +205,7 @@ fn put_txn_in_store(
     ledger_store
         .put_transaction_infos(0, txn_infos, &mut cs)
         .unwrap();
-    aptos_db.db.write_schemas(cs.batch).unwrap();
+    aptos_db.ledger_db.write_schemas(cs.batch).unwrap();
 }
 
 // Ensure that transaction accumulator has been pruned as well. The idea to verify is get the

--- a/storage/aptosdb/src/pruner/utils.rs
+++ b/storage/aptosdb/src/pruner/utils.rs
@@ -16,22 +16,20 @@ use std::{sync::Arc, time::Instant};
 
 /// A useful utility function to instantiate all db pruners.
 pub fn create_db_pruners(
-    db: Arc<DB>,
-    transaction_store: Arc<TransactionStore>,
-    ledger_store: Arc<LedgerStore>,
-    event_store: Arc<EventStore>,
+    ledger_db: Arc<DB>,
+    state_merkle_db: Arc<DB>,
 ) -> Vec<Mutex<Arc<dyn DBPruner + Send + Sync>>> {
     vec![
         Mutex::new(Arc::new(StateStorePruner::new(
-            Arc::clone(&db),
+            Arc::clone(&state_merkle_db),
             0,
             Instant::now(),
         ))),
         Mutex::new(Arc::new(LedgerPruner::new(
-            Arc::clone(&db),
-            Arc::clone(&transaction_store),
-            Arc::clone(&event_store),
-            Arc::clone(&ledger_store),
+            Arc::clone(&ledger_db),
+            Arc::new(TransactionStore::new(Arc::clone(&ledger_db))),
+            Arc::new(EventStore::new(Arc::clone(&ledger_db))),
+            Arc::new(LedgerStore::new(Arc::clone(&ledger_db))),
         ))),
     ]
 }

--- a/storage/aptosdb/src/pruner/worker.rs
+++ b/storage/aptosdb/src/pruner/worker.rs
@@ -3,10 +3,7 @@
 use aptos_types::transaction::Version;
 use schemadb::{SchemaBatch, DB};
 
-use crate::{
-    pruner::{db_pruner::DBPruner, utils},
-    EventStore, LedgerStore, TransactionStore,
-};
+use crate::pruner::{db_pruner::DBPruner, utils};
 use aptos_infallible::Mutex;
 use itertools::zip_eq;
 use std::sync::{mpsc::Receiver, Arc};
@@ -14,7 +11,7 @@ use std::sync::{mpsc::Receiver, Arc};
 /// Maintains all the DBPruners and periodically calls the db_pruner's prune method to prune the DB.
 /// This also exposes API to report the progress to the parent thread.
 pub struct Worker {
-    db: Arc<DB>,
+    ledger_db: Arc<DB>,
     command_receiver: Receiver<Command>,
     /// Keeps tracks of all the DB pruners
     db_pruners: Vec<Mutex<Arc<dyn DBPruner + Send + Sync>>>,
@@ -30,18 +27,15 @@ pub struct Worker {
 
 impl Worker {
     pub(crate) fn new(
-        db: Arc<DB>,
-        transaction_store: Arc<TransactionStore>,
-        ledger_store: Arc<LedgerStore>,
-        event_store: Arc<EventStore>,
+        ledger_db: Arc<DB>,
+        state_merkle_db: Arc<DB>,
         command_receiver: Receiver<Command>,
         min_readable_versions: Arc<Mutex<Vec<Version>>>,
         max_version_to_prune_per_batch: u64,
     ) -> Self {
-        let db_pruners =
-            utils::create_db_pruners(db.clone(), transaction_store, ledger_store, event_store);
+        let db_pruners = utils::create_db_pruners(ledger_db.clone(), state_merkle_db);
         Self {
-            db: Arc::clone(&db),
+            ledger_db: Arc::clone(&ledger_db),
             db_pruners,
             command_receiver,
             min_readable_versions,
@@ -55,16 +49,18 @@ impl Worker {
             // Process a reasonably small batch of work before trying to receive commands again,
             // in case `Command::Quit` is received (that's when we should quit.)
             let mut error_in_pruning = false;
-            let mut db_batch = SchemaBatch::new();
+            let mut ledger_db_batch = SchemaBatch::new();
             for db_pruner in &self.db_pruners {
                 let result = db_pruner
                     .lock()
-                    .prune(&mut db_batch, self.max_version_to_prune_per_batch);
+                    .prune(&mut ledger_db_batch, self.max_version_to_prune_per_batch);
                 result.map_err(|_| error_in_pruning = true).ok();
             }
             // Commit all the changes to DB atomically
-            let result = self.db.write_schemas(db_batch);
-            result.map_err(|_| error_in_pruning = true).ok();
+            self.ledger_db
+                .write_schemas(ledger_db_batch)
+                .map_err(|_| error_in_pruning = true)
+                .ok();
             let mut pruning_pending = false;
             for db_pruner in &self.db_pruners {
                 // if any of the pruner has pending pruning, then we don't block on receive

--- a/storage/aptosdb/src/schema/ledger_info/mod.rs
+++ b/storage/aptosdb/src/schema/ledger_info/mod.rs
@@ -12,6 +12,7 @@
 //! `epoch` is serialized in big endian so that records in RocksDB will be in order of their
 //! numeric value.
 
+use super::LEDGER_INFO_CF_NAME;
 use crate::schema::ensure_slice_len_eq;
 use anyhow::Result;
 use aptos_types::ledger_info::LedgerInfoWithSignatures;
@@ -19,7 +20,6 @@ use byteorder::{BigEndian, ReadBytesExt};
 use schemadb::{
     define_schema,
     schema::{KeyCodec, ValueCodec},
-    DEFAULT_CF_NAME,
 };
 use std::mem::size_of;
 
@@ -27,7 +27,7 @@ define_schema!(
     LedgerInfoSchema,
     u64, /* epoch num */
     LedgerInfoWithSignatures,
-    DEFAULT_CF_NAME
+    LEDGER_INFO_CF_NAME
 );
 
 impl KeyCodec<LedgerInfoSchema> for u64 {

--- a/storage/aptosdb/src/schema/mod.rs
+++ b/storage/aptosdb/src/schema/mod.rs
@@ -33,6 +33,7 @@ pub const EVENT_BY_VERSION_CF_NAME: ColumnFamilyName = "event_by_version";
 pub const EVENT_CF_NAME: ColumnFamilyName = "event";
 pub const JELLYFISH_MERKLE_NODE_CF_NAME: ColumnFamilyName = "jellyfish_merkle_node";
 pub const LEDGER_COUNTERS_CF_NAME: ColumnFamilyName = "ledger_counters";
+pub const LEDGER_INFO_CF_NAME: ColumnFamilyName = "ledger_info";
 pub const STALE_NODE_INDEX_CF_NAME: ColumnFamilyName = "stale_node_index";
 pub const STATE_VALUE_CF_NAME: ColumnFamilyName = "state_value";
 pub const TRANSACTION_CF_NAME: ColumnFamilyName = "transaction";

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -36,7 +36,7 @@ fn put_value_set(
     state_store
         .put_value_sets(vec![&value_set], version, &mut cs)
         .unwrap();
-    state_store.db.write_schemas(cs.batch).unwrap();
+    state_store.ledger_db.write_schemas(cs.batch).unwrap();
     state_store.set_latest_checkpoint(version, root);
     root
 }
@@ -48,7 +48,7 @@ fn prune_stale_indices(
     limit: usize,
 ) {
     pruner::state_store::prune_state_store(
-        Arc::clone(&store.db),
+        &store.state_merkle_db,
         min_readable_version,
         target_min_readable_version,
         limit,
@@ -683,7 +683,7 @@ fn update_store(
         store
             .put_value_sets(vec![&value_state_set], version, &mut cs)
             .unwrap();
-        store.db.write_schemas(cs.batch).unwrap();
+        store.ledger_db.write_schemas(cs.batch).unwrap();
         store.set_latest_checkpoint(version, root_hashes[0]);
     }
 }

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -613,15 +613,15 @@ pub fn put_transaction_info(db: &AptosDB, version: Version, txn_info: &Transacti
     db.ledger_store
         .put_transaction_infos(version, &[txn_info.clone()], &mut cs)
         .unwrap();
-    db.db.write_schemas(cs.batch).unwrap();
+    db.ledger_db.write_schemas(cs.batch).unwrap();
 }
 
 pub fn put_as_state_root(db: &AptosDB, version: Version, key: StateKey, value: StateValue) {
     let leaf_node = Node::new_leaf(key.hash(), value.hash(), (key.clone(), version));
-    db.db
+    db.state_merkle_db
         .put::<JellyfishMerkleNodeSchema>(&NodeKey::new_empty_path(version), &leaf_node)
         .unwrap();
-    db.db
+    db.ledger_db
         .put::<StateValueSchema>(&(key, version), &value)
         .unwrap();
     db.state_store

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -25,7 +25,7 @@ use aptos_types::{
 use schemadb::{ReadOptions, SchemaBatch, SchemaIterator, DB};
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct TransactionStore {
     db: Arc<DB>,
 }

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -155,7 +155,7 @@ async fn test_startup_sync_state() {
     let node_config = swarm.validator(node_to_restart).unwrap().config().clone();
     swarm.validator_mut(node_to_restart).unwrap().stop();
     // TODO Remove hardcoded path to state db
-    let state_db_path = node_config.storage.dir().join("aptosdb");
+    let state_db_path = node_config.storage.dir();
     // Verify that state_db_path exists and
     // we are not deleting a non-existent directory
     assert!(state_db_path.as_path().exists());

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -491,7 +491,7 @@ fn stop_validator_and_delete_storage(swarm: &mut LocalSwarm, validator: AccountA
 
     // Delete the validator storage
     let node_config = swarm.validator_mut(validator).unwrap().config().clone();
-    let state_db_path = node_config.storage.dir().join("aptosdb");
+    let state_db_path = node_config.storage.dir();
     info!(
         "Deleting state db path {:?} for validator {:?}",
         state_db_path.as_path(),

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -93,7 +93,7 @@ async fn test_db_restore() {
     insert_waypoint(&mut node0_config, genesis_waypoint);
     node0_config.save(node0_config_path).unwrap();
     let db_dir = node0_config.storage.dir();
-    fs::remove_dir_all(db_dir.join("aptosdb")).unwrap();
+    fs::remove_dir_all(db_dir.clone()).unwrap();
     fs::remove_dir_all(db_dir.join("consensusdb")).unwrap();
 
     // restore db from backup


### PR DESCRIPTION
## Motivation

Split aptosdb into two separate dbs to facilitate async state commit.

follow-ups:
1. delete impractical ledger counters.
2. make *Store as traits to avoid too many `Arc` of stores, instead of structs.

## Test Plan

UT


