### PR TITLE
Revert "[forge] remove direct eks cluster scaling"

### DIFF
--- a/scripts/fgi/kube.py
+++ b/scripts/fgi/kube.py
@@ -74,7 +74,7 @@ def create_forge_job(context, user, tag, base_tag, timeout_secs, forge_envs, for
     cmd = template["spec"]["template"]["spec"]["containers"][0]["command"][2]
     template["spec"]["template"]["spec"]["containers"][0]["command"][2] = cmd.replace(
         "tail -f /dev/null",
-        f"timeout {timeout_secs} forge {' '.join(forge_args)} test k8s-swarm --image-tag {tag} --base-image-tag {base_tag}".strip(),
+        f"timeout {timeout_secs} forge {' '.join(forge_args)} test k8s-swarm --cluster-name {cluster_name} --image-tag {tag} --base-image-tag {base_tag}".strip(),
     )
     # additional environment variables
     for env_var in forge_envs:

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -20,7 +20,7 @@ use kube::{
     api::{Api, ListParams},
     client::Client as K8sClient,
 };
-use std::{collections::HashMap, convert::TryFrom, env, str, sync::Arc};
+use std::{collections::HashMap, convert::TryFrom, env, process::Command, str, sync::Arc};
 use tokio::time::Duration;
 
 const JSON_RPC_PORT: u32 = 80;
@@ -33,6 +33,7 @@ pub struct K8sSwarm {
     fullnodes: HashMap<PeerId, K8sNode>,
     root_account: LocalAccount,
     kube_client: K8sClient,
+    cluster_name: String,
     helm_repo: String,
     versions: Arc<HashMap<Version, String>>,
     pub chain_id: ChainId,
@@ -41,6 +42,7 @@ pub struct K8sSwarm {
 impl K8sSwarm {
     pub async fn new(
         root_key: &[u8],
+        cluster_name: &str,
         helm_repo: &str,
         image_tag: &str,
         base_image_tag: &str,
@@ -78,6 +80,7 @@ impl K8sSwarm {
             root_account,
             kube_client,
             chain_id: ChainId::new(NamedChain::DEVNET.id()),
+            cluster_name: cluster_name.to_string(),
             helm_repo: helm_repo.to_string(),
             versions: Arc::new(versions),
         })
@@ -190,10 +193,21 @@ impl Swarm for K8sSwarm {
         ChainInfo::new(&mut self.root_account, rest_api_url, self.chain_id)
     }
 
-    // returns a kubectl logs command to retrieve the logs manually
-    // and instructions to check the actual live logs location from fgi
+    // Returns env CENTRAL_LOGGING_ADDRESS if present (without timestamps)
+    // otherwise returns a kubectl logs command to retrieve the logs manually
     fn logs_location(&mut self) -> String {
-        "See fgi output for more information.".to_string()
+        if let Ok(central_logging_address) = std::env::var("CENTRAL_LOGGING_ADDRESS") {
+            central_logging_address
+        } else {
+            let hostname_output = Command::new("hostname")
+                .output()
+                .expect("failed to get pod hostname");
+            let hostname = String::from_utf8(hostname_output.stdout).unwrap();
+            format!(
+                "aws eks --region us-west-2 update-kubeconfig --name {} && kubectl logs {}",
+                &self.cluster_name, hostname
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Forge runs were failing healthcheck after tests start: https://github.com/aptos-labs/aptos-core/runs/6789662419?check_suite_focus=true

This is likely due to the cluster autoscaler not being fast enough / Forge timeout not being configured correctly in the right place. We can revisit this in the future, but for now bring back the direct cluster scaling upon forge test start/end