### PR TITLE
[storage][state_store] Fix e2e test after removing PRE_GENESIS_VERSION

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -14,7 +14,6 @@ use crate::{
     },
 };
 use aptos_temppath::TempPath;
-use aptos_types::transaction::PRE_GENESIS_VERSION;
 use aptosdb::AptosDB;
 use std::{convert::TryInto, sync::Arc};
 use storage_interface::DbReader;
@@ -57,7 +56,7 @@ fn end_to_end() {
         StateSnapshotRestoreController::new(
             StateSnapshotRestoreOpt {
                 manifest_handle,
-                version: PRE_GENESIS_VERSION,
+                version,
             },
             GlobalRestoreOpt {
                 dry_run: false,
@@ -79,9 +78,10 @@ fn end_to_end() {
     let tgt_db = AptosDB::new_for_test(&tgt_db_dir);
     assert_eq!(
         tgt_db
-            .get_latest_tree_state()
+            .get_latest_state_checkpoint()
             .unwrap()
-            .state_checkpoint_hash,
+            .map(|(_, hash)| hash)
+            .unwrap(),
         state_root_hash,
     );
 


### PR DESCRIPTION
### Description
Fix a test failure after removing PRE_GENESIS_VERSION in state_store
The test failed because 
in this function call 
```
tgt_db.get_latest_tree_state()
```
https://github.com/aptos-labs/aptos-core/blob/88d2fc2acf8180ad285568712e224c806b4551f3/storage/aptosdb/src/lib.rs#L1129 returns `None` because the recovered db doesn't have txn infos. We need to call a different API to the the root hash at that version.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
UT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1688)
<!-- Reviewable:end -->
