### PR TITLE
[ts-sdk] Add API doc link in Readme

### DIFF
--- a/ecosystem/typescript/sdk/.gitignore
+++ b/ecosystem/typescript/sdk/.gitignore
@@ -12,3 +12,6 @@ dist/
 .nyc_output/
 build/
 yarn.lock
+
+# Doc generation output
+docs/

--- a/ecosystem/typescript/sdk/README.md
+++ b/ecosystem/typescript/sdk/README.md
@@ -8,7 +8,8 @@ You need to connect to an [Aptos][repo] node to use this library, or run one
 yourself locally.
 
 ## API Docs
-Docs can be found [here](API.md)
+
+Docs can be found [here][api-doc]
 
 ## Usage
 
@@ -59,20 +60,15 @@ $  npx swagger-typescript-api@latest -p ../../../api/doc/openapi.yaml -o ./src/a
 yarn test
 ```
 
-[examples]: https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/
-
-[repo]: https://github.com/aptos-labs/aptos-core
-
-[npm-image-version]: https://img.shields.io/npm/v/aptos.svg
-
-[npm-image-downloads]: https://img.shields.io/npm/dm/aptos.svg
-
-[npm-url]: https://npmjs.org/package/aptos
-
-[discord-image]: https://img.shields.io/discord/945856774056083548?label=Discord&logo=discord&style=flat~~~~
-
-[discord-url]:  https://discord.gg/aptoslabs
-
 ## Semantic versioning
 
 This project follows [semver](https://semver.org/) as closely as possible
+
+[examples]: https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/
+[repo]: https://github.com/aptos-labs/aptos-core
+[npm-image-version]: https://img.shields.io/npm/v/aptos.svg
+[npm-image-downloads]: https://img.shields.io/npm/dm/aptos.svg
+[npm-url]: https://npmjs.org/package/aptos
+[discord-image]: https://img.shields.io/discord/945856774056083548?label=Discord&logo=discord&style=flat~~~~
+[discord-url]: https://discord.gg/aptoslabs
+[api-doc]: https://aptos-labs.github.io/ts-sdk-doc/

--- a/ecosystem/typescript/sdk/typedoc.json
+++ b/ecosystem/typescript/sdk/typedoc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src/index.ts"],
+  "out": "docs",
+  "cleanOutputDir": false,
+  "excludeInternal": true,
+  "excludePrivate": true
+}


### PR DESCRIPTION
### Description
Generate API doc site through TypeDoc and host the site through GH pages. Update README.md with the API doc link.

### Test Plan
https://aptos-labs.github.io/ts-sdk-doc/
