### PR TITLE
[perf] Allow perf to run as non root in docker image

### DIFF
--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -33,7 +33,7 @@ FROM debian-base AS validator
 RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*
 
 ### Needed to run debugging tools like perf
-RUN apt-get update && apt-get install -y linux-tools-4.19 sudo procps
+RUN apt-get update && apt-get install -y linux-tools sudo procps linux-perf
 
 RUN addgroup --system --gid 6180 aptos && adduser --system --ingroup aptos --no-create-home --uid 6180 aptos
 


### PR DESCRIPTION
### Description

Allow us to run perf as non root to make it possible to debug performance issue

### Test Plan

Testing using github action build image and deploy to sherry net
