### PR TITLE
[crypto] replace aes-gcm crate with ring crate in noise.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,6 @@ dependencies = [
 name = "aptos-crypto"
 version = "0.0.3"
 dependencies = [
- "aes-gcm",
  "anyhow",
  "aptos-crypto-derive",
  "aptos-workspace-hack",
@@ -302,6 +301,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rand_core 0.5.1",
+ "ring",
  "ripemd160",
  "serde 1.0.137",
  "serde-name",
@@ -2690,7 +2690,7 @@ dependencies = [
  "diesel_derives",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.1.43",
+ "num-traits 0.2.15",
  "pq-sys",
  "r2d2",
  "serde_json",
@@ -7358,7 +7358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static 1.4.0",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -8701,7 +8701,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/crates/aptos-crypto/Cargo.toml
+++ b/crates/aptos-crypto/Cargo.toml
@@ -10,7 +10,6 @@ publish = ["crates-io"]
 edition = "2018"
 
 [dependencies]
-aes-gcm = "0.9.4"
 anyhow = "1.0.57"
 bcs = "0.1.3"
 blst = "0.3.7"
@@ -26,6 +25,7 @@ proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 rand = "0.7.3"
 rand_core = { version = "0.5.1", default-features = false }
+ring = { version = "0.16.20", features = ["std"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde-name = "0.1.1"
 serde_bytes = "0.11.6"

--- a/crates/aptos-crypto/benches/noise.rs
+++ b/crates/aptos-crypto/benches/noise.rs
@@ -23,9 +23,9 @@ const MSG_SIZE: usize = 4096;
 
 fn benchmarks(c: &mut Criterion) {
     // bench the handshake
-    let mut group = c.benchmark_group("handshake");
+    let mut group = c.benchmark_group("noise-handshake");
     group.throughput(Throughput::Elements(1));
-    group.bench_function("xx", |b| {
+    group.bench_function("connect", |b| {
         // setup keys first
         let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);
         let initiator_static = x25519::PrivateKey::generate(&mut rng);
@@ -72,10 +72,10 @@ fn benchmarks(c: &mut Criterion) {
     });
     group.finish();
 
-    let mut transport_group = c.benchmark_group("transport");
+    let mut transport_group = c.benchmark_group("noise-transport");
     transport_group.throughput(Throughput::Bytes(MSG_SIZE as u64 * 2));
     transport_group.bench_function("AES-GCM throughput", |b| {
-        let mut buffer_msg = [0u8; MSG_SIZE * 2];
+        let mut buffer_msg = [0u8; MSG_SIZE + AES_GCM_TAGLEN];
 
         // setup keys first
         let mut rng = ::rand::rngs::StdRng::from_seed(TEST_SEED);


### PR DESCRIPTION
### Description

AES encryption in our custom [Noise protocol](http://www.noiseprotocol.org/) implementation was a bit slow on Apple M1.
This PR switches out the `aes-gcm` crate with the `ring` crate for a faster AES implementation.

We get ~17x improvement on Apple M1 and ~3x improvement on x86.

### Previous M1 performance

```
noise-transport/AES-GCM throughput
                        time:   [59.676 us 59.742 us 59.820 us]
                        thrpt:  [130.60 MiB/s 130.77 MiB/s 130.92 MiB/s]
```

### Better M1 performance

```
noise-transport/AES-GCM throughput
                        time:   [3.2379 us 3.2386 us 3.2393 us]
                        thrpt:  [2.3553 GiB/s 2.3558 GiB/s 2.3562 GiB/s]
                 change:
                        time:   [-94.573% -94.562% -94.551%] (p = 0.00 < 0.05)
                        thrpt:  [+1735.2% +1739.1% +1742.7%]
                        Performance has improved.
```

### Previous x86 performance (from @msmouse)

```
transport/AES-GCM throughput
                        time:   [8.3833 us 8.4206 us 8.4648 us]
                        thrpt:  [922.94 MiB/s 927.78 MiB/s 931.91 MiB/s]
  5 (5.00%) high mild
```

### New x86 performance (from @msmouse)
```
noise-transport/AES-GCM throughput
                        time:   [3.4196 us 3.4330 us 3.4469 us]
                        thrpt:  [2.2134 GiB/s 2.2224 GiB/s 2.2311 GiB/s]
```