### PR TITLE
[ecosystem] Require username in onboarding flow.

### DIFF
--- a/ecosystem/platform/server/app/controllers/application_controller.rb
+++ b/ecosystem/platform/server/app/controllers/application_controller.rb
@@ -21,10 +21,12 @@ class ApplicationController < ActionController::Base
     stored_location = stored_location_for(user)
     return stored_location if stored_location.present?
 
-    if user.email.nil?
+    if user.email.nil? || user.username.nil?
       onboarding_email_path
-    else
+    elsif Flipper.enabled?(:it2_registration_open)
       it2_path
+    else
+      it1_path
     end
   end
 
@@ -37,7 +39,9 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_confirmed!
-    redirect_to onboarding_email_path unless current_user&.confirmed?
+    email_confirmed = !!current_user&.confirmed?
+    username_exists = current_user && !current_user.username.nil?
+    redirect_to onboarding_email_path unless email_confirmed && username_exists
   end
 
   def append_info_to_payload(payload)

--- a/ecosystem/platform/server/app/controllers/onboarding_controller.rb
+++ b/ecosystem/platform/server/app/controllers/onboarding_controller.rb
@@ -14,13 +14,13 @@ class OnboardingController < ApplicationController
   layout 'it2'
 
   def email
-    redirect_to it2_path if current_user.confirmed?
+    redirect_to it2_path if current_user.confirmed? && !current_user.username.nil?
   end
 
   def email_success; end
 
   def email_update
-    redirect_to it2_path and return if current_user.confirmed?
+    return redirect_to it2_path if current_user.confirmed? && !current_user.username.nil?
 
     recaptcha_v3_success = verify_recaptcha(action: 'onboarding/email', minimum_score: 0.5,
                                             secret_key: ENV.fetch('RECAPTCHA_V3_SECRET_KEY', nil), model: current_user)
@@ -32,9 +32,11 @@ class OnboardingController < ApplicationController
 
     email_params = params.require(:user).permit(:email, :username, :terms_accepted)
     if current_user.update(email_params)
-      log current_user, 'email updated'
+      log current_user, 'email/username updated'
       if forum_sso?
         redirect_to discourse_sso_path
+      elsif current_user.confirmed?
+        redirect_to it2_path
       else
         redirect_to onboarding_email_success_path
       end

--- a/ecosystem/platform/server/app/models/user.rb
+++ b/ecosystem/platform/server/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
                         authentication_keys: [:username]
 
   validates :username, uniqueness: { case_sensitive: false }, length: { minimum: 3, maximum: 20 },
-                       format: { with: /\A[a-zA-Z0-9]+\z/ }, allow_nil: true
+                       format: { with: /\A[a-zA-Z0-9#]+\z/ }, allow_nil: true
   validates :email, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }, allow_nil: true
 
   validate_aptos_address :mainnet_address

--- a/ecosystem/platform/server/app/views/it2s/show.html.erb
+++ b/ecosystem/platform/server/app/views/it2s/show.html.erb
@@ -58,7 +58,7 @@
                   <% end %>
                   <%= dialog.with_body do %>
                     <% if step.name == :connect_discord %>
-                      <%= render LoginButtonComponent.new(provider: :discord, size: :large, class: 'w-96') %>
+                      <%= render LoginButtonComponent.new(provider: :discord, size: :large, class: 'w-full') %>
                     <% end %>
                   <% end %>
                 <% end %>

--- a/ecosystem/platform/server/app/views/onboarding/email.html.erb
+++ b/ecosystem/platform/server/app/views/onboarding/email.html.erb
@@ -6,20 +6,28 @@
   <% if current_user.errors.any? %>
     <div id="error_explanation" class="flex p-4 mb-4 bg-red-100 rounded-lg dark:bg-red-200" role="alert">
       <div class="ml-3 text-sm font-medium text-red-700 dark:text-red-800">
-      <h2><%= pluralize(current_user.errors.count, 'error') %> prohibited this user from being saved:</h2>
+        <h2><%= pluralize(current_user.errors.count, 'error') %> prohibited this user from being saved:</h2>
 
-      <ul>
-        <% current_user.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
+        <ul>
+          <% current_user.errors.each do |error| %>
+            <li><%= error.full_message %></li>
+          <% end %>
+        </ul>
       </div>
     </div>
   <% end %>
 
   <%= form_with(model: current_user, url: onboarding_email_path, method: :post, data: { turbo: !@show_recaptcha_v2, controller: 'recaptcha', action: 'recaptcha#validate' }, builder: AptosFormBuilder) do |f| %>
-    <div class="mb-8">
-      <%= f.email_field :email, autofocus: true, autocomplete: 'email', required: true, placeholder: 'ENTER YOUR EMAIL ADDRESS', value: current_user.unconfirmed_email || current_user.email || @oauth_email, class: 'md:w-96' %>
+    <% if !current_user.email %>
+      <div class="mb-6">
+        <%= f.label :email, class: 'font-mono uppercase block mb-2' %>
+        <%= f.email_field :email, autofocus: true, autocomplete: 'email', spellcheck: false, required: true, value: current_user.unconfirmed_email || @oauth_email, class: 'md:w-96' %>
+      </div>
+    <% end %>
+
+    <div class="mb-6">
+      <%= f.label :username, class: 'font-mono uppercase block mb-2' %>
+      <%= f.text_field :username, autofocus: true, spellcheck: false, pattern: '[a-zA-Z0-9#]+', minlength: 3, maxlength: 20, value: current_user.username || @oauth_username, class: 'md:w-96' %>
     </div>
 
     <div class="mb-8">
@@ -31,7 +39,7 @@
     </div>
 
     <div class="mb-12">
-      <%= f.submit 'Verify email', class: 'w-72' %>
+      <%= f.submit 'Continue', class: 'w-72' %>
     </div>
 
     <div class="text-sm mb-4">
@@ -40,7 +48,7 @@
         <span>I agree to the Aptos <a href="https://aptoslabs.com/terms/" class="font-bold text-teal-400">Terms of Use</a> and <a href="https://aptoslabs.com/privacy/" class="font-bold text-teal-400">Privacy Policy</a>.</span>
       </label>
     </div>
-        <div class="text-xs text-neutral-500">
+    <div class="text-xs text-neutral-500">
       This site is protected by reCAPTCHA and the Google
       <a href="https://policies.google.com/privacy">Privacy Policy</a> and
       <a href="https://policies.google.com/terms">Terms of Service</a> apply.

--- a/ecosystem/platform/server/app/views/settings/profile.html.erb
+++ b/ecosystem/platform/server/app/views/settings/profile.html.erb
@@ -17,7 +17,7 @@
 
   <div class="mb-6">
     <%= f.label :username, class: 'font-mono uppercase block mb-2' %>
-    <%= f.text_field :username, autofocus: true, spellcheck: false, pattern: '[a-zA-Z0-9]+', minlength: 3, maxlength: 20 %>
+    <%= f.text_field :username, autofocus: true, spellcheck: false, pattern: '[a-zA-Z0-9#]+', minlength: 3, maxlength: 20 %>
   </div>
 
   <div class="mb-6">

--- a/ecosystem/platform/server/test/controllers/users/omniauth_callbacks_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/users/omniauth_callbacks_controller_test.rb
@@ -54,11 +54,7 @@ module Users
 
         assert_difference('User.count') do
           follow_redirect!
-          if provider.to_s == 'google'
-            assert_redirected_to it2_url
-          else
-            assert_redirected_to onboarding_email_url
-          end
+          assert_redirected_to onboarding_email_url
         end
 
         user = User.last


### PR DESCRIPTION
### Description

- Adds username to onboarding form.
- Hides email in onboarding form if already specified.
- Redirects to onboarding form if username isn't present.
- Updates username format to allow `#` characters (to allow Discord user#1337 usernames).
- Redirect to /it1 if /it2 isn't open yet.
- Fix width of "Connect Discord" button.

### Test Plan
Manual testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1634)
<!-- Reviewable:end -->
