### PR TITLE
[NHC] Add support for verifying chain ID and role type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,9 +797,13 @@ name = "aptos-node-checker"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "aptos-api",
+ "aptos-config",
+ "aptos-crypto",
  "aptos-logger",
  "aptos-metrics",
  "aptos-rest-client",
+ "aptos-sdk",
  "aptos-workspace-hack",
  "async-trait",
  "clap 3.1.18",

--- a/ecosystem/node-checker/Cargo.toml
+++ b/ecosystem/node-checker/Cargo.toml
@@ -28,9 +28,13 @@ thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["full"] }
 url = { version = "2.2.2", features = ["serde"] }
 
+aptos-api = { path = "../../api" }
+aptos-config = { path = "../../config" }
+aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics = { path = "../../crates/aptos-metrics" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
+aptos-sdk = { path = "../../sdk" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
 
 [[bin]]

--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -3,12 +3,15 @@
 
 use crate::{
     evaluators::{
+        direct::{get_node_identity, NodeIdentityEvaluatorArgs},
         metrics::{ConsensusProposalsEvaluatorArgs, StateSyncVersionEvaluatorArgs},
         system_information::BuildVersionEvaluatorArgs,
     },
     runner::BlockingRunnerArgs,
 };
-use anyhow::Result;
+use anyhow::{bail, format_err, Result};
+use aptos_config::config::RoleType;
+use aptos_sdk::types::chain_id::ChainId;
 use clap::Parser;
 use once_cell::sync::Lazy;
 use poem_openapi::{types::Example, Object as PoemObject};
@@ -53,12 +56,14 @@ pub struct NodeConfiguration {
     /// set here and doesn't match the chain ID returned by the node, we
     /// will exit, signalling a configuration error.
     #[clap(long)]
-    chain_id: Option<u16>,
+    #[oai(skip)]
+    chain_id: Option<ChainId>,
 
     /// This works the same as `chain_id` above, but for role type. Example
     /// values: "full_node", "validator", etc.
     #[clap(long)]
-    role_type: Option<String>,
+    #[oai(skip)]
+    role_type: Option<RoleType>,
 
     /// The evaluators to use, e.g. state_sync_version, consensus_proposals, etc.
     #[clap(long, required = true, min_values = 1, use_value_delimiter = true)]
@@ -71,19 +76,20 @@ pub struct NodeConfiguration {
     pub runner_args: RunnerArgs,
 }
 
+// TODO: Having comments like "only call this after X" is obviously not great.
+// It'd be better to have an enum with two variants, e.g. unfetched and fetched.
 impl NodeConfiguration {
     /// Only call this after fetch_additional_configuration has been called.
     #[allow(dead_code)]
-    pub fn get_chain_id(&self) -> u16 {
+    pub fn get_chain_id(&self) -> ChainId {
         self.chain_id
             .expect("get_chain_id called before fetch_additional_configuration")
     }
 
     /// Only call this after fetch_additional_configuration has been called.
     #[allow(dead_code)]
-    pub fn get_role_type(&self) -> &str {
+    pub fn get_role_type(&self) -> RoleType {
         self.role_type
-            .as_ref()
             .expect("get_role_type called before fetch_additional_configuration")
     }
 
@@ -91,9 +97,25 @@ impl NodeConfiguration {
     /// If chain_id and role_type are already set, we validate that the values
     /// match up. If they're not set, we set them using the values we find.
     pub async fn fetch_additional_configuration(&mut self) -> Result<()> {
-        // TODO: Dummy code prior to https://github.com/aptos-labs/aptos-core/pull/1466.
-        self.chain_id = Some(16);
-        self.role_type = Some("full_node".to_string());
+        let (reported_chain_id, reported_role_type) =
+            get_node_identity(&self.node_address).await.map_err(|e| {
+                format_err!(
+                    "Failed to fetch chain ID and role type for baseline node configuration: {}",
+                    e
+                )
+            })?;
+        if let Some(configured_chain_id) = self.chain_id {
+            if configured_chain_id != reported_chain_id {
+                bail!("Chain ID mismatch: The baseline configuration {} says the chain ID is {} but the node reports chain ID {}", self.configuration_name, configured_chain_id, reported_chain_id);
+            }
+        }
+        if let Some(configured_role_type) = self.role_type {
+            if configured_role_type != reported_role_type {
+                bail!("Role type mismatch: The baseline configuration {} says the role type is {} but the node reports role type {}", self.configuration_name, configured_role_type, reported_role_type);
+            }
+        }
+        self.chain_id = Some(reported_chain_id);
+        self.role_type = Some(reported_role_type);
         Ok(())
     }
 }
@@ -102,6 +124,9 @@ impl NodeConfiguration {
 pub struct EvaluatorArgs {
     #[clap(flatten)]
     pub consensus_proposals_args: ConsensusProposalsEvaluatorArgs,
+
+    #[clap(flatten)]
+    pub node_identity_args: NodeIdentityEvaluatorArgs,
 
     #[clap(flatten)]
     pub state_sync_version_args: StateSyncVersionEvaluatorArgs,

--- a/ecosystem/node-checker/src/evaluator/types.rs
+++ b/ecosystem/node-checker/src/evaluator/types.rs
@@ -42,9 +42,12 @@ impl From<Vec<EvaluationResult>> for EvaluationSummary {
     fn from(evaluation_results: Vec<EvaluationResult>) -> Self {
         let summary_score = match evaluation_results.len() {
             0 => 0,
-            _ => {
-                evaluation_results.iter().map(|e| e.score).sum::<u8>()
-                    / evaluation_results.len() as u8
+            len => {
+                (evaluation_results
+                    .iter()
+                    .map(|e| e.score as u32)
+                    .sum::<u32>()
+                    / len as u32) as u8
             }
         };
         let summary_explanation = match summary_score {

--- a/ecosystem/node-checker/src/evaluators/direct/mod.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod node_identity;
+mod types;
+
+pub use node_identity::{
+    get_node_identity, NodeIdentityEvaluator, NodeIdentityEvaluatorArgs, NodeIdentityEvaluatorError,
+};
+pub use types::DirectEvaluatorInput;

--- a/ecosystem/node-checker/src/evaluators/direct/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/node_identity.rs
@@ -1,0 +1,160 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    configuration::{EvaluatorArgs, NodeAddress},
+    evaluator::{EvaluationResult, Evaluator},
+};
+use anyhow::{anyhow, format_err, Result};
+use aptos_config::config::RoleType;
+use aptos_sdk::types::chain_id::ChainId;
+use clap::Parser;
+use poem_openapi::Object as PoemObject;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, fmt::Display, str::FromStr};
+use thiserror::Error as ThisError;
+
+use super::DirectEvaluatorInput;
+
+pub const CATEGORY: &str = "node_identity";
+
+/// This function hits the `/` endpoint of the API and returns the chain ID
+/// and role type, extracted from the IndexResponse.
+pub async fn get_node_identity(node_address: &NodeAddress) -> Result<(ChainId, RoleType)> {
+    let mut url = node_address.url.clone();
+    url.set_port(Some(node_address.api_port))
+        .map_err(|_| format_err!("Failed to set port for URL"))?;
+
+    let response = reqwest::get(url)
+        .await
+        .map_err(|e| format_err!("Failed to get node identity {}", e))?;
+    let response_body = response
+        .text()
+        .await
+        .map_err(|e| format_err!("Failed to get body of node identity response {}", e))?;
+
+    let data: HashMap<String, serde_json::Value> =
+        serde_json::from_str(&response_body).map_err(|e| {
+            format_err!(
+                "Failed to process response body as valid JSON with string key/values {}",
+                e
+            )
+        })?;
+
+    let chain_id_raw: u8 = data
+        .get("chain_id")
+        .ok_or_else(|| format_err!("Failed to get chain_id from node identity"))?
+        .as_u64()
+        .ok_or_else(|| anyhow!("Failed to read chain ID from node identity as u8"))?
+        as u8;
+    let chain_id = ChainId::new(chain_id_raw);
+
+    let role_type_raw = data
+        .get("node_role")
+        .ok_or_else(|| format_err!("Failed to get node_role from node identity"))?
+        .as_str()
+        .ok_or_else(|| anyhow!("Failed to read node_role from node identity as str"))?;
+    let role_type = RoleType::from_str(role_type_raw)
+        .map_err(|e| format_err!("Failed to parse node_role {}", e))?;
+
+    Ok((chain_id, role_type))
+}
+
+#[derive(Debug, ThisError)]
+pub enum NodeIdentityEvaluatorError {
+    #[error("Failed to get node identity from node: {0}")]
+    GetNodeIdentityError(anyhow::Error),
+}
+
+// TODO: Consider taking chain_id and role_type here instead.
+#[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
+pub struct NodeIdentityEvaluatorArgs {}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct NodeIdentityEvaluator {
+    args: NodeIdentityEvaluatorArgs,
+}
+
+impl NodeIdentityEvaluator {
+    pub fn new(args: NodeIdentityEvaluatorArgs) -> Self {
+        Self { args }
+    }
+
+    fn build_evaluation_result<T: Display + PartialEq>(
+        &self,
+        baseline_value: T,
+        target_value: T,
+        attribute_str: &str,
+    ) -> EvaluationResult {
+        let (headline, score, explanation) = if baseline_value == target_value {
+            (
+                format!("{} reported by baseline and target match", attribute_str),
+                100,
+                format!(
+                    "The node under investigation reported the same {} {} \
+                as is reported by the baseline node",
+                    attribute_str, target_value
+                ),
+            )
+        } else {
+            (
+                format!(
+                    "{} reported by the target does not match the baseline",
+                    attribute_str
+                ),
+                0,
+                format!(
+                    "The node under investigation reported the {} {}  while the \
+                baseline reported {}. These values should match. Confirm that \
+                the baseline you're using is appropriate for the node you're testing.",
+                    attribute_str, target_value, baseline_value
+                ),
+            )
+        };
+        EvaluationResult {
+            headline,
+            score,
+            explanation,
+            category: CATEGORY.to_string(),
+            evaluator_name: Self::get_name(),
+            links: vec![],
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Evaluator for NodeIdentityEvaluator {
+    type Input = DirectEvaluatorInput;
+    type Error = NodeIdentityEvaluatorError;
+
+    /// Assert that the node identity (role type and chain ID) of the two nodes match.
+    async fn evaluate(&self, input: &Self::Input) -> Result<Vec<EvaluationResult>, Self::Error> {
+        let (target_chain_id, target_role_type) = get_node_identity(&input.target_node_address)
+            .await
+            .map_err(NodeIdentityEvaluatorError::GetNodeIdentityError)?;
+
+        let evaluation_results = vec![
+            self.build_evaluation_result(
+                input.baseline_node_information.chain_id,
+                target_chain_id,
+                "Chain ID",
+            ),
+            self.build_evaluation_result(
+                input.baseline_node_information.role_type,
+                target_role_type,
+                "Role Type",
+            ),
+        ];
+
+        Ok(evaluation_results)
+    }
+
+    fn get_name() -> String {
+        CATEGORY.to_string()
+    }
+
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Self {
+        Self::new(evaluator_args.node_identity_args.clone())
+    }
+}

--- a/ecosystem/node-checker/src/evaluators/direct/types.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/types.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{configuration::NodeAddress, server::NodeInformation};
+
+/// This type of evaluator just takes in the target node address and then
+/// directly fetches whatever information it needs to perform the evaluation.
+/// This is different to other evaluators, where the information they need is
+/// fetched earlier and then passed in, so all they have to do is process it.
+
+#[derive(Debug)]
+pub struct DirectEvaluatorInput {
+    pub baseline_node_information: NodeInformation,
+    pub target_node_address: NodeAddress,
+}

--- a/ecosystem/node-checker/src/evaluators/mod.rs
+++ b/ecosystem/node-checker/src/evaluators/mod.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod build_evaluators;
+
+pub mod direct;
 pub mod metrics;
 pub mod system_information;
 

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -5,13 +5,16 @@ use std::time::Duration;
 
 use super::{Runner, RunnerError};
 use crate::{
-    evaluator::EvaluationSummary,
+    configuration::NodeAddress,
+    evaluator::{EvaluationSummary, Evaluator},
     evaluators::{
+        direct::{DirectEvaluatorInput, NodeIdentityEvaluator},
         metrics::{parse_metrics, MetricsEvaluatorInput},
         system_information::SystemInformationEvaluatorInput,
         EvaluatorType,
     },
     metric_collector::MetricCollector,
+    server::NodeInformation,
 };
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -30,19 +33,25 @@ pub struct BlockingRunnerArgs {
 #[derive(Debug)]
 pub struct BlockingRunner<M: MetricCollector> {
     args: BlockingRunnerArgs,
+    baseline_node_information: NodeInformation,
     baseline_metric_collector: M,
+    node_identity_evaluator: NodeIdentityEvaluator,
     evaluators: Vec<EvaluatorType>,
 }
 
 impl<M: MetricCollector> BlockingRunner<M> {
     pub fn new(
         args: BlockingRunnerArgs,
+        baseline_node_information: NodeInformation,
         baseline_metric_collector: M,
+        node_identity_evaluator: NodeIdentityEvaluator,
         evaluators: Vec<EvaluatorType>,
     ) -> Self {
         Self {
             args,
+            baseline_node_information,
             baseline_metric_collector,
+            node_identity_evaluator,
             evaluators,
         }
     }
@@ -75,8 +84,28 @@ impl<M: MetricCollector> BlockingRunner<M> {
 impl<M: MetricCollector> Runner for BlockingRunner<M> {
     async fn run<T: MetricCollector>(
         &self,
-        target_collector: &T,
+        target_node_address: &NodeAddress,
+        target_metric_collector: &T,
     ) -> Result<EvaluationSummary, RunnerError> {
+        let direct_evaluator_input = DirectEvaluatorInput {
+            baseline_node_information: self.baseline_node_information.clone(),
+            target_node_address: target_node_address.clone(),
+        };
+
+        debug!("Confirming node identity matches");
+        let node_identity_evaluations = self
+            .node_identity_evaluator
+            .evaluate(&direct_evaluator_input)
+            .await
+            .map_err(RunnerError::NodeIdentityEvaluatorError)?;
+
+        // Exit early if a node identity evaluation returned a non-passing result.
+        for evaluation in &node_identity_evaluations {
+            if evaluation.score != 100 {
+                return Ok(EvaluationSummary::from(node_identity_evaluations));
+            }
+        }
+
         debug!("Collecting system information from baseline node");
         let baseline_system_information = self
             .baseline_metric_collector
@@ -86,7 +115,7 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
         debug!("{:?}", baseline_system_information);
 
         debug!("Collecting system information from target node");
-        let target_system_information = target_collector
+        let target_system_information = target_metric_collector
             .collect_system_information()
             .await
             .map_err(RunnerError::MetricCollectorError)?;
@@ -100,7 +129,7 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
             .map_err(RunnerError::MetricCollectorError)?;
 
         debug!("Collecting first round of target metrics");
-        let first_target_metrics = Self::collect_metrics(target_collector).await?;
+        let first_target_metrics = Self::collect_metrics(target_metric_collector).await?;
 
         let first_baseline_metrics = self.parse_response(first_baseline_metrics)?;
         let first_target_metrics = self.parse_response(first_target_metrics)?;
@@ -112,12 +141,12 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
             Self::collect_metrics(&self.baseline_metric_collector).await?;
 
         debug!("Collecting second round of target metrics");
-        let second_target_metrics = Self::collect_metrics(target_collector).await?;
+        let second_target_metrics = Self::collect_metrics(target_metric_collector).await?;
 
         let second_baseline_metrics = self.parse_response(second_baseline_metrics)?;
         let second_target_metrics = self.parse_response(second_target_metrics)?;
 
-        let mut evaluation_results = Vec::new();
+        let mut evaluation_results = node_identity_evaluations;
 
         let metrics_evaluator_input = MetricsEvaluatorInput {
             previous_baseline_metrics: first_baseline_metrics,

--- a/ecosystem/node-checker/src/runner/traits.rs
+++ b/ecosystem/node-checker/src/runner/traits.rs
@@ -6,15 +6,21 @@ use async_trait::async_trait;
 use thiserror::Error as ThisError;
 
 use crate::{
+    configuration::NodeAddress,
     evaluator::EvaluationSummary,
     evaluators::{
-        metrics::MetricsEvaluatorError, system_information::SystemInformationEvaluatorError,
+        direct::NodeIdentityEvaluatorError, metrics::MetricsEvaluatorError,
+        system_information::SystemInformationEvaluatorError,
     },
     metric_collector::{MetricCollector, MetricCollectorError},
 };
 
 #[derive(Debug, ThisError)]
 pub enum RunnerError {
+    /// We failed to get the node identity.
+    #[error("Failed to check identity of node: {0}")]
+    NodeIdentityEvaluatorError(NodeIdentityEvaluatorError),
+
     /// We failed to collect metrics for some reason.
     #[error("Failed to collect metrics: {0}")]
     MetricCollectorError(MetricCollectorError),
@@ -50,6 +56,7 @@ pub enum RunnerError {
 pub trait Runner: Sync + Send + 'static {
     async fn run<M: MetricCollector>(
         &self,
-        target_collector: &M,
+        target_node_address: &NodeAddress,
+        target_metric_collector: &M,
     ) -> Result<EvaluationSummary, RunnerError>;
 }

--- a/ecosystem/node-checker/src/server/api.rs
+++ b/ecosystem/node-checker/src/server/api.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use super::configurations_manager::{ConfigurationsManager, NodeConfigurationWrapper};
 use crate::{
     configuration::{NodeAddress, NodeConfiguration},
     evaluator::EvaluationSummary,
@@ -14,11 +15,14 @@ use poem_openapi::{
 };
 use url::Url;
 
-use super::configurations_manager::{ConfigurationsManager, NodeConfigurationWrapper};
+pub struct PreconfiguredNode<M: MetricCollector> {
+    pub node_address: NodeAddress,
+    pub metric_collector: M,
+}
 
 pub struct Api<M: MetricCollector, R: Runner> {
-    pub configurations_manager: ConfigurationsManager<M, R>,
-    pub target_metric_collector: Option<M>,
+    pub configurations_manager: ConfigurationsManager<R>,
+    pub preconfigured_test_node: Option<PreconfiguredNode<M>>,
     pub allow_preconfigured_test_node_only: bool,
 }
 
@@ -26,7 +30,7 @@ impl<M: MetricCollector, R: Runner> Api<M, R> {
     fn get_baseline_node_configuration(
         &self,
         baseline_configuration_name: &Option<String>,
-    ) -> PoemResult<&NodeConfigurationWrapper<M, R>> {
+    ) -> PoemResult<&NodeConfigurationWrapper<R>> {
         let baseline_configuration_name = match baseline_configuration_name {
             Some(name) => name,
             // TODO: Auto detect this based on the target node.
@@ -76,14 +80,15 @@ impl<M: MetricCollector, R: Runner> Api<M, R> {
         #[oai(default = "NodeAddress::default_api_port")] api_port: Query<u16>,
         #[oai(default = "NodeAddress::default_noise_port")] noise_port: Query<u16>,
     ) -> PoemResult<Json<EvaluationSummary>> {
+        let target_node_address = NodeAddress {
+            url: node_url.0,
+            metrics_port: metrics_port.0,
+            api_port: api_port.0,
+            noise_port: noise_port.0,
+        };
         let request = CheckNodeRequest {
             baseline_configuration_name: baseline_configuration_name.0,
-            target_node: NodeAddress {
-                url: node_url.0,
-                metrics_port: metrics_port.0,
-                api_port: api_port.0,
-                noise_port: noise_port.0,
-            },
+            target_node: target_node_address.clone(),
         };
         if self.allow_preconfigured_test_node_only {
             return Err(PoemError::from((
@@ -103,7 +108,7 @@ impl<M: MetricCollector, R: Runner> Api<M, R> {
 
         let complete_evaluation_result = baseline_node_configuration
             .runner
-            .run(&target_metric_collector)
+            .run(&target_node_address, &target_metric_collector)
             .await;
 
         match complete_evaluation_result {
@@ -121,7 +126,7 @@ impl<M: MetricCollector, R: Runner> Api<M, R> {
         &self,
         baseline_configuration_name: Query<Option<String>>,
     ) -> PoemResult<Json<EvaluationSummary>> {
-        if self.target_metric_collector.is_none() {
+        if self.preconfigured_test_node.is_none() {
             return Err(PoemError::from((
                 StatusCode::METHOD_NOT_ALLOWED,
                 anyhow!(
@@ -129,13 +134,17 @@ impl<M: MetricCollector, R: Runner> Api<M, R> {
                 ),
             )));
         }
+        let preconfigured_test_node = self.preconfigured_test_node.as_ref().unwrap();
 
         let baseline_node_configuration =
             self.get_baseline_node_configuration(&baseline_configuration_name)?;
 
         let complete_evaluation_result = baseline_node_configuration
             .runner
-            .run(self.target_metric_collector.as_ref().unwrap())
+            .run(
+                &preconfigured_test_node.node_address,
+                &preconfigured_test_node.metric_collector,
+            )
             .await;
 
         match complete_evaluation_result {
@@ -148,6 +157,10 @@ impl<M: MetricCollector, R: Runner> Api<M, R> {
         }
     }
 
+    /// Get the different baseline configurations the instance of NHC is
+    /// configured with. This method is best effort, it is infeasible to
+    /// derive (or even represent) some fields of the spec via OpenAPI,
+    /// so note that some fields will be missing from the response.
     #[oai(path = "/get_configurations", method = "get")]
     async fn get_configurations(&self) -> Json<Vec<NodeConfiguration>> {
         Json(
@@ -159,6 +172,8 @@ impl<M: MetricCollector, R: Runner> Api<M, R> {
         )
     }
 
+    /// Get just the keys for the configurations, i.e. the configuration_name
+    /// field.
     #[oai(path = "/get_configuration_keys", method = "get")]
     async fn get_configuration_keys(&self) -> Json<Vec<String>> {
         Json(

--- a/ecosystem/node-checker/src/server/configurations_manager.rs
+++ b/ecosystem/node-checker/src/server/configurations_manager.rs
@@ -5,34 +5,41 @@ use std::{collections::HashMap, path::PathBuf};
 
 use crate::{
     configuration::{read_configuration_from_file, NodeConfiguration},
-    evaluators::build_evaluators,
-    metric_collector::{MetricCollector, ReqwestMetricCollector},
+    evaluator::Evaluator,
+    evaluators::{build_evaluators, direct::NodeIdentityEvaluator},
+    metric_collector::ReqwestMetricCollector,
     runner::{BlockingRunner, Runner},
 };
 use anyhow::{Context, Result};
 
+use super::NodeInformation;
+
 /// This struct is a wrapper to help with all the different baseline
 /// node configurations.
 #[derive(Debug)]
-pub struct ConfigurationsManager<M: MetricCollector, R: Runner> {
+pub struct ConfigurationsManager<R: Runner> {
     /// The key here is the configuration_name.
-    pub configurations: HashMap<String, NodeConfigurationWrapper<M, R>>,
+    pub configurations: HashMap<String, NodeConfigurationWrapper<R>>,
 }
 
 #[derive(Debug)]
-pub struct NodeConfigurationWrapper<M: MetricCollector, R: Runner> {
+pub struct NodeConfigurationWrapper<R: Runner> {
     pub node_configuration: NodeConfiguration,
-    pub baseline_metric_collector: M,
     pub runner: R,
 }
 
 // In this function we finally build our trait objects with concrete implementations.
 // We've piped trait bounds throughout our code but here we're finally facing the
 // music and actually choosing some concrete types.
-fn build_node_configuration_wrapper_with_blocking_runner_and_reqwest_metric_collector(
+fn build_node_configuration_wrapper_with_blocking_runner(
     node_configuration: NodeConfiguration,
-) -> Result<NodeConfigurationWrapper<ReqwestMetricCollector, BlockingRunner<ReqwestMetricCollector>>>
-{
+) -> Result<NodeConfigurationWrapper<BlockingRunner<ReqwestMetricCollector>>> {
+    let baseline_node_information = NodeInformation {
+        node_address: node_configuration.node_address.clone(),
+        chain_id: node_configuration.get_chain_id(),
+        role_type: node_configuration.get_role_type(),
+    };
+
     let baseline_metric_collector = ReqwestMetricCollector::new(
         node_configuration.node_address.url.clone(),
         node_configuration.node_address.metrics_port,
@@ -44,25 +51,28 @@ fn build_node_configuration_wrapper_with_blocking_runner_and_reqwest_metric_coll
     )
     .context("Failed to build evaluators")?;
 
+    let node_identity_evaluator =
+        NodeIdentityEvaluator::from_evaluator_args(&node_configuration.evaluator_args);
+
     let runner = BlockingRunner::new(
         node_configuration.runner_args.blocking_runner_args.clone(),
-        baseline_metric_collector.clone(),
+        baseline_node_information,
+        baseline_metric_collector,
+        node_identity_evaluator,
         evaluators,
     );
 
     let wrapper = NodeConfigurationWrapper {
         node_configuration,
-        // TODO: Consider just fetching this from the runner instead.
-        baseline_metric_collector,
         runner,
     };
 
     Ok(wrapper)
 }
 
-pub async fn build_server_with_blocking_runner_and_reqwest_metric_collector(
+pub async fn build_server_with_blocking_runner(
     baseline_node_config_paths: &[PathBuf],
-) -> Result<ConfigurationsManager<ReqwestMetricCollector, BlockingRunner<ReqwestMetricCollector>>> {
+) -> Result<ConfigurationsManager<BlockingRunner<ReqwestMetricCollector>>> {
     let mut configurations = HashMap::new();
     for path in baseline_node_config_paths.iter() {
         let mut cfg = read_configuration_from_file(path.to_path_buf())
@@ -73,10 +83,7 @@ pub async fn build_server_with_blocking_runner_and_reqwest_metric_collector(
             .await
             .with_context(|| format!("Failed to fetch chain ID and role type for {}", name))?;
 
-        let configuration_wrapper =
-            build_node_configuration_wrapper_with_blocking_runner_and_reqwest_metric_collector(
-                cfg,
-            )?;
+        let configuration_wrapper = build_node_configuration_wrapper_with_blocking_runner(cfg)?;
         configurations.insert(name, configuration_wrapper);
     }
     Ok(ConfigurationsManager { configurations })

--- a/ecosystem/node-checker/src/server/generate_openapi.rs
+++ b/ecosystem/node-checker/src/server/generate_openapi.rs
@@ -28,12 +28,12 @@ pub struct GenerateOpenapi {
 pub async fn generate_openapi(args: GenerateOpenapi) -> Result<()> {
     let configurations: HashMap<
         _,
-        NodeConfigurationWrapper<ReqwestMetricCollector, BlockingRunner<ReqwestMetricCollector>>,
+        NodeConfigurationWrapper<BlockingRunner<ReqwestMetricCollector>>,
     > = HashMap::new();
 
-    let api = Api {
+    let api: Api<ReqwestMetricCollector, _> = Api {
         configurations_manager: ConfigurationsManager { configurations },
-        target_metric_collector: None,
+        preconfigured_test_node: None,
         allow_preconfigured_test_node_only: false,
     };
 

--- a/ecosystem/node-checker/src/server/mod.rs
+++ b/ecosystem/node-checker/src/server/mod.rs
@@ -5,13 +5,15 @@ mod api;
 mod common;
 mod configurations_manager;
 mod generate_openapi;
+mod node_information;
 mod run;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-
 use generate_openapi::{generate_openapi, GenerateOpenapi};
 use run::{run, Run};
+
+pub use node_information::NodeInformation;
 
 #[derive(Clone, Debug, Parser)]
 pub struct Server {

--- a/ecosystem/node-checker/src/server/node_information.rs
+++ b/ecosystem/node-checker/src/server/node_information.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::configuration::NodeAddress;
+use aptos_config::config::RoleType;
+use aptos_sdk::types::chain_id::ChainId;
+
+/// This struct captures all the relevant information needed to address a node
+/// and make assertions about its identity.
+#[derive(Clone, Debug)]
+pub struct NodeInformation {
+    pub node_address: NodeAddress,
+    pub chain_id: ChainId,
+    pub role_type: RoleType,
+}


### PR DESCRIPTION
## Description
Currently it's possible for the user to pass in a URL to a testnet fullnode but select a devnet fullnode baseline (for example) and then run into potentially strange behaviour down the line. With this change, we explicitly check the chain ID and role type and return an evaluation if they don't match the expected baseline. This also adds most of the necessary functionality for an autodetect mode, where you don't have to pass in a baseline configuration at all and we just figure it out based on role type and chain ID.

This evaluator is enabled by default and cannot be disabled. This allows future evaluators to make certain assumptions.

## Test Plan
Generate appropriate config for testing a local fullnode. Notably we leave chain ID and role type unspecified here:
```
cargo run -- configuration create --configuration-name local_devnet_fullnode --configuration-name-pretty "Local Devnet Fullnode" --url http://localhost/ --evaluators state_sync_version > /tmp/local_devnet_fullnode.yaml
```

Run NHC:
```
cargo run -- server run --baseline-node-config-paths /tmp/local_devnet_fullnode.yaml
```

Hit it with a request (the target node == the baseline node here so, so we're comparing it to itself):
```
curl 'localhost:20121/check_node?node_url=http://localhost&baseline_configuration_name=local_devnet_fullnode'
```
```
{
  "evaluation_results": [
    {
      "headline": "Chain ID and role type reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same chain ID (18) and role type (full_node) as is reported by the baseline node",
      "evaluator_name": "node_identity",
      "category": "node_identity",
      "links": []
    },
    {
      "headline": "State sync version is within tolerance",
      "score": 100,
      "explanation": "Successfully pulled metrics from target node twice, saw the version was progressing, and saw that it is within tolerance of the baseline node. Target version: 302087. Baseline version: 302087. Tolerance: 5000.",
      "evaluator_name": "state_sync_version",
      "category": "state_sync",
      "links": []
    }
  ],
  "summary_score": 100,
  "summary_explanation": "100: Awesome!"
}
```

See that if you configure a baseline to expect a particular chain ID / role type and the baseline has something else in reality, NHC will refuse to start up:
```
cargo run -- configuration create --configuration-name local_devnet_fullnode --configuration-name-pretty "Local Devnet Fullnode" --url http://localhost/ --evaluators state_sync_version > /tmp/local_devnet_fullnode.yaml --chain-id 2
```
```
$ cargo run -- server run --baseline-node-config-paths /tmp/local_devnet_fullnode.yaml
Error: Failed to build baseline node configurations

Caused by:
    0: Failed to fetch chain ID and role type for local_devnet_fullnode
    1: Chain ID mismatch: The baseline configuration local_devnet_fullnode says the chain ID is TESTNET but the node reports chain ID 18
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1630)
<!-- Reviewable:end -->
