### PR TITLE
[storage][restore_handler] Get rid of pre_genesis

### DIFF
--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -3,8 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use anyhow::Result;
-use aptos_crypto::{ed25519::Ed25519PrivateKey, hash::CryptoHash, HashValue, PrivateKey, Uniform};
+use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_temppath::TempPath;
 use aptos_transaction_builder::aptos_stdlib;
@@ -15,27 +14,21 @@ use aptos_types::{
     account_view::AccountView,
     contract_event::ContractEvent,
     event::EventHandle,
-    on_chain_config,
     on_chain_config::{
         access_path_for_config, config_address, ConfigurationResource, OnChainConfig, ValidatorSet,
     },
-    proof::SparseMerkleRangeProof,
-    state_store::{state_key::StateKey, state_value::StateValue},
+    state_store::state_key::StateKey,
     test_helpers::transaction_test_helpers::block,
-    transaction::{
-        authenticator::AuthenticationKey, ChangeSet, Transaction, Version, WriteSetPayload,
-        PRE_GENESIS_VERSION,
-    },
+    transaction::{authenticator::AuthenticationKey, ChangeSet, Transaction, WriteSetPayload},
     trusted_state::TrustedState,
     validator_signer::ValidatorSigner,
     waypoint::Waypoint,
     write_set::{WriteOp, WriteSetMut},
 };
 use aptos_vm::AptosVM;
-use aptosdb::{AptosDB, GetRestoreHandler};
+use aptosdb::AptosDB;
 use executor::{
     block_executor::BlockExecutor,
-    components::in_memory_state_calculator::IntoLedgerView,
     db_bootstrapper::{generate_waypoint, maybe_bootstrap},
 };
 use executor_test_helpers::{
@@ -47,10 +40,7 @@ use move_deps::move_core_types::{
     move_resource::{MoveResource, MoveStructType},
 };
 use rand::SeedableRng;
-use std::sync::Arc;
-use storage_interface::{
-    state_view::LatestDbStateCheckpointView, DbReader, DbReaderWriter, StateSnapshotReceiver,
-};
+use storage_interface::{state_view::LatestDbStateCheckpointView, DbReaderWriter};
 
 #[test]
 fn test_empty_db() {
@@ -191,143 +181,6 @@ fn get_configuration(db: &DbReaderWriter) -> ConfigurationResource {
         .get_configuration_resource()
         .unwrap()
         .unwrap()
-}
-
-fn get_state_backup(
-    db: &Arc<AptosDB>,
-) -> (
-    Vec<(StateKey, StateValue)>,
-    SparseMerkleRangeProof,
-    HashValue,
-) {
-    let backup_handler = db.get_backup_handler();
-    let version = db.get_latest_version().unwrap();
-    let accounts = backup_handler
-        .get_account_iter(version)
-        .unwrap()
-        .collect::<Result<Vec<_>>>()
-        .unwrap();
-    let proof = backup_handler
-        .get_account_state_range_proof(CryptoHash::hash(&accounts.last().unwrap().0), version)
-        .unwrap();
-    let db_reader: Arc<dyn DbReader> = db.clone();
-    let root_hash = db
-        .get_latest_tree_state()
-        .unwrap()
-        .into_ledger_view(&db_reader)
-        .unwrap()
-        .state()
-        .root_hash();
-
-    (accounts, proof, root_hash)
-}
-
-fn restore_state_to_db(
-    db: &Arc<AptosDB>,
-    accounts: Vec<(StateKey, StateValue)>,
-    proof: SparseMerkleRangeProof,
-    root_hash: HashValue,
-    version: Version,
-) {
-    let rh = db.get_restore_handler();
-    let mut receiver = rh.get_state_restore_receiver(version, root_hash).unwrap();
-    for (chunk, proof) in vec![(accounts, proof)].into_iter() {
-        receiver.add_chunk(chunk, proof).unwrap();
-    }
-    receiver.finish().unwrap();
-}
-
-#[test]
-fn test_pre_genesis() {
-    let genesis = vm_genesis::test_genesis_change_set_and_validators(Some(1));
-    let genesis_key = &vm_genesis::GENESIS_KEYPAIR.0;
-    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis.0));
-
-    // Create bootstrapped DB.
-    let tmp_dir = TempPath::new();
-    let (db, db_rw) = DbReaderWriter::wrap(AptosDB::new_for_test(&tmp_dir));
-    let signer = ValidatorSigner::new(genesis.1[0].data.address, genesis.1[0].key.clone());
-
-    let waypoint = bootstrap_genesis::<AptosVM>(&db_rw, &genesis_txn).unwrap();
-
-    // Mint for 2 demo accounts.
-    let (account1, account1_key, account2, account2_key) = get_demo_accounts();
-    let txn1 = get_account_transaction(genesis_key, 0, &account1, &account1_key);
-    let txn2 = get_account_transaction(genesis_key, 1, &account2, &account2_key);
-    let txn3 = get_test_coin_mint_transaction(genesis_key, 2, &account1, 2000);
-    let txn4 = get_test_coin_mint_transaction(genesis_key, 3, &account2, 2000);
-    execute_and_commit(block(vec![txn1, txn2, txn3, txn4]), &db_rw, &signer);
-    assert_eq!(get_balance(&account1, &db_rw), 2000);
-    assert_eq!(get_balance(&account2, &db_rw), 2000);
-
-    // Get state tree backup.
-    let (accounts_backup, proof, root_hash) = get_state_backup(&db);
-    // Restore into PRE-GENESIS state of a new empty DB.
-    let tmp_dir = TempPath::new();
-    let (db, db_rw) = DbReaderWriter::wrap(AptosDB::new_for_test(&tmp_dir));
-    restore_state_to_db(&db, accounts_backup, proof, root_hash, PRE_GENESIS_VERSION);
-
-    // DB is not empty, `maybe_bootstrap()` will try to apply and fail the waypoint check.
-    assert!(maybe_bootstrap::<AptosVM>(&db_rw, &genesis_txn, waypoint).is_err());
-    // Nor is it able to boot BlockExecutor.
-    assert!(db_rw.reader.get_startup_info().unwrap().is_none());
-
-    let config_resource = ConfigurationResource::default().bump_epoch_for_test();
-    // New genesis transaction: set validator set and overwrite account1 balance
-    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(ChangeSet::new(
-        WriteSetMut::new(vec![
-            (
-                StateKey::AccessPath(access_path_for_config(ValidatorSet::CONFIG_ID)),
-                WriteOp::Value(bcs::to_bytes(&ValidatorSet::new(vec![])).unwrap()),
-            ),
-            (
-                StateKey::AccessPath(AccessPath::new(
-                    config_address(),
-                    ConfigurationResource::resource_path(),
-                )),
-                WriteOp::Value(bcs::to_bytes(&config_resource).unwrap()),
-            ),
-            (
-                StateKey::AccessPath(AccessPath::new(
-                    account1,
-                    CoinStoreResource::resource_path(),
-                )),
-                WriteOp::Value(
-                    bcs::to_bytes(&CoinStoreResource::new(
-                        1000,
-                        EventHandle::random_handle(0),
-                        EventHandle::random_handle(0),
-                    ))
-                    .unwrap(),
-                ),
-            ),
-        ])
-        .freeze()
-        .unwrap(),
-        vec![ContractEvent::new(
-            on_chain_config::new_epoch_event_key(),
-            0,
-            TypeTag::Struct(ConfigurationResource::struct_tag()),
-            vec![],
-        )],
-    )));
-
-    // Bootstrap DB on top of pre-genesis state.
-    let waypoint = generate_waypoint::<AptosVM>(&db_rw, &genesis_txn).unwrap();
-    assert!(maybe_bootstrap::<AptosVM>(&db_rw, &genesis_txn, waypoint).unwrap());
-
-    let trusted_state = TrustedState::from_epoch_waypoint(waypoint);
-    let state_proof = db_rw
-        .reader
-        .get_state_proof(trusted_state.version())
-        .unwrap();
-    let trusted_state_change = trusted_state.verify_and_ratchet(&state_proof).unwrap();
-    assert!(trusted_state_change.is_epoch_change());
-
-    // Effect of bootstrapping reflected.
-    assert_eq!(get_balance(&account1, &db_rw), 1000);
-    // Pre-genesis state accessible.
-    assert_eq!(get_balance(&account2, &db_rw), 2000);
 }
 
 #[test]

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -13,7 +13,7 @@ use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::definition::LeafCount,
     state_store::{state_key::StateKey, state_value::StateValue},
-    transaction::{Transaction, TransactionInfo, Version, PRE_GENESIS_VERSION},
+    transaction::{Transaction, TransactionInfo, Version},
 };
 use schemadb::DB;
 use std::sync::Arc;
@@ -106,10 +106,7 @@ impl RestoreHandler {
             .ledger_store
             .get_frozen_subtree_hashes(num_transactions)?;
         let state_root_hash = match version {
-            None => self
-                .state_store
-                .get_root_hash_option(PRE_GENESIS_VERSION)?
-                .unwrap_or(*SPARSE_MERKLE_PLACEHOLDER_HASH),
+            None => *SPARSE_MERKLE_PLACEHOLDER_HASH,
             Some(ver) => self.state_store.get_root_hash(ver)?,
         };
         Ok(TreeState::new_at_state_checkpoint(

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -292,10 +292,6 @@ impl StateStore {
         JellyfishMerkleTree::new(self).get_root_hash(version)
     }
 
-    pub fn get_root_hash_option(&self, version: Version) -> Result<Option<HashValue>> {
-        JellyfishMerkleTree::new(self).get_root_hash_option(version)
-    }
-
     /// Finds the rightmost leaf by scanning the entire DB.
     #[cfg(test)]
     pub fn get_rightmost_leaf_naive(&self) -> Result<Option<(NodeKey, LeafNode)>> {


### PR DESCRIPTION
### Description
One of N PRs to get rid of the pre_genesis state
- In `storage/aptosdb/src/backup/restore_handler.rs,` return `SPARSE_MERKLE_PLACEHOLDER_HASH` when the passed in version is `None.`
- In `execution/executor/src/components/in_memory_state_calculator.rs,` 
  - Make `checkpoint_next_version = self.state_checkpoint_version.map_or(0, |v| v+ 1)`

### Test Plan
- The UT `test_pre_genesis` in `execution/executor/tests/db_bootstrapper_test.rs` is broken after the change as expected. Remove the UT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1620)
<!-- Reviewable:end -->
