### PR TITLE
[ecosystem] Disable syslog as it conflicts with Cloud Run.

### DIFF
--- a/ecosystem/platform/server/Dockerfile
+++ b/ecosystem/platform/server/Dockerfile
@@ -5,6 +5,7 @@ FROM phusion/passenger-full:2.3.0
 ADD nginx.conf /etc/nginx/sites-enabled/webapp.conf
 
 RUN npm install -g yarn && \
+  rm -f /etc/my_init.d/10_syslog-ng.init && \
   rm -f /etc/service/nginx/down && \
   rm -f /etc/nginx/sites-enabled/default && \
   mkdir /home/app/webapp && \


### PR DESCRIPTION
### Description

```
[2022-06-16T23:08:53.056299] Error binding socket; addr='AF_UNIX(/dev/log)', error='Address already in use (98)'
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
