### PR TITLE
[txn-emitter] Fix stats collection at end of burst mode

### DIFF
--- a/crates/transaction-emitter-lib/src/emit.rs
+++ b/crates/transaction-emitter-lib/src/emit.rs
@@ -23,7 +23,7 @@ use rand::{
 use rand_core::SeedableRng;
 use std::{
     cmp::{max, min},
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt,
     num::NonZeroU64,
     path::Path,
@@ -220,13 +220,9 @@ impl SubmissionWorker {
 
         let wait_duration = Duration::from_millis(self.params.wait_millis);
 
-        let start_time = Instant::now();
-        let mut total_num_requests = 0;
-
         while !self.stop.load(Ordering::Relaxed) {
             let requests = self.gen_requests(gas_price);
             let num_requests = requests.len();
-            total_num_requests += num_requests;
             let loop_start_time = Instant::now();
             let wait_until = loop_start_time + wait_duration;
             let mut txn_offset_time = 0u64;
@@ -244,7 +240,6 @@ impl SubmissionWorker {
                     loop_start_time,
                     txn_offset_time,
                     num_requests,
-                    false,
                     wait_for_accounts_sequence_timeout,
                 )
                 .await
@@ -259,14 +254,9 @@ impl SubmissionWorker {
         // out of it, update the stats for the whole run.
         if check_stats_at_end {
             debug!("Checking stats for final time at the end");
-            self.update_stats(
-                start_time,
-                0,
-                total_num_requests,
-                true,
-                Duration::from_millis(500),
-            )
-            .await
+            if let Err(e) = self.set_stats_based_on_actual_sequence_numbers().await {
+                error!("Failed to set stats at end of run: {}", e);
+            }
         }
 
         self.accounts
@@ -275,16 +265,11 @@ impl SubmissionWorker {
     /// This function assumes that num_requests == num_accounts, which is
     /// precisely how gen_requests works. If this changes, this code will
     /// need to be fixed.
-    ///
-    /// Note, the latency values are not accurate if --check-stats-at-end
-    /// is used. There is no easy way around this accurately. As such, we
-    /// don't update latency at all if that flag is set.
     async fn update_stats(
         &mut self,
         start_time: Instant,
         txn_offset_time: u64,
         num_requests: usize,
-        skip_latency_stats: bool,
         wait_for_accounts_sequence_timeout: Duration,
     ) {
         match wait_for_accounts_sequence(
@@ -300,14 +285,12 @@ impl SubmissionWorker {
                 self.stats
                     .committed
                     .fetch_add(num_requests as u64, Ordering::Relaxed);
-                if !skip_latency_stats {
-                    self.stats
-                        .latency
-                        .fetch_add(latency * num_requests as u64, Ordering::Relaxed);
-                    self.stats
-                        .latencies
-                        .record_data_point(latency, num_requests as u64);
-                }
+                self.stats
+                    .latency
+                    .fetch_add(latency * num_requests as u64, Ordering::Relaxed);
+                self.stats
+                    .latencies
+                    .record_data_point(latency, num_requests as u64);
             }
             Err(uncommitted) => {
                 let num_uncommitted = uncommitted.len() as u64;
@@ -326,20 +309,40 @@ impl SubmissionWorker {
                 self.stats
                     .expired
                     .fetch_add(num_uncommitted, Ordering::Relaxed);
-                if !skip_latency_stats {
-                    self.stats
-                        .latency
-                        .fetch_add(committed_latency, Ordering::Relaxed);
-                    self.stats
-                        .latencies
-                        .record_data_point(latency, num_committed);
-                }
+                self.stats
+                    .latency
+                    .fetch_add(committed_latency, Ordering::Relaxed);
+                self.stats
+                    .latencies
+                    .record_data_point(latency, num_committed);
                 info!(
                     "[{:?}] Transactions were not committed before expiration: {:?}",
                     self.client, uncommitted
                 );
             }
         }
+    }
+
+    /// Unlike update_stats, which should be used in each loop where the number
+    /// of requests == the number of accounts, this function should be used to
+    /// just pull the sequence numbers from the accounts and set the values
+    /// based on those directly.
+    async fn set_stats_based_on_actual_sequence_numbers(&mut self) -> Result<()> {
+        let accounts_sequence =
+            get_accounts_sequence(&self.client, &mut self.accounts, Duration::from_millis(500))
+                .await?;
+
+        let committed = accounts_sequence.values().sum();
+
+        let mut uncommitted = 0;
+        for account in &self.accounts {
+            uncommitted += account.sequence_number() - accounts_sequence[&account.address()];
+        }
+
+        self.stats.committed.store(committed, Ordering::Relaxed);
+        self.stats.expired.store(uncommitted, Ordering::Relaxed);
+
+        Ok(())
     }
 
     fn gen_requests(&mut self, gas_price: u64) -> Vec<SignedTransaction> {
@@ -634,6 +637,7 @@ impl<'t> TxnEmitter<'t> {
             req.accounts_per_client, num_accounts
         );
         self.mint_accounts(&req, num_accounts).await?;
+        info!("Minting accounts completed");
         let all_accounts = self.accounts.split_off(self.accounts.len() - num_accounts);
         let mut workers = vec![];
         let all_addresses: Vec<_> = all_accounts.iter().map(|d| d.address()).collect();
@@ -784,38 +788,21 @@ pub async fn execute_and_wait_transactions(
     Ok(())
 }
 
-/// This function waits for the submitted transactions to be committed, up to
-/// a deadline. If some accounts still have uncommitted transactions when we
-/// hit the deadline, we return a map of account to the info about the number
-/// of committed transactions, based on the delta between the local sequence
-/// number and the actual sequence number returned by the account. Note, this
-/// can return possibly unexpected results if the emitter was emitting more
-/// transactions per account than the mempool limit of the accounts on the node.
-/// As it is now, the sequence number of the local account incrememnts regardless
-/// of whether the transaction is accepted into the node's mempool or not. So the
-/// local sequence number could be much higher than the real sequence number ever
-/// will be, since not all of the submitted transactions were accepted.
-/// TODO, investigate whether this behaviour is desirable.
-async fn wait_for_accounts_sequence(
+/// This returns a map of account address to its actual sequence number.
+async fn get_accounts_sequence(
     client: &RestClient,
     accounts: &mut [LocalAccount],
     wait_timeout: Duration,
-) -> Result<(), HashSet<AccountAddress>> {
+) -> Result<HashMap<AccountAddress, u64>> {
     let deadline = Instant::now() + wait_timeout;
     let addresses: Vec<_> = accounts.iter().map(|d| d.address()).collect();
-    let mut uncommitted = addresses.clone().into_iter().collect::<HashSet<_>>();
+    let mut out = HashMap::new();
 
     while Instant::now() <= deadline {
         match query_sequence_numbers(client, &addresses).await {
             Ok(sequence_numbers) => {
                 for (account, sequence_number) in zip(accounts.iter(), &sequence_numbers) {
-                    if account.sequence_number() == *sequence_number {
-                        uncommitted.remove(&account.address());
-                    }
-                }
-
-                if uncommitted.is_empty() {
-                    return Ok(());
+                    out.insert(account.address(), *sequence_number);
                 }
             }
             Err(e) => {
@@ -829,7 +816,39 @@ async fn wait_for_accounts_sequence(
         time::sleep(Duration::from_millis(250)).await;
     }
 
-    Err(uncommitted)
+    Ok(out)
+}
+
+/// This function gets the real sequence number of the accounts and then
+/// returns a set containing the accounts that had uncommitted transactions.
+async fn wait_for_accounts_sequence(
+    client: &RestClient,
+    accounts: &mut [LocalAccount],
+    wait_timeout: Duration,
+) -> Result<(), HashSet<AccountAddress>> {
+    let addresses: Vec<_> = accounts.iter().map(|d| d.address()).collect();
+    let mut uncommitted = addresses.clone().into_iter().collect::<HashSet<_>>();
+
+    let sequence_numbers = match get_accounts_sequence(client, accounts, wait_timeout).await {
+        Ok(sequence_numbers) => sequence_numbers,
+        Err(e) => {
+            error!("Failed to get sequence numbers: {:?}", e);
+            return Err(uncommitted);
+        }
+    };
+
+    for account in accounts {
+        let actual_sequence_number = sequence_numbers[&account.address()];
+        if account.sequence_number() == actual_sequence_number {
+            uncommitted.remove(&account.address());
+        }
+    }
+
+    if uncommitted.is_empty() {
+        Ok(())
+    } else {
+        Err(uncommitted)
+    }
 }
 
 pub async fn query_sequence_numbers(

--- a/ecosystem/node-checker/src/server/api.rs
+++ b/ecosystem/node-checker/src/server/api.rs
@@ -215,6 +215,6 @@ pub fn build_openapi_service<M: MetricCollector, R: Runner>(
     // These should have already been validated at this point, so we panic.
     let url: Url = server_args
         .try_into()
-        .expect("Failed to parse liten address");
+        .expect("Failed to parse listen address");
     OpenApiService::new(api, "Aptos Node Checker", version).server(url)
 }


### PR DESCRIPTION
## Description
The stats checking was super wrong for the end-of-burst-mode stats check. This fixes that.

## Test Plan
I'm running this in the context of NHC:
```
cargo run -- configuration create --configuration-name ait2_registration --configuration-name-pretty "AIT2 Registration" --url http://34.65.95.76 --evaluators consensus_proposals,performance_tps,performance_latency --mint-key <key> --duration 3 --accounts-per-client 10 --workers-per-ac 10 --wait-millis 0 --repeat-target-count 20 --burst --minimum-tps 1000 --api-port 80 > /tmp/ait2_registration.yaml
```
```
cargo run -- server run --baseline-node-config-paths /tmp/ait2_registration.yaml --listen-address 0.0.0.0
```
```
time curl 'localhost:20121/check_node?node_url=http://34.65.95.76&baseline_configuration_name=ait2_registration&api_port=80'
```
```
{"evaluation_results":[{"headline":"Chain ID reported by baseline and target match","score":100,"explanation":"The node under investigation reported the same Chain ID 40 as is reported by the baseline node","evaluator_name":"node_identity","category":"node_identity","links":[]},{"headline":"Role Type reported by baseline and target match","score":100,"explanation":"The node under investigation reported the same Role Type validator as is reported by the baseline node","evaluator_name":"node_identity","category":"node_identity","links":[]},{"headline":"Transaction processing speed is too low","score":0,"explanation":"The minimum TPS (transactions per second) required of nodes is 1000, your node hit: 5 (out of 1333 transactions submitted per second). This implies that the hardware you're using to run your node isn't powerful enough, please see the attached link","evaluator_name":"performance_tps","category":"performance","links":["https://aptos.dev/nodes/ait/node-requirements"]},{"headline":"Proposals count is increasing","score":100,"explanation":"Successfully pulled metrics from target node twice and saw that proposals count is increasing","evaluator_name":"consensus_proposals","category":"consensus","links":[]},{"headline":"Average latency is good","score":100,"explanation":"The average latency was 315ms, which is below the maximum allowed latency of 500ms","evaluator_name":"performance_latency","category":"performance","links":[]}],"summary_score":80,"summary_explanation":"80: Getting there!"}
real    1m13.519s
user    0m0.004s
sys     0m0.008s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1690)
<!-- Reviewable:end -->
