### PR TITLE
[txn-emitter] Make transaction emitter resilient against few end points failure

### DIFF
--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -14,7 +14,6 @@ use aptos_sdk::{
     move_types::account_address::AccountAddress,
     types::{account_config::aptos_root_address, chain_id::ChainId, AccountKey, LocalAccount},
 };
-use futures::executor;
 use futures::executor::block_on;
 use rand::seq::SliceRandom;
 use std::convert::TryFrom;


### PR DESCRIPTION
### Description

In load testing I found that if few rest end points are not available, the transaction emitter just fails - this PR is going to take care of that. Instead of failing, we just ignore these end points in the emitter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1680)
<!-- Reviewable:end -->
