### PR TITLE
[consensus] Make leader reputation db fetching work if we ask for older target_rounds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,6 +2164,7 @@ dependencies = [
  "futures",
  "itertools",
  "mirai-annotations",
+ "move-deps",
  "network",
  "num-derive",
  "num-traits 0.2.15",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -62,6 +62,7 @@ aptos-config = { path = "../config", features = ["fuzzing"] }
 aptos-mempool = { path = "../mempool", features = ["fuzzing"] }
 consensus-types = { path = "consensus-types", default-features = false, features = ["fuzzing"] }
 executor-test-helpers = { path = "../execution/executor-test-helpers" }
+move-deps = { path = "../aptos-move/move-deps", features = ["address32"] }
 network = { path = "../network", features = ["fuzzing"] }
 safety-rules = { path = "safety-rules", features = ["testing"] }
 vm-validator = { path = "../vm-validator" }


### PR DESCRIPTION
And improving caching, to reduce number of DB calls.

For #1395