### PR TITLE
[CP] Autotrust email + prefill email verif

### DIFF
--- a/ecosystem/platform/server/app/models/user.rb
+++ b/ecosystem/platform/server/app/models/user.rb
@@ -104,7 +104,11 @@ class User < ApplicationRecord
                           username: "#{raw_info['username'].downcase}##{raw_info['discriminator']}"
                         })
     when 'google'
-      # No additional data from Google.
+      # No additional data from Google. But we can trust the email!
+      if !confirmed? && !User.exists?(email: auth[:email])
+        self.email = auth[:email]
+        confirm
+      end
     else
       raise 'Unknown Provider!'
     end

--- a/ecosystem/platform/server/app/views/onboarding/email.html.erb
+++ b/ecosystem/platform/server/app/views/onboarding/email.html.erb
@@ -19,7 +19,7 @@
 
   <%= form_with(model: current_user, url: onboarding_email_path, method: :post, data: { turbo: !@show_recaptcha_v2, controller: 'recaptcha', action: 'recaptcha#validate' }, builder: AptosFormBuilder) do |f| %>
     <div class="mb-8">
-      <%= f.email_field :email, autofocus: true, autocomplete: 'email', required: true, placeholder: 'ENTER YOUR EMAIL ADDRESS', class: 'md:w-96' %>
+      <%= f.email_field :email, autofocus: true, autocomplete: 'email', required: true, placeholder: 'ENTER YOUR EMAIL ADDRESS', value: current_user.unconfirmed_email || current_user.email || @oauth_email, class: 'md:w-96' %>
     </div>
 
     <div class="mb-8">

--- a/ecosystem/platform/server/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -54,7 +54,11 @@ module Users
 
         assert_difference('User.count') do
           follow_redirect!
-          assert_redirected_to onboarding_email_url
+          if provider.to_s == 'google'
+            assert_redirected_to it2_url
+          else
+            assert_redirected_to onboarding_email_url
+          end
         end
 
         user = User.last


### PR DESCRIPTION
### Description
if it's a google oauth, trust the email. Otherwise, pre-populate the email field with the authorization email

### Test Plan
tested manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1611)
<!-- Reviewable:end -->
