### PR TITLE
feat(ts-sdk): memoize chain id in aptos client

### DIFF
--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -52,6 +52,7 @@
     "buffer": "^6.0.3",
     "js-sha3": "^0.8.0",
     "tweetnacl": "^1.0.3",
+    "typescript-memoize": "^1.1.0",
     "yarn": "^1.22.18"
   },
   "version": "1.1.1"

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -1,4 +1,5 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
+import { MemoizeExpiring } from 'typescript-memoize';
 import { Accounts } from './api/Accounts';
 import { Events } from './api/Events';
 import { Transactions } from './api/Transactions';
@@ -521,6 +522,7 @@ export class AptosClient {
    * @param params Request params
    * @returns Current chain id
    */
+  @MemoizeExpiring(5 * 60 * 1000) // cache result for 5 minutes
   async getChainId(params: RequestParams = {}): Promise<number> {
     const result = await this.getLedgerInfo(params);
     return result.chain_id;


### PR DESCRIPTION
### Description
`getChainId` can be cached. This will reduce the number of API calls.

### Test Plan
yarn test
