### PR TITLE
[Documentation] Renaming txn_base_cost to total_gas_units_consumed.

### DIFF
--- a/developer-docs-site/docs/guides/sign-a-transaction.md
+++ b/developer-docs-site/docs/guides/sign-a-transaction.md
@@ -63,7 +63,7 @@ A raw transaction consists of the following fields:
 * **sequence_number** (uint64): Sequence number of this transaction. This must match the sequence number stored in the sender's account at the time the transaction executes.
 * **payload**: Instructions for the Aptos Blockchain, including publishing a module, execute a script function or execute a script payload.
 * **max_gas_amount** (uint64): Maximum total gas to spend for this transaction. The account must have more than this gas or the transaction will be discarded during validation.
-* **gas_unit_price** (uint64): Price to be paid per gas unit. During execution the `total_gas_amount`, calculated as: `total_gas_amount = txn_base_cost * gas_unit_price`, must not exceed `max_gas_amount` or the transaction will abort during the execution. `txn_base_cost` represents the total units of gas consumed when executing the transaction.
+* **gas_unit_price** (uint64): Price to be paid per gas unit. During execution the `total_gas_amount`, calculated as: `total_gas_amount = total_gas_units_consumed * gas_unit_price`, must not exceed `max_gas_amount` or the transaction will abort during the execution. `total_gas_units_consumed` represents the total units of gas consumed when executing the transaction.
 * **expiration_timestamp_secs** (uint64): The blockchain timestamp at which the blockchain would discard this transaction.
 * **chain_id** (uint8): The chain ID of the blockchain that this transaction is intended to be run on.
 


### PR DESCRIPTION
@jjleng and I discussed and decided that renaming `txn_base_cost` to `total_gas_units_consumed` conveys a clearer meaning. This variable is used only in the doc, not in the code. 