### PR TITLE
[consensus] Add failed_authors to Block

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -30,6 +30,7 @@ pub struct ConsensusConfig {
     // the period = (poll_count - 1) * 30ms
     pub quorum_store_poll_count: u64,
     pub intra_consensus_channel_buffer_size: usize,
+    pub max_failed_authors_to_store: usize,
 }
 
 impl Default for ConsensusConfig {
@@ -52,6 +53,7 @@ impl Default for ConsensusConfig {
             quorum_store_pull_timeout_ms: 1000,
             quorum_store_poll_count: 20,
             intra_consensus_channel_buffer_size: 10,
+            max_failed_authors_to_store: 10,
         }
     }
 }

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -46,6 +46,7 @@ prop_compose! {
             aptos_infallible::duration_since_epoch().as_micros() as u64,
             parent_qc,
             &signer,
+            Vec::new(),
         )
     }
 }
@@ -87,6 +88,7 @@ prop_compose! {
                 block_data: BlockData::new_proposal(
                     block.payload().unwrap().clone(),
                     block.author().unwrap(),
+                    (*block.block_data().failed_authors().unwrap()).clone(),
                     block.round(),
                     aptos_infallible::duration_since_epoch().as_micros() as u64,
                     block.quorum_cert().clone(),

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -98,7 +98,8 @@ prop_compose! {
     ) -> BlockType {
         BlockType::Proposal{
             payload: Payload::DirectMempool(txns),
-            author
+            author,
+            failed_authors: Vec::new(),
         }
     }
 }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -68,6 +68,7 @@ pub fn make_proposal_with_qc_and_proof(
             qc.certified_block().timestamp_usecs() + 1,
             qc,
             validator_signer,
+            Vec::new(),
         ),
         None,
         false,

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -350,6 +350,7 @@ async fn test_illegal_timestamp() {
         genesis.timestamp_usecs(),
         certificate_for_genesis(),
         &signer,
+        Vec::new(),
     );
     let result = block_store
         .execute_and_insert_block(block_with_illegal_timestamp)

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -69,8 +69,8 @@ use std::{
 };
 
 /// Range of rounds (window) that we might be calling proposer election
-/// functions with at any given time.
-const PROPSER_ELECTION_CACHING_WINDOW: usize = 3;
+/// functions with at any given time, in addition to the proposer history length.
+const PROPSER_ELECTION_CACHING_WINDOW_ADDITION: usize = 3;
 
 #[allow(clippy::large_enum_variant)]
 pub enum LivenessStorageData {
@@ -218,7 +218,8 @@ impl EpochManager {
                 // LeaderReputation is not cheap, so we can cache the amount of rounds round_manager needs.
                 Box::new(CachedProposerElection::new(
                     proposer_election,
-                    PROPSER_ELECTION_CACHING_WINDOW,
+                    self.config.max_failed_authors_to_store
+                        + PROPSER_ELECTION_CACHING_WINDOW_ADDITION,
                 ))
             }
             ConsensusProposerType::RoundProposer(round_proposers) => {
@@ -490,6 +491,7 @@ impl EpochManager {
             Arc::new(payload_manager),
             self.time_service.clone(),
             self.config.max_block_size,
+            self.config.max_failed_authors_to_store,
         );
 
         let mut round_manager = RoundManager::new(

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -36,7 +36,14 @@ fn add_execution_phase_test_cases(
 ) {
     let genesis_qc = certificate_for_genesis();
     let (signers, _validators) = random_validator_verifier(1, None, false);
-    let block = Block::new_proposal(Payload::new_empty(), 1, 1, genesis_qc, &signers[0]);
+    let block = Block::new_proposal(
+        Payload::new_empty(),
+        1,
+        1,
+        genesis_qc,
+        &signers[0],
+        Vec::new(),
+    );
 
     // happy path
     phase_tester.add_test_case(
@@ -64,7 +71,8 @@ fn add_execution_phase_test_cases(
         &LedgerInfo::mock_genesis(None),
         random_hash_value,
     );
-    let bad_block = Block::new_proposal(Payload::new_empty(), 1, 1, bad_qc, &signers[0]);
+    let bad_block =
+        Block::new_proposal(Payload::new_empty(), 1, 1, bad_qc, &signers[0], Vec::new());
     phase_tester.add_test_case(
         ExecutionRequest {
             ordered_blocks: vec![ExecutedBlock::new(

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -3,12 +3,18 @@
 
 use crate::{
     block_storage::BlockReader,
-    liveness::proposal_generator::ProposalGenerator,
+    liveness::{
+        proposal_generator::ProposalGenerator, rotating_proposer_election::RotatingProposer,
+        unequivocal_proposer_election::UnequivocalProposerElection,
+    },
     test_utils::{build_empty_tree, MockPayloadManager, TreeInserter},
     util::mock_time_service::SimulatedTimeService,
 };
 use aptos_types::validator_signer::ValidatorSigner;
-use consensus_types::block::{block_test_utils::certificate_for_genesis, Block};
+use consensus_types::{
+    block::{block_test_utils::certificate_for_genesis, Block},
+    common::Author,
+};
 use futures::{future::BoxFuture, FutureExt};
 use std::sync::Arc;
 
@@ -26,22 +32,26 @@ async fn test_proposal_generation_empty_tree() {
         Arc::new(MockPayloadManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
+        10,
     );
+    let mut proposer_election =
+        UnequivocalProposerElection::new(Box::new(RotatingProposer::new(vec![signer.author()], 1)));
     let genesis = block_store.ordered_root();
 
     // Generate proposals for an empty tree.
     let proposal_data = proposal_generator
-        .generate_proposal(1, empty_callback())
+        .generate_proposal(1, &mut proposer_election, empty_callback())
         .await
         .unwrap();
     let proposal = Block::new_proposal_from_block_data(proposal_data, &signer);
     assert_eq!(proposal.parent_id(), genesis.id());
     assert_eq!(proposal.round(), 1);
     assert_eq!(proposal.quorum_cert().certified_block().id(), genesis.id());
+    assert_eq!(proposal.block_data().failed_authors().unwrap().len(), 0);
 
     // Duplicate proposals on the same round are not allowed
     let proposal_err = proposal_generator
-        .generate_proposal(1, empty_callback())
+        .generate_proposal(1, &mut proposer_election, empty_callback())
         .await
         .err();
     assert!(proposal_err.is_some());
@@ -57,7 +67,12 @@ async fn test_proposal_generation_parent() {
         Arc::new(MockPayloadManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
+        10,
     );
+    let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
+        vec![inserter.signer().author()],
+        1,
+    )));
     let genesis = block_store.ordered_root();
     let a1 = inserter
         .insert_block_with_qc(certificate_for_genesis(), &genesis, 1)
@@ -66,36 +81,47 @@ async fn test_proposal_generation_parent() {
         .insert_block_with_qc(certificate_for_genesis(), &genesis, 2)
         .await;
 
+    let original_res = proposal_generator
+        .generate_proposal(10, &mut proposer_election, empty_callback())
+        .await
+        .unwrap();
     // With no certifications the parent is genesis
     // generate proposals for an empty tree.
-    assert_eq!(
-        proposal_generator
-            .generate_proposal(10, empty_callback())
-            .await
-            .unwrap()
-            .parent_id(),
-        genesis.id()
-    );
+    assert_eq!(original_res.parent_id(), genesis.id());
+    // test that we have authors for the skipped rounds (1, 2, .. 9)
+    assert_eq!(original_res.failed_authors().unwrap().len(), 9);
+    assert_eq!(original_res.failed_authors().unwrap().first().unwrap().0, 1);
+    assert_eq!(original_res.failed_authors().unwrap().last().unwrap().0, 9);
 
     // Once a1 is certified, it should be the one to choose from
     inserter.insert_qc_for_block(a1.as_ref(), None);
     let a1_child_res = proposal_generator
-        .generate_proposal(11, empty_callback())
+        .generate_proposal(11, &mut proposer_election, empty_callback())
         .await
         .unwrap();
     assert_eq!(a1_child_res.parent_id(), a1.id());
     assert_eq!(a1_child_res.round(), 11);
     assert_eq!(a1_child_res.quorum_cert().certified_block().id(), a1.id());
 
+    // test that we have authors for the skipped rounds (2, 3, .. 10)
+    assert_eq!(a1_child_res.failed_authors().unwrap().len(), 9);
+    assert_eq!(a1_child_res.failed_authors().unwrap().first().unwrap().0, 2);
+    assert_eq!(a1_child_res.failed_authors().unwrap().last().unwrap().0, 10);
+
     // Once b1 is certified, it should be the one to choose from
     inserter.insert_qc_for_block(b1.as_ref(), None);
     let b1_child_res = proposal_generator
-        .generate_proposal(12, empty_callback())
+        .generate_proposal(15, &mut proposer_election, empty_callback())
         .await
         .unwrap();
     assert_eq!(b1_child_res.parent_id(), b1.id());
-    assert_eq!(b1_child_res.round(), 12);
+    assert_eq!(b1_child_res.round(), 15);
     assert_eq!(b1_child_res.quorum_cert().certified_block().id(), b1.id());
+
+    // test that we have authors for the skipped rounds (5,  .. 14), as the limit of 10 has been reached
+    assert_eq!(b1_child_res.failed_authors().unwrap().len(), 10);
+    assert_eq!(b1_child_res.failed_authors().unwrap().first().unwrap().0, 5);
+    assert_eq!(b1_child_res.failed_authors().unwrap().last().unwrap().0, 14);
 }
 
 #[tokio::test]
@@ -108,7 +134,12 @@ async fn test_old_proposal_generation() {
         Arc::new(MockPayloadManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
+        10,
     );
+    let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
+        vec![inserter.signer().author()],
+        1,
+    )));
     let genesis = block_store.ordered_root();
     let a1 = inserter
         .insert_block_with_qc(certificate_for_genesis(), &genesis, 1)
@@ -116,8 +147,45 @@ async fn test_old_proposal_generation() {
     inserter.insert_qc_for_block(a1.as_ref(), None);
 
     let proposal_err = proposal_generator
-        .generate_proposal(1, empty_callback())
+        .generate_proposal(1, &mut proposer_election, empty_callback())
         .await
         .err();
     assert!(proposal_err.is_some());
+}
+
+#[tokio::test]
+async fn test_correct_failed_authors() {
+    let inserter = TreeInserter::default();
+    let author = inserter.signer().author();
+    let peer1 = Author::random();
+    let peer2 = Author::random();
+    let block_store = inserter.block_store();
+    let mut proposal_generator = ProposalGenerator::new(
+        author,
+        block_store.clone(),
+        Arc::new(MockPayloadManager::new(None)),
+        Arc::new(SimulatedTimeService::new()),
+        1,
+        10,
+    );
+    let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
+        vec![author, peer1, peer2],
+        1,
+    )));
+    let genesis = block_store.ordered_root();
+
+    let result = proposal_generator
+        .generate_proposal(6, &mut proposer_election, empty_callback())
+        .await
+        .unwrap();
+    // With no certifications the parent is genesis
+    // generate proposals for an empty tree.
+    assert_eq!(result.parent_id(), genesis.id());
+    // test that we have authors for the skipped rounds (1, 2, .. 5)
+    assert_eq!(result.failed_authors().unwrap().len(), 5);
+    assert_eq!(result.failed_authors().unwrap()[0], (1, peer1));
+    assert_eq!(result.failed_authors().unwrap()[1], (2, peer2));
+    assert_eq!(result.failed_authors().unwrap()[2], (3, author));
+    assert_eq!(result.failed_authors().unwrap()[3], (4, peer1));
+    assert_eq!(result.failed_authors().unwrap()[4], (5, peer2));
 }

--- a/consensus/src/liveness/unequivocal_proposer_election_test.rs
+++ b/consensus/src/liveness/unequivocal_proposer_election_test.rs
@@ -45,6 +45,7 @@ fn test_is_valid_proposal() {
         1,
         quorum_cert.clone(),
         &chosen_validator_signer,
+        Vec::new(),
     );
     let bad_author_proposal = Block::new_proposal(
         Payload::new_empty(),
@@ -52,6 +53,7 @@ fn test_is_valid_proposal() {
         1,
         quorum_cert.clone(),
         &another_validator_signer,
+        Vec::new(),
     );
     let bad_duplicate_proposal = Block::new_proposal(
         Payload::new_empty(),
@@ -59,6 +61,7 @@ fn test_is_valid_proposal() {
         2,
         quorum_cert.clone(),
         &chosen_validator_signer,
+        Vec::new(),
     );
     let next_good_proposal = Block::new_proposal(
         Payload::new_empty(),
@@ -66,6 +69,7 @@ fn test_is_valid_proposal() {
         3,
         quorum_cert.clone(),
         &chosen_validator_signer,
+        Vec::new(),
     );
     let next_bad_duplicate_proposal = Block::new_proposal(
         Payload::new_empty(),
@@ -73,6 +77,7 @@ fn test_is_valid_proposal() {
         4,
         quorum_cert,
         &chosen_validator_signer,
+        Vec::new(),
     );
 
     let pe =

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -614,7 +614,14 @@ mod tests {
         );
         let previous_qc = certificate_for_genesis();
         let proposal = ProposalMsg::new(
-            Block::new_proposal(Payload::new_empty(), 1, 1, previous_qc.clone(), &signers[0]),
+            Block::new_proposal(
+                Payload::new_empty(),
+                1,
+                1,
+                previous_qc.clone(),
+                &signers[0],
+                Vec::new(),
+            ),
             SyncInfo::new(previous_qc.clone(), previous_qc, None),
         );
         timed_block_on(&mut runtime, async {

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -145,6 +145,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         Arc::new(MockPayloadManager::new(None)),
         time_service,
         1,
+        10,
     );
 
     //

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -7,7 +7,7 @@ use aptos_logger::Level;
 use aptos_types::{ledger_info::LedgerInfo, validator_signer::ValidatorSigner};
 use consensus_types::{
     block::{block_test_utils::certificate_for_genesis, Block},
-    common::Round,
+    common::{Author, Round},
     executed_block::ExecutedBlock,
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
@@ -136,6 +136,7 @@ impl TreeInserter {
                 parent.timestamp_usecs() + 1,
                 round,
                 Payload::new_empty(),
+                vec![],
             ))
             .await
             .unwrap()
@@ -166,8 +167,16 @@ impl TreeInserter {
         timestamp_usecs: u64,
         round: Round,
         payload: Payload,
+        failed_authors: Vec<(Round, Author)>,
     ) -> Block {
-        Block::new_proposal(payload, round, timestamp_usecs, parent_qc, &self.signer)
+        Block::new_proposal(
+            payload,
+            round,
+            timestamp_usecs,
+            parent_qc,
+            &self.signer,
+            failed_authors,
+        )
     }
 }
 

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -99,6 +99,11 @@ BlockType:
               TYPENAME: Payload
           - author:
               TYPENAME: AccountAddress
+          - failed_authors:
+              SEQ:
+                TUPLE:
+                  - U64
+                  - TYPENAME: AccountAddress
     1:
       NilBlock: UNIT
     2:


### PR DESCRIPTION
We want to have on the ledger who were the proposers/leaders for the failed rounds.
We are going to do that by adding failed_authors into the block, and
having proposer populate it.
    
Test Plan: added some unit tests for this
    
RFC:
 - not sure if BlockType.Proposal.failed_authors, let me know if there is a better place.
 - not sure if I need to add serialization for that field, or is that automatic.
 - not sure what special needs to be done for changes like this that make a breaking protocol change

For: #1395