### PR TITLE
[storage-interface] move ExecutedTrees to storage-interface

### DIFF
--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{ExecutedTrees, StateComputeResult, TransactionData};
+use crate::{StateComputeResult, TransactionData};
 use anyhow::{bail, ensure, Result};
 use aptos_crypto::hash::{CryptoHash, TransactionAccumulatorHasher};
 use aptos_types::{
@@ -14,6 +14,7 @@ use aptos_types::{
     transaction::{Transaction, TransactionInfo, TransactionStatus, TransactionToCommit},
 };
 use std::sync::Arc;
+use storage_interface::ExecutedTrees;
 
 #[derive(Default)]
 pub struct ExecutedChunk {
@@ -101,7 +102,7 @@ impl ExecutedChunk {
                 if &txn_data.txn_info != expected_txn_info {
                     bail!(
                         "Transaction infos don't match. version: {}, txn_info:{}, expected_txn_info:{}",
-                        self.result_view.transaction_accumulator.version() + 1 + idx as u64
+                        self.result_view.txn_accumulator().version() + 1 + idx as u64
                             - self.to_commit.len() as u64,
                         &txn_data.txn_info,
                         expected_txn_info,

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -27,11 +27,11 @@ use aptos_types::{
 };
 use aptos_vm::VMExecutor;
 use executor_types::{
-    ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, ExecutedTrees, TransactionReplayer,
+    ChunkCommitNotification, ChunkExecutorTrait, ExecutedChunk, TransactionReplayer,
 };
 use fail::fail_point;
 use std::{marker::PhantomData, sync::Arc};
-use storage_interface::{cached_state_view::CachedStateView, DbReaderWriter};
+use storage_interface::{cached_state_view::CachedStateView, DbReaderWriter, ExecutedTrees};
 
 pub struct ChunkExecutor<V> {
     db: DbReaderWriter,

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -24,8 +24,9 @@ use aptos_types::{
     transaction::{Transaction, TransactionInfo, TransactionOutput, TransactionStatus},
     write_set::WriteSet,
 };
-use executor_types::{ExecutedChunk, ExecutedTrees, TransactionData};
+use executor_types::{ExecutedChunk, TransactionData};
 use std::{collections::HashMap, iter::repeat, ops::Deref, sync::Arc};
+use storage_interface::ExecutedTrees;
 
 pub struct ApplyChunkOutput;
 

--- a/execution/executor/src/components/block_tree/test.rs
+++ b/execution/executor/src/components/block_tree/test.rs
@@ -5,8 +5,9 @@ use crate::components::block_tree::{epoch_genesis_block_id, BlockLookup, BlockTr
 use aptos_crypto::{hash::PRE_GENESIS_BLOCK_ID, HashValue};
 use aptos_infallible::Mutex;
 use aptos_types::{block_info::BlockInfo, epoch_state::EpochState, ledger_info::LedgerInfo};
-use executor_types::{ExecutedChunk, ExecutedTrees};
+use executor_types::ExecutedChunk;
 use std::sync::Arc;
+use storage_interface::ExecutedTrees;
 
 impl BlockTree {
     pub fn new_empty() -> Self {

--- a/execution/executor/src/components/chunk_commit_queue.rs
+++ b/execution/executor/src/components/chunk_commit_queue.rs
@@ -6,9 +6,9 @@
 use anyhow::{anyhow, Result};
 
 use crate::components::in_memory_state_calculator::IntoLedgerView;
-use executor_types::{ExecutedChunk, ExecutedTrees};
+use executor_types::ExecutedChunk;
 use std::{collections::VecDeque, sync::Arc};
-use storage_interface::DbReader;
+use storage_interface::{DbReader, ExecutedTrees};
 
 pub struct ChunkCommitQueue {
     persisted_view: ExecutedTrees,

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -9,10 +9,13 @@ use aptos_logger::trace;
 use aptos_state_view::StateView;
 use aptos_types::transaction::{Transaction, TransactionOutput};
 use aptos_vm::VMExecutor;
-use executor_types::{ExecutedChunk, ExecutedTrees};
+use executor_types::ExecutedChunk;
 use fail::fail_point;
 use std::collections::HashSet;
-use storage_interface::cached_state_view::{CachedStateView, StateCache};
+use storage_interface::{
+    cached_state_view::{CachedStateView, StateCache},
+    ExecutedTrees,
+};
 
 pub struct ChunkOutput {
     /// Input transactions.

--- a/execution/executor/src/components/in_memory_state_calculator.rs
+++ b/execution/executor/src/components/in_memory_state_calculator.rs
@@ -1,8 +1,15 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::components::apply_chunk_output::ParsedTransactionOutput;
+use std::{
+    collections::{hash_map, HashMap, HashSet},
+    sync::Arc,
+};
+
 use anyhow::{anyhow, bail, ensure, Result};
+use once_cell::sync::Lazy;
+use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_state_view::{account_with_state_cache::AsAccountWithStateCache, StateViewId};
 use aptos_types::{
@@ -16,20 +23,16 @@ use aptos_types::{
     transaction::{Transaction, TransactionPayload, Version},
     write_set::{WriteOp, WriteSet},
 };
-use executor_types::{ExecutedTrees, ProofReader};
-use once_cell::sync::Lazy;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use executor_types::ProofReader;
 use scratchpad::{FrozenSparseMerkleTree, SparseMerkleTree, StateStoreStatus};
-use std::{
-    collections::{hash_map, HashMap, HashSet},
-    sync::Arc,
-};
 use storage_interface::{
     cached_state_view::{CachedStateView, StateCache},
     in_memory_state::InMemoryState,
     sync_proof_fetcher::SyncProofFetcher,
-    DbReader, TreeState,
+    DbReader, ExecutedTrees, TreeState,
 };
+
+use crate::components::apply_chunk_output::ParsedTransactionOutput;
 
 pub trait IntoLedgerView {
     fn into_ledger_view(self, db: &Arc<dyn DbReader>) -> Result<ExecutedTrees>;

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -1,18 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    block_executor::BlockExecutor,
-    chunk_executor::ChunkExecutor,
-    components::chunk_output::ChunkOutput,
-    db_bootstrapper::{generate_waypoint, maybe_bootstrap},
-    mock_vm::{
-        encode_mint_transaction, encode_reconfiguration_transaction, encode_transfer_transaction,
-        MockVM, DISCARD_STATUS, KEEP_STATUS,
-    },
-};
+use std::{collections::BTreeMap, iter::once};
 
-use crate::components::in_memory_state_calculator::IntoLedgerView;
+use proptest::prelude::*;
+
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
 use aptos_state_view::StateViewId;
 use aptos_types::{
@@ -31,10 +23,19 @@ use aptos_types::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use aptosdb::AptosDB;
-use executor_types::{BlockExecutorTrait, ChunkExecutorTrait, ExecutedTrees, TransactionReplayer};
-use proptest::prelude::*;
-use std::{collections::BTreeMap, iter::once};
-use storage_interface::DbReaderWriter;
+use executor_types::{BlockExecutorTrait, ChunkExecutorTrait, TransactionReplayer};
+use storage_interface::{DbReaderWriter, ExecutedTrees};
+
+use crate::{
+    block_executor::BlockExecutor,
+    chunk_executor::ChunkExecutor,
+    components::{chunk_output::ChunkOutput, in_memory_state_calculator::IntoLedgerView},
+    db_bootstrapper::{generate_waypoint, maybe_bootstrap},
+    mock_vm::{
+        encode_mint_transaction, encode_reconfiguration_transaction, encode_transfer_transaction,
+        MockVM, DISCARD_STATUS, KEEP_STATUS,
+    },
+};
 
 mod chunk_executor_tests;
 

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -4,7 +4,7 @@
 use aptos_types::{
     epoch_change::Verifier, epoch_state::EpochState, ledger_info::LedgerInfoWithSignatures,
 };
-use executor_types::ExecutedTrees;
+use storage_interface::ExecutedTrees;
 
 use crate::error::Error;
 

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -35,7 +35,6 @@ use aptos_types::{
 use channel::{aptos_channel, message_queues::QueueStyle};
 use claim::assert_ok;
 use consensus_notifications::{ConsensusNotificationSender, ConsensusNotifier};
-use executor_types::ExecutedTrees;
 use futures::{executor::block_on, future::FutureExt, StreamExt};
 use memsocket::MemoryListener;
 use netcore::transport::ConnectionOrigin;
@@ -70,6 +69,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use storage_interface::ExecutedTrees;
 use tokio::runtime::Runtime;
 use vm_genesis::GENESIS_KEYPAIR;
 

--- a/storage/storage-interface/src/executed_trees.rs
+++ b/storage/storage-interface/src/executed_trees.rs
@@ -1,0 +1,115 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    cached_state_view::CachedStateView, in_memory_state::InMemoryState,
+    no_proof_fetcher::NoProofFetcher, sync_proof_fetcher::SyncProofFetcher, DbReader,
+};
+use anyhow::Result;
+use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
+use aptos_state_view::StateViewId;
+use aptos_types::{proof::accumulator::InMemoryAccumulator, transaction::Version};
+use std::sync::Arc;
+
+/// A wrapper of the in-memory state sparse merkle tree and the transaction accumulator that
+/// represent a specific state collectively. Usually it is a state after executing a block.
+#[derive(Clone, Debug)]
+pub struct ExecutedTrees {
+    /// The in-memory representation of state after execution.
+    state: InMemoryState,
+
+    /// The in-memory Merkle Accumulator representing a blockchain state consistent with the
+    /// `state_tree`.
+    transaction_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+}
+
+impl ExecutedTrees {
+    pub fn state(&self) -> &InMemoryState {
+        &self.state
+    }
+
+    pub fn txn_accumulator(&self) -> &Arc<InMemoryAccumulator<TransactionAccumulatorHasher>> {
+        &self.transaction_accumulator
+    }
+
+    pub fn version(&self) -> Option<Version> {
+        let num_elements = self.txn_accumulator().num_leaves() as u64;
+        num_elements.checked_sub(1)
+    }
+
+    pub fn state_id(&self) -> HashValue {
+        self.txn_accumulator().root_hash()
+    }
+
+    pub fn new(
+        state: InMemoryState,
+        transaction_accumulator: Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
+    ) -> Self {
+        Self {
+            state,
+            transaction_accumulator,
+        }
+    }
+
+    pub fn new_at_state_checkpoint(
+        state_root_hash: HashValue,
+        frozen_subtrees_in_accumulator: Vec<HashValue>,
+        num_leaves_in_accumulator: u64,
+    ) -> Self {
+        let state = InMemoryState::new_at_checkpoint(
+            state_root_hash,
+            num_leaves_in_accumulator.checked_sub(1),
+        );
+        let transaction_accumulator = Arc::new(
+            InMemoryAccumulator::new(frozen_subtrees_in_accumulator, num_leaves_in_accumulator)
+                .expect("The startup info read from storage should be valid."),
+        );
+
+        Self::new(state, transaction_accumulator)
+    }
+
+    pub fn new_empty() -> Self {
+        Self::new(
+            InMemoryState::new_empty(),
+            Arc::new(InMemoryAccumulator::new_empty()),
+        )
+    }
+
+    pub fn is_same_view(&self, rhs: &Self) -> bool {
+        self.transaction_accumulator.root_hash() == rhs.transaction_accumulator.root_hash()
+    }
+
+    pub fn verified_state_view(
+        &self,
+        id: StateViewId,
+        reader: Arc<dyn DbReader>,
+    ) -> Result<CachedStateView> {
+        CachedStateView::new(
+            id,
+            reader.clone(),
+            self.transaction_accumulator.num_leaves(),
+            self.state.current.clone(),
+            Arc::new(SyncProofFetcher::new(reader)),
+        )
+    }
+
+    pub fn state_view(
+        &self,
+        id: StateViewId,
+        reader: Arc<dyn DbReader>,
+    ) -> Result<CachedStateView> {
+        CachedStateView::new(
+            id,
+            reader.clone(),
+            self.transaction_accumulator.num_leaves(),
+            self.state.current.clone(),
+            Arc::new(NoProofFetcher::new(reader)),
+        )
+    }
+}
+
+impl Default for ExecutedTrees {
+    fn default() -> Self {
+        Self::new_empty()
+    }
+}

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -39,6 +39,7 @@ use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
 pub mod cached_state_view;
+mod executed_trees;
 pub mod in_memory_state;
 #[cfg(any(feature = "testing", feature = "fuzzing"))]
 pub mod mock;
@@ -46,6 +47,8 @@ pub mod no_proof_fetcher;
 pub mod proof_fetcher;
 pub mod state_view;
 pub mod sync_proof_fetcher;
+
+pub use executed_trees::ExecutedTrees;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct StartupInfo {


### PR DESCRIPTION
### Description

If we let state store maintain in_mem_state, ExecutedTrees and be read directly from `get_startup_info` and replace `TreeState`.

### Test Plan
ut

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1715)
<!-- Reviewable:end -->
