### PR TITLE
[testnet] Fix minor bug in forge terraform

### DIFF
--- a/terraform/aptos-node-testnet/outputs.tf
+++ b/terraform/aptos-node-testnet/outputs.tf
@@ -1,5 +1,5 @@
 output "forge-s3-bucket" {
-  value = aws_s3_bucket.aptos-testnet-helm[0].bucket
+  value = length(aws_s3_bucket.aptos-testnet-helm) > 0 ? aws_s3_bucket.aptos-testnet-helm[0].bucket : null
 }
 
 output "oidc_provider" {


### PR DESCRIPTION
This was preventing a non forge testnet from coming online because it assumed there was a index 0
