### PR TITLE
[docker] build aptos CLI tool

### DIFF
--- a/docker/build-common.sh
+++ b/docker/build-common.sh
@@ -35,6 +35,7 @@ if [ "$IMAGE_TARGET" = "release" ]; then
           -p aptos-writeset-generator \
           -p transaction-emitter \
           -p aptos-indexer \
+          -p aptos \
           "$@"
 
   # Build our core modules!

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -107,6 +107,7 @@ COPY --from=builder /aptos/target/release/db-backup /usr/local/bin/
 COPY --from=builder /aptos/target/release/db-backup-verify /usr/local/bin/
 COPY --from=builder /aptos/target/release/db-restore /usr/local/bin/
 COPY --from=builder /aptos/target/release/aptos-transaction-replay /usr/local/bin/
+COPY --from=builder /aptos/target/release/aptos /usr/local/bin/
 
 ### Get Aptos Move modules bytecodes for genesis ceremony
 RUN mkdir -p /aptos-framework/move/build
@@ -118,7 +119,7 @@ RUN rm -rf /aptos-framework/move/build
 
 
 ### Init / Genesis Image ###
-### TODO(christian|rusty|sherry): This image is appears to be a subset of the tools image. We can probably get rid of this in favor for the tools image.
+### TODO(christian|rustie|sherry): This image is appears to be a subset of the tools image. We can probably get rid of this in favor for the tools image.
 
 FROM debian-base AS init
 
@@ -129,6 +130,7 @@ RUN cd /usr/local/bin && wget "https://releases.hashicorp.com/vault/1.5.0/vault_
 RUN mkdir -p /opt/aptos/bin
 COPY --from=builder /aptos/target/release/aptos-genesis-tool /usr/local/bin/
 COPY --from=builder /aptos/target/release/aptos-operational-tool /usr/local/bin/
+COPY --from=builder /aptos/target/release/aptos /usr/local/bin/
 
 ### Get Aptos Move modules bytecodes for genesis ceremony
 RUN mkdir -p /aptos-framework/move/build


### PR DESCRIPTION
so we can start testing it in automated genesis ceremonies in deployments.

Build in `init` and `tools` images, though we should consider killing `init` and just putting everything in `tools`