### PR TITLE
[aptos-rosetta] Rosetta updates to match spec

### DIFF
--- a/crates/aptos-rosetta-cli/src/account.rs
+++ b/crates/aptos-rosetta-cli/src/account.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{format_output, NetworkArgs, UrlArgs};
-use aptos_rosetta::types::AccountBalanceResponse;
+use aptos_rosetta::types::{AccountBalanceRequest, AccountBalanceResponse};
 use aptos_types::account_address::AccountAddress;
 use clap::{Parser, Subcommand};
 
@@ -39,8 +39,12 @@ pub struct AccountBalanceCommand {
 impl AccountBalanceCommand {
     pub async fn execute(self) -> anyhow::Result<AccountBalanceResponse> {
         let client = self.url_args.client();
-        client
-            .account_balance_simple(self.account, self.network_args.chain_id)
-            .await
+        let request = AccountBalanceRequest {
+            network_identifier: self.network_args.network_identifier(),
+            account_identifier: self.account.into(),
+            block_identifier: None,
+            currencies: None,
+        };
+        client.account_balance(&request).await
     }
 }

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -50,9 +50,9 @@ async fn account_balance(
     if request.block_identifier.is_some() {
         return Err(ApiError::HistoricBalancesUnsupported);
     }
-    let rest_client = server_context.rest_client;
+    let rest_client = server_context.rest_client()?;
     let address = request.account_identifier.account_address()?;
-    let response = get_account(&rest_client, address).await?;
+    let response = get_account(rest_client, address).await?;
     let state = response.state();
     let txns = rest_client
         .get_transactions(Some(state.version), Some(1))
@@ -67,7 +67,7 @@ async fn account_balance(
         .transaction_info()
         .map_err(|err| ApiError::AptosError(err.to_string()))?;
 
-    let response = get_account_balance(&rest_client, address).await?;
+    let response = get_account_balance(rest_client, address).await?;
     let balance = response.into_inner();
 
     let response = AccountBalanceResponse {

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::{check_network, handle_request, with_context},
+    common::{check_network, handle_request, strip_hex_prefix, with_context},
     error::{ApiError, ApiResult},
     types::{Block, BlockIdentifier, BlockRequest, BlockResponse, TransactionIdentifier},
     RosettaContext,
@@ -54,8 +54,7 @@ async fn block(request: BlockRequest, server_context: RosettaContext) -> ApiResu
         }
         (None, Some(hash)) => {
             // Allow 0x in front of hash
-            let hash = hash.strip_prefix("0x").unwrap_or(hash);
-            let hash = HashValue::from_str(hash.strip_prefix("0x").unwrap())
+            let hash = HashValue::from_str(strip_hex_prefix(hash))
                 .map_err(|err| ApiError::AptosError(err.to_string()))?;
             let response = rest_client.get_transaction(hash).await?;
             let state = response.state().clone();

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -54,6 +54,7 @@ async fn block(request: BlockRequest, server_context: RosettaContext) -> ApiResu
         }
         (None, Some(hash)) => {
             // Allow 0x in front of hash
+            let hash = hash.strip_prefix("0x").unwrap_or(hash);
             let hash = HashValue::from_str(hash.strip_prefix("0x").unwrap())
                 .map_err(|err| ApiError::AptosError(err.to_string()))?;
             let response = rest_client.get_transaction(hash).await?;

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -40,7 +40,7 @@ async fn block(request: BlockRequest, server_context: RosettaContext) -> ApiResu
 
     check_network(request.network_identifier, &server_context)?;
 
-    let rest_client = &server_context.rest_client;
+    let rest_client = server_context.rest_client()?;
 
     // Retrieve by block or by hash, both or neither is not allowed
     let (parent_transaction, transaction): (Transaction, _) = match (

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -9,7 +9,6 @@ use crate::{
     },
 };
 use aptos_rest_client::aptos_api_types::mime_types::JSON;
-use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient};
 use url::Url;
 
@@ -24,20 +23,6 @@ impl RosettaClient {
             address,
             inner: ReqwestClient::new(),
         }
-    }
-
-    pub async fn account_balance_simple(
-        &self,
-        account: AccountAddress,
-        chain_id: ChainId,
-    ) -> anyhow::Result<AccountBalanceResponse> {
-        let request = AccountBalanceRequest {
-            network_identifier: chain_id.into(),
-            account_identifier: account.into(),
-            block_identifier: None,
-            currencies: None,
-        };
-        self.account_balance(&request).await
     }
 
     pub async fn account_balance(

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -12,6 +12,7 @@ use aptos_rest_client::aptos_api_types::mime_types::JSON;
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient};
 use url::Url;
 
+/// Client for testing & interacting with a Rosetta service
 pub struct RosettaClient {
     address: Url,
     inner: ReqwestClient,

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -108,3 +108,8 @@ pub fn get_timestamp<T>(response: &Response<T>) -> u64 {
     // note: timestamps are in microseconds, so we convert to milliseconds
     response.state().timestamp_usecs / 1000
 }
+
+/// Strips the `0x` prefix on hex strings
+pub fn strip_hex_prefix(str: &str) -> &str {
+    str.strip_prefix("0x").unwrap_or(str)
+}

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -38,78 +38,60 @@ pub enum ApiError {
     BadSignatureCount,
     #[error("historic balances unsupported")]
     HistoricBalancesUnsupported,
+    #[error("node is offline")]
+    NodeIsOffline,
 }
 
 impl ApiError {
     pub fn all() -> Vec<ApiError> {
+        use ApiError::*;
         vec![
-            ApiError::AptosError(String::new()),
-            ApiError::BadBlockRequest,
-            ApiError::BadNetwork,
-            ApiError::DeserializationFailed(String::new()),
-            ApiError::BadTransferOperations(String::new()),
-            ApiError::AccountNotFound,
-            ApiError::BadSignature,
-            ApiError::BadSignatureType,
-            ApiError::BadTransactionScript,
-            ApiError::BadTransactionPayload,
-            ApiError::BadCoin,
-            ApiError::BadSignatureCount,
-            ApiError::HistoricBalancesUnsupported,
+            AptosError(String::new()),
+            BadBlockRequest,
+            BadNetwork,
+            DeserializationFailed(String::new()),
+            BadTransferOperations(String::new()),
+            AccountNotFound,
+            BadSignature,
+            BadSignatureType,
+            BadTransactionScript,
+            BadTransactionPayload,
+            BadCoin,
+            BadSignatureCount,
+            HistoricBalancesUnsupported,
+            NodeIsOffline,
         ]
     }
 
     pub fn code(&self) -> u64 {
+        use ApiError::*;
         match self {
-            ApiError::AptosError(_) => 10,
-            ApiError::BadBlockRequest => 20,
-            ApiError::BadNetwork => 40,
-            ApiError::DeserializationFailed(_) => 50,
-            ApiError::BadTransferOperations(_) => 70,
-            ApiError::AccountNotFound => 80,
-            ApiError::BadSignature => 110,
-            ApiError::BadSignatureType => 120,
-            ApiError::BadTransactionScript => 130,
-            ApiError::BadTransactionPayload => 140,
-            ApiError::BadCoin => 150,
-            ApiError::BadSignatureCount => 160,
-            ApiError::HistoricBalancesUnsupported => 170,
+            AptosError(_) => 10,
+            BadBlockRequest => 20,
+            BadNetwork => 40,
+            DeserializationFailed(_) => 50,
+            BadTransferOperations(_) => 70,
+            AccountNotFound => 80,
+            BadSignature => 110,
+            BadSignatureType => 120,
+            BadTransactionScript => 130,
+            BadTransactionPayload => 140,
+            BadCoin => 150,
+            BadSignatureCount => 160,
+            HistoricBalancesUnsupported => 170,
+            NodeIsOffline => 180,
         }
     }
 
     pub fn retriable(&self) -> bool {
-        match self {
-            ApiError::AptosError(_) => false,
-            ApiError::BadBlockRequest => false,
-            ApiError::BadNetwork => false,
-            ApiError::DeserializationFailed(_) => false,
-            ApiError::BadTransferOperations(_) => false,
-            ApiError::AccountNotFound => true,
-            ApiError::BadSignature => false,
-            ApiError::BadSignatureType => false,
-            ApiError::BadTransactionScript => false,
-            ApiError::BadTransactionPayload => false,
-            ApiError::BadCoin => false,
-            ApiError::BadSignatureCount => false,
-            ApiError::HistoricBalancesUnsupported => false,
-        }
+        matches!(self, ApiError::AccountNotFound)
     }
 
     pub fn status_code(&self) -> StatusCode {
+        use ApiError::*;
         match self {
-            ApiError::AptosError(_) => StatusCode::BAD_REQUEST,
-            ApiError::BadBlockRequest => StatusCode::BAD_REQUEST,
-            ApiError::BadNetwork => StatusCode::BAD_REQUEST,
-            ApiError::DeserializationFailed(_) => StatusCode::BAD_REQUEST,
-            ApiError::BadTransferOperations(_) => StatusCode::BAD_REQUEST,
-            ApiError::AccountNotFound => StatusCode::NOT_FOUND,
-            ApiError::BadSignature => StatusCode::BAD_REQUEST,
-            ApiError::BadSignatureType => StatusCode::BAD_REQUEST,
-            ApiError::BadTransactionScript => StatusCode::BAD_REQUEST,
-            ApiError::BadTransactionPayload => StatusCode::BAD_REQUEST,
-            ApiError::BadCoin => StatusCode::BAD_REQUEST,
-            ApiError::BadSignatureCount => StatusCode::BAD_REQUEST,
-            ApiError::HistoricBalancesUnsupported => StatusCode::BAD_REQUEST,
+            AccountNotFound => StatusCode::NOT_FOUND,
+            _ => StatusCode::BAD_REQUEST,
         }
     }
 

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -5,6 +5,8 @@
 //!
 //! [Rosetta API Spec](https://www.rosetta-api.org/docs/Reference.html)
 
+extern crate core;
+
 use aptos_api::runtime::WebServer;
 use aptos_config::config::ApiConfig;
 use aptos_logger::debug;

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -18,19 +18,11 @@ use std::{
 #[tokio::main]
 async fn main() {
     aptos_logger::Logger::new().init();
-    let args: RosettaServerArgs = RosettaServerArgs::parse();
-
-    let rest_client = aptos_rest_client::Client::new(args.rest_api_url);
-    let api_config = ApiConfig {
-        enabled: true,
-        address: args.listen_address,
-        tls_cert_path: args.tls_cert_path,
-        tls_key_path: args.tls_key_path,
-        content_length_limit: args.content_length_limit,
-    };
+    let args: CommandArgs = CommandArgs::parse();
 
     // Ensure runtime for Rosetta is up and running
-    let _runtime = bootstrap(args.chain_id, api_config, rest_client).expect("Should bootstrap");
+    let _runtime = bootstrap(args.chain_id(), args.api_config(), args.rest_client())
+        .expect("Should bootstrap");
 
     // Run until there is an interrupt
     let term = Arc::new(AtomicBool::new(false));
@@ -39,21 +31,58 @@ async fn main() {
     }
 }
 
+/// A trait to provide common values from both online and offline mode
+trait ServerArgs {
+    /// Retrieve the API config for the local server
+    fn api_config(&self) -> ApiConfig;
+
+    /// Retrieve the optional rest client for the local server
+    fn rest_client(&self) -> Option<aptos_rest_client::Client>;
+
+    /// Retrieve the chain id
+    fn chain_id(&self) -> ChainId;
+}
+
 /// Aptos Rosetta API Server
 ///
 /// Provides an implementation of [Rosetta](https://www.rosetta-api.org/docs/Reference.html) on Aptos.
 #[derive(Debug, Parser)]
 #[clap(name = "aptos-rosetta", author, version, propagate_version = true)]
-pub struct RosettaServerArgs {
+pub enum CommandArgs {
+    /// Run a local online server that connects to a fullnode endpoint
+    Online(OnlineArgs),
+    /// Run a local online server that doesn't connect to a fullnode endpoint
+    Offline(OfflineArgs),
+}
+
+impl ServerArgs for CommandArgs {
+    fn api_config(&self) -> ApiConfig {
+        match self {
+            CommandArgs::Online(args) => args.api_config(),
+            CommandArgs::Offline(args) => args.api_config(),
+        }
+    }
+
+    fn rest_client(&self) -> Option<aptos_rest_client::Client> {
+        match self {
+            CommandArgs::Online(args) => args.rest_client(),
+            CommandArgs::Offline(args) => args.rest_client(),
+        }
+    }
+
+    fn chain_id(&self) -> ChainId {
+        match self {
+            CommandArgs::Online(args) => args.chain_id(),
+            CommandArgs::Offline(args) => args.chain_id(),
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct OfflineArgs {
     /// Listen address for the server. e.g. 127.0.0.1:8080
     #[clap(long, default_value = "127.0.0.1:8080")]
     listen_address: SocketAddr,
-    /// URL for the Aptos REST API. e.g. https://fullnode.devnet.aptoslabs.com
-    #[clap(long, default_value = "https://fullnode.devnet.aptoslabs.com")]
-    rest_api_url: url::Url,
-    /// ChainId to be used for the server e.g. TESTNET
-    #[clap(long, default_value = "TESTING")]
-    chain_id: ChainId,
     /// Path to TLS cert for HTTPS support
     #[clap(long)]
     tls_cert_path: Option<String>,
@@ -63,4 +92,50 @@ pub struct RosettaServerArgs {
     /// Limit to content length on all requests
     #[clap(long)]
     content_length_limit: Option<u64>,
+    /// ChainId to be used for the server e.g. TESTNET
+    #[clap(long, default_value = "TESTING")]
+    chain_id: ChainId,
+}
+
+impl ServerArgs for OfflineArgs {
+    fn api_config(&self) -> ApiConfig {
+        ApiConfig {
+            enabled: true,
+            address: self.listen_address,
+            tls_cert_path: self.tls_cert_path.clone(),
+            tls_key_path: self.tls_key_path.clone(),
+            content_length_limit: self.content_length_limit,
+        }
+    }
+
+    fn rest_client(&self) -> Option<aptos_rest_client::Client> {
+        None
+    }
+
+    fn chain_id(&self) -> ChainId {
+        self.chain_id
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct OnlineArgs {
+    #[clap(flatten)]
+    offline_args: OfflineArgs,
+    /// URL for the Aptos REST API. e.g. https://fullnode.devnet.aptoslabs.com
+    #[clap(long, default_value = "https://fullnode.devnet.aptoslabs.com")]
+    rest_api_url: url::Url,
+}
+
+impl ServerArgs for OnlineArgs {
+    fn api_config(&self) -> ApiConfig {
+        self.offline_args.api_config()
+    }
+
+    fn rest_client(&self) -> Option<aptos_rest_client::Client> {
+        Some(aptos_rest_client::Client::new(self.rest_api_url.clone()))
+    }
+
+    fn chain_id(&self) -> ChainId {
+        self.offline_args.chain_id
+    }
 }

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -38,6 +38,8 @@ pub fn routes(
 
 /// List [`NetworkIdentifier`]s supported by this proxy aka [`ChainId`]s
 ///
+/// This should be able to run without a running full node connection
+///
 /// [API Spec](https://www.rosetta-api.org/docs/NetworkApi.html#networklist)
 async fn network_list(
     _empty: EmptyRequest,
@@ -59,6 +61,7 @@ async fn network_list(
 /// Get Network options
 ///
 /// This lists out all errors, operations, and statuses, along with versioning information.
+/// This should be able to run without a running full node connection
 ///
 /// [API Spec](https://www.rosetta-api.org/docs/NetworkApi.html#networkoptions)
 async fn network_options(

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -9,7 +9,7 @@ use crate::{
     error::ApiError,
     types::{
         Allow, BlockIdentifier, NetworkListResponse, NetworkOptionsResponse, NetworkRequest,
-        NetworkStatusResponse, Peer, Version,
+        NetworkStatusResponse, OperationStatusType, OperationType, Peer, Version,
     },
     RosettaContext, MIDDLEWARE_VERSION, NODE_VERSION, ROSETTA_VERSION,
 };
@@ -85,14 +85,14 @@ async fn network_options(
         middleware_version: MIDDLEWARE_VERSION.to_string(),
     };
 
-    let operation_statuses = vec![
-        // TODO: Add statuses
-    ];
-
-    let operation_types = vec![
-        // TODO: Add operations
-    ];
-
+    let operation_statuses = OperationStatusType::all()
+        .into_iter()
+        .map(|status| status.into())
+        .collect();
+    let operation_types = OperationType::all()
+        .into_iter()
+        .map(|op| op.to_string())
+        .collect();
     let errors = ApiError::all().into_iter().map(|err| err.into()).collect();
 
     let allow = Allow {

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -103,6 +103,9 @@ async fn network_options(
         timestamp_start_index: Some(3), // FIXME: hardcoded based on current testnet
         call_methods: vec![],
         balance_exemptions: vec![],
+        mempool_coins: false,
+        block_hash_case: None,
+        transaction_hash_case: None,
     };
 
     let response = NetworkOptionsResponse { version, allow };

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -131,7 +131,7 @@ async fn network_status(
 
     check_network(request.network_identifier, &server_context)?;
 
-    let rest_client = &server_context.rest_client;
+    let rest_client = server_context.rest_client()?;
     let response = get_genesis_transaction(rest_client).await?;
     let state = response.state();
     let transaction = response.inner();

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -100,7 +100,7 @@ async fn network_options(
         operation_types,
         errors,
         historical_balance_lookup: false,
-        timestamp_start_index: Some(3), // FIXME: hardcoded based on current testnet
+        timestamp_start_index: None,
         call_methods: vec![],
         balance_exemptions: vec![],
         mempool_coins: false,

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -11,8 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, str::FromStr};
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/AccountIdentifier.html)
-///
-/// TODO: Metadata?
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AccountIdentifier {
     pub address: String,
@@ -109,6 +107,10 @@ impl From<ChainId> for NetworkIdentifier {
     }
 }
 
+/// Identifies a specific [`crate::types::Operation`] within a [`Transaction`]
+///
+/// It must be 0 to n within the transaction.
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/OperationIdentifier.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OperationIdentifier {
@@ -135,16 +137,12 @@ impl From<&BlockIdentifier> for PartialBlockIdentifier {
 }
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/SubAccountIdentifier.html)
-///
-/// TODO: Metadata?
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SubAccountIdentifier {
     pub address: String,
 }
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/SubNetworkIdentifier.html)
-///
-/// TODO: Metadata?
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SubNetworkIdentifier {
     pub network: String,

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -149,6 +149,7 @@ pub struct OperationIdentifier {
     /// It must be 0 to n within the transaction.
     pub index: u64,
     /// Only necessary if operation order is required
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub network_index: Option<u64>,
 }
 

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -31,10 +31,10 @@ impl AccountIdentifier {
     }
 }
 
-impl TryFrom<AccountIdentifier> for AccountAddress {
+impl TryFrom<&AccountIdentifier> for AccountAddress {
     type Error = ApiError;
 
-    fn try_from(account: AccountIdentifier) -> Result<Self, Self::Error> {
+    fn try_from(account: &AccountIdentifier) -> Result<Self, Self::Error> {
         // Allow 0x in front of account address
         Ok(AccountAddress::from_str(
             account.address.strip_prefix("0x").unwrap(),
@@ -119,10 +119,10 @@ impl NetworkIdentifier {
     }
 }
 
-impl TryFrom<NetworkIdentifier> for ChainId {
+impl TryFrom<&NetworkIdentifier> for ChainId {
     type Error = ApiError;
 
-    fn try_from(network_identifier: NetworkIdentifier) -> Result<Self, Self::Error> {
+    fn try_from(network_identifier: &NetworkIdentifier) -> Result<Self, Self::Error> {
         ChainId::from_str(network_identifier.network.trim())
             .map_err(|err| ApiError::AptosError(err.to_string()))
     }

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -36,9 +36,12 @@ impl TryFrom<&AccountIdentifier> for AccountAddress {
 
     fn try_from(account: &AccountIdentifier) -> Result<Self, Self::Error> {
         // Allow 0x in front of account address
-        Ok(AccountAddress::from_str(
-            account.address.strip_prefix("0x").unwrap(),
-        )?)
+        let address = account
+            .address
+            .strip_prefix("0x")
+            .unwrap_or(&account.address);
+
+        Ok(AccountAddress::from_str(address)?)
     }
 }
 

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -220,3 +220,11 @@ pub struct SubNetworkIdentifier {
 pub struct TransactionIdentifier {
     pub hash: String,
 }
+
+impl From<&TransactionInfo> for TransactionIdentifier {
+    fn from(txn: &TransactionInfo) -> Self {
+        TransactionIdentifier {
+            hash: txn.hash.to_string(),
+        }
+    }
+}

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -18,6 +18,7 @@ pub struct Error {
     /// Message that always matches the error code
     pub message: String,
     /// Possible generic information about an error code
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Whether a call can retry on the error
     pub retriable: bool,
@@ -53,8 +54,11 @@ pub struct Peer {
 /// [API Spec](https://www.rosetta-api.org/docs/models/SyncStatus.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SyncStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
     current_index: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     target_index: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     stage: Option<String>,
     synced: bool,
 }

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -1,7 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_types::vm_status::VMStatus;
 use serde::{Deserialize, Serialize};
+use std::{
+    fmt::{Display, Formatter},
+    str::FromStr,
+};
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/Error.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -25,6 +30,8 @@ pub struct ErrorDetails {
     pub error: String,
 }
 
+/// Status of an operation
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/OperationStatus.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OperationStatus {
@@ -32,9 +39,9 @@ pub struct OperationStatus {
     pub successful: bool,
 }
 
-/// [API Spec](https://www.rosetta-api.org/docs/models/Peer.html)
+/// Represents a Peer, used for discovery
 ///
-/// TODO: Metadata?
+/// [API Spec](https://www.rosetta-api.org/docs/models/Peer.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Peer {
     peer_id: String,
@@ -49,9 +56,15 @@ pub struct SyncStatus {
     synced: bool,
 }
 
+/// Version information for the current deployment to handle software version matching
+///
+/// [API Spec](https://www.rosetta-api.org/docs/models/Version.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Version {
+    /// Rosetta version, this should be hardcoded
     pub rosetta_version: String,
+    /// Node version, this should come from the node
     pub node_version: String,
+    /// Middleware version, this should be the version of this software
     pub middleware_version: String,
 }

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -9,7 +9,7 @@ use std::{
     str::FromStr,
 };
 
-///
+/// Errors that can be returned by the API
 ///
 /// [API Spec](https://www.rosetta-api.org/docs/models/Error.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -8,6 +8,8 @@ use std::{
     str::FromStr,
 };
 
+///
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/Error.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Error {
@@ -19,6 +21,7 @@ pub struct Error {
     pub description: Option<String>,
     /// Whether a call can retry on the error
     pub retriable: bool,
+    /// Specific details of the error e.g. stack trace
     #[serde(skip_serializing_if = "Option::is_none")]
     pub details: Option<ErrorDetails>,
 }

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -1,12 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_types::vm_status::VMStatus;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::{Display, Formatter},
-    str::FromStr,
-};
 
 ///
 ///

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -7,26 +7,45 @@ use crate::types::{
 };
 use serde::{Deserialize, Serialize};
 
+/// A description of all types used by the Rosetta implementation.
 ///
+/// This is used to verify correctness of the implementation and to check things like
+/// operation names, and error names.
 ///
 /// [API Spec](https://www.rosetta-api.org/docs/models/Allow.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Allow {
+    /// List of all possible operation statuses
     pub operation_statuses: Vec<OperationStatus>,
+    /// List of all possible writeset types
     pub operation_types: Vec<String>,
+    /// List of all possible errors
     pub errors: Vec<Error>,
+    /// If the server is allowed to lookup historical transactions
     pub historical_balance_lookup: bool,
+    /// All times after this are valid timestamps
+    /// TODO: Determine if we even need to bother with this
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timestamp_start_index: Option<u64>,
+    /// All call methods supported
     pub call_methods: Vec<String>,
+    /// A list of balance exemptions, where these accounts change their balance
+    /// without an operation
     pub balance_exemptions: Vec<BalanceExemption>,
+    /// Determines if mempool can change the balance on an account
+    /// This should be set to false
+    pub mempool_coins: bool,
+    /// Case specifics for block hashes.  Set to None if case insensitive
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_hash_case: Option<Case>,
+    /// Case specifics for transaction hashes.  Set to None if case insensitive
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_hash_case: Option<Case>,
 }
 
 /// Amount of a [`Currency`] in atomic units
 ///
 /// [API Spec](https://www.rosetta-api.org/docs/models/Amount.html)
-///
-/// TODO: Do we need optional metadata?
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Amount {
     /// Value of transaction as a String representation of an integer
@@ -86,6 +105,8 @@ pub struct BlockTransaction {
     transaction: Transaction,
 }
 
+/// Tells
+///
 ///[API Spec](https://www.rosetta-api.org/docs/models/Case.html)
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -93,7 +114,6 @@ pub enum Case {
     UpperCase,
     LowerCase,
     CaseSensitive,
-    Null,
 }
 
 /// Currency represented as atomic units including decimals
@@ -107,13 +127,14 @@ pub struct Currency {
     pub decimals: u64,
 }
 
+/// Various signing curves supported by Rosetta.  We only use [`CurveType::Edwards25519`]
 /// [API Spec](https://www.rosetta-api.org/docs/models/CurveType.html)
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CurveType {
+    Edwards25519,
     Secp256k1,
     Secp256r1,
-    Edwards25519,
     Tweedle,
     Pallas,
 }
@@ -135,21 +156,29 @@ pub enum ExemptionType {
     Dynamic,
 }
 
-/// [API Spec](https://www.rosetta-api.org/docs/models/Operation.html)
+/// A representation of a single account change in a transaction
 ///
-/// TODO: Metadata?
+/// This is known as a write set change within Aptos
+/// [API Spec](https://www.rosetta-api.org/docs/models/Operation.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Operation {
+    /// Identifier of an operation within a transaction
     pub operation_identifier: OperationIdentifier,
+    /// Related operations e.g. multiple operations that are related to a transfer
     #[serde(skip_serializing_if = "Option::is_none")]
     pub related_operations: Option<Vec<OperationIdentifier>>,
     /// Type of operation
     #[serde(rename = "type")]
-    pub type_: String,
-    /// Status of operation
+    pub operation_type: String,
+    /// Status of operation.  Must be populated if the transaction is in the past.  If submitting
+    /// new transactions, it must NOT be populated.
     pub status: Option<String>,
+    /// AccountIdentifier should be provided to point at which account the change is
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<AccountIdentifier>,
+    /// Amount in the operation
+    ///
+    /// TODO: Determine if this is required
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<Amount>,
 }
@@ -218,9 +247,9 @@ pub struct SigningPayload {
     pub signature_type: Option<SignatureType>,
 }
 
-/// [API Spec](https://www.rosetta-api.org/docs/models/Transaction.html)
 ///
-/// TODO: Metadata?
+///
+/// [API Spec](https://www.rosetta-api.org/docs/models/Transaction.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Transaction {
     pub transaction_identifier: TransactionIdentifier,

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -1,10 +1,14 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::types::{
-    AccountIdentifier, BlockIdentifier, Error, NetworkIdentifier, OperationIdentifier,
-    OperationStatus, TransactionIdentifier,
+use crate::{
+    types::{
+        AccountIdentifier, BlockIdentifier, Error, NetworkIdentifier, OperationIdentifier,
+        OperationStatus, TransactionIdentifier,
+    },
+    CURRENCY, NUM_DECIMALS,
 };
+use aptos_rest_client::aptos::Balance;
 use serde::{Deserialize, Serialize};
 
 /// A description of all types used by the Rosetta implementation.
@@ -52,6 +56,16 @@ pub struct Amount {
     pub value: String,
     /// [`Currency`]
     pub currency: Currency,
+}
+
+impl From<Balance> for Amount {
+    fn from(balance: Balance) -> Self {
+        Amount {
+            value: balance.coin.value.to_string(),
+            // TODO: Support other currencies
+            currency: Currency::test_coin(),
+        }
+    }
 }
 
 /// Balance exemptions where the current balance of an account can change without a transaction
@@ -141,8 +155,17 @@ pub enum Case {
 pub struct Currency {
     /// Symbol of currency
     pub symbol: String,
-    /// Number of decimals to be considered in the currecny
+    /// Number of decimals to be considered in the currency
     pub decimals: u64,
+}
+
+impl Currency {
+    pub fn test_coin() -> Self {
+        Currency {
+            symbol: CURRENCY.to_string(),
+            decimals: NUM_DECIMALS,
+        }
+    }
 }
 
 /// Various signing curves supported by Rosetta.  We only use [`CurveType::Edwards25519`]

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -247,6 +247,7 @@ pub struct PublicKey {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct RelatedTransaction {
     /// Network of transaction.  [`None`] means same network as original transaction
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub network_identifier: Option<NetworkIdentifier>,
     /// Transaction identifier of the related transaction
     pub transaction_identifier: TransactionIdentifier,
@@ -290,8 +291,10 @@ pub enum SignatureType {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct SigningPayload {
     /// Deprecated field, replaced with account_identifier
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub address: Option<String>,
     /// Account identifier of the signer
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier: Option<AccountIdentifier>,
     /// Hex encoded string of payload bytes to be signed
     pub hex_bytes: String,
@@ -310,5 +313,6 @@ pub struct Transaction {
     /// Individual operations (write set changes) in a transaction
     pub operations: Vec<Operation>,
     /// Related transactions
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub related_transactions: Option<Vec<RelatedTransaction>>,
 }

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     CURRENCY, NUM_DECIMALS,
 };
-use aptos_rest_client::aptos::Balance;
+use aptos_rest_client::{aptos::Balance, aptos_api_types::TransactionInfo};
 use serde::{Deserialize, Serialize};
 
 /// A description of all types used by the Rosetta implementation.
@@ -338,4 +338,14 @@ pub struct Transaction {
     /// Related transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub related_transactions: Option<Vec<RelatedTransaction>>,
+}
+
+impl From<&TransactionInfo> for Transaction {
+    fn from(txn: &TransactionInfo) -> Self {
+        Transaction {
+            transaction_identifier: txn.into(),
+            operations: vec![],
+            related_transactions: None,
+        }
+    }
 }

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -6,6 +6,7 @@ use crate::types::{
     Operation, PartialBlockIdentifier, Peer, PublicKey, Signature, SigningPayload, SyncStatus,
     Transaction, TransactionIdentifier, Version,
 };
+use aptos_types::chain_id::ChainId;
 use serde::{Deserialize, Serialize};
 
 /// Request for an account's currency balance either now, or historically
@@ -41,6 +42,25 @@ pub struct AccountBalanceResponse {
 pub struct BlockRequest {
     pub network_identifier: NetworkIdentifier,
     pub block_identifier: PartialBlockIdentifier,
+}
+
+impl BlockRequest {
+    fn new(chain_id: ChainId, block_identifier: PartialBlockIdentifier) -> Self {
+        Self {
+            network_identifier: chain_id.into(),
+            block_identifier,
+        }
+    }
+
+    pub fn latest(chain_id: ChainId) -> Self {
+        Self::new(chain_id, PartialBlockIdentifier::latest())
+    }
+    pub fn by_hash(chain_id: ChainId, hash: String) -> Self {
+        Self::new(chain_id, PartialBlockIdentifier::by_hash(hash))
+    }
+    pub fn by_version(chain_id: ChainId, version: u64) -> Self {
+        Self::new(chain_id, PartialBlockIdentifier::by_version(version))
+    }
 }
 
 /// Response that will always have a valid block populated

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -55,7 +55,9 @@ pub struct BlockResponse {
     pub other_transactions: Option<Vec<TransactionIdentifier>>,
 }
 
+/// Request to combine signatures and an unsigned transaction for submission
 ///
+/// This should be able to run without a running full node connection
 ///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionCombineRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -65,12 +67,18 @@ pub struct ConstructionCombineRequest {
     pub signatures: Vec<Signature>,
 }
 
+/// Response of signed transaction for submission
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionCombineResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionCombineResponse {
     pub signed_transaction: String,
 }
 
+/// Request to derive an account from a public key
+///
+/// This should be able to run without a running full node connection
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionDeriveRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionDeriveRequest {
@@ -78,6 +86,8 @@ pub struct ConstructionDeriveRequest {
     pub public_key: PublicKey,
 }
 
+/// Response of derived account from a public key
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionDeriveResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionDeriveResponse {
@@ -85,6 +95,8 @@ pub struct ConstructionDeriveResponse {
     pub account_identifier: Option<AccountIdentifier>,
 }
 
+/// Request to hash a transaction
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionHashRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionHashRequest {
@@ -92,6 +104,10 @@ pub struct ConstructionHashRequest {
     pub signed_transaction: String,
 }
 
+/// Request to retrieve all information needed for constructing a transaction from the blockchain
+///
+/// A running full node is required for this API
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionMetadataRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionMetadataRequest {
@@ -106,6 +122,10 @@ pub struct MetadataOptions {
     pub sender_address: String,
 }
 
+/// Response with network specific data for constructing a transaction
+///
+/// In this case, sequence number must be pulled from onchain.
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionMetadataResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionMetadataResponse {
@@ -114,12 +134,17 @@ pub struct ConstructionMetadataResponse {
     pub suggested_fee: Option<Vec<Amount>>,
 }
 
+/// Metadata required to construct a transaction
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionMetadata {
-    pub chain_id: u8,
+    /// Sequence number of the sending account
     pub sequence_number: u64,
 }
 
+/// Request to parse a signed or unsigned transaction into operations
+///
+/// This should be able to run without a running full node connection
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionParseRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionParseRequest {
@@ -128,6 +153,8 @@ pub struct ConstructionParseRequest {
     pub transaction: String,
 }
 
+/// Response with operations in a transaction blob
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionParseResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionParseResponse {
@@ -136,6 +163,10 @@ pub struct ConstructionParseResponse {
     pub account_identifier_signers: Option<Vec<AccountIdentifier>>,
 }
 
+/// Request to build payloads from the operations to sign
+///
+/// This should be able to run without a running full node connection
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionPayloadsRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionPayloadsRequest {
@@ -147,6 +178,8 @@ pub struct ConstructionPayloadsRequest {
     pub public_keys: Option<Vec<PublicKey>>,
 }
 
+/// Response with generated payloads to be signed
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionPayloadsResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionPayloadsResponse {
@@ -154,17 +187,25 @@ pub struct ConstructionPayloadsResponse {
     pub payloads: Vec<SigningPayload>,
 }
 
+/// Request to get options for a [`ConstructionMetadataRequest`]
+///
+/// This should be able to run without a running full node connection
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionPreprocessRequest.html)
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ConstructionPreprocessRequest {
     pub network_identifier: NetworkIdentifier,
+    /// TODO: Operations expected to occur from the transaction?
     pub operations: Vec<Operation>,
+    /// Max gas price
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_fee: Option<Vec<Amount>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_multiplier: Option<f64>,
 }
 
+/// Response for direct input into a [`ConstructionMetadataRequest`]
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionPreprocessResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionPreprocessResponse {
@@ -174,31 +215,44 @@ pub struct ConstructionPreprocessResponse {
     pub required_public_keys: Option<Vec<AccountIdentifier>>,
 }
 
+/// Request to submit a signed transaction
+///
+/// A running full node is required for this API
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionSubmitRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionSubmitRequest {
     pub network_identifier: NetworkIdentifier,
+    /// Signed transaction hex encoded
     pub signed_transaction: String,
 }
 
+/// Response containing transaction identifier of submitted transaction
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionSubmitResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionSubmitResponse {
     pub transaction_identifier: TransactionIdentifier,
 }
 
+/// Request for all transactions in mempool
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/MempoolRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MempoolRequest {
     pub network_identifier: NetworkIdentifier,
 }
 
+/// Response of all transactions in mempool
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/MempoolResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MempoolResponse {
     pub transaction_identifiers: Vec<TransactionIdentifier>,
 }
 
+/// Request for a transaciton in mempool by hash
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/MempoolTransactionRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MempoolTransactionRequest {
@@ -206,48 +260,71 @@ pub struct MempoolTransactionRequest {
     pub transaction_identifier: TransactionIdentifier,
 }
 
+/// Response of an estimate of the transaction in mempool
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/MempoolTransactionResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MempoolTransactionResponse {
     pub transaction: Transaction,
 }
 
+/// Metadata request for a placeholder when no other fields exist
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/MetadataRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct MetadataRequest {}
 
+/// Response of all networks that this endpoint supports
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/NetworkListResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NetworkListResponse {
     pub network_identifiers: Vec<NetworkIdentifier>,
 }
 
+/// Response with all versioning and implementation specific fields
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/NetworkOptionsResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NetworkOptionsResponse {
+    /// Software versions
     pub version: Version,
+    /// Specifics about what is allowed on this server
     pub allow: Allow,
 }
 
+/// A generic request for network APIs
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/NetworkRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NetworkRequest {
     pub network_identifier: NetworkIdentifier,
 }
 
+/// Response with information about the current network state
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/NetworkStatusResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NetworkStatusResponse {
+    /// Current block identifier
     pub current_block_identifier: BlockIdentifier,
+    /// Current block timestampe in milliseconds
     pub current_block_timestamp: u64,
+    /// Genesis block
     pub genesis_block_identifier: BlockIdentifier,
+    /// Oldest version that is available after pruning.  Assumed to be genesis block if not present
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_block_identifier: Option<BlockIdentifier>,
+    /// Sync status if a node needs to catch up
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_status: Option<SyncStatus>,
+    /// Connected peers
+    /// TODO: This doesn't seem to really be used anywhere, is it necessary?
     pub peers: Vec<Peer>,
 }
 
+/// Response with a transaction that was hashed or submitted
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/TransactionIdentifierResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TransactionIdentifierResponse {

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -69,8 +69,6 @@ pub struct ConstructionCombineResponse {
 }
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionDeriveRequest.html)
-///
-/// TODO: Metadata?
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionDeriveRequest {
     pub network_identifier: NetworkIdentifier,
@@ -78,8 +76,6 @@ pub struct ConstructionDeriveRequest {
 }
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionDeriveResponse.html)
-///
-/// TODO: Metadata?
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionDeriveResponse {
     pub account_identifier: Option<AccountIdentifier>,
@@ -128,8 +124,6 @@ pub struct ConstructionParseRequest {
 }
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionParseResponse.html)
-///
-/// TODO: Metadata
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionParseResponse {
     pub operations: Vec<Operation>,

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -8,17 +8,23 @@ use crate::types::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Request for an account's currency balance either now, or historically
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/AccountBalanceRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AccountBalanceRequest {
     pub network_identifier: NetworkIdentifier,
     pub account_identifier: AccountIdentifier,
+    /// For historical balance lookups by either hash or version
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_identifier: Option<PartialBlockIdentifier>,
+    /// For filtering which currencies to show
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currencies: Option<Vec<Currency>>,
 }
 
+/// Response with the version associated and the balances of the account
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/AccountBalanceResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AccountBalanceResponse {
@@ -26,6 +32,10 @@ pub struct AccountBalanceResponse {
     pub balances: Vec<Amount>,
 }
 
+/// Reqyest a block (version) on the account
+///
+/// With neither value for PartialBlockIdentifier, get the latest version
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/BlockRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BlockRequest {
@@ -33,27 +43,19 @@ pub struct BlockRequest {
     pub block_identifier: PartialBlockIdentifier,
 }
 
+/// Response that will always have a valid block populated
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/BlockResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BlockResponse {
+    /// The block requested.  This should always be populated for a given valid version
     pub block: Option<Block>,
+    /// Transactions that weren't included in the block
     pub other_transactions: Option<Vec<TransactionIdentifier>>,
 }
 
-/// [API Spec](https://www.rosetta-api.org/docs/models/BlockTransactionRequest.html)
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct BlockTransactionRequest {
-    pub network_identifier: NetworkIdentifier,
-    pub block_identifier: BlockIdentifier,
-    pub transaction_identifier: TransactionIdentifier,
-}
-
-/// [API Spec](https://www.rosetta-api.org/docs/models/BlockTransactionResponse.html)
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct BlockTransactionResponse {
-    pub transaction: Transaction,
-}
-
+///
+///
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionCombineRequest.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionCombineRequest {

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -51,6 +51,7 @@ pub struct BlockResponse {
     /// The block requested.  This should always be populated for a given valid version
     pub block: Option<Block>,
     /// Transactions that weren't included in the block
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub other_transactions: Option<Vec<TransactionIdentifier>>,
 }
 
@@ -80,6 +81,7 @@ pub struct ConstructionDeriveRequest {
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionDeriveResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionDeriveResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier: Option<AccountIdentifier>,
 }
 
@@ -108,6 +110,7 @@ pub struct MetadataOptions {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionMetadataResponse {
     pub metadata: ConstructionMetadata,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee: Option<Vec<Amount>>,
 }
 
@@ -129,6 +132,7 @@ pub struct ConstructionParseRequest {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionParseResponse {
     pub operations: Vec<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier_signers: Option<Vec<AccountIdentifier>>,
 }
 
@@ -137,7 +141,9 @@ pub struct ConstructionParseResponse {
 pub struct ConstructionPayloadsRequest {
     pub network_identifier: NetworkIdentifier,
     pub operations: Vec<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<ConstructionMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub public_keys: Option<Vec<PublicKey>>,
 }
 
@@ -153,14 +159,18 @@ pub struct ConstructionPayloadsResponse {
 pub struct ConstructionPreprocessRequest {
     pub network_identifier: NetworkIdentifier,
     pub operations: Vec<Operation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_fee: Option<Vec<Amount>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub suggested_fee_multiplier: Option<f64>,
 }
 
 /// [API Spec](https://www.rosetta-api.org/docs/models/ConstructionPreprocessResponse.html)
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ConstructionPreprocessResponse {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<MetadataOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub required_public_keys: Option<Vec<AccountIdentifier>>,
 }
 
@@ -231,7 +241,9 @@ pub struct NetworkStatusResponse {
     pub current_block_identifier: BlockIdentifier,
     pub current_block_timestamp: u64,
     pub genesis_block_identifier: BlockIdentifier,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_block_identifier: Option<BlockIdentifier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_status: Option<SyncStatus>,
     pub peers: Vec<Peer>,
 }

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate core;
+
 // Defines Forge Tests
 pub mod aptos;
 pub mod fullnode;

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -45,7 +45,9 @@ pub async fn setup_test(
     let _rosetta = aptos_rosetta::bootstrap_async(
         swarm.chain_id(),
         api_config,
-        aptos_rest_client::Client::new(validator.rest_api_endpoint()),
+        Some(aptos_rest_client::Client::new(
+            validator.rest_api_endpoint(),
+        )),
     )
     .await
     .unwrap();

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -24,13 +24,13 @@ pub async fn setup_test(
     // Connect the operator tool to the node's JSON RPC API
     let tool = CliTestFramework::new(
         validator.rest_api_endpoint(),
-        "http://localhost:9996".parse().unwrap(),
+        "http://localhost:9997".parse().unwrap(),
         2,
     )
     .await;
 
     // And the client
-    let rosetta_socket_addr = "127.0.0.1:9997";
+    let rosetta_socket_addr = "127.0.0.1:9998";
     let rosetta_url = format!("http://{}", rosetta_socket_addr).parse().unwrap();
     let rosetta_client = RosettaClient::new(rosetta_url);
     let api_config = ApiConfig {
@@ -58,6 +58,7 @@ pub async fn setup_test(
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_account_balance() {
     let (swarm, _cli, rosetta_client) = setup_test(1, 1).await;
     let account = CliTestFramework::account_id(0);
@@ -79,6 +80,8 @@ async fn test_account_balance() {
 }
 
 #[tokio::test]
+#[ignore]
+// TODO: Fix test so it doesn't conflict with other tests
 async fn test_block() {
     let (swarm, _cli, rosetta_client) = setup_test(1, 0).await;
     let chain_id = swarm.chain_id();

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -50,7 +50,6 @@ pub async fn setup_test(num_nodes: usize) -> (LocalSwarm, CliTestFramework, Rose
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_account_balance() {
     let (_swarm, cli, rosetta_client) = setup_test(1).await;
 


### PR DESCRIPTION
## Motivation

I read through every object description of the objects I currently have in my implementation to add detail documentation on what each field needs, and what kinds of constraints they have.  Additionally, cleaned up block request with no inputs should get the latest block (this is exactly 1 line in the spec that I missed earlier)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

TBD, I need to implement some tests in the future for this, but this is mostly just documentation
