### PR TITLE
[api] support transaction simulation

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -272,6 +272,44 @@ paths:
           $ref: '#/components/responses/415'
         "500":
           $ref: '#/components/responses/500'
+  /transactions/simulate:
+    post:
+      summary: Simulate transaction
+      operationId: simulate_transaction
+      description: |
+        **Submit transaction for simulation result using JSON **
+
+          * Create a SignedTransaction with zero-padded signature
+          * Submit the user transaction request with the zero-padded siganture.
+          * The request header "Content-Type" must set to "application/json".
+
+      tags:
+        - transactions
+      requestBody:
+        description: |
+          User transaction request with transaction sender's signature.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubmitTransactionRequest'
+      responses:
+        "200":
+          description: Transaction simulation completed.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OnChainTransaction'
+        "400":
+          $ref: '#/components/responses/400'
+        "413":
+          $ref: '#/components/responses/413'
+        "415":
+          $ref: '#/components/responses/415'
+        "500":
+          $ref: '#/components/responses/500'
   /accounts/{address}/transactions:
     get:
       summary: Get account transactions

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -34,6 +34,8 @@ pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Inf
         .or(transactions::get_transaction(context.clone()))
         .or(transactions::get_transactions(context.clone()))
         .or(transactions::get_account_transactions(context.clone()))
+        .or(transactions::simulate_bcs_transactions(context.clone()))
+        .or(transactions::simulate_json_transactions(context.clone()))
         .or(transactions::submit_bcs_transactions(context.clone()))
         .or(transactions::submit_json_transactions(context.clone()))
         .or(transactions::create_signing_message(context.clone()))

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -11,7 +11,7 @@ use crate::{
         charge_global_write_gas_usage, get_transaction_output, AptosVMImpl, AptosVMInternals,
     },
     counters::*,
-    data_cache::StateViewCache,
+    data_cache::{AsMoveResolver, StateViewCache},
     errors::expect_only_successful_execution,
     logging::AdapterLogSchema,
     move_vm_ext::{MoveResolverExt, SessionExt, SessionId},
@@ -66,6 +66,8 @@ static EXECUTION_CONCURRENCY_LEVEL: OnceCell<usize> = OnceCell::new();
 
 #[derive(Clone)]
 pub struct AptosVM(pub(crate) AptosVMImpl);
+
+struct AptosSimulationVM(AptosVM);
 
 impl AptosVM {
     pub fn new<S: StateView>(state: &S) -> Self {
@@ -803,6 +805,43 @@ impl AptosVM {
         BLOCK_TRANSACTION_COUNT.observe(count as f64);
         Ok(res)
     }
+
+    pub fn simulate_signed_transaction(
+        txn: &SignedTransaction,
+        state_view: &impl StateView,
+    ) -> (VMStatus, TransactionOutput) {
+        let vm = AptosVM::new(state_view);
+        let simulation_vm = AptosSimulationVM(vm);
+        let log_context = AdapterLogSchema::new(state_view.id(), 0);
+        simulation_vm.simulate_signed_transaction(&state_view.as_move_resolver(), txn, &log_context)
+    }
+
+    fn run_prologue_with_payload<S: MoveResolverExt>(
+        &self,
+        session: &mut SessionExt<S>,
+        payload: &TransactionPayload,
+        txn_data: &TransactionMetadata,
+        log_context: &AdapterLogSchema,
+    ) -> Result<(), VMStatus> {
+        match payload {
+            TransactionPayload::Script(_) => {
+                self.0.check_gas(txn_data, log_context)?;
+                self.0.run_script_prologue(session, txn_data, log_context)
+            }
+            TransactionPayload::ScriptFunction(_) => {
+                // NOTE: Script and ScriptFunction shares the same prologue
+                self.0.check_gas(txn_data, log_context)?;
+                self.0.run_script_prologue(session, txn_data, log_context)
+            }
+            TransactionPayload::ModuleBundle(_module) => {
+                self.0.check_gas(txn_data, log_context)?;
+                self.0.run_module_prologue(session, txn_data, log_context)
+            }
+            TransactionPayload::WriteSet(_cs) => {
+                self.0.run_writeset_prologue(session, txn_data, log_context)
+            }
+        }
+    }
 }
 
 // Executor external API
@@ -891,25 +930,7 @@ impl VMAdapter for AptosVM {
     ) -> Result<(), VMStatus> {
         let txn_data = TransactionMetadata::new(transaction);
         //let account_blob = session.data_cache.get_resource
-        match transaction.payload() {
-            TransactionPayload::Script(_) => {
-                self.0.check_gas(&txn_data, log_context)?;
-                self.0.run_script_prologue(session, &txn_data, log_context)
-            }
-            TransactionPayload::ScriptFunction(_) => {
-                // NOTE: Script and ScriptFunction shares the same prologue
-                self.0.check_gas(&txn_data, log_context)?;
-                self.0.run_script_prologue(session, &txn_data, log_context)
-            }
-            TransactionPayload::ModuleBundle(_module) => {
-                self.0.check_gas(&txn_data, log_context)?;
-                self.0.run_module_prologue(session, &txn_data, log_context)
-            }
-            TransactionPayload::WriteSet(_cs) => {
-                self.0
-                    .run_writeset_prologue(session, &txn_data, log_context)
-            }
-        }
+        self.run_prologue_with_payload(session, transaction.payload(), &txn_data, log_context)
     }
 
     fn should_restart_execution(vm_output: &TransactionOutput) -> bool {
@@ -986,5 +1007,88 @@ impl AsRef<AptosVMImpl> for AptosVM {
 impl AsMut<AptosVMImpl> for AptosVM {
     fn as_mut(&mut self) -> &mut AptosVMImpl {
         &mut self.0
+    }
+}
+
+impl AptosSimulationVM {
+    fn validate_simulated_transaction<S: MoveResolverExt>(
+        &self,
+        session: &mut SessionExt<S>,
+        transaction: &SignedTransaction,
+        txn_data: &TransactionMetadata,
+        log_context: &AdapterLogSchema,
+    ) -> Result<(), VMStatus> {
+        self.0.check_transaction_format(transaction)?;
+        self.0
+            .run_prologue_with_payload(session, transaction.payload(), txn_data, log_context)
+    }
+
+    /*
+    Executes a SignedTransaction without performing signature verification
+     */
+    fn simulate_signed_transaction<S: MoveResolverExt>(
+        &self,
+        storage: &S,
+        txn: &SignedTransaction,
+        log_context: &AdapterLogSchema,
+    ) -> (VMStatus, TransactionOutput) {
+        // simulation transactions should not carry valid signatures, otherwise malicious fullnodes
+        // may execute them without user's explicit permission.
+        if txn.clone().check_signature().is_ok() {
+            return discard_error_vm_status(VMStatus::Error(StatusCode::INVALID_SIGNATURE));
+        }
+
+        // Revalidate the transaction.
+        let txn_data = TransactionMetadata::new(txn);
+        let mut session = self.0.new_session(storage, SessionId::txn_meta(&txn_data));
+        if let Err(err) =
+            self.validate_simulated_transaction::<S>(&mut session, txn, &txn_data, log_context)
+        {
+            return discard_error_vm_status(err);
+        };
+
+        let gas_schedule = match self.0 .0.get_gas_schedule(log_context) {
+            Err(err) => return discard_error_vm_status(err),
+            Ok(s) => s,
+        };
+        let mut gas_status = GasStatus::new(gas_schedule, txn_data.max_gas_amount());
+
+        let result = match txn.payload() {
+            payload @ TransactionPayload::Script(_)
+            | payload @ TransactionPayload::ScriptFunction(_) => {
+                self.0.execute_script_or_script_function(
+                    session,
+                    &mut gas_status,
+                    &txn_data,
+                    payload,
+                    log_context,
+                )
+            }
+            TransactionPayload::ModuleBundle(m) => {
+                self.0
+                    .execute_modules(session, &mut gas_status, &txn_data, m, log_context)
+            }
+            TransactionPayload::WriteSet(_) => {
+                return discard_error_vm_status(VMStatus::Error(StatusCode::UNREACHABLE));
+            }
+        };
+
+        match result {
+            Ok(output) => output,
+            Err(err) => {
+                let txn_status = TransactionStatus::from(err.clone());
+                if txn_status.is_discarded() {
+                    discard_error_vm_status(err)
+                } else {
+                    self.0.failed_transaction_cleanup_and_keep_vm_status(
+                        err,
+                        &mut gas_status,
+                        &txn_data,
+                        storage,
+                        log_context,
+                    )
+                }
+            }
+        }
     }
 }

--- a/ecosystem/typescript/sdk/src/api/Transactions.ts
+++ b/ecosystem/typescript/sdk/src/api/Transactions.ts
@@ -61,6 +61,23 @@ export class Transactions<SecurityDataType = unknown> {
       ...params,
     });
   /**
+   * @description **Submit transaction for simulation result using JSON ** * Create a SignedTransaction with zero-padded signature * Submit the user transaction request with the zero-padded siganture. * The request header "Content-Type" must set to "application/json".
+   *
+   * @tags transactions
+   * @name SimulateTransaction
+   * @summary Simulate transaction
+   * @request POST:/transactions/simulate
+   */
+  simulateTransaction = (data: SubmitTransactionRequest, params: RequestParams = {}) =>
+    this.http.request<OnChainTransaction[], AptosError>({
+      path: `/transactions/simulate`,
+      method: "POST",
+      body: data,
+      type: ContentType.Json,
+      format: "json",
+      ...params,
+    });
+  /**
    * @description There are two types of transaction identifiers: 1. Transaction hash: included in any transaction JSON respond from server. 2. Transaction version: included in on-chain transaction JSON respond from server. When given transaction hash, server first looks up on-chain transaction by hash; if no on-chain transaction found, then look up transaction by hash in the mempool (pending) transactions. When given a transaction version, server looks up the transaction on-chain by version. To create a transaction hash: 1. Create hash message bytes: "Aptos::Transaction" bytes + BCS bytes of [Transaction](https://aptos-labs.github.io/aptos-core/aptos_types/transaction/enum.Transaction.html). 2. Apply hash algorithm `SHA3-256` to the hash message bytes. 3. Hex-encode the hash bytes with `0x` prefix.
    *
    * @tags transactions

--- a/ecosystem/typescript/sdk/src/api/data-contracts.ts
+++ b/ecosystem/typescript/sdk/src/api/data-contracts.ts
@@ -971,7 +971,7 @@ export interface Event {
 export type TransactionSignature = Ed25519Signature | MultiEd25519Signature | MultiAgentSignature;
 
 /**
-* Please refer to https://github.com/aptos-labs/aptos-core/tree/main/specifications/crypto#signature-and-verification for
+* Please refer to https://github.com/aptos-labs/aptos-core/tree/main/documentation/specifications/crypto#signature-and-verification for
 more details.
 */
 export interface Ed25519Signature {
@@ -996,11 +996,13 @@ export interface Ed25519Signature {
 }
 
 /**
- * Multi ed25519 signature, please refer to https://github.com/aptos-labs/aptos-core/tree/main/specifications/crypto#multi-signatures for more details.
+ * Multi ed25519 signature, please refer to https://github.com/aptos-labs/aptos-core/tree/main/documentation/specifications/crypto#multi-signatures for more details.
  */
 export interface MultiEd25519Signature {
   /** @example multi_ed25519_signature */
   type: string;
+
+  /** all public keys of the sender account */
   public_keys: HexEncodedBytes[];
 
   /** signatures created based on the `threshold` */


### PR DESCRIPTION
### Description

Allows fullnodes to simulate a transaction without sending it to mempool/consensus. Useful for:
- wallets estimating gas cost
- wallets preview transaction outcome (e.g. how wallet balance will be affected by transaction)

Requested from: https://github.com/aptos-labs/aptos-core/issues/619



### Test Plan
Existing `cargo test` passes. Added test case to `ecosystem/typesystem/sdk/src/aptos_client.test.ts` which exercises the SDK API and the simulation.
