### PR TITLE
[storage] explicitly forbid `save_transactions()` from being called concurrently

### DIFF
--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -171,8 +171,6 @@ mod tests {
             true,
         );
 
-        aptos_logger::info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-
         super::run_benchmark(
             5, /* block_size */
             5, /* num_transfer_blocks */

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1262,7 +1262,7 @@ impl DbWriter for AptosDB {
     ) -> Result<()> {
         gauged_api("save_state_snapshot", || {
             let mut cs = ChangeSet::new();
-            let root_hash = *self
+            let root_hash = self
                 .state_store
                 .merklize_value_sets(
                     vec![jmt_update_refs(&jmt_updates)],


### PR DESCRIPTION
…rrently

### Description
see discussion on https://github.com/aptos-labs/aptos-core/pull/1502

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

existing coverage