### PR TITLE
[Storage][Pruner] Ignore error in state index pruning

### DIFF
--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -137,6 +137,12 @@ impl StateStorePruner {
         // least 60000 versions (assuming the pruner deletes as slow as 1000 versions per second,
         // this imposes at most one minute of work in vain after restarting.)
         let now = Instant::now();
+        if self.min_readable_version.load(Ordering::Relaxed) < self.index_min_nonpurged_version() {
+            warn!("State pruner inconsistent, min_readable_version is {} and  index_min_non-purged_version is {}",
+                self.min_readable_version.load(Ordering::Relaxed), self.index_min_nonpurged_version());
+            return Ok(());
+        }
+
         if now - *self.index_purged_at.lock() > MIN_INTERVAL
             && self.min_readable_version.load(Ordering::Relaxed)
                 - self.index_min_nonpurged_version()


### PR DESCRIPTION
We have been seeing few full node crash with issue

```
2022-06-13T22:28:15.665526Z [aptosdb_pruner] ERROR crates/crash-handler/src/lib.rs:38 details = '''panicked at 'attempt to subtract with overflow', storage/aptosdb/src/pruner/state_store/mod.rs:141:16'''
```

It is not entirely clear how the pruner gets into this state but the pruner issue should not crash the node. Also, adding some more logging to help us understand this further. 
