### PR TITLE
[tf][aptos-node-testnet] prometheus

### DIFF
--- a/terraform/aptos-node-testnet/forge.tf
+++ b/terraform/aptos-node-testnet/forge.tf
@@ -158,8 +158,7 @@ resource "helm_release" "forge" {
   values = [
     jsonencode({
       forge = {
-        numValidators = var.num_validators
-        helmBucket    = aws_s3_bucket.aptos-testnet-helm[0].bucket
+        helmBucket = aws_s3_bucket.aptos-testnet-helm[0].bucket
         image = {
           tag = var.image_tag
         }

--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -11,6 +11,7 @@ data "aws_caller_identity" "current" {}
 locals {
   workspace = var.workspace_name_override != "" ? var.workspace_name_override : terraform.workspace
   aws_tags  = "Terraform=testnet,Workspace=${local.workspace}"
+  chain_name = var.chain_name != "" ? var.chain_name : "${local.workspace}net"
 }
 
 module "validator" {
@@ -27,7 +28,7 @@ module "validator" {
 
   chain_id       = var.chain_id
   era            = var.era
-  chain_name     = var.chain_name
+  chain_name     = local.chain_name
   image_tag      = var.image_tag
   validator_name = "aptos-node"
 
@@ -76,7 +77,7 @@ resource "helm_release" "genesis" {
   values = [
     jsonencode({
       chain = {
-        name     = var.chain_name
+        name     = local.chain_name
         era      = var.era
         chain_id = var.chain_id
       }

--- a/terraform/aptos-node-testnet/outputs.tf
+++ b/terraform/aptos-node-testnet/outputs.tf
@@ -1,3 +1,8 @@
 output "forge-s3-bucket" {
   value = aws_s3_bucket.aptos-testnet-helm[0].bucket
 }
+
+output "oidc_provider" {
+  value     = module.validator.oidc_provider
+  sensitive = true
+}

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -73,8 +73,8 @@ variable "era" {
 }
 
 variable "chain_name" {
-  description = "Aptos chain name"
-  default     = "devnet"
+  description = "Aptos chain name. If unset, defaults to using the workspace name"
+  default     = ""
 }
 
 variable "image_tag" {

--- a/terraform/aptos-node/aws/cluster.tf
+++ b/terraform/aptos-node/aws/cluster.tf
@@ -78,7 +78,9 @@ resource "aws_eks_node_group" "nodes" {
   lifecycle {
     ignore_changes = [
       # ignore changes to the desired size that may occur due to cluster autoscaler
-      scaling_config[0].desired_size
+      scaling_config[0].desired_size,
+      # ignore changes to max size, especially when it decreases to < desired_size, which fails
+      scaling_config[0].max_size,
     ]
   }
 

--- a/terraform/helm/forge/values.yaml
+++ b/terraform/helm/forge/values.yaml
@@ -1,6 +1,5 @@
 # Forge testing framework
 forge:
-  numValidators:
   helmBucket:
   image:
     repo: aptos/forge

--- a/terraform/helm/monitoring/values.yaml
+++ b/terraform/helm/monitoring/values.yaml
@@ -91,3 +91,4 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  annotations:


### PR DESCRIPTION
Get prometheus to work on `aptos-node-testnet` TF setup. This includes some cleanup around the use of `chain_name`. It defaults to the workspace name. This makes it easier to identify prometheus metrics when metrics across many chains/networks are getting shipped to a remote metrics server via remote_write.

Also some general cleanup around EKS nodegroup sizes and TF lifecycle ignores, and some TF output propagation. 