### PR TITLE
[crypto] add BLS12381 multisignature benchmarks

### DIFF
--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -62,3 +62,7 @@ harness = false
 [[bench]]
 name = "ed25519"
 harness = false
+
+[[bench]]
+name = "bls12381"
+harness = false

--- a/crates/aptos-crypto/benches/bls12381.rs
+++ b/crates/aptos-crypto/benches/bls12381.rs
@@ -1,0 +1,236 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::{
+    measurement::Measurement, BatchSize, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
+};
+use rand::{distributions::Alphanumeric, rngs::ThreadRng, thread_rng, Rng};
+
+use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
+use serde::{Deserialize, Serialize};
+
+use aptos_crypto::{
+    bls12381,
+    bls12381::ProofOfPossession,
+    test_utils::{random_keypairs, random_subset, KeyPair},
+    traits::{Signature, SigningKey, Uniform},
+};
+
+#[derive(Debug, CryptoHasher, BCSCryptoHash, Serialize, Deserialize)]
+struct TestAptosCrypto(String);
+
+fn random_message(rng: &mut ThreadRng) -> TestAptosCrypto {
+    TestAptosCrypto(
+        rng.sample_iter(&Alphanumeric)
+            .take(256)
+            .map(char::from)
+            .collect::<String>(),
+    )
+}
+
+fn bench_group(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bls12381");
+
+    pop_create(&mut group);
+    pop_create_with_pubkey(&mut group);
+    pop_verify(&mut group);
+
+    sign(&mut group);
+    verify_signature_share(&mut group);
+
+    let mut size = 128;
+    for _ in 1..=4 {
+        aggregate_sigshare(&mut group, size);
+        aggregate_pks(&mut group, size);
+        verify_multisig(&mut group, size);
+        size *= 2;
+    }
+
+    group.finish();
+}
+
+fn pop_create<M: Measurement>(g: &mut BenchmarkGroup<M>) {
+    let mut rng = thread_rng();
+
+    let priv_key = bls12381::PrivateKey::generate(&mut rng);
+
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("pop_create", move |b| {
+        b.iter(|| ProofOfPossession::create(&priv_key))
+    });
+}
+
+fn pop_create_with_pubkey<M: Measurement>(g: &mut BenchmarkGroup<M>) {
+    let mut rng = thread_rng();
+
+    let kp = KeyPair::<bls12381::PrivateKey, bls12381::PublicKey>::generate(&mut rng);
+
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("pop_create_with_pubkey", move |b| {
+        b.iter(|| ProofOfPossession::create_with_pubkey(&kp.private_key, &kp.public_key))
+    });
+}
+
+fn pop_verify<M: Measurement>(g: &mut BenchmarkGroup<M>) {
+    let mut rng = thread_rng();
+
+    let kp = KeyPair::<bls12381::PrivateKey, bls12381::PublicKey>::generate(&mut rng);
+    let pop = ProofOfPossession::create_with_pubkey(&kp.private_key, &kp.public_key);
+
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("pop_verify", move |b| {
+        b.iter(|| {
+            let result = pop.verify(&kp.public_key);
+            assert!(result.is_ok());
+        })
+    });
+}
+
+fn sign<M: Measurement>(g: &mut BenchmarkGroup<M>) {
+    let mut rng = thread_rng();
+
+    let priv_key = bls12381::PrivateKey::generate(&mut rng);
+    let msg = random_message(&mut rng);
+
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("sign", move |b| b.iter(|| priv_key.sign(&msg)));
+}
+
+fn verify_signature_share<M: Measurement>(g: &mut BenchmarkGroup<M>) {
+    let mut rng = thread_rng();
+
+    let keypair = KeyPair::<bls12381::PrivateKey, bls12381::PublicKey>::generate(&mut rng);
+    let msg = random_message(&mut rng);
+    let sig = keypair.private_key.sign(&msg);
+
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("verify_signature_share", move |b| {
+        b.iter(|| {
+            let result = sig.verify(&msg, &keypair.public_key);
+            assert!(result.is_ok());
+        })
+    });
+}
+
+fn aggregate_pks<M: Measurement>(g: &mut BenchmarkGroup<M>, size: usize) {
+    let mut rng = thread_rng();
+
+    // pick a bunch of random keypairs
+    let key_pairs: Vec<KeyPair<bls12381::PrivateKey, bls12381::PublicKey>> =
+        random_keypairs(&mut rng, size);
+
+    g.throughput(Throughput::Elements(size as u64));
+    g.bench_with_input(
+        BenchmarkId::new("aggregate_pks", size),
+        &size,
+        |b, &_size| {
+            b.iter_batched(
+                || {
+                    let mut pks = vec![];
+                    for kp in key_pairs.iter() {
+                        pks.push(&kp.public_key);
+                    }
+
+                    pks
+                },
+                |pks| {
+                    let result = bls12381::PublicKey::aggregate(pks);
+                    assert!(result.is_ok());
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+fn aggregate_sigshare<M: Measurement>(g: &mut BenchmarkGroup<M>, size: usize) {
+    let mut rng = thread_rng();
+
+    // pick a bunch of random keypairs
+    let key_pairs: Vec<KeyPair<bls12381::PrivateKey, bls12381::PublicKey>> =
+        random_keypairs(&mut rng, size);
+
+    g.throughput(Throughput::Elements(size as u64));
+    g.bench_with_input(
+        BenchmarkId::new("aggregate_sigshare", size),
+        &size,
+        |b, &_size| {
+            // pick a random message to aggregate a multisignature on
+            let msg = random_message(&mut rng);
+
+            b.iter_batched(
+                || {
+                    // each signer computes a signature share on the random message
+                    let mut sigshares = vec![];
+                    for kp in key_pairs.iter() {
+                        sigshares.push(kp.private_key.sign(&msg));
+                    }
+                    sigshares
+                },
+                |sigshares| {
+                    let result = bls12381::Signature::aggregate(sigshares);
+                    assert!(result.is_ok());
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+/// Benchmarks the time to verify a multisignature from the perspective of a verifier who has the
+/// public keys of `n` signers and receives a multisignature from `size` of them
+fn verify_multisig<M: Measurement>(g: &mut BenchmarkGroup<M>, size: usize) {
+    let mut rng = thread_rng();
+
+    // pick `n` random keypairs
+    let mut key_pairs = vec![];
+    let n = size * 2;
+
+    for _ in 0..n {
+        key_pairs.push(KeyPair::<bls12381::PrivateKey, bls12381::PublicKey>::generate(&mut rng));
+    }
+
+    g.throughput(Throughput::Elements(size as u64));
+    g.bench_with_input(
+        BenchmarkId::new("verify_multisig", size),
+        &size,
+        |b, &size| {
+            // pick a random message to aggregate a multisignature on
+            let msg = random_message(&mut rng);
+
+            b.iter_batched(
+                || {
+                    // pick a random subset of signers
+                    let subset = random_subset(&mut rng, n, size);
+
+                    // each of the selected signers computes a signature share on the random message
+                    let mut sigshares = vec![];
+                    let mut pks = vec![];
+
+                    for i in subset {
+                        sigshares.push(key_pairs[i].private_key.sign(&msg));
+                        pks.push(&key_pairs[i].public_key)
+                    }
+
+                    let multisig = bls12381::Signature::aggregate(sigshares).unwrap();
+
+                    (pks, multisig)
+                },
+                |(pks, multisig)| {
+                    let aggpk = bls12381::PublicKey::aggregate(pks).unwrap();
+
+                    let result = multisig.verify(&msg, &aggpk);
+
+                    assert!(result.is_ok());
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
+}
+
+criterion_group!(bls12381_benches, bench_group);
+criterion_main!(bls12381_benches);

--- a/crates/aptos-crypto/src/unit_tests/bls12381_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/bls12381_test.rs
@@ -7,10 +7,10 @@ use crate::{
         bls12381_keys::{PrivateKey, PublicKey},
         ProofOfPossession,
     },
-    test_utils::{KeyPair, TestAptosCrypto},
+    test_utils::{random_subset, KeyPair, TestAptosCrypto},
     Signature, SigningKey, Uniform,
 };
-use rand::{distributions::Alphanumeric, prelude::IteratorRandom, Rng};
+use rand::{distributions::Alphanumeric, Rng};
 use rand_core::OsRng;
 use std::iter::zip;
 
@@ -170,18 +170,6 @@ fn bls12381_multisig_wrong_messages_aggregated() {
     // i.e., it is not an aggregate signature on a single message
     assert!(multisig.verify(&message, &aggpk).is_err());
     assert!(multisig.verify(&message_wrong, &aggpk).is_err());
-}
-
-/// Returns `subset_size` numbers picked uniformly at random from 0 to `max_set_size - 1` (inclusive).
-pub fn random_subset(mut rng: &mut OsRng, max_set_size: usize, subset_size: usize) -> Vec<usize> {
-    let mut vec = (0..max_set_size)
-        .choose_multiple(&mut rng, subset_size)
-        .into_iter()
-        .collect::<Vec<usize>>();
-
-    vec.sort_unstable();
-
-    vec
 }
 
 /// Returns two different sets of signer IDs (i.e., numbers in 0..num_signers)


### PR DESCRIPTION
### Description

Added benchmarks for the BLS12-381 multisignature APIs: 

- creating a proof-of-possession (PoP) from the secret key (SK)
- creating a PoP from the SK and its associated public key (PK)
- verifying a PoP
- creating a signature share
- verifying a signature share
- aggregating signature shares
- aggregating public keys
- verifying a multisignature, including the required public key aggregation

### Machine description & benchmark results

  Model Name:	MacBook Pro
  Model Identifier:	MacBookPro18,2
  Chip:	Apple M1 Max
  Total Number of Cores:	10 (8 performance and 2 efficiency)
  Memory:	64 GB

#### Proofs-of-possesion (PoPs)

```
bls12381/pop_create     
                        time:   [386.54 us 387.91 us 389.56 us]
                        thrpt:  [2.5670 Kelem/s 2.5779 Kelem/s 2.5871 Kelem/s]
bls12381/pop_create_with_pubkey
                        time:   [305.03 us 306.30 us 307.67 us]
                        thrpt:  [3.2502 Kelem/s 3.2648 Kelem/s 3.2784 Kelem/s]
bls12381/pop_verify     
                        time:   [722.83 us 723.14 us 723.51 us]
                        thrpt:  [1.3822 Kelem/s 1.3829 Kelem/s 1.3834 Kelem/s]
```

#### Signing and verifying messages individually

```
bls12381/sign           
                        time:   [318.51 us 330.42 us 343.96 us]
                        thrpt:  [2.9074 Kelem/s 3.0265 Kelem/s 3.1396 Kelem/s]
bls12381/verify_signature_share
                        time:   [700.19 us 704.57 us 708.84 us]
                        thrpt:  [1.4108 Kelem/s 1.4193 Kelem/s 1.4282 Kelem/s]
```

#### Aggregation of signature shares and public keys

```
bls12381/aggregate_sigshare/128
                        time:   [143.32 us 144.11 us 145.00 us]
                        thrpt:  [882.74 Kelem/s 888.20 Kelem/s 893.10 Kelem/s]
bls12381/aggregate_sigshare/1024
                        time:   [1.1852 ms 1.2050 ms 1.2301 ms]
                        thrpt:  [832.48 Kelem/s 849.79 Kelem/s 863.96 Kelem/s]

bls12381/aggregate_pks/128
                        time:   [57.712 us 57.801 us 57.917 us]
                        thrpt:  [2.2101 Melem/s 2.2145 Melem/s 2.2179 Melem/s]
bls12381/aggregate_pks/1024
                        time:   [448.50 us 450.96 us 453.52 us]
                        thrpt:  [2.2579 Melem/s 2.2707 Melem/s 2.2832 Melem/s]
```

#### Verifying a multisignature

```
bls12381/verify_multisig/128
                        time:   [777.11 us 782.20 us 787.50 us]
                        thrpt:  [162.54 Kelem/s 163.64 Kelem/s 164.71 Kelem/s]
bls12381/verify_multisig/1024
                        time:   [1.1719 ms 1.1790 ms 1.1867 ms]
                        thrpt:  [862.92 Kelem/s 868.54 Kelem/s 873.80 Kelem/s]
```