### PR TITLE
[aptos-cli] Update CLI version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "aptos-config",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -141,6 +141,7 @@ impl CliTestFramework {
             profile_options: profile(index),
             prompt_options: PromptOptions::yes(),
             encoding_options: EncodingOptions::default(),
+            skip_faucet: false,
         }
         .execute()
         .await


### PR DESCRIPTION
### Description
To match documentation and descriptions, let's launch a new version (which might not work with devnet at this point)

Additionally, allow for no faucet in init.

### Test Plan
```
$ cargo run -p aptos -- --version
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/aptos --version`
aptos 0.2.0

cargo run -p aptos -- init --profile ait2 --private-key XXXXXXX --rest-url http://sherryx.aptosdev.com --skip-faucet --assume-yes
Configuring for profile ait2
Using command line argument for rest URL http://sherryx.aptosdev.com/
Not configuring a faucet because --skip-faucet was provided
Using command line argument for private key
Aptos is now set up for account XXXXXX!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1666)
<!-- Reviewable:end -->
