### PR TITLE
[Smoke tests] Retain smoke test data from failed runs.

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -92,3 +92,13 @@ jobs:
         env:
           RUST_BACKTRACE: full
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+      - name: 'Upload smoke test logs for failures'
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: failed-smoke-test-logs
+          # Retain all smoke test data except for the db (which may be large).
+          path: |
+            /tmp/.tmp*
+            !/tmp/.tmp*/**/db/
+          retention-days: 1


### PR DESCRIPTION
### Description

This PR updates CI/CD to retain smoke test data (e.g., logs and configs) when the smoke tests fail. This is necessary to debug node failures. To do this, we use github artifacts. Note: we only retain the logs for 1 day and we don't include db files (to prevent the artifacts from becoming too large).

### Test Plan

I forced a smoke test failure with a panic and saw that the build artifact was produced. See the bottom of this run: https://github.com/aptos-labs/aptos-core/actions/runs/2478362256
