### PR TITLE
[REST API] Add node role to index.

### DIFF
--- a/api/goldens/aptos_api__tests__index_test__test_get_index.json
+++ b/api/goldens/aptos_api__tests__index_test__test_get_index.json
@@ -2,5 +2,6 @@
   "chain_id": 4,
   "epoch": 0,
   "ledger_version": "0",
-  "ledger_timestamp": "0"
+  "ledger_timestamp": "0",
+  "node_role": "validator"
 }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_api_types::{Error, LedgerInfo, TransactionOnChainData};
-use aptos_config::config::ApiConfig;
+use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::HashValue;
 use aptos_mempool::{MempoolClientRequest, MempoolClientSender, SubmissionStatus};
 use aptos_types::{
@@ -36,7 +36,7 @@ pub struct Context {
     chain_id: ChainId,
     db: Arc<dyn DbReader>,
     mp_sender: MempoolClientSender,
-    api_config: ApiConfig,
+    node_config: NodeConfig,
 }
 
 impl Context {
@@ -44,13 +44,13 @@ impl Context {
         chain_id: ChainId,
         db: Arc<dyn DbReader>,
         mp_sender: MempoolClientSender,
-        api_config: ApiConfig,
+        node_config: NodeConfig,
     ) -> Self {
         Self {
             chain_id,
             db,
             mp_sender,
-            api_config,
+            node_config,
         }
     }
 
@@ -68,8 +68,12 @@ impl Context {
         self.chain_id
     }
 
+    pub fn node_role(&self) -> RoleType {
+        self.node_config.base.role
+    }
+
     pub fn content_length_limit(&self) -> u64 {
-        self.api_config.content_length_limit()
+        self.node_config.api.content_length_limit()
     }
 
     pub fn filter(self) -> impl Filter<Extract = (Context,), Error = Infallible> + Clone {

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -10,8 +10,9 @@ use crate::{
     metrics::{metrics, status_metrics},
     state, transactions,
 };
-use aptos_api_types::{Error, Response};
-
+use aptos_api_types::{Error, LedgerInfo, Response};
+use aptos_config::config::RoleType;
+use serde::Serialize;
 use std::convert::Infallible;
 use warp::{
     body::BodyDeserializeError,
@@ -24,6 +25,25 @@ use warp::{
 
 const OPEN_API_HTML: &str = include_str!("../doc/spec.html");
 const OPEN_API_SPEC: &str = include_str!("../doc/openapi.yaml");
+
+/// The struct holding all data returned to the client by the
+/// index endpoint (i.e., GET "/"). The data is flattened into
+/// a single JSON map to offer easier parsing for clients.
+#[derive(Serialize)]
+pub struct IndexResponse {
+    #[serde(flatten)]
+    ledger_info: LedgerInfo,
+    node_role: RoleType,
+}
+
+impl IndexResponse {
+    pub fn new(ledger_info: LedgerInfo, node_role: RoleType) -> IndexResponse {
+        Self {
+            ledger_info,
+            node_role,
+        }
+    }
+}
 
 pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
     index(context.clone())
@@ -84,8 +104,10 @@ pub fn index(context: Context) -> BoxedFilter<(impl Reply,)> {
 
 pub async fn handle_index(context: Context) -> Result<impl Reply, Rejection> {
     fail_point("endpoint_index")?;
-    let info = context.get_latest_ledger_info()?;
-    Ok(Response::new(info.clone(), &info)?)
+    let ledger_info = context.get_latest_ledger_info()?;
+    let node_role = context.node_role();
+    let index_response = IndexResponse::new(ledger_info.clone(), node_role);
+    Ok(Response::new(ledger_info, &index_response)?)
 }
 
 async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -29,11 +29,11 @@ pub fn bootstrap(
         .build()
         .expect("[api] failed to create runtime");
 
-    let api_config = config.api.clone();
-    let api = WebServer::from(api_config.clone());
+    let api = WebServer::from(config.api.clone());
+    let node_config = config.clone();
 
     runtime.spawn(async move {
-        let context = Context::new(chain_id, db, mp_sender, api_config);
+        let context = Context::new(chain_id, db, mp_sender, node_config);
         let routes = index::routes(context);
         api.serve(routes).await;
     });

--- a/api/src/tests/index_test.rs
+++ b/api/src/tests/index_test.rs
@@ -5,7 +5,7 @@ use crate::{current_function_name, tests::new_test_context};
 use serde_json::json;
 
 #[tokio::test]
-async fn test_get_ledger_info() {
+async fn test_get_index() {
     let mut context = new_test_context(current_function_name!());
     let resp = context.get("/").await;
     context.check_golden_output(resp);

--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -1,12 +1,16 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{context::Context, index, tests::pretty};
+use crate::{
+    context::Context,
+    index,
+    tests::{golden_output::GoldenOutputs, pretty},
+};
 use aptos_api_types::{
     mime_types, HexEncodedBytes, TransactionOnChainData, X_APTOS_CHAIN_ID,
     X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
 };
-use aptos_config::config::ApiConfig;
+use aptos_config::config::NodeConfig;
 use aptos_crypto::{hash::HashValue, SigningKey};
 use aptos_mempool::mocks::MockSharedMempool;
 use aptos_sdk::{
@@ -28,16 +32,14 @@ use aptos_types::{
 use aptos_vm::AptosVM;
 use aptosdb::AptosDB;
 use bytes::Bytes;
-use executor::db_bootstrapper;
+use executor::{block_executor::BlockExecutor, db_bootstrapper};
 use executor_types::BlockExecutorTrait;
 use hyper::Response;
 use mempool_notifications::MempoolNotificationSender;
 use storage_interface::DbReaderWriter;
 
-use crate::tests::golden_output::GoldenOutputs;
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
-use executor::block_executor::BlockExecutor;
 use rand::SeedableRng;
 use serde_json::{json, Value};
 use std::{boxed::Box, collections::BTreeMap, iter::once, sync::Arc};
@@ -74,7 +76,7 @@ pub fn new_test_context(test_name: &'static str) -> TestContext {
             ChainId::test(),
             db.clone(),
             mempool.ac_client.clone(),
-            ApiConfig::default(),
+            NodeConfig::default(),
         ),
         rng,
         root_key,

--- a/api/types/src/response.rs
+++ b/api/types/src/response.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{Error, LedgerInfo};
-
 use anyhow::Result;
 use serde::Serialize;
 use warp::http::header::{HeaderValue, CONTENT_TYPE};


### PR DESCRIPTION
### Description

This PR updates the index of the REST API (i.e., GET "/") to also return the node type. This will be useful for the health checker as it provides an endpoint that should always be open (as opposed to the metrics port which will typically be closed).

Instead of getting:
```
{"chain_id":17,"epoch":2,"ledger_version":"297097","ledger_timestamp":"1655482318232056"}
```

We now get:
```
{"chain_id":17,"epoch":2,"ledger_version":"295814","ledger_timestamp":"1655482046099160","node_role":"full_node"}
```

Note: I've kept the same flat map structure to ensure that existing clients are not broken when trying to parse the data (e.g., JSON deserialization should just ignore the new field).

### Test Plan
I've updated the golden files for the unit tests and also run a fullnode to ensure the output is as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1466)
<!-- Reviewable:end -->
