### PR TITLE
[storage] wrap state merkle rocksdb into StateMerkleDb

### DIFF
--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -55,7 +55,8 @@ impl RestoreHandler {
         expected_root_hash: HashValue,
     ) -> Result<StateSnapshotRestore<StateKey, StateValue>> {
         StateSnapshotRestore::new_overwrite(
-            Arc::clone(&self.state_store),
+            &self.state_store.state_merkle_db,
+            &self.state_store,
             version,
             expected_root_hash,
         )

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -24,6 +24,7 @@ mod event_store;
 mod ledger_counters;
 mod ledger_store;
 mod pruner;
+mod state_merkle_db;
 mod state_store;
 mod system_store;
 mod transaction_store;

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -1,0 +1,179 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::schema::jellyfish_merkle_node::JellyfishMerkleNodeSchema;
+use anyhow::Result;
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_jellyfish_merkle::{
+    node_type::NodeKey, JellyfishMerkleTree, TreeReader, TreeUpdateBatch, TreeWriter,
+};
+use aptos_types::{
+    nibble::{nibble_path::NibblePath, ROOT_NIBBLE_HEIGHT},
+    proof::{SparseMerkleProof, SparseMerkleRangeProof},
+    state_store::state_key::StateKey,
+    transaction::Version,
+};
+use schemadb::{SchemaBatch, DB};
+use std::{collections::HashMap, ops::Deref, sync::Arc};
+
+pub(crate) type LeafNode = aptos_jellyfish_merkle::node_type::LeafNode<StateKey>;
+pub(crate) type Node = aptos_jellyfish_merkle::node_type::Node<StateKey>;
+type NodeBatch = aptos_jellyfish_merkle::NodeBatch<StateKey>;
+
+#[derive(Debug)]
+pub struct StateMerkleDb(Arc<DB>);
+
+impl Deref for StateMerkleDb {
+    type Target = DB;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl StateMerkleDb {
+    pub fn new(state_merkle_rocksdb: Arc<DB>) -> Self {
+        Self(state_merkle_rocksdb)
+    }
+
+    pub fn get_with_proof(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<(Option<(HashValue, (StateKey, Version))>, SparseMerkleProof)> {
+        JellyfishMerkleTree::new(self).get_with_proof(state_key.hash(), version)
+    }
+
+    pub fn get_range_proof(
+        &self,
+        rightmost_key: HashValue,
+        version: Version,
+    ) -> Result<SparseMerkleRangeProof> {
+        JellyfishMerkleTree::new(self).get_range_proof(rightmost_key, version)
+    }
+
+    pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
+        JellyfishMerkleTree::new(self).get_root_hash(version)
+    }
+
+    pub fn get_leaf_count(&self, version: Version) -> Result<usize> {
+        JellyfishMerkleTree::new(self).get_leaf_count(version)
+    }
+
+    pub fn batch_put_value_set(
+        &self,
+        value_set: Vec<(HashValue, &(HashValue, StateKey))>,
+        node_hashes: Option<&HashMap<NibblePath, HashValue>>,
+        persisted_version: Option<Version>,
+        version: Version,
+    ) -> Result<(HashValue, TreeUpdateBatch<StateKey>)> {
+        JellyfishMerkleTree::new(self).batch_put_value_set(
+            value_set,
+            node_hashes,
+            persisted_version,
+            version,
+        )
+    }
+
+    /// Finds the rightmost leaf by scanning the entire DB.
+    #[cfg(test)]
+    pub fn get_rightmost_leaf_naive(&self) -> Result<Option<(NodeKey, LeafNode)>> {
+        let mut ret = None;
+
+        let mut iter = self.iter::<JellyfishMerkleNodeSchema>(Default::default())?;
+        iter.seek_to_first();
+
+        while let Some((node_key, node)) = iter.next().transpose()? {
+            if let Node::Leaf(leaf_node) = node {
+                match ret {
+                    None => ret = Some((node_key, leaf_node)),
+                    Some(ref other) => {
+                        if leaf_node.account_key() > other.1.account_key() {
+                            ret = Some((node_key, leaf_node));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ret)
+    }
+}
+
+impl TreeReader<StateKey> for StateMerkleDb {
+    fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
+        self.get::<JellyfishMerkleNodeSchema>(node_key)
+    }
+
+    fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>> {
+        // Since everything has the same version during restore, we seek to the first node and get
+        // its version.
+        let mut iter = self.iter::<JellyfishMerkleNodeSchema>(Default::default())?;
+        iter.seek_to_first();
+        let version = match iter.next().transpose()? {
+            Some((node_key, _node)) => node_key.version(),
+            None => return Ok(None),
+        };
+
+        // The encoding of key and value in DB looks like:
+        //
+        // | <-------------- key --------------> | <- value -> |
+        // | version | num_nibbles | nibble_path |    node     |
+        //
+        // Here version is fixed. For each num_nibbles, there could be a range of nibble paths
+        // of the same length. If one of them is the rightmost leaf R, it must be at the end of this
+        // range. Otherwise let's assume the R is in the middle of the range, so we
+        // call the node at the end of this range X:
+        //   1. If X is leaf, then X.account_key() > R.account_key(), because the nibble path is a
+        //      prefix of the account key. So R is not the rightmost leaf.
+        //   2. If X is internal node, then X must be on the right side of R, so all its children's
+        //      account keys are larger than R.account_key(). So R is not the rightmost leaf.
+        //
+        // Given that num_nibbles ranges from 0 to ROOT_NIBBLE_HEIGHT, there are only
+        // ROOT_NIBBLE_HEIGHT+1 ranges, so we can just find the node at the end of each range and
+        // then pick the one with the largest account key.
+        let mut ret = None;
+
+        for num_nibbles in 1..=ROOT_NIBBLE_HEIGHT + 1 {
+            let mut iter = self.iter::<JellyfishMerkleNodeSchema>(Default::default())?;
+            // nibble_path is always non-empty except for the root, so if we use an empty nibble
+            // path as the seek key, the iterator will end up pointing to the end of the previous
+            // range.
+            let seek_key = (version, num_nibbles as u8);
+            iter.seek_for_prev(&seek_key)?;
+
+            if let Some((node_key, node)) = iter.next().transpose()? {
+                debug_assert_eq!(node_key.version(), version);
+                debug_assert!(node_key.nibble_path().num_nibbles() < num_nibbles);
+
+                if let Node::Leaf(leaf_node) = node {
+                    match ret {
+                        None => ret = Some((node_key, leaf_node)),
+                        Some(ref other) => {
+                            if leaf_node.account_key() > other.1.account_key() {
+                                ret = Some((node_key, leaf_node));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(ret)
+    }
+}
+
+impl TreeWriter<StateKey> for StateMerkleDb {
+    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
+        let mut batch = SchemaBatch::new();
+        add_node_batch(&mut batch, node_batch.iter())?;
+        self.write_schemas(batch)
+    }
+}
+
+pub fn add_node_batch<'a>(
+    batch: &'a mut SchemaBatch,
+    mut node_batch: impl Iterator<Item = (&'a NodeKey, &'a Node)>,
+) -> Result<()> {
+    node_batch
+        .try_for_each(|(node_key, node)| batch.put::<JellyfishMerkleNodeSchema>(node_key, node))
+}

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -12,16 +12,17 @@ use crate::{
         jellyfish_merkle_node::JellyfishMerkleNodeSchema, stale_node_index::StaleNodeIndexSchema,
         state_value::StateValueSchema,
     },
+    state_merkle_db::{add_node_batch, StateMerkleDb},
     AptosDbError, OTHER_TIMERS_SECONDS,
 };
 use anyhow::{anyhow, ensure, format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{
     iterator::JellyfishMerkleIterator, node_type::NodeKey, restore::StateSnapshotRestore,
-    JellyfishMerkleTree, StateValueWriter, TreeReader, TreeWriter,
+    StateValueWriter,
 };
 use aptos_types::{
-    nibble::{nibble_path::NibblePath, ROOT_NIBBLE_HEIGHT},
+    nibble::nibble_path::NibblePath,
     proof::{SparseMerkleProof, SparseMerkleRangeProof},
     state_store::{
         state_key::StateKey,
@@ -34,9 +35,6 @@ use schemadb::{ReadOptions, SchemaBatch, DB};
 use std::{collections::HashMap, sync::Arc};
 use storage_interface::{DbReader, StateSnapshotReceiver};
 
-type LeafNode = aptos_jellyfish_merkle::node_type::LeafNode<StateKey>;
-type Node = aptos_jellyfish_merkle::node_type::Node<StateKey>;
-type NodeBatch = aptos_jellyfish_merkle::NodeBatch<StateKey>;
 type StateValueBatch = aptos_jellyfish_merkle::StateValueBatch<StateKey, StateValue>;
 
 pub const MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX: usize = 10_000;
@@ -44,7 +42,7 @@ pub const MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX: usize = 10_000;
 #[derive(Debug)]
 pub(crate) struct StateStore {
     ledger_db: Arc<DB>,
-    state_merkle_db: Arc<DB>,
+    pub state_merkle_db: Arc<StateMerkleDb>,
 }
 
 // "using an Arc<dyn DbReader> as an Arc<dyn StateReader>" is not allowed in stable Rust. Actually we
@@ -58,8 +56,7 @@ impl DbReader for StateStore {
         state_key: &StateKey,
         version: Version,
     ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
-        let (leaf_data, proof) =
-            JellyfishMerkleTree::new(self).get_with_proof(state_key.hash(), version)?;
+        let (leaf_data, proof) = self.state_merkle_db.get_with_proof(state_key, version)?;
         Ok((
             match leaf_data {
                 Some((_, (key, version))) => Some(self.expect_value_by_version(&key, version)?),
@@ -103,7 +100,7 @@ impl StateStore {
     pub fn new(ledger_db: Arc<DB>, state_merkle_db: Arc<DB>) -> Self {
         Self {
             ledger_db,
-            state_merkle_db,
+            state_merkle_db: Arc::new(StateMerkleDb::new(state_merkle_db)),
         }
     }
 
@@ -203,7 +200,7 @@ impl StateStore {
         rightmost_key: HashValue,
         version: Version,
     ) -> Result<SparseMerkleRangeProof> {
-        JellyfishMerkleTree::new(self).get_range_proof(rightmost_key, version)
+        self.state_merkle_db.get_range_proof(rightmost_key, version)
     }
 
     /// Put the `value_state_sets` into its own CF.
@@ -238,12 +235,8 @@ impl StateStore {
                 .with_label_values(&["jmt_update"])
                 .start_timer();
 
-            JellyfishMerkleTree::new(self).batch_put_value_set(
-                value_set,
-                node_hashes,
-                base_version,
-                version,
-            )
+            self.state_merkle_db
+                .batch_put_value_set(value_set, node_hashes, base_version, version)
         }?;
 
         let mut batch = SchemaBatch::new();
@@ -276,37 +269,11 @@ impl StateStore {
     }
 
     pub fn get_root_hash(&self, version: Version) -> Result<HashValue> {
-        JellyfishMerkleTree::new(self).get_root_hash(version)
-    }
-
-    /// Finds the rightmost leaf by scanning the entire DB.
-    #[cfg(test)]
-    pub fn get_rightmost_leaf_naive(&self) -> Result<Option<(NodeKey, LeafNode)>> {
-        let mut ret = None;
-
-        let mut iter = self
-            .state_merkle_db
-            .iter::<JellyfishMerkleNodeSchema>(Default::default())?;
-        iter.seek_to_first();
-
-        while let Some((node_key, node)) = iter.next().transpose()? {
-            if let Node::Leaf(leaf_node) = node {
-                match ret {
-                    None => ret = Some((node_key, leaf_node)),
-                    Some(ref other) => {
-                        if leaf_node.account_key() > other.1.account_key() {
-                            ret = Some((node_key, leaf_node));
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(ret)
+        self.state_merkle_db.get_root_hash(version)
     }
 
     pub fn get_value_count(&self, version: Version) -> Result<usize> {
-        JellyfishMerkleTree::new(self).get_leaf_count(version)
+        self.state_merkle_db.get_leaf_count(version)
     }
 
     pub fn get_state_key_and_value_iter(
@@ -315,16 +282,17 @@ impl StateStore {
         start_hashed_key: HashValue,
     ) -> Result<impl Iterator<Item = Result<(StateKey, StateValue)>> + Send + Sync> {
         let store = Arc::clone(self);
-        Ok(
-            JellyfishMerkleIterator::new(Arc::clone(self), version, start_hashed_key)?.map(
-                move |res| match res {
-                    Ok((_hashed_key, (key, version))) => {
-                        Ok((key.clone(), store.expect_value_by_version(&key, version)?))
-                    }
-                    Err(err) => Err(err),
-                },
-            ),
-        )
+        Ok(JellyfishMerkleIterator::new(
+            Arc::clone(&self.state_merkle_db),
+            version,
+            start_hashed_key,
+        )?
+        .map(move |res| match res {
+            Ok((_hashed_key, (key, version))) => {
+                Ok((key.clone(), store.expect_value_by_version(&key, version)?))
+            }
+            Err(err) => Err(err),
+        }))
     }
 
     pub fn get_value_chunk_with_proof(
@@ -333,9 +301,12 @@ impl StateStore {
         first_index: usize,
         chunk_size: usize,
     ) -> Result<StateValueChunkWithProof> {
-        let result_iter =
-            JellyfishMerkleIterator::new_by_index(Arc::clone(self), version, first_index)?
-                .take(chunk_size);
+        let result_iter = JellyfishMerkleIterator::new_by_index(
+            Arc::clone(&self.state_merkle_db),
+            version,
+            first_index,
+        )?
+        .take(chunk_size);
         let state_key_values: Vec<(StateKey, StateValue)> = result_iter
             .into_iter()
             .map(|res| {
@@ -371,86 +342,11 @@ impl StateStore {
         expected_root_hash: HashValue,
     ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
         Ok(Box::new(StateSnapshotRestore::new_overwrite(
-            Arc::clone(self),
+            &self.state_merkle_db,
+            self,
             version,
             expected_root_hash,
         )?))
-    }
-}
-
-impl TreeReader<StateKey> for StateStore {
-    fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node>> {
-        self.state_merkle_db
-            .get::<JellyfishMerkleNodeSchema>(node_key)
-    }
-
-    fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode)>> {
-        // Since everything has the same version during restore, we seek to the first node and get
-        // its version.
-        let mut iter = self
-            .state_merkle_db
-            .iter::<JellyfishMerkleNodeSchema>(Default::default())?;
-        iter.seek_to_first();
-        let version = match iter.next().transpose()? {
-            Some((node_key, _node)) => node_key.version(),
-            None => return Ok(None),
-        };
-
-        // The encoding of key and value in DB looks like:
-        //
-        // | <-------------- key --------------> | <- value -> |
-        // | version | num_nibbles | nibble_path |    node     |
-        //
-        // Here version is fixed. For each num_nibbles, there could be a range of nibble paths
-        // of the same length. If one of them is the rightmost leaf R, it must be at the end of this
-        // range. Otherwise let's assume the R is in the middle of the range, so we
-        // call the node at the end of this range X:
-        //   1. If X is leaf, then X.account_key() > R.account_key(), because the nibble path is a
-        //      prefix of the account key. So R is not the rightmost leaf.
-        //   2. If X is internal node, then X must be on the right side of R, so all its children's
-        //      account keys are larger than R.account_key(). So R is not the rightmost leaf.
-        //
-        // Given that num_nibbles ranges from 0 to ROOT_NIBBLE_HEIGHT, there are only
-        // ROOT_NIBBLE_HEIGHT+1 ranges, so we can just find the node at the end of each range and
-        // then pick the one with the largest account key.
-        let mut ret = None;
-
-        for num_nibbles in 1..=ROOT_NIBBLE_HEIGHT + 1 {
-            let mut iter = self
-                .state_merkle_db
-                .iter::<JellyfishMerkleNodeSchema>(Default::default())?;
-            // nibble_path is always non-empty except for the root, so if we use an empty nibble
-            // path as the seek key, the iterator will end up pointing to the end of the previous
-            // range.
-            let seek_key = (version, num_nibbles as u8);
-            iter.seek_for_prev(&seek_key)?;
-
-            if let Some((node_key, node)) = iter.next().transpose()? {
-                debug_assert_eq!(node_key.version(), version);
-                debug_assert!(node_key.nibble_path().num_nibbles() < num_nibbles);
-
-                if let Node::Leaf(leaf_node) = node {
-                    match ret {
-                        None => ret = Some((node_key, leaf_node)),
-                        Some(ref other) => {
-                            if leaf_node.account_key() > other.1.account_key() {
-                                ret = Some((node_key, leaf_node));
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(ret)
-    }
-}
-
-impl TreeWriter<StateKey> for StateStore {
-    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
-        let mut batch = SchemaBatch::new();
-        add_node_batch(&mut batch, node_batch.iter())?;
-        self.state_merkle_db.write_schemas(batch)
     }
 }
 
@@ -460,14 +356,6 @@ impl StateValueWriter<StateKey, StateValue> for StateStore {
         add_kv_batch(&mut batch, node_batch)?;
         self.ledger_db.write_schemas(batch)
     }
-}
-
-fn add_node_batch<'a>(
-    batch: &'a mut SchemaBatch,
-    mut node_batch: impl Iterator<Item = (&'a NodeKey, &'a Node)>,
-) -> Result<()> {
-    node_batch
-        .try_for_each(|(node_key, node)| batch.put::<JellyfishMerkleNodeSchema>(node_key, node))
 }
 
 fn add_kv_batch(batch: &mut SchemaBatch, kv_batch: &StateValueBatch) -> Result<()> {

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -8,7 +8,7 @@ use proptest::{
     prelude::*,
 };
 
-use aptos_jellyfish_merkle::restore::StateSnapshotRestore;
+use aptos_jellyfish_merkle::{restore::StateSnapshotRestore, TreeReader};
 use aptos_temppath::TempPath;
 use aptos_types::{
     access_path::AccessPath, account_address::AccountAddress, state_store::state_key::StateKeyTag,
@@ -409,7 +409,7 @@ proptest! {
         let store2 = &db2.state_store;
 
         let mut restore =
-            StateSnapshotRestore::new(Arc::clone(store2), version, expected_root_hash).unwrap();
+            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash).unwrap();
 
         let mut ordered_input: Vec<_> = input
             .into_iter()
@@ -507,7 +507,7 @@ proptest! {
         let store2 = &db2.state_store;
 
         let mut restore =
-            StateSnapshotRestore::new(Arc::clone(store2), version, expected_root_hash).unwrap();
+            StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash).unwrap();
 
         let mut ordered_input: Vec<_> = input
             .into_iter()
@@ -525,8 +525,8 @@ proptest! {
 
         restore.add_chunk(batch1, proof_of_batch1).unwrap();
 
-        let expected = store2.get_rightmost_leaf_naive().unwrap();
-        let actual = store2.get_rightmost_leaf().unwrap();
+        let expected = store2.state_merkle_db.get_rightmost_leaf_naive().unwrap();
+        let actual = store2.state_merkle_db.get_rightmost_leaf().unwrap();
         prop_assert_eq!(actual, expected);
     }
 

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -143,11 +143,15 @@ impl RestoreRunMode {
             Self::Restore { restore_handler } => {
                 restore_handler.get_state_restore_receiver(version, expected_root_hash)
             }
-            Self::Verify => StateSnapshotRestore::new_overwrite(
-                Arc::new(MockStore),
-                version,
-                expected_root_hash,
-            ),
+            Self::Verify => {
+                let mock_store = Arc::new(MockStore);
+                StateSnapshotRestore::new_overwrite(
+                    &mock_store,
+                    &mock_store,
+                    version,
+                    expected_root_hash,
+                )
+            }
         }
     }
 }

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -708,33 +708,35 @@ pub struct StateSnapshotRestore<K, V> {
 }
 
 impl<K: crate::Key + CryptoHash + Hash + Eq, V: crate::Value> StateSnapshotRestore<K, V> {
-    pub fn new<D: 'static + TreeReader<K> + TreeWriter<K> + StateValueWriter<K, V>>(
-        store: Arc<D>,
+    pub fn new<T: 'static + TreeReader<K> + TreeWriter<K>, S: 'static + StateValueWriter<K, V>>(
+        tree_store: &Arc<T>,
+        value_store: &Arc<S>,
         version: Version,
         expected_root_hash: HashValue,
     ) -> Result<Self> {
         Ok(Self {
             tree_restore: JellyfishMerkleRestore::new(
-                Arc::clone(&store),
+                Arc::clone(tree_store),
                 version,
                 expected_root_hash,
             )?,
-            kv_restore: StateValueRestore::new(store, version),
+            kv_restore: StateValueRestore::new(Arc::clone(value_store), version),
         })
     }
 
-    pub fn new_overwrite<D: 'static + TreeWriter<K> + StateValueWriter<K, V>>(
-        store: Arc<D>,
+    pub fn new_overwrite<T: 'static + TreeWriter<K>, S: 'static + StateValueWriter<K, V>>(
+        tree_store: &Arc<T>,
+        value_store: &Arc<S>,
         version: Version,
         expected_root_hash: HashValue,
     ) -> Result<Self> {
         Ok(Self {
             tree_restore: JellyfishMerkleRestore::new_overwrite(
-                Arc::clone(&store),
+                Arc::clone(tree_store),
                 version,
                 expected_root_hash,
             )?,
-            kv_restore: StateValueRestore::new(store, version),
+            kv_restore: StateValueRestore::new(Arc::clone(value_store), version),
         })
     }
 }

--- a/storage/jellyfish-merkle/src/restore/restore_test.rs
+++ b/storage/jellyfish-merkle/src/restore/restore_test.rs
@@ -136,7 +136,7 @@ proptest! {
         let restore_db = Arc::new(MockSnapshotStore::default());
         {
             let mut restore =
-                StateSnapshotRestore::new(Arc::clone(&restore_db), version, expected_root_hash ).unwrap();
+                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash ).unwrap();
             let proof = tree
                 .get_range_proof(batch1.last().map(|(key, _value)| *key).unwrap(), version)
                 .unwrap();
@@ -159,7 +159,7 @@ proptest! {
                 .collect();
 
             let mut restore =
-                StateSnapshotRestore::new(Arc::clone(&restore_db), version, expected_root_hash).unwrap();
+                StateSnapshotRestore::new(&restore_db, &restore_db,  version, expected_root_hash ).unwrap();
             let proof = tree
                 .get_range_proof(
                     remaining_accounts.last().map(|(h, _)| *h).unwrap(),
@@ -231,11 +231,11 @@ fn restore_without_interruption<V>(
     let expected_root_hash = tree.get_root_hash(source_version).unwrap();
 
     let mut restore = if try_resume {
-        StateSnapshotRestore::new(Arc::clone(target_db), target_version, expected_root_hash)
-            .unwrap()
+        StateSnapshotRestore::new(target_db, target_db, target_version, expected_root_hash).unwrap()
     } else {
         StateSnapshotRestore::new_overwrite(
-            Arc::clone(target_db),
+            target_db,
+            target_db,
             target_version,
             expected_root_hash,
         )


### PR DESCRIPTION
### Description
We wrap the state_merkle_db into its own type and implement `TreeReader` and `TreeWriter` on top of it to follow principle of least knowledge. Also, it helps us to read merkle nodes without constructing a state_store upfront ( I need this for constructing a state_store with InMemState)

`ledger_db` should be wrapped in its own struct too. But due to time limit, leave it as it is for now.

### Test Plan
ut

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1650)
<!-- Reviewable:end -->
