### PR TITLE
chore(ts-sdk): add package to autogen changelog

### DIFF
--- a/ecosystem/typescript/sdk/.versionrc.json
+++ b/ecosystem/typescript/sdk/.versionrc.json
@@ -1,0 +1,19 @@
+{
+  "types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "hidden": true },
+    { "type": "docs", "hidden": true },
+    { "type": "style", "hidden": true },
+    { "type": "refactor", "hidden": true },
+    { "type": "perf", "hidden": true },
+    { "type": "test", "hidden": true }
+  ],
+  "skip": {
+    "bump": true,
+    "commit": true,
+    "tag": true
+  },
+  "path": ".",
+  "header": "# Changelog\n\nAll notable changes to this project will be documented in this file.\n"
+}

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -15,7 +15,8 @@
     "_fmt": "prettier 'src/**/*.ts' 'examples/**/*.js' 'examples/**/*.ts'",
     "fmt": "yarn _fmt --write",
     "fmt:check": "yarn _fmt --check",
-    "cov:clean": "rm -rf coverage"
+    "cov:clean": "rm -rf coverage",
+    "changelog": "standard-version --skip.bump --skip.commit --skip.tag"
   },
   "repository": {
     "type": "git",
@@ -42,6 +43,7 @@
     "eslint-plugin-import": "^2.25.4",
     "jest": "^27.5.1",
     "prettier": "^2.6.2",
+    "standard-version": "^9.5.0",
     "ts-jest": "^27.1.4",
     "ts-loader": "^9.2.8",
     "ts-node": "^10.7.0",


### PR DESCRIPTION
### Description
We use standard-version to autogen change log based on commit messages. At the moment, we are not going to fully automate the SDK release. But being able to generate a change log with one command is very convenient.

### Test Plan
Ran the `yarn changelog`

Sample output
[CHANGELOG.md](https://github.com/aptos-labs/aptos-core/files/8995361/CHANGELOG.md)

