### PR TITLE
[consensus] Create ProposerAndVoterHeuristic

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -90,6 +90,15 @@ pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Failed proposals from this validator when using LeaderReputation as the ProposerElection
+pub static FAILED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_failed_proposals_in_window",
+        "Total number of this validator's committed proposals in the current reputation window"
+    )
+    .unwrap()
+});
+
 /// Committed votes from this validator when using LeaderReputation as the ProposerElection
 pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
@@ -100,9 +109,9 @@ pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
 });
 
 /// The number of block events the LeaderReputation uses
-pub static LEADER_REPUTATION_WINDOW_SIZE: Lazy<IntGauge> = Lazy::new(|| {
+pub static LEADER_REPUTATION_HISTORY_SIZE: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_leader_reputation_window_size",
+        "aptos_leader_reputation_history_size",
         "Total number of new block events in the current reputation window"
     )
     .unwrap()

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     counters::{
-        COMMITTED_PROPOSALS_IN_WINDOW, COMMITTED_VOTES_IN_WINDOW, LEADER_REPUTATION_WINDOW_SIZE,
+        COMMITTED_PROPOSALS_IN_WINDOW, COMMITTED_VOTES_IN_WINDOW, FAILED_PROPOSALS_IN_WINDOW,
+        LEADER_REPUTATION_HISTORY_SIZE,
     },
     liveness::proposer_election::{next, ProposerElection},
 };
@@ -11,7 +12,7 @@ use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_types::block_metadata::{new_block_event_key, NewBlockEvent};
 use consensus_types::common::{Author, Round};
-use std::{cmp::Ordering, collections::HashSet, sync::Arc};
+use std::{cmp::Ordering, collections::HashMap, convert::TryFrom, sync::Arc};
 use storage_interface::{DbReader, Order};
 
 /// Interface to query committed BlockMetadata.
@@ -22,6 +23,7 @@ pub trait MetadataBackend: Send + Sync {
 }
 
 pub struct AptosDBBackend {
+    epoch: u64,
     window_size: usize,
     seek_len: u64,
     aptos_db: Arc<dyn DbReader>,
@@ -29,8 +31,9 @@ pub struct AptosDBBackend {
 }
 
 impl AptosDBBackend {
-    pub fn new(window_size: usize, seek_len: u64, aptos_db: Arc<dyn DbReader>) -> Self {
+    pub fn new(epoch: u64, window_size: usize, seek_len: u64, aptos_db: Arc<dyn DbReader>) -> Self {
         Self {
+            epoch,
             window_size,
             seek_len,
             aptos_db,
@@ -49,7 +52,10 @@ impl AptosDBBackend {
         let mut result = vec![];
         for event in events {
             let e = bcs::from_bytes::<NewBlockEvent>(event.event.event_data())?;
-            if e.round() <= target_round && result.len() < self.window_size {
+            if e.epoch() == self.epoch
+                && e.round() <= target_round
+                && result.len() < self.window_size
+            {
                 result.push((event.transaction_version, e));
             }
         }
@@ -93,23 +99,23 @@ pub trait ReputationHeuristic: Send + Sync {
         -> Vec<u64>;
 }
 
-/// If candidate appear in the history, it's assigned active_weight otherwise inactive weight.
-pub struct ActiveInactiveHeuristic {
-    author: Author,
-    active_weight: u64,
-    inactive_weight: u64,
+pub struct NewBlockEventAggregation {
+    // Window sizes are in number of succesfull blocks, not number of rounds.
+    // i.e. we can be looking at different number of rounds for the same window,
+    // dependig on how many failures we have.
+    voter_window_size: usize,
+    proposer_window_size: usize,
 }
 
-impl ActiveInactiveHeuristic {
-    pub fn new(author: Author, active_weight: u64, inactive_weight: u64) -> Self {
+impl NewBlockEventAggregation {
+    pub fn new(voter_window_size: usize, proposer_window_size: usize) -> Self {
         Self {
-            author,
-            active_weight,
-            inactive_weight,
+            voter_window_size,
+            proposer_window_size,
         }
     }
 
-    fn bitmap_to_voters<'a>(
+    pub fn bitmap_to_voters<'a>(
         validators: &'a [Author],
         bitmap: &[bool],
     ) -> Result<Vec<&'a Author>, String> {
@@ -127,38 +133,136 @@ impl ActiveInactiveHeuristic {
             .filter_map(|(validator, &voted)| if voted { Some(validator) } else { None })
             .collect())
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use crate::liveness::leader_reputation::ActiveInactiveHeuristic;
-    use aptos_types::account_address::AccountAddress;
-
-    #[test]
-    fn test_bitmap_to_voters() {
-        let validators: Vec<_> = (0..4)
-            .into_iter()
-            .map(|_| AccountAddress::random())
-            .collect();
-        let bitmap = vec![true, true, false, true];
-
-        if let Ok(voters) = ActiveInactiveHeuristic::bitmap_to_voters(&validators, &bitmap) {
-            assert_eq!(&validators[0], voters[0]);
-            assert_eq!(&validators[1], voters[1]);
-            assert_eq!(&validators[3], voters[2]);
-        }
+    pub fn indices_to_validators<'a>(
+        validators: &'a [Author],
+        indices: &[u64],
+    ) -> Result<Vec<&'a Author>, String> {
+        indices
+            .iter()
+            .map(|index| {
+                usize::try_from(*index)
+                    .map_err(|_err| format!("index {} out of bounds", index))
+                    .and_then(|index| {
+                        validators.get(index).ok_or(format!(
+                            "index {} is larger than number of validators {}",
+                            index,
+                            validators.len()
+                        ))
+                    })
+            })
+            .collect()
     }
 
-    #[test]
-    fn test_bitmap_to_voters_mismatched_lengths() {
-        let validators: Vec<_> = (0..4) // size of 4
-            .into_iter()
-            .map(|_| AccountAddress::random())
-            .collect();
-        let bitmap_too_long = vec![true, true, false, true, true]; // size of 5
-        assert!(ActiveInactiveHeuristic::bitmap_to_voters(&validators, &bitmap_too_long).is_err());
-        let bitmap_too_short = vec![true, true, false];
-        assert!(ActiveInactiveHeuristic::bitmap_to_voters(&validators, &bitmap_too_short).is_err());
+    fn history_iter(
+        history: &[NewBlockEvent],
+        epoch: u64,
+        window_size: usize,
+    ) -> impl Iterator<Item = &NewBlockEvent> {
+        let start = if history.len() > window_size {
+            history.len() - window_size
+        } else {
+            0
+        };
+
+        (&history[start..])
+            .iter()
+            .filter(move |&meta| meta.epoch() == epoch)
+    }
+
+    pub fn count_votes(
+        &self,
+        epoch: u64,
+        candidates: &[Author],
+        history: &[NewBlockEvent],
+    ) -> HashMap<Author, u32> {
+        Self::history_iter(history, epoch, self.voter_window_size).fold(
+            HashMap::new(),
+            |mut map, meta| {
+                match Self::bitmap_to_voters(candidates, meta.previous_block_votes()) {
+                    Ok(voters) => {
+                        for &voter in voters {
+                            let count = map.entry(voter).or_insert(0);
+                            *count += 1;
+                        }
+                    }
+                    Err(msg) => {
+                        error!(
+                            "Voter conversion from bitmap failed at epoch {}, round {}: {}",
+                            meta.epoch(),
+                            meta.round(),
+                            msg
+                        )
+                    }
+                }
+                map
+            },
+        )
+    }
+
+    pub fn count_proposals(&self, epoch: u64, history: &[NewBlockEvent]) -> HashMap<Author, u32> {
+        Self::history_iter(history, epoch, self.proposer_window_size).fold(
+            HashMap::new(),
+            |mut map, meta| {
+                let count = map.entry(meta.proposer()).or_insert(0);
+                *count += 1;
+                map
+            },
+        )
+    }
+
+    pub fn count_failed_proposals(
+        &self,
+        epoch: u64,
+        candidates: &[Author],
+        history: &[NewBlockEvent],
+    ) -> HashMap<Author, u32> {
+        Self::history_iter(history, epoch, self.proposer_window_size).fold(
+            HashMap::new(),
+            |mut map, meta| {
+                match Self::indices_to_validators(candidates, meta.failed_proposer_indices()) {
+                    Ok(failed_proposers) => {
+                        for &failed_proposer in failed_proposers {
+                            let count = map.entry(failed_proposer).or_insert(0);
+                            *count += 1;
+                        }
+                    }
+                    Err(msg) => {
+                        error!(
+                            "Failed proposer conversion from indices failed at epoch {}, round {}: {}",
+                            meta.epoch(),
+                            meta.round(),
+                            msg
+                        )
+                    }
+                }
+                map
+            },
+        )
+    }
+}
+
+/// If candidate appear in the history, it's assigned active_weight otherwise inactive weight.
+pub struct ActiveInactiveHeuristic {
+    author: Author,
+    active_weight: u64,
+    inactive_weight: u64,
+    aggregation: NewBlockEventAggregation,
+}
+
+impl ActiveInactiveHeuristic {
+    pub fn new(
+        author: Author,
+        active_weight: u64,
+        inactive_weight: u64,
+        window_size: usize,
+    ) -> Self {
+        Self {
+            author,
+            active_weight,
+            inactive_weight,
+            aggregation: NewBlockEventAggregation::new(window_size, window_size),
+        }
     }
 }
 
@@ -169,51 +273,108 @@ impl ReputationHeuristic for ActiveInactiveHeuristic {
         candidates: &[Author],
         history: &[NewBlockEvent],
     ) -> Vec<u64> {
-        let mut committed_proposals: usize = 0;
-        let mut committed_votes: usize = 0;
+        let votes = self.aggregation.count_votes(epoch, candidates, history);
+        let proposals = self.aggregation.count_proposals(epoch, history);
 
-        let set = history.iter().filter(|&meta| meta.epoch() == epoch).fold(
-            HashSet::new(),
-            |mut set, meta| {
-                set.insert(meta.proposer());
-                if meta.proposer() == self.author {
-                    committed_proposals = committed_proposals.checked_add(1).expect(
-                        "Should not overflow the number of committed proposals in a window",
-                    );
-                }
-
-                match Self::bitmap_to_voters(candidates, meta.previous_block_votes()) {
-                    Ok(voters) => {
-                        for &voter in voters {
-                            set.insert(voter);
-                            if voter == self.author {
-                                committed_votes = committed_votes.checked_add(1).expect(
-                                    "Should not overflow the number of committed votes in a window",
-                                );
-                            }
-                        }
-                    }
-                    Err(msg) => {
-                        warn!(
-                            "Voter conversion from bitmap failed at epoch {}, round {}: {}",
-                            meta.epoch(),
-                            meta.round(),
-                            msg
-                        )
-                    }
-                }
-                set
-            },
-        );
-
-        COMMITTED_PROPOSALS_IN_WINDOW.set(committed_proposals as i64);
-        COMMITTED_VOTES_IN_WINDOW.set(committed_votes as i64);
-        LEADER_REPUTATION_WINDOW_SIZE.set(history.len() as i64);
+        COMMITTED_PROPOSALS_IN_WINDOW.set(*proposals.get(&self.author).unwrap_or(&0) as i64);
+        COMMITTED_VOTES_IN_WINDOW.set(*votes.get(&self.author).unwrap_or(&0) as i64);
+        LEADER_REPUTATION_HISTORY_SIZE.set(proposals.values().sum::<u32>() as i64);
 
         candidates
             .iter()
             .map(|author| {
-                if set.contains(author) {
+                if votes.contains_key(author) || proposals.contains_key(author) {
+                    self.active_weight
+                } else {
+                    self.inactive_weight
+                }
+            })
+            .collect()
+    }
+}
+
+/// Heuristic that looks at successful and failed proposals, as well as voting history,
+/// to define node reputation, used for leader selection.
+///
+/// We want to optimize leader selection to primarily maximize network's throughput,
+/// but we also, in combinatoin with staking rewards logic, need to be reasonably fair.
+///
+/// Logic is:
+///  * if proposer round failure rate within the proposer window is strictly above threshold, use failed_weight (default 1).
+///  * otherwise, if node had no proposal rounds and no successful votes, use inactive_weight (default 10).
+///  * otherwise, use the default active_weight (default 100).
+///
+/// We primarily want to avoid failed rounds, as they have a largest negative effect on the network.
+/// So if we see a node having failures to propose, when it was the leader, we want to avoid that node.
+/// We add a threshold (instead of penalizing on a single failure), so that transient issues in the network,
+/// or malicious behaviour of the next leader is avoided. In general, we expect there to be
+/// proposer_window_size/num_validators opportunities for a node to be a leader, so a single failure, or a
+/// subset of following leaders being malicious will not be enough to exclude a node.
+/// On the other hand, single failure, without any successes before will exclude the note.
+/// Threshold probably makes the most sense to be between:
+///  * 10% (aggressive exclusion with 1 failure in 10 proposals being enough for exclusion)
+///  * and 33% (much less aggressive exclusion, with 1 failure for every 2 successes, should still reduce failed
+///    rounds by at least 66%, and is enough to avoid byzantine attacks as well as the rest of the protocol)
+pub struct ProposerAndVoterHeuristic {
+    author: Author,
+    active_weight: u64,
+    inactive_weight: u64,
+    failed_weight: u64,
+    failure_threshold_percent: u32,
+    aggregation: NewBlockEventAggregation,
+}
+
+impl ProposerAndVoterHeuristic {
+    pub fn new(
+        author: Author,
+        active_weight: u64,
+        inactive_weight: u64,
+        failed_weight: u64,
+        failure_threshold_percent: u32,
+        voter_window_size: usize,
+        proposer_window_size: usize,
+    ) -> Self {
+        Self {
+            author,
+            active_weight,
+            inactive_weight,
+            failed_weight,
+            failure_threshold_percent,
+            aggregation: NewBlockEventAggregation::new(voter_window_size, proposer_window_size),
+        }
+    }
+}
+
+impl ReputationHeuristic for ProposerAndVoterHeuristic {
+    fn get_weights(
+        &self,
+        epoch: u64,
+        candidates: &[Author],
+        history: &[NewBlockEvent],
+    ) -> Vec<u64> {
+        let votes = self.aggregation.count_votes(epoch, candidates, history);
+        let proposals = self.aggregation.count_proposals(epoch, history);
+        let failed_proposals = self
+            .aggregation
+            .count_failed_proposals(epoch, candidates, history);
+
+        COMMITTED_PROPOSALS_IN_WINDOW.set(*proposals.get(&self.author).unwrap_or(&0) as i64);
+        FAILED_PROPOSALS_IN_WINDOW.set(*proposals.get(&self.author).unwrap_or(&0) as i64);
+        COMMITTED_VOTES_IN_WINDOW.set(*votes.get(&self.author).unwrap_or(&0) as i64);
+        LEADER_REPUTATION_HISTORY_SIZE.set(proposals.values().sum::<u32>() as i64);
+
+        candidates
+            .iter()
+            .map(|author| {
+                let cur_votes = *votes.get(author).unwrap_or(&0);
+                let cur_proposals = *proposals.get(author).unwrap_or(&0);
+                let cur_failed_proposals = *failed_proposals.get(author).unwrap_or(&0);
+
+                if cur_failed_proposals * 100
+                    > (cur_proposals + cur_failed_proposals) * self.failure_threshold_percent
+                {
+                    self.failed_weight
+                } else if cur_proposals > 0 || cur_votes > 0 {
                     self.active_weight
                 } else {
                     self.inactive_weight

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -1,9 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+
 use crate::liveness::{
     leader_reputation::{
-        ActiveInactiveHeuristic, LeaderReputation, MetadataBackend, ReputationHeuristic,
+        ActiveInactiveHeuristic, LeaderReputation, MetadataBackend, NewBlockEventAggregation,
+        ReputationHeuristic,
     },
     proposer_election::{next, ProposerElection},
 };
@@ -14,6 +17,8 @@ use aptos_types::{
 };
 use consensus_types::common::{Author, Round};
 use itertools::Itertools;
+
+use super::leader_reputation::ProposerAndVoterHeuristic;
 
 struct MockHistory {
     window_size: usize,
@@ -37,9 +42,237 @@ impl MetadataBackend for MockHistory {
     }
 }
 
-fn create_block(epoch: u64, proposer: Author, voters: Vec<bool>) -> NewBlockEvent {
-    NewBlockEvent::new(epoch, 0, voters, proposer, vec![], 0)
+struct TestBlockBuilder {
+    epoch: u64,
+    round: Round,
 }
+
+impl TestBlockBuilder {
+    fn new() -> Self {
+        Self { epoch: 0, round: 0 }
+    }
+
+    fn new_epoch(&mut self) -> &mut Self {
+        self.epoch += 1;
+        self
+    }
+
+    fn create_block(
+        &mut self,
+        proposer: Author,
+        voters: Vec<bool>,
+        failed_proposers: Vec<u64>,
+    ) -> NewBlockEvent {
+        self.round += 1 + failed_proposers.len() as u64;
+        NewBlockEvent::new(
+            self.epoch,
+            self.round,
+            voters,
+            proposer,
+            failed_proposers,
+            self.round * 3600,
+        )
+    }
+}
+
+/// #### NewBlockEventAggregation tests ####
+
+#[test]
+fn test_aggregation_bitmap_to_voters() {
+    let validators: Vec<_> = (0..4).into_iter().map(|_| Author::random()).collect();
+    let bitmap = vec![true, true, false, true];
+
+    if let Ok(voters) = NewBlockEventAggregation::bitmap_to_voters(&validators, &bitmap) {
+        assert_eq!(&validators[0], voters[0]);
+        assert_eq!(&validators[1], voters[1]);
+        assert_eq!(&validators[3], voters[2]);
+    } else {
+        unreachable!();
+    }
+}
+
+#[test]
+fn test_aggregation_bitmap_to_voters_mismatched_lengths() {
+    let validators: Vec<_> = (0..4) // size of 4
+        .into_iter()
+        .map(|_| Author::random())
+        .collect();
+    let bitmap_too_long = vec![true, true, false, true, true]; // size of 5
+    assert!(NewBlockEventAggregation::bitmap_to_voters(&validators, &bitmap_too_long).is_err());
+    let bitmap_too_short = vec![true, true, false];
+    assert!(NewBlockEventAggregation::bitmap_to_voters(&validators, &bitmap_too_short).is_err());
+}
+
+#[test]
+fn test_aggregation_indices_to_authors() {
+    let validators: Vec<_> = (0..4).into_iter().map(|_| Author::random()).collect();
+    let indices = vec![2u64, 2, 0, 3];
+
+    if let Ok(authors) = NewBlockEventAggregation::indices_to_validators(&validators, &indices) {
+        assert_eq!(&validators[2], authors[0]);
+        assert_eq!(&validators[2], authors[1]);
+        assert_eq!(&validators[0], authors[2]);
+        assert_eq!(&validators[3], authors[3]);
+    } else {
+        unreachable!();
+    }
+}
+
+#[test]
+fn test_aggregation_indices_to_authors_out_of_index() {
+    let validators: Vec<_> = (0..4).into_iter().map(|_| Author::random()).collect();
+    let indices = vec![0, 0, 4, 0];
+    assert!(NewBlockEventAggregation::indices_to_validators(&validators, &indices).is_err());
+}
+
+struct Example1 {
+    validators: Vec<Author>,
+    block_builder: TestBlockBuilder,
+    history: Vec<NewBlockEvent>,
+}
+
+impl Example1 {
+    fn new() -> Self {
+        Self {
+            validators: (0..4).into_iter().map(|_| Author::random()).collect(),
+            block_builder: TestBlockBuilder::new(),
+            history: vec![],
+        }
+    }
+
+    fn step1(&mut self) {
+        self.history.push(self.block_builder.create_block(
+            self.validators[0],
+            vec![false, true, true, false],
+            vec![3],
+        ));
+        self.history.push(self.block_builder.create_block(
+            self.validators[0],
+            vec![false, true, true, false],
+            vec![],
+        ));
+        self.history.push(self.block_builder.create_block(
+            self.validators[1],
+            vec![true, false, true, false],
+            vec![2],
+        ));
+        self.history.push(self.block_builder.create_block(
+            self.validators[2],
+            vec![true, true, false, false],
+            vec![],
+        ));
+    }
+
+    fn step2(&mut self) {
+        self.history.push(self.block_builder.create_block(
+            self.validators[3],
+            vec![true, true, false, false],
+            vec![1],
+        ));
+        self.history.push(self.block_builder.create_block(
+            self.validators[3],
+            vec![true, true, false, false],
+            vec![1],
+        ));
+    }
+
+    fn step3(&mut self) {
+        self.block_builder.new_epoch();
+        self.history.push(self.block_builder.create_block(
+            self.validators[3],
+            vec![true, true, false, false],
+            vec![0],
+        ));
+    }
+}
+
+fn example1_init() {}
+
+#[test]
+fn test_aggregation_counting() {
+    let mut example1 = Example1::new();
+    let validators = example1.validators.clone();
+    let aggregation = NewBlockEventAggregation::new(2, 5);
+
+    example1.step1();
+
+    assert_eq!(
+        aggregation.count_proposals(0, &example1.history),
+        HashMap::from([(validators[0], 2), (validators[1], 1), (validators[2], 1),])
+    );
+    assert_eq!(
+        aggregation.count_failed_proposals(0, &validators, &example1.history),
+        HashMap::from([(validators[2], 1), (validators[3], 1),])
+    );
+    assert_eq!(
+        aggregation.count_votes(0, &validators, &example1.history),
+        HashMap::from([(validators[0], 2), (validators[1], 1), (validators[2], 1),])
+    );
+
+    example1.step2();
+
+    assert_eq!(
+        aggregation.count_proposals(0, &example1.history),
+        HashMap::from([
+            (validators[0], 1),
+            (validators[1], 1),
+            (validators[2], 1),
+            (validators[3], 2),
+        ])
+    );
+    assert_eq!(
+        aggregation.count_failed_proposals(0, &validators, &example1.history),
+        HashMap::from([(validators[2], 1), (validators[1], 2),])
+    );
+    assert_eq!(
+        aggregation.count_votes(0, &validators, &example1.history),
+        HashMap::from([(validators[0], 2), (validators[1], 2),])
+    );
+
+    example1.step3();
+
+    assert_eq!(
+        aggregation.count_proposals(1, &example1.history),
+        HashMap::from([(validators[3], 1),])
+    );
+    assert_eq!(
+        aggregation.count_failed_proposals(1, &validators, &example1.history),
+        HashMap::from([(validators[0], 1),])
+    );
+    assert_eq!(
+        aggregation.count_votes(1, &validators, &example1.history),
+        HashMap::from([(validators[0], 1), (validators[1], 1),])
+    );
+}
+
+/// ####
+
+#[test]
+fn test_proposer_and_voter_heuristic() {
+    let mut example1 = Example1::new();
+    let validators = example1.validators.clone();
+    let heuristic = ProposerAndVoterHeuristic::new(validators[0], 100, 10, 1, 49, 2, 5);
+
+    example1.step1();
+    assert_eq!(
+        heuristic.get_weights(0, &validators, &example1.history),
+        vec![100, 100, 1, 1]
+    );
+
+    example1.step2();
+    assert_eq!(
+        heuristic.get_weights(0, &validators, &example1.history),
+        vec![100, 1, 1, 100]
+    );
+
+    example1.step3();
+    assert_eq!(
+        heuristic.get_weights(1, &validators, &example1.history),
+        vec![1, 100, 10, 100]
+    );
+}
+
+/// #### ActiveInactiveHeuristic tests ####
 
 #[test]
 fn test_simple_heuristic() {
@@ -52,7 +285,13 @@ fn test_simple_heuristic() {
         proposers.push(signer.author());
         signers.push(signer);
     }
-    let heuristic = ActiveInactiveHeuristic::new(proposers[0], active_weight, inactive_weight);
+    let mut block_builder = TestBlockBuilder::new();
+    let heuristic = ActiveInactiveHeuristic::new(
+        proposers[0],
+        active_weight,
+        inactive_weight,
+        proposers.len(),
+    );
     // 1. Window size not enough
     let weights = heuristic.get_weights(0, &proposers, &[]);
     assert_eq!(weights.len(), proposers.len());
@@ -64,15 +303,67 @@ fn test_simple_heuristic() {
         0,
         &proposers,
         &[
-            create_block(
-                0,
+            block_builder.create_block(
                 proposers[0],
                 vec![false, true, true, false, false, false, false, false],
+                vec![],
             ),
-            create_block(
-                0,
+            block_builder.create_block(
                 proposers[0],
                 vec![false, false, false, true, false, false, false, false],
+                vec![],
+            ),
+        ],
+    );
+    assert_eq!(weights.len(), proposers.len());
+    for (i, w) in weights.iter().enumerate() {
+        let expected = if i < 4 {
+            active_weight
+        } else {
+            inactive_weight
+        };
+        assert_eq!(*w, expected);
+    }
+}
+
+#[test]
+fn test_with_failed_heuristic() {
+    let active_weight = 9;
+    let inactive_weight = 1;
+    let mut proposers = vec![];
+    let mut signers = vec![];
+    for i in 0..8 {
+        let signer = ValidatorSigner::random([i; 32]);
+        proposers.push(signer.author());
+        signers.push(signer);
+    }
+    let mut block_builder = TestBlockBuilder::new();
+    let heuristic = ActiveInactiveHeuristic::new(
+        proposers[0],
+        active_weight,
+        inactive_weight,
+        proposers.len(),
+    );
+    // 1. Window size not enough
+    let weights = heuristic.get_weights(0, &proposers, &[]);
+    assert_eq!(weights.len(), proposers.len());
+    for w in weights {
+        assert_eq!(w, inactive_weight);
+    }
+    // 2. Sliding window with [proposer 0, voters 1, 2], [proposer 0, voters 3]
+    let weights = heuristic.get_weights(
+        0,
+        &proposers,
+        &[
+            block_builder.create_block(
+                proposers[0],
+                vec![false, true, true, false, false, false, false, false],
+                vec![],
+            ),
+            block_builder.create_block(
+                proposers[0],
+                vec![false, false, false, true, false, false, false, false],
+                vec![],
             ),
         ],
     );
@@ -98,31 +389,37 @@ fn test_epoch_change() {
         proposers.push(signer.author());
         signers.push(signer);
     }
-    let heuristic = ActiveInactiveHeuristic::new(proposers[0], active_weight, inactive_weight);
+    let mut block_builder = TestBlockBuilder::new();
+    let heuristic = ActiveInactiveHeuristic::new(
+        proposers[0],
+        active_weight,
+        inactive_weight,
+        proposers.len(),
+    );
     // History with [proposer 0, voters 1, 2], [proposer 0, voters 3] in current epoch
     let weights = heuristic.get_weights(
         2,
         &proposers,
         &[
-            create_block(
-                2,
+            block_builder.create_block(
+                proposers[0],
+                vec![false, true, true, true, true, true, true, true],
+                vec![],
+            ),
+            block_builder.new_epoch().create_block(
+                proposers[0],
+                vec![false, true, true, true, true, true, true, true],
+                vec![],
+            ),
+            block_builder.new_epoch().create_block(
                 proposers[0],
                 vec![false, true, true, false, false, false, false, false],
+                vec![],
             ),
-            create_block(
-                2,
+            block_builder.create_block(
                 proposers[0],
                 vec![false, false, false, true, false, false, false, false],
-            ),
-            create_block(
-                1,
-                proposers[0],
-                vec![false, true, true, true, true, true, true, true],
-            ),
-            create_block(
-                0,
-                proposers[0],
-                vec![false, true, true, true, true, true, true, true],
+                vec![],
             ),
         ],
     );
@@ -137,15 +434,18 @@ fn test_epoch_change() {
     }
 }
 
+/// #### LeaderReputation test ####
+
 #[test]
 fn test_api() {
     let active_weight = 9;
     let inactive_weight = 1;
     let proposers: Vec<AccountAddress> =
         (0..5).map(|_| AccountAddress::random()).sorted().collect();
+    let mut block_builder = TestBlockBuilder::new();
     let history = vec![
-        create_block(0, proposers[0], vec![false, true, true, false, false]),
-        create_block(0, proposers[0], vec![false, false, false, true, false]),
+        block_builder.create_block(proposers[0], vec![false, true, true, false, false], vec![]),
+        block_builder.create_block(proposers[0], vec![false, false, false, true, false], vec![]),
     ];
     let leader_reputation = LeaderReputation::new(
         0,
@@ -155,6 +455,7 @@ fn test_api() {
             proposers[0],
             active_weight,
             inactive_weight,
+            proposers.len(),
         )),
         4,
     );


### PR DESCRIPTION
    Heuristic that looks at successful and failed proposals, as well as voting history,
    to define node reputation, used for leader selection.
    
    We want to optimize leader selection to primarily maximize network's throughput,
    but we also, in combinatoin with staking rewards logic, need to be reasonably fair.
    
    Logic is:
     * if proposer round failure rate within the proposer window is strictly above threshold, use failed_weight (default 1).
     * otherwise, if node had no proposal rounds and no successful votes, use inactive_weight (default 10).
     * otherwise, use the default active_weight (default 100).
    
    We primarily want to avoid failed rounds, as they have a largest negative effect on the network.
    So if we see a node having failures to propose, when it was the leader, we want to avoid that node.
    We add a threshold (instead of penalizing on a single failure), so that transient issues in the network,
    or malicious behaviour of the next leader is avoided. In general, we expect there to be
    proposer_window_size/num_validators opportunities for a node to be a leader, so a single failure, or a
    subset of following leaders being malicious will not be enough to exclude a node.
    On the other hand, single failure, without any successes before will exclude the note.
    Threshold probably makes the most sense to be between:
     * 10% (aggressive exclusion with 1 failure in 10 proposals being enough for exclusion)
     * and 33% (much less aggressive exclusion, with 1 failure for every 2 successes, should still reduce failed
       rounds by at least 66%, and is enough to avoid byzantine attacks as well as the rest of the protocol)
    



For #1395 