### PR TITLE
cicd: fix reusing docker layer cache from main branch

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -41,6 +41,12 @@ env:
   # For more info also see https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
   GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
+  # TARGET_CACHE_ID is used as part of the docker tag / cache key inside our bake.hcl docker bake files.
+  # The goal here is to have a branch or PR-local cache such that consecutive pushes to a shared branch or a specific PR can
+  # reuse layers from a previous docker build/commit.
+  # We use `pr-<pr_number>` as cache-id for PRs and simply <branch_name> otherwise.
+  TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
+
 permissions:
   contents: read
   id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
@@ -99,7 +105,6 @@ jobs:
         run: docker/docker-bake-rust-all.sh
         env:
           IMAGE_TARGET: ${{ matrix.IMAGE_TARGET }}
-          GIT_BRANCH: ${{ github.head_ref }}
 
   sdk-integration-test:
     needs: rust-images
@@ -149,8 +154,6 @@ jobs:
       - uses: ./.github/actions/docker-buildx-setup
 
       - name: Build and Push Community Platform image
-        env:
-          GIT_BRANCH: ${{ github.head_ref }}
         run: |
           cd ecosystem/platform/server
           docker buildx bake --progress=plain --push -f ./docker-bake.hcl
@@ -178,8 +181,6 @@ jobs:
       - uses: ./.github/actions/docker-buildx-setup
 
       - name: Build and Push Indexer Server image
-        env:
-          GIT_BRANCH: ${{ github.head_ref }}
         run: |
           cd ecosystem/indexer-server
           docker buildx bake --progress=plain --push -f ./docker-bake.hcl

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -14,7 +14,7 @@ name: "Build+Push Images"
 on: # build on main branch OR when a PR is labeled with `CICD:build-images`
   # Allow us to run this specific workflow without a PR
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
@@ -74,9 +74,19 @@ jobs:
           required-permission: write
           comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
 
+  determine-last-green-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: talentpair/last-green-commit-action@d95cfa836b22ef047dd0a8ddb1e6d9567982d702
+        id: last-green-commit
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      lastGreenCommit: ${{ steps.last-green-commit.outputs.result  }}
+
   rust-images:
     # trigger only for push events (on protected branches as defined above) OR on PR events with the "CICD:build-images" label.
-    needs: permission-check
+    needs: [permission-check, determine-last-green-commit]
     strategy:
       matrix:
         IMAGE_TARGET: [release, test]
@@ -105,6 +115,7 @@ jobs:
         run: docker/docker-bake-rust-all.sh
         env:
           IMAGE_TARGET: ${{ matrix.IMAGE_TARGET }}
+          LAST_GREEN_COMMIT: ${{ needs.determine-last-green-commit.outputs.lastGreenCommit }}
 
   sdk-integration-test:
     needs: rust-images
@@ -132,7 +143,7 @@ jobs:
       merge_or_canary: ${{ github.event.pull_request.auto_merge != null && 'merge' || 'canary' }}
 
   community-platform:
-    needs: permission-check
+    needs: [permission-check]
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3
@@ -159,7 +170,7 @@ jobs:
           docker buildx bake --progress=plain --push -f ./docker-bake.hcl
 
   indexer-server:
-    needs: permission-check
+    needs: [permission-check]
     runs-on: high-perf-docker
     steps:
       - uses: actions/checkout@v3

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -16,6 +16,7 @@ variable "GIT_REV" {
   default = substr("${GIT_SHA}", 0, 8)
 }
 
+variable "LAST_GREEN_COMMIT" {}
 
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 
@@ -153,13 +154,16 @@ function "generate_cache_from" {
   result = [
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-main",
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-auto",
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_target_cache_id}"
+    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_target_cache_id}",
+    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:${LAST_GREEN_COMMIT}",
   ]
 }
 
 function "generate_cache_to" {
   params = [target]
-  result = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_target_cache_id},mode=max"]
+  result = [
+    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_target_cache_id},mode=max",
+  ]
 }
 
 function "generate_tags" {

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -2,6 +2,8 @@
 # It provides a high-level mechenanism to build multiple dockerfiles in one shot.
 # Check https://crazymax.dev/docker-allhands2-buildx-bake and https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition for an intro.
 
+variable "TARGET_CACHE_ID" {}
+
 variable "BUILD_DATE" {}
 
 variable "GITHUB_SHA" {}
@@ -14,7 +16,6 @@ variable "GIT_REV" {
   default = substr("${GIT_SHA}", 0, 8)
 }
 
-variable "GIT_BRANCH" {}
 
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 
@@ -28,8 +29,8 @@ variable "gh_image_cache" {
   default = "ghcr.io/aptos-labs/aptos-core"
 }
 
-variable "normalized_git_branch" {
-  default = regex_replace("${GIT_BRANCH}", "[^a-zA-Z0-9]", "-")
+variable "normalized_target_cache_id" {
+  default = regex_replace("${TARGET_CACHE_ID}", "[^a-zA-Z0-9]", "-")
 }
 
 # images with IMAGE_TARGET=release for rust build
@@ -152,13 +153,13 @@ function "generate_cache_from" {
   result = [
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-main",
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-auto",
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_git_branch}"
+    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_target_cache_id}"
   ]
 }
 
 function "generate_cache_to" {
   params = [target]
-  result = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_git_branch},mode=max"]
+  result = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/${target}:cache-${normalized_target_cache_id},mode=max"]
 }
 
 function "generate_tags" {

--- a/docker/docker-bake-rust-all.sh
+++ b/docker/docker-bake-rust-all.sh
@@ -11,5 +11,5 @@ set -ex
 export GIT_REV=$(git rev-parse --short=8 HEAD)
 export GIT_SHA=$(git rev-parse HEAD)
 export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-export GIT_BRANCH="${GIT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
+export TARGET_CACHE_ID="${CACHE_SUFFIX:-from-local}"
 docker buildx bake --push --progress=plain --file docker/docker-bake-rust-all.hcl $IMAGE_TARGET

--- a/ecosystem/indexer-server/docker-bake.hcl
+++ b/ecosystem/indexer-server/docker-bake.hcl
@@ -4,14 +4,14 @@
 
 
 variable "GIT_SHA" {}
-variable "GIT_BRANCH" {}
+variable "TARGET_CACHE_ID" {}
 variable "AWS_ECR_ACCOUNT_NUM" {}
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 variable "ecr_base" {
   default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
 }
-variable "normalized_git_branch" {
-  default = regex_replace("${GIT_BRANCH}", "[^a-zA-Z0-9]", "-")
+variable "normalized_target_cache_id" {
+  default = regex_replace("${TARGET_CACHE_ID}", "[^a-zA-Z0-9]", "-")
 }
 
 group "default" {
@@ -26,9 +26,9 @@ target "indexer-server" {
   cache-from = [
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/indexer-server:cache-main",
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/indexer-server:cache-auto",
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/indexer-server:cache-${normalized_git_branch}",
+    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/indexer-server:cache-${normalized_target_cache_id}",
   ]
-  cache-to = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/indexer-server:cache-${normalized_git_branch},mode=max"]
+  cache-to = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/indexer-server:cache-${normalized_target_cache_id},mode=max"]
   tags = [
     "${ecr_base}/indexer-server:${GIT_SHA}",
     "${GCP_DOCKER_ARTIFACT_REPO}/indexer-server:${GIT_SHA}",

--- a/ecosystem/platform/server/docker-bake.hcl
+++ b/ecosystem/platform/server/docker-bake.hcl
@@ -3,16 +3,16 @@
 # Check https://crazymax.dev/docker-allhands2-buildx-bake and https://docs.docker.com/engine/reference/commandline/buildx_bake/#file-definition for an intro.
 
 
+variable "TARGET_CACHE_ID" {}
 variable "GIT_SHA" {}
-variable "GIT_BRANCH" {}
 variable "AWS_ECR_ACCOUNT_NUM" {}
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 variable "ecr_base" {
   default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
 }
 
-variable "normalized_git_branch" {
-  default = regex_replace("${GIT_BRANCH}", "[^a-zA-Z0-9]", "-")
+variable "normalized_target_cache_id" {
+  default = regex_replace("${TARGET_CACHE_ID}", "[^a-zA-Z0-9]", "-")
 }
 
 group "default" {
@@ -27,9 +27,9 @@ target "community-platform" {
   cache-from = [
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache-main",
     "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache-auto",
-    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache-${normalized_git_branch}",
+    "type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache-${normalized_target_cache_id}",
   ]
-  cache-to = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache-${normalized_git_branch},mode=max"]
+  cache-to = ["type=registry,ref=${GCP_DOCKER_ARTIFACT_REPO}/community-platform:cache-${normalized_target_cache_id},mode=max"]
   tags = [
     "${ecr_base}/community-platform:${GIT_SHA}",
     "${GCP_DOCKER_ARTIFACT_REPO}/community-platform:${GIT_SHA}",


### PR DESCRIPTION
### Description

This fixes reusing the cache from the main branch. It turns out the previously used expression `github.head_ref` is only defined for pull_request and pull_request_target events and therefore the bash script defaulted to `git rev-parse --abbrev-ref HEAD` which just returned `HEAD` instead of `main` (this is due to github actions by default doing a shallow checkout or something), which is why we never got a cache hit on the first build of a PR (the docker --cache-from pulls `cache-main` instead of `cache-HEAD`). 
Also while thinking a bit more about it I realized that using github.head_ref (which resolves to the branch name of the PR) is actually not guaranteed to be unique for PRs from forks, so its probably not a good idea to use the branch name anyways. So instead we're now using the pr number to determine a cache key for PRs and for all other cases we use the branch name (=other cases meaning push events to main or other well known branches) via `github.ref_name`.

Furthermore this PR adds a "determine-last-green-commit" job which should increase the cache hit ratio in some circumstances. Without it the first image build in a PR will only have the tip of the main branch available as potential cache source, which is not ideal.
Ideally we want to use the most recent ancestor commit for a which an image build succeeded as cache source.
This is because typically a PR is a handful of commits behind main.
If someone opens a PR that just changes a README, but the main branch contains a few Rust code changes which are not yet in the commit history of the PR/branch, an PR image build that uses the tip of the main branch as cache source, would recompile the Rust code unnecessarily.
By using `determine-last-green-commit` - which traverses the PRs commit history until it finds a passing build - we avoid this situation and should - in theory - have cache hits for trivial PRs which don't change any of the Rust code.

### Test Plan
Ran the workflow a few times and printed out the ref generated to make sure it's what we want.
