### PR TITLE
[NHC] Add a latency evaluator

### DIFF
--- a/ecosystem/node-checker/src/configuration/create.rs
+++ b/ecosystem/node-checker/src/configuration/create.rs
@@ -26,7 +26,14 @@ pub async fn create(args: Create) -> Result<()> {
     }
     let output = match args.output_args.format {
         OutputFormat::Json => serde_json::to_string_pretty(&args.node_configuration)?,
-        OutputFormat::Yaml => serde_yaml::to_string(&args.node_configuration)?,
+        OutputFormat::Yaml => {
+            let mut output = format!(
+                "# Base config generated with: {}\n",
+                std::env::args().collect::<Vec<_>>().join(" ")
+            );
+            output.push_str(&serde_yaml::to_string(&args.node_configuration)?);
+            output
+        }
     };
     args.output_args.write(&output)
 }

--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -3,7 +3,9 @@
 
 use crate::{
     evaluators::{
-        direct::{get_node_identity, NodeIdentityEvaluatorArgs, TpsEvaluatorArgs},
+        direct::{
+            get_node_identity, LatencyEvaluatorArgs, NodeIdentityEvaluatorArgs, TpsEvaluatorArgs,
+        },
         metrics::{ConsensusProposalsEvaluatorArgs, StateSyncVersionEvaluatorArgs},
         system_information::BuildVersionEvaluatorArgs,
     },
@@ -127,6 +129,9 @@ pub struct EvaluatorArgs {
 
     #[clap(flatten)]
     pub consensus_proposals_args: ConsensusProposalsEvaluatorArgs,
+
+    #[clap(flatten)]
+    pub latency_args: LatencyEvaluatorArgs,
 
     #[clap(flatten)]
     pub node_identity_args: NodeIdentityEvaluatorArgs,

--- a/ecosystem/node-checker/src/evaluators/build_evaluators.rs
+++ b/ecosystem/node-checker/src/evaluators/build_evaluators.rs
@@ -5,7 +5,10 @@ use crate::{
     configuration::EvaluatorArgs,
     evaluator::Evaluator,
     evaluators::{
-        direct::{DirectEvaluatorInput, TpsEvaluator, TpsEvaluatorError},
+        direct::{
+            DirectEvaluatorInput, LatencyEvaluator, LatencyEvaluatorError, TpsEvaluator,
+            TpsEvaluatorError,
+        },
         metrics::{
             ConsensusProposalsEvaluator, MetricsEvaluatorError, MetricsEvaluatorInput,
             StateSyncVersionEvaluator,
@@ -43,6 +46,7 @@ pub enum EvaluatorType {
         >,
     ),
     Tps(Box<dyn Evaluator<Input = DirectEvaluatorInput, Error = TpsEvaluatorError>>),
+    Latency(Box<dyn Evaluator<Input = DirectEvaluatorInput, Error = LatencyEvaluatorError>>),
 }
 
 pub fn build_evaluators(
@@ -87,6 +91,16 @@ pub fn build_evaluators(
         Some(_) => {
             evaluators.push(EvaluatorType::Tps(Box::new(
                 TpsEvaluator::from_evaluator_args(evaluator_args)?,
+            )));
+        }
+        None => log_did_not_build(&name),
+    }
+
+    let name = LatencyEvaluator::get_name();
+    match evaluator_names.take(&name) {
+        Some(_) => {
+            evaluators.push(EvaluatorType::Latency(Box::new(
+                LatencyEvaluator::from_evaluator_args(evaluator_args)?,
             )));
         }
         None => log_did_not_build(&name),

--- a/ecosystem/node-checker/src/evaluators/direct/latency.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/latency.rs
@@ -1,0 +1,142 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::DirectEvaluatorInput;
+use crate::{
+    configuration::EvaluatorArgs,
+    evaluator::{EvaluationResult, Evaluator},
+};
+use anyhow::Result;
+use clap::Parser;
+use poem_openapi::Object as PoemObject;
+use serde::{Deserialize, Serialize};
+use thiserror::Error as ThisError;
+use tokio::time::{Duration, Instant};
+use url::Url;
+
+pub const CATEGORY: &str = "performance";
+
+#[derive(Debug, ThisError)]
+pub enum LatencyEvaluatorError {}
+
+#[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
+pub struct LatencyEvaluatorArgs {
+    /// The number of times to hit the node to check latency.
+    #[clap(long, default_value_t = 5)]
+    pub num_samples: u16,
+
+    /// The delay between each call.
+    #[clap(long, default_value_t = 20)]
+    pub delay_between_samples_ms: u64,
+
+    /// The number of responses that are allowed to be errors.
+    #[clap(long, default_value_t = 1)]
+    pub num_allowed_errors: u16,
+
+    /// If the average latency exceeds this value, it will fail the evaluation.
+    #[clap(long, default_value_t = 500)]
+    pub max_latency_ms: u64,
+}
+
+#[derive(Debug)]
+pub struct LatencyEvaluator {
+    args: LatencyEvaluatorArgs,
+}
+
+impl LatencyEvaluator {
+    pub fn new(args: LatencyEvaluatorArgs) -> Self {
+        Self { args }
+    }
+
+    fn build_evaluation_result(
+        &self,
+        headline: String,
+        score: u8,
+        explanation: String,
+    ) -> EvaluationResult {
+        EvaluationResult {
+            headline,
+            score,
+            explanation,
+            category: CATEGORY.to_string(),
+            evaluator_name: Self::get_name(),
+            links: vec![],
+        }
+    }
+
+    async fn get_latency_datapoint(&self, target_url: Url) -> Result<Duration> {
+        let start = Instant::now();
+        reqwest::get(target_url).await?;
+        Ok(start.elapsed())
+    }
+}
+
+#[async_trait::async_trait]
+impl Evaluator for LatencyEvaluator {
+    type Input = DirectEvaluatorInput;
+    type Error = LatencyEvaluatorError;
+
+    async fn evaluate(&self, input: &Self::Input) -> Result<Vec<EvaluationResult>, Self::Error> {
+        let mut target_url = input.target_node_address.url.clone();
+        target_url
+            .set_port(Some(input.target_node_address.api_port))
+            .unwrap();
+
+        let mut errors = vec![];
+
+        let mut latencies = vec![];
+        for _ in 0..self.args.num_samples {
+            match self.get_latency_datapoint(target_url.clone()).await {
+                Ok(latency) => latencies.push(latency),
+                Err(e) => errors.push(e),
+            }
+            if errors.len() as u16 > self.args.num_allowed_errors {
+                return Ok(vec![self.build_evaluation_result(
+                    "Node returned too many errors while checking latency".to_string(),
+                    0,
+                    format!(
+                        "The node returned too many errors while checking latency, the tolerance was {} errors out of {} calls: {}",
+                        self.args.num_allowed_errors, self.args.num_samples, errors.into_iter().map(|e| e.to_string()).collect::<Vec<String>>().join(", ")
+                    ),
+                )]);
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(
+                self.args.delay_between_samples_ms,
+            ))
+            .await;
+        }
+
+        let average_latency =
+            latencies.iter().sum::<Duration>().as_millis() as u64 / latencies.len() as u64;
+
+        let evaluation_result = if average_latency > self.args.max_latency_ms {
+            self.build_evaluation_result(
+                "Average latency too high".to_string(),
+                50,
+                format!(
+                    "The average latency was {}ms, which is higher than the maximum allowed latency of {}ms",
+                    average_latency, self.args.max_latency_ms
+                ),
+            )
+        } else {
+            self.build_evaluation_result(
+                "Average latency is good".to_string(),
+                100,
+                format!(
+                    "The average latency was {}ms, which is below the maximum allowed latency of {}ms",
+                    average_latency, self.args.max_latency_ms
+                ),
+            )
+        };
+
+        Ok(vec![evaluation_result])
+    }
+
+    fn get_name() -> String {
+        format!("{}_latency", CATEGORY)
+    }
+
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        Ok(Self::new(evaluator_args.latency_args.clone()))
+    }
+}

--- a/ecosystem/node-checker/src/evaluators/direct/mod.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/mod.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+mod latency;
 mod node_identity;
 mod tps;
 mod types;
 
+pub use latency::{LatencyEvaluator, LatencyEvaluatorArgs, LatencyEvaluatorError};
 pub use node_identity::{
     get_node_identity, NodeIdentityEvaluator, NodeIdentityEvaluatorArgs, NodeIdentityEvaluatorError,
 };

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -201,6 +201,10 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
                     .map_err(RunnerError::SystemInformationEvaluatorError)?,
                 // The TPS evaluator has already been used above.
                 EvaluatorType::Tps(_) => vec![],
+                EvaluatorType::Latency(evaluator) => evaluator
+                    .evaluate(&direct_evaluator_input)
+                    .await
+                    .map_err(RunnerError::LatencyEvaluatorError)?,
             };
             evaluation_results.append(&mut local_evaluation_results);
         }

--- a/ecosystem/node-checker/src/runner/traits.rs
+++ b/ecosystem/node-checker/src/runner/traits.rs
@@ -9,7 +9,7 @@ use crate::{
     configuration::NodeAddress,
     evaluator::EvaluationSummary,
     evaluators::{
-        direct::{NodeIdentityEvaluatorError, TpsEvaluatorError},
+        direct::{LatencyEvaluatorError, NodeIdentityEvaluatorError, TpsEvaluatorError},
         metrics::MetricsEvaluatorError,
         system_information::SystemInformationEvaluatorError,
     },
@@ -45,6 +45,9 @@ pub enum RunnerError {
     /// evaluator, this is an actual failure in the evaluation process.
     #[error("Failed to evaluate TPS: {0}")]
     TpsEvaluatorError(TpsEvaluatorError),
+
+    #[error("Failed to evaluate latency: {0}")]
+    LatencyEvaluatorError(LatencyEvaluatorError),
 }
 
 /// This trait describes a Runner, something that can take in instances of other


### PR DESCRIPTION
## Description
This PR adds a latency evaluator to NHC.

## Test Plan
Generate a config, this time targeting a local fullnode
```
cargo run -- configuration create --configuration-name local_fullnode --configuration-name-pretty "Local FullNode" --url http://localhost/ --evaluators performance_latency  > /tmp/local_fullnode.yaml
```

Run NHC:
```
cargo run -- server run --baseline-node-config-paths /tmp/local_fullnode.yaml
```

Hit it with a request:
```
curl 'localhost:20121/check_node?node_url=http://localhost&baseline_configuration_name=local_fullnode'
```
```
{
  "evaluation_results": [
    {
      "headline": "Chain ID and role type reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same chain ID \"TESTING\" and role type \"validator\" as is reported by the baseline node",
      "evaluator_name": "node_identity",
      "category": "node_identity",
      "links": []
    },
    {
      "headline": "Average latency good",
      "score": 100,
      "explanation": "The average latency was 1ms, which is below the maximum allowed latency of 500ms",
      "evaluator_name": "performance_latency",
      "category": "performance",
      "links": []
    }
  ],
  "summary_score": 100,
  "summary_explanation": "100: Awesome!"
}
```
(The results are obviously super good because it's localhost).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1646)
<!-- Reviewable:end -->
