### PR TITLE
cicd: make sure all sdk integration tests are run against local node+…

### DIFF
--- a/.github/workflows/sdk-integration-test.yaml
+++ b/.github/workflows/sdk-integration-test.yaml
@@ -14,6 +14,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      APTOS_NODE_URL: http://localhost:8080
+      APTOS_FAUCET_URL: http://localhost:8000
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,9 +41,7 @@ jobs:
       # Run package install, test, build
       - run: cd ./ecosystem/typescript/sdk && yarn install
       - run: cd ./ecosystem/typescript/sdk && yarn test
-        env:
-          APTOS_NODE_URL: http://localhost:8080
-          APTOS_FAUCET_URL: http://localhost:8000
+
       - run: cd ./ecosystem/typescript/sdk && yarn build
       # Run example code in typescript
       - run: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install && yarn test


### PR DESCRIPTION
…faucet instead of devnet

Moving the environment variable setting to the job level to make sure it applies to all steps.
Fixes failures like these https://github.com/aptos-labs/aptos-core/runs/7102190155?check_suite_focus=true

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
