### PR TITLE
infra: update docker image references to aptoslabs

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -92,7 +92,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-      - name: 'Upload smoke test logs for failures'
+      - name: Upload smoke test logs for failures
         uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/developer-docs-site/docs/tutorials/full-node/network-identity-fullnode.md
+++ b/developer-docs-site/docs/tutorials/full-node/network-identity-fullnode.md
@@ -59,7 +59,7 @@ Follow the below detailed steps:
 
     ```
     $ cd ~/my-full-node
-    $ docker run -it aptoslab/tools:devnet /bin/bash
+    $ docker run -it aptoslabs/tools:devnet /bin/bash
     ```
 
 2. Run the [Aptos CLI](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos/README.md) `aptos` to produce a hex encoded static x25519 private key. This will be the private key for your network identity.
@@ -87,7 +87,7 @@ Follow the below detailed steps:
 
   **Using Docker**
 
-  Run this step from inside the `aptoslab/tools` Docker container. Open a new terminal and `cd` into the directory where you started the Docker container for your FullNode. Making sure to provide the full path to where you want the private key TXT file to be stored, run the command as below:
+  Run this step from inside the `aptoslabs/tools` Docker container. Open a new terminal and `cd` into the directory where you started the Docker container for your FullNode. Making sure to provide the full path to where you want the private key TXT file to be stored, run the command as below:
 
   ```
   aptos-operational-tool generate-key \
@@ -107,7 +107,7 @@ Follow the below detailed steps:
 
     **Using Docker**
 
-    From inside the `aptoslab/tools` Docker container:
+    From inside the `aptoslabs/tools` Docker container:
 
     ```
     $ aptos-operational-tool extract-peer-from-file \

--- a/developer-docs-site/docs/tutorials/full-node/update-fullnode-with-new-releases.md
+++ b/developer-docs-site/docs/tutorials/full-node/update-fullnode-with-new-releases.md
@@ -26,7 +26,7 @@ When `devnet` is wiped and updated with newer versions, you will need to update 
 
 4. If you use the Rust binary, pull the latest of `devnet` branch, and build the binary again.
 
-5. Download the latest Docker images with: `docker pull docker.io/aptoslab/validator:devnet`.
+5. Download the latest Docker images with: `docker pull docker.io/aptoslabs/validator:devnet`.
 
 5. Download the new [genesis.blob][devnet_genesis] file and the new [waypoint][devnet_waypoint].
 

--- a/developer-docs-site/docs/tutorials/validator-node/connect-to-testnet.md
+++ b/developer-docs-site/docs/tutorials/validator-node/connect-to-testnet.md
@@ -19,13 +19,13 @@ Only do this if you got confirmation email from Aptos team for your eligibility.
 
 - Stop your node and remove the data volumes, `docker-compose down --volumes`
 - Download the `genesis.blob` and `waypoint.txt` file published by Aptos Labs team.
-- Update your docker image to use tag `testnet_317f80bb`. Check the image sha256 [here](https://hub.docker.com/layers/validator/aptoslab/validator/testnet_317f80bb/images/sha256-5184f637f15a9c071475c5bfb3050777c04aa410e9d43c7ff5e7c4a99a55a252?context=explore)
+- Update your docker image to use tag `testnet_317f80bb`. Check the image sha256 [here](https://hub.docker.com/layers/validator/aptoslabs/validator/testnet_317f80bb/images/sha256-5184f637f15a9c071475c5bfb3050777c04aa410e9d43c7ff5e7c4a99a55a252?context=explore)
 - Restarting the node: `docker-compose up`
 
 ## Using Terraform
 
 - Increase `era` number in your Terraform config, this will wipe the data once applied.
-- Update your docker image to use tag `testnet_317f80bb` in the Terraform config. Check the image sha256 [here](https://hub.docker.com/layers/validator/aptoslab/validator/testnet_317f80bb/images/sha256-5184f637f15a9c071475c5bfb3050777c04aa410e9d43c7ff5e7c4a99a55a252?context=explore)
+- Update your docker image to use tag `testnet_317f80bb` in the Terraform config. Check the image sha256 [here](https://hub.docker.com/layers/validator/aptoslabs/validator/testnet_317f80bb/images/sha256-5184f637f15a9c071475c5bfb3050777c04aa410e9d43c7ff5e7c4a99a55a252?context=explore)
 - Apply Terraform: `terraform apply`
 - Download the `genesis.blob` and `waypoint.txt` file published by Aptos Labs team.
 - Recreate the secrets, make sure the secret name matches your `era` number, e.g. if you have `era = 3`, you should replace the secret name to be `${WORKSPACE}-aptos-node-genesis-e3`

--- a/docker/compose/aptos-node/docker-compose-fullnode.yaml
+++ b/docker/compose/aptos-node/docker-compose-fullnode.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   fullnode:
-    image: "${VALIDATOR_IMAGE_REPO:-aptoslab/validator}:${IMAGE_TAG:-testnet}"
+    image: "${VALIDATOR_IMAGE_REPO:-aptoslabs/validator}:${IMAGE_TAG:-testnet}"
     networks:
       shared:
     volumes:

--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -4,7 +4,7 @@
 version: "3.8"
 services:
   validator:
-    image: "${VALIDATOR_IMAGE_REPO:-aptoslab/validator}:${IMAGE_TAG:-testnet}"
+    image: "${VALIDATOR_IMAGE_REPO:-aptoslabs/validator}:${IMAGE_TAG:-testnet}"
     networks:
       shared:
     volumes:

--- a/docker/compose/data-restore/docker-compose.yaml
+++ b/docker/compose/data-restore/docker-compose.yaml
@@ -3,7 +3,7 @@
 version: "3.8"
 services:
   restore:
-    image: aptoslab/tools:devnet
+    image: aptoslabs/tools:devnet
     volumes:
       - type: volume
         source: db

--- a/docker/compose/public_full_node/docker-compose.yaml
+++ b/docker/compose/public_full_node/docker-compose.yaml
@@ -31,7 +31,7 @@
 version: "3.8"
 services:
   fullnode:
-    image: aptoslab/validator:devnet
+    image: aptoslabs/validator:devnet
     volumes:
       - type: volume
         source: db

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -9,8 +9,8 @@
 # * If you use this compose for different Aptos Networks, you will need remove the db volume first.
 # * If you would like to use the current Aptos version within this repository, execute the
 #     `build.sh` in `docker/validator` and change the image tag below to aptos_e2e:latest
-# * Validator images can be found at https://hub.docker.com/repository/docker/aptoslab/validator/tags
-# * Faucet images can be found at https://hub.docker.com/repository/docker/aptoslab/faucet/tags
+# * Validator images can be found at https://hub.docker.com/repository/docker/aptoslabs/validator/tags
+# * Faucet images can be found at https://hub.docker.com/repository/docker/aptoslabs/faucet/tags
 
 # Monitoring:
 # If you want to install the monitoring components for your validator-testnet

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -8,7 +8,7 @@ imageTag: testnet
 validator:
   name:
   image:
-    repo: aptoslab/validator
+    repo: aptoslabs/validator
     tag:
     pullPolicy: IfNotPresent
   resources:

--- a/terraform/helm/fullnode/README.md
+++ b/terraform/helm/fullnode/README.md
@@ -51,4 +51,4 @@ Deployment
 
 [REST API]: https://github.com/aptos-labs/aptos-core/blob/main/api/doc/openapi.yaml
 [values.yaml]: values.yaml
-[Aptos dockerhub]: https://hub.docker.com/r/aptoslab/validator/tags?page=1&ordering=last_updated
+[Aptos dockerhub]: https://hub.docker.com/r/aptoslabs/validator/tags?page=1&ordering=last_updated

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -18,7 +18,7 @@ enable_state_sync_v2: true
 rust_log: info
 
 image:
-  repo: aptoslab/validator
+  repo: aptoslabs/validator
   tag: devnet
   pullPolicy: IfNotPresent
 
@@ -59,7 +59,7 @@ logging:
 
 backup:
   image:
-    repo: aptoslab/tools
+    repo: aptoslabs/tools
     tag: devnet
     pullPolicy: IfNotPresent
   resources:
@@ -101,7 +101,7 @@ backup_verify:
 
 restore:
   image:
-    repo: aptoslab/tools
+    repo: aptoslabs/tools
     tag: devnet
     pullPolicy: IfNotPresent
   resources:

--- a/terraform/helm/indexer/values.yaml
+++ b/terraform/helm/indexer/values.yaml
@@ -5,7 +5,7 @@ indexTokenData: false
 
 indexer:
   image:
-    repo: aptoslab/indexer
+    repo: aptoslabs/indexer
     tag: devnet
     pullPolicy: IfNotPresent
 

--- a/terraform/helm/validator-lite/values.yaml
+++ b/terraform/helm/validator-lite/values.yaml
@@ -9,7 +9,7 @@ nameOverride: aptos-validator
 validator:
   name:
   image:
-    repo: aptoslab/validator
+    repo: aptoslabs/validator
     tag:
     pullPolicy: IfNotPresent
   resources:

--- a/terraform/helm/validator/values.yaml
+++ b/terraform/helm/validator/values.yaml
@@ -8,7 +8,7 @@ imageTag: release-1.5_b0cbf54f
 validator:
   name:
   image:
-    repo: aptoslab/validator
+    repo: aptoslabs/validator
     tag:
     pullPolicy: IfNotPresent
   resources:
@@ -39,7 +39,7 @@ validator:
 
 tools:
   image:
-    repo: aptoslab/tools
+    repo: aptoslabs/tools
     tag:
     pullPolicy: IfNotPresent
   resources:
@@ -55,7 +55,7 @@ tools:
 
 backup:
   image:
-    repo: aptoslab/tools
+    repo: aptoslabs/tools
     tag:
     pullPolicy: IfNotPresent
   resources:
@@ -105,7 +105,7 @@ backup_verify:
 
 restore:
   image:
-    repo: aptoslab/tools
+    repo: aptoslabs/tools
     tag:
     pullPolicy: IfNotPresent
   resources:
@@ -157,7 +157,7 @@ fullnode:
 
 keymanager:
   image:
-    repo: aptoslab/validator_tcb
+    repo: aptoslabs/validator_tcb
     tag:
     pullPolicy: IfNotPresent
   resources:

--- a/terraform/testnet/testnet/values.yaml
+++ b/terraform/testnet/testnet/values.yaml
@@ -13,7 +13,7 @@ genesis:
   vaultRoleId:
   vaultSecretId:
   image:
-    repo: aptoslab/init
+    repo: aptoslabs/init
     tag:
     pullPolicy: IfNotPresent
   resources:
@@ -61,7 +61,7 @@ serviceAccount:
 faucet:
   enabled: true
   image:
-    repo: aptoslab/faucet
+    repo: aptoslabs/faucet
     tag:
     pullPolicy: IfNotPresent
   resources:
@@ -160,7 +160,7 @@ monitoring:
 load_test:
   enabled: false
   image:
-    repo: aptoslab/txn-emitter
+    repo: aptoslabs/txn-emitter
     tag:
     pullPolicy: IfNotPresent
   resources:


### PR DESCRIPTION
### Description

This updates the docker image references and changes them from `aptoslab` to `aptoslabs`. In a later PR might be able to remove the old `aptoslab` image building altogether.

### Test Plan

verified that images are all pushed to `aptoslabs` on dockerhub these days