### PR TITLE
docs: optimize netlify building behaviour

### DIFF
--- a/developer-docs-site/netlify.toml
+++ b/developer-docs-site/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+# Ignore the build when nothing in the docs directory has changed.
+# This is a workaround/override for netlify's default ignore behaviour which 
+# only checks whether are any changes between the last builds (on the same branch)
+# which leads it to skipping the deploy preview on some commits as observed by @rajkaramchedu in the past.
+# What we really want is to check whether there are any changes in the current branch compared to main
+# and this command achieves that.
+# More details can be found here https://docs.netlify.com/configure-builds/ignore-builds/ 
+# and here https://answers.netlify.com/t/builds-cancelled-for-a-new-branch-due-to-no-content-change/17169/4
+ignore = "if [ \"$PULL_REQUEST\" == \"true\" ]; then git diff --quiet main $COMMIT_REF . ; else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF; fi"


### PR DESCRIPTION
This adds a custom netlify ignore rule (https://docs.netlify.com/configure-builds/ignore-builds/ ) to remedy an issue @rajkaramchedu  noticed  that occurs when he rebases a PR with a doc change AFTER he created the PR.
Currently what happens is that netlify "aborts" the PR build and doesn't link to the docs preview site in those instances.
What we want is to build every commit on a PR that has a change with respect to `main`.

### Test Plan

tested this manually on a seperate test branch a few times.