### PR TITLE
[tf/helm][forge] get forge to run on aptos-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2308,7 +2308,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.2",
  "subtle",
- "time 0.3.9",
+ "time 0.3.11",
  "version_check",
 ]
 
@@ -4189,12 +4189,12 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.1",
 ]
 
 [[package]]
@@ -6435,7 +6435,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
- "time 0.3.9",
+ "time 0.3.11",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
@@ -6638,11 +6638,12 @@ dependencies = [
 
 [[package]]
 name = "prometheus-parse"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c996f3caea1c51aa034c0d2dfd8447a12c555f4567b02677ef8a865ac4cce712"
+checksum = "ef7a8ed15bcffc55fe0328931ef20d393bb89ad704756a37bd20cffb4804f306"
 dependencies = [
  "chrono",
+ "itertools",
  "lazy_static 1.4.0",
  "regex",
 ]
@@ -7689,7 +7690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static 1.4.0",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "serial_test_derive",
 ]
 
@@ -8624,9 +8625,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
  "itoa 1.0.2",
  "libc",
@@ -9087,7 +9088,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -32,7 +32,6 @@ futures-io = { version = "0.3.21", features = ["std"] }
 futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.21", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
-hashbrown = { version = "0.11.2", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14.18", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
@@ -85,7 +84,6 @@ futures-io = { version = "0.3.21", features = ["std"] }
 futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.21", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
-hashbrown = { version = "0.11.2", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14.18", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
@@ -117,18 +115,22 @@ url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 
 [target.x86_64-apple-darwin.dependencies]
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 

--- a/scripts/fgi/kube.py
+++ b/scripts/fgi/kube.py
@@ -9,11 +9,11 @@ import tempfile
 import time
 
 FORGE_K8S_CLUSTERS = [
-    "rustie-test"
+    "forge-0",
 ]
 
 WORKSPACE_CHART_BUCKETS = {
-    "rustie-test": "aptos-testnet-rustie-test-helm-0066a343"
+    "forge-0": "aptos-testnet-forge-0-helm-38891543",
 }
 
 AWS_ACCOUNT = (

--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -12,6 +12,40 @@ locals {
   workspace  = var.workspace_name_override != "" ? var.workspace_name_override : terraform.workspace
   aws_tags   = "Terraform=testnet,Workspace=${local.workspace}"
   chain_name = var.chain_name != "" ? var.chain_name : "${local.workspace}net"
+
+  # Forge assumes the chain_id is 4
+  chain_id = var.enable_forge ? 4 : var.chain_id
+
+  # use this map to programatically set helm values
+  aptos_node_helm_values_computed = {
+    service = {
+      validator = {
+        external = {
+          type = var.enable_forge ? "NodePort" : null
+        }
+        enableRestApi     = var.enable_forge
+        enableMetricsPort = var.enable_forge
+      }
+      fullnode = {
+        external = {
+          type = var.enable_forge ? "NodePort" : null
+        }
+        enableRestApi     = var.enable_forge
+        enableMetricsPort = var.enable_forge
+      }
+    }
+  }
+}
+
+# merge the operator-provided helm values via TF var
+# with the computed helm values
+module "aptos-node-helm-values-deepmerge" {
+  # https://registry.terraform.io/modules/Invicton-Labs/deepmerge/null/0.1.5
+  source = "Invicton-Labs/deepmerge/null"
+  maps = [
+    local.aptos_node_helm_values_computed,
+    var.aptos_node_helm_values,
+  ]
 }
 
 module "validator" {
@@ -28,18 +62,21 @@ module "validator" {
   permissions_boundary_policy = var.permissions_boundary_policy
   workspace_name_override     = var.workspace_name_override
 
+  # if forge enabled, standardize the helm release name for ease of operations
+  helm_release_name_override = var.enable_forge ? "aptos-node" : ""
+
   k8s_api_sources = var.admin_sources_ipv4
   k8s_admin_roles = var.k8s_admin_roles
   k8s_admins      = var.k8s_admins
 
-  chain_id       = var.chain_id
+  chain_id       = local.chain_id
   era            = var.era
   chain_name     = local.chain_name
   image_tag      = var.image_tag
   validator_name = "aptos-node"
 
   num_validators = var.num_validators
-  helm_values    = var.aptos_node_helm_values
+  helm_values    = module.aptos-node-helm-values-deepmerge.merged
 
   # allow all nodegroups to surge to 2x their size, in case of total nodes replacement
   validator_instance_num = var.num_validator_instance > 0 ? 2 * var.num_validator_instance : var.num_validators
@@ -57,7 +94,7 @@ module "validator" {
 }
 
 locals {
-  aptos_node_helm_prefix = "${module.validator.helm_release_name}-aptos-node"
+  aptos_node_helm_prefix = var.enable_forge ? "aptos-node" : "${module.validator.helm_release_name}-aptos-node"
 }
 
 provider "helm" {
@@ -85,7 +122,7 @@ resource "helm_release" "genesis" {
       chain = {
         name     = local.chain_name
         era      = var.era
-        chain_id = var.chain_id
+        chain_id = local.chain_id
       }
       imageTag = var.image_tag
       genesis = {

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -62,7 +62,7 @@ variable "k8s_admins" {
 ### Testnet config
 
 variable "chain_id" {
-  description = "Aptos chain ID"
+  description = "Aptos chain ID. If var.enable_forge set, defaults to 4"
   default     = 4
 }
 

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -139,11 +139,14 @@ locals {
       domain = local.domain
     }
   })
+
+  # override the helm release name if an override exists, otherwise adopt the workspace name
+  helm_release_name = var.helm_release_name_override != "" ? var.helm_release_name_override : local.workspace_name
 }
 
 resource "helm_release" "validator" {
   count       = var.helm_enable_validator ? 1 : 0
-  name        = local.workspace_name
+  name        = local.helm_release_name
   chart       = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
   max_history = 5
   wait        = false
@@ -162,7 +165,7 @@ resource "helm_release" "validator" {
 
 resource "helm_release" "logger" {
   count       = var.enable_logger ? 1 : 0
-  name        = "${local.workspace_name}-log"
+  name        = "${local.helm_release_name}-log"
   chart       = "${path.module}/../../helm/logger"
   max_history = 5
   wait        = false
@@ -178,7 +181,7 @@ resource "helm_release" "logger" {
       serviceAccount = {
         create = false
         # this name must match the serviceaccount created by the aptos-node helm chart
-        name = "${local.workspace_name}-aptos-node-validator"
+        name = "${local.helm_release_name}-aptos-node-validator"
       }
     }),
     jsonencode(var.logger_helm_values),
@@ -192,7 +195,7 @@ resource "helm_release" "logger" {
 
 resource "helm_release" "monitoring" {
   count       = var.enable_monitoring ? 1 : 0
-  name        = "${local.workspace_name}-mon"
+  name        = "${local.helm_release_name}-mon"
   chart       = "${path.module}/../../helm/monitoring"
   max_history = 5
   wait        = false

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -200,3 +200,8 @@ variable "monitoring_helm_values" {
   type        = any
   default     = {}
 }
+
+variable "helm_release_name_override" {
+  description = "If set, overrides the name of the aptos-node helm chart"
+  default     = ""
+}

--- a/terraform/helm/forge/files/cleanup_forge.sh
+++ b/terraform/helm/forge/files/cleanup_forge.sh
@@ -3,4 +3,5 @@
 # Script to be run in a Forge pod after the test runs as cleanup
 # This separates the pod lifecycle from aptos-core
 
-echo "Forge clean"
+kubectl delete deployment,sts -l "app.kubernetes.io/part-of=aptos-node"
+echo "Forge cleaned"

--- a/terraform/helm/forge/files/init_forge.sh
+++ b/terraform/helm/forge/files/init_forge.sh
@@ -5,6 +5,7 @@
 
 # set up internal helm repo, naming it testnet-internal
 echo "Setting up repo s3://{{ .Values.forge.helmBucket }}/charts"
-helm plugin install https://github.com/C123R/helm-blob.git
+# use helm-s3 plugin for now, as the auth works with serviceaccount
+helm plugin install https://github.com/hypnoglow/helm-s3.git
 helm repo add testnet-internal s3://{{ .Values.forge.helmBucket }}/charts
 helm search repo testnet-internal --versions

--- a/terraform/helm/forge/templates/forge.yaml
+++ b/terraform/helm/forge/templates/forge.yaml
@@ -47,7 +47,9 @@ spec:
           {{- toYaml .Values.forge.resources | nindent 10 }}
         env:
         - name: RUST_BACKTRACE
-          value: "1"
+          value: "full"
+        - name: RUST_LOG
+          value: "debug"
         volumeMounts:
         - name: forge-scripts
           mountPath: /etc/forge/scripts

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -23,12 +23,16 @@ pub struct K8sFactory {
     base_image_tag: String,
 }
 
-const DEFAULT_ROOT_KEY: &str = "5243ca72b0766d9e9cbf2debf6153443b01a1e0e6d086c7ea206eaf6f8043956";
+// These are test keys for forge ephemeral networks. Do not use these elsewhere!
+pub const DEFAULT_ROOT_KEY: &str =
+    "48136DF3174A3DE92AFDB375FFE116908B69FF6FAB9B1410E548A33FEA1D159D";
+const DEFAULT_ROOT_PRIV_KEY: &str =
+    "E25708D90C72A53B400B27FC7602C4D546C7B7469FA6E12544F0EBFB2F16AE19";
 
 impl K8sFactory {
     pub fn new(helm_repo: String, image_tag: String, base_image_tag: String) -> Result<K8sFactory> {
         let root_key: [u8; ED25519_PRIVATE_KEY_LENGTH] =
-            hex::decode(DEFAULT_ROOT_KEY)?.try_into().unwrap();
+            hex::decode(DEFAULT_ROOT_PRIV_KEY)?.try_into().unwrap();
 
         Ok(Self {
             root_key,


### PR DESCRIPTION
Make sure all helm values are set properly, k8s resources created correctly, and hooks in the test runner working as intended.

k8s changes:
* Revert usage of https://github.com/C123R/helm-blob back to https://github.com/hypnoglow/helm-s3. Under the hood they do roughly the same thing in terms of setting up the repo, but the former is unable to authenticate with k8s service account from testing. 
* Clean up compute resources in multiple places with `kubectl delete deployment,sts -l "app.kubernetes.io/part-of=aptos-node"`. In the future if we're using namespaces, we can just delete the entire namespace, but for now since it's cheap, run it at forge start (ensure the cluster is clean), when the test is complete, and again after Forge runs to its entirety (in case the test crashes)
* If forge enabled, make validator and fullnode external service types `NodePort`

test runner changes:
* Increase genesis timeout to 3 min. There's room to optimize genesis, but for the moment key (and k8s secret) generation for 30 validators, as well as additional cleanup time, takes >1 min
* Hard-code a default root keypair for Forge, and use it when `helm upgrade` genesis. It is then used by the txn emitter.
* Hard-code Forge to use chain_id = 4 (instead of the previous NamedChain "Devnet")


Test:
1. Run forge operator commands locally. For example, `forge operator resize` the cluster to a number of validators, and is useful for resetting the cluster for various tests. Under the hood, `forge test k8s-swarm` (the main forge test command) invokes the same functions as part of its startup process to ensure the cluster is available to test on:
```
# NOTE: the helm repo has been initialized as part of TF apply on a forge cluster
$ cargo run -p forge-cli -- operator resize --helm-repo testnet-rustie-test --num-validators 4 --validator-image-tag $GIT_SHA --testnet-image-tag $GIT_SHA    
...
467a2626c3699e4 --testnet-image-tag 3d7684f20eaaeb1e9b2859a18467a2626c3699e4`
Deleting collection of deployments: []
Deleting collection of stateful_sets: []
aptos-node resources removed
new chain era: fg1720331619
["upgrade", "rustie-test", "testnet-rustie-test/aptos-node", "--reuse-values", "--history-max", "2", "--set", "chain.era=fg1720331619", "--set", "numValidators=4", "--set", "imageTag=3d7684f20eaaeb1e9b2859a18467a2626c3699e4"]
Release "rustie-test" has been upgraded. Happy Helming!
NAME: rustie-test
LAST DEPLOYED: Wed Jun 29 13:54:41 2022
NAMESPACE: default
STATUS: deployed
REVISION: 117
TEST SUITE: None
NOTES:
Your aptos-node deployment named rustie-test is now deployed.

To start the nodes, specify either .Values.loadTestGenesis or populate the following configmaps with genesis data:
    - rustie-test-aptos-node-0-genesis-efg1720331619
    - rustie-test-aptos-node-1-genesis-efg1720331619
    - rustie-test-aptos-node-2-genesis-efg1720331619
    - rustie-test-aptos-node-3-genesis-efg1720331619
["upgrade", "genesis", "testnet-rustie-test/aptos-genesis", "--reuse-values", "--history-max", "2", "--set", "chain.era=fg1720331619", "--set", "genesis.numValidators=4", "--set", "chain.rootKey=0x48136DF3174A3DE92AFDB375FFE116908B69FF6FAB9B1410E548A33FEA1D159D", "--set", "imageTag=3d7684f20eaaeb1e9b2859a18467a2626c3699e4"]
Release "genesis" has been upgraded. Happy Helming!
NAME: genesis
LAST DEPLOYED: Wed Jun 29 13:55:44 2022
NAMESPACE: default
STATUS: deployed
REVISION: 77
TEST SUITE: None
NOTES:
Your aptos-genesis deployment named genesis is now deployed.

To check automated genesis ceremony status:

    $ kubectl logs -f job/genesis-aptos-genesis-efg1720331619

The resulting genesis ConfigMaps can be mounted by aptos-node, and will be located at:
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: None })
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: None })
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: None })
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: None })
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: None })
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: None })
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: Some(1), completion_time: None, conditions: None, failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: None })
Checking status of k8s job: genesis-aptos-genesis-efg1720331619
Status: Some(JobStatus { active: None, completion_time: Some(Time(2022-06-29T20:56:15Z)), conditions: Some([JobCondition { last_probe_time: Some(Time(2022-06-29T20:56:15Z)), last_transition_time: Some(Time(2022-06-29T20:56:15Z)), message: None, reason: None, status: "True", type_: "Complete" }]), failed: None, start_time: Some(Time(2022-06-29T20:55:46Z)), succeeded: Some(1) })
Genesis completed running
Genesis done
```



2. Run forge via fgi against my testnet
```
$ time ./scripts/fgi/run -W rustie-test --tag $GIT_SHA --suite land_blocking

# same output as above....
...
all up : 1867 TPS, 2234 ms latency, 3600 ms p99 latency,no expired txns
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1566)
<!-- Reviewable:end -->
