### PR TITLE
cicd: env for sdk-integration-test

### DIFF
--- a/.github/workflows/sdk-integration-test.yaml
+++ b/.github/workflows/sdk-integration-test.yaml
@@ -14,6 +14,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      APTOS_NODE_URL: http://localhost:8080
+      APTOS_FAUCET_URL: http://localhost:8000
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,9 +41,6 @@ jobs:
       # Run package install, test, build
       - run: cd ./ecosystem/typescript/sdk && yarn install
       - run: cd ./ecosystem/typescript/sdk && yarn test
-        env:
-          APTOS_NODE_URL: http://localhost:8080
-          APTOS_FAUCET_URL: http://localhost:8000
       - run: cd ./ecosystem/typescript/sdk && yarn build
       # Run example code in typescript
       - run: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install && yarn test


### PR DESCRIPTION
### Description
Use the correct env variables in CICD for SDK integration tests

### Test Plan
Verify results through the github UI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1617)
<!-- Reviewable:end -->
