### PR TITLE
[ecosystem] Use stylesheet_link_tag for typekit.

### DIFF
--- a/ecosystem/platform/server/app/views/layouts/_application.html.erb
+++ b/ecosystem/platform/server/app/views/layouts/_application.html.erb
@@ -8,7 +8,7 @@
 
     <%= favicon_link_tag asset_path('favicon.ico') %>
 
-    <link rel="stylesheet" href="https://use.typekit.net/<%= ENV.fetch('TYPEKIT_CSS_ID') %>.css">
+    <%= stylesheet_link_tag "https://use.typekit.net/#{ENV.fetch('TYPEKIT_CSS_ID')}.css" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
     <%= render 'layouts/google_analytics' %>


### PR DESCRIPTION
### Description

The advantage of this is that Rails will emit a preload header for this asset, which will speed up IPL.

Before:

```
Link: </assets/application-2b489e056db0d21d59f4b9465d13b591662813ce.css>; rel=preload; as=style; nopush
```

After:

```
Link: <https://use.typekit.net/ifl8enc.css>; rel=preload; as=style; nopush,</assets/application-2b489e056db0d21d59f4b9465d13b591662813ce.css>; rel=preload; as=style; nopush
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
