### PR TITLE
[aptos-faucet-cli] Add a CLI to work as a faucet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,6 +389,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-faucet-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos",
+ "aptos-config",
+ "aptos-crypto",
+ "aptos-faucet",
+ "aptos-infallible",
+ "aptos-logger",
+ "aptos-rest-client",
+ "aptos-sdk",
+ "aptos-workspace-hack",
+ "bcs",
+ "bytes",
+ "clap 3.1.18",
+ "futures",
+ "hex",
+ "rand 0.7.3",
+ "reqwest",
+ "serde 1.0.137",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "tokio",
+ "url",
+ "warp",
+]
+
+[[package]]
 name = "aptos-fuzz"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "crates/aptos-crypto",
     "crates/aptos-crypto-derive",
     "crates/aptos-faucet",
+    "crates/aptos-faucet-cli",
     "crates/aptos-genesis",
     "crates/aptos-id-generator",
     "crates/aptos-infallible",

--- a/crates/aptos-faucet-cli/Cargo.toml
+++ b/crates/aptos-faucet-cli/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "aptos-faucet-cli"
+version = "0.1.0"
+authors = ["Aptos Labs <opensource@aptoslabs.com>"]
+description = "CLI for minting coins directly in testnets"
+repository = "https://github.com/aptos-labs/aptos-core"
+homepage = "https://aptoslabs.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.57"
+bcs = "0.1.3"
+bytes = "1.1.0"
+clap = "3.1.18"
+futures = "0.3.21"
+hex = "0.4.3"
+rand = "0.7.3"
+reqwest = { version = "0.11.10", features = ["blocking"], default-features = false }
+serde = { version = "1.0.137", features = ["derive"] }
+serde_json = "1.0.81"
+serde_yaml = "0.8.24"
+tokio = { version = "1.18.2", features = ["full"] }
+url = "2.2.2"
+warp = "0.3.2"
+
+aptos = { path = "../aptos" }
+aptos-config = { path = "../../config" }
+aptos-crypto = { path = "../aptos-crypto" }
+aptos-faucet = { path = "../aptos-faucet" }
+aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-rest-client = { path = "../../crates/aptos-rest-client" }
+aptos-sdk = { path = "../../sdk" }
+aptos-workspace-hack = { path = "../aptos-workspace-hack" }
+
+[dev-dependencies]
+serde_json = "1.0.81"
+tempfile = "3.3.0"
+
+aptos-config = { path = "../../config" }
+aptos-infallible = { path = "../../crates/aptos-infallible" }

--- a/crates/aptos-faucet-cli/README.md
+++ b/crates/aptos-faucet-cli/README.md
@@ -1,0 +1,56 @@
+# Faucet
+
+Faucet is a service for creating and funding accounts on the Aptos Network. It is meant to be used for devnets and testnets. By default, the Faucet takes the provided account, creates a new account, mints a lot of Coin<TestCoin> into that account, and delegates minting capability to that account. That account is then used to provide mint services via the faucet.
+
+
+## Mint API
+
+The Mint API can create and fund your account.
+
+* Base URL: `http://faucet.testnet.aptoslabs.com/`
+* Path: `/mint`
+* Method: POST
+
+URL Query Params:
+
+| param name             | type   | required? | description                                                 |
+|------------------------|--------|-----------|-------------------------------------------------------------|
+| `amount`               | int    | Y         | Amount of coins to mint. This is not always enabled.        |
+| `pub_key`              | string | Y         | Your account public key (ed25519)                           |
+| `return_txns`          | bool   | N         | Returns the transactions for creating / funding the account |
+
+Notes:
+* Type bool means you set value to a string "true" or "false"
+* For existing accounts as defined by the pub_key, the service submits 1 transfer funds transaction.
+* For new accounts as defined by the pub_key, the service first issues a transaction for creating the account and another for transferring funds.
+* All funds transferred come from the account 0xa550c18.
+* Clients should retry their request if the requests or the transaction execution failed. One reason for failure is that, under load, the service may issue transactions with duplicate sequence numbers. Only one of those transactions will be executed, the rest will fail.
+
+### Response
+
+If the query param `return_txns` is not provided, or it is not "true", the server returns a json-encoded list of transaction hash values. These can be used to monitor the status of submitted transactions.
+
+If the query param `return_txns` is set, the server will respond with the transactions for creating and funding your account.
+The response HTTP body is hex encoded bytes of BCS encoded `Vec<aptos_types::transaction::SignedTransaction>`.
+
+Decode Example ([source code generator](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/transaction-builder-generator)):
+
+``` python
+  de = bcs.BcsDeserializer(bytes.fromhex(response.text))
+  length = de.deserialize_len()
+
+  txns = []
+  for i in range(length):
+    txns.push(de.deserialize_any(aptos_types.SignedTransaction))
+
+```
+
+You should retry the mint API call if the transaction execution fails.
+
+
+## Example
+
+```bash
+curl -X POST http://faucet.testnet.aptoslabs.com/mint\?amount\=1000000\&pub_key\=459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d\&return_txns\=true
+01000000000000000000000000000000dd05a600000000000001e001a11ceb0b010000000701000202020403061004160205181d0735600895011000000001010000020001000003020301010004010300010501060c0108000506080005030a020a020005060c05030a020a020109000b4469656d4163636f756e741257697468647261774361706162696c6974791b657874726163745f77697468647261775f6361706162696c697479087061795f66726f6d1b726573746f72655f77697468647261775f6361706162696c69747900000000000000000000000000000001010104010c0b0011000c050e050a010a020b030b0438000b051102020107000000000000000000000000000000010358555303585553000403a74fd7c46952c497e75afb0a7932586d0140420f00000000000400040040420f00000000000000000000000000035855532a610f6000000000020020056244e7bf776e471d818dc18fdf7b8833c5439ac9a96e126f8f32c7bc7c14b64026a2c45c8e4066c661dc4f36baa6ad61499999b548b9f63ad15853660c408cedec3078b7773a829ec48de8b04291cd11530734b2f91d5e42f35a4c6378cb7c09
+```

--- a/crates/aptos-faucet-cli/src/main.rs
+++ b/crates/aptos-faucet-cli/src/main.rs
@@ -1,0 +1,132 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos::common::types::EncodingType;
+use aptos_config::keys::ConfigKey;
+use aptos_crypto::ed25519::Ed25519PrivateKey;
+use aptos_faucet::{mint, mint::MintParams, Service};
+use aptos_sdk::types::{
+    account_address::AccountAddress, account_config::aptos_root_address, chain_id::ChainId,
+    LocalAccount,
+};
+use clap::Parser;
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+#[tokio::main]
+async fn main() {
+    aptos_logger::Logger::new().init();
+    let args: FaucetCliArgs = FaucetCliArgs::parse();
+    args.execute().await
+}
+
+#[derive(Debug, Parser)]
+#[clap(name = "aptos-rosetta-cli", author, version, propagate_version = true)]
+pub struct FaucetCliArgs {
+    /// Aptos fullnode/validator server URL
+    #[clap(long, default_value = "https://fullnode.devnet.aptoslabs.com/")]
+    pub server_url: String,
+    /// Path to the private key for creating test account and minting coins.
+    /// To keep Testnet simple, we used one private key for aptos root account
+    /// To manually generate a keypair, use generate-key:
+    /// `cargo run -p generate-keypair -- -o <output_file_path>`
+    #[clap(long, default_value = "/opt/aptos/etc/mint.key")]
+    pub mint_key_file_path: String,
+    /// Ed25519PrivateKey for minting coins
+    #[clap(long, parse(try_from_str = ConfigKey::from_encoded_string))]
+    pub mint_key: Option<ConfigKey<Ed25519PrivateKey>>,
+    /// Address of the account to send transactions from.
+    /// On Testnet, for example, this is a550c18.
+    /// If not present, the mint key's address is used
+    #[clap(long, parse(try_from_str = AccountAddress::from_hex_literal))]
+    pub mint_account_address: Option<AccountAddress>,
+    /// Chain ID of the network this client is connecting to.
+    /// For mainnet: "MAINNET" or 1, testnet: "TESTNET" or 2, devnet: "DEVNET" or 3,
+    /// local swarm: "TESTING" or 4
+    /// Note: Chain ID of 0 is not allowed; Use number if chain id is not predefined.
+    #[clap(long, default_value = "3")]
+    pub chain_id: ChainId,
+    /// Amount of coins to mint
+    #[clap(long)]
+    pub amount: u64,
+    /// Addresses of accounts to mint coins to, split by commas
+    #[clap(long, group = "account-group")]
+    pub accounts: Option<String>,
+    /// File of addresses of account to mint coins to.  Formatted in YAML
+    #[clap(long, group = "account-group", parse(from_os_str))]
+    pub account_file: Option<PathBuf>,
+}
+
+impl FaucetCliArgs {
+    async fn execute(self) {
+        let mint_account_address = self.mint_account_address.unwrap_or_else(aptos_root_address);
+        let mint_key = if let Some(ref key) = self.mint_key {
+            key.private_key()
+        } else {
+            EncodingType::BCS
+                .load_key::<Ed25519PrivateKey>("mint key", Path::new(&self.mint_key_file_path))
+                .unwrap()
+        };
+        let faucet_account = LocalAccount::new(mint_account_address, mint_key, 0);
+        let service = Service::new(self.server_url, self.chain_id, faucet_account, None);
+
+        let accounts: HashSet<AccountAddress> = if let Some(accounts) = self.accounts {
+            accounts
+                .trim()
+                .split(',')
+                .map(process_account_address)
+                .collect()
+        } else if let Some(path) = self.account_file {
+            let strings: Vec<String> =
+                serde_yaml::from_str(&std::fs::read_to_string(path.as_path()).unwrap()).unwrap();
+            strings
+                .into_iter()
+                .map(|str| process_account_address(&str))
+                .collect()
+        } else {
+            panic!("Either --accounts or --account-file must be specified");
+        };
+
+        // Iterate through accounts to mint the tokens
+        for account in accounts {
+            let response = mint::process(
+                &service,
+                MintParams {
+                    amount: self.amount,
+                    auth_key: None,
+                    address: Some(account.to_hex_literal()),
+                    pub_key: None,
+                    return_txns: None,
+                },
+            )
+            .await;
+            match response {
+                Ok(response) => println!(
+                    "SUCCESS: Account: {} Response: {:?}",
+                    account.to_hex_literal(),
+                    response
+                ),
+                Err(response) => println!(
+                    "FAILURE: Account: {} Response: {:?}",
+                    account.to_hex_literal(),
+                    response
+                ),
+            }
+        }
+    }
+}
+
+/// Allow 0x to be in front of addresses
+fn process_account_address(str: &str) -> AccountAddress {
+    let str = str.trim();
+    if let Ok(address) = AccountAddress::from_hex_literal(str) {
+        address
+    } else if let Ok(address) = AccountAddress::from_str(str) {
+        address
+    } else {
+        panic!("Account address is in an invalid format {}", str)
+    }
+}

--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -147,7 +147,7 @@ impl FaucetArgs {
 
 pub struct Service {
     pub faucet_account: Mutex<LocalAccount>,
-    transaction_factory: TransactionFactory,
+    pub transaction_factory: TransactionFactory,
     client: Client,
     endpoint: String,
     maximum_amount: Option<u64>,

--- a/x.toml
+++ b/x.toml
@@ -173,6 +173,7 @@ members = [
     # Please keep this list in alphabetical order!
 
     "testcases",
+    "aptos-faucet-cli",
     "aptos-fuzz",
     "aptos-fuzzer",
     "aptos-proptest-helpers",


### PR DESCRIPTION
### Description
For minting coins without a present faucet, this allows for testing without having to run a faucet locally.

### Test Plan
Ran against local test node
```
 cargo run -p aptos-faucet-cli -- --amount 10000 --mint-key-file-path /private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/a05ade92c4e95ec2e8c8ba741eb3eefd/mint.key --chain-id TESTING --server-url http://localhost:8080 --accounts 0x1,0x2,0x3,0x4

SUCCESS: Account: 0x1 Response: SubmittedTxnsHashes([HashValue(d949272283505d4acdcfa0c954b4da5824aac0deb40d992e13d9cf4fb34d9bde)])
SUCCESS: Account: 0x2 Response: SubmittedTxnsHashes([HashValue(83966106457a8b5eb145b843bfe63e8c4ffb97f1814233f47cf13a05626f74a3)])
SUCCESS: Account: 0x3 Response: SubmittedTxnsHashes([HashValue(888a04100b98c60384655f4df0bde1d655e2726fe4a391dbb08b4c54f262b384)])
SUCCESS: Account: 0x4 Response: SubmittedTxnsHashes([HashValue(cd97c129e379aaf610770bd65d06763c266b9ceebaa4fc04ad5d8b6550ecdcd8)])

```