### PR TITLE
[sdk][typescript] Helper method for creating multisig bitmap

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -19,7 +19,7 @@ import {
   MultiEd25519Signature,
   Ed25519Signature,
 } from './transaction_builder/aptos_types';
-import { bcsSerializeUint32, bcsSerializeUint64, bcsToBytes } from './transaction_builder/bcs';
+import { bcsSerializeUint64, bcsToBytes } from './transaction_builder/bcs';
 import { AuthenticationKey } from './transaction_builder/aptos_types/authentication_key';
 import { SigningMessage, TransactionBuilderMultiEd25519 } from './transaction_builder';
 
@@ -218,13 +218,11 @@ test(
     const txnBuilder = new TransactionBuilderMultiEd25519((signingMessage: SigningMessage) => {
       const sigHexStr1 = account1.signBuffer(signingMessage);
       const sigHexStr3 = account3.signBuffer(signingMessage);
-      let bitmap = 0;
-      bitmap |= 128;
-      bitmap |= 128 >> 2;
+      const bitmap = MultiEd25519Signature.createBitmap([0, 2]);
 
       const muliEd25519Sig = new MultiEd25519Signature(
         [new Ed25519Signature(sigHexStr1.toUint8Array()), new Ed25519Signature(sigHexStr3.toUint8Array())],
-        bcsSerializeUint32(bitmap),
+        bitmap,
       );
 
       return muliEd25519Sig;

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/authentication_key.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/authentication_key.ts
@@ -1,7 +1,6 @@
 import * as SHA3 from 'js-sha3';
 import { HexString } from '../../hex_string';
 import { Bytes } from '../bcs';
-import { AccountAddress } from './account_address';
 import { MultiEd25519PublicKey } from './multi_ed25519';
 
 /**
@@ -43,6 +42,6 @@ export class AuthenticationKey {
    * AuthenticationKey bytes are directly translated to AccountAddress.
    */
   derivedAddress(): HexString {
-    return HexString.fromUint8Array(this.bytes.subarray(AuthenticationKey.LENGTH - AccountAddress.LENGTH));
+    return HexString.fromUint8Array(this.bytes);
   }
 }

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/multi_ed25519.test.ts
@@ -44,4 +44,22 @@ describe('MultiEd25519', () => {
       'e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a88052ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102c0000000',
     );
   });
+
+  it('creates a valid bitmap', () => {
+    expect(MultiEd25519Signature.createBitmap([0, 2, 31])).toEqual(
+      new Uint8Array([0b10100000, 0b00000000, 0b00000000, 0b00000001]),
+    );
+  });
+
+  it('throws exception when creating a bitmap with wrong bits', async () => {
+    expect(() => {
+      MultiEd25519Signature.createBitmap([32]);
+    }).toThrow('Invalid bit value 32.');
+  });
+
+  it('throws exception when creating a bitmap with duplicate bits', async () => {
+    expect(() => {
+      MultiEd25519Signature.createBitmap([2, 2]);
+    }).toThrow('Duplicated bits detected.');
+  });
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
@@ -1,6 +1,6 @@
 import { Deserializer } from './deserializer';
 import { Serializer } from './serializer';
-import { AnyNumber, Bytes, Seq, Uint32 } from './types';
+import { AnyNumber, Bytes, Seq } from './types';
 
 interface Serializable {
   serialize(serializer: Serializer): void;
@@ -37,11 +37,5 @@ export function bcsToBytes<T extends Serializable>(value: T): Bytes {
 export function bcsSerializeUint64(value: AnyNumber): Bytes {
   const serializer = new Serializer();
   serializer.serializeU64(value);
-  return serializer.getBytes();
-}
-
-export function bcsSerializeUint32(value: Uint32): Bytes {
-  const serializer = new Serializer();
-  serializer.serializeU32(value);
   return serializer.getBytes();
 }


### PR DESCRIPTION
## Motivation

multisig transaction submission requires a bitmap be provided along with the multisig signature. Manually creating a bitmap is error prone. Adding a helper method to SDK to help bitmap creation.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#pull-requests)?

(You must have submitted a [signed CLA](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md#contributor-license-agreement) that includes your GitHub handle prior to us accepting and landing your work. Write your answer here.)

## Test Plan

Jest tests


