### PR TITLE
Take 2: Fix stats collection at end of txn emitter run

### DIFF
--- a/crates/transaction-emitter-lib/src/emit.rs
+++ b/crates/transaction-emitter-lib/src/emit.rs
@@ -44,6 +44,8 @@ use aptos_sdk::{
 };
 use rand::rngs::StdRng;
 
+// So the regression msut be from the change to get_accounts_sequence where I build that hashmap.
+
 /// Max transactions per account in mempool
 const MAX_TXN_BATCH_SIZE: usize = 100;
 const MAX_TXNS: u64 = 1_000_000;
@@ -67,7 +69,7 @@ impl Default for EmitThreadParams {
             wait_millis: 0,
             wait_committed: true,
             txn_expiration_time_secs: 30,
-            check_stats_at_end: true,
+            check_stats_at_end: false,
         }
     }
 }
@@ -142,7 +144,7 @@ impl EmitJobRequest {
                 wait_millis: wait_time,
                 wait_committed: true,
                 txn_expiration_time_secs: 30,
-                check_stats_at_end: true,
+                check_stats_at_end: false,
             })
             .accounts_per_client(1)
     }

--- a/crates/transaction-emitter-lib/src/emit.rs
+++ b/crates/transaction-emitter-lib/src/emit.rs
@@ -23,7 +23,7 @@ use rand::{
 use rand_core::SeedableRng;
 use std::{
     cmp::{max, min},
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     fmt,
     num::NonZeroU64,
     path::Path,
@@ -220,13 +220,9 @@ impl SubmissionWorker {
 
         let wait_duration = Duration::from_millis(self.params.wait_millis);
 
-        let start_time = Instant::now();
-        let mut total_num_requests = 0;
-
         while !self.stop.load(Ordering::Relaxed) {
             let requests = self.gen_requests(gas_price);
             let num_requests = requests.len();
-            total_num_requests += num_requests;
             let loop_start_time = Instant::now();
             let wait_until = loop_start_time + wait_duration;
             let mut txn_offset_time = 0u64;
@@ -244,7 +240,6 @@ impl SubmissionWorker {
                     loop_start_time,
                     txn_offset_time,
                     num_requests,
-                    false,
                     wait_for_accounts_sequence_timeout,
                 )
                 .await
@@ -259,14 +254,9 @@ impl SubmissionWorker {
         // out of it, update the stats for the whole run.
         if check_stats_at_end {
             debug!("Checking stats for final time at the end");
-            self.update_stats(
-                start_time,
-                0,
-                total_num_requests,
-                true,
-                Duration::from_millis(500),
-            )
-            .await
+            if let Err(e) = self.set_stats_based_on_actual_sequence_numbers().await {
+                error!("Failed to set stats at end of run: {}", e);
+            }
         }
 
         self.accounts
@@ -275,16 +265,11 @@ impl SubmissionWorker {
     /// This function assumes that num_requests == num_accounts, which is
     /// precisely how gen_requests works. If this changes, this code will
     /// need to be fixed.
-    ///
-    /// Note, the latency values are not accurate if --check-stats-at-end
-    /// is used. There is no easy way around this accurately. As such, we
-    /// don't update latency at all if that flag is set.
     async fn update_stats(
         &mut self,
         start_time: Instant,
         txn_offset_time: u64,
         num_requests: usize,
-        skip_latency_stats: bool,
         wait_for_accounts_sequence_timeout: Duration,
     ) {
         match wait_for_accounts_sequence(
@@ -300,14 +285,12 @@ impl SubmissionWorker {
                 self.stats
                     .committed
                     .fetch_add(num_requests as u64, Ordering::Relaxed);
-                if !skip_latency_stats {
-                    self.stats
-                        .latency
-                        .fetch_add(latency * num_requests as u64, Ordering::Relaxed);
-                    self.stats
-                        .latencies
-                        .record_data_point(latency, num_requests as u64);
-                }
+                self.stats
+                    .latency
+                    .fetch_add(latency * num_requests as u64, Ordering::Relaxed);
+                self.stats
+                    .latencies
+                    .record_data_point(latency, num_requests as u64);
             }
             Err(uncommitted) => {
                 let num_uncommitted = uncommitted.len() as u64;
@@ -326,20 +309,40 @@ impl SubmissionWorker {
                 self.stats
                     .expired
                     .fetch_add(num_uncommitted, Ordering::Relaxed);
-                if !skip_latency_stats {
-                    self.stats
-                        .latency
-                        .fetch_add(committed_latency, Ordering::Relaxed);
-                    self.stats
-                        .latencies
-                        .record_data_point(latency, num_committed);
-                }
+                self.stats
+                    .latency
+                    .fetch_add(committed_latency, Ordering::Relaxed);
+                self.stats
+                    .latencies
+                    .record_data_point(latency, num_committed);
                 info!(
                     "[{:?}] Transactions were not committed before expiration: {:?}",
                     self.client, uncommitted
                 );
             }
         }
+    }
+
+    /// Unlike update_stats, which should be used in each loop where the number
+    /// of requests == the number of accounts, this function should be used to
+    /// just pull the sequence numbers from the accounts and set the values
+    /// based on those directly.
+    async fn set_stats_based_on_actual_sequence_numbers(&mut self) -> Result<()> {
+        let accounts_sequence =
+            get_accounts_sequence(&self.client, &mut self.accounts, Duration::from_millis(500))
+                .await?;
+
+        let committed = accounts_sequence.values().sum();
+
+        let mut uncommitted = 0;
+        for account in &self.accounts {
+            uncommitted += account.sequence_number() - accounts_sequence[&account.address()];
+        }
+
+        self.stats.committed.store(committed, Ordering::Relaxed);
+        self.stats.expired.store(uncommitted, Ordering::Relaxed);
+
+        Ok(())
     }
 
     fn gen_requests(&mut self, gas_price: u64) -> Vec<SignedTransaction> {
@@ -635,6 +638,7 @@ impl<'t> TxnEmitter<'t> {
             req.accounts_per_client, num_accounts
         );
         self.mint_accounts(&req, num_accounts).await?;
+        info!("Minting accounts completed");
         let all_accounts = self.accounts.split_off(self.accounts.len() - num_accounts);
         let mut workers = vec![];
         let all_addresses: Vec<_> = all_accounts.iter().map(|d| d.address()).collect();
@@ -790,38 +794,21 @@ pub async fn execute_and_wait_transactions(
     Ok(())
 }
 
-/// This function waits for the submitted transactions to be committed, up to
-/// a deadline. If some accounts still have uncommitted transactions when we
-/// hit the deadline, we return a map of account to the info about the number
-/// of committed transactions, based on the delta between the local sequence
-/// number and the actual sequence number returned by the account. Note, this
-/// can return possibly unexpected results if the emitter was emitting more
-/// transactions per account than the mempool limit of the accounts on the node.
-/// As it is now, the sequence number of the local account incrememnts regardless
-/// of whether the transaction is accepted into the node's mempool or not. So the
-/// local sequence number could be much higher than the real sequence number ever
-/// will be, since not all of the submitted transactions were accepted.
-/// TODO, investigate whether this behaviour is desirable.
-async fn wait_for_accounts_sequence(
+/// This returns a map of account address to its actual sequence number.
+async fn get_accounts_sequence(
     client: &RestClient,
     accounts: &mut [LocalAccount],
     wait_timeout: Duration,
-) -> Result<(), HashSet<AccountAddress>> {
+) -> Result<HashMap<AccountAddress, u64>> {
     let deadline = Instant::now() + wait_timeout;
     let addresses: Vec<_> = accounts.iter().map(|d| d.address()).collect();
-    let mut uncommitted = addresses.clone().into_iter().collect::<HashSet<_>>();
+    let mut out = HashMap::new();
 
     while Instant::now() <= deadline {
         match query_sequence_numbers(client, &addresses).await {
             Ok(sequence_numbers) => {
                 for (account, sequence_number) in zip(accounts.iter(), &sequence_numbers) {
-                    if account.sequence_number() == *sequence_number {
-                        uncommitted.remove(&account.address());
-                    }
-                }
-
-                if uncommitted.is_empty() {
-                    return Ok(());
+                    out.insert(account.address(), *sequence_number);
                 }
             }
             Err(e) => {
@@ -835,7 +822,39 @@ async fn wait_for_accounts_sequence(
         time::sleep(Duration::from_millis(250)).await;
     }
 
-    Err(uncommitted)
+    Ok(out)
+}
+
+/// This function gets the real sequence number of the accounts and then
+/// returns a set containing the accounts that had uncommitted transactions.
+async fn wait_for_accounts_sequence(
+    client: &RestClient,
+    accounts: &mut [LocalAccount],
+    wait_timeout: Duration,
+) -> Result<(), HashSet<AccountAddress>> {
+    let addresses: Vec<_> = accounts.iter().map(|d| d.address()).collect();
+    let mut uncommitted = addresses.clone().into_iter().collect::<HashSet<_>>();
+
+    let sequence_numbers = match get_accounts_sequence(client, accounts, wait_timeout).await {
+        Ok(sequence_numbers) => sequence_numbers,
+        Err(e) => {
+            error!("Failed to get sequence numbers: {:?}", e);
+            return Err(uncommitted);
+        }
+    };
+
+    for account in accounts {
+        let actual_sequence_number = sequence_numbers[&account.address()];
+        if account.sequence_number() == actual_sequence_number {
+            uncommitted.remove(&account.address());
+        }
+    }
+
+    if uncommitted.is_empty() {
+        Ok(())
+    } else {
+        Err(uncommitted)
+    }
 }
 
 pub async fn query_sequence_numbers(

--- a/ecosystem/node-checker/src/server/api.rs
+++ b/ecosystem/node-checker/src/server/api.rs
@@ -215,6 +215,6 @@ pub fn build_openapi_service<M: MetricCollector, R: Runner>(
     // These should have already been validated at this point, so we panic.
     let url: Url = server_args
         .try_into()
-        .expect("Failed to parse liten address");
+        .expect("Failed to parse listen address");
     OpenApiService::new(api, "Aptos Node Checker", version).server(url)
 }


### PR DESCRIPTION
## Description
We identified that this PR (https://github.com/aptos-labs/aptos-core/pull/1690) introduced a regression 

## Test Plan
Repro: todo

A (previous commit): todo
B (this PR): todo

See https://github.com/aptos-labs/aptos-core/blob/main/testsuite/testcases/src/performance_test.rs#L26.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1719)
<!-- Reviewable:end -->
