### PR TITLE
[NHC] Fix listen address behavior for 80

### DIFF
--- a/ecosystem/node-checker/src/server/generate_openapi.rs
+++ b/ecosystem/node-checker/src/server/generate_openapi.rs
@@ -37,11 +37,7 @@ pub async fn generate_openapi(args: GenerateOpenapi) -> Result<()> {
         allow_preconfigured_test_node_only: false,
     };
 
-    let api_service = build_openapi_service(
-        api,
-        args.server_args.listen_address.clone(),
-        &args.server_args.api_path,
-    );
+    let api_service = build_openapi_service(api, args.server_args.clone());
 
     let spec = match args.output_args.format {
         OutputFormat::Json => api_service.spec(),

--- a/ecosystem/node-checker/src/server/run.rs
+++ b/ecosystem/node-checker/src/server/run.rs
@@ -92,26 +92,14 @@ pub async fn run(args: Run) -> Result<()> {
     };
 
     let api_endpoint = format!("/{}", args.server_args.api_path);
-    let api_service = build_openapi_service(
-        api,
-        args.server_args.listen_address.clone(),
-        &args.server_args.api_path,
-    );
+    let api_service = build_openapi_service(api, args.server_args.clone());
     let ui = api_service.swagger_ui();
     let spec_json = api_service.spec_endpoint();
     let spec_yaml = api_service.spec_endpoint_yaml();
 
     Server::new(TcpListener::bind((
-        args.server_args
-            .listen_address
-            .host_str()
-            .with_context(|| {
-                format!(
-                    "Failed to pull host from {}",
-                    args.server_args.listen_address
-                )
-            })?,
-        args.server_args.listen_address.port().unwrap(),
+        args.server_args.listen_address,
+        args.server_args.listen_port,
     )))
     .run(
         Route::new()


### PR DESCRIPTION
## Description
Turns out the `url` crate handles 80 differently (https://github.com/servo/rust-url/issues/28), which meant the way I was dealing with ports wasn't correct. This PR fixes that.

## Test Plan
```
cargo run --release -- server run --baseline-node-config-paths /tmp/eh.yaml --listen-address 0.0.0.0 --listen-port 80
```
```
curl localhost/get_configuration_keys
```
Previously this second command would fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1677)
<!-- Reviewable:end -->
