### PR TITLE
[Telemetry] Add missing telemetry metrics for AIT2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,8 @@ dependencies = [
  "network",
  "once_cell",
  "prometheus",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "reqwest",
  "serde 1.0.137",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ dependencies = [
 name = "aptos-telemetry"
 version = "0.1.0"
 dependencies = [
+ "aptos-api",
  "aptos-config",
  "aptos-infallible",
  "aptos-logger",

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -7,7 +7,7 @@ mod events;
 mod health_check;
 mod index;
 pub(crate) mod log;
-mod metrics;
+pub mod metrics;
 mod page;
 pub mod param;
 pub mod runtime;

--- a/api/src/metrics.rs
+++ b/api/src/metrics.rs
@@ -15,7 +15,7 @@ static HISTOGRAM: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-static RESPONSE_STATUS: Lazy<HistogramVec> = Lazy::new(|| {
+pub static RESPONSE_STATUS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "aptos_api_response_status",
         "API requests latency grouped by status code only",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -64,13 +64,36 @@ pub enum BootstrappingMode {
     ExecuteTransactionsFromGenesis,     // Executes transactions (starting at genesis)
 }
 
+impl BootstrappingMode {
+    pub fn to_label(&self) -> &'static str {
+        match self {
+            BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
+                "apply_transaction_outputs_from_genesis"
+            }
+            BootstrappingMode::DownloadLatestAccountStates => "download_latest_account_states",
+            BootstrappingMode::ExecuteTransactionsFromGenesis => {
+                "execute_transactions_from_genesis"
+            }
+        }
+    }
+}
+
 /// The continuous syncing mode determines how the node will stay up-to-date
 /// once it has bootstrapped and the blockchain continues to grow, e.g.,
 /// continuously executing all transactions.
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum ContinuousSyncingMode {
-    ExecuteTransactions,     // Executes transactions to stay up-to-date
     ApplyTransactionOutputs, // Applies transaction outputs to stay up-to-date
+    ExecuteTransactions,     // Executes transactions to stay up-to-date
+}
+
+impl ContinuousSyncingMode {
+    pub fn to_label(&self) -> &'static str {
+        match self {
+            ContinuousSyncingMode::ApplyTransactionOutputs => "apply_transaction_outputs",
+            ContinuousSyncingMode::ExecuteTransactions => "execute_transactions",
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -16,6 +16,8 @@ shadow-rs = "0.11.0"
 futures = "0.3.21"
 once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }
+rand = "0.7.3"
+rand_core = "0.5.1"
 reqwest = { version = "0.11.10", features = ["json"] }
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = "1.0.81"

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1.18.2" }
 tokio-stream = "0.1.8"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
+aptos-api = { path = "../../api" }
 aptos-config = { path = "../../config" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }

--- a/crates/aptos-telemetry/src/core_metrics.rs
+++ b/crates/aptos-telemetry/src/core_metrics.rs
@@ -92,8 +92,8 @@ fn collect_mempool_metrics(core_metrics: &mut BTreeMap<String, String>) {
 
 /// Collects the REST metrics and appends it to the given map
 fn collect_rest_metrics(core_metrics: &mut BTreeMap<String, String>) {
-    let rest_response_count =
-        sum_all_histogram_counts(aptos_api::metrics::RESPONSE_STATUS.collect());
+    let rest_response_metrics = aptos_api::metrics::RESPONSE_STATUS.collect();
+    let rest_response_count = sum_all_histogram_counts(&rest_response_metrics);
     core_metrics.insert(REST_RESPONSE_COUNT.into(), rest_response_count.to_string());
 }
 
@@ -181,15 +181,15 @@ fn collect_storage_metrics(core_metrics: &mut BTreeMap<String, String>) {
 
 /// Collects the telemetry metrics and appends it to the given map
 fn collect_telemetry_metrics(core_metrics: &mut BTreeMap<String, String>) {
-    let telemetry_failure_count =
-        utils::sum_all_gauges(crate::metrics::APTOS_TELEMETRY_FAILURE.collect());
+    let telemetry_failure_metrics = crate::metrics::APTOS_TELEMETRY_FAILURE.collect();
+    let telemetry_failure_count = utils::sum_all_gauges(&telemetry_failure_metrics);
     core_metrics.insert(
         TELEMETRY_FAILURE_COUNT.into(),
         telemetry_failure_count.to_string(),
     );
 
-    let telemetry_success_count =
-        utils::sum_all_gauges(crate::metrics::APTOS_TELEMETRY_SUCCESS.collect());
+    let telemetry_success_metrics = crate::metrics::APTOS_TELEMETRY_SUCCESS.collect();
+    let telemetry_success_count = utils::sum_all_gauges(&telemetry_success_metrics);
     core_metrics.insert(
         TELEMETRY_SUCCESS_COUNT.into(),
         telemetry_success_count.to_string(),

--- a/crates/aptos-telemetry/src/utils.rs
+++ b/crates/aptos-telemetry/src/utils.rs
@@ -27,7 +27,7 @@ pub(crate) fn insert_optional_value(
 }
 
 /// Sums all gauge counts in the given set of metric families
-pub fn sum_all_gauges(metric_families: Vec<MetricFamily>) -> f64 {
+pub fn sum_all_gauges(metric_families: &Vec<MetricFamily>) -> f64 {
     let mut gauge_sum = 0.0;
     for metric_family in metric_families {
         for metric in metric_family.get_metric() {
@@ -38,11 +38,22 @@ pub fn sum_all_gauges(metric_families: Vec<MetricFamily>) -> f64 {
 }
 
 /// Sums all histogram sample counts in the given set of metric families
-pub fn sum_all_histogram_counts(metric_families: Vec<MetricFamily>) -> f64 {
+pub fn sum_all_histogram_counts(metric_families: &Vec<MetricFamily>) -> f64 {
     let mut count_sum = 0.0;
     for metric_family in metric_families {
         for metric in metric_family.get_metric() {
             count_sum += metric.get_histogram().get_sample_count() as f64
+        }
+    }
+    count_sum
+}
+
+/// Sums all histogram sample sums in the given set of metric families
+pub fn sum_all_histogram_sums(metric_families: &Vec<MetricFamily>) -> f64 {
+    let mut count_sum = 0.0;
+    for metric_family in metric_families {
+        for metric in metric_family.get_metric() {
+            count_sum += metric.get_histogram().get_sample_sum() as f64
         }
     }
     count_sum

--- a/crates/aptos-telemetry/src/utils.rs
+++ b/crates/aptos-telemetry/src/utils.rs
@@ -4,7 +4,16 @@
 #![forbid(unsafe_code)]
 
 use crate::{build_information::collect_build_info, system_information::collect_system_info};
+use prometheus::proto::MetricFamily;
 use std::collections::BTreeMap;
+
+/// Used to expose system and build information
+pub fn get_system_and_build_information(chain_id: Option<String>) -> BTreeMap<String, String> {
+    let mut information: BTreeMap<String, String> = BTreeMap::new();
+    collect_build_info(chain_id, &mut information);
+    collect_system_info(&mut information);
+    information
+}
 
 /// Inserts an optional value into the given map iff the value exists
 pub(crate) fn insert_optional_value(
@@ -17,10 +26,24 @@ pub(crate) fn insert_optional_value(
     }
 }
 
-/// Used to expose system and build information
-pub fn get_system_and_build_information(chain_id: Option<String>) -> BTreeMap<String, String> {
-    let mut information: BTreeMap<String, String> = BTreeMap::new();
-    collect_build_info(chain_id, &mut information);
-    collect_system_info(&mut information);
-    information
+/// Sums all gauge counts in the given set of metric families
+pub fn sum_all_gauges(metric_families: Vec<MetricFamily>) -> f64 {
+    let mut gauge_sum = 0.0;
+    for metric_family in metric_families {
+        for metric in metric_family.get_metric() {
+            gauge_sum += metric.get_gauge().get_value();
+        }
+    }
+    gauge_sum
+}
+
+/// Sums all histogram sample counts in the given set of metric families
+pub fn sum_all_histogram_counts(metric_families: Vec<MetricFamily>) -> f64 {
+    let mut count_sum = 0.0;
+    for metric_family in metric_families {
+        for metric in metric_family.get_metric() {
+            count_sum += metric.get_histogram().get_sample_count() as f64
+        }
+    }
+    count_sum
 }


### PR DESCRIPTION
### Description

This PR adds the missing information required by telemetry for AIT2. The PR offers the following commits:
1. Force all metric events to include a secret random token that can be used to correlate events at the telemetry backend.
2. Forward the missing state sync, REST and telemetry metrics to the backend.
3. Forward network traffic and message information to the backend.

Note: there's a number of performance related metrics we still haven't included. This is something we'll need to figure out and do after the AIT2 cut. We still need to identify the right way for parsing and displaying this information (e.g., histograms, buckets, averages, etc.)

### Test Plan
Manually tested by running a fullnode. But, we need a better testing plan long term.
