### PR TITLE
[NHC] Implement `nhc server generate-openapi`

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -135,7 +135,7 @@ jobs:
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/rust-setup
-      - run: cargo xtest --doc --unit --changed-since "origin/main"
+      - run: cargo xtest --doc --unit --changed-since "origin/main" --exclude aptos-node-checker
 
   rust-unit-nextest:
     runs-on: high-perf-docker

--- a/ecosystem/node-checker/README.md
+++ b/ecosystem/node-checker/README.md
@@ -15,15 +15,14 @@ git clone git@github.com:aptos-labs/aptos-core.git
 cd aptos-core/ecosystem/node-checker
 ```
 
-Next, generate a baseline configuration. In this example we generate a configuration for a FullNode on the devnet, running on a machien in the local network:
+Next, generate a baseline configuration. In this example we generate a configuration for a FullNode on the devnet, running on a machine in the local network:
 ```
-cargo run -- -d configuration create --configuration-name "My Server Devnet Fullnode" --url http://192.168.86.2 --evaluators state_sync -o /tmp/my_server_devnet_fullnode.yaml
+cargo run -- configuration create --configuration-name "My Server Devnet Fullnode" --url http://192.168.86.2 --evaluators state_sync -o /tmp/my_server_devnet_fullnode.yaml
 ```
-The output should look like this: https://gist.github.com/banool/c16f8747eabf818f2e0fc701f054ee9d.
 
 Finally, run NHC:
 ```
-cargo run -- -d server run --baseline-node-config-paths /tmp/my_server_devnet_fullnode.yaml
+cargo run -- server run --baseline-node-config-paths /tmp/my_server_devnet_fullnode.yaml
 ```
 Where `--baseline-node-url` is the node that will be used as the baseline against which NHC will compare the test node (the node under investigation).
 

--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)]
-
 use crate::{metric_evaluator::StateSyncMetricsEvaluatorArgs, runner::BlockingRunnerArgs};
 use anyhow::Result;
 use clap::Parser;
@@ -23,7 +21,7 @@ pub static DEFAULT_NOISE_PORT_STR: Lazy<String> = Lazy::new(|| format!("{}", DEF
 // To briefly explain why many of these structs derive 3 different classes of traits:
 // - Parser (clap): To allow users to generate configs easily using nhc configuration create
 // - Serialize / Deserialize (serde): So we can read / write configs from / to disk
-// - PoemoOject: So we can return the configuration over the API
+// - PoemObject: So we can return the configuration over the API
 
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
 #[clap(author, version, about, long_about = None)]
@@ -43,20 +41,20 @@ pub struct NodeConfiguration {
     #[clap(long)]
     pub configuration_name_pretty: String,
 
-    /// The chain ID we expect to find when we speak to the node.
-    /// If not given, we will just assume the value we find is correct.
-    /// If given, we will check that the value is correct, exiting if not.
+    /// The chain ID we expect to find when we speak to the baseline node
+    /// at `node_address`. Regardless of whether this is set, at startup we
+    /// will contact the node to see what its chain ID is. If `chain_id` is
+    /// set here and doesn't match the chain ID returned by the node, we
+    /// will exit, signalling a configuration error.
     #[clap(long)]
     chain_id: Option<u16>,
 
-    /// The role type we expect to find when we speak to the node.
-    /// If not given, we will just assume the value we find is correct.
-    /// If given, we will check that the value is correct, exiting if not.
-    /// e.g. "full_node", "validator_node", etc.
+    /// This works the same as `chain_id` above, but for role type. Example
+    /// values: "full_node", "validator", etc.
     #[clap(long)]
     role_type: Option<String>,
 
-    /// The (metric) evaluators to use, e.g. state_sync, api, etc.
+    /// The evaluators to use, e.g. state_sync_version, consensus_proposals, etc.
     #[clap(long, required = true, min_values = 1, use_value_delimiter = true)]
     pub evaluators: Vec<String>,
 
@@ -69,12 +67,14 @@ pub struct NodeConfiguration {
 
 impl NodeConfiguration {
     /// Only call this after fetch_additional_configuration has been called.
+    #[allow(dead_code)]
     pub fn get_chain_id(&self) -> u16 {
         self.chain_id
             .expect("get_chain_id called before fetch_additional_configuration")
     }
 
     /// Only call this after fetch_additional_configuration has been called.
+    #[allow(dead_code)]
     pub fn get_role_type(&self) -> &str {
         self.role_type
             .as_ref()
@@ -85,7 +85,7 @@ impl NodeConfiguration {
     /// If chain_id and role_type are already set, we validate that the values
     /// match up. If they're not set, we set them using the values we find.
     pub async fn fetch_additional_configuration(&mut self) -> Result<()> {
-        // TODO: Dummy code while I wait for Josh to implement the /configuration endpoint.
+        // TODO: Dummy code prior to https://github.com/aptos-labs/aptos-core/pull/1466.
         self.chain_id = Some(16);
         self.role_type = Some("full_node".to_string());
         Ok(())

--- a/ecosystem/node-checker/src/configuration/validate.rs
+++ b/ecosystem/node-checker/src/configuration/validate.rs
@@ -17,6 +17,6 @@ pub struct Validate {
 
 pub async fn validate(args: Validate) -> Result<()> {
     let configuration = read_configuration_from_file(args.path)?;
-    debug!("{:#?}", configuration);
+    debug!("Using configuration: {:#?}", configuration);
     Ok(())
 }

--- a/ecosystem/node-checker/src/metric_evaluator/state_sync_evaluator.rs
+++ b/ecosystem/node-checker/src/metric_evaluator/state_sync_evaluator.rs
@@ -44,7 +44,7 @@ impl StateSyncMetricsEvaluator {
         metrics_round: &str,
     ) -> Option<EvaluationResult> {
         match version {
-            Some(_v) => None,
+            Some(_) => None,
             None => Some(EvaluationResult {
                 headline: "State sync version metric missing".to_string(),
                 score: 0,

--- a/ecosystem/node-checker/src/server/configurations_manager.rs
+++ b/ecosystem/node-checker/src/server/configurations_manager.rs
@@ -26,9 +26,9 @@ pub struct NodeConfigurationWrapper<M: MetricCollector, R: Runner> {
     pub runner: R,
 }
 
-// In this function we finally build our trait objects with concrete implementaitons.
+// In this function we finally build our trait objects with concrete implementations.
 // We've piped trait bounds throughout our code but here we're finally facing the
-// music and actually choosing some concrete types).
+// music and actually choosing some concrete types.
 fn build_node_configuration_wrapper_with_blocking_runner_and_reqwest_metric_collector(
     node_configuration: NodeConfiguration,
 ) -> Result<NodeConfigurationWrapper<ReqwestMetricCollector, BlockingRunner<ReqwestMetricCollector>>>
@@ -50,14 +50,14 @@ fn build_node_configuration_wrapper_with_blocking_runner_and_reqwest_metric_coll
         evaluators,
     );
 
-    let w = NodeConfigurationWrapper {
+    let wrapper = NodeConfigurationWrapper {
         node_configuration,
         // TODO: Consider just fetching this from the runner instead.
         baseline_metric_collector,
         runner,
     };
 
-    Ok(w)
+    Ok(wrapper)
 }
 
 pub async fn build_server_with_blocking_runner_and_reqwest_metric_collector(

--- a/ecosystem/node-checker/src/server/generate_openapi.rs
+++ b/ecosystem/node-checker/src/server/generate_openapi.rs
@@ -1,16 +1,64 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(unused_variables)]
-
+use crate::{metric_collector::ReqwestMetricCollector, runner::BlockingRunner};
 use anyhow::Result;
-use clap::Parser;
+use clap::{ArgEnum, Parser};
+use std::{collections::HashMap, path::PathBuf};
+use url::Url;
+
+use super::{
+    api::{build_openapi_service, Api},
+    configurations_manager::{ConfigurationsManager, NodeConfigurationWrapper},
+};
+
+#[derive(ArgEnum, Clone, Debug)]
+enum OutputFormat {
+    Json,
+    Yaml,
+}
 
 #[derive(Clone, Debug, Parser)]
-pub struct GenerateOpenapi {}
+pub struct GenerateOpenapi {
+    /// What address to listen on.
+    #[clap(long, default_value = "http://0.0.0.0")]
+    pub listen_address: Url,
 
-// TODO: To implement this, I first want to make fake implementations of the
-// major traits that we need to feed into Api.
+    /// What port to listen on.
+    #[clap(long, default_value = "20121")]
+    pub listen_port: u16,
+
+    #[clap(short, long)]
+    output_path: Option<PathBuf>,
+
+    #[clap(short, long, arg_enum, default_value = "yaml")]
+    format: OutputFormat,
+}
+
 pub async fn generate_openapi(args: GenerateOpenapi) -> Result<()> {
+    let configurations: HashMap<
+        _,
+        NodeConfigurationWrapper<ReqwestMetricCollector, BlockingRunner<ReqwestMetricCollector>>,
+    > = HashMap::new();
+
+    let api = Api {
+        configurations_manager: ConfigurationsManager { configurations },
+        target_metric_collector: None,
+        allow_preconfigured_test_node_only: false,
+    };
+
+    let api_service =
+        build_openapi_service(api, args.listen_address.clone(), args.listen_port, None);
+
+    let s = match args.format {
+        OutputFormat::Json => api_service.spec(),
+        OutputFormat::Yaml => api_service.spec_yaml(),
+    };
+
+    match args.output_path {
+        Some(path) => std::fs::write(path, s)?,
+        None => println!("{}", s),
+    }
+
     Ok(())
 }

--- a/ecosystem/node-checker/src/server/generate_openapi.rs
+++ b/ecosystem/node-checker/src/server/generate_openapi.rs
@@ -28,9 +28,12 @@ pub struct GenerateOpenapi {
     #[clap(long, default_value = "20121")]
     pub listen_port: u16,
 
+    /// By default, the spec is written to stdout. If this is provided, the
+    /// tool will instead write the spec to the provided path.
     #[clap(short, long)]
     output_path: Option<PathBuf>,
 
+    /// What format to output the spec in.
     #[clap(short, long, arg_enum, default_value = "yaml")]
     format: OutputFormat,
 }
@@ -50,14 +53,14 @@ pub async fn generate_openapi(args: GenerateOpenapi) -> Result<()> {
     let api_service =
         build_openapi_service(api, args.listen_address.clone(), args.listen_port, None);
 
-    let s = match args.format {
+    let spec = match args.format {
         OutputFormat::Json => api_service.spec(),
         OutputFormat::Yaml => api_service.spec_yaml(),
     };
 
     match args.output_path {
-        Some(path) => std::fs::write(path, s)?,
-        None => println!("{}", s),
+        Some(path) => std::fs::write(path, spec)?,
+        None => println!("{}", spec),
     }
 
     Ok(())

--- a/ecosystem/node-checker/src/server/run.rs
+++ b/ecosystem/node-checker/src/server/run.rs
@@ -39,17 +39,16 @@ pub struct Run {
     #[clap(long)]
     pub target_node_url: Option<Url>,
 
-    // The following 3 arguments are only relevant if the user sets test_node_url.
     /// The metrics port for the target node.
-    #[clap(long, default_value = &DEFAULT_METRICS_PORT_STR)]
+    #[clap(long, requires = "target-node-url", default_value = &DEFAULT_METRICS_PORT_STR)]
     pub target_metrics_port: u16,
 
     /// The API port for the target node.
-    #[clap(long, default_value = &DEFAULT_API_PORT_STR)]
+    #[clap(long, requires = "target-node-url", default_value = &DEFAULT_API_PORT_STR)]
     pub target_api_port: u16,
 
     /// The port over which validator nodes can talk to the target node.
-    #[clap(long, default_value = &DEFAULT_NOISE_PORT_STR)]
+    #[clap(long, requires = "target-node-url", default_value = &DEFAULT_NOISE_PORT_STR)]
     pub target_noise_port: u16,
 
     /// If a test node is preconfigured, you can set this to prevent the server


### PR DESCRIPTION
## Description
This adds CLI support for generating the OpenAPI spec.

## Test Plan
```
cargo run server generate-openapi
```