### PR TITLE
[vm] expect failed block prologue transaction

### DIFF
--- a/aptos-move/e2e-tests/src/utils.rs
+++ b/aptos-move/e2e-tests/src/utils.rs
@@ -33,7 +33,7 @@ pub fn close_module_publishing(
     *dr_seqno = dr_seqno.checked_add(1).unwrap();
 }
 
-pub fn start_with_released_df() -> (FakeExecutor, Account) {
+pub fn start_with_released_af() -> (FakeExecutor, Account) {
     let executor = FakeExecutor::from_fresh_genesis();
     let mut dr_account = Account::new_aptos_root();
 

--- a/aptos-move/e2e-tests/src/versioning.rs
+++ b/aptos-move/e2e-tests/src/versioning.rs
@@ -20,7 +20,7 @@ pub struct VersionedTestEnv {
 impl VersionedTestEnv {
     // At each release, this function will need to be updated to handle the release logic
     pub fn new(version_number: u64) -> Option<Self> {
-        let (executor, dr_account) = utils::start_with_released_df();
+        let (executor, dr_account) = utils::start_with_released_af();
         let dr_sequence_number = 0;
 
         Some(Self {

--- a/aptos-move/e2e-testsuite/src/tests/block_prologue.rs
+++ b/aptos-move/e2e-testsuite/src/tests/block_prologue.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::HashValue;
+use aptos_types::{
+    account_address::AccountAddress, block_metadata::BlockMetadata, transaction::Transaction,
+};
+use language_e2e_tests::executor::FakeExecutor;
+
+#[test]
+fn block_prologue_abort() {
+    let mut executor = FakeExecutor::from_fresh_genesis();
+    // ensure normal metadata can succeed
+    executor.new_block();
+    // this transaction will fail
+    let new_block_txn = BlockMetadata::new(
+        HashValue::zero(),
+        0,
+        0,
+        vec![false; 1],
+        AccountAddress::random(),
+        executor.get_block_time(),
+    );
+    // the result should aborted transaction but not aborted vm.
+    let mut outputs = executor
+        .execute_transaction_block(vec![Transaction::BlockMetadata(new_block_txn)])
+        .unwrap();
+    assert_eq!(outputs.len(), 1);
+    let output = outputs.pop().unwrap();
+    assert!(output.write_set().is_empty());
+    assert!(output.events().is_empty());
+    assert_eq!(output.gas_used(), 0);
+}

--- a/aptos-move/e2e-testsuite/src/tests/mod.rs
+++ b/aptos-move/e2e-testsuite/src/tests/mod.rs
@@ -12,6 +12,7 @@
 //! Set env REGENERATE_GOLDENFILES to update the golden files when running tests..
 
 mod account_universe;
+mod block_prologue;
 mod create_account;
 mod data_store;
 mod execution_strategies;


### PR DESCRIPTION
VM returns proper error on block prologue transaction so that parallel execution will not abort on speculative execution.