### PR TITLE
Add title argument to CLI release workflow

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -56,12 +56,16 @@ jobs:
       - build-linux-binary
       - build-os-x-binary
     runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "write"
+      packages: "write"
+      pull-requests: "read" 
     steps:
       - name: Download prebuilt binaries
         uses: actions/download-artifact@v3
         with:
           name: cli-builds
-
       - name: Create GitHub Release
         uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -57,10 +57,8 @@ jobs:
       - build-os-x-binary
     runs-on: ubuntu-latest
     permissions:
-      id-token: "write"
       contents: "write"
-      packages: "write"
-      pull-requests: "read" 
+      pull-requests: "read"
     steps:
       - name: Download prebuilt binaries
         uses: actions/download-artifact@v3

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -9,11 +9,15 @@ on:
       release_tag:
         type: string
         required: true
-        description: "The release tag to create. E.g. `aptos-cli-v0.2.3` :"
+        description: "The release tag to create. E.g. `aptos-cli-v0.2.3`:"
       source_git_ref_override:
         type: string
         required: false
-        description: "GIT_SHA_OVERRIDE: Use this to override the Git SHA1, branch or tag to build the binaries from. Defaults to the workflow Git REV, but can be different than that:"
+        description: "GIT_SHA_OVERRIDE: Use this to override the Git SHA1, branch name (e.g. devnet) or tag to build the binaries from. Defaults to the workflow Git REV, but can be different than that:"
+      release_title:
+        type: string
+        required: false
+        description: "Name of the release, e.g. \"Aptos CLI devnet release 2022-06-09\":"
 
 jobs:
   build-linux-binary:
@@ -64,5 +68,6 @@ jobs:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.event.inputs.release_tag }}"
           prerelease: false
+          title: "${{ github.event.inputs.release_title }}"
           files: |
             aptos-cli-*.zip


### PR DESCRIPTION
### Description
Adds the ability to specify a name for the release.

### Test Plan
> what is testing?

quote: Christian

In seriousness, testing a manually triggered action from a branch isn't possible, I have to test from a clone of the repo. Stay posted.

### Updated test plan
See https://github.com/banool/aptos-core/actions/runs/2477553972. This is a run on my clone of the repo using this updated workflow. I confirmed that the title of the workflow ran successfully and the release had the given title. I also did a run where I didn't specify the title and it correctly fell back to the default title: https://github.com/banool/aptos-core/actions/runs/2477607202.