### PR TITLE
[consensus] separate block retrieval from round manager

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -4,13 +4,12 @@
 use crate::{
     block_storage::{BlockReader, BlockStore},
     logging::{LogEvent, LogSchema},
-    network::NetworkSender,
+    network::{IncomingBlockRetrievalRequest, NetworkSender},
     network_interface::ConsensusMsg,
     persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
     state_replication::StateComputer,
 };
 use anyhow::bail;
-
 use aptos_crypto::HashValue;
 use aptos_logger::prelude::*;
 use aptos_types::{
@@ -19,12 +18,14 @@ use aptos_types::{
 };
 use consensus_types::{
     block::Block,
-    block_retrieval::{BlockRetrievalRequest, BlockRetrievalStatus, MAX_BLOCKS_PER_REQUEST},
+    block_retrieval::{
+        BlockRetrievalRequest, BlockRetrievalResponse, BlockRetrievalStatus, MAX_BLOCKS_PER_REQUEST,
+    },
     common::Author,
     quorum_cert::QuorumCert,
     sync_info::SyncInfo,
 };
-
+use fail::fail_point;
 use rand::{prelude::*, Rng};
 use std::{clone::Clone, cmp::min, sync::Arc, time::Duration};
 
@@ -276,6 +277,50 @@ impl BlockStore {
         {
             network.notify_commit_proof(ledger_info.clone()).await
         }
+    }
+
+    /// Retrieve a n chained blocks from the block store starting from
+    /// an initial parent id, returning with <n (as many as possible) if
+    /// id or its ancestors can not be found.
+    ///
+    /// The current version of the function is not really async, but keeping it this way for
+    /// future possible changes.
+    pub async fn process_block_retrieval(
+        &self,
+        request: IncomingBlockRetrievalRequest,
+    ) -> anyhow::Result<()> {
+        fail_point!("consensus::process_block_retrieval", |_| {
+            Err(anyhow::anyhow!("Injected error in process_block_retrieval"))
+        });
+        let mut blocks = vec![];
+        let mut status = BlockRetrievalStatus::Succeeded;
+        let mut id = request.req.block_id();
+        while (blocks.len() as u64) < request.req.num_blocks() {
+            if let Some(executed_block) = self.get_block(id) {
+                blocks.push(executed_block.block().clone());
+                if request.req.match_target_id(id) {
+                    status = BlockRetrievalStatus::SucceededWithTarget;
+                    break;
+                }
+                id = executed_block.parent_id();
+            } else {
+                status = BlockRetrievalStatus::NotEnoughBlocks;
+                break;
+            }
+        }
+
+        if blocks.is_empty() {
+            status = BlockRetrievalStatus::IdNotFound;
+        }
+
+        let response = Box::new(BlockRetrievalResponse::new(status, blocks));
+        let response_bytes = request
+            .protocol
+            .to_bytes(&ConsensusMsg::BlockRetrievalResponse(response))?;
+        request
+            .response_sender
+            .send(Ok(response_bytes.into()))
+            .map_err(|e| anyhow::anyhow!("{:?}", e))
     }
 }
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -735,7 +735,7 @@ fn response_on_block_retrieval() {
             protocol: ProtocolId::ConsensusRpcBcs,
             response_sender: tx1,
         };
-        node.round_manager
+        node.block_store
             .process_block_retrieval(single_block_request)
             .await
             .unwrap();
@@ -759,7 +759,7 @@ fn response_on_block_retrieval() {
             response_sender: tx2,
         };
 
-        node.round_manager
+        node.block_store
             .process_block_retrieval(missing_block_request)
             .await
             .unwrap();
@@ -782,7 +782,7 @@ fn response_on_block_retrieval() {
             protocol: ProtocolId::ConsensusRpcBcs,
             response_sender: tx3,
         };
-        node.round_manager
+        node.block_store
             .process_block_retrieval(many_block_request)
             .await
             .unwrap();


### PR DESCRIPTION
Block retrieval is independent from the round manager logic and it's blocked by the single thread round manager (especially when it's awaiting mempool),
this commit splits it out to epoch manager.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1649)
<!-- Reviewable:end -->
