### PR TITLE
[execution] Tests should use common utilities for managing accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3011,6 +3011,7 @@ dependencies = [
  "aptos-config",
  "aptos-crypto",
  "aptos-genesis-tool",
+ "aptos-sdk",
  "aptos-state-view",
  "aptos-temppath",
  "aptos-transaction-builder",

--- a/execution/executor-test-helpers/Cargo.toml
+++ b/execution/executor-test-helpers/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.7.3"
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-genesis-tool = { path = "../../config/management/genesis", features = ["testing"] }
+aptos-sdk = { path = "../../sdk" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }


### PR DESCRIPTION
### Description
https://github.com/aptos-labs/aptos-core/issues/353


### Test Plan
cargo x test -p executor -- test_execution_with_storage
cargo xtest -p executor-benchmark --lib   

cargo xfmt
cargo xlint 
cargo xclippy --workspace --all-targets


