### PR TITLE
[tf][aptos-node/testnet] new testnet with aptos-node

### DIFF
--- a/terraform/aptos-node-testnet/addons.tf
+++ b/terraform/aptos-node-testnet/addons.tf
@@ -1,0 +1,140 @@
+resource "helm_release" "metrics-server" {
+  name        = "metrics-server"
+  namespace   = "kube-system"
+  chart       = "${path.module}/../helm/k8s-metrics"
+  max_history = 5
+  wait        = false
+
+  values = [
+    jsonencode({
+      coredns = {
+        maxReplicas = var.num_validators
+      }
+      autoscaler = {
+        enabled     = true
+        clusterName = module.validator.aws_eks_cluster.name
+        image = {
+          # EKS does not report patch version
+          tag = "v${module.validator.aws_eks_cluster.version}.0"
+        }
+        serviceAccount = {
+          annotations = {
+            "eks.amazonaws.com/role-arn" = aws_iam_role.cluster-autoscaler.arn
+          }
+        }
+      }
+    })
+  ]
+}
+
+
+# access control
+data "aws_iam_policy_document" "cluster-autoscaler-assume-role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${module.validator.oidc_provider}"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.validator.oidc_provider}:sub"
+      # the name of the kube-system cluster-autoscaler service account
+      values = ["system:serviceaccount:kube-system:cluster-autoscaler"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.validator.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cluster-autoscaler" {
+  statement {
+    sid = "Autoscaling"
+    actions = [
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/k8s.io/cluster-autoscaler/${module.validator.aws_eks_cluster.name}"
+      values   = ["owned"]
+    }
+  }
+
+  statement {
+    sid = "DescribeAutoscaling"
+    actions = [
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeAutoScalingGroups",
+      "ec2:DescribeLaunchTemplateVersions",
+      "autoscaling:DescribeTags",
+      "autoscaling:DescribeLaunchConfigurations"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "cluster-autoscaler" {
+  name                 = "aptos-node-testnet-${local.workspace}-cluster-autoscaler"
+  path                 = var.iam_path
+  permissions_boundary = var.permissions_boundary_policy
+  assume_role_policy   = data.aws_iam_policy_document.cluster-autoscaler-assume-role.json
+}
+
+resource "aws_iam_role_policy" "cluster-autoscaler" {
+  name   = "Helm"
+  role   = aws_iam_role.cluster-autoscaler.name
+  policy = data.aws_iam_policy_document.cluster-autoscaler.json
+}
+
+resource "kubernetes_namespace" "chaos-mesh" {
+  metadata {
+    annotations = {
+      name = "chaos-mesh"
+    }
+
+    name = "chaos-mesh"
+  }
+}
+
+resource "helm_release" "chaos-mesh" {
+  name      = "chaos-mesh"
+  namespace = kubernetes_namespace.chaos-mesh.metadata[0].name
+
+  chart       = "${path.module}/../helm/chaos"
+  max_history = 5
+  wait        = false
+
+  values = [
+    jsonencode({
+      # Only create the ingress if an ACM certificate exists
+      ingress = {
+        enable                   = length(aws_acm_certificate.ingress) > 0 ? true : false
+        domain                   = length(aws_acm_certificate.ingress) > 0 ? "chaos.${local.domain}" : ""
+        acm_certificate          = length(aws_acm_certificate.ingress) > 0 ? aws_acm_certificate.ingress[0].arn : null
+        loadBalancerSourceRanges = join(",", var.client_sources_ipv4)
+        aws_tags                 = local.aws_tags
+      }
+      chaos-mesh = {
+        chaosDaemon = {
+          podSecurityPolicy = true
+          # tolerate pod assignment on nodes in the validator nodegroup
+          tolerations = [{
+            key    = "aptos.org/nodepool"
+            value  = "validators"
+            effect = "NoExecute"
+          }]
+        }
+      }
+    })
+  ]
+}

--- a/terraform/aptos-node-testnet/dns.tf
+++ b/terraform/aptos-node-testnet/dns.tf
@@ -1,0 +1,45 @@
+data "aws_route53_zone" "aptos" {
+  count   = var.zone_id != "" ? 1 : 0
+  zone_id = var.zone_id
+}
+
+locals {
+  dns_prefix = var.workspace_dns ? "${terraform.workspace}." : ""
+  domain     = var.zone_id != "" ? "${local.dns_prefix}${data.aws_route53_zone.aptos[0].name}" : null
+}
+
+resource "aws_acm_certificate" "ingress" {
+  count = var.zone_id != "" ? 1 : 0
+
+  domain_name               = local.domain
+  subject_alternative_names = concat(["*.${local.domain}"], var.tls_sans)
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = {
+    Terraform = "testnet"
+    Workspace = terraform.workspace
+  }
+}
+
+resource "aws_route53_record" "ingress-acm-validation" {
+  for_each = var.zone_id == "" ? {} : { for dvo in aws_acm_certificate.ingress[0].domain_validation_options : dvo.domain_name => dvo }
+
+  zone_id         = var.zone_id
+  allow_overwrite = true
+  name            = each.value.resource_record_name
+  type            = each.value.resource_record_type
+  records         = [each.value.resource_record_value]
+  ttl             = 60
+}
+
+resource "aws_acm_certificate_validation" "ingress" {
+  count = var.zone_id != "" ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.ingress[0].arn
+  validation_record_fqdns = [for dvo in aws_acm_certificate.ingress[0].domain_validation_options : dvo.resource_record_name]
+  depends_on              = [aws_route53_record.ingress-acm-validation]
+}

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -1,0 +1,137 @@
+### Infrastructure config 
+
+variable "region" {
+  description = "AWS region"
+}
+
+variable "zone_id" {
+  description = "Route53 Zone ID to create records in"
+  default     = ""
+}
+
+variable "workspace_name_override" {
+  description = "If specified, overrides the usage of Terraform workspace for naming purposes"
+  default     = ""
+}
+
+variable "tls_sans" {
+  description = "List of Subject Alternate Names to include in TLS certificate"
+  type        = list(string)
+  default     = []
+}
+
+variable "workspace_dns" {
+  description = "Include Terraform workspace name in DNS records"
+  default     = true
+}
+
+variable "iam_path" {
+  default     = "/"
+  description = "Path to use when naming IAM objects"
+}
+
+variable "permissions_boundary_policy" {
+  default     = ""
+  description = "ARN of IAM policy to set as permissions boundary on created roles"
+}
+
+variable "admin_sources_ipv4" {
+  description = "List of CIDR subnets which can access Kubernetes API"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "client_sources_ipv4" {
+  description = "List of CIDR subnets which can access the testnet API"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "k8s_admin_roles" {
+  description = "List of AWS roles to configure as Kubernetes administrators"
+  type        = list(string)
+  default     = []
+}
+
+variable "k8s_admins" {
+  description = "List of AWS usernames to configure as Kubernetes administrators"
+  type        = list(string)
+  default     = []
+}
+
+### Testnet config
+
+variable "chain_id" {
+  description = "Aptos chain ID"
+  default     = 4
+}
+
+
+variable "era" {
+  description = "Chain era, used to start a clean chain"
+  default     = 15
+}
+
+variable "chain_name" {
+  description = "Aptos chain name"
+  default     = "devnet"
+}
+
+variable "image_tag" {
+  description = "Docker image tag for Aptos node"
+  default     = "devnet"
+}
+
+### Helm values
+
+variable "aptos_node_helm_values" {
+  description = "Map of values to pass to aptos-node helm chart"
+  type        = any
+  default     = {}
+}
+
+variable "genesis_helm_values" {
+  description = "Map of values to pass to genesis helm chart"
+  type        = any
+  default     = {}
+}
+
+variable "logger_helm_values" {
+  description = "Map of values to pass to logger helm chart"
+  type        = any
+  default     = {}
+}
+
+variable "monitoring_helm_values" {
+  description = "Map of values to pass to monitoring helm chart"
+  type        = any
+  default     = {}
+}
+
+
+### EKS nodegroups
+
+variable "num_validators" {
+  default = 4
+}
+
+variable "num_utility_instance" {
+  description = "Number of instances for utilities node pool, when it's 0, it will be set to var.num_validators"
+  default     = 0
+}
+
+variable "num_validator_instance" {
+  description = "Number of instances for validator node pool, when it's 0, it will be set to 2 * var.num_validators"
+  default     = 0
+}
+
+variable "utility_instance_type" {
+  description = "Instance type used for utilities"
+  default     = "t3.medium"
+}
+
+variable "validator_instance_type" {
+  description = "Instance type used for validator and fullnodes"
+  default     = "c5.xlarge"
+}
+

--- a/terraform/aptos-node/aws/cluster.tf
+++ b/terraform/aptos-node/aws/cluster.tf
@@ -33,12 +33,16 @@ locals {
   pools = {
     utilities = {
       instance_type = var.utility_instance_type
-      size          = var.utility_instance_num
+      min_size      = var.utility_instance_min_num
+      desired_size  = var.utility_instance_num
+      max_size      = var.utility_instance_max_num > 0 ? var.utility_instance_max_num : 2 * var.utility_instance_num
       taint         = false
     }
     validators = {
       instance_type = var.validator_instance_type
-      size          = var.validator_instance_num
+      min_size      = var.validator_instance_min_num
+      desired_size  = var.validator_instance_num
+      max_size      = var.validator_instance_max_num > 0 ? var.validator_instance_max_num : 2 * var.validator_instance_num
       taint         = true
     }
   }
@@ -48,7 +52,7 @@ resource "aws_launch_template" "nodes" {
   for_each      = local.pools
   name          = "aptos-${local.workspace_name}/${each.key}"
   instance_type = each.value.instance_type
-  user_data     = base64encode(
+  user_data = base64encode(
     templatefile("${path.module}/templates/eks_user_data.sh", {
       taints = each.value.taint ? "aptos.org/nodepool=${each.key}:NoExecute" : ""
     })
@@ -71,19 +75,26 @@ resource "aws_eks_node_group" "nodes" {
   subnet_ids      = [aws_subnet.private[0].id]
   tags            = local.default_tags
 
+  lifecycle {
+    ignore_changes = [
+      # ignore changes to the desired size that may occur due to cluster autoscaler
+      scaling_config[0].desired_size
+    ]
+  }
+
   launch_template {
     id      = aws_launch_template.nodes[each.key].id
     version = aws_launch_template.nodes[each.key].latest_version
   }
 
   scaling_config {
-    desired_size = lookup(var.node_pool_sizes, each.key, each.value.size)
-    min_size     = lookup(var.node_pool_sizes, each.key, each.value.size)
-    max_size     = lookup(var.node_pool_sizes, each.key, each.value.size)
+    desired_size = each.value.desired_size
+    min_size     = each.value.min_size
+    max_size     = each.value.max_size
   }
 
   update_config {
-    max_unavailable = 1
+    max_unavailable_percentage = 50
   }
 
   depends_on = [
@@ -92,4 +103,14 @@ resource "aws_eks_node_group" "nodes" {
     aws_iam_role_policy_attachment.nodes-ecr,
     kubernetes_config_map.aws-auth,
   ]
+}
+
+resource "aws_iam_openid_connect_provider" "cluster" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"] # Thumbprint of Root CA for EKS OIDC, Valid until 2037
+  url             = aws_eks_cluster.aptos.identity[0].oidc[0].issuer
+}
+
+locals {
+  oidc_provider = replace(aws_iam_openid_connect_provider.cluster.url, "https://", "")
 }

--- a/terraform/aptos-node/aws/dns.tf
+++ b/terraform/aptos-node/aws/dns.tf
@@ -46,11 +46,3 @@ resource "aws_route53_record" "fullnode" {
   ttl     = 3600
   records = [data.kubernetes_service.fullnode-lb[0].status[0].load_balancer[0].ingress[0].hostname]
 }
-
-output "validator_endpoint" {
-  value = var.zone_id != "" ? "/dns4/${aws_route53_record.validator[0].fqdn}/tcp/${data.kubernetes_service.validator-lb[0].spec[0].port[0].port}" : null
-}
-
-output "fullnode_endpoint" {
-  value = var.zone_id != "" ? "/dns4/${aws_route53_record.fullnode[0].fqdn}/tcp/${data.kubernetes_service.fullnode-lb[0].spec[0].port[0].port}" : null
-}

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -95,7 +95,8 @@ resource "helm_release" "calico" {
 
 locals {
   helm_values = jsonencode({
-    imageTag = var.image_tag
+    numValidators = var.num_validators
+    imageTag      = var.image_tag
     chain = {
       era        = var.era
       chain_id   = var.chain_id
@@ -140,7 +141,7 @@ resource "helm_release" "validator" {
   count       = var.helm_enable_validator ? 1 : 0
   name        = local.workspace_name
   chart       = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
-  max_history = 100
+  max_history = 5
   wait        = false
 
   values = [
@@ -159,7 +160,7 @@ resource "helm_release" "logger" {
   count       = var.enable_logger ? 1 : 0
   name        = "${local.workspace_name}-log"
   chart       = "${path.module}/../../helm/logger"
-  max_history = 10
+  max_history = 5
   wait        = false
 
   values = [
@@ -172,6 +173,7 @@ resource "helm_release" "logger" {
       }
       serviceAccount = {
         create = false
+        # this name must match the serviceaccount created by the aptos-node helm chart
         name = "${local.workspace_name}-aptos-node-validator"
       }
     }),
@@ -188,7 +190,7 @@ resource "helm_release" "monitoring" {
   count       = var.enable_monitoring ? 1 : 0
   name        = "${local.workspace_name}-mon"
   chart       = "${path.module}/../../helm/monitoring"
-  max_history = 10
+  max_history = 5
   wait        = false
 
   values = [

--- a/terraform/aptos-node/aws/network.tf
+++ b/terraform/aptos-node/aws/network.tf
@@ -194,28 +194,3 @@ resource "aws_security_group_rule" "nodes-egress" {
   cidr_blocks       = ["0.0.0.0/0"]
   description       = "Allow all outgoing traffic"
 }
-
-output "vpc_id" {
-  value     = aws_vpc.vpc.id
-  sensitive = true
-}
-
-output "aws_subnet_public" {
-  value     = aws_subnet.public
-}
-
-output "aws_subnet_private" {
-  value     = aws_subnet.private
-}
-
-output "aws_vpc_cidr_block" {
-  value = aws_vpc.vpc.cidr_block
-}
-
-output "aws_eip_nat_public_ip" {
-  value = aws_eip.nat.public_ip
-}
-
-output "cluster_security_group_id" {
-  value = aws_eks_cluster.aptos.vpc_config[0].cluster_security_group_id
-}

--- a/terraform/aptos-node/aws/outputs.tf
+++ b/terraform/aptos-node/aws/outputs.tf
@@ -1,0 +1,56 @@
+output "helm_release_name" {
+  value = helm_release.validator[0].name
+}
+
+output "aws_eks_cluster" {
+  value     = aws_eks_cluster.aptos
+  sensitive = true
+}
+
+output "aws_eks_cluster_auth_token" {
+  value     = data.aws_eks_cluster_auth.aptos.token
+  sensitive = true
+}
+
+output "oidc_provider" {
+  value     = local.oidc_provider
+  sensitive = true
+}
+
+
+### Node outputs
+
+output "validator_endpoint" {
+  value = var.zone_id != "" ? "/dns4/${aws_route53_record.validator[0].fqdn}/tcp/${data.kubernetes_service.validator-lb[0].spec[0].port[0].port}" : null
+}
+
+output "fullnode_endpoint" {
+  value = var.zone_id != "" ? "/dns4/${aws_route53_record.fullnode[0].fqdn}/tcp/${data.kubernetes_service.fullnode-lb[0].spec[0].port[0].port}" : null
+}
+
+### Network outputs
+
+output "vpc_id" {
+  value     = aws_vpc.vpc.id
+  sensitive = true
+}
+
+output "aws_subnet_public" {
+  value = aws_subnet.public
+}
+
+output "aws_subnet_private" {
+  value = aws_subnet.private
+}
+
+output "aws_vpc_cidr_block" {
+  value = aws_vpc.vpc.cidr_block
+}
+
+output "aws_eip_nat_public_ip" {
+  value = aws_eip.nat.public_ip
+}
+
+output "cluster_security_group_id" {
+  value = aws_eks_cluster.aptos.vpc_config[0].cluster_security_group_id
+}

--- a/terraform/aptos-node/aws/terraform.tfvars
+++ b/terraform/aptos-node/aws/terraform.tfvars
@@ -1,6 +1,4 @@
 #region = ""  # Specify the region
 #validator_name = ""  # Specify your validator node owner
-#ssh_pub_key     = ""  # Specify the content of your SSH public key (e.g. from `ssh-keygen -f ec2_rsa`)
-#ssh_sources_ipv4 = ["0.0.0.0/0"]  # Optionally specify IP ranges which can SSH to the bastion host
 #k8s_api_sources = ["0.0.0.0/0"]  # Optionally specify IP ranges which can access the Kubernetes API
 #zone_id = ""  # Optionally specify a Route 53 zone ID to create DNS records in

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -8,19 +8,23 @@ variable "k8s_api_sources" {
   default     = ["0.0.0.0/0"]
 }
 
+variable "num_validators" {
+  default = 1
+}
+
 variable "era" {
   description = "Chain era, used to start a clean chain"
-  default = 1
+  default     = 1
 }
 
 variable "chain_id" {
   description = "Aptos chain ID"
-  default = "TESTING"
+  default     = "TESTING"
 }
 
 variable "chain_name" {
   description = "Aptos chain name"
-  default = "testnet"
+  default     = "testnet"
 }
 
 variable "validator_name" {
@@ -120,11 +124,6 @@ variable "helm_enable_validator" {
   default     = true
 }
 
-variable "helm_release_name" {
-  description = "Override the Helm release name used when referencing Kubernetes service accounts"
-  default     = ""
-}
-
 variable "utility_instance_type" {
   description = "Instance type used for utilities"
   default     = "t3.medium"
@@ -133,6 +132,16 @@ variable "utility_instance_type" {
 variable "utility_instance_num" {
   description = "Number of instances for utilities"
   default     = 1
+}
+
+variable "utility_instance_min_num" {
+  description = "Minimum number of instances for utilities"
+  default     = 1
+}
+
+variable "utility_instance_max_num" {
+  description = "Maximum number of instances for utilities. If left 0, defaults to 2 * var.utility_instance_num"
+  default     = 0
 }
 
 variable "validator_instance_type" {
@@ -145,10 +154,14 @@ variable "validator_instance_num" {
   default     = 2
 }
 
-variable "node_pool_sizes" {
-  type        = map(number)
-  default     = {}
-  description = "Override the number of nodes in the specified pool"
+variable "validator_instance_min_num" {
+  description = "Minimum number of instances for validators"
+  default     = 1
+}
+
+variable "validator_instance_max_num" {
+  description = "Maximum number of instances for utilities. If left 0, defaults to 2 * var.validator_instance_num"
+  default     = 0
 }
 
 variable "workspace_name_override" {

--- a/terraform/aptos-node/azure/kubernetes.tf
+++ b/terraform/aptos-node/azure/kubernetes.tf
@@ -17,7 +17,7 @@ provider "helm" {
 resource "helm_release" "validator" {
   name        = terraform.workspace
   chart       = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
-  max_history = 100
+  max_history = 5
   wait        = false
 
   values = [

--- a/terraform/aptos-node/azure/terraform.tfvars
+++ b/terraform/aptos-node/azure/terraform.tfvars
@@ -1,7 +1,5 @@
 #region = ""  # Specify the region
 #validator_name = ""  # Specify your validator node owner
-#ssh_pub_key     = ""  # Specify the content of your SSH public key (e.g. from `ssh-keygen -f az_rsa`)
-#ssh_sources_ipv4 = ["0.0.0.0/0"]  # Optionally specify IP ranges which can SSH to the bastion host
 #k8s_api_sources = ["0.0.0.0/0"]  # Optionally specify IP ranges which can access the Kubernetes API
 #zone_name = ""  # Optionally specify an Azure DNS zone name to create DNS records in
 #zone_resource_group = ""  # Name of the resource group the DNS zone is in

--- a/terraform/aptos-node/gcp/kubernetes.tf
+++ b/terraform/aptos-node/gcp/kubernetes.tf
@@ -26,7 +26,7 @@ provider "helm" {
 resource "helm_release" "validator" {
   name        = terraform.workspace
   chart       = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
-  max_history = 100
+  max_history = 5
   wait        = false
 
   values = [

--- a/terraform/aptos-node/gcp/terraform.tfvars
+++ b/terraform/aptos-node/gcp/terraform.tfvars
@@ -1,11 +1,6 @@
 #region = ""  # Specify the region
 #zone = ""  # Specify the zone suffix
 #validator_name = ""  # Specify your validator node owner
-#ssh_sources_ipv4 = ["0.0.0.0/0"]  # Optionally specify IP ranges which can SSH to the bastion host
 #k8s_api_sources = ["0.0.0.0/0"]  # Optionally specify IP ranges which can access the Kubernetes API
-#
-#ssh_keys = {
-# user1 = "ssh-rsa ..."  # Specify your username and content of your SSH public key (e.g. from `ssh-keygen -f gcp_rsa`)
-#}
 #zone_name = "" # Optionally specify a GCP Cloud DNS zone name to create DNS records in
 #zone_project = "" # GCP project which the DNS zone is in


### PR DESCRIPTION
Stacked on https://github.com/aptos-labs/aptos-core/pull/1419. Only review latest commit

Creates new TF module `aptos-node-testnet` which invokes the `aptos-node` AWS terraform to spin up a cluster, and install validators. Also installs chaos mesh, cluster autoscaler, monitoring, and logging, by default.

Also, reorganize some variables in `aptos-node` AWS terraform:
* more customization for EKS nodegroup sizes (min, desired, and max) for compatibility with cluster autoscaler
* output some values for use by `aptos-node-testnet`

# Test

Invoke the Terraform module via submodule. e.g.

```
module "aptos-testnet" {
  source = "../../../../aptos-core/terraform/aptos-node-testnet/"

  era            = "5"
  num_validators = 4
  image_tag      = "265eca19f26b61c9994ba5a30d711fd749efc5cb"

... <CUSTOMIZATION>
}
```

Then check the created k8s cluster to see everything is running. Check the REST API by port forwarding:

```
$ kubectl port-forward svc/rustie-test-aptos-node-3-validator-lb 8080:80

$ curl localhost:8080
{"chain_id":4,"epoch":2,"ledger_version":"10419","ledger_timestamp":"1655504998622632"}%
```