### PR TITLE
[Documentation] Adding the missing fullnode-gcp doc.

### DIFF
--- a/developer-docs-site/docs/tutorials/run-a-fullnode-on-gcp.md
+++ b/developer-docs-site/docs/tutorials/run-a-fullnode-on-gcp.md
@@ -368,5 +368,5 @@ This likely means that the state of the install is out of sync with the saved te
 
 ### Fullnode "NoAvailablePeers" Error message
 
-If your node cannot state sync, and the logs are showing "NoAvailablePeers", it's likely due to network congestion. You can try add some extra upstream peers for your fullnode to state sync from. See the guide [Add upstream seed peers](#add-upstream-seed-peers)
+If your node cannot state sync, and the logs are showing "NoAvailablePeers", it's likely due to network congestion. You can try add some extra upstream peers for your fullnode to state sync from. See the guide [Add upstream seed peers](#add-upstream-seed-peers).
 

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -79,6 +79,7 @@ const sidebars = {
             "tutorials/full-node/troubleshooting-fullnode",
           ],
         },
+        "tutorials/run-a-fullnode-on-gcp",
       ],
     },
     "tutorials/local-testnet-devnet-incentivized-testnet",


### PR DESCRIPTION
The FullNode on GCP doc was missing in the sidebar. Adding it. 