### PR TITLE
[ecosystem] Update gzip settings for Cloud Run.

### DIFF
--- a/ecosystem/platform/server/nginx.conf
+++ b/ecosystem/platform/server/nginx.conf
@@ -19,11 +19,17 @@ server {
     # to file uploads. The following line enables uploads of up to 50 MB:
     client_max_body_size 50M;
 
+    # Compression settings
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 10240;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/xml;
+    gzip_disable "MSIE [1-6]\.";
+
     location ~ ^/assets/ {
-      gzip_static on;
       expires max;
       add_header Cache-Control public;
       add_header ETag "";
-      break;
     }
 }


### PR DESCRIPTION
### Description

Adds `gzip_vary` and `gzip_proxied` config per [GCP documentation](https://cloud.google.com/load-balancing/docs/https/troubleshooting-ext-https-lbs#compression-not-working).

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
