### PR TITLE
fix(ts-sdk): fix a typo, natual now becomes natural

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -106,7 +106,7 @@ test(
     const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString('0x1::TestCoin::TestCoin'));
 
     const scriptFunctionPayload = new TxnBuilderTypes.TransactionPayloadScriptFunction(
-      TxnBuilderTypes.ScriptFunction.natual(
+      TxnBuilderTypes.ScriptFunction.natural(
         '0x1::Coin',
         'transfer',
         [token],
@@ -177,7 +177,7 @@ test(
     const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString('0x1::TestCoin::TestCoin'));
 
     const scriptFunctionPayload = new TxnBuilderTypes.TransactionPayloadScriptFunction(
-      TxnBuilderTypes.ScriptFunction.natual(
+      TxnBuilderTypes.ScriptFunction.natural(
         '0x1::Coin',
         'transfer',
         [token],

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/transaction.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/transaction.ts
@@ -161,8 +161,17 @@ export class ScriptFunction {
    * ```
    * @returns
    */
-  static natual(module: string, func: string, ty_args: Seq<TypeTag>, args: Seq<Bytes>): ScriptFunction {
+  static natural(module: string, func: string, ty_args: Seq<TypeTag>, args: Seq<Bytes>): ScriptFunction {
     return new ScriptFunction(ModuleId.fromStr(module), new Identifier(func), ty_args, args);
+  }
+
+  /**
+   * `natual` is deprecated, please use `natural`
+   *
+   * @deprecated.
+   */
+  static natual(module: string, func: string, ty_args: Seq<TypeTag>, args: Seq<Bytes>): ScriptFunction {
+    return ScriptFunction.natural(module, func, ty_args, args);
   }
 
   serialize(serializer: Serializer): void {

--- a/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
@@ -53,7 +53,7 @@ function sign(rawTxn: RawTransaction): Bytes {
 
 test('serialize script function payload with no type args', () => {
   const scriptFunctionPayload = new TransactionPayloadScriptFunction(
-    ScriptFunction.natual(
+    ScriptFunction.natural(
       `${ADDRESS_1}::TestCoin`,
       'transfer',
       [],
@@ -82,7 +82,7 @@ test('serialize script function payload with type args', () => {
   const token = new TypeTagStruct(StructTag.fromString(`${ADDRESS_4}::TestCoin::TestCoin`));
 
   const scriptFunctionPayload = new TransactionPayloadScriptFunction(
-    ScriptFunction.natual(
+    ScriptFunction.natural(
       `${ADDRESS_1}::Coin`,
       'transfer',
       [token],
@@ -111,7 +111,7 @@ test('serialize script function payload with type args but no function args', ()
   const token = new TypeTagStruct(StructTag.fromString(`${ADDRESS_4}::TestCoin::TestCoin`));
 
   const scriptFunctionPayload = new TransactionPayloadScriptFunction(
-    ScriptFunction.natual(`${ADDRESS_1}::Coin`, 'fake_func', [token], []),
+    ScriptFunction.natural(`${ADDRESS_1}::Coin`, 'fake_func', [token], []),
   );
 
   const rawTxn = new RawTransaction(


### PR DESCRIPTION
### Description
`natual` is a typo. Changed it to `natural`.  Since `natual` is a public interface, we keep it as is but mark it as deprecated. In the next major release, it is going to be removed.

### Test Plan
yarn test
