### PR TITLE
[aptos-framework] Add coin type to coin events

### DIFF
--- a/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
@@ -4,7 +4,7 @@
   "hash": "",
   "state_root_hash": "",
   "event_root_hash": "",
-  "gas_used": "38",
+  "gas_used": "43",
   "success": false,
   "vm_status": "Move abort by INVALID_ARGUMENT - EINSUFFICIENT_BALANCE\n An argument provided to an operation is invalid. Example: a signing key has the wrong format.\n When there's not enough funds to withdraw from an account or from `Coin` resource.",
   "accumulator_root_hash": "",

--- a/aptos-move/framework/aptos-framework/sources/Coin.move
+++ b/aptos-move/framework/aptos-framework/sources/Coin.move
@@ -76,11 +76,13 @@ module AptosFramework::Coin {
 
     /// Event emitted when some amount of a coin is deposited into an account.
     struct DepositEvent has drop, store {
+        type_info: TypeInfo::TypeInfo,
         amount: u64,
     }
 
     /// Event emitted when some amount of a coin is withdrawn from an account.
     struct WithdrawEvent has drop, store {
+        type_info: TypeInfo::TypeInfo,
         amount: u64,
     }
 
@@ -189,7 +191,7 @@ module AptosFramework::Coin {
         let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
         Event::emit_event<DepositEvent>(
             &mut coin_store.deposit_events,
-            DepositEvent { amount: coin.value },
+            DepositEvent { amount: coin.value, type_info: TypeInfo::type_of<CoinType>() },
         );
 
         merge(&mut coin_store.coin, coin);
@@ -343,7 +345,7 @@ module AptosFramework::Coin {
 
         Event::emit_event<WithdrawEvent>(
             &mut coin_store.withdraw_events,
-            WithdrawEvent { amount },
+            WithdrawEvent { amount, type_info: TypeInfo::type_of<CoinType>() },
         );
 
         extract(&mut coin_store.coin, amount)


### PR DESCRIPTION
### Description
Prior to this, there is indirection to determine which coin is
in an event.  This lets us lookup the type directly from the event.

This does seem to slightly increase the gas cost.

### Test Plan
Whatever tests already exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1718)
<!-- Reviewable:end -->
