### PR TITLE
[executor-benchmark] support creation of large DBs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2994,6 +2994,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "schemadb",
+ "scratchpad",
  "serde 1.0.137",
  "storage-client",
  "storage-interface",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,7 @@ dependencies = [
  "executor",
  "executor-types",
  "indicatif",
+ "itertools",
  "jemallocator",
  "num_cpus",
  "rand 0.7.3",

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -37,6 +37,7 @@ aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptosdb = { path = "../../storage/aptosdb" }
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
+scratchpad = { path = "../../storage/scratchpad" }
 schemadb = { path = "../../storage/schemadb" }
 storage-client = { path = "../../storage/storage-client" }
 storage-interface = { path = "../../storage/storage-interface" }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 chrono = "0.4.19"
 criterion = "0.3.5"
 indicatif = "0.15.0"
+itertools = "0.10.3"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 num_cpus = "1.13.1"
 rand = "0.7.3"
@@ -37,8 +38,8 @@ aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 aptosdb = { path = "../../storage/aptosdb" }
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
-scratchpad = { path = "../../storage/scratchpad" }
 schemadb = { path = "../../storage/schemadb" }
+scratchpad = { path = "../../storage/scratchpad" }
 storage-client = { path = "../../storage/storage-client" }
 storage-interface = { path = "../../storage/storage-interface" }
 

--- a/execution/executor-benchmark/benches/executor_benchmark.rs
+++ b/execution/executor-benchmark/benches/executor_benchmark.rs
@@ -27,17 +27,12 @@ fn executor_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {
     let parent_block_id = executor.committed_block_id();
     let executor = Arc::new(executor);
 
-    let mut generator = TransactionGenerator::new(genesis_key, NUM_ACCOUNTS, NUM_SEED_ACCOUNTS);
+    let mut generator = TransactionGenerator::new(genesis_key, NUM_ACCOUNTS);
     let (commit_tx, _commit_rx) = std::sync::mpsc::sync_channel(50 /* bound */);
 
     let mut executor = TransactionExecutor::new(executor, parent_block_id, 0, Some(commit_tx));
 
-    let txns = generator.create_seed_accounts(SMALL_BLOCK_SIZE);
-    for txn_block in txns {
-        executor.execute_block(txn_block);
-    }
-
-    let txns = generator.mint_seed_accounts(INITIAL_BALANCE * 10_000, SMALL_BLOCK_SIZE);
+    let txns = generator.create_seed_accounts(SMALL_BLOCK_SIZE, INITIAL_BALANCE * 10_000);
     for txn_block in txns {
         executor.execute_block(txn_block);
     }

--- a/execution/executor-benchmark/src/account_generator.rs
+++ b/execution/executor-benchmark/src/account_generator.rs
@@ -1,0 +1,92 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_sdk::{move_types::account_address::AccountAddress, types::LocalAccount};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{collections::VecDeque, sync::mpsc};
+
+type Seed = [u8; 32];
+
+pub struct AccountGenerator {
+    receiver: mpsc::Receiver<LocalAccount>,
+}
+
+impl AccountGenerator {
+    const USER_ACCOUNTS_SEED: Seed = [1; 32];
+    const SEED_ACCOUNTS_SEED: Seed = [2; 32];
+
+    pub fn new_for_seed_accounts() -> Self {
+        Self::new(Self::SEED_ACCOUNTS_SEED)
+    }
+
+    pub fn new_for_user_accounts() -> Self {
+        Self::new(Self::USER_ACCOUNTS_SEED)
+    }
+
+    fn new(seed: Seed) -> Self {
+        let (sender, receiver) = mpsc::sync_channel(100 /* bound */);
+
+        std::thread::Builder::new()
+            .name("account_generator".to_string())
+            .spawn(move || {
+                let mut rng = StdRng::from_seed(seed);
+                while sender.send(LocalAccount::generate(&mut rng)).is_ok() {}
+            })
+            .expect("Failed to spawn transaction generator thread.");
+
+        Self { receiver }
+    }
+
+    pub fn generate(&mut self) -> LocalAccount {
+        self.receiver.recv().unwrap()
+    }
+}
+
+pub struct AccountCache {
+    generator: AccountGenerator,
+    pub accounts: VecDeque<LocalAccount>,
+    rng: StdRng,
+}
+
+impl AccountCache {
+    const SEED: Seed = [1; 32];
+
+    pub fn new(generator: AccountGenerator) -> Self {
+        Self {
+            generator,
+            accounts: VecDeque::new(),
+            rng: StdRng::from_seed(Self::SEED),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.accounts.len()
+    }
+
+    pub fn accounts(&self) -> &VecDeque<LocalAccount> {
+        &self.accounts
+    }
+
+    pub fn grow(&mut self, n: usize) {
+        let accounts: Vec<_> = (0..n).map(|_| self.generator.generate()).collect();
+        self.accounts.extend(accounts);
+    }
+
+    pub fn get_random(&mut self) -> &mut LocalAccount {
+        let indices = rand::seq::index::sample(&mut self.rng, self.accounts.len(), 1);
+        let index = indices.index(0);
+
+        &mut self.accounts[index]
+    }
+
+    pub fn get_random_transfer(&mut self) -> (&mut LocalAccount, AccountAddress) {
+        let indices = rand::seq::index::sample(&mut self.rng, self.accounts.len(), 2);
+        let sender_idx = indices.index(0);
+        let receiver_idx = indices.index(1);
+
+        let receiver = self.accounts[receiver_idx].address();
+        let sender = &mut self.accounts[sender_idx];
+
+        (sender, receiver)
+    }
+}

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -33,6 +33,7 @@ pub fn run(
     block_size: usize,
     db_dir: impl AsRef<Path>,
     storage_pruner_config: StoragePrunerConfig,
+    verify_sequence_numbers: bool,
 ) {
     println!("Initializing...");
 
@@ -108,8 +109,10 @@ pub fn run(
     // Wait until all transactions are committed.
     exe_thread.join().unwrap();
     commit_thread.join().unwrap();
-    // Do a sanity check on the sequence number to make sure all transactions are committed.
-    generator.verify_sequence_number(db.clone());
+    if verify_sequence_numbers {
+        // Do a sanity check on the sequence number to make sure all transactions are committed.
+        generator.verify_sequence_numbers(db.clone());
+    }
 
     let final_version = generator.version();
     // Write metadata

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -116,12 +116,14 @@ pub fn run(
 
     // Wait for generator to finish.
     let mut generator = gen_thread.join().unwrap();
+    println!("Finishing up...");
     generator.drop_sender();
     // Wait until all transactions are committed.
     exe_thread.join().unwrap();
     commit_thread.join().unwrap();
     state_commit_thread.join().unwrap();
     if verify_sequence_numbers {
+        println!("Verifying sequence numbers...");
         // Do a sanity check on the sequence number to make sure all transactions are committed.
         generator.verify_sequence_numbers(db.clone());
     }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -46,7 +46,7 @@ pub fn run_benchmark(
     num_transfer_blocks: usize,
     source_dir: impl AsRef<Path>,
     checkpoint_dir: impl AsRef<Path>,
-    verify: bool,
+    verify_sequence_numbers: bool,
 ) {
     // Create rocksdb checkpoint.
     if checkpoint_dir.as_ref().exists() {
@@ -124,8 +124,8 @@ pub fn run_benchmark(
     commit_thread.join().unwrap();
 
     // Do a sanity check on the sequence number to make sure all transactions are committed.
-    if verify {
-        generator.verify_sequence_number(db.clone());
+    if verify_sequence_numbers {
+        generator.verify_sequence_numbers(db.clone());
     }
 }
 
@@ -145,6 +145,7 @@ mod tests {
             5,     /* block_size */
             storage_dir.as_ref(),
             NO_OP_STORAGE_PRUNER_CONFIG, /* prune_window */
+            true,
         );
 
         super::run_benchmark(
@@ -152,7 +153,7 @@ mod tests {
             5, /* num_transfer_blocks */
             storage_dir.as_ref(),
             checkpoint_dir,
-            false,
+            true,
         );
     }
 }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -11,7 +11,9 @@ use crate::{
     transaction_committer::TransactionCommitter, transaction_executor::TransactionExecutor,
     transaction_generator::TransactionGenerator,
 };
-use aptos_config::config::{NodeConfig, RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{
+    NodeConfig, RocksdbConfig, StoragePrunerConfig, NO_OP_STORAGE_PRUNER_CONFIG,
+};
 use aptos_logger::prelude::*;
 
 use crate::state_committer::StateCommitter;
@@ -49,6 +51,7 @@ pub fn run_benchmark(
     source_dir: impl AsRef<Path>,
     checkpoint_dir: impl AsRef<Path>,
     verify_sequence_numbers: bool,
+    pruner_config: StoragePrunerConfig,
 ) {
     // Create rocksdb checkpoint.
     if checkpoint_dir.as_ref().exists() {
@@ -68,6 +71,7 @@ pub fn run_benchmark(
 
     let (mut config, genesis_key) = aptos_genesis_tool::test_config();
     config.storage.dir = checkpoint_dir.as_ref().to_path_buf();
+    config.storage.storage_pruner_config = pruner_config;
 
     let (db, executor) = init_db_and_executor(&config);
     let start_version = db.reader.get_latest_version().unwrap();
@@ -171,6 +175,7 @@ mod tests {
             storage_dir.as_ref(),
             checkpoint_dir,
             true,
+            NO_OP_STORAGE_PRUNER_CONFIG,
         );
     }
 }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+mod account_generator;
 pub mod db_generator;
 pub mod state_committer;
 pub mod transaction_committer;
@@ -69,7 +70,7 @@ pub fn run_benchmark(
     .create_checkpoint(checkpoint_dir.as_ref())
     .expect("db checkpoint creation fails.");
 
-    let (mut config, genesis_key) = aptos_genesis_tool::test_config();
+    let (mut config, _genesis_key) = aptos_genesis_tool::test_config();
     config.storage.dir = checkpoint_dir.as_ref().to_path_buf();
     config.storage.storage_pruner_config = pruner_config;
 
@@ -84,12 +85,8 @@ pub fn run_benchmark(
     let (commit_sender, commit_receiver) = mpsc::sync_channel(3 /* bound */);
     let (state_commit_sender, state_commit_receiver) = mpsc::sync_channel(100 /* bound */);
 
-    let mut generator = TransactionGenerator::new_with_existing_db(
-        genesis_key,
-        block_sender,
-        source_dir,
-        start_version,
-    );
+    let mut generator =
+        TransactionGenerator::new_with_existing_db(block_sender, source_dir, start_version);
     let start_version = generator.version();
 
     // Spawn two threads to run transaction generator and executor separately.

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -20,6 +20,12 @@ struct Opt {
 
     #[structopt(subcommand)]
     cmd: Command,
+
+    #[structopt(
+        long,
+        about = "Verify sequence number of all the accounts after execution finishes"
+    )]
+    verify_sequence_numbers: bool,
 }
 
 impl Opt {
@@ -69,12 +75,6 @@ enum Command {
 
         #[structopt(long, parse(from_os_str))]
         checkpoint_dir: PathBuf,
-
-        #[structopt(
-            long,
-            about = "Verify sequence number of all the accounts after execution finishes"
-        )]
-        verify: bool,
     },
 }
 
@@ -106,13 +106,13 @@ fn main() {
                     Some(default_store_prune_window.unwrap_or(10_000_000)),
                     10_000,
                 ),
+                opt.verify_sequence_numbers,
             );
         }
         Command::RunExecutor {
             blocks,
             data_dir,
             checkpoint_dir,
-            verify,
         } => {
             aptos_logger::Logger::new().init();
             executor_benchmark::run_benchmark(
@@ -120,7 +120,7 @@ fn main() {
                 blocks,
                 data_dir,
                 checkpoint_dir,
-                verify,
+                opt.verify_sequence_numbers,
             );
         }
     }

--- a/execution/executor-benchmark/src/state_committer.rs
+++ b/execution/executor-benchmark/src/state_committer.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::HashValue;
+use aptos_logger::info;
+use aptos_types::{
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use executor_types::StateSnapshotDelta;
+use scratchpad::SparseMerkleTree;
+use std::{
+    collections::VecDeque,
+    sync::{mpsc, Arc},
+};
+use storage_interface::DbWriter;
+
+const NUM_COMMITTED_SMTS_TO_CACHE: usize = 10;
+const NUM_COMMITS_TO_BATCH: usize = 10;
+
+pub struct StateCommitter {
+    commit_receiver: mpsc::Receiver<StateSnapshotDelta>,
+    db: Arc<dyn DbWriter>,
+
+    // keep some recently committed SMTs in mem as a naive cache
+    cache_queue: VecDeque<SparseMerkleTree<StateValue>>,
+    version: Version,
+    smt: SparseMerkleTree<StateValue>,
+    committed_smt: SparseMerkleTree<StateValue>,
+    updates: Vec<(HashValue, (HashValue, StateKey))>,
+    num_pending_commits: usize,
+}
+
+impl StateCommitter {
+    pub fn new(
+        commit_receiver: mpsc::Receiver<StateSnapshotDelta>,
+        db: Arc<dyn DbWriter>,
+        committed_smt: SparseMerkleTree<StateValue>,
+    ) -> Self {
+        let mut cache_queue = VecDeque::new();
+        cache_queue.push_back(committed_smt.clone());
+
+        Self {
+            commit_receiver,
+            db,
+
+            cache_queue,
+            version: 0,
+            smt: committed_smt.clone(),
+            committed_smt,
+            updates: Vec::new(),
+            num_pending_commits: 0,
+        }
+    }
+
+    pub fn run(mut self) {
+        while let Ok(StateSnapshotDelta {
+            version,
+            smt,
+            jmt_updates,
+        }) = self.commit_receiver.recv()
+        {
+            self.version = version;
+            self.smt = smt;
+            self.updates.extend(jmt_updates.into_iter());
+            self.num_pending_commits += 1;
+
+            if self.num_pending_commits >= NUM_COMMITS_TO_BATCH {
+                self.commit();
+            }
+        }
+        self.commit();
+    }
+
+    fn commit(&mut self) {
+        // commit
+        let mut to_commit = Vec::new();
+        std::mem::swap(&mut to_commit, &mut self.updates);
+        let node_hashes = self
+            .smt
+            .clone()
+            .freeze()
+            .new_node_hashes_since(&self.committed_smt.clone().freeze());
+        self.db
+            .save_state_snapshot(to_commit, Some(&node_hashes), self.version)
+            .unwrap();
+        info!(version = self.version, "State snapshot saved.");
+
+        // reset pending updates
+        self.num_pending_commits = 0;
+        self.committed_smt = self.smt.clone();
+
+        // cache maintenance
+        if self.cache_queue.len() >= NUM_COMMITTED_SMTS_TO_CACHE {
+            self.cache_queue.pop_front();
+        }
+        self.cache_queue.push_back(self.smt.clone());
+    }
+}

--- a/execution/executor-benchmark/src/state_committer.rs
+++ b/execution/executor-benchmark/src/state_committer.rs
@@ -15,8 +15,8 @@ use std::{
 };
 use storage_interface::DbWriter;
 
-const NUM_COMMITTED_SMTS_TO_CACHE: usize = 10;
-const NUM_COMMITS_TO_BATCH: usize = 10;
+const NUM_COMMITTED_SMTS_TO_CACHE: usize = 5;
+const NUM_COMMITS_TO_BATCH: usize = 20;
 
 pub struct StateCommitter {
     commit_receiver: mpsc::Receiver<StateSnapshotDelta>,
@@ -69,6 +69,7 @@ impl StateCommitter {
                 self.commit();
             }
         }
+        println!("Final state commit...");
         self.commit();
     }
 

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -34,10 +34,9 @@ const MAX_ACCOUNTS_INVOLVED_IN_P2P: usize = 1_000_000;
 
 fn get_progress_bar(num_accounts: usize) -> ProgressBar {
     let bar = ProgressBar::new(num_accounts as u64);
-    bar.set_style(
-        ProgressStyle::default_bar()
-            .template("[{elapsed_precise} {per_sec}] {bar:100.cyan/blue} {percent}% ETA {eta_precise}"),
-    );
+    bar.set_style(ProgressStyle::default_bar().template(
+        "[{elapsed_precise} {per_sec}] {bar:100.cyan/blue} {percent}% ETA {eta_precise}",
+    ));
     bar
 }
 
@@ -422,7 +421,7 @@ impl TransactionGenerator {
     }
 
     /// Verifies the sequence numbers in storage match what we have locally.
-    pub fn verify_sequence_number(&self, db: Arc<dyn DbReader>) {
+    pub fn verify_sequence_numbers(&self, db: Arc<dyn DbReader>) {
         println!(
             "[{}] verify {} account sequence numbers.",
             now_fmt!(),

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -36,7 +36,7 @@ fn get_progress_bar(num_accounts: usize) -> ProgressBar {
     let bar = ProgressBar::new(num_accounts as u64);
     bar.set_style(
         ProgressStyle::default_bar()
-            .template("[{elapsed_precise}] {bar:100.cyan/blue} {percent}% ETA {eta_precise}"),
+            .template("[{elapsed_precise} {per_sec}] {bar:100.cyan/blue} {percent}% ETA {eta_precise}"),
     );
     bar
 }

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -1,31 +1,27 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_crypto::{
-    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
-    PrivateKey, SigningKey, Uniform,
-};
-use aptos_logger::info;
-use aptos_sdk::transaction_builder::TransactionFactory;
+use crate::account_generator::{AccountCache, AccountGenerator};
+use aptos_crypto::ed25519::Ed25519PrivateKey;
+use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_types::{
-    account_address::AccountAddress,
     account_config::aptos_root_address,
     account_view::AccountView,
     chain_id::ChainId,
-    transaction::{RawTransaction, SignedTransaction, Transaction, Version},
+    transaction::{Transaction, Version},
 };
 use chrono::Local;
 use indicatif::{ProgressBar, ProgressStyle};
-use rand::{rngs::StdRng, SeedableRng};
+use itertools::Itertools;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 use std::{
     fs::File,
     io::{Read, Write},
+    iter::once,
     path::Path,
     sync::{mpsc, Arc},
-    time::Instant,
 };
 use storage_interface::{state_view::LatestDbStateCheckpointView, DbReader};
 
@@ -57,134 +53,88 @@ struct P2pTestCase {
     num_accounts: usize,
 }
 
-// TODO: use LocalAccount instead
-#[derive(Deserialize, Serialize)]
-struct AccountData {
-    private_key: Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
-    address: AccountAddress,
-    sequence_number: u64,
-}
-
 pub struct TransactionGenerator {
     /// The current state of the accounts. The main purpose is to keep track of the sequence number
     /// so generated transactions are guaranteed to be successfully executed.
-    accounts_cache: Vec<AccountData>,
+    accounts_cache: Option<AccountCache>,
 
     /// The current state of seed accounts. The purpose of the seed accounts to parallelize the
     /// account creation and minting process so that they are not blocked on sequence number of
     /// a single root account.
-    seed_accounts_cache: Vec<AccountData>,
+    seed_accounts_cache: Option<AccountCache>,
 
     /// Total number of accounts in the DB
     num_accounts: usize,
 
-    /// Used to mint accounts.
-    genesis_key: Ed25519PrivateKey,
-
     /// Record the number of txns generated.
     version: Version,
-
-    /// For deterministic transaction generation.
-    rng: StdRng,
 
     /// Each generated block of transactions are sent to this channel. Using `SyncSender` to make
     /// sure if execution is slow to consume the transactions, we do not run out of memory.
     block_sender: Option<mpsc::SyncSender<Vec<Transaction>>>,
+
+    /// Transaction Factory
+    transaction_factory: TransactionFactory,
+
+    /// root account is used across creating and minting.
+    root_account: Option<LocalAccount>,
 }
 
 impl TransactionGenerator {
-    pub fn new(
-        genesis_key: Ed25519PrivateKey,
-        num_accounts: usize,
-        num_seed_accounts: usize,
-    ) -> Self {
-        Self::new_impl(genesis_key, num_accounts, num_seed_accounts, None)
+    pub fn new(genesis_key: Ed25519PrivateKey, num_accounts: usize) -> Self {
+        Self::new_impl(genesis_key, num_accounts, None)
     }
 
     pub fn new_with_sender(
         genesis_key: Ed25519PrivateKey,
         num_accounts: usize,
-        num_seed_accounts: usize,
         block_sender: mpsc::SyncSender<Vec<Transaction>>,
     ) -> Self {
-        Self::new_impl(
-            genesis_key,
-            num_accounts,
-            num_seed_accounts,
-            Some(block_sender),
-        )
+        Self::new_impl(genesis_key, num_accounts, Some(block_sender))
     }
 
     fn new_impl(
         genesis_key: Ed25519PrivateKey,
         num_accounts: usize,
-        num_seed_accounts: usize,
         block_sender: Option<mpsc::SyncSender<Vec<Transaction>>>,
     ) -> Self {
-        let seed = [1u8; 32];
-        let rng = StdRng::from_seed(seed);
         Self {
-            seed_accounts_cache: Self::gen_account_cache(num_seed_accounts, true),
-            accounts_cache: Self::gen_account_cache(num_accounts, false),
+            seed_accounts_cache: None,
+            root_account: Some(LocalAccount::new(aptos_root_address(), genesis_key, 0)),
+            accounts_cache: None,
             num_accounts,
-            genesis_key,
             version: 0,
-            rng,
             block_sender,
+            transaction_factory: Self::create_transaction_factory(),
         }
     }
 
-    fn gen_account_cache(num_accounts: usize, seed_account: bool) -> Vec<AccountData> {
-        let start = Instant::now();
-        let seed = if seed_account { [1u8; 32] } else { [2u8; 32] };
-        let mut rng = StdRng::from_seed(seed);
-
-        let mut accounts = Vec::with_capacity(num_accounts);
-        if seed_account {
-            println!(
-                "[{}] Generating {} seed accounts.",
-                now_fmt!(),
-                num_accounts
-            );
+    fn gen_account_cache(num_accounts: usize, seed_account: bool) -> AccountCache {
+        let (name, generator) = if seed_account {
+            ("seed", AccountGenerator::new_for_seed_accounts())
         } else {
-            println!("[{}] Generating {} accounts.", now_fmt!(), num_accounts);
-        }
+            ("user", AccountGenerator::new_for_user_accounts())
+        };
+
+        println!(
+            "[{}] Generating cache of {} {} accounts.",
+            now_fmt!(),
+            num_accounts,
+            name,
+        );
+        let mut accounts = AccountCache::new(generator);
         let bar = get_progress_bar(num_accounts);
-        for _i in 0..num_accounts {
-            let private_key = Ed25519PrivateKey::generate(&mut rng);
-            let public_key = private_key.public_key();
-            let address = aptos_types::account_address::from_public_key(&public_key);
-            let account = AccountData {
-                private_key,
-                public_key,
-                address,
-                sequence_number: 0,
-            };
-            accounts.push(account);
+        for _ in 0..num_accounts {
+            accounts.grow(1);
             bar.inc(1);
         }
         bar.finish();
         println!("[{}] done.", now_fmt!());
 
-        if seed_account {
-            info!(
-                num_accounts_generated = num_accounts,
-                time_ms = %start.elapsed().as_millis(),
-                "Seed Account cache generation finished.",
-            );
-        } else {
-            info!(
-                num_accounts_generated = num_accounts,
-                time_ms = %start.elapsed().as_millis(),
-                "Account cache generation finished.",
-            );
-        }
         accounts
     }
 
     pub fn new_with_existing_db<P: AsRef<Path>>(
-        genesis_key: Ed25519PrivateKey,
         block_sender: mpsc::SyncSender<Vec<Transaction>>,
         db_dir: P,
         version: Version,
@@ -196,21 +146,25 @@ impl TransactionGenerator {
         let test_case: TestCase = toml::from_slice(&contents).expect("Must exist.");
         let TestCase::P2p(P2pTestCase { num_accounts }) = test_case;
 
-        let seed = [1u8; 32];
-        let rng = StdRng::from_seed(seed);
-        let num_seed_accounts = (num_accounts / 1000).max(1);
+        let num_cached_accounts = std::cmp::min(num_accounts, MAX_ACCOUNTS_INVOLVED_IN_P2P);
+        let accounts_cache = Some(Self::gen_account_cache(num_cached_accounts, false));
+
         Self {
-            seed_accounts_cache: Self::gen_account_cache(num_seed_accounts, true),
-            accounts_cache: Self::gen_account_cache(
-                std::cmp::min(num_accounts, MAX_ACCOUNTS_INVOLVED_IN_P2P),
-                false,
-            ),
+            seed_accounts_cache: None,
+            root_account: None,
+            accounts_cache,
             num_accounts,
-            genesis_key,
             version,
-            rng,
             block_sender: Some(block_sender),
+            transaction_factory: Self::create_transaction_factory(),
         }
+    }
+
+    fn create_transaction_factory() -> TransactionFactory {
+        TransactionFactory::new(ChainId::test())
+            .with_transaction_expiration_time(300)
+            .with_gas_unit_price(1)
+            .with_max_gas_amount(1000)
     }
 
     // Write metadata
@@ -230,10 +184,9 @@ impl TransactionGenerator {
 
     pub fn run_mint(&mut self, init_account_balance: u64, block_size: usize) {
         assert!(self.block_sender.is_some());
-        self.create_seed_accounts(block_size);
         // Ensure that seed accounts have enough balance to transfer money to at least 1000 account with
         // balance init_account_balance.
-        self.mint_seed_accounts(init_account_balance * 10_000, block_size);
+        self.create_seed_accounts(block_size, init_account_balance * 1_000_000_000);
         self.create_and_fund_accounts(init_account_balance, block_size);
     }
 
@@ -242,48 +195,65 @@ impl TransactionGenerator {
         self.gen_transfer_transactions(block_size, num_transfer_blocks);
     }
 
-    pub fn transaction_factory() -> TransactionFactory {
-        TransactionFactory::new(ChainId::test())
-            .with_transaction_expiration_time(300)
-            .with_gas_unit_price(1)
-            .with_max_gas_amount(1000)
-    }
+    pub fn create_seed_accounts(
+        &mut self,
+        block_size: usize,
+        seed_account_balance: u64,
+    ) -> Vec<Vec<Transaction>> {
+        let mut txn_block = Vec::new();
 
-    pub fn create_seed_accounts(&mut self, block_size: usize) -> Vec<Vec<Transaction>> {
-        let root_address = aptos_root_address();
-        let mut txn_block = vec![];
+        let num_seed_accounts = (self.num_accounts / 1000).max(1).min(1000);
+        let seed_accounts_cache = Self::gen_account_cache(num_seed_accounts, true);
 
         println!(
             "[{}] Generating {} seed account creation txns.",
             now_fmt!(),
-            self.seed_accounts_cache.len(),
+            num_seed_accounts,
         );
-        let bar = get_progress_bar(self.seed_accounts_cache.len());
-        for (i, block) in self.seed_accounts_cache.chunks(block_size).enumerate() {
-            let mut transactions = Vec::with_capacity(block_size + 1);
-            for (j, account) in block.iter().enumerate() {
-                let txn = create_transaction(
-                    &self.genesis_key,
-                    self.genesis_key.public_key(),
-                    Self::transaction_factory()
-                        .create_user_account(&account.public_key)
-                        .sender(root_address)
-                        .sequence_number((i * block_size + j) as u64)
-                        .build(),
-                );
-                transactions.push(txn);
-            }
-            transactions.push(Transaction::StateCheckpoint);
+        let bar = get_progress_bar(num_seed_accounts);
+
+        for chunk in seed_accounts_cache
+            .accounts
+            .iter()
+            .collect::<Vec<_>>()
+            .chunks(block_size / 2)
+        {
+            let transactions: Vec<_> = chunk
+                .iter()
+                .flat_map(|account| {
+                    let create = self
+                        .root_account
+                        .as_mut()
+                        .unwrap()
+                        .sign_with_transaction_builder(
+                            self.transaction_factory
+                                .create_user_account(account.public_key()),
+                        );
+                    let mint = self
+                        .root_account
+                        .as_mut()
+                        .unwrap()
+                        .sign_with_transaction_builder(
+                            self.transaction_factory
+                                .mint(account.address(), seed_account_balance),
+                        );
+                    vec![create, mint]
+                })
+                .map(Transaction::UserTransaction)
+                .chain(once(Transaction::StateCheckpoint))
+                .collect();
             self.version += transactions.len() as Version;
+            bar.inc(transactions.len() as u64 - 1);
             if let Some(sender) = &self.block_sender {
                 sender.send(transactions).unwrap();
             } else {
                 txn_block.push(transactions);
             }
-            bar.inc(block_size as u64);
         }
         bar.finish();
         println!("[{}] done.", now_fmt!());
+        self.seed_accounts_cache = Some(seed_accounts_cache);
+
         txn_block
     }
 
@@ -298,29 +268,28 @@ impl TransactionGenerator {
         println!(
             "[{}] Generating {} account creation txns.",
             now_fmt!(),
-            self.accounts_cache.len(),
+            self.num_accounts,
         );
-        let bar = get_progress_bar(self.accounts_cache.len());
-        for (_, block) in self.accounts_cache.chunks(block_size).enumerate() {
-            let mut transactions = Vec::with_capacity(block_size + 1);
-            for (_, account) in block.iter().enumerate() {
-                let seed_index =
-                    rand::seq::index::sample(&mut self.rng, self.seed_accounts_cache.len(), 1)
-                        .index(0);
-                let seed_account = &self.seed_accounts_cache[seed_index];
-                let txn = create_transaction(
-                    &seed_account.private_key,
-                    seed_account.public_key.clone(),
-                    Self::transaction_factory()
-                        .create_and_fund_user_account(&account.public_key, init_account_balance)
-                        .sender(seed_account.address)
-                        .sequence_number(seed_account.sequence_number)
-                        .build(),
-                );
-                self.seed_accounts_cache[seed_index].sequence_number += 1;
-                transactions.push(txn);
-            }
-            transactions.push(Transaction::StateCheckpoint);
+        let mut generator = AccountGenerator::new_for_user_accounts();
+        let bar = get_progress_bar(self.num_accounts);
+
+        for chunk in &(0..self.num_accounts).chunks(block_size) {
+            let transactions: Vec<_> = chunk
+                .map(|_| {
+                    self.seed_accounts_cache
+                        .as_mut()
+                        .unwrap()
+                        .get_random()
+                        .sign_with_transaction_builder(
+                            self.transaction_factory.create_and_fund_user_account(
+                                generator.generate().public_key(),
+                                init_account_balance,
+                            ),
+                        )
+                })
+                .map(Transaction::UserTransaction)
+                .chain(once(Transaction::StateCheckpoint))
+                .collect();
             self.version += transactions.len() as Version;
             if let Some(sender) = &self.block_sender {
                 sender.send(transactions).unwrap();
@@ -331,51 +300,7 @@ impl TransactionGenerator {
         }
         bar.finish();
         println!("[{}] done.", now_fmt!());
-        txn_block
-    }
 
-    /// Generates transactions that allocate `init_account_balance` to every account.
-    pub fn mint_seed_accounts(
-        &mut self,
-        seed_account_balance: u64,
-        block_size: usize,
-    ) -> Vec<Vec<Transaction>> {
-        let root_address = aptos_root_address();
-        let mut txn_block = vec![];
-
-        let total_accounts = self.seed_accounts_cache.len();
-        println!(
-            "[{}] Generating {} mint txns for seed accounts.",
-            now_fmt!(),
-            total_accounts,
-        );
-        let bar = get_progress_bar(total_accounts);
-        for (i, block) in self.seed_accounts_cache.chunks(block_size).enumerate() {
-            let mut transactions = Vec::with_capacity(block_size + 1);
-            for (j, account) in block.iter().enumerate() {
-                let txn = create_transaction(
-                    &self.genesis_key,
-                    self.genesis_key.public_key(),
-                    Self::transaction_factory()
-                        .mint(account.address, seed_account_balance)
-                        .sender(root_address)
-                        .sequence_number((total_accounts + i * block_size + j) as u64)
-                        .build(),
-                );
-                transactions.push(txn);
-            }
-            transactions.push(Transaction::StateCheckpoint);
-            self.version += transactions.len() as Version;
-
-            if let Some(sender) = &self.block_sender {
-                sender.send(transactions).unwrap();
-            } else {
-                txn_block.push(transactions);
-            }
-            bar.inc(block.len() as u64)
-        }
-        bar.finish();
-        println!("[{}] done.", now_fmt!());
         txn_block
     }
 
@@ -387,28 +312,19 @@ impl TransactionGenerator {
     ) -> Vec<Vec<Transaction>> {
         let mut txn_block = vec![];
 
-        for _i in 0..num_blocks {
-            let mut transactions = Vec::with_capacity(block_size + 1);
-            for _j in 0..block_size {
-                let indices = rand::seq::index::sample(&mut self.rng, self.accounts_cache.len(), 2);
-                let sender_idx = indices.index(0);
-                let receiver_idx = indices.index(1);
-
-                let sender = &self.accounts_cache[sender_idx];
-                let receiver = &self.accounts_cache[receiver_idx];
-                let txn = create_transaction(
-                    &sender.private_key,
-                    sender.public_key.clone(),
-                    Self::transaction_factory()
-                        .transfer(receiver.address, 1)
-                        .sender(sender.address)
-                        .sequence_number(sender.sequence_number)
-                        .build(),
-                );
-                transactions.push(txn);
-                self.accounts_cache[sender_idx].sequence_number += 1;
-            }
-            transactions.push(Transaction::StateCheckpoint);
+        for _ in 0..num_blocks {
+            let transactions: Vec<_> = (0..block_size)
+                .into_iter()
+                .map(|_| {
+                    let (sender, receiver) =
+                        self.accounts_cache.as_mut().unwrap().get_random_transfer();
+                    sender.sign_with_transaction_builder(
+                        self.transaction_factory.transfer(receiver, 1),
+                    )
+                })
+                .map(Transaction::UserTransaction)
+                .chain(once(Transaction::StateCheckpoint))
+                .collect();
             self.version += transactions.len() as Version;
 
             if let Some(sender) = &self.block_sender {
@@ -422,26 +338,37 @@ impl TransactionGenerator {
 
     /// Verifies the sequence numbers in storage match what we have locally.
     pub fn verify_sequence_numbers(&self, db: Arc<dyn DbReader>) {
+        if self.accounts_cache.is_none() {
+            println!("Cannot verify account sequence numbers.");
+            return;
+        }
+
+        let num_accounts_in_cache = self.accounts_cache.as_ref().unwrap().len();
         println!(
             "[{}] verify {} account sequence numbers.",
             now_fmt!(),
-            self.accounts_cache.len(),
+            num_accounts_in_cache,
         );
-        let bar = get_progress_bar(self.accounts_cache.len());
-        self.accounts_cache.par_iter().for_each(|account| {
-            let address = account.address;
-            let db_state_view = db.latest_state_checkpoint_view().unwrap();
-            let address_account_view = db_state_view.as_account_with_state_view(&address);
-            assert_eq!(
-                address_account_view
-                    .get_account_resource()
-                    .unwrap()
-                    .unwrap()
-                    .sequence_number(),
-                account.sequence_number
-            );
-            bar.inc(1);
-        });
+        let bar = get_progress_bar(num_accounts_in_cache);
+        self.accounts_cache
+            .as_ref()
+            .unwrap()
+            .accounts()
+            .par_iter()
+            .for_each(|account| {
+                let address = account.address();
+                let db_state_view = db.latest_state_checkpoint_view().unwrap();
+                let address_account_view = db_state_view.as_account_with_state_view(&address);
+                assert_eq!(
+                    address_account_view
+                        .get_account_resource()
+                        .unwrap()
+                        .unwrap()
+                        .sequence_number(),
+                    account.sequence_number()
+                );
+                bar.inc(1);
+            });
         bar.finish();
         println!("[{}] done.", now_fmt!());
     }
@@ -450,14 +377,4 @@ impl TransactionGenerator {
     pub fn drop_sender(&mut self) {
         self.block_sender.take().unwrap();
     }
-}
-
-fn create_transaction(
-    private_key: &Ed25519PrivateKey,
-    public_key: Ed25519PublicKey,
-    raw_txn: RawTransaction,
-) -> Transaction {
-    let signature = private_key.sign(&raw_txn);
-    let signed_txn = SignedTransaction::new(raw_txn, public_key, signature);
-    Transaction::UserTransaction(signed_txn)
 }

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -86,7 +86,7 @@ pub trait ChunkExecutorTrait: Send + Sync {
 pub struct StateSnapshotDelta {
     pub version: Version,
     pub smt: SparseMerkleTree<StateValue>,
-    pub value_sets: Vec<Vec<(HashValue, (HashValue, StateKey))>>,
+    pub jmt_updates: Vec<(HashValue, (HashValue, StateKey))>,
 }
 
 pub trait BlockExecutorTrait: Send + Sync {
@@ -112,11 +112,24 @@ pub trait BlockExecutorTrait: Send + Sync {
     /// and only `C` and `E` have signatures, we will send `A`, `B` and `C` in the first batch,
     /// then `D` and `E` later in the another batch.
     /// Commits a block and all its ancestors in a batch manner.
+    fn commit_blocks_ext(
+        &self,
+        block_ids: Vec<HashValue>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        save_state_snapshots: bool,
+    ) -> Result<Option<StateSnapshotDelta>, Error>;
+
     fn commit_blocks(
         &self,
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
-    ) -> Result<Option<StateSnapshotDelta>, Error>;
+    ) -> Result<Option<StateSnapshotDelta>, Error> {
+        self.commit_blocks_ext(
+            block_ids,
+            ledger_info_with_sigs,
+            true, /* save_state_snapshots */
+        )
+    }
 }
 
 pub trait TransactionReplayer: Send {

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -8,10 +8,14 @@ use anyhow::Result;
 use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
 use aptos_state_view::StateViewId;
-use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Transaction};
+use aptos_types::{
+    ledger_info::LedgerInfoWithSignatures, state_store::state_value::StateValue,
+    transaction::Transaction,
+};
 use aptos_vm::VMExecutor;
 use executor_types::{BlockExecutorTrait, Error, StateComputeResult, StateSnapshotDelta};
 use fail::fail_point;
+use scratchpad::SparseMerkleTree;
 use std::marker::PhantomData;
 
 use crate::{
@@ -22,7 +26,7 @@ use crate::{
         APTOS_EXECUTOR_VM_EXECUTE_BLOCK_SECONDS,
     },
 };
-use storage_interface::{jmt_update_sets, DbReaderWriter};
+use storage_interface::{jmt_updates, DbReaderWriter};
 
 pub struct BlockExecutor<V> {
     pub db: DbReaderWriter,
@@ -41,6 +45,16 @@ where
             block_tree,
             phantom: PhantomData,
         }
+    }
+
+    pub fn root_smt(&self) -> SparseMerkleTree<StateValue> {
+        self.block_tree
+            .root_block()
+            .output
+            .result_view
+            .state()
+            .current
+            .clone()
     }
 }
 
@@ -119,10 +133,11 @@ where
         Ok(block.output.as_state_compute_result(parent_accumulator))
     }
 
-    fn commit_blocks(
+    fn commit_blocks_ext(
         &self,
         block_ids: Vec<HashValue>,
         ledger_info_with_sigs: LedgerInfoWithSignatures,
+        save_state_snapshots: bool,
     ) -> Result<Option<StateSnapshotDelta>, Error> {
         let _timer = APTOS_EXECUTOR_COMMIT_BLOCKS_SECONDS.start_timer();
         let committed_block = self.block_tree.root_block();
@@ -169,10 +184,11 @@ where
             fail_point!("executor::commit_blocks", |_| {
                 Err(anyhow::anyhow!("Injected error in commit_blocks.").into())
             });
-            self.db.writer.save_transactions(
+            self.db.writer.save_transactions_ext(
                 &txns_to_commit,
                 first_version,
                 Some(&ledger_info_with_sigs),
+                save_state_snapshots,
             )?;
             self.block_tree
                 .prune(ledger_info_with_sigs.ledger_info())
@@ -180,12 +196,12 @@ where
         };
         let jmt_updates = txns_to_commit
             .iter()
-            .flat_map(|t| jmt_update_sets(&[t.state_updates()]))
+            .flat_map(|t| jmt_updates(t.state_updates()))
             .collect();
         Ok(Some(StateSnapshotDelta {
             version: ledger_info_with_sigs.ledger_info().version(),
             smt: committed_smt,
-            value_sets: jmt_updates,
+            jmt_updates,
         }))
     }
 }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -94,8 +94,8 @@ use std::{
     time::{Duration, Instant},
 };
 use storage_interface::{
-    jmt_update_ref_sets, jmt_update_sets, DbReader, DbWriter, Order, StartupInfo,
-    StateSnapshotReceiver, TreeState,
+    jmt_update_refs, jmt_updates, DbReader, DbWriter, Order, StartupInfo, StateSnapshotReceiver,
+    TreeState,
 };
 
 pub const LEDGER_DB_NAME: &str = "ledger_db";
@@ -1244,14 +1244,11 @@ impl DbWriter for AptosDB {
         version: Version,
     ) -> Result<()> {
         gauged_api("save_state_snapshot", || {
-            let jmt_updates = vec![jmt_updates];
-            let jmt_updates_ref = jmt_update_ref_sets(&jmt_updates);
-
             let mut cs = ChangeSet::new();
             let root_hash = *self
                 .state_store
                 .merklize_value_sets(
-                    jmt_updates_ref,
+                    vec![jmt_update_refs(&jmt_updates)],
                     node_hashes.map(|hashes| vec![hashes]),
                     version,
                     &mut cs,
@@ -1268,11 +1265,12 @@ impl DbWriter for AptosDB {
     /// it carries is generated after the `txns_to_commit` are applied.
     /// Note that even if `txns_to_commit` is empty, `frist_version` is checked to be
     /// `ledger_info_with_sigs.ledger_info.version + 1` if `ledger_info_with_sigs` is not `None`.
-    fn save_transactions(
+    fn save_transactions_ext(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        save_state_snapshots: bool,
     ) -> Result<()> {
         gauged_api("save_transactions", || {
             let num_txns = txns_to_commit.len() as u64;
@@ -1300,26 +1298,26 @@ impl DbWriter for AptosDB {
             let new_root_hash =
                 self.save_transactions_impl(txns_to_commit, first_version, &mut cs)?;
 
-            // find all the checkpoint versions
-            for (idx, value_set, jf_node_hashes) in txns_to_commit
-                .iter()
-                .enumerate()
-                .filter(|(_idx, txn_to_commit)| !txn_to_commit.state_updates().is_empty())
-                .map(|(idx, txn_to_commit)| {
-                    (
-                        idx,
-                        jmt_update_sets(vec![txn_to_commit.state_updates()].as_slice())
-                            .pop()
-                            .unwrap(),
-                        txn_to_commit.jf_node_hashes(),
-                    )
-                })
-            {
-                self.save_state_snapshot(
-                    value_set,
-                    jf_node_hashes,
-                    first_version + idx as LeafCount,
-                )?;
+            if save_state_snapshots {
+                // find all the checkpoint versions
+                for (idx, jmt_updates, jf_node_hashes) in txns_to_commit
+                    .iter()
+                    .enumerate()
+                    .filter(|(_idx, txn_to_commit)| !txn_to_commit.state_updates().is_empty())
+                    .map(|(idx, txn_to_commit)| {
+                        (
+                            idx,
+                            jmt_updates(txn_to_commit.state_updates()),
+                            txn_to_commit.jf_node_hashes(),
+                        )
+                    })
+                {
+                    self.save_state_snapshot(
+                        jmt_updates,
+                        jf_node_hashes,
+                        first_version + idx as LeafCount,
+                    )?;
+                }
             }
 
             // If expected ledger info is provided, verify result root hash and save the ledger info.

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
 use aptos_types::state_store::{state_key::StateKey, state_value::StateValue};
-use storage_interface::{jmt_update_ref_sets, jmt_update_sets};
+use storage_interface::{jmt_update_refs, jmt_updates};
 
 use crate::{change_set::ChangeSet, pruner::*, state_store::StateStore, AptosDB};
 
@@ -21,15 +21,10 @@ fn put_value_set(
         .iter()
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect();
-    let jmt_update_sets = jmt_update_sets(&[&value_set]);
+    let jmt_updates = jmt_updates(&value_set);
 
     let root = state_store
-        .merklize_value_sets(
-            jmt_update_ref_sets(&jmt_update_sets),
-            None,
-            version,
-            &mut cs,
-        )
+        .merklize_value_sets(vec![jmt_update_refs(&jmt_updates)], None, version, &mut cs)
         .unwrap()[0];
     state_store
         .put_value_sets(vec![&value_set], version, &mut cs)

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -655,13 +655,28 @@ pub trait DbWriter: Send + Sync {
     /// See [`AptosDB::save_transactions`].
     ///
     /// [`AptosDB::save_transactions`]: ../aptosdb/struct.AptosDB.html#method.save_transactions
+    fn save_transactions_ext(
+        &self,
+        txns_to_commit: &[TransactionToCommit],
+        first_version: Version,
+        ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+        save_state_snapshots: bool,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
     fn save_transactions(
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
-        unimplemented!()
+        self.save_transactions_ext(
+            txns_to_commit,
+            first_version,
+            ledger_info_with_sigs,
+            true, /* save_state_snapshots */
+        )
     }
 
     /// Persists merklized states as authenticated state checkpoint.
@@ -759,25 +774,17 @@ impl SaveTransactionsRequest {
     }
 }
 
-pub fn jmt_update_sets(
-    state_update_sets: &[&HashMap<StateKey, StateValue>],
-) -> Vec<Vec<(HashValue, (HashValue, StateKey))>> {
-    state_update_sets
+pub fn jmt_updates(
+    state_updates: &HashMap<StateKey, StateValue>,
+) -> Vec<(HashValue, (HashValue, StateKey))> {
+    state_updates
         .iter()
-        .map(|updates| {
-            updates
-                .iter()
-                .map(|(k, v)| (k.hash(), (v.hash(), k.clone())))
-                .collect()
-        })
+        .map(|(k, v)| (k.hash(), (v.hash(), k.clone())))
         .collect()
 }
 
-pub fn jmt_update_ref_sets(
-    jmt_update_sets: &[Vec<(HashValue, (HashValue, StateKey))>],
-) -> Vec<Vec<(HashValue, &(HashValue, StateKey))>> {
-    jmt_update_sets
-        .iter()
-        .map(|vec| vec.iter().map(|(x, y)| (*x, y)).collect())
-        .collect()
+pub fn jmt_update_refs(
+    jmt_updates: &[(HashValue, (HashValue, StateKey))],
+) -> Vec<(HashValue, &(HashValue, StateKey))> {
+    jmt_updates.iter().map(|(x, y)| (*x, y)).collect()
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -670,7 +670,7 @@ pub trait DbWriter: Send + Sync {
     /// [`AptosDB::save_state_snapshot`]: ../aptosdb/struct.AptosDB.html#method.save_state_snapshot
     fn save_state_snapshot(
         &self,
-        jmt_updates: &[Vec<(HashValue, (HashValue, StateKey))>],
+        jmt_updates: Vec<(HashValue, (HashValue, StateKey))>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         version: Version,
     ) -> Result<()> {


### PR DESCRIPTION
### Description
1. make state committing its seperate thread.
2. make generation of key pairs asynchronous.
3. stop generating key pairs for all accounts to be created beforehand and hold in memory.

### Test Plan
creating a 10M accounts DB took me 40mins on my linux box. More optimizations coming, but I'm gonna archive the changes so far.