### PR TITLE
[Storage][Pruner] Disable Txn accumulator pruning temporarily

### DIFF
--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -11,9 +11,7 @@ use aptos_types::{
     transaction::{SignedTransaction, Transaction},
 };
 
-use accumulator::HashReader;
 use aptos_types::{
-    proof::position::Position,
     transaction::{TransactionInfo, Version},
     write_set::WriteSet,
 };
@@ -23,7 +21,6 @@ proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
     #[test]
-    #[ignore] // ignore due to flakiness - TODO: @sitalkedia to fix it
     fn test_txn_store_pruner(txns in vec(
         prop_oneof![
             any::<BlockMetadata>().prop_map(Transaction::BlockMetadata),
@@ -140,7 +137,6 @@ fn verify_txn_store_pruner(
                 ledger_version,
             );
         }
-        verify_transaction_accumulator_pruned(&ledger_store, i as u64);
     }
 }
 
@@ -206,25 +202,6 @@ fn put_txn_in_store(
         .put_transaction_infos(0, txn_infos, &mut cs)
         .unwrap();
     aptos_db.ledger_db.write_schemas(cs.batch).unwrap();
-}
-
-// Ensure that transaction accumulator has been pruned as well. The idea to verify is get the
-// inorder position  of the left child of the accumulator root and ensure that all lower index
-// position from the DB should be deleted. We need to make several conversion between inorder and
-// postorder transaction because the DB stores the indices in postorder, while the APIs for the
-// accumulator deals with inorder.
-fn verify_transaction_accumulator_pruned(ledger_store: &LedgerStore, min_readable_version: u64) {
-    let min_readable_position = if min_readable_version > 0 {
-        Position::root_from_leaf_index(min_readable_version).left_child()
-    } else {
-        Position::root_from_leaf_index(min_readable_version)
-    };
-    let min_readable_position_postorder = min_readable_position.to_postorder_index();
-    for i in 0..min_readable_position_postorder {
-        assert!(ledger_store
-            .get(Position::from_postorder_index(i).unwrap())
-            .is_err())
-    }
 }
 
 fn verify_transaction_in_transaction_store(

--- a/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
@@ -35,11 +35,6 @@ impl DBSubPruner for TransactionStorePruner {
             target_version,
             db_batch,
         )?;
-        self.transaction_store.prune_transaction_accumulator(
-            min_readable_version,
-            target_version,
-            db_batch,
-        )?;
         Ok(())
     }
 }

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -10,7 +10,6 @@ use crate::{
         transaction::TransactionSchema, transaction_by_account::TransactionByAccountSchema,
         transaction_by_hash::TransactionByHashSchema, write_set::WriteSetSchema,
     },
-    transaction_accumulator::TransactionAccumulatorSchema,
     transaction_info::TransactionInfoSchema,
 };
 use anyhow::{ensure, format_err, Result};
@@ -296,23 +295,6 @@ impl TransactionStore {
     ) -> anyhow::Result<()> {
         for version in begin..end {
             db_batch.delete::<WriteSetSchema>(&version)?;
-        }
-        Ok(())
-    }
-
-    /// Prune the transaction schema store between a range of version in [begin, end).
-    pub fn prune_transaction_accumulator(
-        &self,
-        begin: Version,
-        end: Version,
-        db_batch: &mut SchemaBatch,
-    ) -> anyhow::Result<()> {
-        let begin_position = self.get_min_proof_node(begin);
-        let end_position = self.get_min_proof_node(end);
-        for position in begin_position.to_postorder_index()..end_position.to_postorder_index() {
-            db_batch.delete::<TransactionAccumulatorSchema>(&Position::from_postorder_index(
-                position,
-            )?)?;
         }
         Ok(())
     }


### PR DESCRIPTION
We observed the validator node OOMing with large DB because of inefficient way to doing txn accumulator pruning resuling in large DB writes. See https://github.com/aptos-labs/aptos-core/issues/1288 for an alternative way to doing more incremental pruning. While we work on the smarter way to do pruning, disabling this for now. 
