### PR TITLE
[Storage][Pruner] Make sure we can disable state and ledger pruner independently

### DIFF
--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -90,7 +90,7 @@ fn test_error_if_version_is_pruned() {
             pruning_batch_size: 1,
         },
     );
-    pruner.testonly_update_min_version(&[5, 10]);
+    pruner.testonly_update_min_version(&[Some(5), Some(10)]);
     let pruner = Some(pruner);
     assert_eq!(
         error_if_version_is_pruned(&pruner, PrunerIndex::StateStorePrunerIndex, "State", 4)

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -30,6 +30,23 @@ proptest! {
         verify_event_store_pruner(event_batches);
     }
 
+        #[test]
+    fn test_event_store_pruner_disabled(
+        mut universe in any_with::<AccountInfoUniverse>(3),
+        gen_batches in vec(vec((any::<Index>(), any::<ContractEventGen>()), 0..=2), 0..4),
+    ) {
+        let event_batches = gen_batches
+            .into_iter()
+            .map(|gens| {
+                gens.into_iter()
+                    .map(|(index, gen)| gen.materialize(*index, &mut universe))
+                    .collect()
+            })
+            .collect();
+
+        verify_event_store_pruner_disabled(event_batches);
+    }
+
 }
 
 fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
@@ -75,6 +92,44 @@ fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
             verify_events_in_store(&events, j as u64, event_store);
             verify_event_by_key_in_store(&events, j as u64, event_store);
             verify_event_by_version_in_store(&events, j as u64, event_store);
+        }
+    }
+}
+
+fn verify_event_store_pruner_disabled(events: Vec<Vec<ContractEvent>>) {
+    let tmp_dir = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp_dir);
+    let event_store = &aptos_db.event_store;
+    let mut cs = ChangeSet::new();
+    let num_versions = events.len();
+    let pruner = Pruner::new(
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
+        StoragePrunerConfig {
+            state_store_prune_window: Some(0),
+            ledger_prune_window: None,
+            pruning_batch_size: 1,
+        },
+    );
+
+    // Write events to DB
+    for (version, events_for_version) in events.iter().enumerate() {
+        event_store
+            .put_events(version as u64, events_for_version, &mut cs)
+            .unwrap();
+    }
+    aptos_db.ledger_db.write_schemas(cs.batch).unwrap();
+
+    // Verify no pruning has happened.
+    for _i in (0..=num_versions).step_by(2) {
+        pruner
+            .ensure_disabled(PrunerIndex::LedgerPrunerIndex as usize)
+            .unwrap();
+        // ensure that all events up to i * 2 are valid in DB
+        for version in 0..num_versions {
+            verify_events_in_store(&events, version as u64, event_store);
+            verify_event_by_key_in_store(&events, version as u64, event_store);
+            verify_event_by_version_in_store(&events, version as u64, event_store);
         }
     }
 }

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -135,6 +135,77 @@ fn test_state_store_pruner() {
 }
 
 #[test]
+fn test_state_store_pruner_disabled() {
+    let key = StateKey::Raw(String::from("test_key1").into_bytes());
+
+    let prune_batch_size = 10;
+    let num_versions = 25;
+    let tmp_dir = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp_dir);
+    let state_store = &StateStore::new(
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
+    );
+    let pruner = Pruner::new(
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
+        StoragePrunerConfig {
+            state_store_prune_window: None,
+            ledger_prune_window: Some(0),
+            pruning_batch_size: prune_batch_size,
+        },
+    );
+
+    let mut root_hashes = vec![];
+    // Insert 25 values in the db.
+    for i in 0..num_versions {
+        let value = StateValue::from(vec![i as u8]);
+        root_hashes.push(put_value_set(
+            &aptos_db.ledger_db,
+            state_store,
+            vec![(key.clone(), value.clone())],
+            i as u64, /* version */
+        ));
+    }
+
+    // Prune till version=0. This should basically be a no-op
+    {
+        pruner
+            .ensure_disabled(PrunerIndex::StateStorePrunerIndex as usize)
+            .unwrap();
+        for i in 0..num_versions {
+            verify_state_in_store(
+                state_store,
+                key.clone(),
+                Some(&StateValue::from(vec![i as u8])),
+                i,
+            );
+        }
+    }
+
+    // Notify the pruner to update the version to be 10 - since we use a batch size of 10,
+    // we expect versions 0 to 9 to be pruned.
+    {
+        pruner
+            .ensure_disabled(PrunerIndex::StateStorePrunerIndex as usize)
+            .unwrap();
+        for i in 0..prune_batch_size {
+            assert!(state_store
+                .get_state_value_with_proof_by_version(&key, i as u64)
+                .is_ok());
+        }
+        for i in 0..num_versions as usize {
+            verify_state_in_store(
+                state_store,
+                key.clone(),
+                Some(&StateValue::from(vec![i as u8])),
+                i as u64,
+            );
+        }
+    }
+}
+
+#[test]
 fn test_worker_quit_eagerly() {
     let key = StateKey::Raw(String::from("test_key1").into_bytes());
 
@@ -172,17 +243,21 @@ fn test_worker_quit_eagerly() {
             Arc::clone(&db),
             Arc::clone(&aptos_db.state_merkle_db),
             command_receiver,
-            Arc::new(Mutex::new(vec![0, 0])), /* progress */
-            100,
+            Arc::new(Mutex::new(vec![Some(0), Some(0)])), /* progress */
+            StoragePrunerConfig {
+                state_store_prune_window: Some(1),
+                ledger_prune_window: Some(1),
+                pruning_batch_size: 100,
+            },
         );
         command_sender
             .send(Command::Prune {
-                target_db_versions: vec![1, 0],
+                target_db_versions: vec![Some(1), Some(0)],
             })
             .unwrap();
         command_sender
             .send(Command::Prune {
-                target_db_versions: vec![2, 0],
+                target_db_versions: vec![Some(2), Some(0)],
             })
             .unwrap();
         command_sender.send(Command::Quit).unwrap();

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -124,7 +124,10 @@ fn verify_txn_store_pruner(
             )
             .unwrap();
         // ensure that all transaction up to i * 2 has been pruned
-        assert_eq!(*pruner.last_version_sent_to_pruners.lock(), i as u64);
+        assert_eq!(
+            *pruner.last_version_sent_to_pruners.as_ref().lock(),
+            i as u64
+        );
         for j in 0..i {
             verify_txn_not_in_store(transaction_store, &txns, j as u64, ledger_version);
         }


### PR DESCRIPTION
### Description
- In `storage/aptosdb/src/pruner/mod.rs`, 
  - make `state_store_prune_window` and `ledger_prune_window` options and make corresponding changes.
  - make `last_version_sent_to_pruners` option and it will be None if both `_prune_window` are None.
  - In `wake_pruner`, send a target db version with value = None if the corresponding pruner is disabled.
- In `storage/aptosdb/src/pruner/worker.rs`
  - When receive the Prune command, only execute the command if the target db version is not None
### Test Plan
- Add a test in `storage/aptosdb/src/pruner/state_store/test.rs` to make state store pruner config None
- Add a test in  `storage/aptosdb/src/pruner/event_store/test.rs` to make ledger store pruner config None.
