### PR TITLE
[helm][aptos-node] separate external service type for fullnode vs val…

### DIFF
--- a/terraform/helm/aptos-node/templates/haproxy.yaml
+++ b/terraform/helm/aptos-node/templates/haproxy.yaml
@@ -45,7 +45,7 @@ spec:
     port: 80
     targetPort: 8180
   {{- end }}
-  type: {{ $.Values.service.external.type }}
+  type: {{ $.Values.service.validator.external.type }}
   externalTrafficPolicy: Local
   {{- with $.Values.service.validator.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
@@ -90,7 +90,7 @@ spec:
     targetPort: {{ add 8443 $index }}
   {{- end }}
   {{- end }}
-  type: {{ $.Values.service.external.type }}
+  type: {{ $.Values.service.fullnode.external.type }}
   externalTrafficPolicy: Local
   {{- with (index $.Values.service $config.name).loadBalancerSourceRanges }}
   loadBalancerSourceRanges:

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -88,14 +88,16 @@ haproxy:
 
 service:
   domain:
-  external:
-    type: LoadBalancer
   validator:
+    external: 
+      type: LoadBalancer
     loadBalancerSourceRanges:
     enableRestApi: false
     enableMetricsPort: false
   # NOTE: these values apply for all fullnode groups
   fullnode:
+    external: 
+      type: LoadBalancer
     loadBalancerSourceRanges:
     enableRestApi: true
     enableMetricsPort: false


### PR DESCRIPTION
…idator

### Description

testnet does not support dynamic validator set yet, so don't expose each individual validator with LoadBalancer (NLB).

### Test Plan
Apply to a testnet
