### PR TITLE
[consensus] Cache ProposerElection calls

### DIFF
--- a/consensus/src/liveness/cached_proposer_election.rs
+++ b/consensus/src/liveness/cached_proposer_election.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use aptos_infallible::Mutex;
+use consensus_types::common::{Author, Round};
+
+use super::proposer_election::ProposerElection;
+
+// Wrapper around ProposerElection.
+//
+// Function get_valid_proposer can be expensive, and we want to make sure
+// it is computed only once for a given round.
+// Additionally, provides is_valid_proposal that remembers, and rejects if
+// the same leader proposes multiple blocks.
+pub struct CachedProposerElection {
+    proposer_election: Box<dyn ProposerElection + Send + Sync>,
+    // We use BTreeMap since we want a fixed window of cached elements
+    // to look back (and caller knows how big of a window it needs).
+    // LRU cache wouldn't work as well, as access order of the elements
+    // would define eviction, and could lead to evicting still needed elements.
+    recent_elections: Mutex<BTreeMap<Round, Author>>,
+    window: usize,
+}
+
+impl CachedProposerElection {
+    pub fn new(proposer_election: Box<dyn ProposerElection + Send + Sync>, window: usize) -> Self {
+        Self {
+            proposer_election,
+            recent_elections: Mutex::new(BTreeMap::new()),
+            window,
+        }
+    }
+}
+
+impl ProposerElection for CachedProposerElection {
+    fn get_valid_proposer(&self, round: Round) -> Author {
+        let mut recent_elections = self.recent_elections.lock();
+
+        if round > self.window as u64 {
+            *recent_elections = recent_elections.split_off(&(round - self.window as u64));
+        }
+
+        *recent_elections
+            .entry(round)
+            .or_insert_with(|| self.proposer_election.get_valid_proposer(round))
+    }
+}

--- a/consensus/src/liveness/cached_proposer_election_test.rs
+++ b/consensus/src/liveness/cached_proposer_election_test.rs
@@ -1,0 +1,71 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{cell::Cell, sync::Arc};
+
+use aptos_infallible::Mutex;
+use consensus_types::common::{Author, Round};
+
+use crate::liveness::cached_proposer_election::CachedProposerElection;
+
+use super::proposer_election::ProposerElection;
+
+struct MockProposerElection {
+    proposers: Vec<Author>,
+    asked: Arc<Mutex<Cell<u32>>>,
+}
+
+impl MockProposerElection {
+    pub fn new(proposers: Vec<Author>, asked: Arc<Mutex<Cell<u32>>>) -> Self {
+        Self { proposers, asked }
+    }
+}
+
+impl ProposerElection for MockProposerElection {
+    fn get_valid_proposer(&self, round: Round) -> Author {
+        let round_uszie = round as usize;
+        let asked = self.asked.lock();
+        asked.replace(asked.get() + 1);
+        self.proposers[round_uszie % self.proposers.len()]
+    }
+}
+
+#[test]
+fn test_get_valid_proposer_caching() {
+    let asked = Arc::new(Mutex::new(Cell::new(0)));
+    let authors: Vec<Author> = (0..4).map(|_| Author::random()).collect();
+    let cpe = CachedProposerElection::new(
+        Box::new(MockProposerElection::new(authors.clone(), asked.clone())),
+        10,
+    );
+
+    assert_eq!(asked.lock().get(), 0);
+
+    assert_eq!(cpe.get_valid_proposer(0), authors[0]);
+    assert_eq!(asked.lock().get(), 1);
+    assert!(cpe.is_valid_proposer(authors[0], 0));
+    assert!(!cpe.is_valid_proposer(authors[1], 0));
+    assert_eq!(asked.lock().get(), 1);
+
+    assert_eq!(cpe.get_valid_proposer(1), authors[1]);
+    assert_eq!(asked.lock().get(), 2);
+    assert!(cpe.is_valid_proposer(authors[1], 1));
+    assert!(!cpe.is_valid_proposer(authors[0], 1));
+    assert_eq!(asked.lock().get(), 2);
+
+    assert_eq!(cpe.get_valid_proposer(0), authors[0]);
+    assert_eq!(asked.lock().get(), 2);
+
+    assert_eq!(cpe.get_valid_proposer(11), authors[3]);
+    assert_eq!(asked.lock().get(), 3);
+    assert!(cpe.is_valid_proposer(authors[3], 11));
+    assert!(!cpe.is_valid_proposer(authors[0], 11));
+    assert_eq!(asked.lock().get(), 3);
+
+    // round=0 is outside the caching window, and round=1 is still inside
+    assert_eq!(cpe.get_valid_proposer(0), authors[0]);
+    assert_eq!(asked.lock().get(), 4);
+
+    assert_eq!(cpe.get_valid_proposer(1), authors[1]);
+    assert_eq!(asked.lock().get(), 4);
+}

--- a/consensus/src/liveness/mod.rs
+++ b/consensus/src/liveness/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod cached_proposer_election;
 pub(crate) mod leader_reputation;
 pub(crate) mod proposal_generator;
 pub(crate) mod proposer_election;
@@ -9,6 +10,8 @@ pub(crate) mod round_proposer_election;
 pub(crate) mod round_state;
 pub(crate) mod unequivocal_proposer_election;
 
+#[cfg(test)]
+mod cached_proposer_election_test;
 #[cfg(test)]
 mod leader_reputation_test;
 #[cfg(test)]


### PR DESCRIPTION
ProposerElection calls are not cheap, and in the round_manager
we call them multiple times for the same round. We should cache
the calls within the window of rounds that we call it for.
    
Added unit test for it

Closes: #1395