### PR TITLE
[CICD] Cache Rust dependencies

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -7,3 +7,6 @@ runs:
       with:
         override: true
         components: rustfmt, clippy
+    - uses: bmwill/rust-cache@v1
+      with:
+        path: ~/.cargo/registry/src/**/librocksdb-sys-*


### PR DESCRIPTION
Makes Rust jobs faster by ~2 minutes