### PR TITLE
[Docs] Adding sidebar links for REST API and TS-SDK API.

### DIFF
--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -96,6 +96,32 @@ const sidebars = {
         "reference/node-liveness-criteria",
       ],
     },
+    {
+      type: "category",
+      label: "SDKs",
+      collapsible: true,
+      collapsed: true,
+      items: [
+        {
+          type: "link",
+          label: "Typescript SDK",
+          href: "https://aptos-labs.github.io/ts-sdk-doc/",
+        },
+      ],
+    },
+    {
+      type: "category",
+      label: "APIs",
+      collapsible: true,
+      collapsed: true,
+      items: [
+        {
+          type: "link",
+          label: "REST API",
+          href: "/rest-api",
+        },
+      ],
+    },
     "reference/telemetry",
     "reference/glossary",
   ],


### PR DESCRIPTION
Here is the first of smaller commits. This one adds the links for the APIs in the sidebar. All these smaller commits are keeping in view the final reorg we want to get to, as shown in this preview: https://deploy-preview-1515--aptos-developer-docs.netlify.app/