### PR TITLE
[ecosystem] light dismiss of dialog when clicking backdrop overlay

### DIFF
--- a/ecosystem/platform/server/app/components/dialog_component.html.erb
+++ b/ecosystem/platform/server/app/components/dialog_component.html.erb
@@ -1,13 +1,15 @@
 <%= content_tag :dialog, **@rest do %>
-  <div class="flex items-center mb-2">
-    <h3 class="font-mono uppercase text-2xl"><%= title %></h3>
-    <form method="dialog" class="ml-auto text-right">
-      <button class="flex items-center justify-center w-6 h-6 fill-white/50 hover:text-neutral-300" type="submit" aria-label="Close Dialog">
-        <span class="sr-only">Close Dialog</span>
-        <%= render IconComponent.new(:close) %>
-      </button>
-    </form>
+  <div class="p-8">
+    <div class="flex items-center mb-2">
+      <h3 class="font-mono uppercase text-2xl"><%= title %></h3>
+      <form method="dialog" class="ml-auto text-right">
+        <button class="flex items-center justify-center w-6 h-6 fill-white/50 hover:text-neutral-300" type="submit" aria-label="Close Dialog">
+          <span class="sr-only">Close Dialog</span>
+          <%= render IconComponent.new(:close) %>
+        </button>
+      </form>
+    </div>
+    <div class="mb-8"><%= render DividerComponent.new %></div>
+    <%= body %>
   </div>
-  <div class="mb-8"><%= render DividerComponent.new %></div>
-  <%= body %>
 <% end %>

--- a/ecosystem/platform/server/app/components/dialog_component.rb
+++ b/ecosystem/platform/server/app/components/dialog_component.rb
@@ -12,7 +12,7 @@ class DialogComponent < ViewComponent::Base
   def initialize(**rest)
     @rest = rest
     @rest[:class] = [
-      'rounded-xl border-none bg-neutral-900 text-white p-8 w-96 fixed',
+      'rounded-xl border-none bg-neutral-900 text-white w-96 fixed p-0',
       @rest[:class]
     ]
 
@@ -21,5 +21,6 @@ class DialogComponent < ViewComponent::Base
 
     @rest[:data] ||= {}
     @rest[:data][:controller] = 'dialog'
+    @rest[:data][:action] = 'click->dialog#handleClick'
   end
 end

--- a/ecosystem/platform/server/app/javascript/controllers/dialog_controller.ts
+++ b/ecosystem/platform/server/app/javascript/controllers/dialog_controller.ts
@@ -9,4 +9,10 @@ export default class extends Controller<HTMLDialogElement> {
   connect() {
     dialogPolyfill.registerDialog(this.element);
   }
+
+  handleClick(e: Event) {
+    if (e.target === this.element) {
+      this.element.close();
+    }
+  }
 }


### PR DESCRIPTION
## Motivation

Allow closing of `<dialog>` when clicking backdrop overlay (outside of content container) via `event.target.nodeName`

## Test Plan

Manual Test - confirm `<dialog>` closes when clicking backdrop overlay. 

https://user-images.githubusercontent.com/98909677/172192677-96c90be4-6798-42dd-b1ce-4318c555904b.mp4

