### PR TITLE
[crypto] added support for BLS aggregate signatures

### DIFF
--- a/crates/aptos-crypto/README.md
+++ b/crates/aptos-crypto/README.md
@@ -4,7 +4,7 @@ title: Crypto
 custom_edit_url: https://github.com/aptos-labs/aptos-core/edit/main/crypto/crypto/README.md
 ---
 
-The crypto component hosts all the implementations of cryptographic primitives we use in Aptos: hashing, (multi)signatures, and key derivation/generation.
+The crypto component hosts all the implementations of cryptographic primitives we use in Aptos: hashing, signatures, multisignatures, aggregate signatures, and key derivation/generation.
 
 To enforce type-safety for signature schemes, we rely on traits from  [`traits.rs`](src/traits.rs) and [`validatable.rs`](src/validatable.rs).
 
@@ -20,9 +20,9 @@ Aptos makes use of several cryptographic algorithms:
   + Used to generate keys from a salt (optional), seed, and application-info (optional)
 - **Ed25519** signatures and (naive) multisignatures
   + Based on the [ed25519-dalek](https://docs.rs/ed25519-dalek/) crate with additional security checks (e.g., for malleability)
-- **Boneh-Shacham-Lynn (BLS) multisignatures**
+- **Boneh-Shacham-Lynn (BLS) multisignatures and aggregate signatures**
   + Based on the [blst](https://docs.rs/blst/) crate
-  + Implemented on top of Barreto-Scott-Lynn BLS12-381 elliptic curves
+  + Implemented on top of Barreto-Lynn-Scott BLS12-381 elliptic curves
 - The **[Noise Protocol Framework](http://www.noiseprotocol.org/)**
   - Used to create authenticated and encrypted communications channels between validators
 - **X25519** key exchange
@@ -36,7 +36,7 @@ Before implementing a cryptographic primitive, be sure to read [`traits.rs`](src
 ## How is this module organized?
 ```
     crypto/src
-    ├── bls12-381/          # BLS (multi)signatures over BLS12-381 curves
+    ├── bls12-381/          # Boneh-Lynn-Shacham (BLS) signatures over (Barreto-Lynn-Scott) BLS12-381 curves
     ├── unit_tests/         # Unit tests
     ├── lib.rs
     ├── ed25519.rs          # Ed25519 implementation of the signing/verification API in traits.rs

--- a/crates/aptos-crypto/src/bls12381/bls12381_keys.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_keys.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module provides APIs for private keys and public keys used in BLS multi-signatures
-//! implemented on top of BLS12-381 elliptic curves (https://github.com/supranational/blst).
+//! This module provides APIs for private keys and public keys used in Boneh-Lynn-Shacham (BLS)
+//! aggregate signatures (including individual signatures and multisignatures) implemented on top of
+//! Barreto-Lynn-Scott BLS12-381 elliptic curves (https://github.com/supranational/blst).
 //!
 //! The `PublicKey` struct is used to represent both the public key of an individual signer
 //! as well as the aggregate public key of several signers. Before passing this struct as an
@@ -20,7 +21,7 @@
 //! their PoPs verified.
 
 use crate::{
-    bls12381, bls12381::DST_BLS_MULTISIG_IN_G2_WITH_POP, hash::CryptoHash, signing_message, traits,
+    bls12381, bls12381::DST_BLS_SIG_IN_G2_WITH_POP, hash::CryptoHash, signing_message, traits,
     CryptoMaterialError, Length, Uniform, ValidCryptoMaterial, ValidCryptoMaterialStringExt,
     VerifyingKey,
 };
@@ -58,7 +59,8 @@ impl PublicKey {
     }
 
     /// Group-checks the public key (i.e., verifies the public key is a valid group element).
-    /// WARNING: This function is called implicitly when verifying the proof-of-possession (PoP) for
+    ///
+    /// WARNING: Group-checking is done implicitly when verifying the proof-of-possession (PoP) for
     /// this public key  in `ProofOfPossession::verify`, so this function should not be called
     /// separately for most use-cases. We leave it here just in case.
     pub fn group_check(&self) -> Result<()> {
@@ -67,6 +69,7 @@ impl PublicKey {
 
     /// Aggregates the public keys of several signers into an aggregate public key, which can be later
     /// used to verify a multisig aggregated from those signers.
+    ///
     /// WARNING: This function assumes all public keys have had their proofs-of-possession verified
     /// and have thus been group-checked.
     pub fn aggregate(pubkeys: Vec<&Self>) -> Result<PublicKey> {
@@ -107,20 +110,16 @@ impl traits::SigningKey for PrivateKey {
 
     fn sign<T: CryptoHash + Serialize>(&self, message: &T) -> bls12381::Signature {
         bls12381::Signature {
-            sig: self.privkey.sign(
-                &signing_message(message),
-                DST_BLS_MULTISIG_IN_G2_WITH_POP,
-                &[],
-            ),
+            sig: self
+                .privkey
+                .sign(&signing_message(message), DST_BLS_SIG_IN_G2_WITH_POP, &[]),
         }
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
     fn sign_arbitrary_message(&self, message: &[u8]) -> bls12381::Signature {
         bls12381::Signature {
-            sig: self
-                .privkey
-                .sign(message, DST_BLS_MULTISIG_IN_G2_WITH_POP, &[]),
+            sig: self.privkey.sign(message, DST_BLS_SIG_IN_G2_WITH_POP, &[]),
         }
     }
 }
@@ -154,8 +153,9 @@ impl Uniform for PrivateKey {
     where
         R: ::rand::RngCore + ::rand::CryptoRng,
     {
-        // CRYPTONOTE(Alin): This "initial key material (IKM)?" is the randomness used inside key_gen below
-        // to pseudo-randomly derive the secret key via an HKDF (see https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#section-2.3)
+        // CRYPTONOTE(Alin): This "initial key material (IKM)" is the randomness used inside key_gen
+        // below to pseudo-randomly derive the secret key via an HKDF
+        // (see https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature#section-2.3)
         let mut ikm = [0u8; 32];
         rng.fill_bytes(&mut ikm);
         let privkey =
@@ -201,6 +201,7 @@ impl TryFrom<&[u8]> for PublicKey {
     type Error = CryptoMaterialError;
 
     /// Deserializes a PublicKey from a sequence of bytes.
+    ///
     /// WARNING: Does NOT group-check the public key! Instead, the caller is responsible for
     /// verifying the public key's proof-of-possession (PoP) via `ProofOfPossession::verify`,
     /// which implicitly group checks the public key.

--- a/crates/aptos-crypto/src/bls12381/bls12381_sigs.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_sigs.rs
@@ -1,20 +1,25 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module provides APIs for aggregating and verifying BLS multi-signatures
-//! implemented on top of BLS12-381 elliptic curves (https://github.com/supranational/blst).
+//! This module provides APIs for aggregating and verifying Boneh-Lynn-Shacham (BLS) aggregate
+//! signatures (including individual signatures and multisignatures), implemented on top of
+//! Barreto-Lynn-Scott BLS12-381 elliptic curves (https://github.com/supranational/blst).
 //!
-//! The `Signature` struct is used to represent either a signature share from an individual
-//! signer or a multisignature aggregated from many such signers.
+//! The `Signature` struct is used to represent either a:
 //!
-//! The signature verification APIs in `Signature::verify` and `Signature::verify_arbitrary_msg` do NOT
+//!  1. signature share from an individual signer
+//!  2. multisignature on a single message from many signers
+//!  3. aggregate signature on different messages from many signers
+//!
+//! The signature verification APIs in `Signature::verify`, `Signature::verify_arbitrary_msg`,
+//! `Signature::verify_aggregate` and `Signature::verify_aggregate_arbitrary_msg` do NOT
 //! assume the signature to be a valid group element and will implicitly "group-check" it. This
 //! makes the caller's job easier and, more importantly, makes the library safer to use.
 
 use crate::{
     bls12381::{
         bls12381_keys::{PrivateKey, PublicKey},
-        DST_BLS_MULTISIG_IN_G2_WITH_POP,
+        DST_BLS_SIG_IN_G2_WITH_POP,
     },
     hash::CryptoHash,
     signing_message, traits, CryptoMaterialError, Length, ValidCryptoMaterial,
@@ -27,15 +32,15 @@ use serde::Serialize;
 use std::convert::TryFrom;
 
 #[derive(Debug, Clone, Eq, SerializeKey, DeserializeKey)]
-/// Either A BLS signature share from an individual signer or a BLS multisignature aggregate from
-/// multiple such signers
+/// Either (1) a BLS signature share from an individual signer, (2) a BLS multisignature or (3) a
+/// BLS aggregate signature
 pub struct Signature {
     pub(crate) sig: blst::min_pk::Signature,
 }
 
-////////////////////////////////////////////////
-// Implementation of (multi)signature structs //
-////////////////////////////////////////////////
+////////////////////////////////////////
+// Implementation of Signature struct //
+////////////////////////////////////////
 
 impl Signature {
     /// The length of a serialized Signature struct.
@@ -48,17 +53,19 @@ impl Signature {
     }
 
     /// Group-checks the signature (i.e., verifies the signature is a valid group element).
-    /// WARNING: This is called implicitly when verifying the signature in this struct's
-    /// `Signature::verify_arbitrary_msg` trait implementation. Therefore, this function should not
-    /// be called separately for most use-cases. We leave it here just in case.
+    ///
+    /// WARNING: Group-checking is done implicitly when verifying signatures via
+    /// `Signature::verify_arbitrary_msg`. Therefore, this function should not be called separately
+    /// for most use-cases. We leave it here just in case.
     pub fn group_check(&self) -> Result<()> {
         self.sig.validate(true).map_err(|e| anyhow!("{:?}", e))
     }
 
-    /// Optimistically-aggregate multiple signatures. The individual signature shares could be
-    /// adversarial. Nonetheless, for performance reasons, we do not group-check the signature shares
-    /// here, since the verification of the returned multisignature includes such a group check. As
-    /// a result, adversarial signature shares cannot lead to forgeries.
+    /// Optimistically-aggregate signatures shares into either (1) a multisignature or (2) an aggregate
+    /// signature. The individual signature shares could be adversarial. Nonetheless, for performance
+    /// reasons, we do not group-check the signature shares here, since the verification of the
+    /// returned multi-or-aggregate signature includes such a group check. As a result, adversarial
+    /// signature shares cannot lead to forgeries.
     pub fn aggregate(sigs: Vec<Self>) -> Result<Signature> {
         let sigs: Vec<_> = sigs.iter().map(|s| &s.sig).collect();
         let agg_sig = blst::min_pk::AggregateSignature::aggregate(&sigs[..], false)
@@ -66,6 +73,45 @@ impl Signature {
         Ok(Signature {
             sig: agg_sig.to_signature(),
         })
+    }
+
+    /// Verifies an aggregate signature on the messages in `msgs` under the public keys in `pks`.
+    /// Specifically, verifies that each `msgs[i]` is signed under `pks[i]`. The messages in `msgs`
+    /// do *not* have to be all different, since we use proofs-of-possession (PoPs) to prevent rogue
+    /// key attacks.
+    ///
+    /// WARNING: This function assumes that the public keys have been group-checked by the caller
+    /// implicitly when verifying their proof-of-possession (PoP) in `ProofOfPossession::verify`.
+    pub fn verify_aggregate_arbitrary_msg(&self, msgs: &[&[u8]], pks: &[&PublicKey]) -> Result<()> {
+        let pks = pks
+            .iter()
+            .map(|&pk| &pk.pubkey)
+            .collect::<Vec<&blst::min_pk::PublicKey>>();
+
+        let result = self
+            .sig
+            .aggregate_verify(true, msgs, DST_BLS_SIG_IN_G2_WITH_POP, &pks, false);
+
+        if result == BLST_ERROR::BLST_SUCCESS {
+            Ok(())
+        } else {
+            Err(anyhow!("{:?}", result))
+        }
+    }
+
+    /// Serializes the messages of type `T` to bytes and calls `Signature::verify_aggregate_arbitrary_msg`.
+    pub fn verify_aggregate<T: CryptoHash + Serialize>(
+        &self,
+        msgs: &[&T],
+        pks: &[&PublicKey],
+    ) -> Result<()> {
+        let msgs = msgs
+            .iter()
+            .map(|&m| signing_message(m))
+            .collect::<Vec<Vec<u8>>>();
+        let msgs_refs = msgs.iter().map(|m| m.as_slice()).collect::<Vec<&[u8]>>();
+
+        self.verify_aggregate_arbitrary_msg(&msgs_refs, pks)
     }
 }
 
@@ -76,12 +122,15 @@ impl traits::Signature for Signature {
     type VerifyingKeyMaterial = PublicKey;
     type SigningKeyMaterial = PrivateKey;
 
+    /// Serializes the message of type `T` to bytes and calls `Signature::verify_arbitrary_msg`.
     fn verify<T: CryptoHash + Serialize>(&self, message: &T, public_key: &PublicKey) -> Result<()> {
         self.verify_arbitrary_msg(&signing_message(message), public_key)
     }
 
     /// Verifies a BLS signature share or multisignature. Does not assume the signature to be
-    /// group-checked.
+    /// group-checked. (For verifying aggregate signatures on different messages, a different
+    /// `verify_aggregate_arbitray_msg` function can be used.)
+    ///
     /// WARNING: This function does assume the public key has been group-checked by the caller
     /// implicitly when verifying the public key's proof-of-possession (PoP) in
     /// `ProofOfPossession::verify`.
@@ -89,7 +138,7 @@ impl traits::Signature for Signature {
         let result = self.sig.verify(
             true,
             message,
-            DST_BLS_MULTISIG_IN_G2_WITH_POP,
+            DST_BLS_SIG_IN_G2_WITH_POP,
             &[],
             &public_key.pubkey,
             false,
@@ -121,6 +170,7 @@ impl TryFrom<&[u8]> for Signature {
     type Error = CryptoMaterialError;
 
     /// Deserializes a Signature from a sequence of bytes.
+    ///
     /// WARNING: Does NOT group-check the signature! Instead, this will be done implicitly when
     /// verifying the signature.
     fn try_from(bytes: &[u8]) -> std::result::Result<Signature, CryptoMaterialError> {

--- a/crates/aptos-crypto/src/bls12381/mod.rs
+++ b/crates/aptos-crypto/src/bls12381/mod.rs
@@ -1,29 +1,32 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module provides APIs for Boneh-Lynn-Shacham (BLS) multi-signatures on top of Barreto-Lynn-Scott
-//! BLS12-381 elliptic curves. This module wraps the [blst](https://github.com/supranational/blst)
-//! library.
+//! This module provides APIs for Boneh-Lynn-Shacham (BLS) aggregate signatures (including
+//! individual signatures and multisignatures) on top of Barreto-Lynn-Scott BLS12-381 elliptic
+//! curves. This module wraps the [blst](https://github.com/supranational/blst) library.
 //!
-//! More specifically, we build BLS multisignatures as described in [^BLS04], [^Bold03] but using
-//! the proof-of-possession (PoP) scheme from [^RY07] to prevent rogue-key attacks [^MOR01] where
-//! malicious signers adversarially pick their public keys in order to forge a multisignature.
+//! Our multisignature and aggregate signature implementations are described in [^BLS04], [^Bold03],
+//! except we use the proof-of-possession (PoP) scheme from [^RY07] to prevent rogue-key attacks
+//! [^MOR01] where malicious signers adversarially pick their public keys in order to forge a
+//! multisignature or forge an aggregate signature.
 //!
 //! We implement the `Minimal-pubkey-size` variant from the BLS IETF draft standard [^bls-ietf-draft],
 //! which puts the signatures in the group $\mathbb{G}_2$ and the public keys in $\mathbb{G}_1$. The
 //! reasoning behind this choice is to minimize public key size, since public keys are posted on the
 //! blockchain.
 //!
-//! # Overview of BLS multisignatures
+//! # Overview of normal Boneh-Lynn-Shacham (BLS) signatures
 //!
 //! In a _normal signature scheme_, we have a single _signer_ who generates its own key-pair:
 //! a _private-key_ and a corresponding _public key_. The signer can produce a _signature_ on a
 //! _message_ `m` using its private-key. Any _verifier_ who has the public key can check that
 //! the signature on `m` was produced by the signer.
 //!
+//! # Overview of Boneh-Lynn-Shacham (BLS) multisignatures
+//!
 //! In a _multisignature scheme_, we have `n` signers. Each signer `i` has their own key-pair `(sk_i, pk_i)`.
-//! Any subset of `k` signers can collaborate to produce a succinct signature on the same message `m`.
-//! This is referred to as a _multisignature_ on `m`.
+//! Any subset of `k` signers can collaborate to produce a succinct _multisignature_ on the *same*
+//! message `m`.
 //!
 //! Typically, the `k` signers first agree on the message `m` via some protocol (e.g., `m` is the
 //! latest block header in a blockchain protocol). Then, each signer produces a _signature share_ `s_i`
@@ -53,15 +56,33 @@
 //! valid proofs-of-possession (PoPs). Otherwise, multisignatures can be forged via _rogue-key attacks_
 //! [^MOR01].
 //!
+//! # Overview of Boneh-Lynn-Shacham (BLS) aggregate signatures
+//!
+//! In an _aggregate signature scheme_ any subset of `k` out of `n` signers can collaborate to produce
+//! a succinct _aggregate signature_ over (potentially) different message. Specifically, such an
+//! aggregate signature is a succinct representation of `k` normal signatures, where the `i`th signature
+//! from the `i`th signer is on some message `m_i`. Importantly, `m_i` might differ from the other `k-1` messages
+//! signed by the other signers.
+//!
+//! Note that an aggregate signature where all the signed messages `m_i` are the same is just a
+//! multisignature.
+//!
+//! Just like in a multisignature scheme, in an aggregate signature scheme there is an _aggregator_
+//! who receives _signature shares_ `s_i` from each signer `i` on their *own* message `m_i` and
+//! aggregates the valid signature shares into an aggregate signature. (In contrast, recall that,
+//! in a multisignature scheme, every signer `i` signed the same message `m`.)
+//!
+//! Aggregation proceeds the same as in a multisignature scheme (see notes in previous section).
+//!
 //! # A note on subgroup checks
 //!
 //! This library was written so that users who know nothing about _small subgroup attacks_ need not
-//! worry about them [^LL97], [^BCM+15e], as long as library users always verify a public key's
-//! proof-of-possession (PoP) before aggregating it with other PKs or before verifying signatures
+//! worry about them [^LL97], [^BCM+15e], **as long as library users always verify a public key's
+//! proof-of-possession (PoP)** before aggregating it with other PKs or before verifying signatures
 //! with it.
 //!
 //! Nonetheless, we still provide `group_check` methods for the `PublicKey` and `Signature` structs,
-//! in case manual verification of subgroup membership is needed.
+//! in case manual verification of subgroup membership is ever needed.
 //!
 //! # A note on domain separation tags (DSTs)
 //!
@@ -69,18 +90,18 @@
 //! use of domain separation tags (DSTs) as per the BLS IETF draft standard [^bls-ietf-draft].
 //!
 //! Specifically, **when signing a message** `m`, instead of signing as `H(m)^sk`, where `sk` is the
-//! secret key, the library actually signs as `H(sig_dst | m)^sk`, where `sig_dst` is a domain
-//! separation tag for message signing.
+//! secret key, the library actually signs as `H(sig_dst | m)^sk`, where `sig_dst` is a DST for
+//! message signing.
 //!
 //! In contrast, **when computing a proof-of-possesion (PoP)**, instead of signing the public key as
-//! `H(pk)^sk`, the  library actually signs as `H(sig_pop | pk)^sk`, where `sig_pop` is a domain
-//! separation tag for signatures used during PoP creation.
+//! `H(pk)^sk`, the  library actually signs as `H(sig_pop | pk)^sk`, where `sig_pop` is a DST for
+//! signatures used during PoP creation.
 //!
 //! This way, we can clearly separate the message spaces of these two use cases of the secret key `sk`.
 //!
 //! # How to use this module to aggregate and verify multisignatures
 //!
-//! A typical use of the library would look as follows:
+//! A typical use of the multisignature library would look as follows:
 //!
 //! ```
 //! use std::iter::zip;
@@ -114,7 +135,7 @@
 //!
 //! // Each signer then computes a signature share on a message. Again, we simulate using a vector.
 //! let mut sigshares = vec![];
-//! let message = Message("test".to_owned()); // b"some random message";
+//! let message = Message("test".to_owned());
 //! for kp in key_pairs.iter() {
 //!     let sig = kp.private_key.sign(&message);
 //!     sigshares.push(sig);
@@ -127,11 +148,14 @@
 //! // proof-of-possession (PoP)!
 //!
 //! ///////////////////////////////////////////////////////////////////////////////////////////////
-//! // WARNING: The aggregator and any other party verifying multisigs or signature shares MUST  //
-//! // verify *every* signer's PoP before verifying any signature or multisignature.             //
+//! // WARNING: Before relying on a public key to verify an individual signature share or a      //
+//! // multisignature, one must MUST first verify that public key's PoP.                         //
 //! //                                                                                           //
 //! //                  The importance of this step cannot be overstated!                        //
 //! //                                                                                           //
+//! // Put differently, a public key with an unverified PoP cannot be used securely for any      //
+//! // signature verification. This is why the code below first verifies PoPs of all public keys //
+//! // that are later used to verify the multisignature against.                                 //
 //! ///////////////////////////////////////////////////////////////////////////////////////////////
 //! for i in 0..pops.len() {
 //!     assert!(pops[i].verify(&key_pairs[i].public_key).is_ok());
@@ -172,6 +196,96 @@
 //! }
 //! ```
 //!
+//! # How to use this module to aggregate and verify aggregate signatures
+//!
+//! A typical use of the aggregate signature library would look as follows:
+//!
+//! ```
+//! use std::iter::zip;
+//! use aptos_crypto::test_utils::KeyPair;
+//! use aptos_crypto::{bls12381, Signature, SigningKey, Uniform};
+//! use aptos_crypto::bls12381::bls12381_keys::{PrivateKey, PublicKey};
+//! use aptos_crypto::bls12381::ProofOfPossession;
+//! use aptos_crypto_derive::{CryptoHasher, BCSCryptoHash};
+//! use rand_core::OsRng;
+//! use serde::{Serialize, Deserialize};
+//!
+//! // Each signer locally generates their own BLS key-pair with a proof-of-possesion (PoP).
+//! // We simulate this here, by storing each signer's key-pair in a vector.
+//! let mut rng = OsRng;
+//!
+//! let num_signers = 1000;
+//!
+//! let mut key_pairs = vec![];
+//! let mut pops = vec![];
+//! for _ in 0..num_signers {
+//!     let kp = KeyPair::<PrivateKey, PublicKey>::generate(&mut rng);
+//!     pops.push(ProofOfPossession::create_with_pubkey(&kp.private_key, &kp.public_key));
+//!     // Alternatively, but slower, can choose not to provide the PK and have it computed inside
+//!     // pops.push(ProofOfPossession::create(&kp.private_key));
+//!     key_pairs.push(kp);
+//! }
+//!
+//! // Any arbitrary struct can be signed as long as it is properly "derived"
+//! #[derive(CryptoHasher, BCSCryptoHash, Serialize, Deserialize)]
+//! struct Message(String, usize);
+//!
+//! // Each signer `i` then computes a signature share on its own message `m_i`, which might
+//! // differ from other signer's message `m_j`. Again, we simulate this using a vector.
+//! let mut sigshares = vec![];
+//! let mut messages = vec![];
+//! for i in 0..num_signers {
+//!     let message = Message("different message".to_owned(), i);
+//!     let sig = key_pairs[i].private_key.sign(&message);
+//!
+//!     messages.push(message);
+//!     sigshares.push(sig);
+//! }
+//!
+//! // Then, an aggregator receives some of these signature shares and will attempt to aggregate
+//! // them in an aggregate signature. This aggregator can proceed _optimistically_ as follows:
+//!
+//! // First, when the aggregator boots up, it must verify that each signer's public key has a valid
+//! // proof-of-possession (PoP)!
+//!
+//! ///////////////////////////////////////////////////////////////////////////////////////////////
+//! // WARNING: Before relying on the public keys of the signers for verifying aggregate         //
+//! // signatures or signature shares, one MUST first verify *every* signer's PoP.               //
+//! //                                                                                           //
+//! //                  The importance of this step cannot be overstated!                        //
+//! //                                                                                           //
+//! ///////////////////////////////////////////////////////////////////////////////////////////////
+//! for i in 0..pops.len() {
+//!     assert!(pops[i].verify(&key_pairs[i].public_key).is_ok());
+//! }
+//!
+//! // Second, now that the aggregator trusts the set of public keys, it can safely aggregate
+//! // signature shares _optimistically_ into an aggregate signature which hopefully verifies. In this
+//! // example, we assume the aggregator receives a signature share from every signer (for simplicity).
+//!
+//! // Here, we simulate the aggregator receiving all signature shares.
+//! let sigshares_received = sigshares;
+//!
+//! // Here, the aggregator aggregates the received signature shares into an aggregate signature.
+//! let aggsig = bls12381::Signature::aggregate(sigshares_received.clone()).unwrap();
+//!
+//! // Third, the aggregator checks that the _optimistic_ aggregation from above succeeded by
+//! // verifying the aggregate signature. For this, the aggregator will need to know the public keys
+//! // of the signers whose signature shares were aggregated.
+//! let msgs_refs = messages.iter().map(|m| m).collect::<Vec<&Message>>();
+//! let pks_refs = key_pairs.iter().map(|kp| &kp.public_key).collect::<Vec<&PublicKey>>();
+//! assert!(aggsig.verify_aggregate(&msgs_refs, &pks_refs).is_ok());
+//!
+//! // If the aggregate signature failed verification, the aggregator can individually verify each
+//! // of the signature shares to identify which ones are invalid and exclude them. There are also
+//! // optimized methods for identifying bad signature shares faster when their relative frequency
+//! // is low [^LM07]. However, we will not implement these yet.
+//! for i in 0..num_signers {
+//!     let (msg, sigshare, pk) = (msgs_refs[i], &sigshares_received[i], pks_refs[i]);
+//!     assert!(sigshare.verify(msg, pk).is_ok());
+//! }
+//! ```
+//!
 //! References:
 //!
 //! [^bls-ietf-draft]: BLS Signatures; by D. Boneh, S. Gorbunov, R. Wahby, H. Wee, Z. Zhang; https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature
@@ -184,7 +298,7 @@
 //! [^RY07]: The Power of Proofs-of-Possession: Securing Multiparty Signatures against Rogue-Key Attacks; by Ristenpart, Thomas and Yilek, Scott; in Advances in Cryptology - EUROCRYPT 2007; 2007
 
 /// Domain separation tag (DST) for hashing a message before signing it.
-const DST_BLS_MULTISIG_IN_G2_WITH_POP: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
+const DST_BLS_SIG_IN_G2_WITH_POP: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
 pub mod bls12381_keys;
 pub mod bls12381_pop;


### PR DESCRIPTION
### Description

Added support for BLS aggregate signatures, where signature shares on _different_ messages can be aggregated together into a succinct _aggregate signature_.

### Benchmarks

**Multi-threaded** performance for verifying $n$ signature shares seems to be $n \times 38.8$ microseconds.

```
bls12381/verify_aggsig/128
                        time:   [6.0326 ms 6.0914 ms 6.1539 ms]
                        thrpt:  [20.800 Kelem/s 21.013 Kelem/s 21.218 Kelem/s]

bls12381/verify_aggsig/256
                        time:   [10.485 ms 10.566 ms 10.654 ms]
                        thrpt:  [24.029 Kelem/s 24.229 Kelem/s 24.416 Kelem/s]

bls12381/verify_aggsig/512
                        time:   [20.383 ms 20.457 ms 20.537 ms]
                        thrpt:  [24.930 Kelem/s 25.028 Kelem/s 25.119 Kelem/s]

bls12381/verify_aggsig/1024
                        time:   [39.613 ms 39.801 ms 40.045 ms]
                        thrpt:  [25.571 Kelem/s 25.728 Kelem/s 25.850 Kelem/s]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1624)
<!-- Reviewable:end -->
