### PR TITLE
simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,4 @@
-<!--
-Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.
+### Description
 
-The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
--->
-
-## Motivation
-
-(Write your motivation for proposed changes here.)
-
-### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?
-
-(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)
-
-## Test Plan
-
-(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)
-
-## Related PRs
-
-(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
+### Test Plan
+<!-- Please provide us with clear details for verifying that your changes work. -->


### PR DESCRIPTION
### Description

This PR simplifies the PR template and cleans up unnecessary stuff.
I noticed we have a good amount of PRs which still contain a lot of boilerplate from the original template which just adds noise.
With this change the hope is we get more meaningful and dense PR descriptions.
A typical PR simply should have a Description (that is implied, so no header required for that.) and a Test Plan.
Related PRs can and should be mentioned in context of the PR Description.

### Test Plan
not necessary