### PR TITLE
[Storage][lazy commit] impl DbReader for StateStore

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -734,7 +734,7 @@ impl DbReader for AptosDB {
             let version = ledger_info_with_sigs.ledger_info().version();
             let (blob, _proof) = self
                 .state_store
-                .get_value_with_proof_by_version(&state_key, version)?;
+                .get_state_value_with_proof_by_version(&state_key, version)?;
             Ok(blob)
         })
     }
@@ -1068,7 +1068,7 @@ impl DbReader for AptosDB {
             )?;
 
             self.state_store
-                .get_value_by_version(state_store_key, version)
+                .get_state_value_by_version(state_store_key, version)
         })
     }
 
@@ -1110,7 +1110,7 @@ impl DbReader for AptosDB {
             )?;
 
             self.state_store
-                .get_value_with_proof_by_version(state_store_key, version)
+                .get_state_value_with_proof_by_version(state_store_key, version)
         })
     }
 
@@ -1162,12 +1162,12 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_state_checkpoint_before(
+    fn get_state_snapshot_before(
         &self,
         next_version: Version,
     ) -> Result<Option<(Version, HashValue)>> {
         gauged_api("get_state_checkpoint_before", || {
-            self.state_store.get_checkpoint_before(next_version)
+            self.state_store.get_state_snapshot_before(next_version)
         })
     }
 

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
 use aptos_types::state_store::{state_key::StateKey, state_value::StateValue};
-use storage_interface::{jmt_update_refs, jmt_updates};
+use storage_interface::{jmt_update_refs, jmt_updates, DbReader};
 
 use crate::{change_set::ChangeSet, pruner::*, state_store::StateStore, AptosDB};
 
@@ -42,7 +42,7 @@ fn verify_state_in_store(
     version: Version,
 ) {
     let (value, _proof) = state_store
-        .get_value_with_proof_by_version(&key, version)
+        .get_state_value_with_proof_by_version(&key, version)
         .unwrap();
 
     assert_eq!(value.as_ref(), expected_value);
@@ -120,7 +120,7 @@ fn test_state_store_pruner() {
             .unwrap();
         for i in 0..prune_batch_size {
             assert!(state_store
-                .get_value_with_proof_by_version(&key, i as u64)
+                .get_state_value_with_proof_by_version(&key, i as u64)
                 .is_err());
         }
         for i in prune_batch_size..num_versions as usize {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -377,8 +377,8 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
-    /// Returns the latest state checkpoint strictly before `next_version` if any.
-    fn get_state_checkpoint_before(
+    /// Returns the latest state snapshot strictly before `next_version` if any.
+    fn get_state_snapshot_before(
         &self,
         next_version: Version,
     ) -> Result<Option<(Version, HashValue)>> {


### PR DESCRIPTION
### Description
For lazy commit, we have to initiate `CachedStateView` inside state store where an `Arc<DbReader>` is not available.
Also, trait upcasting coercion is experimental so creating another trait and letting `Arc<DbReader>` upcast when needed don't work either. 

We just use blanket implementation for now.

### Test Plan
cargo xtest
