### PR TITLE
enable overflow checks in release mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ default-members = [
 
 [profile.release]
 debug = true
+overflow-checks = true
 
 [profile.cli]
 inherits = "release"


### PR DESCRIPTION
### Description
Makes it behave the same as debug mode.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

put this in one of the cli tools and it panics at runtime (in release mode):

```
    let mut a = u64::MAX - 10;
    for _ in 0..100 {
        a = a + 1;
        println!("{}", a);
    }
```

output:

```
17:42 $ cargo run --release -p executor-benchmark
   Compiling executor-benchmark v0.1.0 (/home/msmouse/work/aptos_repos/aptos-core/execution/executor-benchmark)                                                                                      Finished release [optimized + debuginfo] target(s) in 25.69s
     Running `target/release/executor-benchmark`
18446744073709551606
18446744073709551607
18446744073709551608
18446744073709551609
18446744073709551610
18446744073709551611
18446744073709551612
18446744073709551613
18446744073709551614
18446744073709551615
thread 'main' panicked at 'attempt to add with overflow', execution/executor-benchmark/src/main.rs:111:13                                                                                        note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1619)
<!-- Reviewable:end -->
