### PR TITLE
[consensus] Add failed authors to NIL block

### DIFF
--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -35,7 +35,7 @@ fn test_nil_block() {
     let genesis_block = Block::make_genesis_block();
     let quorum_cert = certificate_for_genesis();
 
-    let nil_block = Block::new_nil(1, quorum_cert);
+    let nil_block = Block::new_nil(1, quorum_cert, vec![]);
     assert_eq!(
         nil_block.quorum_cert().certified_block().id(),
         genesis_block.id()
@@ -222,7 +222,7 @@ fn test_block_metadata_bitmaps() {
 #[test]
 fn test_nil_block_metadata_bitmaps() {
     let quorum_cert = certificate_for_genesis();
-    let nil_block = Block::new_nil(1, quorum_cert);
+    let nil_block = Block::new_nil(1, quorum_cert, vec![]);
     let nil_block_metadata = nil_block.new_block_metadata(&Vec::new());
     assert_eq!(AccountAddress::ZERO, nil_block_metadata.proposer());
     assert_eq!(0, nil_block_metadata.previous_block_votes().len());

--- a/consensus/safety-rules/src/fuzzing_utils.rs
+++ b/consensus/safety-rules/src/fuzzing_utils.rs
@@ -104,6 +104,19 @@ prop_compose! {
     }
 }
 
+// This generates an arbitrary BlockType::Proposal enum instance.
+prop_compose! {
+    pub fn arb_nil_block(
+    )(
+        author in any::<AccountAddress>(),
+        round in any::<u64>(),
+    ) -> BlockType {
+        BlockType::NilBlock{
+            failed_authors: vec![(round, author)],
+        }
+    }
+}
+
 // This generates an arbitrary MaybeSignedVoteProposal.
 prop_compose! {
     pub fn arb_maybe_signed_vote_proposal(
@@ -230,7 +243,7 @@ prop_compose! {
 fn arb_block_type() -> impl Strategy<Value = BlockType> {
     prop_oneof![
         arb_block_type_proposal(),
-        Just(BlockType::NilBlock),
+        arb_nil_block(),
         Just(BlockType::Genesis),
     ]
 }


### PR DESCRIPTION
NIL block is sometimes added to blockchain to progress the consensus when proposer is unable to propose. So it always represents an author failing, in addition to potentially some previous blocks also failing. So adding missing information to failed_authors. 

### Test Plan
Unit tests and swarm test.
