### PR TITLE
[txn-emitter] Fix some timing bugs, allow building RestClient with own client

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -27,7 +27,7 @@ use crate::aptos::{AptosVersion, Balance};
 pub use types::{Account, Resource, RestError};
 pub mod aptos;
 
-const USER_AGENT: &str = concat!("aptos-client-sdk-rust / ", env!("CARGO_PKG_VERSION"));
+pub const USER_AGENT: &str = concat!("aptos-client-sdk-rust / ", env!("CARGO_PKG_VERSION"));
 
 #[derive(Clone, Debug)]
 pub struct Client {
@@ -363,5 +363,11 @@ impl Client {
         }
 
         Ok(())
+    }
+}
+
+impl From<(ReqwestClient, Url)> for Client {
+    fn from((inner, base_url): (ReqwestClient, Url)) -> Self {
+        Client { inner, base_url }
     }
 }

--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -94,7 +94,7 @@ fn parse_target(target: &str) -> Result<Url> {
     if url.scheme().is_empty() {
         bail!("Scheme must not be empty, try prefixing URL with http://");
     }
-    if url.port().is_none() {
+    if url.port_or_known_default().is_none() {
         url.set_port(Some(DEFAULT_API_PORT)).map_err(|_| {
             anyhow::anyhow!(
                 "Failed to set port to default value, make sure you have set a scheme like http://"

--- a/crates/transaction-emitter-lib/src/emit.rs
+++ b/crates/transaction-emitter-lib/src/emit.rs
@@ -506,6 +506,7 @@ impl<'t> TxnEmitter<'t> {
                     )
                 })
                 .collect();
+            debug!("Creating {} seed accounts", batch_size);
             execute_and_wait_transactions(&client, creation_account, create_requests).await?;
             i += batch_size;
             seed_accounts.append(&mut batch);
@@ -691,8 +692,8 @@ impl<'t> TxnEmitter<'t> {
     pub async fn periodic_stat(&mut self, job: &EmitJob, duration: Duration, interval_secs: u64) {
         let deadline = Instant::now() + duration;
         let mut prev_stats: Option<TxnStats> = None;
+        let window = Duration::from_secs(min(interval_secs, 1));
         while Instant::now() < deadline {
-            let window = Duration::from_secs(interval_secs);
             tokio::time::sleep(window).await;
             let stats = self.peek_job_stats(job);
             let delta = &stats - &prev_stats.unwrap_or_default();
@@ -709,7 +710,9 @@ impl<'t> TxnEmitter<'t> {
         let job = self.start_job(emit_job_request).await?;
         info!("Starting emitting txns for {} secs", duration.as_secs());
         tokio::time::sleep(duration).await;
+        info!("Ran for {} secs, stopping job...", duration.as_secs());
         let stats = self.stop_job(job).await;
+        info!("Stopped job");
         Ok(stats)
     }
 
@@ -719,9 +722,12 @@ impl<'t> TxnEmitter<'t> {
         emit_job_request: EmitJobRequest,
         interval_secs: u64,
     ) -> Result<TxnStats> {
+        info!("Starting emitting txns for {} secs", duration.as_secs());
         let job = self.start_job(emit_job_request).await?;
         self.periodic_stat(&job, duration, interval_secs).await;
+        info!("Ran for {} secs, stopping job...", duration.as_secs());
         let stats = self.stop_job(job).await;
+        info!("Stopped job");
         Ok(stats)
     }
 
@@ -885,6 +891,7 @@ where
                     )
                 })
                 .collect();
+            debug!("Creating {} new accounts", batch_size);
             execute_and_wait_transactions(&client, &mut source_account, creation_requests).await?;
             batch
         };
@@ -997,10 +1004,14 @@ impl StatsAccumulator {
 
 impl TxnStats {
     pub fn rate(&self, window: Duration) -> TxnStatsRate {
+        let mut window_secs = window.as_secs();
+        if window_secs < 1 {
+            window_secs = 1;
+        }
         TxnStatsRate {
-            submitted: self.submitted / window.as_secs(),
-            committed: self.committed / window.as_secs(),
-            expired: self.expired / window.as_secs(),
+            submitted: self.submitted / window_secs,
+            committed: self.committed / window_secs,
+            expired: self.expired / window_secs,
             latency: if self.committed == 0 {
                 0u64
             } else {

--- a/crates/transaction-emitter-lib/src/instance.rs
+++ b/crates/transaction-emitter-lib/src/instance.rs
@@ -1,14 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{format_err, Result};
 use aptos_rest_client::Client as RestClient;
 use reqwest::Url;
-use std::{
-    fmt,
-    time::{Duration, Instant},
-};
-use tokio::time;
+use std::fmt;
 
 #[derive(Clone)]
 pub struct Instance {
@@ -24,16 +19,6 @@ impl Instance {
             url,
             inspection_service_port,
         }
-    }
-
-    pub async fn wait_server_ready(&self, deadline: Instant) -> Result<()> {
-        while self.rest_client().get_ledger_information().await.is_err() {
-            if Instant::now() > deadline {
-                return Err(format_err!("wait_server_ready for {} timed out", self));
-            }
-            time::sleep(Duration::from_secs(3)).await;
-        }
-        Ok(())
     }
 
     pub fn peer_name(&self) -> &String {

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -11,7 +11,10 @@ use anyhow::{Context, Result};
 use aptos_sdk::transaction_builder::TransactionFactory;
 use rand::{rngs::StdRng, Rng};
 use rand_core::{OsRng, SeedableRng};
-use std::{cmp::min, time::Duration};
+use std::{
+    cmp::{max, min},
+    time::Duration,
+};
 
 pub async fn emit_transactions(
     cluster_args: &ClusterArgs,
@@ -58,7 +61,11 @@ pub async fn emit_transactions_with_cluster(
         emit_job_request = emit_job_request.vasp();
     }
     let stats = emitter
-        .emit_txn_for_with_stats(duration, emit_job_request, min(10, args.duration / 5))
+        .emit_txn_for_with_stats(
+            duration,
+            emit_job_request,
+            min(10, max(args.duration / 5, 1)),
+        )
         .await?;
     Ok(stats)
 }


### PR DESCRIPTION
## Description
This is a collection of bug fixes and quality of life improvements, e.g. fixing a bug where sometimes we would divide by zero in checking stats, making sure we can build our own reqwest client (for an upcoming http2 experiment), etc.

## Test Plan
```
time RUST_LOG=info cargo run -p transaction-emitter --release -- emit-tx -t http://34.65.95.76 --mint-key <key> --chain-id 40 --duration 3 --workers-per-ac 16 --accounts-per-client 16 --txn-expiration-time-secs 100
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1713)
<!-- Reviewable:end -->
