### PR TITLE
Fix permissions for release CLI workflow

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -56,12 +56,16 @@ jobs:
       - build-linux-binary
       - build-os-x-binary
     runs-on: ubuntu-latest
+    permissions:
+      id-token: "write"
+      contents: "write"
+      packages: "write"
+      pull-requests: "read" 
     steps:
       - name: Download prebuilt binaries
         uses: actions/download-artifact@v3
         with:
           name: cli-builds
-
       - name: Create GitHub Release
         uses: "marvinpinto/action-automatic-releases@v1.2.1"
         with:


### PR DESCRIPTION
### Description
Previously we gave workflows read and write permissions globally, but now we opt for more granular permissions. This aims to fix that.

### Test Plan
See this run: https://github.com/aptos-labs/aptos-core/actions/runs/2477911721.