### PR TITLE
[storage] make rocksdb configs separate for ledger_db and state_merkl…

### DIFF
--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -3,7 +3,7 @@
 
 use crate::AptosValidatorInterface;
 use anyhow::{anyhow, Result};
-use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_types::{
     account_address::AccountAddress,
     account_state::AccountState,
@@ -24,7 +24,7 @@ impl DBDebuggerInterface {
             db_root_path,
             true,
             NO_OP_STORAGE_PRUNER_CONFIG,
-            RocksdbConfig::default(),
+            RocksdbConfigs::default(),
         )?)))
     }
 }

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -445,7 +445,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
             &node_config.storage.dir(),
             false, /* readonly */
             node_config.storage.storage_pruner_config,
-            node_config.storage.rocksdb_config,
+            node_config.storage.rocksdb_configs,
         )
         .expect("DB should open."),
     );

--- a/config/management/genesis/src/verify.rs
+++ b/config/management/genesis/src/verify.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_global_constants::{
     CONSENSUS_KEY, FULLNODE_NETWORK_KEY, OPERATOR_ACCOUNT, OPERATOR_KEY, OWNER_ACCOUNT, OWNER_KEY,
     SAFETY_DATA, VALIDATOR_NETWORK_KEY, WAYPOINT,
@@ -213,7 +213,7 @@ fn compute_genesis(
         db_path,
         false,
         NO_OP_STORAGE_PRUNER_CONFIG,
-        RocksdbConfig::default(),
+        RocksdbConfigs::default(),
     )
     .map_err(|e| Error::UnexpectedError(e.to_string()))?;
     let db_rw = DbReaderWriter::new(aptosdb);

--- a/config/management/genesis/src/waypoint.rs
+++ b/config/management/genesis/src/waypoint.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_management::{config::ConfigPath, error::Error, secure_backend::SharedBackend};
 use aptos_temppath::TempPath;
 use aptos_types::{chain_id::ChainId, transaction::Transaction, waypoint::Waypoint};
@@ -44,7 +44,7 @@ pub fn create_genesis_waypoint(genesis: &Transaction) -> Result<Waypoint, Error>
         &path,
         false,
         NO_OP_STORAGE_PRUNER_CONFIG,
-        RocksdbConfig::default(),
+        RocksdbConfigs::default(),
     )
     .map_err(|e| Error::UnexpectedError(e.to_string()))?;
     let db_rw = DbReaderWriter::new(aptosdb);

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -11,7 +11,7 @@ pub mod keys;
 pub mod test_utils;
 
 use crate::config::ValidatorConfiguration;
-use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_crypto::ed25519::Ed25519PublicKey;
 use aptos_temppath::TempPath;
 use aptos_types::{chain_id::ChainId, transaction::Transaction, waypoint::Waypoint};
@@ -121,7 +121,7 @@ impl GenesisInfo {
             &path,
             false,
             NO_OP_STORAGE_PRUNER_CONFIG,
-            RocksdbConfig::default(),
+            RocksdbConfigs::default(),
         )?;
         let db_rw = DbReaderWriter::new(aptosdb);
         executor::db_bootstrapper::generate_waypoint::<AptosVM>(&db_rw, genesis)

--- a/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{ensure, format_err, Context, Result};
-use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Transaction, waypoint::Waypoint};
 use aptos_vm::AptosVM;
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
             &opt.db_dir,
             false,
             NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
-            RocksdbConfig::default(),
+            RocksdbConfigs::default(),
         )
     } else {
         // When not committing, we open the DB as secondary so the tool is usable along side a
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
             opt.db_dir.as_path(),
             &tmpdir.as_ref().to_path_buf().join(LEDGER_DB_NAME),
             &tmpdir.as_ref().to_path_buf().join(STATE_MERKLE_DB_NAME),
-            RocksdbConfig::default(),
+            RocksdbConfigs::default(),
         )
     }
     .with_context(|| format_err!("Failed to open DB."))?;

--- a/execution/executor-benchmark/src/db_generator.rs
+++ b/execution/executor-benchmark/src/db_generator.rs
@@ -3,7 +3,7 @@
 
 use crate::{transaction_generator::TransactionGenerator, Pipeline};
 use aptos_config::{
-    config::{RocksdbConfig, StoragePrunerConfig},
+    config::{RocksdbConfigs, StoragePrunerConfig},
     utils::get_genesis_txn,
 };
 use aptos_jellyfish_merkle::metrics::{
@@ -37,12 +37,14 @@ pub fn run(
 
     let (config, genesis_key) = aptos_genesis::test_utils::test_config();
     // Create executor.
+    let mut rocksdb_configs = RocksdbConfigs::default();
+    rocksdb_configs.state_merkle_db_config.max_open_files = -1;
     let (db, db_rw) = DbReaderWriter::wrap(
         AptosDB::open(
             &db_dir,
             false,                 /* readonly */
             storage_pruner_config, /* pruner */
-            RocksdbConfig::default(),
+            rocksdb_configs,
         )
         .expect("DB should open."),
     );

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -14,7 +14,7 @@ use crate::{
     transaction_generator::TransactionGenerator,
 };
 use aptos_config::config::{
-    NodeConfig, RocksdbConfig, StoragePrunerConfig, NO_OP_STORAGE_PRUNER_CONFIG,
+    NodeConfig, RocksdbConfigs, StoragePrunerConfig, NO_OP_STORAGE_PRUNER_CONFIG,
 };
 
 use crate::{pipeline::Pipeline, state_committer::StateCommitter};
@@ -30,7 +30,7 @@ pub fn init_db_and_executor(config: &NodeConfig) -> (DbReaderWriter, BlockExecut
             &config.storage.dir(),
             false,                       /* readonly */
             NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
-            RocksdbConfig::default(),
+            RocksdbConfigs::default(),
         )
         .expect("DB should open."),
     );
@@ -59,7 +59,7 @@ pub fn run_benchmark(
         &source_dir,
         true,                        /* readonly */
         NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
-        RocksdbConfig::default(),
+        RocksdbConfigs::default(),
     )
     .expect("db open failure.")
     .create_checkpoint(checkpoint_dir.as_ref())

--- a/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
@@ -165,7 +165,7 @@ pub fn state_sync_v1_network_config() -> AppConfig {
 mod tests {
     use crate::StateSyncMultiplexer;
     use aptos_config::{
-        config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG},
+        config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG},
         utils::get_genesis_txn,
     };
     use aptos_crypto::HashValue;
@@ -200,7 +200,7 @@ mod tests {
             &tmp_dir,
             false,
             NO_OP_STORAGE_PRUNER_CONFIG,
-            RocksdbConfig::default(),
+            RocksdbConfigs::default(),
         )
         .unwrap();
         let (_, db_rw) = DbReaderWriter::wrap(db);

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -40,10 +40,15 @@ pub(super) fn state_merkle_db_column_families() -> Vec<ColumnFamilyName> {
     ]
 }
 
-pub(super) fn gen_rocksdb_options(config: &RocksdbConfig) -> Options {
+pub(super) fn gen_rocksdb_options(config: &RocksdbConfig, readonly: bool) -> Options {
     let mut db_opts = Options::default();
     db_opts.set_max_open_files(config.max_open_files);
     db_opts.set_max_total_wal_size(config.max_total_wal_size);
+    if !readonly {
+        db_opts.create_if_missing(true);
+        db_opts.create_missing_column_families(true);
+    }
+
     db_opts
 }
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -53,7 +53,7 @@ use crate::{
     transaction_store::TransactionStore,
 };
 use anyhow::{ensure, Result};
-use aptos_config::config::{RocksdbConfig, StoragePrunerConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{RocksdbConfigs, StoragePrunerConfig, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_crypto::hash::{HashValue, SPARSE_MERKLE_PLACEHOLDER_HASH};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
@@ -303,7 +303,7 @@ impl AptosDB {
         db_root_path: P,
         readonly: bool,
         storage_pruner_config: StoragePrunerConfig,
-        rocksdb_config: RocksdbConfig,
+        rocksdb_configs: RocksdbConfigs,
     ) -> Result<Self> {
         ensure!(
             storage_pruner_config.eq(&NO_OP_STORAGE_PRUNER_CONFIG) || !readonly,
@@ -314,35 +314,31 @@ impl AptosDB {
         let state_merkle_db_path = db_root_path.as_ref().join(STATE_MERKLE_DB_NAME);
         let instant = Instant::now();
 
-        let mut db_opts = gen_rocksdb_options(&rocksdb_config);
-
         let (ledger_db, state_merkle_db) = if readonly {
             (
                 DB::open_cf_readonly(
-                    &db_opts,
+                    &gen_rocksdb_options(&rocksdb_configs.ledger_db_config, true),
                     ledger_db_path.clone(),
                     "ledger_db_ro",
                     ledger_db_column_families(),
                 )?,
                 DB::open_cf_readonly(
-                    &db_opts,
+                    &gen_rocksdb_options(&rocksdb_configs.state_merkle_db_config, true),
                     state_merkle_db_path.clone(),
                     "state_merkle_db_ro",
                     state_merkle_db_column_families(),
                 )?,
             )
         } else {
-            db_opts.create_if_missing(true);
-            db_opts.create_missing_column_families(true);
             (
                 DB::open_cf(
-                    &db_opts,
+                    &gen_rocksdb_options(&rocksdb_configs.ledger_db_config, false),
                     ledger_db_path.clone(),
                     "ledger_db",
                     gen_ledger_cfds(),
                 )?,
                 DB::open_cf(
-                    &db_opts,
+                    &gen_rocksdb_options(&rocksdb_configs.state_merkle_db_config, false),
                     state_merkle_db_path.clone(),
                     "state_merkle_db",
                     gen_state_merkle_cfds(),
@@ -364,7 +360,7 @@ impl AptosDB {
         db_root_path: P,
         ledger_db_secondary_path: P,
         state_merkle_db_secondary_path: P,
-        mut rocksdb_config: RocksdbConfig,
+        mut rocksdb_configs: RocksdbConfigs,
     ) -> Result<Self> {
         let ledger_db_primary_path = db_root_path.as_ref().join(LEDGER_DB_NAME);
         let ledger_db_secondary_path = ledger_db_secondary_path.as_ref().to_path_buf();
@@ -372,19 +368,19 @@ impl AptosDB {
         let state_merkle_db_secondary_path = state_merkle_db_secondary_path.as_ref().to_path_buf();
 
         // Secondary needs `max_open_files = -1` per https://github.com/facebook/rocksdb/wiki/Secondary-instance
-        rocksdb_config.max_open_files = -1;
-        let db_opts = gen_rocksdb_options(&rocksdb_config);
+        rocksdb_configs.ledger_db_config.max_open_files = -1;
+        rocksdb_configs.state_merkle_db_config.max_open_files = -1;
 
         Ok(Self::new_with_dbs(
             DB::open_cf_as_secondary(
-                &db_opts,
+                &gen_rocksdb_options(&rocksdb_configs.ledger_db_config, false),
                 ledger_db_primary_path,
                 ledger_db_secondary_path,
                 "ledgerdb_sec",
                 ledger_db_column_families(),
             )?,
             DB::open_cf_as_secondary(
-                &db_opts,
+                &gen_rocksdb_options(&rocksdb_configs.state_merkle_db_config, false),
                 state_merkle_db_primary_path,
                 state_merkle_db_secondary_path,
                 "state_merkle_db_sec",
@@ -401,7 +397,7 @@ impl AptosDB {
             db_root_path,
             false,                       /* readonly */
             NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
-            RocksdbConfig::default(),
+            RocksdbConfigs::default(),
         )
         .expect("Unable to open AptosDB")
     }

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod stream;
 pub mod test_utils;
 
 use anyhow::{anyhow, Result};
-use aptos_config::config::{RocksdbConfig, NO_OP_STORAGE_PRUNER_CONFIG};
+use aptos_config::config::{RocksdbConfig, RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG};
 use aptos_crypto::HashValue;
 use aptos_infallible::duration_since_epoch;
 use aptos_jellyfish_merkle::{
@@ -46,20 +46,27 @@ pub struct GlobalBackupOpt {
 
 #[derive(Clone, StructOpt)]
 pub struct RocksdbOpt {
-    // using a smaller value than a node since we don't care much about reading performance
-    // in this tool.
-    #[structopt(long, default_value = "1000")]
-    max_open_files: i32,
-    // using the same default with a node (1GB).
-    #[structopt(long, default_value = "1073741824")]
-    max_total_wal_size: u64,
+    #[structopt(long, default_value = "5000")]
+    ledger_db_max_open_files: i32,
+    #[structopt(long, default_value = "1073741824")] // 1GB
+    ledger_db_max_total_wal_size: u64,
+    #[structopt(long, default_value = "5000")]
+    state_merkle_db_max_open_files: i32,
+    #[structopt(long, default_value = "1073741824")] // 1GB
+    state_merkle_db_max_total_wal_size: u64,
 }
 
-impl From<RocksdbOpt> for RocksdbConfig {
+impl From<RocksdbOpt> for RocksdbConfigs {
     fn from(opt: RocksdbOpt) -> Self {
         Self {
-            max_open_files: opt.max_open_files,
-            max_total_wal_size: opt.max_total_wal_size,
+            ledger_db_config: RocksdbConfig {
+                max_open_files: opt.ledger_db_max_open_files,
+                max_total_wal_size: opt.ledger_db_max_total_wal_size,
+            },
+            state_merkle_db_config: RocksdbConfig {
+                max_open_files: opt.state_merkle_db_max_open_files,
+                max_total_wal_size: opt.state_merkle_db_max_total_wal_size,
+            },
         }
     }
 }


### PR DESCRIPTION
…e_db


### Description
The state tree needs way more files to be open while the db is large.

### Test Plan
setting max_open_files to -1 (unlimited), on 32 core 128GB test machine I was able to create a 100M accounts DB in < 3.5 hours (compared to > 4.5 hours while max_open_files = 10k)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1661)
<!-- Reviewable:end -->
