### PR TITLE
[tf][testnet] dns fixes for when workspace_dns set

### DIFF
--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -17,9 +17,14 @@ locals {
 module "validator" {
   source = "../aptos-node/aws"
 
-  region                      = var.region
-  iam_path                    = var.iam_path
-  zone_id                     = var.zone_id
+  region   = var.region
+  iam_path = var.iam_path
+  zone_id  = var.zone_id
+  # do not create the main fullnode and validator DNS records
+  # instead, rely on external-dns from the testnet-addons
+  create_records = false
+  workspace_dns  = var.workspace_dns
+
   permissions_boundary_policy = var.permissions_boundary_policy
   workspace_name_override     = var.workspace_name_override
 
@@ -34,7 +39,7 @@ module "validator" {
   validator_name = "aptos-node"
 
   num_validators = var.num_validators
-  helm_values = var.aptos_node_helm_values
+  helm_values    = var.aptos_node_helm_values
 
   # allow all nodegroups to surge to 2x their size, in case of total nodes replacement
   validator_instance_num = var.num_validator_instance > 0 ? 2 * var.num_validator_instance : var.num_validators
@@ -86,7 +91,7 @@ resource "helm_release" "genesis" {
       genesis = {
         numValidators   = var.num_validators
         username_prefix = local.aptos_node_helm_prefix
-        domain = local.domain
+        domain          = local.domain
         validator = {
           enable_onchain_discovery = false
         }

--- a/terraform/aptos-node/aws/outputs.tf
+++ b/terraform/aptos-node/aws/outputs.tf
@@ -21,11 +21,11 @@ output "oidc_provider" {
 ### Node outputs
 
 output "validator_endpoint" {
-  value = var.zone_id != "" ? "/dns4/${aws_route53_record.validator[0].fqdn}/tcp/${data.kubernetes_service.validator-lb[0].spec[0].port[0].port}" : null
+  value = var.zone_id == "" || !var.create_records ? null : "/dns4/${aws_route53_record.validator[0].fqdn}/tcp/${data.kubernetes_service.validator-lb[0].spec[0].port[0].port}"
 }
 
 output "fullnode_endpoint" {
-  value = var.zone_id != "" ? "/dns4/${aws_route53_record.fullnode[0].fqdn}/tcp/${data.kubernetes_service.fullnode-lb[0].spec[0].port[0].port}" : null
+  value = var.zone_id == "" || !var.create_records ? null : "/dns4/${aws_route53_record.fullnode[0].fqdn}/tcp/${data.kubernetes_service.fullnode-lb[0].spec[0].port[0].port}"
 }
 
 ### Network outputs

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -42,9 +42,19 @@ variable "zone_id" {
   default     = ""
 }
 
+variable "workspace_dns" {
+  description = "Include Terraform workspace name in DNS records"
+  default     = true
+}
+
 variable "record_name" {
   description = "DNS record name to use (<workspace> is replaced with the TF workspace name)"
   default     = "<workspace>.aptos"
+}
+
+variable "create_records" {
+  description = "Creates DNS records in var.zone_id that point to k8s service, as opposed to using external-dns or other means"
+  default     = true
 }
 
 variable "helm_chart" {

--- a/terraform/helm/testnet-addons/templates/waypoint.yaml
+++ b/terraform/helm/testnet-addons/templates/waypoint.yaml
@@ -52,6 +52,20 @@ spec:
           capabilities:
             drop:
             - ALL
+      {{- with .Values.waypoint }}
+      {{- with .nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -9,6 +9,11 @@ genesis:
   # prefix used to get the genesis configuration
   username_prefix: aptos-node
 
+waypoint:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
So we can properly account for `workspace_dns = false`, for example with `devnet.aptoslabs.com`

* propagate the `var.workspace_dns` down to `aptos-node` TF module.
* introduce `var.create_records`, which defaults to true, as in creating the DNS records for the NLB spun up by k8s controllers. We don't want this in the testnet case, so set that to false
* Use above two variables as conditional flags in `count` in various  DNS resources and outputs