### PR TITLE
[NHC] Separate evaluator types better and run simultaneously

### DIFF
--- a/ecosystem/node-checker/src/evaluators/direct/latency.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/latency.rs
@@ -5,6 +5,7 @@ use super::DirectEvaluatorInput;
 use crate::{
     configuration::EvaluatorArgs,
     evaluator::{EvaluationResult, Evaluator},
+    evaluators::EvaluatorType,
 };
 use anyhow::Result;
 use clap::Parser;
@@ -144,5 +145,11 @@ impl Evaluator for LatencyEvaluator {
 
     fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
         Ok(Self::new(evaluator_args.latency_args.clone()))
+    }
+
+    fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {
+        Ok(EvaluatorType::Latency(Box::new(Self::from_evaluator_args(
+            evaluator_args,
+        )?)))
     }
 }

--- a/ecosystem/node-checker/src/evaluators/direct/tps.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/tps.rs
@@ -4,6 +4,7 @@
 use crate::{
     configuration::EvaluatorArgs,
     evaluator::{EvaluationResult, Evaluator},
+    evaluators::EvaluatorType,
 };
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -183,5 +184,11 @@ impl Evaluator for TpsEvaluator {
             .get_mint_key()
             .context("Failed to get private key for TPS evaluator")?;
         Ok(Self::new(evaluator_args.tps_args.clone()))
+    }
+
+    fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {
+        Ok(EvaluatorType::Tps(Box::new(Self::from_evaluator_args(
+            evaluator_args,
+        )?)))
     }
 }

--- a/ecosystem/node-checker/src/evaluators/metrics/consensus/proposals.rs
+++ b/ecosystem/node-checker/src/evaluators/metrics/consensus/proposals.rs
@@ -11,6 +11,7 @@ use super::{
 use crate::{
     configuration::EvaluatorArgs,
     evaluator::{EvaluationResult, Evaluator},
+    evaluators::EvaluatorType,
 };
 use anyhow::Result;
 use clap::Parser;
@@ -151,6 +152,12 @@ impl Evaluator for ConsensusProposalsEvaluator {
 
     fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
         Ok(Self::new(evaluator_args.consensus_proposals_args.clone()))
+    }
+
+    fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {
+        Ok(EvaluatorType::Metrics(Box::new(Self::from_evaluator_args(
+            evaluator_args,
+        )?)))
     }
 }
 

--- a/ecosystem/node-checker/src/evaluators/metrics/state_sync/version.rs
+++ b/ecosystem/node-checker/src/evaluators/metrics/state_sync/version.rs
@@ -11,6 +11,7 @@ use super::{
 use crate::{
     configuration::EvaluatorArgs,
     evaluator::{EvaluationResult, Evaluator},
+    evaluators::EvaluatorType,
 };
 use anyhow::Result;
 use clap::Parser;
@@ -207,6 +208,12 @@ impl Evaluator for StateSyncVersionEvaluator {
 
     fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
         Ok(Self::new(evaluator_args.state_sync_version_args.clone()))
+    }
+
+    fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {
+        Ok(EvaluatorType::Metrics(Box::new(Self::from_evaluator_args(
+            evaluator_args,
+        )?)))
     }
 }
 

--- a/ecosystem/node-checker/src/evaluators/system_information/build_version.rs
+++ b/ecosystem/node-checker/src/evaluators/system_information/build_version.rs
@@ -13,6 +13,7 @@ use super::{
 use crate::{
     configuration::EvaluatorArgs,
     evaluator::{EvaluationResult, Evaluator},
+    evaluators::EvaluatorType,
     metric_collector::SystemInformation,
 };
 use anyhow::Result;
@@ -142,6 +143,12 @@ impl Evaluator for BuildVersionEvaluator {
 
     fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
         Ok(Self::new(evaluator_args.build_version_args.clone()))
+    }
+
+    fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {
+        Ok(EvaluatorType::SystemInformation(Box::new(
+            Self::from_evaluator_args(evaluator_args)?,
+        )))
     }
 }
 

--- a/ecosystem/node-checker/src/runner/traits.rs
+++ b/ecosystem/node-checker/src/runner/traits.rs
@@ -20,11 +20,11 @@ use crate::{
 pub enum RunnerError {
     /// We failed to get the node identity.
     #[error("Failed to check identity of node: {0}")]
-    NodeIdentityEvaluatorError(NodeIdentityEvaluatorError),
+    NodeIdentityEvaluatorError(#[from] NodeIdentityEvaluatorError),
 
     /// We failed to collect metrics for some reason.
     #[error("Failed to collect metrics: {0}")]
-    MetricCollectorError(MetricCollectorError),
+    MetricCollectorError(#[from] MetricCollectorError),
 
     /// We couldn't parse the metrics.
     #[error("Failed to parse metrics: {0}")]
@@ -33,21 +33,21 @@ pub enum RunnerError {
     /// One of the metrics evaluators failed. This is not the same as a poor score from
     /// an evaluator, this is an actual failure in the evaluation process.
     #[error("Failed to evaluate metrics: {0}")]
-    MetricEvaluatorError(MetricsEvaluatorError),
+    MetricEvaluatorError(#[from] MetricsEvaluatorError),
 
     /// One of the system information evaluators failed. This is not the same
     /// as a poor score from an evaluator, this is an actual failure in the
     /// evaluation process.
     #[error("Failed to evaluate system information: {0}")]
-    SystemInformationEvaluatorError(SystemInformationEvaluatorError),
+    SystemInformationEvaluatorError(#[from] SystemInformationEvaluatorError),
 
     /// The TPS evaluator failed. This is not the same as a poor score from an
     /// evaluator, this is an actual failure in the evaluation process.
     #[error("Failed to evaluate TPS: {0}")]
-    TpsEvaluatorError(TpsEvaluatorError),
+    TpsEvaluatorError(#[from] TpsEvaluatorError),
 
     #[error("Failed to evaluate latency: {0}")]
-    LatencyEvaluatorError(LatencyEvaluatorError),
+    LatencyEvaluatorError(#[from] LatencyEvaluatorError),
 }
 
 /// This trait describes a Runner, something that can take in instances of other

--- a/ecosystem/node-checker/src/server/configurations_manager.rs
+++ b/ecosystem/node-checker/src/server/configurations_manager.rs
@@ -45,7 +45,7 @@ fn build_node_configuration_wrapper_with_blocking_runner(
         node_configuration.node_address.metrics_port,
     );
 
-    let evaluators = build_evaluators(
+    let evaluator_set = build_evaluators(
         &node_configuration.evaluators,
         &node_configuration.evaluator_args,
     )
@@ -59,7 +59,7 @@ fn build_node_configuration_wrapper_with_blocking_runner(
         baseline_node_information,
         baseline_metric_collector,
         node_identity_evaluator,
-        evaluators,
+        evaluator_set,
     );
 
     let wrapper = NodeConfigurationWrapper {


### PR DESCRIPTION
## Description
Prior to this, evaluators would be run mostly serially, with some attempt to order evaluators down the line. I see that this is going to get out of hand pretty quickly. With this PR, I make a split out different evaluator types into different functions, where we collect all the prerequisite information and then run the evaluators concurrently. These functions are then also run concurrently (in async terms).

One additional win here is we no longer fetch information we don't need. For example, if we don't have any metrics based evaluators configured, we won't fetch metrics.

## Test Plan
Generate config:
```
cargo run -- configuration create --configuration-name ait2_registration --configuration-name-pretty "AIT2 Registration" --url http://34.65.95.76 --evaluators consensus_proposals,performance_tps,performance_latency --mint-key <key> --duration 3 --accounts-per-client 11 --workers-per-ac 11 --wait-millis 0 --repeat-target-count 16 --minimum-tps 500 --api-port 80 > /tmp/ait2_registration.yaml
```

Run server:
```
cargo run  -- server run --baseline-node-config-paths /tmp/ait2_registration.yaml --listen-address 0.0.0.0
```

Hit server:
```
{
  "evaluation_results": [
    {
      "headline": "Chain ID reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Chain ID 40 as is reported by the baseline node",
      "evaluator_name": "node_identity",
      "category": "node_identity",
      "links": []
    },
    {
      "headline": "Role Type reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Role Type validator as is reported by the baseline node",
      "evaluator_name": "node_identity",
      "category": "node_identity",
      "links": []
    },
    {
      "headline": "Proposals count is increasing",
      "score": 100,
      "explanation": "Successfully pulled metrics from target node twice and saw that proposals count is increasing",
      "evaluator_name": "consensus_proposals",
      "category": "consensus",
      "links": []
    },
    {
      "headline": "Transaction processing speed is sufficient",
      "score": 100,
      "explanation": "The minimum TPS (transactions per second) required of nodes is 500, your node hit: 645 (out of 645 transactions submitted per second). Your node could theoretically hit even higher TPS, the evaluation suite only tests to check your node meets the minimum requirements.",
      "evaluator_name": "performance_tps",
      "category": "performance",
      "links": []
    },
    {
      "headline": "Average latency is good",
      "score": 100,
      "explanation": "The average latency was 377ms, which is below the maximum allowed latency of 500ms",
      "evaluator_name": "performance_latency",
      "category": "performance",
      "links": []
    }
  ],
  "summary_score": 100,
  "summary_explanation": "100: Awesome!"
}

real    1m4.109s
user    0m0.029s
sys     0m0.020s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1709)
<!-- Reviewable:end -->
