### PR TITLE
Adding network toggle to Aptos Wallet

### DIFF
--- a/ecosystem/web-wallet/README.md
+++ b/ecosystem/web-wallet/README.md
@@ -11,7 +11,7 @@
 *todo: Add a release build folder so you don't have to yarn build*
 
 **B. Webpage**
-1. `yarn start`
+1. `yarn run`
 
 ## Linting
 ```bash

--- a/ecosystem/web-wallet/README.md
+++ b/ecosystem/web-wallet/README.md
@@ -11,7 +11,7 @@
 *todo: Add a release build folder so you don't have to yarn build*
 
 **B. Webpage**
-1. `yarn run`
+1. `yarn start`
 
 ## Linting
 ```bash

--- a/ecosystem/web-wallet/src/core/components/CreateNFTModal.tsx
+++ b/ecosystem/web-wallet/src/core/components/CreateNFTModal.tsx
@@ -25,7 +25,6 @@ import React from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import useWalletState from 'core/hooks/useWalletState';
 import { secondaryTextColor } from 'pages/Login';
-import { NODE_URL } from 'core/constants';
 import { AptosAccountState } from 'core/types';
 
 // eslint-disable-next-line global-require
@@ -60,6 +59,7 @@ interface CreateTokenAndCollectionProps {
   collectionName?: string,
   description?: string,
   name?: string,
+  nodeUrl: string,
   supply: number,
   uri?: string
 }
@@ -69,13 +69,14 @@ const createTokenAndCollection = async ({
   collectionName,
   description,
   name,
+  nodeUrl,
   supply,
   uri,
 }: CreateTokenAndCollectionProps): Promise<void> => {
   if (!account || !(collectionName && description && uri && name)) {
     return;
   }
-  const aptosClient = new AptosClient(NODE_URL);
+  const aptosClient = new AptosClient(nodeUrl);
   const tokenClient = new TokenClient(aptosClient);
 
   const collectionTxnHash = await tokenClient.createCollection(
@@ -107,7 +108,7 @@ export default function CreateNFTModal() {
   const { colorMode } = useColorMode();
   const { isOpen, onClose, onOpen } = useDisclosure();
   const { handleSubmit, register, watch } = useForm();
-  const { aptosAccount } = useWalletState();
+  const { aptosAccount, aptosNetwork } = useWalletState();
   const queryClient = useQueryClient();
 
   const collectionName: string | undefined = watch('collectionName');
@@ -127,6 +128,7 @@ export default function CreateNFTModal() {
       collectionName,
       description,
       name: tokenName,
+      nodeUrl: aptosNetwork as string,
       supply,
       uri,
     })

--- a/ecosystem/web-wallet/src/core/components/TransferDrawer.tsx
+++ b/ecosystem/web-wallet/src/core/components/TransferDrawer.tsx
@@ -38,7 +38,6 @@ import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { getUserTransaction } from 'core/queries/transaction';
 import { ExternalLinkIcon } from '@chakra-ui/icons';
 import {
-  NODE_URL,
   secondaryErrorMessageColor, STATIC_GAS_AMOUNT,
 } from 'core/constants';
 import numeral from 'numeral';
@@ -52,7 +51,7 @@ export const secondaryDividerColor = {
 
 function TransferDrawer() {
   const { colorMode } = useColorMode();
-  const { aptosAccount } = useWalletState();
+  const { aptosAccount, aptosNetwork } = useWalletState();
   const toast = useToast();
   const queryClient = useQueryClient();
   const {
@@ -109,7 +108,7 @@ function TransferDrawer() {
       }
       const fromAccountResources = await getAccountResources({
         address: aptosAccount.address().hex(),
-        nodeUrl: NODE_URL,
+        nodeUrl: aptosNetwork as string,
       });
       const tokenBalance = getTestCoinTokenBalanceFromAccountResources({
         accountResources: fromAccountResources,

--- a/ecosystem/web-wallet/src/core/constants.ts
+++ b/ecosystem/web-wallet/src/core/constants.ts
@@ -4,6 +4,7 @@
 export const KEY_LENGTH: number = 64;
 export const WALLET_STATE_LOCAL_STORAGE_KEY = 'aptosWalletState';
 export const WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY = 'aptosWalletNetworkState';
+export const WALLET_STATE_FAUCET_LOCAL_STORAGE_KEY = 'aptosWalletFaucetState';
 
 export const STATIC_GAS_AMOUNT = 150;
 
@@ -11,9 +12,20 @@ export const LOCAL_NODE_URL = 'http://0.0.0.0:8080';
 export const DEVNET_NODE_URL = 'https://fullnode.devnet.aptoslabs.com';
 export const LOCAL_FAUCET_URL = 'http://0.0.0.0:8000';
 export const DEVNET_FAUCET_URL = 'https://faucet.devnet.aptoslabs.com';
+export const LOCAL_URL_CONFIG = {
+  faucet: LOCAL_FAUCET_URL,
+  network: LOCAL_NODE_URL,
+};
+export const DEVNET_URL_CONFIG = {
+  faucet: DEVNET_FAUCET_URL,
+  network: DEVNET_NODE_URL,
+};
 
 export const NODE_URL = LOCAL_NODE_URL;
 export const FAUCET_URL = LOCAL_FAUCET_URL;
+
+// export const NODE_URL = DEVNET_NODE_URL;
+// export const FAUCET_URL = DEVNET_FAUCET_URL;
 
 export const secondaryBgColor = {
   dark: 'gray.900',

--- a/ecosystem/web-wallet/src/core/constants.ts
+++ b/ecosystem/web-wallet/src/core/constants.ts
@@ -21,12 +21,6 @@ export const DEVNET_URL_CONFIG = {
   network: DEVNET_NODE_URL,
 };
 
-export const NODE_URL = LOCAL_NODE_URL;
-export const FAUCET_URL = LOCAL_FAUCET_URL;
-
-// export const NODE_URL = DEVNET_NODE_URL;
-// export const FAUCET_URL = DEVNET_FAUCET_URL;
-
 export const secondaryBgColor = {
   dark: 'gray.900',
   light: 'white',

--- a/ecosystem/web-wallet/src/core/hooks/useWalletState.ts
+++ b/ecosystem/web-wallet/src/core/hooks/useWalletState.ts
@@ -8,6 +8,7 @@ import {
   WALLET_STATE_FAUCET_LOCAL_STORAGE_KEY,
   WALLET_STATE_LOCAL_STORAGE_KEY,
   WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY,
+  LOCAL_URL_CONFIG,
 } from 'core/constants';
 import { AptosAccountState, LocalStorageState } from 'core/types';
 import {
@@ -31,11 +32,11 @@ export default function useWalletState() {
   );
 
   const [aptosAccount, setAptosAccount] = useState<AptosAccountState>(() => getAptosAccountState());
-  const [aptosNetwork, setAptosNetwork] = useState<AptosNetwork | null>(
-    () => getLocalStorageNetworkState(),
+  const [aptosNetwork, setAptosNetwork] = useState<AptosNetwork>(
+    () => (getLocalStorageNetworkState() || LOCAL_URL_CONFIG.network as AptosNetwork),
   );
-  const [aptosFaucet, setAptosFaucet] = useState<AptosFaucet | null>(
-    () => getLocalStorageFaucetState(),
+  const [aptosFaucet, setAptosFaucet] = useState<AptosFaucet>(
+    () => (getLocalStorageFaucetState() || LOCAL_URL_CONFIG.faucet as AptosFaucet),
   );
 
   const updateWalletState = useCallback(({ aptosAccountState }: UpdateWalletStateProps) => {

--- a/ecosystem/web-wallet/src/core/hooks/useWalletState.ts
+++ b/ecosystem/web-wallet/src/core/hooks/useWalletState.ts
@@ -4,9 +4,18 @@
 import { useState, useCallback } from 'react';
 import constate from 'constate';
 import { getAptosAccountState, getLocalStorageState } from 'core/utils/account';
-import { WALLET_STATE_LOCAL_STORAGE_KEY, WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY } from 'core/constants';
+import {
+  WALLET_STATE_FAUCET_LOCAL_STORAGE_KEY,
+  WALLET_STATE_LOCAL_STORAGE_KEY,
+  WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY,
+} from 'core/constants';
 import { AptosAccountState, LocalStorageState } from 'core/types';
-import { AptosNetwork, getLocalStorageNetworkState } from 'core/utils/network';
+import {
+  AptosFaucet,
+  AptosNetwork,
+  getLocalStorageFaucetState,
+  getLocalStorageNetworkState,
+} from 'core/utils/network';
 
 const defaultValue: LocalStorageState = {
   aptosAccountObject: undefined,
@@ -24,6 +33,9 @@ export default function useWalletState() {
   const [aptosAccount, setAptosAccount] = useState<AptosAccountState>(() => getAptosAccountState());
   const [aptosNetwork, setAptosNetwork] = useState<AptosNetwork | null>(
     () => getLocalStorageNetworkState(),
+  );
+  const [aptosFaucet, setAptosFaucet] = useState<AptosFaucet | null>(
+    () => getLocalStorageFaucetState(),
   );
 
   const updateWalletState = useCallback(({ aptosAccountState }: UpdateWalletStateProps) => {
@@ -48,6 +60,16 @@ export default function useWalletState() {
     }
   }, []);
 
+  const updateFaucetState = useCallback((faucet: AptosFaucet) => {
+    try {
+      setAptosFaucet(faucet);
+      window.localStorage.setItem(WALLET_STATE_FAUCET_LOCAL_STORAGE_KEY, faucet);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  }, []);
+
   const signOut = useCallback(() => {
     setAptosAccount(undefined);
     setLocalStorageState({ aptosAccountObject: undefined });
@@ -56,8 +78,10 @@ export default function useWalletState() {
 
   return {
     aptosAccount,
+    aptosFaucet,
     aptosNetwork,
     signOut,
+    updateFaucetState,
     updateNetworkState,
     updateWalletState,
     walletState: localStorageState,

--- a/ecosystem/web-wallet/src/core/mutations/transaction.ts
+++ b/ecosystem/web-wallet/src/core/mutations/transaction.ts
@@ -4,7 +4,7 @@
 import {
   AptosAccount, AptosClient, MaybeHexString, Types,
 } from 'aptos';
-import { NODE_URL } from 'core/constants';
+import { LOCAL_NODE_URL } from 'core/constants';
 import {
   type GetTestCoinTokenBalanceFromAccountResourcesProps,
 } from 'core/queries/account';
@@ -17,7 +17,7 @@ export interface SubmitTransactionProps {
 
 export const submitTransaction = async ({
   fromAccount,
-  nodeUrl = NODE_URL,
+  nodeUrl = LOCAL_NODE_URL,
   payload,
 }: SubmitTransactionProps) => {
   const client = new AptosClient(nodeUrl);
@@ -38,7 +38,7 @@ export type SendTestCoinTransactionProps = Omit<SubmitTransactionProps & TestCoi
 export const sendTestCoinTransaction = async ({
   amount,
   fromAccount,
-  nodeUrl = NODE_URL,
+  nodeUrl = LOCAL_NODE_URL,
   toAddress,
 }: SendTestCoinTransactionProps) => {
   const payload: Types.TransactionPayload = {

--- a/ecosystem/web-wallet/src/core/queries/account.ts
+++ b/ecosystem/web-wallet/src/core/queries/account.ts
@@ -4,7 +4,7 @@
 import {
   AptosClient, MaybeHexString, Types,
 } from 'aptos';
-import { NODE_URL } from 'core/constants';
+import { LOCAL_NODE_URL } from 'core/constants';
 import { AptosAccountState } from 'core/types';
 
 export interface GetAccountResourcesProps {
@@ -13,7 +13,7 @@ export interface GetAccountResourcesProps {
 }
 
 export const getAccountResources = async ({
-  nodeUrl = NODE_URL,
+  nodeUrl = LOCAL_NODE_URL,
   address,
 }: GetAccountResourcesProps) => {
   const client = new AptosClient(nodeUrl);
@@ -61,7 +61,7 @@ export const getTestCoinTokenBalanceFromAccountResources = ({
 };
 
 export const accountExists = async ({
-  nodeUrl = NODE_URL,
+  nodeUrl = LOCAL_NODE_URL,
   address,
 }: GetAccountResourcesProps) => {
   const client = new AptosClient(nodeUrl);

--- a/ecosystem/web-wallet/src/core/queries/faucet.ts
+++ b/ecosystem/web-wallet/src/core/queries/faucet.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FaucetClient } from 'aptos';
-import { FAUCET_URL, NODE_URL } from 'core/constants';
+import { LOCAL_FAUCET_URL, LOCAL_NODE_URL } from 'core/constants';
 
 export interface FundAccountWithFaucetProps {
   address: string;
@@ -11,8 +11,8 @@ export interface FundAccountWithFaucetProps {
 }
 
 export const fundAccountWithFaucet = async ({
-  nodeUrl = NODE_URL,
-  faucetUrl = FAUCET_URL,
+  nodeUrl = LOCAL_NODE_URL,
+  faucetUrl = LOCAL_FAUCET_URL,
   address,
 }: FundAccountWithFaucetProps): Promise<void> => {
   const faucetClient = new FaucetClient(nodeUrl, faucetUrl);

--- a/ecosystem/web-wallet/src/core/queries/transaction.ts
+++ b/ecosystem/web-wallet/src/core/queries/transaction.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosClient } from 'aptos';
-import { NODE_URL } from 'core/constants';
+import { LOCAL_NODE_URL } from 'core/constants';
 
 export interface GetTransactionProps {
   nodeUrl?: string,
@@ -11,7 +11,7 @@ export interface GetTransactionProps {
 
 export const getTransaction = async ({
   txnHashOrVersion,
-  nodeUrl = NODE_URL,
+  nodeUrl = LOCAL_NODE_URL,
 }: GetTransactionProps) => {
   const aptosClient = new AptosClient(nodeUrl);
   if (txnHashOrVersion) {
@@ -23,7 +23,7 @@ export const getTransaction = async ({
 
 export const getUserTransaction = async ({
   txnHashOrVersion,
-  nodeUrl = NODE_URL,
+  nodeUrl = LOCAL_NODE_URL,
 }: GetTransactionProps) => {
   const aptosClient = new AptosClient(nodeUrl);
   if (txnHashOrVersion) {

--- a/ecosystem/web-wallet/src/core/utils/network.ts
+++ b/ecosystem/web-wallet/src/core/utils/network.ts
@@ -1,13 +1,21 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-import { WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY } from 'core/constants';
+import { WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY, WALLET_STATE_FAUCET_LOCAL_STORAGE_KEY } from 'core/constants';
 
 export type AptosNetwork = 'http://0.0.0.0:8080' | 'https://fullnode.devnet.aptoslabs.com';
+export type AptosFaucet = 'http://0.0.0.0:8080' | 'https://faucet.devnet.aptoslabs.com';
 
 export function getLocalStorageNetworkState(): AptosNetwork | null {
   // Get network from local storage by key
   return (window.localStorage.getItem(
     WALLET_STATE_NETWORK_LOCAL_STORAGE_KEY,
   ) as AptosNetwork | null);
+}
+
+export function getLocalStorageFaucetState(): AptosFaucet | null {
+  // Get faucet from from local storage by key
+  return (window.localStorage.getItem(
+    WALLET_STATE_FAUCET_LOCAL_STORAGE_KEY,
+  ) as AptosFaucet | null);
 }

--- a/ecosystem/web-wallet/src/pages/CreateWallet.tsx
+++ b/ecosystem/web-wallet/src/pages/CreateWallet.tsx
@@ -20,7 +20,7 @@ import ChakraLink from 'core/components/ChakraLink';
 import CreateWalletHeader from 'core/components/CreateWalletHeader';
 import withSimulatedExtensionContainer from 'core/components/WithSimulatedExtensionContainer';
 import { createNewAccount } from 'core/utils/account';
-import { NODE_URL, FAUCET_URL, secondaryBgColor } from 'core/constants';
+import { secondaryBgColor } from 'core/constants';
 
 export interface CredentialHeaderAndBodyProps {
   body?: string;
@@ -48,7 +48,12 @@ export function CredentialHeaderAndBody({
 
 function NewAccountState() {
   const [isAccountBeingCreated, setIsAccountBeingCreated] = useState<boolean>(false);
-  const { aptosAccount, updateWalletState } = useWalletState();
+  const {
+    aptosAccount,
+    aptosFaucet,
+    aptosNetwork,
+    updateWalletState,
+  } = useWalletState();
   const privateKeyObject = aptosAccount?.toPrivateKeyObject();
   const privateKeyHex = privateKeyObject?.privateKeyHex;
   const publicKeyHex = privateKeyObject?.publicKeyHex;
@@ -56,7 +61,7 @@ function NewAccountState() {
 
   const createAccountOnClick = async () => {
     setIsAccountBeingCreated(true);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = new FaucetClient(aptosNetwork as string, aptosFaucet as string);
     const account = createNewAccount();
     await faucetClient.fundAccount(account.address(), 0);
     updateWalletState({ aptosAccountState: account });

--- a/ecosystem/web-wallet/src/pages/Gallery.tsx
+++ b/ecosystem/web-wallet/src/pages/Gallery.tsx
@@ -19,11 +19,12 @@ import SquareBox from 'core/components/SquareBox';
 import CreateNFTModal from 'core/components/CreateNFTModal';
 import GalleryItem from 'core/components/GalleryItem';
 import withSimulatedExtensionContainer from 'core/components/WithSimulatedExtensionContainer';
-import { NODE_URL, validStorageUris } from 'core/constants';
+import { validStorageUris } from 'core/constants';
 import useWalletState from 'core/hooks/useWalletState';
 import WalletLayout from 'core/layouts/WalletLayout';
 import { MetadataJson } from 'core/types/TokenMetadata';
 import { AptosAccountState } from 'core/types';
+import { AptosNetwork } from 'core/utils/network';
 
 interface TokenAttributes {
   description?: string;
@@ -38,7 +39,8 @@ type CollectionDict = Record<string, TokenAttributes[]>;
 type StorageDict = Record<string, MetadataJson>;
 
 interface GetGalleryItemsProps {
-  aptosAccount: AptosAccountState
+  aptosAccount: AptosAccountState,
+  aptosNetwork: AptosNetwork,
 }
 
 const secondaryBorderColor = {
@@ -49,11 +51,12 @@ const secondaryBorderColor = {
 // this is a temporary workaround until we get the indexer working
 const getGalleryItems = async ({
   aptosAccount,
+  aptosNetwork,
 }: GetGalleryItemsProps) => {
   if (!aptosAccount) {
     return undefined;
   }
-  const aptosClient = new AptosClient(NODE_URL);
+  const aptosClient = new AptosClient(aptosNetwork as string);
   const hexAddress = aptosAccount?.address().hex();
   if (hexAddress) {
     const collectionDict: CollectionDict = {};
@@ -125,11 +128,11 @@ const getGalleryItems = async ({
 };
 
 function Gallery() {
-  const { aptosAccount } = useWalletState();
+  const { aptosAccount, aptosNetwork } = useWalletState();
   const { colorMode } = useColorMode();
   const {
     data: galleryItems,
-  } = useQuery('gallery-items', () => getGalleryItems({ aptosAccount }));
+  } = useQuery('gallery-items', () => getGalleryItems({ aptosAccount, aptosNetwork }));
 
   return (
     <WalletLayout>

--- a/ecosystem/web-wallet/src/pages/Login.tsx
+++ b/ecosystem/web-wallet/src/pages/Login.tsx
@@ -16,6 +16,7 @@ import {
   Input,
   InputGroup,
   InputRightAddon,
+  Select,
   Text,
   useColorMode,
   VStack,
@@ -23,9 +24,15 @@ import {
 import { SubmitHandler, useForm } from 'react-hook-form';
 import ChakraLink from 'core/components/ChakraLink';
 import useWalletState from 'core/hooks/useWalletState';
+import { AptosFaucet, AptosNetwork } from 'core/utils/network';
 import { AptosWhiteLogo, AptosBlackLogo } from 'core/components/AptosLogo';
 import withSimulatedExtensionContainer from 'core/components/WithSimulatedExtensionContainer';
-import { secondaryBgColor, secondaryErrorMessageColor } from 'core/constants';
+import {
+  secondaryBgColor,
+  secondaryErrorMessageColor,
+  LOCAL_URL_CONFIG,
+  DEVNET_URL_CONFIG,
+} from 'core/constants';
 import { getAccountResources } from 'core/queries/account';
 
 export const secondaryTextColor = {
@@ -35,7 +42,12 @@ export const secondaryTextColor = {
 
 function Login() {
   const { colorMode } = useColorMode();
-  const { aptosAccount, updateWalletState } = useWalletState();
+  const {
+    aptosAccount,
+    updateFaucetState,
+    updateNetworkState,
+    updateWalletState,
+  } = useWalletState();
   const navigate = useNavigate();
   const {
     formState: { errors }, handleSubmit, register, setError, watch,
@@ -126,6 +138,32 @@ function Login() {
             </ChakraLink>
           </VStack>
         </form>
+        <Select
+          placeholder="Choose network"
+          justifyContent="center"
+          alignSelf="center"
+          marginTop={4}
+          w="80%"
+          maxW="350px"
+          onChange={
+            (n) => {
+              switch (n.target.value) {
+                case 'devnet':
+                  updateFaucetState(DEVNET_URL_CONFIG.faucet as AptosFaucet);
+                  updateNetworkState(DEVNET_URL_CONFIG.network as AptosNetwork);
+                  break;
+
+                default:
+                  updateFaucetState(LOCAL_URL_CONFIG.faucet as AptosFaucet);
+                  updateNetworkState(LOCAL_URL_CONFIG.network as AptosNetwork);
+                  break;
+              }
+            }
+          }
+        >
+          <option value="localnet">localnet</option>
+          <option value="devnet">devnet</option>
+        </Select>
       </Flex>
       {/* TODO: Fill this in later */}
       {/* <HStack spacing={2} color={secondaryTextColor[colorMode]}>


### PR DESCRIPTION
## Motivation

Hey folks - noticed network/faucet configs were hardcoded to localnet. This generally required rebuilding the wallet package to switch between locl & devnet.

Proposal: Add a simple toggle to the login screen that allows the user to toggle between localnet and devnet.

Notes:

* The implemented UI dropdown component is easy to add elsewhere in the app in case a different placement is preferred than what's been implemented.)
* For posterity, a few more improvements were made:
  *  Hardcoded `NODE_URL` and `FAUCET_URL` have been removed in favor of dynamic configurations. Where appropriate, fallback urls have been hardcoded to local.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

✅

## Test Plan

Test via creating a  new wallet:
  1. Open wallet
  2. Choose {localnet|devnet} using the new available dropdown on the Login screen.
  3. Create a wallet (will not work on localnet if no local node is running).
  4. New wallet can be verified on chain.

Apologies if I missed relevant documentation somewhere. Would love to hear feedback!