### PR TITLE
No Stop Idx to avoid skipping txns due to speculative status

### DIFF
--- a/aptos-move/parallel-executor/src/executor.rs
+++ b/aptos-move/parallel-executor/src/executor.rs
@@ -13,7 +13,16 @@ use mvhashmap::MVHashMap;
 use num_cpus;
 use once_cell::sync::Lazy;
 use rayon::prelude::*;
-use std::{collections::HashSet, hash::Hash, marker::PhantomData, sync::Arc, thread::spawn};
+use std::{
+    collections::HashSet,
+    hash::Hash,
+    marker::PhantomData,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    thread::spawn,
+};
 
 static RAYON_EXEC_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
     rayon::ThreadPoolBuilder::new()
@@ -166,20 +175,22 @@ where
         };
 
         let result = match execute_result {
+            // These statuses are the results of speculative execution, so even for
+            // SkipRest (skip the rest of transactions) and Abort (abort execution with
+            // user defined error), no immediate action is taken. Instead the statuses
+            // are recorded and (final statuses) are analyzed when the block is executed.
             ExecutionStatus::Success(output) => {
-                // Commit the side effects to the versioned_data_cache.
+                // Apply the writes to the versioned_data_cache.
                 apply_writes(&output);
                 ExecutionStatus::Success(output)
             }
             ExecutionStatus::SkipRest(output) => {
-                // Commit and skip the rest of the transactions.
+                // Apply the writes and record status indicating skip.
                 apply_writes(&output);
-                scheduler.set_stop_idx(idx_to_execute + 1);
                 ExecutionStatus::SkipRest(output)
             }
             ExecutionStatus::Abort(err) => {
-                // Abort the execution with user defined error.
-                scheduler.set_stop_idx(idx_to_execute + 1);
+                // Record the status indicating abort.
                 ExecutionStatus::Abort(Error::UserError(err))
             }
         };
@@ -313,16 +324,23 @@ where
         });
 
         // Extract outputs in parallel.
-        let valid_results_size = scheduler.num_txn_to_execute();
-        let chunk_size =
-            (valid_results_size + 4 * self.concurrency_level - 1) / (4 * self.concurrency_level);
+        let num_txns = scheduler.num_txn_to_execute();
+        let valid_results_size = AtomicUsize::new(num_txns);
+        let chunk_size = (num_txns + 4 * self.concurrency_level - 1) / (4 * self.concurrency_level);
         RAYON_EXEC_POOL.install(|| {
-            (0..valid_results_size)
+            (0..num_txns)
                 .collect::<Vec<TxnIndex>>()
                 .par_chunks(chunk_size)
                 .map(|chunk| {
                     for idx in chunk.iter() {
-                        outcomes.set_result(*idx, last_input_output.take_output(*idx));
+                        let res = last_input_output.take_output(*idx);
+                        match &res {
+                            ExecutionStatus::Abort(_) | ExecutionStatus::SkipRest(_) => {
+                                valid_results_size.fetch_min(*idx + 1, Ordering::SeqCst);
+                            }
+                            ExecutionStatus::Success(_) => {}
+                        }
+                        outcomes.set_result(*idx, res);
                     }
                 })
                 .collect::<()>();
@@ -335,6 +353,6 @@ where
             drop(versioned_data_cache);
             drop(scheduler);
         });
-        outcomes.get_all_results(valid_results_size)
+        outcomes.get_all_results(valid_results_size.load(Ordering::SeqCst))
     }
 }

--- a/aptos-move/parallel-executor/src/unit_tests/mod.rs
+++ b/aptos-move/parallel-executor/src/unit_tests/mod.rs
@@ -291,8 +291,6 @@ fn scheduler_incarnation() {
             SchedulerTask::ExecutionTask((j, 0), None, _) if j == i
         ));
     }
-    // Should not matter since drain_idx is already 5.
-    s.set_stop_idx(3);
 
     // execution index = 5
     assert!(s.wait_for_dependency(1, 0).is_some());
@@ -378,7 +376,7 @@ fn scheduler_incarnation() {
 
 #[test]
 fn scheduler_stop_idx() {
-    let s = Scheduler::new(5);
+    let s = Scheduler::new(3);
     let fake_counter = AtomicUsize::new(0);
 
     for i in 0..2 {
@@ -388,8 +386,6 @@ fn scheduler_stop_idx() {
             SchedulerTask::ExecutionTask((j, 0), None, _) if j == i
         ));
     }
-    // stop_idx is now 3, no txn > 2 has been scheduled, so txns 3,4 won't ever execute.
-    s.set_stop_idx(3);
 
     assert!(matches!(
         s.next_task(),
@@ -427,7 +423,7 @@ fn scheduler_stop_idx() {
 
 #[test]
 fn scheduler_drain_idx() {
-    let s = Scheduler::new(5);
+    let s = Scheduler::new(3);
     let fake_counter = AtomicUsize::new(0);
 
     for i in 0..3 {
@@ -437,8 +433,6 @@ fn scheduler_drain_idx() {
             SchedulerTask::ExecutionTask((j, 0), None, _) if j == i
         ));
     }
-    // 3 txns have already been scheduled, will finish at 3 despite stop idx 2.
-    s.set_stop_idx(2);
 
     // Finish executions & dispatch validation tasks.
     assert!(matches!(


### PR DESCRIPTION
Get rid of stop index optimization due to speculative errors, execute whole block & check final outputs

Seems to pass tests :-)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Aptos Core project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/aptos-labs/aptos-core/tree/main/developer-docs-site, and link to your PR here.)
