### PR TITLE
[quorum_store] fix compile warnings

### DIFF
--- a/consensus/src/quorum_store/counters.rs
+++ b/consensus/src/quorum_store/counters.rs
@@ -15,10 +15,6 @@ pub const REQUEST_SUCCESS_LABEL: &str = "success";
 pub const CALLBACK_FAIL_LABEL: &str = "callback_fail";
 pub const CALLBACK_SUCCESS_LABEL: &str = "callback_success";
 
-/// Monitor counters, used by monitor! macro
-pub static OP_COUNTERS: Lazy<aptos_metrics_core::op_counters::OpMetrics> =
-    Lazy::new(|| aptos_metrics_core::op_counters::OpMetrics::new_and_registered("quorum_store"));
-
 /// Counter for tracking latency of quorum store processing requests from consensus
 /// A 'fail' result means the quorum store's callback response to consensus failed.
 static QUORUM_STORE_SERVICE_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -40,7 +40,6 @@ pub struct ExecutionProxy {
     txn_notifier: Arc<dyn TxnNotifier>,
     state_sync_notifier: Arc<dyn ConsensusNotificationSender>,
     async_state_sync_notifier: channel::Sender<NotificationType>,
-    commit_notifier: Arc<dyn CommitNotifier>,
     async_commit_notifier: channel::Sender<CommitType>,
     validators: Mutex<Vec<AccountAddress>>,
 }
@@ -85,7 +84,6 @@ impl ExecutionProxy {
             txn_notifier,
             state_sync_notifier,
             async_state_sync_notifier: tx,
-            commit_notifier,
             async_commit_notifier: commit_tx,
             validators: Mutex::new(vec![]),
         }


### PR DESCRIPTION
### Description

OP_COUNTERS defined in consensus is the only one used by monitor macro. Removing this.
There's no reason to have commit_notifier as a field

### Test Plan
compile