### PR TITLE
[tf] update to terraform 1.2.0

### DIFF
--- a/developer-docs-site/docs/nodes/full-node/run-a-fullnode-on-gcp.md
+++ b/developer-docs-site/docs/nodes/full-node/run-a-fullnode-on-gcp.md
@@ -78,7 +78,7 @@ You can deploy a public FullNode on GCP by using the Aptos fullnode Terraform mo
 4. Modify `main.tf` file to configure Terraform, and create fullnode from Terraform module. Example content for `main.tf`:
   ```
   terraform {
-    required_version = "~> 1.1.0"
+    required_version = "~> 1.2.0"
     backend "gcs" {
       bucket = "BUCKET_NAME" # bucket name created in step 2
       prefix = "state/fullnode"

--- a/terraform/aptos-node/aws/README.md
+++ b/terraform/aptos-node/aws/README.md
@@ -40,7 +40,7 @@ Install pre-requisites if needed:
   }
 
   terraform {
-    required_version = "~> 1.1.0"
+    required_version = "~> 1.2.0"
     backend "s3" {
       bucket = "terraform.aptos-node"
       key    = "state/aptos-node"

--- a/terraform/aptos-node/gcp/README.md
+++ b/terraform/aptos-node/gcp/README.md
@@ -39,7 +39,7 @@ Install pre-requisites if needed:
 4. Modify `main.tf` file to configure Terraform, and create fullnode from Terraform module. Example content for `main.tf`:
   ```
   terraform {
-    required_version = "~> 1.1.0"
+    required_version = "~> 1.2.0"
     backend "gcs" {
       bucket = "BUCKET_NAME" # bucket name created in step 2
       prefix = "state/aptos-node"

--- a/terraform/fullnode/aws/versions.tf
+++ b/terraform/fullnode/aws/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.2.0"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/terraform/fullnode/gcp/versions.tf
+++ b/terraform/fullnode/gcp/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.2.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/terraform/modules/eks/versions.tf
+++ b/terraform/modules/eks/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.2.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/modules/indexer/versions.tf
+++ b/terraform/modules/indexer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.2.0"
   required_providers {
     helm = {
       source = "hashicorp/helm"


### PR DESCRIPTION
So we can use the same terraform version across all deployments. Terraform version was already bumped and tested for the `aptos-node` and `aptos-node-testnet` deployments, so this PR just does it for the rest of the deployments

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1728)
<!-- Reviewable:end -->
