### PR TITLE
[NHC] Add build commit hash evaluator from system information

### DIFF
--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -99,13 +99,13 @@ impl NodeConfiguration {
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
 pub struct EvaluatorArgs {
     #[clap(flatten)]
-    pub state_sync_evaluator_args: StateSyncMetricsEvaluatorArgs,
+    pub build_version_evaluator_args: BuildVersionEvaluatorArgs,
 
     #[clap(flatten)]
     pub consensus_evaluator_args: ConsensusMetricsEvaluatorArgs,
 
     #[clap(flatten)]
-    pub build_version_evaluator_args: BuildVersionEvaluatorArgs,
+    pub state_sync_evaluator_args: StateSyncMetricsEvaluatorArgs,
 }
 
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]

--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -4,6 +4,7 @@
 use crate::{
     metric_evaluator::{ConsensusMetricsEvaluatorArgs, StateSyncMetricsEvaluatorArgs},
     runner::BlockingRunnerArgs,
+    system_information_evaluator::BuildVersionEvaluatorArgs,
 };
 use anyhow::Result;
 use clap::Parser;
@@ -102,6 +103,9 @@ pub struct EvaluatorArgs {
 
     #[clap(flatten)]
     pub consensus_evaluator_args: ConsensusMetricsEvaluatorArgs,
+
+    #[clap(flatten)]
+    pub build_version_evaluator_args: BuildVersionEvaluatorArgs,
 }
 
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]

--- a/ecosystem/node-checker/src/main.rs
+++ b/ecosystem/node-checker/src/main.rs
@@ -7,6 +7,7 @@ mod metric_collector;
 mod metric_evaluator;
 mod runner;
 mod server;
+mod system_information_evaluator;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};

--- a/ecosystem/node-checker/src/metric_collector/mod.rs
+++ b/ecosystem/node-checker/src/metric_collector/mod.rs
@@ -5,4 +5,4 @@ mod reqwest_metric_collector;
 mod traits;
 
 pub use reqwest_metric_collector::ReqwestMetricCollector;
-pub use traits::{MetricCollector, MetricCollectorError};
+pub use traits::{MetricCollector, MetricCollectorError, SystemInformation};

--- a/ecosystem/node-checker/src/metric_collector/reqwest_metric_collector.rs
+++ b/ecosystem/node-checker/src/metric_collector/reqwest_metric_collector.rs
@@ -8,8 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use log::debug;
 use reqwest::{Client as ReqwestClient, Url};
-use std::collections::HashMap;
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 use url::Host;
 
 // TODO Make it possible to reject nodes unless they are a specific type.

--- a/ecosystem/node-checker/src/metric_collector/reqwest_metric_collector.rs
+++ b/ecosystem/node-checker/src/metric_collector/reqwest_metric_collector.rs
@@ -3,7 +3,7 @@
 
 use std::net::{IpAddr, Ipv4Addr};
 
-use super::traits::{MetricCollector, MetricCollectorError};
+use super::traits::{MetricCollector, MetricCollectorError, SystemInformation};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use log::debug;
@@ -90,9 +90,7 @@ impl MetricCollector for ReqwestMetricCollector {
     /// We know that this endpoint returns JSON that is actually just HashMap<String, String>.
     /// Better than this would be to have that endpoint return a serialized struct that we can
     /// use here to deseralize. TODO for that.
-    async fn collect_system_information(
-        &self,
-    ) -> Result<HashMap<String, String>, MetricCollectorError> {
+    async fn collect_system_information(&self) -> Result<SystemInformation, MetricCollectorError> {
         let body = self.get_data_from_node("system_information").await?;
         let raw_map: HashMap<String, serde_json::Value> = serde_json::from_str(&body)
             .context("Failed to process response body as JSON")
@@ -106,6 +104,6 @@ impl MetricCollector for ReqwestMetricCollector {
                 .to_owned();
             out.insert(key, string_value);
         }
-        Ok(out)
+        Ok(SystemInformation(out))
     }
 }

--- a/ecosystem/node-checker/src/metric_collector/reqwest_metric_collector.rs
+++ b/ecosystem/node-checker/src/metric_collector/reqwest_metric_collector.rs
@@ -92,18 +92,9 @@ impl MetricCollector for ReqwestMetricCollector {
     /// use here to deseralize. TODO for that.
     async fn collect_system_information(&self) -> Result<SystemInformation, MetricCollectorError> {
         let body = self.get_data_from_node("system_information").await?;
-        let raw_map: HashMap<String, serde_json::Value> = serde_json::from_str(&body)
-            .context("Failed to process response body as JSON")
+        let data: HashMap<String, String> = serde_json::from_str(&body)
+            .context("Failed to process response body as valid JSON with string key/values")
             .map_err(|e| MetricCollectorError::ResponseParseError(anyhow!(e)))?;
-        let mut out = HashMap::new();
-        for (key, value) in raw_map.into_iter() {
-            let string_value = value
-                .as_str()
-                .with_context(|| format!("Failed to convert value to String: {}", value))
-                .map_err(|e| MetricCollectorError::ResponseParseError(anyhow!(e)))?
-                .to_owned();
-            out.insert(key, string_value);
-        }
-        Ok(SystemInformation(out))
+        Ok(SystemInformation(data))
     }
 }

--- a/ecosystem/node-checker/src/metric_collector/traits.rs
+++ b/ecosystem/node-checker/src/metric_collector/traits.rs
@@ -8,6 +8,9 @@ use thiserror::Error as ThisError;
 
 // TODO: Consider using thiserror.
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct SystemInformation(pub HashMap<String, String>);
+
 #[derive(Debug, ThisError)]
 pub enum MetricCollectorError {
     /// We were unable to get data from the node.
@@ -36,7 +39,5 @@ pub trait MetricCollector: Sync + Send + 'static {
     /// Hit the system_information endpoint of the metrics port and return the response
     /// as a hashmap. Unfortunately the endpoint itself returns the results as just a
     /// map, not as a serialized version of a type, so this is the best we can do for now.
-    async fn collect_system_information(
-        &self,
-    ) -> Result<HashMap<String, String>, MetricCollectorError>;
+    async fn collect_system_information(&self) -> Result<SystemInformation, MetricCollectorError>;
 }

--- a/ecosystem/node-checker/src/metric_collector/traits.rs
+++ b/ecosystem/node-checker/src/metric_collector/traits.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{Error, Result};
 use async_trait::async_trait;
+use std::collections::HashMap;
 use thiserror::Error as ThisError;
 
 // TODO: Consider using thiserror.
@@ -29,5 +30,13 @@ pub enum MetricCollectorError {
 ///  - 'static is required because this will be stored on the todo which needs to be 'static
 #[async_trait]
 pub trait MetricCollector: Sync + Send + 'static {
+    /// Hit the metrics endpoint of the metrics port and return the repsonse as lines.
     async fn collect_metrics(&self) -> Result<Vec<String>, MetricCollectorError>;
+
+    /// Hit the system_information endpoint of the metrics port and return the response
+    /// as a hashmap. Unfortunately the endpoint itself returns the results as just a
+    /// map, not as a serialized version of a type, so this is the best we can do for now.
+    async fn collect_system_information(
+        &self,
+    ) -> Result<HashMap<String, String>, MetricCollectorError>;
 }

--- a/ecosystem/node-checker/src/metric_collector/traits.rs
+++ b/ecosystem/node-checker/src/metric_collector/traits.rs
@@ -33,7 +33,7 @@ pub enum MetricCollectorError {
 ///  - 'static is required because this will be stored on the todo which needs to be 'static
 #[async_trait]
 pub trait MetricCollector: Sync + Send + 'static {
-    /// Hit the metrics endpoint of the metrics port and return the repsonse as lines.
+    /// Hit the metrics endpoint of the metrics port and return the response as lines.
     async fn collect_metrics(&self) -> Result<Vec<String>, MetricCollectorError>;
 
     /// Hit the system_information endpoint of the metrics port and return the response

--- a/ecosystem/node-checker/src/metric_evaluator/traits.rs
+++ b/ecosystem/node-checker/src/metric_evaluator/traits.rs
@@ -12,9 +12,9 @@ pub enum MetricsEvaluatorError {
     ///   - The metric name.
     ///   - Explanation.
     /// When the target node is missing a metric, we return an Evaluation
-    /// indiating that something is wrong with the target node, but if the
+    /// indicating that something is wrong with the target node, but if the
     /// baseline node is missing a metric, it implies that something is wrong
-    /// without our node checker configuration, so we return an error here.
+    /// with our node checker configuration, so we return an error here.
     #[error("A baseline metric was missing. Metric name: {0}, Explanation: {1}")]
     MissingBaselineMetric(String, String),
 }

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -70,6 +70,21 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
         &self,
         target_collector: &T,
     ) -> Result<EvaluationSummary, RunnerError> {
+        debug!("Collecting system information from baseline node");
+        let baseline_system_information = self
+            .baseline_metric_collector
+            .collect_system_information()
+            .await
+            .map_err(RunnerError::MetricCollectorError)?;
+        debug!("{:?}", baseline_system_information);
+
+        debug!("Collecting system information from target node");
+        let target_system_information = target_collector
+            .collect_system_information()
+            .await
+            .map_err(RunnerError::MetricCollectorError)?;
+        debug!("{:?}", target_system_information);
+
         debug!("Collecting first round of baseline metrics");
         let first_baseline_metrics = self
             .baseline_metric_collector

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -8,6 +8,7 @@ use crate::{
     evaluator::EvaluationSummary,
     metric_collector::MetricCollector,
     metric_evaluator::{parse_metrics, MetricsEvaluator},
+    system_information_evaluator::SystemInformationEvaluator,
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -27,19 +28,22 @@ pub struct BlockingRunnerArgs {
 pub struct BlockingRunner<M: MetricCollector> {
     args: BlockingRunnerArgs,
     baseline_metric_collector: M,
-    evaluators: Vec<Box<dyn MetricsEvaluator>>,
+    metrics_evaluators: Vec<Box<dyn MetricsEvaluator>>,
+    system_information_evaluators: Vec<Box<dyn SystemInformationEvaluator>>,
 }
 
 impl<M: MetricCollector> BlockingRunner<M> {
     pub fn new(
         args: BlockingRunnerArgs,
         baseline_metric_collector: M,
-        evaluators: Vec<Box<dyn MetricsEvaluator>>,
+        metrics_evaluators: Vec<Box<dyn MetricsEvaluator>>,
+        system_information_evaluators: Vec<Box<dyn SystemInformationEvaluator>>,
     ) -> Self {
         Self {
             args,
             baseline_metric_collector,
-            evaluators,
+            metrics_evaluators,
+            system_information_evaluators,
         }
     }
 
@@ -112,7 +116,7 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
 
         let mut evaluation_results = Vec::new();
 
-        for evaluator in &self.evaluators {
+        for evaluator in &self.metrics_evaluators {
             let mut es = evaluator
                 .evaluate_metrics(
                     &first_baseline_metrics,
@@ -121,6 +125,16 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
                     &second_target_metrics,
                 )
                 .map_err(RunnerError::MetricEvaluatorError)?;
+            evaluation_results.append(&mut es);
+        }
+
+        for evaluator in &self.system_information_evaluators {
+            let mut es = evaluator
+                .evaluate_system_information(
+                    &baseline_system_information,
+                    &target_system_information,
+                )
+                .map_err(RunnerError::SystemInformationEvaluatorError)?;
             evaluation_results.append(&mut es);
         }
 

--- a/ecosystem/node-checker/src/runner/traits.rs
+++ b/ecosystem/node-checker/src/runner/traits.rs
@@ -9,6 +9,7 @@ use crate::{
     evaluator::EvaluationSummary,
     metric_collector::{MetricCollector, MetricCollectorError},
     metric_evaluator::MetricsEvaluatorError,
+    system_information_evaluator::SystemInformationEvaluatorError,
 };
 
 #[derive(Debug, ThisError)]
@@ -21,10 +22,16 @@ pub enum RunnerError {
     #[error("Failed to parse metrics")]
     ParseMetricsError(Error),
 
-    /// One of the evaluators failed. This is not the same as a poor score from
+    /// One of the metrics evaluators failed. This is not the same as a poor score from
     /// an evaluator, this is an actual failure in the evaluation process.
     #[error("Failed to evaluate metrics")]
     MetricEvaluatorError(MetricsEvaluatorError),
+
+    /// One of the system information evaluators failed. This is not the same
+    /// as a poor score from an evaluator, this is an actual failure in the
+    /// evaluation process.
+    #[error("Failed to evaluate system information")]
+    SystemInformationEvaluatorError(SystemInformationEvaluatorError),
 }
 
 // This runner doesn't block in the multithreading sense, but from the user

--- a/ecosystem/node-checker/src/server/configurations_manager.rs
+++ b/ecosystem/node-checker/src/server/configurations_manager.rs
@@ -6,10 +6,12 @@ use std::{collections::HashMap, path::PathBuf};
 use crate::{
     configuration::{read_configuration_from_file, NodeConfiguration},
     metric_collector::{MetricCollector, ReqwestMetricCollector},
-    metric_evaluator::build_evaluators,
+    metric_evaluator::build_evaluators as build_metric_evaluators,
     runner::{BlockingRunner, Runner},
+    system_information_evaluator::build_evaluators as build_system_information_evaluators,
 };
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 
 /// This struct is a wrapper to help with all the different baseline
 /// node configurations.
@@ -38,16 +40,24 @@ fn build_node_configuration_wrapper_with_blocking_runner_and_reqwest_metric_coll
         node_configuration.node_address.metrics_port,
     );
 
-    let evaluators = build_evaluators(
-        &node_configuration.evaluators,
+    let mut evaluator_strings: HashSet<String> =
+        node_configuration.evaluators.iter().cloned().collect();
+
+    let metric_evaluators =
+        build_metric_evaluators(&mut evaluator_strings, &node_configuration.evaluator_args)
+            .context("Failed to build metric evaluators")?;
+
+    let system_information_evaluators = build_system_information_evaluators(
+        &mut evaluator_strings,
         &node_configuration.evaluator_args,
     )
-    .context("Failed to build evaluators")?;
+    .context("Failed to build system information evaluators")?;
 
     let runner = BlockingRunner::new(
         node_configuration.runner_args.blocking_runner_args.clone(),
         baseline_metric_collector.clone(),
-        evaluators,
+        metric_evaluators,
+        system_information_evaluators,
     );
 
     let wrapper = NodeConfigurationWrapper {

--- a/ecosystem/node-checker/src/system_information_evaluator/build_evaluators.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/build_evaluators.rs
@@ -6,37 +6,29 @@
 #![allow(unused_mut)]
 
 use crate::{
-    configuration::EvaluatorArgs, system_information_evaluator::SystemInformationEvaluator,
+    configuration::EvaluatorArgs,
+    system_information_evaluator::{
+        build_version_evaluator::BUILD_VERSION_EVALUATOR_NAME, BuildVersionEvaluator,
+        SystemInformationEvaluator,
+    },
 };
-use anyhow::{bail, Result};
-use log::info;
+use anyhow::Result;
 use std::collections::HashSet;
 
 pub fn build_evaluators(
-    evaluators: &[String],
+    evaluators_strings: &mut HashSet<String>,
     evaluator_args: &EvaluatorArgs,
 ) -> Result<Vec<Box<dyn SystemInformationEvaluator>>> {
-    let evaluator_strings: HashSet<String> = evaluators.iter().cloned().collect();
-    if evaluator_strings.is_empty() {
-        bail!("No evaluators specified");
-    }
-
     let mut evaluators: Vec<Box<dyn SystemInformationEvaluator>> = vec![];
 
-    let in_use_evaluators_names = evaluators
-        .iter()
-        .map(|e| e.get_name())
-        .collect::<HashSet<_>>();
-    for evaluator_string in evaluator_strings {
-        if !in_use_evaluators_names.contains(&evaluator_string) {
-            bail!("Evaluator {} does not exist", evaluator_string);
-        }
+    if evaluators_strings
+        .take(BUILD_VERSION_EVALUATOR_NAME)
+        .is_some()
+    {
+        evaluators.push(Box::new(BuildVersionEvaluator::new(
+            evaluator_args.build_version_evaluator_args.clone(),
+        )));
     }
-
-    info!(
-        "Running with the following evaluators: {:?}",
-        in_use_evaluators_names
-    );
 
     Ok(evaluators)
 }

--- a/ecosystem/node-checker/src/system_information_evaluator/build_evaluators.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/build_evaluators.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+use crate::{
+    configuration::EvaluatorArgs, system_information_evaluator::SystemInformationEvaluator,
+};
+use anyhow::{bail, Result};
+use log::info;
+use std::collections::HashSet;
+
+pub fn build_evaluators(
+    evaluators: &[String],
+    evaluator_args: &EvaluatorArgs,
+) -> Result<Vec<Box<dyn SystemInformationEvaluator>>> {
+    let evaluator_strings: HashSet<String> = evaluators.iter().cloned().collect();
+    if evaluator_strings.is_empty() {
+        bail!("No evaluators specified");
+    }
+
+    let mut evaluators: Vec<Box<dyn SystemInformationEvaluator>> = vec![];
+
+    let in_use_evaluators_names = evaluators
+        .iter()
+        .map(|e| e.get_name())
+        .collect::<HashSet<_>>();
+    for evaluator_string in evaluator_strings {
+        if !in_use_evaluators_names.contains(&evaluator_string) {
+            bail!("Evaluator {} does not exist", evaluator_string);
+        }
+    }
+
+    info!(
+        "Running with the following evaluators: {:?}",
+        in_use_evaluators_names
+    );
+
+    Ok(evaluators)
+}

--- a/ecosystem/node-checker/src/system_information_evaluator/build_version_evaluator.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/build_version_evaluator.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// TODO: Sometimes build_commit_hash is an empty string (so far I've noticed
+// this happens when targeting a node running from a container). Figure out
+// what to do in this case.
+
 use super::{
     get_value, GetValueResult, SystemInformationEvaluator, SystemInformationEvaluatorError,
     EVALUATOR_SOURCE,
@@ -33,7 +37,7 @@ impl BuildVersionEvaluator {
 
     fn get_build_commit_hash(&self, system_information: &SystemInformation) -> GetValueResult {
         let evaluation_on_missing_fn = || EvaluationResult {
-            headline: "State sync version metric missing".to_string(),
+            headline: "Build commit hash value missing".to_string(),
             score: 0,
             explanation: format!(
                 "The build information from the node is missing: {}",
@@ -59,7 +63,6 @@ impl SystemInformationEvaluator for BuildVersionEvaluator {
     ) -> Result<Vec<EvaluationResult>, SystemInformationEvaluatorError> {
         let mut evaluation_results = vec![];
 
-        // Get previous proposals count from the target node.
         let baseline_build_commit_hash = match self
             .get_build_commit_hash(baseline_system_information)
         {

--- a/ecosystem/node-checker/src/system_information_evaluator/build_version_evaluator.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/build_version_evaluator.rs
@@ -1,0 +1,183 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    get_value, GetValueResult, SystemInformationEvaluator, SystemInformationEvaluatorError,
+    EVALUATOR_SOURCE,
+};
+use crate::{evaluator::EvaluationResult, metric_collector::SystemInformation};
+use anyhow::Result;
+use clap::Parser;
+use log::debug;
+use poem_openapi::Object as PoemObject;
+use serde::{Deserialize, Serialize};
+
+pub const BUILD_VERSION_EVALUATOR_NAME: &str = "build_commit_hash";
+
+// TODO: Use the key in crates/aptos-telemetry/src/build_information.rs
+const BUILD_COMMIT_HASH_KEY: &str = "build_commit_hash";
+
+#[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
+pub struct BuildVersionEvaluatorArgs {}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct BuildVersionEvaluator {
+    args: BuildVersionEvaluatorArgs,
+}
+
+impl BuildVersionEvaluator {
+    pub fn new(args: BuildVersionEvaluatorArgs) -> Self {
+        Self { args }
+    }
+
+    fn get_build_commit_hash(&self, system_information: &SystemInformation) -> GetValueResult {
+        let evaluation_on_missing_fn = || EvaluationResult {
+            headline: "State sync version metric missing".to_string(),
+            score: 0,
+            explanation: format!(
+                "The build information from the node is missing: {}",
+                BUILD_COMMIT_HASH_KEY
+            ),
+            source: EVALUATOR_SOURCE.to_string(),
+            links: vec![],
+        };
+        get_value(
+            system_information,
+            BUILD_COMMIT_HASH_KEY,
+            evaluation_on_missing_fn,
+        )
+    }
+}
+
+impl SystemInformationEvaluator for BuildVersionEvaluator {
+    /// Assert that the build commit hashes match.
+    fn evaluate_system_information(
+        &self,
+        baseline_system_information: &SystemInformation,
+        target_system_information: &SystemInformation,
+    ) -> Result<Vec<EvaluationResult>, SystemInformationEvaluatorError> {
+        let mut evaluation_results = vec![];
+
+        // Get previous proposals count from the target node.
+        let baseline_build_commit_hash = match self
+            .get_build_commit_hash(baseline_system_information)
+        {
+            GetValueResult::Present(value) => value,
+            GetValueResult::Missing(_evaluation_result) => {
+                return
+                    Err(SystemInformationEvaluatorError::BaselineMissingKey(
+                        BUILD_COMMIT_HASH_KEY.to_string(),
+                        format!("The latest set of metrics from the baseline node did not contain the necessary key \"{}\"", BUILD_COMMIT_HASH_KEY),
+                    ));
+            }
+        };
+
+        let target_build_commit_hash = match self.get_build_commit_hash(target_system_information) {
+            GetValueResult::Present(value) => Some(value),
+            GetValueResult::Missing(evaluation_result) => {
+                evaluation_results.push(evaluation_result);
+                None
+            }
+        };
+
+        match target_build_commit_hash {
+            Some(target_build_commit_hash) => {
+                evaluation_results.push({
+                    if baseline_build_commit_hash == target_build_commit_hash {
+                        EvaluationResult {
+                            headline: "Build commit hashes match".to_string(),
+                            score: 100,
+                            explanation: format!(
+                                "The build commit hash from the target node ({}) matches the build commit hash from the baseline node ({}).",
+                                target_build_commit_hash, baseline_build_commit_hash
+                            ),
+                            source: EVALUATOR_SOURCE.to_string(),
+                            links: vec![],
+                        }
+                    } else {
+                        EvaluationResult {
+                            headline: "Build commit hash mismatch".to_string(),
+                            score: 50,
+                            explanation: format!(
+                                "The build commit hash from the target node ({}) does not match the build commit hash from the baseline node ({}).",
+                                target_build_commit_hash, baseline_build_commit_hash
+                            ),
+                            source: EVALUATOR_SOURCE.to_string(),
+                            links: vec![],
+                        }
+                    }
+                });
+            }
+            None => debug!(
+                "Not evaluating build commit hash because we're missing data from the target"
+            ),
+        }
+
+        Ok(evaluation_results)
+    }
+
+    fn get_name(&self) -> String {
+        BUILD_VERSION_EVALUATOR_NAME.to_string()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn get_system_information(build_commit_hash: &str) -> SystemInformation {
+        let mut inner = HashMap::new();
+        inner.insert(
+            BUILD_COMMIT_HASH_KEY.to_string(),
+            build_commit_hash.to_string(),
+        );
+        SystemInformation(inner)
+    }
+
+    fn test_evaluator(
+        baseline_build_commit_hash: Option<&str>,
+        target_build_commit_hash: Option<&str>,
+        expected_score: u8,
+    ) {
+        let baseline_system_information = match baseline_build_commit_hash {
+            Some(v) => get_system_information(v),
+            None => SystemInformation(HashMap::new()),
+        };
+
+        let target_system_information = match target_build_commit_hash {
+            Some(v) => get_system_information(v),
+            None => SystemInformation(HashMap::new()),
+        };
+
+        let evaluator = BuildVersionEvaluator::new(BuildVersionEvaluatorArgs {});
+        let evaluations = evaluator
+            .evaluate_system_information(&baseline_system_information, &target_system_information)
+            .expect("Failed to evaluate system information");
+
+        assert_eq!(evaluations.len(), 1);
+        assert_eq!(evaluations[0].score, expected_score);
+    }
+
+    #[test]
+    fn test_same() {
+        test_evaluator(Some("aaaaaaaaaa"), Some("aaaaaaaaaa"), 100);
+    }
+
+    #[test]
+    fn test_different() {
+        test_evaluator(Some("aaaaaaaaaa"), Some("bbbbbbbbbb"), 50);
+    }
+
+    #[test]
+    fn test_missing_target_metric() {
+        test_evaluator(Some("aaaaaaaaaa"), None, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "did not contain the necessary key")]
+    fn test_both_missing_metrics() {
+        test_evaluator(None, None, 0);
+    }
+}

--- a/ecosystem/node-checker/src/system_information_evaluator/mod.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/mod.rs
@@ -1,0 +1,8 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod build_evaluators;
+mod traits;
+
+pub use build_evaluators::build_evaluators;
+pub use traits::{SystemInformationEvaluator, SystemInformationEvaluatorError};

--- a/ecosystem/node-checker/src/system_information_evaluator/mod.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/mod.rs
@@ -2,7 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod build_evaluators;
+mod build_version_evaluator;
 mod traits;
 
+use crate::{evaluator::EvaluationResult, metric_collector::SystemInformation};
+
 pub use build_evaluators::build_evaluators;
+pub use build_version_evaluator::{BuildVersionEvaluator, BuildVersionEvaluatorArgs};
 pub use traits::{SystemInformationEvaluator, SystemInformationEvaluatorError};
+
+pub const EVALUATOR_SOURCE: &str = "system_information";
+
+/// This is a convenience function that returns the value if it was
+/// found, or an Evaluation if not.
+pub fn get_value<F>(
+    metrics: &SystemInformation,
+    metric_key: &str,
+    evaluation_on_missing_fn: F,
+) -> GetValueResult
+where
+    F: FnOnce() -> EvaluationResult,
+{
+    let metric_value = metrics.0.get(metric_key);
+    match metric_value {
+        Some(v) => GetValueResult::Present(v.to_string()),
+        None => GetValueResult::Missing(evaluation_on_missing_fn()),
+    }
+}
+
+pub enum GetValueResult {
+    Present(String),
+    Missing(EvaluationResult),
+}

--- a/ecosystem/node-checker/src/system_information_evaluator/traits.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/traits.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)]
+
+use crate::evaluator::EvaluationResult;
+use anyhow::Result;
+use std::collections::HashMap;
+use thiserror::Error as ThisError;
+
+#[derive(Debug, ThisError)]
+pub enum SystemInformationEvaluatorError {
+    /// The key we're looking for is missing from the baseline. Args:
+    ///   - The key name.
+    ///   - Explanation.
+    /// When the target node is missing a key, we return an Evaluation
+    /// indicating that something is wrong with the target node, but if the
+    /// baseline node is missing a key, it implies that something is wrong
+    /// with our node checker configuration, so we return an error here.
+    #[error("A key was unexpectedly missing from the baseline system information. Key name: {0}, Explanation: {1}")]
+    BaselineMissingKey(String, String),
+}
+
+/// This trait defines evaluators that operate on the data from /system_information
+/// on the metrics port.
+pub trait SystemInformationEvaluator: Sync + Send {
+    fn evaluate_system_information(
+        &self,
+        baseline_system_information: &HashMap<String, String>,
+        target_system_information: &HashMap<String, String>,
+    ) -> Result<Vec<EvaluationResult>, SystemInformationEvaluatorError>;
+
+    fn get_name(&self) -> String;
+}
+
+impl std::fmt::Debug for dyn SystemInformationEvaluator {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            fmt,
+            "SystemInformationEvaluator {{ name: {:?} }}",
+            self.get_name()
+        )
+    }
+}

--- a/ecosystem/node-checker/src/system_information_evaluator/traits.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/traits.rs
@@ -3,9 +3,8 @@
 
 #![allow(dead_code)]
 
-use crate::evaluator::EvaluationResult;
+use crate::{evaluator::EvaluationResult, metric_collector::SystemInformation};
 use anyhow::Result;
-use std::collections::HashMap;
 use thiserror::Error as ThisError;
 
 #[derive(Debug, ThisError)]
@@ -26,8 +25,8 @@ pub enum SystemInformationEvaluatorError {
 pub trait SystemInformationEvaluator: Sync + Send {
     fn evaluate_system_information(
         &self,
-        baseline_system_information: &HashMap<String, String>,
-        target_system_information: &HashMap<String, String>,
+        baseline_system_information: &SystemInformation,
+        target_system_information: &SystemInformation,
     ) -> Result<Vec<EvaluationResult>, SystemInformationEvaluatorError>;
 
     fn get_name(&self) -> String;

--- a/ecosystem/node-checker/src/system_information_evaluator/traits.rs
+++ b/ecosystem/node-checker/src/system_information_evaluator/traits.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)]
-
 use crate::{evaluator::EvaluationResult, metric_collector::SystemInformation};
 use anyhow::Result;
 use thiserror::Error as ThisError;


### PR DESCRIPTION
## Description
This PR adds an evaluator that asserts that the build commit hash between the two nodes are the same. This is a good way to check that the operator is running the version of the node that they should be.

**Note**: This field is not populated when the node is running from a container, it's just an empty string, so for now we shouldn't enable this until we have a better value we can use that is always populated, since a node might erroneously fail this evaluation if it is using source while the baseline is running from a container, for example.

## Test Plan
Generate an appropriate baseline node config (in that case just localhost for simplicity):
```
cargo run -- configuration create --configuration-name local_devnet_fullnode --configuration-name-pretty "Local Devnet Fullnode" --url http://localhost --evaluators state_sync_version,consensus_proposals,system_information_build_commit_hash -o /tmp/local_devnet_fullnode.yaml
```

Run NHC with that config (in this case, targeting my local fullnode):
```
cargo run -- server run --baseline-node-config-paths /tmp/local_devnet_fullnode.yaml --target-node-url http://localhost
```

Hit it with a request:
```
curl 'http://0.0.0.0:20121/api/check_node?node_url=http://localhost&baseline_configuration_name=local_devnet_fullnode'
```

Output:
```
{
  "evaluation_results": [
    {
      "headline": "Proposals count is not progressing",
      "score": 50,
      "explanation": "Successfully pulled metrics from target node twice, but the proposal count isn't progressing.",
      "evaluator_name": "consensus_proposals",
      "category": "consensus",
      "links": []
    },
    {
      "headline": "State sync version is within tolerance",
      "score": 100,
      "explanation": "Successfully pulled metrics from target node twice, saw the version was progressing, and saw that it is within tolerance of the baseline node. Target version: 115005. Baseline version: 115005. Tolerance: 5000.",
      "evaluator_name": "state_sync_version",
      "category": "state_sync",
      "links": []
    },
    {
      "headline": "Build commit hashes match",
      "score": 100,
      "explanation": "The build commit hash from the target node (39bdd6acf1bcf523970b6be057f884a848712c7c) matches the build commit hash from the baseline node (39bdd6acf1bcf523970b6be057f884a848712c7c).",
      "evaluator_name": "system_information_build_commit_hash",
      "category": "system_information",
      "links": []
    }
  ],
  "summary_score": 83,
  "summary_explanation": "83: Good!"
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1454)
<!-- Reviewable:end -->
