### PR TITLE
[docs] updated crates/aptos-crypto/README.md

### DIFF
--- a/crates/aptos-crypto/README.md
+++ b/crates/aptos-crypto/README.md
@@ -4,32 +4,53 @@ title: Crypto
 custom_edit_url: https://github.com/aptos-labs/aptos-core/edit/main/crypto/crypto/README.md
 ---
 
-The crypto component hosts all the implementations of cryptographic primitives we use in Aptos: hashing, signing, and key derivation/generation. The parts of the library using traits.rs contains the crypto API enforcing type safety, verifiable random functions, EdDSA & MultiEdDSA signatures.
+The crypto component hosts all the implementations of cryptographic primitives we use in Aptos: hashing, (multi)signatures, and key derivation/generation.
+
+To enforce type safety for signature schemes, we rely on traits from  [`traits.rs`](src/traits.rs) and [`validatable.rs`](src/validatable.rs).
 
 ## Overview
 
 Aptos makes use of several cryptographic algorithms:
 
-* SHA-3 as the main hash function. It is standardized in [FIPS 202](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf). It is based on the [tiny_keccak](https://docs.rs/tiny-keccak/1.4.2/tiny_keccak/) library.
-* HKDF: HMAC-based Extract-and-Expand Key Derivation Function (HKDF) based on [RFC 5869](https://tools.ietf.org/html/rfc5869). It is used to generate keys from a salt (optional), seed, and application-info (optional).
-* traits.rs introduces new abstractions for the crypto API.
-* Ed25519 performs signatures using the new API design based on [ed25519-dalek](https://docs.rs/ed25519-dalek/1.0.0-pre.1/ed25519_dalek/) library with additional security checks (e.g. for malleability).
-* X25519 to perform key exchanges. It is used to secure communications between validators via the [Noise Protocol Framework](http://www.noiseprotocol.org/noise.html). It is based on the x25519-dalek library.
+- **SHA-3** as the main hash function
+  + Standardized in [FIPS 202](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf)
+  + Based on the [tiny_keccak](https://docs.rs/tiny-keccak/) crate
+- **HKDF: HMAC-based Extract-and-Expand Key Derivation Function**
+  + Standardized in [RFC 5869](https://tools.ietf.org/html/rfc5869)
+  + Used to generate keys from a salt (optional), seed, and application-info (optional)
+- **Ed25519** signatures and (naive) multisignatures
+  + Based on the [ed25519-dalek](https://docs.rs/ed25519-dalek/) crate with additional security checks (e.g., for malleability)
+- **Boneh-Shacham-Lynn (BLS) multisignatures**
+  + Based on the [blst](https://docs.rs/blst/) crate
+  + Implemented on top of Barreto-Scott-Lynn BLS12-381 elliptic curves
+- The **[Noise Protocol Framework](http://www.noiseprotocol.org/)**
+  - Used to create authenticated and encrypted communications channels between validators
+- **X25519** key exchange
+  + Based on the [x25519-dalek](https://docs.rs/x25519-dalek) crate
+  + Used in our implementation of the [Noise Protocol Framework](http://www.noiseprotocol.org/)
+
+## Traits for safer cryptography implementation
+
+Before implementing a cryptographic primitive, be sure to read [`traits.rs`](src/traits.rs) and [`validatable.rs`](src/validatable.rs) to understand how to comply with our API as well as **some** of the security issues involved.
 
 ## How is this module organized?
 ```
     crypto/src
-    ├── hash.rs             # Hash function (SHA-3)
-    ├── hkdf.rs             # HKDF implementation (HMAC-based Extract-and-Expand Key Derivation Function based on RFC 5869)
-    ├── macros/             # Derivations for SilentDebug and SilentDisplay
-    ├── utils.rs            # Serialization utility functions
+    ├── bls12-381/          # BLS (multi)signatures over BLS12-381 curves
+    ├── unit_tests/         # Unit tests
     ├── lib.rs
     ├── ed25519.rs          # Ed25519 implementation of the signing/verification API in traits.rs
+    ├── hash.rs             # Hash function (SHA-3)
+    ├── hkdf.rs             # HKDF implementation
     ├── multi_ed25519.rs    # MultiEd25519 implementation of the signing/verification API in traits.rs
-    ├── x25519.rs           # X25519 wrapper
+    ├── noise.rs            # Noise Protocol Framework implementation
     ├── test_utils.rs
-    ├── traits.rs           # New API design and the necessary abstractions
-    └── unit_tests/         # Tests
+    ├── traits.rs           # Traits for safer implementations of signature schemes
+    ├── validatable.rs      # Traits for deferring validation of group elements (e.g., public keys, signatures)
+    └── x25519.rs           # X25519 implementation
+
 ```
 
-Note: This crate historically had support for BLS12381, ECVRF, and SlIP-0010, though were removed due to lack of use. The last git revision before there removal is 00301524.
+## Changelog
+
+ - This crate historically had support for (a different) BLS12-381, [EC-VRF](https://tools.ietf.org/id/draft-goldbe-vrf-01.html#rfc.section.5), and [SLIP-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md), though were removed due to lack of use. The last git revision before the removal is 00301524.

--- a/crates/aptos-crypto/README.md
+++ b/crates/aptos-crypto/README.md
@@ -6,7 +6,7 @@ custom_edit_url: https://github.com/aptos-labs/aptos-core/edit/main/crypto/crypt
 
 The crypto component hosts all the implementations of cryptographic primitives we use in Aptos: hashing, (multi)signatures, and key derivation/generation.
 
-To enforce type safety for signature schemes, we rely on traits from  [`traits.rs`](src/traits.rs) and [`validatable.rs`](src/validatable.rs).
+To enforce type-safety for signature schemes, we rely on traits from  [`traits.rs`](src/traits.rs) and [`validatable.rs`](src/validatable.rs).
 
 ## Overview
 
@@ -31,7 +31,7 @@ Aptos makes use of several cryptographic algorithms:
 
 ## Traits for safer cryptography implementation
 
-Before implementing a cryptographic primitive, be sure to read [`traits.rs`](src/traits.rs) and [`validatable.rs`](src/validatable.rs) to understand how to comply with our API as well as **some** of the security issues involved.
+Before implementing a cryptographic primitive, be sure to read [`traits.rs`](src/traits.rs) and [`validatable.rs`](src/validatable.rs) to understand how to comply with our API as well as **some** of the security concerns involved.
 
 ## How is this module organized?
 ```


### PR DESCRIPTION
### Description

Brings our cryptography crate's documentation in line with its **current, actual** implementation
