### PR TITLE
[Documentation] Recommending git clone, instead of fork and clone.

### DIFF
--- a/developer-docs-site/docs/tutorials/full-node/network-identity-fullnode.md
+++ b/developer-docs-site/docs/tutorials/full-node/network-identity-fullnode.md
@@ -42,10 +42,10 @@ To create a static identity for your FullNode:
 
 Follow the below detailed steps:
 
-1. Fork and clone the [aptos-labs/aptos-core](https://github.com/aptos-labs/aptos-core) repo. For example:
+1. Clone the [aptos-labs/aptos-core](https://github.com/aptos-labs/aptos-core) repo. For example:
 
     ```
-    $ git clone https://github.com/<YOUR-GITHUB-USERID>/aptos-core.git
+    $ git clone https://github.com/aptos-labs/aptos-core.git
     $ cd aptos-core
     $ ./scripts/dev_setup.sh
     $ source ~/.cargo/env

--- a/developer-docs-site/docs/tutorials/full-node/run-a-fullnode.md
+++ b/developer-docs-site/docs/tutorials/full-node/run-a-fullnode.md
@@ -69,15 +69,11 @@ This document describes how to configure your public FullNode using both the met
 
 ### Using Aptos-core source code
 
-1. Fork and clone the Aptos repo.
+1. Clone the Aptos repo.
 
-    - Fork the Aptos Core repo by clicking on the **Fork** on the top right of this repo page: https://github.com/aptos-labs/aptos-core.
-    - Clone your fork.
-
-      ```
-      git clone https://github.com/<YOUR-GITHUB-USERID>/aptos-core
-
-      ```
+    ```
+    git clone https://github.com/aptos-labs/aptos-core.git
+    ```
 
 2. `cd` into `aptos-core` directory.
 

--- a/developer-docs-site/docs/tutorials/run-a-local-testnet.md
+++ b/developer-docs-site/docs/tutorials/run-a-local-testnet.md
@@ -22,15 +22,11 @@ The rest of this document describes:
 
 ## Using the Aptos-core source code
 
-1. Fork and clone the Aptos repo.
-
-  - Fork the Aptos Core repo by clicking on the **Fork** on the top right of this repo page: https://github.com/aptos-labs/aptos-core.
-  - Clone your fork.
+1. Clone the Aptos repo.
 
     ```
-    git clone https://github.com/<YOUR-GITHUB-USERID>/aptos-core
+    git clone https://github.com/aptos-labs/aptos-core.git
     ```
-
 
 2. `cd` into `aptos-core` directory.
 

--- a/developer-docs-site/docs/tutorials/validator-node/using-source-code.md
+++ b/developer-docs-site/docs/tutorials/validator-node/using-source-code.md
@@ -10,7 +10,6 @@ sidebar_position: 13
 
       ```
       git clone https://github.com/aptos-labs/aptos-core.git
-
       ```
 
 2. `cd` into `aptos-core` directory.


### PR DESCRIPTION
Document to use `git clone` instead of fork and clone approach, wherever we provide node deployment instructions for the source. 

cc: @geekflyer 