### PR TITLE
[aptos-cli] Validator Tooling

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/configs/Stake.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/Stake.move
@@ -453,7 +453,7 @@ module AptosFramework::Stake {
     }
 
     /// This can only called by the operator of the validator/staking pool.
-    public fun join_validator_set(
+    public(script) fun join_validator_set(
         account: &signer,
         pool_address: address,
     ) acquires StakePool, StakePoolEvents, ValidatorConfig, ValidatorSetConfiguration, ValidatorSet {
@@ -587,7 +587,7 @@ module AptosFramework::Stake {
     /// is still operational.
     ///
     /// Can only be called by the operator of the validator/staking pool.
-    public fun leave_validator_set(
+    public(script) fun leave_validator_set(
         account: &signer,
         pool_address: address,
     ) acquires StakePool, StakePoolEvents, ValidatorSet, ValidatorSetConfiguration {

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -320,6 +320,18 @@ pub struct ProfileOptions {
     pub profile: String,
 }
 
+impl ProfileOptions {
+    pub fn account_address(&self) -> CliTypedResult<AccountAddress> {
+        if let Some(profile) = CliConfig::load_profile(&self.profile)? {
+            if let Some(account) = profile.account {
+                return Ok(account);
+            }
+        }
+
+        Err(CliError::ConfigNotFoundError(self.profile.clone()))
+    }
+}
+
 impl Default for ProfileOptions {
     fn default() -> Self {
         Self {

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -8,6 +8,7 @@ pub mod common;
 pub mod config;
 pub mod genesis;
 pub mod move_tool;
+pub mod node;
 pub mod op;
 pub mod test;
 
@@ -30,18 +31,22 @@ pub enum Tool {
     Key(op::key::KeyTool),
     #[clap(subcommand)]
     Move(move_tool::MoveTool),
+    #[clap(subcommand)]
+    Node(node::NodeTool),
 }
 
 impl Tool {
     pub async fn execute(self) -> CliResult {
+        use Tool::*;
         match self {
-            Tool::Account(tool) => tool.execute().await,
-            Tool::Config(tool) => tool.execute().await,
+            Account(tool) => tool.execute().await,
+            Config(tool) => tool.execute().await,
+            Genesis(tool) => tool.execute().await,
             // TODO: Replace entirely with config init
-            Tool::Genesis(tool) => tool.execute().await,
-            Tool::Init(tool) => tool.execute_serialized_success().await,
-            Tool::Key(tool) => tool.execute().await,
-            Tool::Move(tool) => tool.execute().await,
+            Init(tool) => tool.execute_serialized_success().await,
+            Key(tool) => tool.execute().await,
+            Move(tool) => tool.execute().await,
+            Node(tool) => tool.execute().await,
         }
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -6,11 +6,10 @@ mod aptos_debug_natives;
 use crate::{
     common::{
         types::{
-            load_account_arg, AccountAddressWrapper, CliError, CliTypedResult, EncodingOptions,
-            MovePackageDir, ProfileOptions, PromptOptions, TransactionSummary,
-            WriteTransactionOptions,
+            load_account_arg, AccountAddressWrapper, CliError, CliTypedResult, MovePackageDir,
+            PromptOptions, TransactionOptions, TransactionSummary,
         },
-        utils::{check_if_file_exists, submit_transaction},
+        utils::check_if_file_exists,
     },
     CliCommand, CliResult,
 };
@@ -234,13 +233,9 @@ fn compile_move(build_config: BuildConfig, package_dir: &Path) -> CliTypedResult
 #[derive(Parser)]
 pub struct PublishPackage {
     #[clap(flatten)]
-    encoding_options: EncodingOptions,
-    #[clap(flatten)]
     move_options: MovePackageDir,
     #[clap(flatten)]
-    write_options: WriteTransactionOptions,
-    #[clap(flatten)]
-    profile_options: ProfileOptions,
+    txn_options: TransactionOptions,
 }
 
 #[async_trait]
@@ -267,27 +262,14 @@ impl CliCommand<TransactionSummary> for PublishPackage {
                     .serialize(get_bytecode_version_from_env())
             })
             .collect();
-        let compiled_payload = TransactionPayload::ModuleBundle(ModuleBundle::new(compiled_units));
 
-        // Now that it's compiled, lets send it
-        let sender_key = self.write_options.private_key_options.extract_private_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )?;
-
-        submit_transaction(
-            self.write_options
-                .rest_options
-                .url(&self.profile_options.profile)?,
-            self.write_options
-                .chain_id(&self.profile_options.profile)
-                .await?,
-            sender_key,
-            compiled_payload,
-            self.write_options.max_gas,
-        )
-        .await
-        .map(TransactionSummary::from)
+        // Send the compiled module
+        self.txn_options
+            .submit_transaction(TransactionPayload::ModuleBundle(ModuleBundle::new(
+                compiled_units,
+            )))
+            .await
+            .map(TransactionSummary::from)
     }
 }
 
@@ -295,11 +277,7 @@ impl CliCommand<TransactionSummary> for PublishPackage {
 #[derive(Parser)]
 pub struct RunFunction {
     #[clap(flatten)]
-    encoding_options: EncodingOptions,
-    #[clap(flatten)]
-    write_options: WriteTransactionOptions,
-    #[clap(flatten)]
-    profile_options: ProfileOptions,
+    txn_options: TransactionOptions,
     /// Function name as `<ADDRESS>::<MODULE_ID>::<FUNCTION_NAME>`
     ///
     /// Example: `0x842ed41fad9640a2ad08fdd7d3e4f7f505319aac7d67e1c0dd6a7cce8732c7e3::Message::set_message`
@@ -338,29 +316,15 @@ impl CliCommand<TransactionSummary> for RunFunction {
             type_args.push(type_tag)
         }
 
-        let script_function = ScriptFunction::new(
-            self.function_id.module_id.clone(),
-            self.function_id.function_id.clone(),
-            type_args,
-            args,
-        );
-
-        submit_transaction(
-            self.write_options
-                .rest_options
-                .url(&self.profile_options.profile)?,
-            self.write_options
-                .chain_id(&self.profile_options.profile)
-                .await?,
-            self.write_options.private_key_options.extract_private_key(
-                self.encoding_options.encoding,
-                &self.profile_options.profile,
-            )?,
-            TransactionPayload::ScriptFunction(script_function),
-            self.write_options.max_gas,
-        )
-        .await
-        .map(TransactionSummary::from)
+        self.txn_options
+            .submit_transaction(TransactionPayload::ScriptFunction(ScriptFunction::new(
+                self.function_id.module_id.clone(),
+                self.function_id.function_id.clone(),
+                type_args,
+                args,
+            )))
+            .await
+            .map(TransactionSummary::from)
     }
 }
 

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1,0 +1,352 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    common::{
+        types::{CliCommand, CliError, CliResult, CliTypedResult, TransactionOptions},
+        utils::read_from_file,
+    },
+    genesis::git::from_yaml,
+};
+use aptos_crypto::{ed25519::Ed25519PublicKey, x25519, PrivateKey, ValidCryptoMaterialStringExt};
+use aptos_genesis::{config::HostAndPort, keys::PrivateIdentity};
+use aptos_rest_client::Transaction;
+use aptos_types::account_address::AccountAddress;
+use async_trait::async_trait;
+use clap::Parser;
+use std::{
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+/// Tool for manipulating nodes
+///
+#[derive(Parser)]
+pub enum NodeTool {
+    AddStake(AddStake),
+    UnlockStake(UnlockStake),
+    WithdrawStake(WithdrawStake),
+    IncreaseLockup(IncreaseLockup),
+    RegisterValidatorCandidate(RegisterValidatorCandidate),
+    JoinValidatorSet(JoinValidatorSet),
+    LeaveValidatorSet(LeaveValidatorSet),
+}
+
+impl NodeTool {
+    pub async fn execute(self) -> CliResult {
+        use NodeTool::*;
+        match self {
+            AddStake(tool) => tool.execute_serialized().await,
+            UnlockStake(tool) => tool.execute_serialized().await,
+            WithdrawStake(tool) => tool.execute_serialized().await,
+            IncreaseLockup(tool) => tool.execute_serialized().await,
+            RegisterValidatorCandidate(tool) => tool.execute_serialized().await,
+            JoinValidatorSet(tool) => tool.execute_serialized().await,
+            LeaveValidatorSet(tool) => tool.execute_serialized().await,
+        }
+    }
+}
+
+/// Stake coins for an account to the stake pool
+#[derive(Parser)]
+pub struct AddStake {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    /// Amount of coins to add to stake
+    #[clap(long)]
+    pub amount: u64,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for AddStake {
+    fn command_name(&self) -> &'static str {
+        "AddStake"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.txn_options
+            .submit_script_function(
+                AccountAddress::ONE,
+                "Stake",
+                "add_stake",
+                vec![],
+                vec![bcs::to_bytes(&self.amount)?],
+            )
+            .await
+    }
+}
+
+/// Unlock staked coins
+///
+/// Coins can only be unlocked if they no longer have an applied lockup period
+#[derive(Parser)]
+pub struct UnlockStake {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    /// Amount of coins to unlock
+    #[clap(long)]
+    pub amount: u64,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for UnlockStake {
+    fn command_name(&self) -> &'static str {
+        "UnlockStake"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.txn_options
+            .submit_script_function(
+                AccountAddress::ONE,
+                "Stake",
+                "unlock",
+                vec![],
+                vec![bcs::to_bytes(&self.amount)?],
+            )
+            .await
+    }
+}
+
+/// Withdraw all unlocked staked coins
+///
+/// Before calling `WithdrawStake`, `UnlockStake` must be called first.
+#[derive(Parser)]
+pub struct WithdrawStake {
+    #[clap(flatten)]
+    pub(crate) node_op_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for WithdrawStake {
+    fn command_name(&self) -> &'static str {
+        "WithdrawStake"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.node_op_options
+            .submit_script_function(AccountAddress::ONE, "Stake", "withdraw", vec![], vec![])
+            .await
+    }
+}
+
+/// Increase lockup of all staked coins in an account
+#[derive(Parser)]
+pub struct IncreaseLockup {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    /// Number of seconds to increase the lockup period by
+    #[clap(long)]
+    pub(crate) lockup_timestamp_secs: u64,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for IncreaseLockup {
+    fn command_name(&self) -> &'static str {
+        "IncreaseLockup"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        if self.lockup_timestamp_secs
+            <= SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs()
+        {
+            return Err(CliError::CommandArgumentError(
+                "--lockup-timestamp-secs is in the past".to_string(),
+            ));
+        }
+
+        self.txn_options
+            .submit_script_function(
+                AccountAddress::ONE,
+                "Stake",
+                "increase_lockup",
+                vec![],
+                vec![bcs::to_bytes(&self.lockup_timestamp_secs)?],
+            )
+            .await
+    }
+}
+
+/// Register the current account as a Validator candidate
+#[derive(Parser)]
+pub struct RegisterValidatorCandidate {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    /// Private keys file, created from the `genesis keys` command
+    #[clap(long)]
+    pub(crate) private_keys_file: Option<PathBuf>,
+    /// Hex encoded Consensus public key
+    #[clap(long, parse(try_from_str = Ed25519PublicKey::from_encoded_string))]
+    pub(crate) consensus_public_key: Option<Ed25519PublicKey>,
+    /// Host and port pair for the validator e.g. 127.0.0.1:6180
+    #[clap(long)]
+    pub(crate) validator_host: HostAndPort,
+    /// Validator x25519 public network key
+    #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
+    pub(crate) validator_network_public_key: Option<x25519::PublicKey>,
+    /// Host and port pair for the fullnode e.g. 127.0.0.1:6180.  Optional
+    #[clap(long)]
+    pub(crate) full_node_host: Option<HostAndPort>,
+    /// Full node x25519 public network key
+    #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
+    pub(crate) full_node_network_public_key: Option<x25519::PublicKey>,
+}
+
+impl RegisterValidatorCandidate {
+    fn consensus_public_key(&self) -> CliTypedResult<Ed25519PublicKey> {
+        if let Some(ref consensus_public_key) = self.consensus_public_key {
+            Ok(consensus_public_key.clone())
+        } else if let Some(ref file) = self.private_keys_file {
+            let identity: PrivateIdentity =
+                from_yaml(&String::from_utf8(read_from_file(file)?).map_err(CliError::from)?)?;
+            Ok(identity.consensus_private_key.public_key())
+        } else {
+            Err(CliError::CommandArgumentError(
+                "Must provide either --validator-identity-file or --consensus-public-key"
+                    .to_string(),
+            ))
+        }
+    }
+
+    fn network_keys(&self) -> CliTypedResult<(x25519::PublicKey, Option<x25519::PublicKey>)> {
+        let identity: Option<PrivateIdentity> = if let Some(ref file) = self.private_keys_file {
+            from_yaml(&String::from_utf8(read_from_file(file)?).map_err(CliError::from)?)?
+        } else {
+            None
+        };
+
+        let validator_network_public_key =
+            if let Some(public_key) = self.validator_network_public_key {
+                Ok(public_key)
+            } else if let Some(ref identity) = identity {
+                Ok(identity.validator_network_private_key.public_key())
+            } else {
+                Err(CliError::CommandArgumentError(
+                    "Must provide either --validator-identity-file or --consensus-public-key"
+                        .to_string(),
+                ))
+            }?;
+
+        let full_node_network_public_key =
+            if let Some(public_key) = self.full_node_network_public_key {
+                Some(public_key)
+            } else {
+                identity.map(|identity| identity.full_node_network_private_key.public_key())
+            };
+
+        Ok((validator_network_public_key, full_node_network_public_key))
+    }
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for RegisterValidatorCandidate {
+    fn command_name(&self) -> &'static str {
+        "RegisterValidatorCandidate"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        let consensus_public_key = self.consensus_public_key()?;
+        let (validator_network_public_key, full_node_network_public_key) = self.network_keys()?;
+        let validator_network_addresses = vec![self
+            .validator_host
+            .as_network_address(validator_network_public_key)?];
+        let full_node_network_addresses =
+            match (self.full_node_host.as_ref(), full_node_network_public_key) {
+                (Some(host), Some(public_key)) => vec![host.as_network_address(public_key)?],
+                _ => vec![],
+            };
+
+        self.txn_options
+            .submit_script_function(
+                AccountAddress::ONE,
+                "Stake",
+                "register_validator_candidate",
+                vec![],
+                vec![
+                    bcs::to_bytes(&consensus_public_key)?,
+                    // Double BCS encode, so that we can hide the original type
+                    bcs::to_bytes(&bcs::to_bytes(&validator_network_addresses)?)?,
+                    bcs::to_bytes(&bcs::to_bytes(&full_node_network_addresses)?)?,
+                ],
+            )
+            .await
+    }
+}
+
+/// Arguments used for operator of the staking pool
+#[derive(Parser)]
+pub struct OperatorArgs {
+    /// Address of the Staking pool
+    #[clap(long)]
+    pub(crate) pool_address: Option<AccountAddress>,
+}
+
+/// Join the validator set after meeting staking requirements
+#[derive(Parser)]
+pub struct JoinValidatorSet {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(flatten)]
+    pub(crate) operator_args: OperatorArgs,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for JoinValidatorSet {
+    fn command_name(&self) -> &'static str {
+        "JoinValidatorSet"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        let address = if let Some(address) = self.operator_args.pool_address {
+            address
+        } else {
+            self.txn_options.profile_options.account_address()?
+        };
+
+        self.txn_options
+            .submit_script_function(
+                AccountAddress::ONE,
+                "Stake",
+                "join_validator_set",
+                vec![],
+                vec![bcs::to_bytes(&address)?],
+            )
+            .await
+    }
+}
+
+/// Leave the validator set
+#[derive(Parser)]
+pub struct LeaveValidatorSet {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(flatten)]
+    pub(crate) operator_args: OperatorArgs,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for LeaveValidatorSet {
+    fn command_name(&self) -> &'static str {
+        "LeaveValidatorSet"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        let address = if let Some(address) = self.operator_args.pool_address {
+            address
+        } else {
+            self.txn_options.profile_options.account_address()?
+        };
+
+        self.txn_options
+            .submit_script_function(
+                AccountAddress::ONE,
+                "Stake",
+                "leave_validator_set",
+                vec![],
+                vec![bcs::to_bytes(&address)?],
+            )
+            .await
+    }
+}

--- a/testsuite/smoke-test/src/aptos_cli.rs
+++ b/testsuite/smoke-test/src/aptos_cli.rs
@@ -3,39 +3,42 @@
 
 use crate::smoke_test_environment::new_local_swarm_with_aptos;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
-use aptos_config::keys::ConfigKey;
+use aptos_config::{keys::ConfigKey, utils::get_available_port};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_faucet::FaucetArgs;
 use aptos_types::{account_config::aptos_root_address, chain_id::ChainId};
 use forge::{LocalSwarm, Node};
 use tokio::task::JoinHandle;
 
-pub async fn setup_test(num_nodes: usize) -> (LocalSwarm, CliTestFramework) {
+pub async fn setup_cli_test(num_nodes: usize) -> (LocalSwarm, CliTestFramework, JoinHandle<()>) {
     let swarm = new_local_swarm_with_aptos(num_nodes).await;
     let chain_id = swarm.chain_id();
     let validator = swarm.validators().next().unwrap();
     let root_key = swarm.root_key();
-    let _ = launch_faucet(validator.rest_api_endpoint(), root_key, chain_id);
-
-    // Connect the operator tool to the node's JSON RPC API
-    let tool = CliTestFramework::new(
+    let faucet_port = get_available_port();
+    let faucet = launch_faucet(
         validator.rest_api_endpoint(),
-        "http://localhost:9996".parse().unwrap(),
-        2,
-    )
-    .await;
+        root_key,
+        chain_id,
+        faucet_port,
+    );
+    let faucet_endpoint: reqwest::Url =
+        format!("http://localhost:{}", faucet_port).parse().unwrap();
+    // Connect the operator tool to the node's JSON RPC API
+    let tool = CliTestFramework::new(validator.rest_api_endpoint(), faucet_endpoint, 2).await;
 
-    (swarm, tool)
+    (swarm, tool, faucet)
 }
 
 pub fn launch_faucet(
     endpoint: reqwest::Url,
     mint_key: Ed25519PrivateKey,
     chain_id: ChainId,
+    port: u16,
 ) -> JoinHandle<()> {
     let faucet = FaucetArgs {
         address: "127.0.0.1".to_string(),
-        port: 9996,
+        port,
         server_url: endpoint.to_string(),
         mint_key_file_path: "".to_string(),
         mint_key: Some(ConfigKey::new(mint_key)),
@@ -49,7 +52,7 @@ pub fn launch_faucet(
 
 #[tokio::test]
 async fn test_account_flow() {
-    let (_swarm, cli) = setup_test(1).await;
+    let (_swarm, cli, _faucet) = setup_cli_test(1).await;
 
     assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(0).await.unwrap());
     assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(1).await.unwrap());


### PR DESCRIPTION
### Description
First iteration on tools for validator set changes and staking

### Test Plan
Will do manual testing against a testnet

```
aptos-node 0.1.2
Tool for manipulating nodes

USAGE:
    aptos node <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    add-stake                       Stake coins for an account to the stake pool
    help                            Print this message or the help of the given subcommand(s)
    increase-lockup                 Increase lockup of all staked coins in an account
    join-validator-set              Join the validator set after meeting staking requirements
    leave-validator-set             Leave the validator set
    register-validator-candidate    Register the current account as a Validator candidate
    unlock-stake                    Unlock staked coins
    withdraw-stake                  Withdraw all unlocked staked coins

```

Successfully ran through the whole register, stake, increase-lockup, join-validator-set flow.