### PR TITLE
Fix updating stats in uncommitted case in txn-emitter

### DIFF
--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use ::aptos_logger::{Level, Logger};
 use anyhow::{bail, format_err, Result};
 use aptos::common::types::EncodingType;
 use aptos_config::{config::DEFAULT_PORT, keys::ConfigKey};
@@ -66,6 +67,8 @@ struct Args {
 
 #[tokio::main]
 pub async fn main() {
+    Logger::builder().level(Level::Info).build();
+
     let args = Args::from_args();
 
     if !args.emit_tx && !args.diag {

--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -89,6 +89,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
     let thread_params = EmitThreadParams {
         wait_millis: args.wait_millis,
         wait_committed: !args.burst,
+        txn_expiration_time_secs: args.txn_expiration_time_secs,
     };
     let duration = Duration::from_secs(args.duration);
     let client = cluster.random_instance().rest_client();

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -144,6 +144,7 @@ fn main() -> Result<()> {
         .thread_params(EmitThreadParams {
             wait_millis: args.wait_millis,
             wait_committed: !args.burst,
+            txn_expiration_time_secs: 30,
         });
     if let Some(workers_per_endpoint) = args.workers_per_ac {
         global_emit_job_request =


### PR DESCRIPTION
## Description
What we were doing previously was totally invalid, we were subtracting a number of accounts from a number of transactions. This fixes that up + adds a comment explaining what is going on. The amount of time we were waiting for transactions in this situation was also needlessly long.

## Test Plan
See https://www.notion.so/aptoslabs/Single-node-testnet-transaction-load-test-guide-57e82a909e614243bed9694641f581f9.
