### PR TITLE
cicd: run sdk integration tests against local devnet

### DIFF
--- a/.github/workflows/sdk-integration-test.yaml
+++ b/.github/workflows/sdk-integration-test.yaml
@@ -38,4 +38,7 @@ jobs:
       # Run package install, test, build
       - run: cd ./ecosystem/typescript/sdk && yarn install
       - run: cd ./ecosystem/typescript/sdk && yarn test
+        env:
+          APTOS_NODE_URL: http://localhost:8080
+          APTOS_FAUCET_URL: http://localhost:8000
       - run: cd ./ecosystem/typescript/sdk && yarn build


### PR DESCRIPTION
This fixes the config for running the SDK integration tests

### Test Plan
passes CI

fixes #1402