### PR TITLE
fix: get rid of "natual" calls

### DIFF
--- a/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
@@ -46,7 +46,7 @@ const {
   // TS SDK support 3 types of transaction payloads: `ScriptFunction`, `Script` and `Module`.
   // See https://aptos-labs.github.io/ts-sdk-doc/ for the details.
   const scriptFunctionPayload = new TransactionPayloadScriptFunction(
-    ScriptFunction.natual(
+    ScriptFunction.natural(
       // Fully qualified module name, `AccountAddress::ModuleName`
       '0x1::Coin',
       // Module function

--- a/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
@@ -61,7 +61,7 @@ type SigningMessage = TxnBuilderTypes.SigningMessage;
   // TS SDK support 3 types of transaction payloads: `ScriptFunction`, `Script` and `Module`.
   // See https://aptos-labs.github.io/ts-sdk-doc/ for the details.
   const scriptFunctionPayload = new TxnBuilderTypes.TransactionPayloadScriptFunction(
-    TxnBuilderTypes.ScriptFunction.natual(
+    TxnBuilderTypes.ScriptFunction.natural(
       // Fully qualified module name, `AccountAddress::ModuleName`
       '0x1::Coin',
       // Module function

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -309,7 +309,7 @@ test(
 
     const token = new TxnBuilderTypes.TypeTagStruct(TxnBuilderTypes.StructTag.fromString('0x1::TestCoin::TestCoin'));
     const scriptFunctionPayload = new TxnBuilderTypes.TransactionPayloadScriptFunction(
-      TxnBuilderTypes.ScriptFunction.natual(
+      TxnBuilderTypes.ScriptFunction.natural(
         '0x1::Coin',
         'transfer',
         [token],
@@ -399,7 +399,7 @@ test(
     expect(aliceBalance.value).toBe('1');
 
     const scriptFunctionPayload = new TxnBuilderTypes.TransactionPayloadScriptFunction(
-      TxnBuilderTypes.ScriptFunction.natual(
+      TxnBuilderTypes.ScriptFunction.natural(
         '0x1::Token',
         'direct_transfer_script',
         [],


### PR DESCRIPTION
### Description
Get rid of deprecated "natual"

### Test Plan
yarn test to make sure nothing broken
