### PR TITLE
[tf][aptos-node-testnet] feature parity for testnet ing

### DIFF
--- a/terraform/aptos-node-testnet/auth.tf
+++ b/terraform/aptos-node-testnet/auth.tf
@@ -1,0 +1,202 @@
+# Based on https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#iam-policy
+data "aws_iam_policy_document" "external-dns" {
+  statement {
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ListResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/${var.zone_id}"]
+  }
+
+  statement {
+    actions = [
+      "route53:ListHostedZones",
+    ]
+    resources = ["*"]
+  }
+}
+
+# Based on https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.8/docs/examples/iam-policy.json
+data "aws_iam_policy_document" "alb-ingress" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "acm:DescribeCertificate",
+      "acm:ListCertificates",
+      "acm:GetCertificate"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateTags",
+      "ec2:DeleteTags",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DescribeAccountAttributes",
+      "ec2:DescribeAddresses",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeInternetGateways",
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVpcs",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifyNetworkInterfaceAttribute",
+      "ec2:RevokeSecurityGroupIngress"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "elasticloadbalancing:AddListenerCertificates",
+      "elasticloadbalancing:AddTags",
+      "elasticloadbalancing:CreateListener",
+      "elasticloadbalancing:CreateLoadBalancer",
+      "elasticloadbalancing:CreateRule",
+      "elasticloadbalancing:CreateTargetGroup",
+      "elasticloadbalancing:DeleteListener",
+      "elasticloadbalancing:DeleteLoadBalancer",
+      "elasticloadbalancing:DeleteRule",
+      "elasticloadbalancing:DeleteTargetGroup",
+      "elasticloadbalancing:DeregisterTargets",
+      "elasticloadbalancing:DescribeListenerCertificates",
+      "elasticloadbalancing:DescribeListeners",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeLoadBalancerAttributes",
+      "elasticloadbalancing:DescribeRules",
+      "elasticloadbalancing:DescribeSSLPolicies",
+      "elasticloadbalancing:DescribeTags",
+      "elasticloadbalancing:DescribeTargetGroups",
+      "elasticloadbalancing:DescribeTargetGroupAttributes",
+      "elasticloadbalancing:DescribeTargetHealth",
+      "elasticloadbalancing:ModifyListener",
+      "elasticloadbalancing:ModifyLoadBalancerAttributes",
+      "elasticloadbalancing:ModifyRule",
+      "elasticloadbalancing:ModifyTargetGroup",
+      "elasticloadbalancing:ModifyTargetGroupAttributes",
+      "elasticloadbalancing:RegisterTargets",
+      "elasticloadbalancing:RemoveListenerCertificates",
+      "elasticloadbalancing:RemoveTags",
+      "elasticloadbalancing:SetIpAddressType",
+      "elasticloadbalancing:SetSecurityGroups",
+      "elasticloadbalancing:SetSubnets",
+      "elasticloadbalancing:SetWebACL"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "iam:CreateServiceLinkedRole",
+      "iam:GetServerCertificate",
+      "iam:ListServerCertificates"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "cognito-idp:DescribeUserPoolClient"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "waf-regional:GetWebACLForResource",
+      "waf-regional:GetWebACL",
+      "waf-regional:AssociateWebACL",
+      "waf-regional:DisassociateWebACL"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "tag:GetResources",
+      "tag:TagResources"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "waf:GetWebACL"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "wafv2:GetWebACL",
+      "wafv2:GetWebACLForResource",
+      "wafv2:AssociateWebACL",
+      "wafv2:DisassociateWebACL"
+    ]
+    resources = ["*"]
+  }
+}
+
+data "aws_iam_policy_document" "k8s-aws-integrations-assume-role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${module.validator.oidc_provider}"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.validator.oidc_provider}:sub"
+      values   = ["system:serviceaccount:kube-system:k8s-aws-integrations"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${module.validator.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "k8s-aws-integrations" {
+  name                 = "${local.workspace}-k8s-aws-integrations"
+  path                 = var.iam_path
+  assume_role_policy   = data.aws_iam_policy_document.k8s-aws-integrations-assume-role.json
+  permissions_boundary = var.permissions_boundary_policy
+
+  tags = {
+    Terraform = "testnet"
+    Workspace = terraform.workspace
+  }
+}
+
+resource "aws_iam_role_policy" "k8s-aws-integrations" {
+  count  = var.zone_id != "" ? 1 : 0
+  name   = "External-DNS"
+  role   = aws_iam_role.k8s-aws-integrations.name
+  policy = data.aws_iam_policy_document.external-dns.json
+}
+
+resource "aws_iam_role_policy" "alb-ingress" {
+  name   = "EKS-Ingress"
+  role   = aws_iam_role.k8s-aws-integrations.name
+  policy = data.aws_iam_policy_document.alb-ingress.json
+}

--- a/terraform/aptos-node-testnet/dns.tf
+++ b/terraform/aptos-node-testnet/dns.tf
@@ -4,7 +4,7 @@ data "aws_route53_zone" "aptos" {
 }
 
 locals {
-  dns_prefix = var.workspace_dns ? "${terraform.workspace}." : ""
+  dns_prefix = var.workspace_dns ? "${local.workspace}." : ""
   domain     = var.zone_id != "" ? "${local.dns_prefix}${data.aws_route53_zone.aptos[0].name}" : null
 }
 

--- a/terraform/aptos-node-testnet/forge.tf
+++ b/terraform/aptos-node-testnet/forge.tf
@@ -109,22 +109,6 @@ data "aws_iam_policy_document" "forge" {
       "arn:aws:s3:::${aws_s3_bucket.aptos-testnet-helm[0].id}/*"
     ]
   }
-
-  statement {
-    sid = "UpdateEksNodegroups"
-    actions = [
-      "eks:ListNodegroups",
-      "eks:DescribeNodegroup",
-      "eks:DescribeUpdate",
-      "eks:UpdateNodegroupConfig",
-      "eks:UpdateNodegroupVersion"
-    ]
-    resources = [
-      module.validator.aws_eks_cluster.arn,
-      "arn:aws:eks:${var.region}:${data.aws_caller_identity.current.account_id}:cluster/${module.validator.aws_eks_cluster.name}/*",
-      "arn:aws:eks:${var.region}:${data.aws_caller_identity.current.account_id}:nodegroup/${module.validator.aws_eks_cluster.name}/*"
-    ]
-  }
 }
 
 resource "aws_iam_role" "forge" {

--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -86,6 +86,15 @@ resource "helm_release" "genesis" {
       genesis = {
         numValidators   = var.num_validators
         username_prefix = local.aptos_node_helm_prefix
+        domain = local.domain
+        validator = {
+          enable_onchain_discovery = false
+        }
+        fullnode = {
+          # only enable onchain discovery if var.zone_id has been provided to provision
+          # internet facing network addresses for the fullnodes
+          enable_onchain_discovery = var.zone_id != ""
+        }
       }
     }),
     jsonencode(var.genesis_helm_values)

--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -9,8 +9,8 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 locals {
-  workspace = var.workspace_name_override != "" ? var.workspace_name_override : terraform.workspace
-  aws_tags  = "Terraform=testnet,Workspace=${local.workspace}"
+  workspace  = var.workspace_name_override != "" ? var.workspace_name_override : terraform.workspace
+  aws_tags   = "Terraform=testnet,Workspace=${local.workspace}"
   chain_name = var.chain_name != "" ? var.chain_name : "${local.workspace}net"
 }
 
@@ -19,6 +19,7 @@ module "validator" {
 
   region                      = var.region
   iam_path                    = var.iam_path
+  zone_id                     = var.zone_id
   permissions_boundary_policy = var.permissions_boundary_policy
   workspace_name_override     = var.workspace_name_override
 
@@ -33,7 +34,7 @@ module "validator" {
   validator_name = "aptos-node"
 
   num_validators = var.num_validators
-  helm_values    = var.aptos_node_helm_values
+  helm_values = var.aptos_node_helm_values
 
   # allow all nodegroups to surge to 2x their size, in case of total nodes replacement
   validator_instance_num = var.num_validator_instance > 0 ? 2 * var.num_validator_instance : var.num_validators
@@ -83,7 +84,7 @@ resource "helm_release" "genesis" {
       }
       imageTag = var.image_tag
       genesis = {
-        numValidators = var.num_validators
+        numValidators   = var.num_validators
         username_prefix = local.aptos_node_helm_prefix
       }
     }),

--- a/terraform/aptos-node/aws/dns.tf
+++ b/terraform/aptos-node/aws/dns.tf
@@ -9,14 +9,21 @@ resource "random_string" "validator-dns" {
   length  = 16
 }
 
+data "aws_route53_zone" "aptos" {
+  count   = var.zone_id != "" ? 1 : 0
+  zone_id = var.zone_id
+}
+
 locals {
   record_name = replace(var.record_name, "<workspace>", local.workspace_name)
+  # domain name for external-dns, if it is installed
+  domain = var.zone_id != "" ? "${local.workspace_name}.${data.aws_route53_zone.aptos[0].name}" : null
 }
 
 data "kubernetes_service" "validator-lb" {
   count = var.zone_id != "" ? 1 : 0
   metadata {
-    name = "${local.workspace_name}-aptos-node-validator-lb"
+    name = "${local.workspace_name}-aptos-node-0-validator-lb"
   }
   depends_on = [time_sleep.lb_creation]
 }
@@ -24,7 +31,7 @@ data "kubernetes_service" "validator-lb" {
 data "kubernetes_service" "fullnode-lb" {
   count = var.zone_id != "" ? 1 : 0
   metadata {
-    name = "${local.workspace_name}-aptos-node-fullnode-lb"
+    name = "${local.workspace_name}-aptos-node-0-fullnode-lb"
   }
   depends_on = [time_sleep.lb_creation]
 }

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -134,6 +134,9 @@ locals {
         "eks.amazonaws.com/nodegroup" = "utilities"
       }
     }
+    service = {
+      domain = local.domain
+    }
   })
 }
 

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -115,6 +115,7 @@ locals {
         value  = "validators"
         effect = "NoExecute"
       }]
+      remoteLogAddress = var.enable_logger ? "${local.workspace_name}-log-aptos-logger:5044" : null
     }
     fullnode = {
       storage = {

--- a/terraform/helm/aptos-node/files/haproxy.cfg
+++ b/terraform/helm/aptos-node/files/haproxy.cfg
@@ -49,7 +49,7 @@ backend validator-metrics
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:9101
 
 # Exposes the validator's own REST API
-{{- if $.Values.validator.exposeRestApi }}
+{{- if $.Values.service.validator.enableRestApi }}
 frontend validator-api
     mode http
     option httplog

--- a/terraform/helm/aptos-node/templates/_helpers.tpl
+++ b/terraform/helm/aptos-node/templates/_helpers.tpl
@@ -48,7 +48,7 @@ Selector labels
 */}}
 {{- define "aptos-validator.selectorLabels" -}}
 app.kubernetes.io/part-of: {{ include "aptos-validator.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: helm
 {{- end -}}
 
 {{/*

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -11,7 +11,8 @@ metadata:
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
-    app.kubernetes.io/name: fullnode-{{$i}}
+    app.kubernetes.io/name: fullnode
+    app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
   ports:
   - name: aptosnet
@@ -29,7 +30,8 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}-e{{ $.Values.chain.era }}
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: fullnode-{{$i}}
+    app.kubernetes.io/name: fullnode
+    app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
 spec:
   serviceName: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}
@@ -38,7 +40,8 @@ spec:
   selector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/name: fullnode-{{$i}}
+      app.kubernetes.io/name: fullnode
+      app.kubernetes.io/instance: fullnode-{{$i}}
       group: {{ .name }}
   volumeClaimTemplates:
   - metadata:
@@ -54,7 +57,8 @@ spec:
     metadata:
       labels:
         {{- include "aptos-validator.selectorLabels" $ | nindent 8 }}
-        app.kubernetes.io/name: fullnode-{{$i}}
+        app.kubernetes.io/name: fullnode
+        app.kubernetes.io/instance: fullnode-{{$i}}
         group: {{ .name }}
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default

--- a/terraform/helm/aptos-node/templates/haproxy.yaml
+++ b/terraform/helm/aptos-node/templates/haproxy.yaml
@@ -24,17 +24,23 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode: All
+    {{- if $.Values.service.domain }}
+    external-dns.alpha.kubernetes.io/hostname: val{{$i}}.{{ $.Values.service.domain }}
+    {{- end }}
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
-    app.kubernetes.io/name: haproxy-{{$i}}
+    app.kubernetes.io/name: haproxy
+    app.kubernetes.io/instance: haproxy-{{$i}}
   ports:
   - name: validator
     port: 6180
+  {{- if $.Values.service.validator.enableMetricsPort }}
   - name: metrics
     port: 9101
     targetPort: 9102
-  {{- if $.Values.validator.exposeRestApi }}
+  {{- end }}
+  {{- if $.Values.service.validator.enableRestApi }}
   - name: api
     port: 80
     targetPort: 8180
@@ -57,18 +63,24 @@ metadata:
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
     service.beta.kubernetes.io/oci-load-balancer-security-list-management-mode: All
+    {{- if $.Values.service.domain }}
+    external-dns.alpha.kubernetes.io/hostname: {{ $config.name }}{{$i}}.{{ $.Values.service.domain }}
+    {{- end }}
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
-    app.kubernetes.io/name: haproxy-{{$i}}
+    app.kubernetes.io/name: haproxy
+    app.kubernetes.io/instance: haproxy-{{$i}}
   ports:
   - name: aptosnet
     port: 6182
     targetPort: {{ add 6182 $index }}
+  {{- if $.Values.service.fullnode.enableMetricsPort }}
   - name: metrics
     port: 9101
     targetPort: {{ add 9103 $index }}
-  {{- if $config.enableRestApi }}
+  {{- end }}
+  {{- if $.Values.service.fullnode.enableRestApi }}
   - name: api
     port: 80
     targetPort: {{ add 8080 $index }}
@@ -95,7 +107,8 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-haproxy
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: haproxy-{{$i}}
+    app.kubernetes.io/name: haproxy
+    app.kubernetes.io/instance: haproxy-{{$i}}
 spec:
   replicas: {{ $.Values.haproxy.replicas }}
   strategy:
@@ -104,12 +117,14 @@ spec:
   selector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/name: haproxy-{{$i}}
+      app.kubernetes.io/name: haproxy
+      app.kubernetes.io/instance: haproxy-{{$i}}
   template:
     metadata:
       labels:
         {{- include "aptos-validator.selectorLabels" $ | nindent 8 }}
-        app.kubernetes.io/name: haproxy-{{$i}}
+        app.kubernetes.io/name: haproxy
+        app.kubernetes.io/instance: haproxy-{{$i}}
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
         checksum/haproxy.cfg: {{ tpl ($.Files.Get "files/haproxy.cfg") $ | sha256sum }}

--- a/terraform/helm/aptos-node/templates/networkpolicy.yaml
+++ b/terraform/helm/aptos-node/templates/networkpolicy.yaml
@@ -10,7 +10,8 @@ spec:
   podSelector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/name: validator-{{$i}}
+      app.kubernetes.io/name: validator
+      app.kubernetes.io/instance: validator-{{$i}}
   policyTypes:
   - Ingress
   - Egress
@@ -20,14 +21,15 @@ spec:
     - podSelector:
         matchLabels:
           {{- include "aptos-validator.selectorLabels" $ | nindent 10 }}
-          app.kubernetes.io/name: haproxy-{{$i}}
+          app.kubernetes.io/name: haproxy
+          app.kubernetes.io/instance: haproxy-{{$i}}
     ports:
       # AptosNet from HAproxy
     - protocol: TCP
       port: 6180
     - protocol: TCP
       port: 9101
-  {{- if $.Values.validator.exposeRestApi }}
+  {{- if $.Values.service.validator.enableRestApi }}
       # REST API from HAproxy
     - protocol: TCP
       port: 8080
@@ -46,7 +48,8 @@ spec:
     - podSelector:
         matchLabels:
           {{- include "aptos-validator.selectorLabels" $ | nindent 10 }}
-          app.kubernetes.io/name: fullnode-{{$i}}
+          app.kubernetes.io/name: fullnode
+          app.kubernetes.io/instance: fullnode-{{$i}}
     ports:
     - protocol: TCP
       port: 6181

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -9,7 +9,8 @@ metadata:
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
-    app.kubernetes.io/name: validator-{{$i}}
+    app.kubernetes.io/name: validator
+    app.kubernetes.io/instance: validator-{{$i}}
   ports:
   - name: validator
     port: 6180
@@ -17,7 +18,7 @@ spec:
     port: 6181
   - name: metrics
     port: 9101
-  {{- if $.Values.validator.exposeRestApi }}
+  {{- if $.Values.service.validator.enableRestApi }}
   - name: api
     port: 8080
   {{- end }}
@@ -46,7 +47,8 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    app.kubernetes.io/name: validator-{{$i}}
+    app.kubernetes.io/name: validator
+    app.kubernetes.io/instance: validator-{{$i}}
 spec:
   serviceName: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   replicas: 1
@@ -54,12 +56,14 @@ spec:
   selector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
-      app.kubernetes.io/name: validator-{{$i}}
+      app.kubernetes.io/name: validator
+      app.kubernetes.io/instance: validator-{{$i}}
   template:
     metadata:
       labels:
         {{- include "aptos-validator.selectorLabels" $ | nindent 8 }}
-        app.kubernetes.io/name: validator-{{$i}}
+        app.kubernetes.io/name: validator
+        app.kubernetes.io/instance: validator-{{$i}}
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
         checksum/validator.yaml: {{ tpl ($.Files.Get "files/configs/validator.yaml") $ | sha256sum }}

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -39,13 +39,11 @@ validator:
     ledger_prune_window: 10000000
     state_store_prune_window: 1000000
     pruning_batch_size: 10000
-  exposeRestApi: false
 
 fullnode:
   groups:
   - name: fullnode
     replicas: 1
-    enableRestApi: true
   resources:
     limits:
       cpu: 3.5
@@ -88,12 +86,18 @@ haproxy:
   tls_secret:
 
 service:
+  domain:
   external:
     type: LoadBalancer
   validator:
     loadBalancerSourceRanges:
+    enableRestApi: false
+    enableMetricsPort: false
+  # NOTE: these values apply for all fullnode groups
   fullnode:
     loadBalancerSourceRanges:
+    enableRestApi: false
+    enableMetricsPort: false
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/terraform/helm/genesis/files/genesis.sh
+++ b/terraform/helm/genesis/files/genesis.sh
@@ -18,8 +18,14 @@ VALIDATOR_HOST_SUFFIX=${VALIDATOR_HOST_SUFFIX:-validator-lb}
 FULLNODE_HOST_SUFFIX=${FULLNODE_HOST_SUFFIX:-fullnode-lb}
 MOVE_MODULES_DIR=${MOVE_MODULES_DIR:-"/aptos-framework/move/modules"}
 
-if [[ -z ${ERA} ]] || [[ -z ${NUM_VALIDATORS} ]]; then
+if [ -z ${ERA} ] || [ -z ${NUM_VALIDATORS} ]; then
     echo "ERA (${ERA:-null}) and NUM_VALIDATORS (${NUM_VALIDATORS:-null}) must be set"
+    exit 1
+fi
+
+if [ "${FULLNODE_ENABLE_ONCHAIN_DISCOVERY}" = "true" ] && [ -z ${DOMAIN} ] ||
+    [ "${VALIDATOR_ENABLE_ONCHAIN_DISCOVERY}" = "true" ] && [ -z ${DOMAIN} ]; then
+    echo "If FULLNODE_ENABLE_ONCHAIN_DISCOVERY or VALIDATOR_ENABLE_ONCHAIN_DISCOVERY is set, DOMAIN must be set"
     exit 1
 fi
 
@@ -35,11 +41,25 @@ for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
 username="${USERNAME_PREFIX}-${i}"
 user_dir="${WORKSPACE}/${username}"
 mkdir $user_dir
+
+if [ "${FULLNODE_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
+    fullnode_host="fullnode${i}.${DOMAIN}:6182"
+else
+    fullnode_host="${username}-${FULLNODE_HOST_SUFFIX}:6182"
+fi
+
+if [ "${VALIDATOR_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
+    validator_host="val${i}.${DOMAIN}:6180"
+else
+    validator_host="${username}-${VALIDATOR_HOST_SUFFIX}:6180"
+fi
+
+
 aptos genesis generate-keys --output-dir $user_dir
 aptos genesis set-validator-configuration --keys-dir $user_dir --local-repository-dir $WORKSPACE \
     --username $username \
-    --validator-host "${username}-${VALIDATOR_HOST_SUFFIX}:6180" \
-    --full-node-host "${username}-${FULLNODE_HOST_SUFFIX}:6182"
+    --validator-host $validator_host \
+    --full-node-host $fullnode_host
 done
 
 # get the framework

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -19,6 +19,7 @@ data:
     max_lockup_duration_secs: {{ .Values.chain.max_lockup_duration_secs | int }}
     epoch_duration_secs: {{ .Values.chain.epoch_duration_secs | int }}
     initial_lockup_timestamp: {{ now | date_modify (printf "+%s" .Values.chain.initial_lockup_duration) | unixEpoch }}
+    min_price_per_gas_unit: {{ .Values.chain.min_price_per_gas_unit }}
     allow_new_validators: {{ .Values.chain.allow_new_validators }}
 
 ---
@@ -107,6 +108,16 @@ spec:
           value: {{ .Values.chain.era | quote }}
         - name: MOVE_MODULES_DIR
           value: {{ .Values.genesis.moveModulesDir | quote }}
+        - name: DOMAIN
+          value: {{ .Values.genesis.domain | quote }}
+        - name: VALIDATOR_ENABLE_ONCHAIN_DISCOVERY
+          value: {{ .Values.genesis.validator.enable_onchain_discovery | quote }}
+        - name: FULLNODE_ENABLE_ONCHAIN_DISCOVERY
+          value: {{ .Values.genesis.fullnode.enable_onchain_discovery | quote }}
+        - name: VALIDATOR_INTERNAL_HOST_SUFFIX
+          value: {{ .Values.genesis.validator.internal_host_suffix | quote }}
+        - name: FULLNODE_INTERNAL_HOST_SUFFIX
+          value: {{ .Values.genesis.fullnode.internal_host_suffix | quote }}
         volumeMounts:
         - name: layout
           mountPath: /tmp/layout.yaml

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -23,11 +23,17 @@ genesis:
     pullPolicy: IfNotPresent
   # Number of validators to include in genesis
   numValidators: 1
-  # Assumes the validators and fullnodes are using the service names from
-  # aptos-node helm chart
+  # Controls whether to use public DNS as created by aptos-node helm chart
+  # If not using public DNS, assumes the validators and fullnodes are using the service names
+  # from aptos-node helm chart
   username_prefix: aptos-node
-  validator_host_suffix: validator-lb
-  fullnode_host_suffix: fullnode-lb
+  domain:
+  validator:
+    use_public_dns: false
+    internal_host_suffix: validator-lb
+  fullnode:
+    use_public_dns: true
+    internal_host_suffix: fullnode-lb
   # The path or move modules in the docker image to pull
   # Defaults to the aptos-framework in the aptoslabs/init docker image
   moveModulesDir: /aptos-framework/move/modules

--- a/terraform/helm/testnet-addons/.helmignore
+++ b/terraform/helm/testnet-addons/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/terraform/helm/testnet-addons/Chart.yaml
+++ b/terraform/helm/testnet-addons/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: testnet-addons
+version: 0.1
+description: Additional components for aptos-nodes testnet

--- a/terraform/helm/testnet-addons/templates/_helpers.tpl
+++ b/terraform/helm/testnet-addons/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "testnet-addons.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "testnet-addons.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "testnet-addons.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "testnet-addons.labels" -}}
+helm.sh/chart: {{ include "testnet-addons.chart" . }}
+{{ include "testnet-addons.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "testnet-addons.selectorLabels" -}}
+app.kubernetes.io/part-of: {{ include "testnet-addons.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "testnet-addons.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "testnet-addons.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/terraform/helm/testnet-addons/templates/alb-ingress-controller.yaml
+++ b/terraform/helm/testnet-addons/templates/alb-ingress-controller.yaml
@@ -1,0 +1,85 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    {{ include "testnet-addons.labels" . | nindent 4 }}
+  name: alb-ingress-controller
+rules:
+- apiGroups:
+  - ""
+  - extensions
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - ingresses
+  - ingresses/status
+  - services
+  - pods/status
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+  - patch
+- apiGroups:
+  - ""
+  - extensions
+  resources:
+  - nodes
+  - pods
+  - secrets
+  - services
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    {{ include "testnet-addons.labels" . | nindent 4 }}
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+- kind: ServiceAccount
+  name: k8s-aws-integrations
+  namespace: kube-system
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{ include "testnet-addons.labels" . | nindent 4 }}
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alb-ingress-controller
+  template:
+    metadata:
+      labels:
+        {{ include "testnet-addons.labels" . | nindent 8 }}
+        app.kubernetes.io/name: alb-ingress-controller
+    spec:
+      containers:
+      - name: alb-ingress-controller
+        image: docker.io/amazon/aws-alb-ingress-controller:v1.1.8
+        args:
+        - --ingress-class=alb
+        - --aws-region={{ .Values.aws.region }}
+        - --cluster-name={{ .Values.aws.cluster_name }}
+        - --aws-vpc-id={{ .Values.aws.vpc_id }}
+      serviceAccountName: k8s-aws-integrations

--- a/terraform/helm/testnet-addons/templates/external-dns.yaml
+++ b/terraform/helm/testnet-addons/templates/external-dns.yaml
@@ -1,0 +1,75 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-aws-integrations
+  namespace: kube-system
+  labels:
+    {{ include "testnet-addons.labels" . | nindent 4 }}
+  annotations:
+    eks.amazonaws.com/role-arn: {{ .Values.aws.role_arn }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "pods"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns-viewer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: k8s-aws-integrations
+  namespace: kube-system
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: kube-system
+spec:
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: k8s-aws-integrations
+      containers:
+      - name: external-dns
+        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        args:
+        - --source=service
+        - --source=ingress
+        - --domain-filter={{ .Values.aws.zone_name }}
+        - --provider=aws
+        - --policy=upsert-only
+        - --aws-zone-type=public
+        - --registry=txt
+        - --txt-owner-id={{ .Values.aws.cluster_name }}
+      securityContext:
+        fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files

--- a/terraform/helm/testnet-addons/templates/ingress.yaml
+++ b/terraform/helm/testnet-addons/templates/ingress.yaml
@@ -1,0 +1,62 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}
+  labels:
+    {{- include "testnet-addons.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/tags: {{ .Values.service.aws_tags | quote }}
+    {{- if .Values.ingress.loadBalancerSourceRanges }}
+    alb.ingress.kubernetes.io/inbound-cidrs: {{ join "," .Values.ingress.loadBalancerSourceRanges }}
+    {{- end }}
+    {{- if .Values.service.domain }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.service.domain }}
+    {{- end }}
+    {{- if .Values.ingress.acm_certificate }}
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.acm_certificate }}
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+    {{- end }}
+    {{- if .Values.ingress.wafAclArn }}
+    alb.ingress.kubernetes.io/wafv2-acl-arn: {{ .Values.ingress.wafAclArn }}
+    {{- end }}
+    {{- if .Values.ingress.enableStickyness }}
+    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds={{ .Values.ingress.cookieDurationSeconds }}
+    alb.ingress.kubernetes.io/target-type: ip
+    {{- end }}
+spec:
+  rules:
+  - host: fullnode.{{ .Values.service.domain }}
+    http:
+      paths:
+      - path: /*
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "testnet-addons.fullname" . }}-api
+            port:
+              number: 80
+  - http:
+      paths:
+      - path: /waypoint.txt
+        pathType: Exact
+        backend:
+          service:
+            name: {{ include "testnet-addons.fullname" . }}-waypoint
+            port:
+              number: 80
+      - path: /genesis.blob
+        pathType: Exact
+        backend:
+          service:
+            name: {{ include "testnet-addons.fullname" . }}-waypoint
+            port:
+              number: 80
+      - path: /*
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "testnet-addons.fullname" . }}-api
+            port:
+              number: 80

--- a/terraform/helm/testnet-addons/templates/priority.yaml
+++ b/terraform/helm/testnet-addons/templates/priority.yaml
@@ -1,0 +1,5 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}-high
+value: 40000

--- a/terraform/helm/testnet-addons/templates/psp.yaml
+++ b/terraform/helm/testnet-addons/templates/psp.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}
+roleRef:
+  kind: ClusterRole
+  name: eks:podsecuritypolicy:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ include "testnet-addons.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/terraform/helm/testnet-addons/templates/service.yaml
+++ b/terraform/helm/testnet-addons/templates/service.yaml
@@ -1,0 +1,18 @@
+# aggregate service to serve all REST API from all aptos-node haproxies
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}-api
+  labels:
+    {{- include "testnet-addons.labels" . | nindent 4 }}
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: /-/healthy
+spec:
+  selector:
+    app.kubernetes.io/part-of: aptos-node
+    app.kubernetes.io/name: haproxy
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: NodePort
+  externalTrafficPolicy: Local

--- a/terraform/helm/testnet-addons/templates/serviceaccount.yaml
+++ b/terraform/helm/testnet-addons/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "testnet-addons.serviceAccountName" . }}
+  labels:
+{{ include "testnet-addons.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+{{- end -}}

--- a/terraform/helm/testnet-addons/templates/waypoint.yaml
+++ b/terraform/helm/testnet-addons/templates/waypoint.yaml
@@ -1,0 +1,64 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}-waypoint
+  labels:
+    {{- include "testnet-addons.labels" . | nindent 4 }}
+    app: {{ include "testnet-addons.fullname" . }}-waypoint
+  annotations:
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+spec:
+  selector:
+    {{- include "testnet-addons.selectorLabels" . | nindent 4 }}
+    app: {{ include "testnet-addons.fullname" . }}-waypoint
+  ports:
+  - port: 80
+    targetPort: 8080
+  type: NodePort
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "testnet-addons.fullname" . }}-waypoint
+  labels:
+    {{- include "testnet-addons.labels" . | nindent 4 }}
+    app: {{ include "testnet-addons.fullname" . }}-waypoint
+spec:
+  selector:
+    matchLabels:
+      {{- include "testnet-addons.selectorLabels" . | nindent 6 }}
+      app: {{ include "testnet-addons.fullname" . }}-waypoint
+  template:
+    metadata:
+      labels:
+        {{- include "testnet-addons.selectorLabels" . | nindent 8 }}
+        app: {{ include "testnet-addons.fullname" . }}-waypoint
+    spec:
+      containers:
+      - name: http
+        image: pierrezemb/gostatic
+        imagePullPolicy: IfNotPresent
+        args: ["-port", "8080", "-enable-health"]
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: genesis
+          mountPath: /srv/http
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      volumes:
+      - name: genesis
+        secret:
+          # all validator genesis secrets will have waypoint.txt and genesis.blob
+          secretName: {{ .Values.genesis.username_prefix }}-0-genesis-e{{ .Values.genesis.era }}
+      serviceAccountName: {{ include "testnet-addons.serviceAccountName" . }}

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -1,0 +1,27 @@
+aws:
+  region:
+  cluster_name:
+  vpc_id:
+  role_arn:
+  zone_name:
+
+genesis:
+  # prefix used to get the genesis configuration
+  username_prefix: aptos-node
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+service:
+  domain:
+
+ingress:
+  acm_certificate:
+  wafAclArn:
+  loadBalancerSourceRanges:
+  enableStickyness: true
+  cookieDurationSeconds: 86400


### PR DESCRIPTION
Reaches feature parity with the old `testnet` deployment by exposing the necessary ingresses and services. Services for each validator/fullnode can be created by specifying the right `service.external.type = LoadBalancer`, and Ingress for all (e.g. REST API hitting all fullnodes) and waypoint/genssis is done in a separate `testnet-addons` helm chart.

In detail, `testnet-addons` does:
* create alb-ingress controller
* create external-dns
* create ingress for REST API and genesis/waypoint: try `https://rustie-test.aptosdev.com/`

`aptos-node` does the following if LoadBalancer is specified:
* expose validator-lb
* expose fullnode-lb
* both have flags to open and close certain ports that might be sensitive to DoS

See the updated helm values to configure it
```
service:
  domain:
  external:
    type: LoadBalancer
  validator:
    loadBalancerSourceRanges:
    enableRestApi: false
    enableMetricsPort: false
  # NOTE: these values apply for all fullnode groups
  fullnode:
    loadBalancerSourceRanges:
    enableRestApi: true
    enableMetricsPort: false
```


Test: see that the DNS and services route properly:

```
# waypoint fetching
$ curl https://rustie-test.aptosdev.com/waypoint.txt
0:87e60ceeabd9096e48861d57d84d53d67cd8a58db68e781b49662c5271a5e614%

# REST API service hitting all fullnodes HAproxy
$ curl https://rustie-test.aptosdev.com
{"chain_id":4,"epoch":2,"ledger_version":"13653","ledger_timestamp":"1656016824736884"}%

# genesis blob file
$ wget https://rustie-test.aptosdev.com/genesis.blob

# fullnode aptosnet open
$ for i in $(seq 0 2); do nc -zv fullnode$i.rustie-test.aptosdev.com 6182; done
Connection to fullnode0.rustie-test.aptosdev.com port 6182 [tcp/*] succeeded!
Connection to fullnode1.rustie-test.aptosdev.com port 6182 [tcp/*] succeeded!
Connection to fullnode2.rustie-test.aptosdev.com port 6182 [tcp/*] succeeded!

# validator aptosnet open
$ for i in $(seq 0 2); do nc -zv val$i.rustie-test.aptosdev.com 6180; done
Connection to val0.rustie-test.aptosdev.com port 6180 [tcp/*] succeeded!
Connection to val1.rustie-test.aptosdev.com port 6180 [tcp/*] succeeded!
Connection to val2.rustie-test.aptosdev.com port 6180 [tcp/*] succeeded!
```

Additionally, some changes to `genesis` helm chart to use public DNS names provisioned by external-dns if the `enable_onchain_discovery` helm value is set. Currently, it's enable for fullnodes but not validators. Here's a snippet from the automated genesis ceremony to demonstrate what the flags do at a deeper level. Note that the `validator-host` is still an internal k8s service name, and `full-node-host` is an external DNS name:

```
+ aptos genesis set-validator-configuration --keys-dir /tmp/rustie-test-aptos-node-2 --local-repository-dir /tmp --username rustie-test-aptos-node-2 --validator-host rustie-test-aptos-node-2-validator-lb:6180 --full-node-host fullnode2.rustie-test.aptosdev.com:6182
{
  "Result": "Success"
}
```