### PR TITLE
cicd: add continuous deployment for community plat

### DIFF
--- a/.github/workflows/deploy-community-platform-on-main-push.yaml
+++ b/.github/workflows/deploy-community-platform-on-main-push.yaml
@@ -1,0 +1,18 @@
+name: Deploy community-platform to staging
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ecosystem/platform/server/**"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-community-platform.yaml
+    with:
+      aptos_env: staging
+    secrets: inherit

--- a/.github/workflows/deploy-community-platform.yaml
+++ b/.github/workflows/deploy-community-platform.yaml
@@ -1,0 +1,50 @@
+on:
+  workflow_call:
+    inputs:
+      aptos_env:
+        required: true
+        type: string
+        description: "the environment to deploy into, must be: prod|staging|dev"
+
+permissions:
+  contents: read
+  id-token: write
+
+# only allow one in-flight deployment per environment
+concurrency:
+  group: ${{ inputs.aptos_env }}
+
+env:
+  # this expression is only useful if we deploy from a PR directly, which we sometimes may do during development and maybe in future for the dev environment
+  # but let's keep it here for now to enable these scenarios. For more info on what this expression is doing check the comments in the ./build-images.yaml workflow.
+  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: community-platform-${{ inputs.aptos_env }}
+      url: ${{ inputs.aptos_env == 'prod' && 'https://community.aptoslabs.com' || format('https://community.{0}.gcp.aptosdev.com', inputs.aptos_env) }}
+
+    steps:
+      - name: Wait for images to have been built
+        timeout-minutes: 10
+        uses: lewagon/wait-on-check-action@v1.0.0
+        with:
+          ref: ${{ env.GIT_SHA }}
+          check-regexp: "community-platform.*"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: auth
+        uses: "google-github-actions/auth@v0"
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - id: deploy
+        uses: "google-github-actions/deploy-cloudrun@v0"
+        with:
+          service: community
+          image: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/community-platform:${{ env.GIT_SHA }}
+          project_id: aptos-community-${{ inputs.aptos_env }}
+          region: us-west1


### PR DESCRIPTION
### Description

This automates the deployment of community platform into a staging environment.
Whenever a change is merged to main it will be auto deployed.
Will work on adding a prod workflow soon too (which will be via some manual trigger instead of fully automatic).

### Test Plan
Tested deployment workflow from a branch a few times (but removed capability to trigger deployment from branches now)
