### PR TITLE
allow concurrency-level to go beyond num of cpus

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -53,10 +53,8 @@ use move_deps::{
     move_vm_runtime::session::LoadedFunctionInstantiation,
     move_vm_types::{gas_schedule::GasStatus, loaded_data::runtime_types::Type},
 };
-use num_cpus;
 use once_cell::sync::OnceCell;
 use std::{
-    cmp::min,
     collections::HashSet,
     convert::{AsMut, AsRef},
     sync::Arc,
@@ -96,9 +94,7 @@ impl AptosVM {
     }
 
     /// Sets execution concurrency level when invoked the first time.
-    pub fn set_concurrency_level_once(mut concurrency_level: usize) {
-        concurrency_level = min(concurrency_level, num_cpus::get());
-        // Only the first call succeeds, due to OnceCell semantics.
+    pub fn set_concurrency_level_once(concurrency_level: usize) {
         EXECUTION_CONCURRENCY_LEVEL.set(concurrency_level).ok();
     }
 


### PR DESCRIPTION
### Description

When actual disk IO is involved, concurrency level needs to go beyond
num of cpus to fully leverage the random IO capability of the disk.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

on my 8 core 32GB VM, 100M accounts DB, running: 

```
time  cargo run --release -p executor-benchmark -- --block-size 1000 --concurrency-level 8 run-executor --data-dir ~/work/data/per-block.bak/100M --checkpoint-dir ~/work/data/cp --blocks 100
```

---

(k, so I can't find a case where it helps significantly -- on my machine with concurrent JMT updates the io is the bottleneck anyway)
(I guess it's because the state commit is the bottleneck)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1573)
<!-- Reviewable:end -->
