### PR TITLE
docs: add link to API docs

### DIFF
--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -99,6 +99,11 @@ const sidebars = {
 
     "reference/telemetry",
     "reference/glossary",
+    {
+      type: "link",
+      href: "https://fullnode.devnet.aptoslabs.com/spec.html#",
+      label: "API Docs",
+    },
   ],
 };
 


### PR DESCRIPTION
### Description
adding link to API docs.
note: this is a resurrection of #1270  which I somehow closed lol.

### Test Plan
opening netlify preview and press the link
