### PR TITLE
[Storage] Disable flaky test.

### DIFF
--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -20,6 +20,7 @@ use proptest::{collection::vec, prelude::*};
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]
 
+    #[ignore]
     #[test]
     fn test_txn_store_pruner(txns in vec(
         prop_oneof![


### PR DESCRIPTION
### Description

This test seems to have become more flaky recently (a lot more than others). This PR ignores it for now (to unblock other workflows). We still need to root cause a proper fix (i.e., other tests are also flaking, but at much lower rates)

### Test Plan
The unit tests should pass.