### PR TITLE
[tf][testnet] scale large nodegroups

### DIFF
--- a/terraform/testnet/main.tf
+++ b/terraform/testnet/main.tf
@@ -40,7 +40,9 @@ module "validator" {
   k8s_admins         = var.k8s_admins
   ssh_pub_key        = var.ssh_pub_key
 
-  max_node_pool_surge = var.enable_forge ? 2 : 1
+  # allow all nodegroups to surge to 2x their size, in case of total nodes replacement
+  max_node_pool_surge = 2
+
   node_pool_sizes = var.validator_lite_mode ? {
     utilities  = var.num_utilities_instance > 0 ? var.num_utilities_instance : 3
     validators = var.num_validator_instance > 0 ? var.num_validator_instance : var.num_validators + var.num_public_fullnodes
@@ -79,7 +81,7 @@ provider "kubernetes" {
 resource "helm_release" "testnet" {
   name        = "aptos"
   chart       = "${path.module}/testnet"
-  max_history = var.enable_forge ? 2 : 10
+  max_history = 2
   wait        = false
 
   values = [
@@ -142,7 +144,7 @@ resource "helm_release" "validator" {
   count       = var.num_validators
   name        = "val${count.index}"
   chart       = var.validator_lite_mode ? "${path.module}/../helm/validator-lite" : "${path.module}/../helm/validator"
-  max_history = var.enable_forge ? 2 : 10
+  max_history = 2
   wait        = false
 
   values = [

--- a/terraform/testnet/variables.tf
+++ b/terraform/testnet/variables.tf
@@ -63,6 +63,11 @@ variable "num_validators" {
   default = 4
 }
 
+variable "max_num_validators" {
+  default     = 0
+  description = "Maximum number of validators across all chain eras. AWS limit is < 450"
+}
+
 variable "num_public_fullnodes" {
   default = 1
 }

--- a/terraform/testnet/vault.tf
+++ b/terraform/testnet/vault.tf
@@ -36,7 +36,8 @@ resource "vault_mount" "transit" {
 }
 
 module "vault" {
-  count  = var.num_validators
+  # if we have a maximum number of validators across all chain eras, keep around the vault secrets
+  count  = var.max_num_validators > 0 ? var.max_num_validators : var.num_validators
   source = "../validator/vault-init"
   providers = {
     vault = vault
@@ -44,6 +45,7 @@ module "vault" {
 
   mount_engines     = false
   reset_safety_data = false
+  deletion_allowed  = true
   namespace         = "val${count.index}"
 
   kubernetes_host        = module.validator.kubernetes.kubernetes_host
@@ -108,7 +110,7 @@ resource "vault_policy" "genesis-reset" {
 }
 
 resource "vault_auth_backend" "approle" {
-  type  = "approle"
+  type = "approle"
 }
 
 resource "vault_approle_auth_backend_role" "genesis-reset-role" {

--- a/terraform/validator/aws/cluster.tf
+++ b/terraform/validator/aws/cluster.tf
@@ -73,6 +73,7 @@ resource "aws_eks_node_group" "nodes" {
 
   lifecycle {
     ignore_changes = [
+      # ignore changes to the desired size that may occur due to cluster autoscaler
       scaling_config[0].desired_size
     ]
   }
@@ -89,7 +90,8 @@ resource "aws_eks_node_group" "nodes" {
   }
 
   update_config {
-    max_unavailable = var.max_node_pool_surge > 1 ? lookup(var.node_pool_sizes, each.key, each.value.size) * (var.max_node_pool_surge - 1) : 1
+    # the maximum unavailable nodes is a functino of the desired size multiplied by how much the nodegroup is allowed to surge
+    max_unavailable = var.max_node_pool_surge > 1 ? lookup(var.node_pool_sizes, each.key, each.value.size) * (var.max_node_pool_surge - 1) : lookup(var.node_pool_sizes, each.key, each.value.size)
   }
 
   depends_on = [

--- a/terraform/validator/aws/cluster.tf
+++ b/terraform/validator/aws/cluster.tf
@@ -86,12 +86,13 @@ resource "aws_eks_node_group" "nodes" {
   scaling_config {
     desired_size = lookup(var.node_pool_sizes, each.key, each.value.size)
     min_size     = 1
-    max_size     = lookup(var.node_pool_sizes, each.key, each.value.size) * var.max_node_pool_surge
+    # the maximum nodegroup size in AWS is 450
+    max_size = lookup(var.node_pool_sizes, each.key, each.value.size) * var.max_node_pool_surge > 450 ? 450 : lookup(var.node_pool_sizes, each.key, each.value.size) * var.max_node_pool_surge
   }
 
   update_config {
     # the maximum unavailable nodes is a functino of the desired size multiplied by how much the nodegroup is allowed to surge
-    max_unavailable = var.max_node_pool_surge > 1 ? lookup(var.node_pool_sizes, each.key, each.value.size) * (var.max_node_pool_surge - 1) : lookup(var.node_pool_sizes, each.key, each.value.size)
+    max_unavailable_percentage = 50
   }
 
   depends_on = [


### PR DESCRIPTION
Today, we can scale to 200 validators in a single k8s cluster using Terraform. Any larger than that, we hit issues with Terraform/Vault/Helm. This gets us part of the way to large scale testnets. The rest involves migrating to new `aptos-node` deployments for testnets, and using less helm releases (WIP). Until then, this PR gets us part of the way.

New variable `var.max_num_validators` is an optional upper bound on the maximum number of validators in a testnet across all eras. This is used to prevent re-creation of vault keys.

Also tune the maximum nodegroup size and max unavailable to allow for faster cluster scaling

