### PR TITLE
[consensus] ensure the reset waits for all ongoing tasks finish

### DIFF
--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 
 use futures::{
     channel::{
@@ -90,6 +93,8 @@ pub struct BufferManager {
     stop: bool,
 
     verifier: ValidatorVerifier,
+
+    ongoing_tasks: Arc<AtomicU64>,
 }
 
 impl BufferManager {
@@ -105,6 +110,7 @@ impl BufferManager {
         block_rx: UnboundedReceiver<OrderedBlocks>,
         reset_rx: UnboundedReceiver<ResetRequest>,
         verifier: ValidatorVerifier,
+        ongoing_tasks: Arc<AtomicU64>,
     ) -> Self {
         let buffer = Buffer::<BufferItem>::new();
 
@@ -131,6 +137,7 @@ impl BufferManager {
             stop: false,
 
             verifier,
+            ongoing_tasks,
         }
     }
 
@@ -240,7 +247,7 @@ impl BufferManager {
     }
 
     /// It pops everything in the buffer and if reconfig flag is set, it stops the main loop
-    fn process_reset_request(&mut self, request: ResetRequest) {
+    async fn process_reset_request(&mut self, request: ResetRequest) {
         let ResetRequest { tx, stop } = request;
         debug!("Receive reset");
 
@@ -248,6 +255,10 @@ impl BufferManager {
         self.buffer = Buffer::new();
         self.execution_root = None;
         self.signing_root = None;
+        // Wait for ongoing tasks to finish before sending back ack.
+        while self.ongoing_tasks.load(Ordering::SeqCst) > 0 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
 
         tx.send(sync_ack_new()).unwrap();
     }
@@ -418,7 +429,7 @@ impl BufferManager {
                     }
                 }
                 Some(reset_event) = self.reset_rx.next() => {
-                    self.process_reset_request(reset_event);
+                    self.process_reset_request(reset_event).await;
                 }
                 Some(response) = self.execution_phase_rx.next() => {
                     self.process_execution_response(response).await;

--- a/consensus/src/experimental/pipeline_phase.rs
+++ b/consensus/src/experimental/pipeline_phase.rs
@@ -4,6 +4,10 @@
 use crate::experimental::buffer_manager::{Receiver, Sender};
 use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
 
 #[async_trait]
 pub trait StatelessPipeline: Send + Sync {
@@ -16,6 +20,7 @@ pub struct PipelinePhase<T: StatelessPipeline> {
     rx: Receiver<T::Request>,
     maybe_tx: Option<Sender<T::Response>>,
     processor: Box<T>,
+    ongoing_tasks: Arc<AtomicU64>,
 }
 
 impl<T: StatelessPipeline> PipelinePhase<T> {
@@ -23,18 +28,22 @@ impl<T: StatelessPipeline> PipelinePhase<T> {
         rx: Receiver<T::Request>,
         maybe_tx: Option<Sender<T::Response>>,
         processor: Box<T>,
+        ongoing_tasks: Arc<AtomicU64>,
     ) -> Self {
         Self {
             rx,
             maybe_tx,
             processor,
+            ongoing_tasks,
         }
     }
 
     pub async fn start(mut self) {
         // main loop
         while let Some(req) = self.rx.next().await {
+            self.ongoing_tasks.fetch_add(1, Ordering::SeqCst);
             let response = self.processor.process(req).await;
+            self.ongoing_tasks.fetch_sub(1, Ordering::SeqCst);
             if let Some(tx) = &mut self.maybe_tx {
                 if tx.send(response).await.is_err() {
                     break;

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{atomic::AtomicU64, Arc};
 
 use aptos_crypto::HashValue;
 use aptos_types::{ledger_info::LedgerInfo, validator_verifier::random_validator_verifier};
@@ -94,6 +94,7 @@ fn execution_phase_tests() {
         in_channel_rx,
         Some(out_channel_tx),
         Box::new(execution_phase),
+        Arc::new(AtomicU64::new(0)),
     );
 
     runtime.spawn(execution_phase_pipeline.start());

--- a/consensus/src/experimental/tests/signing_phase_tests.rs
+++ b/consensus/src/experimental/tests/signing_phase_tests.rs
@@ -23,7 +23,10 @@ use aptos_types::{
     validator_signer::ValidatorSigner,
 };
 use safety_rules::Error;
-use std::collections::BTreeMap;
+use std::{
+    collections::BTreeMap,
+    sync::{atomic::AtomicU64, Arc},
+};
 
 pub fn prepare_signing_pipeline(
     signing_phase: SigningPhase,
@@ -36,8 +39,12 @@ pub fn prepare_signing_pipeline(
     let (in_channel_tx, in_channel_rx) = create_channel::<SigningRequest>();
     let (out_channel_tx, out_channel_rx) = create_channel::<SigningResponse>();
 
-    let signing_phase_pipeline =
-        PipelinePhase::new(in_channel_rx, Some(out_channel_tx), Box::new(signing_phase));
+    let signing_phase_pipeline = PipelinePhase::new(
+        in_channel_rx,
+        Some(out_channel_tx),
+        Box::new(signing_phase),
+        Arc::new(AtomicU64::new(0)),
+    );
 
     (in_channel_tx, out_channel_rx, signing_phase_pipeline)
 }


### PR DESCRIPTION
It's a race condition when PersistingPhase has an ongoing request to commit while reset is acknowledged and switch to state sync.
And state sync will try to commit to db as well and result in corrupted db.

We'll make sure db is thread-safe in a separate commit, but this ensures we avoid this specefic race condition.