### PR TITLE
Refactoring wallet, NODE_URL and FAUCET_URL no longer optional args

### DIFF
--- a/ecosystem/web-wallet/src/core/mutations/transaction.ts
+++ b/ecosystem/web-wallet/src/core/mutations/transaction.ts
@@ -4,20 +4,19 @@
 import {
   AptosAccount, AptosClient, MaybeHexString, Types,
 } from 'aptos';
-import { NODE_URL } from 'core/constants';
 import {
   type GetTestCoinTokenBalanceFromAccountResourcesProps,
 } from 'core/queries/account';
 
 export interface SubmitTransactionProps {
   fromAccount: AptosAccount;
-  nodeUrl?: string;
+  nodeUrl: string;
   payload: Types.TransactionPayload,
 }
 
 export const submitTransaction = async ({
   fromAccount,
-  nodeUrl = NODE_URL,
+  nodeUrl,
   payload,
 }: SubmitTransactionProps) => {
   const client = new AptosClient(nodeUrl);
@@ -38,7 +37,7 @@ export type SendTestCoinTransactionProps = Omit<SubmitTransactionProps & TestCoi
 export const sendTestCoinTransaction = async ({
   amount,
   fromAccount,
-  nodeUrl = NODE_URL,
+  nodeUrl,
   toAddress,
 }: SendTestCoinTransactionProps) => {
   const payload: Types.TransactionPayload = {

--- a/ecosystem/web-wallet/src/core/queries/account.ts
+++ b/ecosystem/web-wallet/src/core/queries/account.ts
@@ -4,18 +4,17 @@
 import {
   AptosClient, MaybeHexString, Types,
 } from 'aptos';
-import { NODE_URL } from 'core/constants';
 import { AptosAccountState } from 'core/types';
 import { AptosNetwork } from 'core/utils/network';
 
 export interface GetAccountResourcesProps {
   address?: MaybeHexString;
-  nodeUrl?: string;
+  nodeUrl: string;
 }
 
 export const getAccountResources = async ({
-  nodeUrl = NODE_URL,
   address,
+  nodeUrl,
 }: GetAccountResourcesProps) => {
   const client = new AptosClient(nodeUrl);
   return (address) ? (client.getAccountResources(address)) : undefined;
@@ -62,8 +61,8 @@ export const getTestCoinTokenBalanceFromAccountResources = ({
 };
 
 export const getAccountExists = async ({
-  nodeUrl = NODE_URL,
   address,
+  nodeUrl,
 }: GetAccountResourcesProps) => {
   const client = new AptosClient(nodeUrl);
   try {

--- a/ecosystem/web-wallet/src/core/queries/faucet.ts
+++ b/ecosystem/web-wallet/src/core/queries/faucet.ts
@@ -2,18 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { FaucetClient } from 'aptos';
-import { FAUCET_URL, NODE_URL } from 'core/constants';
 
 export interface FundAccountWithFaucetProps {
   address: string;
-  faucetUrl?: string;
-  nodeUrl?: string;
+  faucetUrl: string;
+  nodeUrl: string;
 }
 
 export const fundAccountWithFaucet = async ({
-  nodeUrl = NODE_URL,
-  faucetUrl = FAUCET_URL,
   address,
+  faucetUrl,
+  nodeUrl,
 }: FundAccountWithFaucetProps): Promise<void> => {
   const faucetClient = new FaucetClient(nodeUrl, faucetUrl);
   await faucetClient.fundAccount(address, 5000);

--- a/ecosystem/web-wallet/src/core/queries/transaction.ts
+++ b/ecosystem/web-wallet/src/core/queries/transaction.ts
@@ -2,16 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosClient } from 'aptos';
-import { NODE_URL } from 'core/constants';
 
 export interface GetTransactionProps {
-  nodeUrl?: string,
+  nodeUrl: string,
   txnHashOrVersion?: string;
 }
 
 export const getTransaction = async ({
+  nodeUrl,
   txnHashOrVersion,
-  nodeUrl = NODE_URL,
 }: GetTransactionProps) => {
   const aptosClient = new AptosClient(nodeUrl);
   if (txnHashOrVersion) {
@@ -22,8 +21,8 @@ export const getTransaction = async ({
 };
 
 export const getUserTransaction = async ({
+  nodeUrl,
   txnHashOrVersion,
-  nodeUrl = NODE_URL,
 }: GetTransactionProps) => {
   const aptosClient = new AptosClient(nodeUrl);
   if (txnHashOrVersion) {

--- a/ecosystem/web-wallet/src/pages/Login.tsx
+++ b/ecosystem/web-wallet/src/pages/Login.tsx
@@ -35,7 +35,7 @@ export const secondaryTextColor = {
 
 function Login() {
   const { colorMode } = useColorMode();
-  const { aptosAccount, updateWalletState } = useWalletState();
+  const { aptosAccount, aptosNetwork, updateWalletState } = useWalletState();
   const navigate = useNavigate();
   const {
     formState: { errors }, handleSubmit, register, setError, watch,
@@ -48,7 +48,10 @@ function Login() {
       const nonHexKey = (key.startsWith('0x')) ? key.substring(2) : key;
       const encodedKey = Uint8Array.from(Buffer.from(nonHexKey, 'hex'));
       const account = new AptosAccount(encodedKey, undefined);
-      const response = await getAccountResources({ address: account.address().hex() });
+      const response = await getAccountResources({
+        address: account.address().hex(),
+        nodeUrl: aptosNetwork,
+      });
       if (!response) {
         setError('privateKey', { message: 'Account not found', type: 'custom' });
         return;


### PR DESCRIPTION

## Motivation
Same as title

## Test Plan

```bash
yarn run build; yarn run lint:fix
```
