### PR TITLE
[helm][aptos-node] enable fullnode rest api by default

### DIFF
--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -96,7 +96,7 @@ service:
   # NOTE: these values apply for all fullnode groups
   fullnode:
     loadBalancerSourceRanges:
-    enableRestApi: false
+    enableRestApi: true
     enableMetricsPort: false
 
 serviceAccount:


### PR DESCRIPTION
We can also wrap these up in Terraform variables to make the operator experience easier, but for now, assume that all fullnodes should have REST API enabled.

Test: spin up a new cluster with these configs
