### PR TITLE
[storage][jellyfish_merkle_tree] Remove PRE_GENESIS test

### DIFF
--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -8,7 +8,7 @@ use crate::test_helper::{
     test_get_with_proof_with_distinct_last_nibble, ValueBlob,
 };
 use aptos_crypto::HashValue;
-use aptos_types::{nibble::Nibble, transaction::PRE_GENESIS_VERSION};
+use aptos_types::nibble::Nibble;
 use mock_tree_store::MockTreeStore;
 use proptest::{collection::hash_set, prelude::*};
 use rand::{rngs::StdRng, Rng, SeedableRng};
@@ -54,45 +54,6 @@ fn test_insert_to_empty_tree() {
     db.write_tree_update_batch(batch).unwrap();
 
     assert_eq!(tree.get(key, 0).unwrap().unwrap(), value_hash);
-}
-
-#[test]
-fn test_insert_to_pre_genesis() {
-    // Set up DB with pre-genesis state (one single leaf node).
-    let db = MockTreeStore::default();
-    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
-    let value1 = gen_value();
-    let pre_genesis_root_key = NodeKey::new_empty_path(PRE_GENESIS_VERSION);
-    db.put_node(
-        pre_genesis_root_key,
-        gen_leaf(key1, &value1, PRE_GENESIS_VERSION),
-    )
-    .unwrap();
-
-    // Genesis inserts one more leaf.
-    let tree = JellyfishMerkleTree::new(&db);
-    let key2 = update_nibble(&key1, 0, 15);
-    let value2 = gen_value();
-    // batch version
-    let (_root_hash, batch) = tree
-        .batch_put_value_set(
-            vec![(key2, &value2)],
-            None,
-            Some(PRE_GENESIS_VERSION),
-            0, /* version */
-        )
-        .unwrap();
-
-    // Check pre-genesis node prunes okay.
-    assert_eq!(batch.stale_node_index_batch.len(), 1);
-    db.write_tree_update_batch(batch).unwrap();
-    assert_eq!(db.num_nodes(), 4);
-    db.purge_stale_nodes(0).unwrap();
-    assert_eq!(db.num_nodes(), 3);
-
-    // Check mixed state reads okay.
-    assert_eq!(tree.get(key1, 0).unwrap().unwrap(), value1.0);
-    assert_eq!(tree.get(key2, 0).unwrap().unwrap(), value2.0);
 }
 
 #[test]


### PR DESCRIPTION
### Description
Remove the pre_genesis UT. This UT is not broken after other pre_genesis changes because  `JellyfishMerkleTree` does not really enforces any invariants on the version numbers. Smaller versions can base on large versions.
### Test Plan
UTs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1689)
<!-- Reviewable:end -->
