### PR TITLE
[NHC] Add support for repeating target in TPS test

### DIFF
--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -11,13 +11,15 @@ use anyhow::{Context, Result};
 use aptos_sdk::transaction_builder::TransactionFactory;
 use rand::{rngs::StdRng, Rng};
 use rand_core::{OsRng, SeedableRng};
-use std::{cmp::min, convert::TryFrom, time::Duration};
+use std::{cmp::min, time::Duration};
 
 pub async fn emit_transactions(
     cluster_args: &ClusterArgs,
     emit_args: &EmitArgs,
 ) -> Result<TxnStats> {
-    let cluster = Cluster::try_from(cluster_args).context("Failed to build cluster")?;
+    let cluster = Cluster::try_from_cluster_args(cluster_args)
+        .await
+        .context("Failed to build cluster")?;
     emit_transactions_with_cluster(&cluster, emit_args, cluster_args.vasp).await
 }
 

--- a/crates/transaction-emitter/src/main.rs
+++ b/crates/transaction-emitter/src/main.rs
@@ -7,7 +7,7 @@ use ::aptos_logger::{Level, Logger};
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use diag::diag;
-use std::{convert::TryFrom, time::Duration};
+use std::time::Duration;
 use transaction_emitter_lib::{emit_transactions, Cluster, ClusterArgs, EmitArgs};
 
 #[derive(Parser, Debug)]
@@ -63,8 +63,9 @@ pub async fn main() -> Result<()> {
             Ok(())
         }
         TxnEmitterCommand::Diag(args) => {
-            let cluster =
-                Cluster::try_from(&args.cluster_args).context("Failed to build cluster")?;
+            let cluster = Cluster::try_from_cluster_args(&args.cluster_args)
+                .await
+                .context("Failed to build cluster")?;
             diag(&cluster).await.context("Diag failed")?;
             Ok(())
         }

--- a/ecosystem/node-checker/src/main.rs
+++ b/ecosystem/node-checker/src/main.rs
@@ -32,6 +32,10 @@ pub struct RootArgs {
 async fn main() -> Result<()> {
     let root_args = RootArgs::parse();
 
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
     let command = root_args.command;
     let result: Result<()> = match command {
         Command::Server(args) => server::run_cmd(args).await,

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -17,7 +17,7 @@ use crate::{
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use clap::Parser;
-use log::debug;
+use log::{debug, info};
 use poem_openapi::Object as PoemObject;
 use prometheus_parse::Scrape as PrometheusScrape;
 use serde::{Deserialize, Serialize};
@@ -86,6 +86,8 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
         target_node_address: &NodeAddress,
         target_metric_collector: &T,
     ) -> Result<EvaluationSummary, RunnerError> {
+        info!("Running evaluation for {}", target_node_address.url);
+
         let direct_evaluator_input = DirectEvaluatorInput {
             baseline_node_information: self.baseline_node_information.clone(),
             target_node_address: target_node_address.clone(),


### PR DESCRIPTION
## Description
This is a quick fix to enhance the throughput of the transaction emitter. Long term we should refactor to make it easier to configure throughput and consider sending requests without waiting for the response.

I also change the cluster stuff to not use `block_on`, it doesn't play nicely when you're already in an async context.

## Test Plan
```
$ cargo run -- configuration create --configuration-name ait2_registration --configuration-name-pretty "AIT2 Registration" --url http://<IP> --evaluators consensus_proposals,performance_tps,performance_latency --mint-key <key> --duration 3 --accounts-per-client 3 --workers-per-ac 4 --wait-millis 8 --burst --api-port 80 > /tmp/ait2_registration.yaml
```
```
curl 'localhost:20121/check_node?node_url=http://dport.me&baseline_configuration_name=ait2_registration' | jq .
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1683)
<!-- Reviewable:end -->
