### PR TITLE
[NHC] Add TPS evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
+ "transaction-emitter-lib",
  "url",
 ]
 
@@ -8963,6 +8964,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
+ "serde 1.0.137",
  "termion",
  "tokio",
  "url",

--- a/crates/transaction-emitter-lib/Cargo.toml
+++ b/crates/transaction-emitter-lib/Cargo.toml
@@ -17,6 +17,7 @@ itertools = "0.10.3"
 rand = "0.7.3"
 rand_core = "0.5.1"
 reqwest = { version = "0.11.10", features = ["blocking", "json"] }
+serde = { version = "1.0.137", features = ["derive"] }
 termion = "1.5.6"
 tokio = { version = "1.18.2", features = ["full"] }
 url = "2.2.2"

--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -1,31 +1,41 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::TryFrom;
+use std::{convert::TryFrom, path::Path};
 
 use anyhow::{bail, format_err, Result};
+use aptos::common::types::EncodingType;
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_sdk::types::chain_id::ChainId;
 use clap::Parser;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 const DEFAULT_API_PORT: u16 = 8080;
 
-#[derive(Clone, Debug, Parser)]
+#[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]
 pub struct MintArgs {
     /// Ed25519PrivateKey for minting coins
     #[clap(long, parse(try_from_str = ConfigKey::from_encoded_string))]
     pub mint_key: Option<ConfigKey<Ed25519PrivateKey>>,
 
-    #[clap(long, default_value = "mint.key")]
+    #[clap(long, default_value = "mint.key", conflicts_with = "mint-key")]
     pub mint_file: String,
-
-    #[clap(long, default_value = "TESTING")]
-    pub chain_id: ChainId,
 }
 
-#[derive(Clone, Debug, Parser)]
+impl MintArgs {
+    pub fn get_mint_key(&self) -> Result<Ed25519PrivateKey> {
+        let key = match &self.mint_key {
+            Some(ref key) => key.private_key(),
+            None => EncodingType::BCS
+                .load_key::<Ed25519PrivateKey>("mint key pair", Path::new(&self.mint_file))?,
+        };
+        Ok(key)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]
 pub struct ClusterArgs {
     /// Nodes the cluster should connect to, e.g. http://node.mysite.com:8080
     /// If the port is not provided, it is assumed to be 8080.
@@ -36,11 +46,14 @@ pub struct ClusterArgs {
     #[clap(long)]
     pub vasp: bool,
 
+    #[clap(long, default_value = "TESTING")]
+    pub chain_id: ChainId,
+
     #[clap(flatten)]
     pub mint_args: MintArgs,
 }
 
-#[derive(Clone, Debug, Parser)]
+#[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]
 pub struct EmitArgs {
     #[clap(long, default_value = "15")]
     pub accounts_per_client: usize,

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -3,7 +3,6 @@
 
 use crate::{emit::query_sequence_numbers, instance::Instance, ClusterArgs};
 use anyhow::{bail, format_err, Result};
-use aptos::common::types::EncodingType;
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     test_utils::KeyPair,
@@ -15,7 +14,7 @@ use aptos_sdk::{
     types::{account_config::aptos_root_address, chain_id::ChainId, AccountKey, LocalAccount},
 };
 use rand::seq::SliceRandom;
-use std::{convert::TryFrom, path::Path};
+use std::convert::TryFrom;
 use url::Url;
 
 #[derive(Debug)]
@@ -129,18 +128,9 @@ impl TryFrom<&ClusterArgs> for Cluster {
             urls.push(url);
         }
 
-        let mint_key = if let Some(ref key) = args.mint_args.mint_key {
-            key.private_key()
-        } else {
-            EncodingType::BCS
-                .load_key::<Ed25519PrivateKey>(
-                    "mint key pair",
-                    Path::new(&args.mint_args.mint_file),
-                )
-                .unwrap()
-        };
+        let mint_key = args.mint_args.get_mint_key()?;
 
-        let cluster = Cluster::from_host_port(urls, mint_key, args.mint_args.chain_id, args.vasp);
+        let cluster = Cluster::from_host_port(urls, mint_key, args.chain_id, args.vasp);
 
         Ok(cluster)
     }

--- a/ecosystem/node-checker/Cargo.toml
+++ b/ecosystem/node-checker/Cargo.toml
@@ -36,6 +36,7 @@ aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-sdk = { path = "../../sdk" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
+transaction-emitter-lib = { path = "../../crates/transaction-emitter-lib" }
 
 [[bin]]
 name = "aptos-node-checker"

--- a/ecosystem/node-checker/src/configuration/create.rs
+++ b/ecosystem/node-checker/src/configuration/create.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use super::NodeConfiguration;
+use super::{common::validate_configuration, NodeConfiguration};
 use crate::common_args::{OutputArgs, OutputFormat};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 
 #[derive(Clone, Debug, Parser)]
@@ -13,9 +13,17 @@ pub struct Create {
 
     #[clap(flatten)]
     output_args: OutputArgs,
+
+    // If set, skip config validation. Use with great care.
+    #[clap(long)]
+    skip_validation: bool,
 }
 
 pub async fn create(args: Create) -> Result<()> {
+    if !args.skip_validation {
+        validate_configuration(&args.node_configuration)
+            .context("Configuration failed validation")?;
+    }
     let output = match args.output_args.format {
         OutputFormat::Json => serde_json::to_string_pretty(&args.node_configuration)?,
         OutputFormat::Yaml => serde_yaml::to_string(&args.node_configuration)?,

--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     evaluators::{
-        direct::{get_node_identity, NodeIdentityEvaluatorArgs},
+        direct::{get_node_identity, NodeIdentityEvaluatorArgs, TpsEvaluatorArgs},
         metrics::{ConsensusProposalsEvaluatorArgs, StateSyncVersionEvaluatorArgs},
         system_information::BuildVersionEvaluatorArgs,
     },
@@ -76,7 +76,7 @@ pub struct NodeConfiguration {
     pub runner_args: RunnerArgs,
 }
 
-// TODO: Having comments like "only call this after X" is obviously not great.
+// TODO: Having comments like "only call this after X" is obviously a bad sign.
 // It'd be better to have an enum with two variants, e.g. unfetched and fetched.
 impl NodeConfiguration {
     /// Only call this after fetch_additional_configuration has been called.
@@ -123,6 +123,9 @@ impl NodeConfiguration {
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
 pub struct EvaluatorArgs {
     #[clap(flatten)]
+    pub build_version_args: BuildVersionEvaluatorArgs,
+
+    #[clap(flatten)]
     pub consensus_proposals_args: ConsensusProposalsEvaluatorArgs,
 
     #[clap(flatten)]
@@ -132,7 +135,8 @@ pub struct EvaluatorArgs {
     pub state_sync_version_args: StateSyncVersionEvaluatorArgs,
 
     #[clap(flatten)]
-    pub build_version_args: BuildVersionEvaluatorArgs,
+    #[oai(skip)]
+    pub tps_args: TpsEvaluatorArgs,
 }
 
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]

--- a/ecosystem/node-checker/src/evaluator/traits.rs
+++ b/ecosystem/node-checker/src/evaluator/traits.rs
@@ -46,7 +46,7 @@ pub trait Evaluator: Debug + Sync + Send {
 
     /// We require this function to ensure we can build all evaluators
     /// from the top level evaluator args.
-    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Self
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> anyhow::Result<Self>
     where
         Self: Sized;
 }

--- a/ecosystem/node-checker/src/evaluators/build_evaluators.rs
+++ b/ecosystem/node-checker/src/evaluators/build_evaluators.rs
@@ -5,6 +5,7 @@ use crate::{
     configuration::EvaluatorArgs,
     evaluator::Evaluator,
     evaluators::{
+        direct::{DirectEvaluatorInput, TpsEvaluator, TpsEvaluatorError},
         metrics::{
             ConsensusProposalsEvaluator, MetricsEvaluatorError, MetricsEvaluatorInput,
             StateSyncVersionEvaluator,
@@ -41,6 +42,7 @@ pub enum EvaluatorType {
             >,
         >,
     ),
+    Tps(Box<dyn Evaluator<Input = DirectEvaluatorInput, Error = TpsEvaluatorError>>),
 }
 
 pub fn build_evaluators(
@@ -54,7 +56,7 @@ pub fn build_evaluators(
     match evaluator_names.take(&name) {
         Some(_) => {
             evaluators.push(EvaluatorType::Metrics(Box::new(
-                ConsensusProposalsEvaluator::from_evaluator_args(evaluator_args),
+                ConsensusProposalsEvaluator::from_evaluator_args(evaluator_args)?,
             )));
         }
         None => log_did_not_build(&name),
@@ -64,7 +66,7 @@ pub fn build_evaluators(
     match evaluator_names.take(&name) {
         Some(_) => {
             evaluators.push(EvaluatorType::Metrics(Box::new(
-                StateSyncVersionEvaluator::from_evaluator_args(evaluator_args),
+                StateSyncVersionEvaluator::from_evaluator_args(evaluator_args)?,
             )));
         }
         None => log_did_not_build(&name),
@@ -74,7 +76,17 @@ pub fn build_evaluators(
     match evaluator_names.take(&name) {
         Some(_) => {
             evaluators.push(EvaluatorType::SystemInformation(Box::new(
-                BuildVersionEvaluator::from_evaluator_args(evaluator_args),
+                BuildVersionEvaluator::from_evaluator_args(evaluator_args)?,
+            )));
+        }
+        None => log_did_not_build(&name),
+    }
+
+    let name = TpsEvaluator::get_name();
+    match evaluator_names.take(&name) {
+        Some(_) => {
+            evaluators.push(EvaluatorType::Tps(Box::new(
+                TpsEvaluator::from_evaluator_args(evaluator_args)?,
             )));
         }
         None => log_did_not_build(&name),

--- a/ecosystem/node-checker/src/evaluators/direct/mod.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/mod.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod node_identity;
+mod tps;
 mod types;
 
 pub use node_identity::{
     get_node_identity, NodeIdentityEvaluator, NodeIdentityEvaluatorArgs, NodeIdentityEvaluatorError,
 };
+pub use tps::{TpsEvaluator, TpsEvaluatorArgs, TpsEvaluatorError};
 pub use types::DirectEvaluatorInput;

--- a/ecosystem/node-checker/src/evaluators/direct/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/node_identity.rs
@@ -154,7 +154,7 @@ impl Evaluator for NodeIdentityEvaluator {
         CATEGORY.to_string()
     }
 
-    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Self {
-        Self::new(evaluator_args.node_identity_args.clone())
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        Ok(Self::new(evaluator_args.node_identity_args.clone()))
     }
 }

--- a/ecosystem/node-checker/src/evaluators/direct/tps.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/tps.rs
@@ -1,0 +1,177 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    configuration::EvaluatorArgs,
+    evaluator::{EvaluationResult, Evaluator},
+};
+use anyhow::{Context, Result};
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+use std::{convert::TryFrom, time::Duration};
+use thiserror::Error as ThisError;
+use transaction_emitter_lib::{
+    emit_transactions_with_cluster, Cluster, ClusterArgs, EmitArgs, MintArgs,
+};
+
+use super::types::DirectEvaluatorInput;
+
+const CATEGORY: &str = "performance";
+const NODE_REQUIREMENTS_LINK: &str = "https://aptos.dev/nodes/ait/node-requirements";
+
+#[derive(Debug, ThisError)]
+pub enum TpsEvaluatorError {
+    /// Failed to build the cluster for the transaction emitter. This
+    /// represents an internal logic error.
+    #[error("Error building the transaction emitter cluster: {0}")]
+    BuildClusterError(anyhow::Error),
+
+    /// There was an error from the transaction emitter that we suspect
+    /// was our own fault, not the fault of the target node.
+    #[error("Error from within the transaction emitter: {0}")]
+    TransactionEmitterError(anyhow::Error),
+
+    /// We return this error if the transaction emitter failed to emit
+    /// more transactions than the configured min TPS. This implies
+    /// a configuration error.
+    #[error("The transaction emitter only submitted {0} TPS but the minimum TPS requirement is {1}, this implies a configuration problem with the NHC instance")]
+    InsufficientSubmittedTransactionsError(u64, u64),
+}
+
+// TODO: Improve the flags situation here. For example, we always want --burst
+// to be set, there is no reason to accept this as an argument.
+
+// As you can see, we skip most of the fields here in terms of generating
+// the OpenAPI spec. The evaluator args structs are only used for informational
+// purposes (e.g. via `/get_configurations`), which is best effort. It is
+// infeasible to derive PoemObject throughout the codebase or manually implement
+// the relevant trait, so we just skip the field.
+#[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]
+pub struct TpsEvaluatorArgs {
+    #[clap(flatten)]
+    pub emit_args: EmitArgs,
+
+    // Ed25519PrivateKey, either on the CLI or from a file, for minting coins.
+    // We choose to take this in in the baseline config because we can't
+    // securely transmit this at request time over the wire.
+    #[clap(flatten)]
+    pub mint_args: MintArgs,
+
+    /// The minimum TPS required to pass the test.
+    #[clap(long, default_value_t = 1000)]
+    pub minimum_tps: u64,
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct TpsEvaluator {
+    args: TpsEvaluatorArgs,
+}
+
+impl TpsEvaluator {
+    pub fn new(args: TpsEvaluatorArgs) -> Self {
+        Self { args }
+    }
+
+    fn build_evaluation_result(
+        &self,
+        headline: String,
+        score: u8,
+        explanation: String,
+        links: Vec<String>,
+    ) -> EvaluationResult {
+        EvaluationResult {
+            headline,
+            score,
+            explanation,
+            category: CATEGORY.to_string(),
+            evaluator_name: Self::get_name(),
+            links,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Evaluator for TpsEvaluator {
+    type Input = DirectEvaluatorInput;
+    type Error = TpsEvaluatorError;
+
+    // You'll see that we're using the baseline chain ID here. This is okay
+    // because at this point we've already asserted the baseline and target
+    // have the same chain id.
+
+    /// This test runs a TPS (transactions per second) evaluation on the target
+    /// node, in which it passes if it meets some preconfigured minimum.
+    async fn evaluate(&self, input: &Self::Input) -> Result<Vec<EvaluationResult>, Self::Error> {
+        let cluster_args = ClusterArgs {
+            targets: vec![input.target_node_address.url.clone()],
+            vasp: false,
+            mint_args: self.args.mint_args.clone(),
+            chain_id: input.baseline_node_information.chain_id,
+        };
+        let cluster = Cluster::try_from(&cluster_args)
+            .context("Failed to build cluster")
+            .map_err(TpsEvaluatorError::BuildClusterError)?;
+
+        let stats = emit_transactions_with_cluster(&cluster, &self.args.emit_args, false)
+            .await
+            .map_err(TpsEvaluatorError::TransactionEmitterError)?;
+
+        // AKA stats per second.
+        let rate = stats.rate(Duration::from_secs(self.args.emit_args.duration));
+
+        if rate.submitted < self.args.minimum_tps {
+            return Err(TpsEvaluatorError::InsufficientSubmittedTransactionsError(
+                rate.submitted,
+                self.args.minimum_tps,
+            ));
+        }
+
+        let mut description = format!("The minimum TPS (transactions per second) \
+            required of nodes is {}, your node hit: {} (out of {} transactions submitted per second).", self.args.minimum_tps, rate.committed, rate.submitted);
+        let evaluation_result = if rate.committed > self.args.minimum_tps {
+            if stats.committed == stats.submitted {
+                description.push_str(
+                    " Your node could theoretically hit \
+                even higher TPS, the evaluation suite only tests to check \
+                your node meets the minimum requirements.",
+                );
+            }
+            self.build_evaluation_result(
+                "Transaction processing speed is sufficient".to_string(),
+                100,
+                description,
+                vec![],
+            )
+        } else {
+            description.push_str(
+                " This implies that the hardware you're \
+            using to run your node isn't powerful enough, please see the attached link",
+            );
+            self.build_evaluation_result(
+                "Transaction processing speed is too low".to_string(),
+                0,
+                description,
+                vec![NODE_REQUIREMENTS_LINK.to_string()],
+            )
+        };
+
+        Ok(vec![evaluation_result])
+    }
+
+    fn get_name() -> String {
+        format!("{}_tps", CATEGORY)
+    }
+
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        // Assert we can get the key. This can fail in a number of ways:
+        //   - The file based option was chosen but the file wasn't there.
+        //   - Either option was chosen but the content was invalid.
+        evaluator_args
+            .tps_args
+            .mint_args
+            .get_mint_key()
+            .context("Failed to get private key for TPS evaluator")?;
+        Ok(Self::new(evaluator_args.tps_args.clone()))
+    }
+}

--- a/ecosystem/node-checker/src/evaluators/metrics/consensus/proposals.rs
+++ b/ecosystem/node-checker/src/evaluators/metrics/consensus/proposals.rs
@@ -149,8 +149,8 @@ impl Evaluator for ConsensusProposalsEvaluator {
         format!("{}_proposals", CATEGORY)
     }
 
-    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Self {
-        Self::new(evaluator_args.consensus_proposals_args.clone())
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        Ok(Self::new(evaluator_args.consensus_proposals_args.clone()))
     }
 }
 

--- a/ecosystem/node-checker/src/evaluators/metrics/state_sync/version.rs
+++ b/ecosystem/node-checker/src/evaluators/metrics/state_sync/version.rs
@@ -205,8 +205,8 @@ impl Evaluator for StateSyncVersionEvaluator {
         format!("{}_version", CATEGORY)
     }
 
-    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Self {
-        Self::new(evaluator_args.state_sync_version_args.clone())
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        Ok(Self::new(evaluator_args.state_sync_version_args.clone()))
     }
 }
 

--- a/ecosystem/node-checker/src/evaluators/system_information/build_version.rs
+++ b/ecosystem/node-checker/src/evaluators/system_information/build_version.rs
@@ -140,8 +140,8 @@ impl Evaluator for BuildVersionEvaluator {
         format!("{}_build_commit_hash", CATEGORY)
     }
 
-    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Self {
-        Self::new(evaluator_args.build_version_args.clone())
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        Ok(Self::new(evaluator_args.build_version_args.clone()))
     }
 }
 

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
-
 use super::{Runner, RunnerError};
 use crate::{
     configuration::NodeAddress,
@@ -23,6 +21,7 @@ use log::debug;
 use poem_openapi::Object as PoemObject;
 use prometheus_parse::Scrape as PrometheusScrape;
 use serde::{Deserialize, Serialize};
+use tokio::time::{Duration, Instant};
 
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
 pub struct BlockingRunnerArgs {
@@ -134,7 +133,39 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
         let first_baseline_metrics = self.parse_response(first_baseline_metrics)?;
         let first_target_metrics = self.parse_response(first_target_metrics)?;
 
-        tokio::time::sleep(Duration::from_secs(self.args.metrics_fetch_delay_secs)).await;
+        let mut evaluation_results = node_identity_evaluations;
+
+        // If the TPS evaluator was specified, run it here because it takes time
+        // to run. This is a bit messy right now, since the TPS evaluator, if
+        // configured differently, could theoretically run longer than the
+        // metrics_fetch_delay. TODO: Change it to metrics_fetch_delay_minimum
+        // and make each evaluator handle the fact that the delay could be longer.
+        // If the specific amount of time matters to a future evaluator, pass it
+        // in to that evaluator and it can slice up the delta as necessary.
+
+        // TODO: We could also get some slight speed wins if we awaited this
+        // evaluator and all the metric collection futures together.
+
+        let metrics_fetch_delay_time =
+            Instant::now() + Duration::from_secs(self.args.metrics_fetch_delay_secs);
+
+        let tps_evaluator = self.evaluators.iter().find_map(|e| match e {
+            EvaluatorType::Tps(evaluator) => Some(evaluator),
+            _ => None,
+        });
+
+        if let Some(tps_evaluator) = tps_evaluator {
+            debug!("Starting TPS evaluator");
+            evaluation_results.append(
+                &mut tps_evaluator
+                    .evaluate(&direct_evaluator_input)
+                    .await
+                    .map_err(RunnerError::TpsEvaluatorError)?,
+            );
+            debug!("TPS evaluator done");
+        }
+
+        tokio::time::sleep_until(metrics_fetch_delay_time).await;
 
         debug!("Collecting second round of baseline metrics");
         let second_baseline_metrics =
@@ -145,8 +176,6 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
 
         let second_baseline_metrics = self.parse_response(second_baseline_metrics)?;
         let second_target_metrics = self.parse_response(second_target_metrics)?;
-
-        let mut evaluation_results = node_identity_evaluations;
 
         let metrics_evaluator_input = MetricsEvaluatorInput {
             previous_baseline_metrics: first_baseline_metrics,
@@ -170,6 +199,8 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
                     .evaluate(&system_information_evaluator_input)
                     .await
                     .map_err(RunnerError::SystemInformationEvaluatorError)?,
+                // The TPS evaluator has already been used above.
+                EvaluatorType::Tps(_) => vec![],
             };
             evaluation_results.append(&mut local_evaluation_results);
         }

--- a/ecosystem/node-checker/src/runner/traits.rs
+++ b/ecosystem/node-checker/src/runner/traits.rs
@@ -9,7 +9,8 @@ use crate::{
     configuration::NodeAddress,
     evaluator::EvaluationSummary,
     evaluators::{
-        direct::NodeIdentityEvaluatorError, metrics::MetricsEvaluatorError,
+        direct::{NodeIdentityEvaluatorError, TpsEvaluatorError},
+        metrics::MetricsEvaluatorError,
         system_information::SystemInformationEvaluatorError,
     },
     metric_collector::{MetricCollector, MetricCollectorError},
@@ -26,19 +27,24 @@ pub enum RunnerError {
     MetricCollectorError(MetricCollectorError),
 
     /// We couldn't parse the metrics.
-    #[error("Failed to parse metrics")]
+    #[error("Failed to parse metrics: {0}")]
     ParseMetricsError(Error),
 
     /// One of the metrics evaluators failed. This is not the same as a poor score from
     /// an evaluator, this is an actual failure in the evaluation process.
-    #[error("Failed to evaluate metrics")]
+    #[error("Failed to evaluate metrics: {0}")]
     MetricEvaluatorError(MetricsEvaluatorError),
 
     /// One of the system information evaluators failed. This is not the same
     /// as a poor score from an evaluator, this is an actual failure in the
     /// evaluation process.
-    #[error("Failed to evaluate system information")]
+    #[error("Failed to evaluate system information: {0}")]
     SystemInformationEvaluatorError(SystemInformationEvaluatorError),
+
+    /// The TPS evaluator failed. This is not the same as a poor score from an
+    /// evaluator, this is an actual failure in the evaluation process.
+    #[error("Failed to evaluate TPS: {0}")]
+    TpsEvaluatorError(TpsEvaluatorError),
 }
 
 /// This trait describes a Runner, something that can take in instances of other

--- a/ecosystem/node-checker/src/server/configurations_manager.rs
+++ b/ecosystem/node-checker/src/server/configurations_manager.rs
@@ -52,7 +52,7 @@ fn build_node_configuration_wrapper_with_blocking_runner(
     .context("Failed to build evaluators")?;
 
     let node_identity_evaluator =
-        NodeIdentityEvaluator::from_evaluator_args(&node_configuration.evaluator_args);
+        NodeIdentityEvaluator::from_evaluator_args(&node_configuration.evaluator_args)?;
 
     let runner = BlockingRunner::new(
         node_configuration.runner_args.blocking_runner_args.clone(),


### PR DESCRIPTION
## Description
This PR adds a TPS evaluator to NHC. The core functionality for this is provided by the recently augmented transaction emitter library. The transaction emitter library generates transactions and submits them to the node in question (in this case a local testnet, hence the mint key). It bursts the node with transactions without waiting for them to be committed, and then checks at the end how many were committed to get an average **committed** transactions per second.

## Test Plan
This is an adaptation on https://www.notion.so/aptoslabs/Single-node-testnet-transaction-load-test-guide-57e82a909e614243bed9694641f581f9. First, do step one there to run a local testnet.

Figure out the path of the mint file from the output of the testnet:
```
export MINT_FILE=`cat /tmp/testnodeoutput | grep "Aptos root key path" | perl -pe "s|.*?path: ||" | tr -d '"'`
```

Generate a config, in which we specify the mint key from the testnet:
```
cargo run -- configuration create --configuration-name local_testnet --configuration-name-pretty "Local Testnet" --url http://localhost/ --evaluators consensus_proposals,performance_tps --mint-file $MINT_FILE --duration 3 --accounts-per-client 3 --workers-per-ac 4 --wait-millis 8 --burst > /tmp/local_testnet.yaml
```

Run NHC:
```
cargo run --release -- server run --baseline-node-config-paths /tmp/local_testnet.yaml
```

Hit it with a request (the target node == the baseline node here so, so we're comparing it to itself):
```
curl 'localhost:20121/check_node?node_url=http://localhost&baseline_configuration_name=local_testnet'
```
```
{
  "evaluation_results": [
    {
      "headline": "Chain ID and role type reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same chain ID \"TESTING\" and role type \"validator\" as is reported by the baseline node",
      "evaluator_name": "node_identity",
      "category": "node_identity",
      "links": []
    },
    {
      "headline": "Transaction processing speed is sufficient",
      "score": 100,
      "explanation": "The minimum TPS (transactions per second) required of nodes is 500, your node hit: 971 (out of 974 transactions submitted per second).",
      "evaluator_name": "performance_tps",
      "category": "performance",
      "links": []
    },
    {
      "headline": "Proposals count is increasing",
      "score": 100,
      "explanation": "Successfully pulled metrics from target node twice and saw that proposals count is increasing",
      "evaluator_name": "consensus_proposals",
      "category": "consensus",
      "links": []
    }
  ],
  "summary_score": 100,
  "summary_explanation": "100: Awesome!"
}
```

With the above configuration, the whole `check_node` node run takes about 6-8 seconds. I don't think we can really reduce this much more. While the duration for submitting transactions above is only 3 seconds, there is additional time spent prior to that on minting seed accounts, additional accounts, funding them, etc. This all takes a few seconds in total.

See that if you try to make a configuration that uses the TPS evaluator but you don't set an appropriate private key value, it won't work:
```
$ cargo run -- configuration create --configuration-name local_testnet --configuration-name-pretty "Local Testnet" --url http://localhost/ --evaluators state_sync_version,performance_tps > /tmp/local_testnet.yaml
Error: Configuration failed validation

Caused by:
    0: Failed to build evaluators
    1: Failed to get private key for TPS evaluator
    2: Unable to read file 'mint.key', error: No such file or directory (os error 2)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1626)
<!-- Reviewable:end -->
