### PR TITLE
cicd: support community-platform deployment to prod

### DIFF
--- a/.github/workflows/deploy-community-platform-to-prod.yaml
+++ b/.github/workflows/deploy-community-platform-to-prod.yaml
@@ -1,0 +1,19 @@
+name: Deploy community-platform to prod
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "ecosystem/platform/server/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-community-platform.yaml
+    with:
+      aptos_env: prod
+    secrets: inherit

--- a/.github/workflows/deploy-community-platform-to-staging.yaml
+++ b/.github/workflows/deploy-community-platform-to-staging.yaml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - "ecosystem/platform/server/**"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Description

This adds support for deploying community platform to prod.
While not visible in the code change itself, the prod environment has been setup such that it requires explicit approval by a repo member to proceed with the deployment (unlike for staging, where deployment happens automatically).
This is leveraging this feature https://docs.github.com/en/actions/managing-workflow-runs/reviewing-deployments

