### PR TITLE
Fix documentation comment parameter reference typo

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/Coin.move
+++ b/aptos-move/framework/aptos-framework/sources/Coin.move
@@ -168,7 +168,7 @@ module AptosFramework::Coin {
     }
 
     /// Burn `coin` from the specified `account` with capability.
-    /// The capability `_cap` should be passed as a reference to `BurnCapability<CoinType>`.
+    /// The capability `burn_cap` should be passed as a reference to `BurnCapability<CoinType>`.
     public fun burn_from<CoinType>(
         account_addr: address,
         amount: u64,


### PR DESCRIPTION
Previously, the documentation comment for `burn_from()` included a reference to `_cap`, which is not actually a valid parameter (and was likely copy-pasted from the `burn()` documentation comment). The proposed change corrects the typo to refer to the actual parameter `burn_cap`. Tagging @davidiw  per #1519 