### PR TITLE
[storage] fix FuturesUnderedX test

### DIFF
--- a/storage/backup/backup-cli/src/utils/stream/futures_unordered_x.rs
+++ b/storage/backup/backup-cli/src/utils/stream/futures_unordered_x.rs
@@ -153,10 +153,10 @@ mod tests {
                         // yield
                         tokio::time::sleep(Duration::from_millis(sleep_ms)).await;
 
-                        let r = _n_running.fetch_sub(1, Ordering::Relaxed);
+                        let r = _n_running.fetch_sub(1, Ordering::SeqCst);
                         assert!(r > 0 && r <= min(max_in_progress, num_sleeps));
                         if r == max_in_progress {
-                            _seen_max_concurrency.store(true, Ordering::Relaxed);
+                            _seen_max_concurrency.store(true, Ordering::SeqCst);
                         }
 
                         n


### PR DESCRIPTION
### Description
 Looks like M1 Macs relaxes indeed on Ordering::Relex..

### Test Plan
unit test