### PR TITLE
[Telemetry] Fetch the appropriate counter based on state sync version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
  "serde_json",
  "shadow-rs",
  "state-sync-driver",
+ "state-sync-v1",
  "sysinfo",
  "tokio",
  "tokio-stream",

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -35,3 +35,4 @@ aptosdb = { path = "../../storage/aptosdb" }
 consensus = { path = "../../consensus" }
 network = { path = "../../network" }
 state-sync-driver = { path = "../../state-sync/state-sync-v2/state-sync-driver" }
+state-sync-v1 = { path = "../../state-sync/state-sync-v1" }

--- a/state-sync/state-sync-v1/src/lib.rs
+++ b/state-sync/state-sync-v1/src/lib.rs
@@ -12,7 +12,7 @@ pub mod chunk_request;
 pub mod chunk_response;
 pub mod client;
 pub mod coordinator;
-mod counters;
+pub mod counters;
 pub mod error;
 pub mod executor_proxy;
 mod logging;


### PR DESCRIPTION
### Description

This PR updates the Aptos telemetry crate to select the correct counter based on which version of state sync is running.

### Test Plan

We'll see if forge works again! 😄 