### PR TITLE
Add support for checking stats once at the end of the txn emitter run

### DIFF
--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -48,10 +48,10 @@ struct Args {
     burst: bool,
 
     /// This can only be set in conjunction with --burst. By default, when burst
-    /// is enabled, we do not ever check the transaction stats. If this is set,
-    /// we will check the stats once at the end.
+    /// is enabled, we check stats once at the end of the emitter run. If you
+    /// would like to opt out of that, you can use this flag.
     #[structopt(long, requires = "burst")]
-    check_stats_at_end: bool,
+    do_not_check_stats_at_end: bool,
 
     #[structopt(long, default_value = "30")]
     txn_expiration_time_secs: u64,
@@ -100,7 +100,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
         wait_millis: args.wait_millis,
         wait_committed: !args.burst,
         txn_expiration_time_secs: args.txn_expiration_time_secs,
-        check_stats_at_end: args.check_stats_at_end,
+        do_not_check_stats_at_end: args.do_not_check_stats_at_end,
     };
     let duration = Duration::from_secs(args.duration);
     let client = cluster.random_instance().rest_client();

--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -46,6 +46,13 @@ struct Args {
     wait_millis: u64,
     #[structopt(long)]
     burst: bool,
+
+    /// This can only be set in conjunction with --burst. By default, when burst
+    /// is enabled, we do not ever check the transaction stats. If this is set,
+    /// we will check the stats once at the end.
+    #[structopt(long, requires = "burst")]
+    check_stats_at_end: bool,
+
     #[structopt(long, default_value = "30")]
     txn_expiration_time_secs: u64,
     #[structopt(long, default_value = "mint.key")]
@@ -93,6 +100,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
         wait_millis: args.wait_millis,
         wait_committed: !args.burst,
         txn_expiration_time_secs: args.txn_expiration_time_secs,
+        check_stats_at_end: args.check_stats_at_end,
     };
     let duration = Duration::from_secs(args.duration);
     let client = cluster.random_instance().rest_client();
@@ -118,7 +126,7 @@ async fn emit_tx(cluster: &Cluster, args: &Args) -> Result<()> {
         emit_job_request = emit_job_request.vasp();
     }
     let stats = emitter
-        .emit_txn_for_with_stats(duration, emit_job_request, 10)
+        .emit_txn_for_with_stats(duration, emit_job_request, min(10, args.duration / 5))
         .await?;
     println!("Total stats: {}", stats);
     println!("Average rate: {}", stats.rate(duration));

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -145,7 +145,7 @@ fn main() -> Result<()> {
             wait_millis: args.wait_millis,
             wait_committed: !args.burst,
             txn_expiration_time_secs: 30,
-            check_stats_at_end: false,
+            do_not_check_stats_at_end: true,
         });
     if let Some(workers_per_endpoint) = args.workers_per_ac {
         global_emit_job_request =

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -145,6 +145,7 @@ fn main() -> Result<()> {
             wait_millis: args.wait_millis,
             wait_committed: !args.burst,
             txn_expiration_time_secs: 30,
+            check_stats_at_end: false,
         });
     if let Some(workers_per_endpoint) = args.workers_per_ac {
         global_emit_job_request =


### PR DESCRIPTION
## Description
As it is now with burst mode, you are only able to get stats regarding what transactions were submitted. With this change, if you provide `--check-stats-at-end`, we check the stats once at the end of the run, which gives us the number of committed / uncommitted transactions too.

## Test Plan
See https://www.notion.so/aptoslabs/Single-node-testnet-transaction-load-test-guide-57e82a909e614243bed9694641f581f9.

The txn emitter invocation (without the env var prefix stuff) is:
```
cargo run -p transaction-emitter --release -- --emit-tx -p localhost:8080 --mint-file "$MP" --chain-id TESTING --workers-per-ac 8 --accounts-per-client 8 --duration 5 --txn-expiration-time-secs 10 --burst --wait-millis 60 --check-stats-at-end
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1602)
<!-- Reviewable:end -->
