### PR TITLE
[Executor][InMemoryState] add current_version to InMemoryState

### DIFF
--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -50,12 +50,8 @@ impl ApplyChunkOutput {
             state_checkpoint_hashes,
             result_state,
             next_epoch_state,
-        ) = InMemoryStateCalculator::new(
-            base_view.state(),
-            state_cache,
-            base_view.txn_accumulator().num_leaves(),
-        )
-        .calculate_for_transaction_chunk(&to_keep, new_epoch)?;
+        ) = InMemoryStateCalculator::new(base_view.state(), state_cache)
+            .calculate_for_transaction_chunk(&to_keep, new_epoch)?;
 
         // Calculate TransactionData and TransactionInfo, i.e. the ledger history diff.
         let (to_commit, transaction_info_hashes) = Self::assemble_ledger_diff(

--- a/execution/executor/src/components/in_memory_state_calculator.rs
+++ b/execution/executor/src/components/in_memory_state_calculator.rs
@@ -68,11 +68,7 @@ impl IntoLedgerView for TreeState {
             let write_sets = db.get_write_sets(checkpoint_next_version, self.num_transactions)?;
             checkpoint_state_view.prime_cache_by_write_set(&write_sets)?;
             let state_cache = checkpoint_state_view.into_state_cache();
-            let calculator = InMemoryStateCalculator::new(
-                &checkpoint_state,
-                state_cache,
-                checkpoint_next_version,
-            );
+            let calculator = InMemoryStateCalculator::new(&checkpoint_state, state_cache);
             calculator.calculate_for_write_sets_after_checkpoint(&write_sets)?
         };
 
@@ -135,7 +131,7 @@ pub(crate) struct InMemoryStateCalculator {
 }
 
 impl InMemoryStateCalculator {
-    pub fn new(base: &InMemoryState, state_cache: StateCache, next_version: Version) -> Self {
+    pub fn new(base: &InMemoryState, state_cache: StateCache) -> Self {
         let StateCache {
             frozen_base,
             state_cache,
@@ -145,6 +141,7 @@ impl InMemoryStateCalculator {
             checkpoint,
             checkpoint_version,
             current,
+            current_version,
             updated_since_checkpoint,
         } = base.clone();
 
@@ -155,7 +152,7 @@ impl InMemoryStateCalculator {
             checkpoint,
             checkpoint_version,
             latest: current.freeze(),
-            next_version,
+            next_version: state_checkpoint_next_version(current_version),
             updated_between_checkpoint_and_latest: updated_since_checkpoint,
             updated_after_latest: HashSet::new(),
         }
@@ -326,6 +323,7 @@ impl InMemoryStateCalculator {
             self.checkpoint,
             self.checkpoint_version,
             latest.unfreeze(),
+            self.next_version.checked_sub(1),
             updated_since_checkpoint,
         );
 

--- a/storage/storage-interface/src/in_memory_state.rs
+++ b/storage/storage-interface/src/in_memory_state.rs
@@ -21,6 +21,7 @@ pub struct InMemoryState {
     pub checkpoint: SparseMerkleTree<StateValue>,
     pub checkpoint_version: Option<Version>,
     pub current: SparseMerkleTree<StateValue>,
+    pub current_version: Option<Version>,
     pub updated_since_checkpoint: HashSet<StateKey>,
 }
 
@@ -29,24 +30,32 @@ impl InMemoryState {
         checkpoint: SparseMerkleTree<StateValue>,
         checkpoint_version: Option<Version>,
         current: SparseMerkleTree<StateValue>,
+        current_version: Option<Version>,
         updated_since_checkpoint: HashSet<StateKey>,
     ) -> Self {
         Self {
             checkpoint,
             checkpoint_version,
             current,
+            current_version,
             updated_since_checkpoint,
         }
     }
 
     pub fn new_empty() -> Self {
         let smt = SparseMerkleTree::new_empty();
-        Self::new(smt.clone(), None, smt, HashSet::new())
+        Self::new(smt.clone(), None, smt, None, HashSet::new())
     }
 
     pub fn new_at_checkpoint(root_hash: HashValue, checkpoint_version: Option<Version>) -> Self {
         let smt = SparseMerkleTree::new(root_hash);
-        Self::new(smt.clone(), checkpoint_version, smt, HashSet::new())
+        Self::new(
+            smt.clone(),
+            checkpoint_version,
+            smt,
+            checkpoint_version,
+            HashSet::new(),
+        )
     }
 
     pub fn checkpoint_root_hash(&self) -> HashValue {


### PR DESCRIPTION
We should include the current SMT version inside InMemoryState instead of pass into the calculator.
Surprisingly, it is quite a small change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1643)
<!-- Reviewable:end -->
