### PR TITLE
cicd: allow to trigger image-build and e2e-tests seperately

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -18,7 +18,7 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
-      # - main - TODO - this disables main branch image building since we assume it's already being built from the auto branch before merging (due to how bors works), possibly reactivate this if we move away from bors
+      - main
       - auto
       - canary
       - devnet

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -26,7 +26,7 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
 
 # cancel redundant builds
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
### Description

This PR fixes 2 things:
- run full tests/builds on main branch
- create concurrency group based off branch name of PR instead of target branch.

