### PR TITLE
[txn-emitter] Add support for account creation

### DIFF
--- a/crates/transaction-emitter-lib/src/lib.rs
+++ b/crates/transaction-emitter-lib/src/lib.rs
@@ -9,6 +9,7 @@ mod atomic_histogram;
 mod cluster;
 mod emit;
 mod instance;
+mod transaction_generator;
 mod wrappers;
 
 // These are the top level things you should need to run the emitter.

--- a/crates/transaction-emitter-lib/src/transaction_generator/account_generator.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/account_generator.rs
@@ -1,0 +1,79 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::transaction_generator::TransactionGenerator;
+use aptos_sdk::{
+    move_types::account_address::AccountAddress,
+    transaction_builder::{aptos_stdlib, TransactionFactory},
+    types::{
+        transaction::{
+            authenticator::{AuthenticationKey, AuthenticationKeyPreimage},
+            SignedTransaction,
+        },
+        LocalAccount,
+    },
+};
+use rand::prelude::{SliceRandom, StdRng};
+use std::{fmt::Debug, sync::Arc};
+
+#[derive(Clone, Debug)]
+pub struct AccountGenerator {
+    rng: StdRng,
+    txn_factory: TransactionFactory,
+}
+
+impl AccountGenerator {
+    pub fn new(rng: StdRng, txn_factory: TransactionFactory) -> Self {
+        Self { rng, txn_factory }
+    }
+}
+
+impl TransactionGenerator for AccountGenerator {
+    fn generate_transactions(
+        &mut self,
+        accounts: Vec<&mut LocalAccount>,
+        all_addresses: Arc<Vec<AccountAddress>>,
+        _invalid_transaction_ratio: usize,
+        gas_price: u64,
+    ) -> Vec<SignedTransaction> {
+        let mut requests = Vec::with_capacity(accounts.len());
+        for account in accounts {
+            let receiver = all_addresses
+                .choose(&mut self.rng)
+                .expect("all_addresses can't be empty");
+            let request = self.gen_single_txn(account, receiver, 0, &self.txn_factory, gas_price);
+            requests.push(request);
+        }
+        requests
+    }
+
+    fn gen_single_txn(
+        &self,
+        from: &mut LocalAccount,
+        _to: &AccountAddress,
+        _num_coins: u64,
+        txn_factory: &TransactionFactory,
+        gas_price: u64,
+    ) -> SignedTransaction {
+        let preimage = AuthenticationKeyPreimage::ed25519(from.public_key());
+        let auth_key = AuthenticationKey::from_preimage(&preimage);
+        from.sign_with_transaction_builder(
+            txn_factory
+                .payload(aptos_stdlib::encode_account_create_account(
+                    auth_key.derived_address(),
+                ))
+                .gas_unit_price(gas_price),
+        )
+    }
+
+    // TODO(skedia): Add support for this.
+    fn generate_invalid_transaction(
+        &self,
+        _rng: &mut StdRng,
+        _sender: &mut LocalAccount,
+        _receiver: &AccountAddress,
+        _gas_price: u64,
+        _reqs: &[SignedTransaction],
+    ) -> SignedTransaction {
+        unimplemented!()
+    }
+}

--- a/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_sdk::{
+    move_types::account_address::AccountAddress,
+    transaction_builder::TransactionFactory,
+    types::{transaction::SignedTransaction, LocalAccount},
+};
+use rand::rngs::StdRng;
+use std::{fmt::Debug, sync::Arc};
+
+pub mod account_generator;
+pub mod p2p_transaction_generator;
+
+pub trait TransactionGenerator: Debug + Sync + Send {
+    fn generate_transactions(
+        &mut self,
+        accounts: Vec<&mut LocalAccount>,
+        all_addresses: Arc<Vec<AccountAddress>>,
+        invalid_transaction_ratio: usize,
+        gas_price: u64,
+    ) -> Vec<SignedTransaction>;
+
+    fn gen_single_txn(
+        &self,
+        from: &mut LocalAccount,
+        to: &AccountAddress,
+        num_coins: u64,
+        txn_factory: &TransactionFactory,
+        gas_price: u64,
+    ) -> SignedTransaction;
+
+    fn generate_invalid_transaction(
+        &self,
+        rng: &mut StdRng,
+        sender: &mut LocalAccount,
+        receiver: &AccountAddress,
+        gas_price: u64,
+        reqs: &[SignedTransaction],
+    ) -> SignedTransaction;
+}

--- a/crates/transaction-emitter-lib/src/transaction_generator/p2p_transaction_generator.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/p2p_transaction_generator.rs
@@ -1,0 +1,157 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use crate::transaction_generator::TransactionGenerator;
+use aptos_sdk::{
+    move_types::account_address::AccountAddress,
+    transaction_builder::{aptos_stdlib, TransactionFactory},
+    types::{chain_id::ChainId, transaction::SignedTransaction, LocalAccount},
+};
+use rand::{
+    distributions::{Distribution, Standard},
+    prelude::{SliceRandom, StdRng},
+    Rng,
+};
+use rand_core::RngCore;
+use std::{cmp::max, fmt::Debug, sync::Arc};
+
+#[derive(Clone, Debug)]
+pub struct P2PTransactionGenerator {
+    rng: StdRng,
+    send_amount: u64,
+    txn_factory: TransactionFactory,
+}
+
+impl P2PTransactionGenerator {
+    pub fn new(rng: StdRng, send_amount: u64, txn_factory: TransactionFactory) -> Self {
+        Self {
+            rng,
+            send_amount,
+            txn_factory,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum InvalidTransactionType {
+    /// invalid tx with wrong chain id
+    ChainId,
+    /// invalid tx with sender not on chain
+    Sender,
+    /// invalid tx with receiver not on chain
+    Receiver,
+    /// duplicate an exist tx
+    Duplication,
+}
+
+impl Distribution<InvalidTransactionType> for Standard {
+    fn sample<R: RngCore + ?Sized>(&self, rng: &mut R) -> InvalidTransactionType {
+        match rng.gen_range(0, 4) {
+            0 => InvalidTransactionType::ChainId,
+            1 => InvalidTransactionType::Sender,
+            2 => InvalidTransactionType::Receiver,
+            _ => InvalidTransactionType::Duplication,
+        }
+    }
+}
+
+impl TransactionGenerator for P2PTransactionGenerator {
+    fn generate_transactions(
+        &mut self,
+        accounts: Vec<&mut LocalAccount>,
+        all_addresses: Arc<Vec<AccountAddress>>,
+        invalid_transaction_ratio: usize,
+        gas_price: u64,
+    ) -> Vec<SignedTransaction> {
+        let mut requests = Vec::with_capacity(accounts.len());
+        let invalid_size = if invalid_transaction_ratio != 0 {
+            // if enable mix invalid tx, at least 1 invalid tx per batch
+            max(1, accounts.len() * invalid_transaction_ratio / 100)
+        } else {
+            0
+        };
+        let mut num_valid_tx = accounts.len() - invalid_size;
+        for sender in accounts {
+            let receiver = all_addresses
+                .choose(&mut self.rng)
+                .expect("all_addresses can't be empty");
+            let request = if num_valid_tx > 0 {
+                num_valid_tx -= 1;
+                self.gen_single_txn(
+                    sender,
+                    receiver,
+                    self.send_amount,
+                    &self.txn_factory,
+                    gas_price,
+                )
+            } else {
+                self.generate_invalid_transaction(
+                    &mut self.rng.clone(),
+                    sender,
+                    receiver,
+                    gas_price,
+                    &requests,
+                )
+            };
+            requests.push(request);
+        }
+        requests
+    }
+
+    fn gen_single_txn(
+        &self,
+        from: &mut LocalAccount,
+        to: &AccountAddress,
+        num_coins: u64,
+        txn_factory: &TransactionFactory,
+        gas_price: u64,
+    ) -> SignedTransaction {
+        from.sign_with_transaction_builder(
+            txn_factory
+                .payload(aptos_stdlib::encode_test_coin_transfer(*to, num_coins))
+                .gas_unit_price(gas_price),
+        )
+    }
+
+    fn generate_invalid_transaction(
+        &self,
+        rng: &mut StdRng,
+        sender: &mut LocalAccount,
+        receiver: &AccountAddress,
+        gas_price: u64,
+        reqs: &[SignedTransaction],
+    ) -> SignedTransaction {
+        let mut invalid_account = LocalAccount::generate(rng);
+        let invalid_address = invalid_account.address();
+        match Standard.sample(rng) {
+            InvalidTransactionType::ChainId => {
+                let txn_factory = &self.txn_factory.clone().with_chain_id(ChainId::new(255));
+                self.gen_single_txn(sender, receiver, self.send_amount, txn_factory, gas_price)
+            }
+            InvalidTransactionType::Sender => self.gen_single_txn(
+                &mut invalid_account,
+                receiver,
+                self.send_amount,
+                &self.txn_factory,
+                gas_price,
+            ),
+            InvalidTransactionType::Receiver => self.gen_single_txn(
+                sender,
+                &invalid_address,
+                self.send_amount,
+                &self.txn_factory,
+                gas_price,
+            ),
+            InvalidTransactionType::Duplication => {
+                // if this is the first tx, default to generate invalid tx with wrong chain id
+                // otherwise, make a duplication of an exist valid tx
+                if reqs.is_empty() {
+                    let txn_factory = &self.txn_factory.clone().with_chain_id(ChainId::new(255));
+                    self.gen_single_txn(sender, receiver, self.send_amount, txn_factory, gas_price)
+                } else {
+                    let random_index = rng.gen_range(0, reqs.len());
+                    reqs[random_index].clone()
+                }
+            }
+        }
+    }
+}

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -50,6 +50,7 @@ pub async fn emit_transactions_with_cluster(
             .accounts_per_client(args.accounts_per_client)
             .thread_params(thread_params)
             .invalid_transaction_ratio(args.invalid_tx)
+            .transaction_type(args.transaction_type)
             .gas_price(1);
     if let Some(workers_per_endpoint) = args.workers_per_ac {
         emit_job_request = emit_job_request.workers_per_endpoint(workers_per_endpoint);

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -81,7 +81,7 @@ impl<TMessage: PartialEq> PartialEq for Event<TMessage> {
 }
 
 /// Configuration needed for AptosNet applications to register with the network
-/// builder. Supports client-only, service-only, and p2p (both) applications.
+/// builder. Supports client-only, service-only, and P2p (both) applications.
 // TODO(philiphayes): separate configs for client & server?
 #[derive(Clone, Default)]
 pub struct AppConfig {

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Example
 //!
-//! Here is a simple example to show how to create two accounts and do a p2p transfer on testnet:
+//! Here is a simple example to show how to create two accounts and do a P2p transfer on testnet:
 //! todo(davidiw) bring back example using rest
 //!
 


### PR DESCRIPTION
### Description

This PR adds support for account creation transactions to the transaction emitter. The purpose of this to be able to run transaction emitter on test-net to generate a very large DB. With 5k TPS, we can expect to generate ~500M accounts DB in 24 hours and observe the network behavior.  The PR also refactors the transaction generator part to be more modular, so that we can plug-in different transaction type like minting NFTs in future. 

### Test Plan

Ran it locally

```
export MP=`cat /tmp/testnodeoutput | grep "Aptos root key path" | perl -pe "s|.*?path: ||" | tr -d '"'` && cargo run -p transaction-emitter --release -- emit-tx -t http://localhost:8080 http://localhost:8080 http://localhost:8080 http://localhost:8080 http://localhost:8080 http://localhost:8080 http://localhost:8080 http://localhost:8080 http://localhost:8080 http://localhost:8080 --mint-file "$MP" --chain-id TESTING --duration 60 --workers-per-ac 8 --accounts-per-client 8 --txn-expiration-time-secs 10  --wait-millis 0 --transaction-type account_generation
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1724)
<!-- Reviewable:end -->
