### PR TITLE
[State Sync Driver] Reset the chunk executor by default.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -161,7 +161,7 @@ impl VerifiedEpochStates {
         &mut self,
         epoch_ending_ledger_info: LedgerInfoWithSignatures,
     ) {
-        debug!(LogSchema::new(LogEntry::Bootstrapper).message(&format!(
+        info!(LogSchema::new(LogEntry::Bootstrapper).message(&format!(
             "Adding a new epoch to the epoch ending ledger infos: {}",
             &epoch_ending_ledger_info
         )));
@@ -419,6 +419,9 @@ impl<
         &mut self,
         global_data_summary: &GlobalDataSummary,
     ) -> Result<(), Error> {
+        // Reset the chunk executor to flush any invalid state currently held in-memory
+        self.storage_synchronizer.reset_chunk_executor()?;
+
         // Always fetch the new epoch ending ledger infos first
         if self.should_fetch_epoch_ending_ledger_infos() {
             return self

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
@@ -42,7 +42,7 @@ async fn test_bootstrap_genesis_waypoint() {
     let mock_streaming_client = create_mock_streaming_client();
 
     // Create the bootstrapper and verify it's not yet bootstrapped
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
     assert!(!bootstrapper.is_bootstrapped());
 
     // Subscribe to a bootstrapped notification
@@ -77,7 +77,7 @@ async fn test_bootstrap_immediate_notification() {
     let mock_streaming_client = create_mock_streaming_client();
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Create a global data summary where only epoch 0 has ended
     let global_data_summary = create_global_summary(0);
@@ -110,7 +110,7 @@ async fn test_bootstrap_no_notification() {
         .return_once(move |_| Ok(data_stream_listener));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Create a global data summary where epoch 0 and 1 have ended
     let global_data_summary = create_global_summary(1);
@@ -151,7 +151,7 @@ async fn test_critical_timeout() {
     }
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Create a global data summary where epoch 0 and 1 have ended
     let global_data_summary = create_global_summary(1);
@@ -224,7 +224,7 @@ async fn test_data_stream_accounts() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Insert an epoch ending ledger info into the verified states of the bootstrapper
     manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
@@ -291,7 +291,7 @@ async fn test_data_stream_transactions() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Insert an epoch ending ledger info into the verified states of the bootstrapper
     manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
@@ -358,7 +358,7 @@ async fn test_data_stream_transaction_outputs() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Insert an epoch ending ledger info into the verified states of the bootstrapper
     manipulate_verified_epoch_states(&mut bootstrapper, true, true, Some(highest_version));
@@ -408,7 +408,7 @@ async fn test_fetch_epoch_ending_ledger_infos() {
         .return_once(move |_| Ok(data_stream_listener));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Set the waypoint as already having been verified (but no fetched ledger infos)
     manipulate_verified_epoch_states(&mut bootstrapper, false, true, None);
@@ -457,7 +457,7 @@ async fn test_waypoint_mismatch() {
         .return_const(Ok(()));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Create a global data summary up to the waypoint
     let mut global_data_summary = create_global_summary(waypoint_epoch);
@@ -501,7 +501,7 @@ async fn test_waypoint_must_be_verified() {
         .return_once(move |_| Ok(data_stream_listener));
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Set fetched ledger infos to true but the waypoint is still not verified
     manipulate_verified_epoch_states(&mut bootstrapper, true, false, None);
@@ -533,7 +533,7 @@ async fn test_waypoint_satisfiable() {
     let mock_streaming_client = create_mock_streaming_client();
 
     // Create the bootstrapper
-    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client);
+    let mut bootstrapper = create_bootstrapper(driver_configuration, mock_streaming_client, true);
 
     // Create an empty global data summary
     let mut global_data_summary = GlobalDataSummary::empty();
@@ -559,12 +559,13 @@ async fn test_waypoint_satisfiable() {
 fn create_bootstrapper(
     driver_configuration: DriverConfiguration,
     mock_streaming_client: MockStreamingClient,
+    expect_reset_executor: bool,
 ) -> Bootstrapper<MockStorageSynchronizer, MockStreamingClient> {
     // Initialize the logger for tests
     aptos_logger::Logger::init_for_testing();
 
     // Create the mock storage synchronizer
-    let mock_storage_synchronizer = create_ready_storage_synchronizer();
+    let mock_storage_synchronizer = create_ready_storage_synchronizer(expect_reset_executor);
 
     // Create the mock db reader with only genesis loaded
     let mut mock_database_reader = create_mock_db_reader();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
@@ -65,6 +65,7 @@ async fn test_critical_timeout() {
     let mut continuous_syncer = create_continuous_syncer(
         driver_configuration,
         mock_streaming_client,
+        true,
         current_synced_version,
         current_synced_epoch,
     );
@@ -149,6 +150,7 @@ async fn test_data_stream_transactions_with_target() {
     let mut continuous_syncer = create_continuous_syncer(
         driver_configuration,
         mock_streaming_client,
+        true,
         current_synced_version,
         current_synced_epoch,
     );
@@ -228,6 +230,7 @@ async fn test_data_stream_transaction_outputs() {
     let mut continuous_syncer = create_continuous_syncer(
         driver_configuration,
         mock_streaming_client,
+        true,
         current_synced_version,
         current_synced_epoch,
     );
@@ -270,6 +273,7 @@ async fn test_data_stream_transaction_outputs() {
 fn create_continuous_syncer(
     driver_configuration: DriverConfiguration,
     mock_streaming_client: MockStreamingClient,
+    expect_reset_executor: bool,
     synced_version: Version,
     current_epoch: Epoch,
 ) -> ContinuousSyncer<MockStorageSynchronizer, MockStreamingClient> {
@@ -277,7 +281,7 @@ fn create_continuous_syncer(
     aptos_logger::Logger::init_for_testing();
 
     // Create the mock storage synchronizer
-    let mock_storage_synchronizer = create_ready_storage_synchronizer();
+    let mock_storage_synchronizer = create_ready_storage_synchronizer(expect_reset_executor);
 
     // Create the mock db reader with the given synced version
     let mut mock_database_reader = create_mock_db_reader();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -96,14 +96,16 @@ pub fn create_mock_storage_synchronizer() -> MockStorageSynchronizer {
 
 /// Creates a mock storage synchronizer that is not currently handling
 /// any pending storage data.
-pub fn create_ready_storage_synchronizer() -> MockStorageSynchronizer {
+pub fn create_ready_storage_synchronizer(expect_reset_executor: bool) -> MockStorageSynchronizer {
     let mut mock_storage_synchronizer = create_mock_storage_synchronizer();
     mock_storage_synchronizer
         .expect_pending_storage_data()
         .return_const(false);
-    mock_storage_synchronizer
-        .expect_reset_chunk_executor()
-        .return_const(Ok(()));
+    if expect_reset_executor {
+        mock_storage_synchronizer
+            .expect_reset_chunk_executor()
+            .return_const(Ok(()));
+    }
 
     mock_storage_synchronizer
 }


### PR DESCRIPTION
### Description

This PR updates the state sync driver to force a reset of the execute-commit pipeline when initializing new data streams. This hardens against edge cases where the pipeline has been put into an invalid state, e.g., if peers maliciously construct data that is passed to the pipeline but eventually fails (e.g., old data, invalid transaction outputs, etc). It also makes the code easier to reason about (e.g., switching between consensus and state sync multiple times).

### Test Plan

Existing unit tests ensure that the mocks are correctly called.
