### PR TITLE
[storage] fix that latest_state_checkpoint is messed up when there's concurrent commits

### DIFF
--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -104,7 +104,8 @@ pub fn run(
     let state_commit_thread = std::thread::Builder::new()
         .name("state_committer".to_string())
         .spawn(|| {
-            let committer = StateCommitter::new(state_commit_receiver, db_writer, base_smt);
+            let committer =
+                StateCommitter::new(state_commit_receiver, db_writer, base_smt, Some(0));
             committer.run();
         })
         .expect("Failed to spawn transaction committer thread.");

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -127,8 +127,13 @@ pub fn run_benchmark(
     let db_writer = db.writer.clone();
     let state_commit_thread = std::thread::Builder::new()
         .name("state_committer".to_string())
-        .spawn(|| {
-            let committer = StateCommitter::new(state_commit_receiver, db_writer, base_smt);
+        .spawn(move || {
+            let committer = StateCommitter::new(
+                state_commit_receiver,
+                db_writer,
+                base_smt,
+                Some(start_version),
+            );
             committer.run();
         })
         .expect("Failed to spawn transaction committer thread.");
@@ -165,6 +170,8 @@ mod tests {
             NO_OP_STORAGE_PRUNER_CONFIG, /* prune_window */
             true,
         );
+
+        aptos_logger::info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 
         super::run_benchmark(
             5, /* block_size */

--- a/execution/executor-benchmark/src/state_committer.rs
+++ b/execution/executor-benchmark/src/state_committer.rs
@@ -28,6 +28,7 @@ pub struct StateCommitter {
     version: Version,
     smt: SparseMerkleTree<StateValue>,
     committed_smt: SparseMerkleTree<StateValue>,
+    committed_version: Option<Version>,
     updates: Vec<(HashValue, (HashValue, StateKey))>,
     num_pending_commits: usize,
 }
@@ -37,6 +38,7 @@ impl StateCommitter {
         commit_receiver: mpsc::Receiver<StateSnapshotDelta>,
         db: Arc<dyn DbWriter>,
         committed_smt: SparseMerkleTree<StateValue>,
+        committed_version: Option<Version>,
     ) -> Self {
         let mut cache_queue = VecDeque::new();
         cache_queue.push_back(committed_smt.clone());
@@ -49,6 +51,7 @@ impl StateCommitter {
             version: 0,
             smt: committed_smt.clone(),
             committed_smt,
+            committed_version,
             updates: Vec::new(),
             num_pending_commits: 0,
         }
@@ -98,13 +101,19 @@ impl StateCommitter {
             .freeze()
             .new_node_hashes_since(&self.committed_smt.clone().freeze());
         self.db
-            .save_state_snapshot(to_commit, Some(&node_hashes), self.version)
+            .save_state_snapshot(
+                to_commit,
+                Some(&node_hashes),
+                self.version,
+                self.committed_version,
+            )
             .unwrap();
         info!("Committing state. Saved.");
 
         // reset pending updates
         self.num_pending_commits = 0;
         self.committed_smt = self.smt.clone();
+        self.committed_version = Some(self.version);
 
         // cache maintenance
         if self.cache_queue.len() >= NUM_COMMITTED_SMTS_TO_CACHE {

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -187,6 +187,11 @@ where
             self.db.writer.save_transactions_ext(
                 &txns_to_commit,
                 first_version,
+                committed_block
+                    .output
+                    .result_view
+                    .state()
+                    .checkpoint_version,
                 Some(&ledger_info_with_sigs),
                 save_state_snapshots,
             )?;

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -96,6 +96,7 @@ impl<V> ChunkExecutor<V> {
             self.db.writer.save_transactions(
                 &txns_to_commit,
                 base_view.txn_accumulator().num_leaves(),
+                base_view.state().checkpoint_version,
                 ledger_info,
             )?;
         }

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -86,6 +86,7 @@ impl DbWriter for FakeDb {
         &self,
         _txns_to_commit: &[TransactionToCommit],
         _first_version: Version,
+        _base_state_version: Option<Version>,
         _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
         Ok(())

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -403,6 +403,7 @@ fn apply_transaction_by_writeset(
         .save_transactions(
             &executed.transactions_to_commit().unwrap(),
             ledger_view.txn_accumulator().num_leaves(),
+            ledger_view.state().checkpoint_version,
             None,
         )
         .unwrap();
@@ -542,6 +543,7 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
             .save_transactions(
                 &executed.transactions_to_commit().unwrap(),
                 ledger_view.txn_accumulator().num_leaves(),
+                ledger_view.state().checkpoint_version,
                 None,
             )
             .unwrap();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -302,6 +302,7 @@ mock! {
             &self,
             txns_to_commit: &[TransactionToCommit],
             first_version: Version,
+            base_state_version: Option<Version>,
             ledger_info_with_sigs: Option<&'a LedgerInfoWithSignatures>,
         ) -> Result<()>;
 

--- a/storage/aptosdb/src/backup/test.rs
+++ b/storage/aptosdb/src/backup/test.rs
@@ -17,7 +17,7 @@ proptest! {
 
         let mut cur_ver = 0;
         for (txns_to_commit, ledger_info_with_sigs) in input.iter() {
-            db.save_transactions(txns_to_commit, cur_ver, Some(ledger_info_with_sigs))
+            db.save_transactions(txns_to_commit, cur_ver, cur_ver.checked_sub(1), Some(ledger_info_with_sigs))
                 .unwrap();
             cur_ver += txns_to_commit.len() as u64;
         }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1254,6 +1254,7 @@ impl DbWriter for AptosDB {
         jmt_updates: Vec<(HashValue, (HashValue, StateKey))>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         version: Version,
+        base_version: Option<Version>,
     ) -> Result<()> {
         gauged_api("save_state_snapshot", || {
             let mut cs = ChangeSet::new();
@@ -1263,6 +1264,7 @@ impl DbWriter for AptosDB {
                     vec![jmt_update_refs(&jmt_updates)],
                     node_hashes.map(|hashes| vec![hashes]),
                     version,
+                    base_version,
                     &mut cs,
                 )?
                 .first()
@@ -1281,6 +1283,7 @@ impl DbWriter for AptosDB {
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
+        base_state_version: Option<Version>,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         save_state_snapshots: bool,
     ) -> Result<()> {
@@ -1311,6 +1314,7 @@ impl DbWriter for AptosDB {
                 self.save_transactions_impl(txns_to_commit, first_version, &mut cs)?;
 
             if save_state_snapshots {
+                let mut base_version = base_state_version;
                 // find all the checkpoint versions
                 for (idx, jmt_updates, jf_node_hashes) in txns_to_commit
                     .iter()
@@ -1324,11 +1328,9 @@ impl DbWriter for AptosDB {
                         )
                     })
                 {
-                    self.save_state_snapshot(
-                        jmt_updates,
-                        jf_node_hashes,
-                        first_version + idx as LeafCount,
-                    )?;
+                    let version = first_version + idx as LeafCount;
+                    self.save_state_snapshot(jmt_updates, jf_node_hashes, version, base_version)?;
+                    base_version = Some(version);
                 }
             }
 

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -36,7 +36,6 @@ fn put_value_set(
         .put_value_sets(vec![&value_set], version, &mut cs)
         .unwrap();
     db.write_schemas(cs.batch).unwrap();
-    state_store.set_latest_checkpoint(version, root);
 
     root
 }

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -24,7 +24,13 @@ fn put_value_set(
     let jmt_updates = jmt_updates(&value_set);
 
     let root = state_store
-        .merklize_value_sets(vec![jmt_update_refs(&jmt_updates)], None, version, &mut cs)
+        .merklize_value_sets(
+            vec![jmt_update_refs(&jmt_updates)],
+            None,
+            version,
+            version.checked_sub(1),
+            &mut cs,
+        )
         .unwrap()[0];
     state_store
         .put_value_sets(vec![&value_set], version, &mut cs)

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -289,15 +289,11 @@ impl StateStore {
         value_sets: Vec<Vec<(HashValue, &(HashValue, StateKey))>>,
         node_hashes: Option<Vec<&HashMap<NibblePath, HashValue>>>,
         first_version: Version,
+        base_version: Option<Version>,
         ledger_db_cs: &mut ChangeSet,
     ) -> Result<Vec<HashValue>> {
         let (new_root_hash_vec, tree_update_batch) = JellyfishMerkleTree::new(self)
-            .batch_put_value_sets(
-                value_sets,
-                node_hashes,
-                self.find_latest_persisted_version_less_than(first_version)?,
-                first_version,
-            )?;
+            .batch_put_value_sets(value_sets, node_hashes, base_version, first_version)?;
 
         let num_versions = new_root_hash_vec.len();
         assert_eq!(num_versions, tree_update_batch.node_stats.len());

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -17,7 +17,6 @@ use crate::{
 };
 use anyhow::{anyhow, ensure, format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_infallible::Mutex;
 use aptos_jellyfish_merkle::{
     iterator::JellyfishMerkleIterator, node_type::NodeKey, restore::StateSnapshotRestore,
     JellyfishMerkleTree, StateValueWriter, TreeReader, TreeWriter,
@@ -47,7 +46,6 @@ pub const MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX: usize = 10_000;
 pub(crate) struct StateStore {
     ledger_db: Arc<DB>,
     state_merkle_db: Arc<DB>,
-    latest_checkpoint: Mutex<Option<(Version, HashValue)>>,
 }
 
 // "using an Arc<dyn DbReader> as an Arc<dyn StateReader>" is not allowed in stable Rust. Actually we
@@ -102,67 +100,25 @@ impl DbReader for StateStore {
         &self,
         next_version: Version,
     ) -> Result<Option<(Version, HashValue)>> {
-        ensure!(
-            next_version != PRE_GENESIS_VERSION,
-            "Nothing before pre-genesis"
-        );
-
-        if let Some((version, root_hash)) = self.latest_checkpoint() {
-            if next_version > version {
-                Ok(Some((version, root_hash)))
-            } else {
-                self.find_latest_persisted_version_from_db(next_version)?
-                    .map(|ver| Ok((ver, self.get_root_hash(ver)?)))
-                    .transpose()
-            }
-        } else {
-            Ok(None)
-        }
+        self.get_state_snapshot_version_before(next_version)?
+            .map(|ver| Ok((ver, self.get_root_hash(ver)?)))
+            .transpose()
     }
 }
 
 impl StateStore {
     pub fn new(ledger_db: Arc<DB>, state_merkle_db: Arc<DB>) -> Self {
-        let myself = Self {
+        Self {
             ledger_db,
             state_merkle_db,
-            latest_checkpoint: Mutex::new(None),
-        };
-
-        let latest_version = myself
-            .find_latest_persisted_version_from_db(Version::MAX)
-            .expect("Failed to query latest node on initialization.");
-        if let Some(version) = latest_version {
-            let root_hash = myself
-                .get_root_hash(version)
-                .expect("Failed to query latest checkpoint root hash on initialization.");
-            myself.set_latest_checkpoint(version, root_hash)
         }
-
-        myself
     }
 
-    pub fn latest_checkpoint(&self) -> Option<(Version, HashValue)> {
-        *self.latest_checkpoint.lock()
-    }
-
-    pub fn set_latest_checkpoint(&self, version: Version, root_hash: HashValue) {
-        *self.latest_checkpoint.lock() = Some((version, root_hash))
-    }
-
-    pub fn find_latest_persisted_version_less_than(
-        &self,
-        next_version: Version,
-    ) -> Result<Option<Version>> {
-        Ok(self
-            .get_state_snapshot_before(next_version)?
-            .map(|(v, _h)| v))
-    }
-
-    fn find_latest_persisted_version_from_db(
-        &self,
-        next_version: Version,
-    ) -> Result<Option<Version>> {
+    fn get_state_snapshot_version_before(&self, next_version: Version) -> Result<Option<Version>> {
+        ensure!(
+            next_version != PRE_GENESIS_VERSION,
+            "Nothing before pre-genesis"
+        );
         if next_version > 0 {
             let max_possible_version = next_version - 1;
             let mut iter = self
@@ -505,10 +461,6 @@ impl TreeWriter<StateKey> for StateStore {
         let mut batch = SchemaBatch::new();
         add_node_batch(&mut batch, node_batch)?;
         self.state_merkle_db.write_schemas(batch)
-    }
-
-    fn finish_version(&self, version: Version, root_hash: HashValue) {
-        self.set_latest_checkpoint(version, root_hash)
     }
 }
 

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -554,8 +554,6 @@ pub fn put_as_state_root(db: &AptosDB, version: Version, key: StateKey, value: S
     db.ledger_db
         .put::<StateValueSchema>(&(key, version), &value)
         .unwrap();
-    db.state_store
-        .set_latest_checkpoint(version, leaf_node.hash());
 }
 
 pub fn test_sync_transactions_impl(

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -111,8 +111,6 @@ impl TreeWriter<StateKey> for MockStore {
     fn write_node_batch(&self, _node_batch: &NodeBatch<StateKey>) -> Result<()> {
         Ok(())
     }
-
-    fn finish_version(&self, _version: Version, _root_hash: HashValue) {}
 }
 
 impl StateValueWriter<StateKey, StateValue> for MockStore {

--- a/storage/backup/backup-cli/src/utils/test_utils.rs
+++ b/storage/backup/backup-cli/src/utils/test_utils.rs
@@ -33,6 +33,7 @@ pub fn tmp_db_with_random_content() -> (
         db.save_transactions(
             txns_to_commit,
             cur_ver, /* first_version */
+            cur_ver.checked_sub(1),
             Some(ledger_info_with_sigs),
         )
         .unwrap();

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -129,9 +129,6 @@ pub trait TreeReader<K> {
 pub trait TreeWriter<K>: Send + Sync {
     /// Writes a node batch into storage.
     fn write_node_batch(&self, node_batch: &NodeBatch<K>) -> Result<()>;
-
-    /// Inform underlying store that a latest version is complete and readable.
-    fn finish_version(&self, version: Version, root_hash: HashValue);
 }
 
 pub trait StateValueWriter<K, V>: Send + Sync {

--- a/storage/jellyfish-merkle/src/mock_tree_store.rs
+++ b/storage/jellyfish-merkle/src/mock_tree_store.rs
@@ -6,7 +6,6 @@ use crate::{
     NodeBatch, StaleNodeIndex, TreeReader, TreeUpdateBatch, TreeWriter,
 };
 use anyhow::{bail, ensure, Result};
-use aptos_crypto::HashValue;
 use aptos_infallible::RwLock;
 use aptos_types::transaction::Version;
 use std::collections::{hash_map::Entry, BTreeSet, HashMap};
@@ -65,8 +64,6 @@ where
         }
         Ok(())
     }
-
-    fn finish_version(&self, _version: Version, _root_hash: HashValue) {}
 }
 
 impl<K> MockTreeStore<K>

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -680,8 +680,6 @@ where
 
         self.freeze(0);
         self.store.write_node_batch(&self.frozen_nodes)?;
-        self.store
-            .finish_version(self.version, self.expected_root_hash);
         Ok(())
     }
 }

--- a/storage/jellyfish-merkle/src/restore/restore_test.rs
+++ b/storage/jellyfish-merkle/src/restore/restore_test.rs
@@ -75,8 +75,6 @@ where
     fn write_node_batch(&self, node_batch: &NodeBatch<K>) -> Result<()> {
         self.tree_store.write_node_batch(node_batch)
     }
-
-    fn finish_version(&self, _version: Version, _root_hash: HashValue) {}
 }
 
 fn init_mock_store<V>(kvs: &BTreeMap<V, V>) -> (MockSnapshotStore<V, V>, Version)

--- a/storage/jellyfish-merkle/src/tree_cache/mod.rs
+++ b/storage/jellyfish-merkle/src/tree_cache/mod.rs
@@ -150,7 +150,7 @@ where
 
         let root_node_key = if let Some(version) = persisted_version {
             if version == PRE_GENESIS_VERSION {
-                assert_eq!(next_version, 0);
+                assert_ne!(next_version, PRE_GENESIS_VERSION);
             } else {
                 assert!(next_version > version);
             }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -659,6 +659,7 @@ pub trait DbWriter: Send + Sync {
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
+        base_state_version: Option<Version>,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         save_state_snapshots: bool,
     ) -> Result<()> {
@@ -669,11 +670,13 @@ pub trait DbWriter: Send + Sync {
         &self,
         txns_to_commit: &[TransactionToCommit],
         first_version: Version,
+        base_state_version: Option<Version>,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
     ) -> Result<()> {
         self.save_transactions_ext(
             txns_to_commit,
             first_version,
+            base_state_version,
             ledger_info_with_sigs,
             true, /* save_state_snapshots */
         )
@@ -688,6 +691,7 @@ pub trait DbWriter: Send + Sync {
         jmt_updates: Vec<(HashValue, (HashValue, StateKey))>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         version: Version,
+        base_version: Option<Version>,
     ) -> Result<()> {
         unimplemented!()
     }


### PR DESCRIPTION
### Description

1. pass base version from executor
2. remove the cache

### Test Plan
unit tests
