### PR TITLE
[aptos-rest-client] Make a Rest Client that is simpler and can support multiple encodings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -927,6 +927,7 @@ dependencies = [
  "bcs",
  "hex",
  "move-deps",
+ "percent-encoding",
  "reqwest",
  "serde 1.0.137",
  "serde_json",

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -28,9 +28,7 @@ pub use move_types::{
     MoveScriptBytecode, MoveStructTag, MoveStructValue, MoveType, MoveValue, ScriptFunctionId,
     U128, U64,
 };
-pub use response::{
-    Response, X_APTOS_CHAIN_ID, X_APTOS_EPOCH, X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
-};
+pub use response::*;
 pub use table::TableItemRequest;
 pub use transaction::{
     BlockMetadataTransaction, DirectWriteSet, Event, GenesisTransaction, PendingTransaction,

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -17,6 +17,7 @@ dpn = []
 anyhow = "1.0.57"
 bcs = "0.1.3"
 hex = "0.4.3"
+percent-encoding = "2.1.0"
 reqwest = { version = "0.11.10", features = ["json", "cookies"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -26,6 +26,7 @@ pub mod types;
 use crate::aptos::{AptosVersion, Balance};
 pub use types::{Account, Resource, RestError};
 pub mod aptos;
+pub mod v2;
 
 pub const USER_AGENT: &str = concat!("aptos-client-sdk-rust / ", env!("CARGO_PKG_VERSION"));
 

--- a/crates/aptos-rest-client/src/state.rs
+++ b/crates/aptos-rest-client/src/state.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_api_types::{
-    X_APTOS_CHAIN_ID, X_APTOS_EPOCH, X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
+    X_APTOS_CHAIN_ID, X_APTOS_EPOCH, X_APTOS_LEDGER_OLDEST_VERSION, X_APTOS_LEDGER_TIMESTAMP,
+    X_APTOS_LEDGER_VERSION,
 };
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -32,9 +33,8 @@ impl State {
             .get(X_APTOS_EPOCH)
             .and_then(|h| h.to_str().ok())
             .and_then(|s| s.parse().ok());
-        // TODO: Why doesn't the constant work?
         let oldest_ledger_version = headers
-            .get("X-Aptos-Ledger-Oldest-Version")
+            .get(X_APTOS_LEDGER_OLDEST_VERSION)
             .and_then(|h| h.to_str().ok())
             .and_then(|s| s.parse().ok());
 

--- a/crates/aptos-rest-client/src/v2/client.rs
+++ b/crates/aptos-rest-client/src/v2/client.rs
@@ -1,0 +1,70 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{v2::types::LedgerResponse, USER_AGENT};
+use anyhow::Result;
+use aptos_api_types::LedgerInfo;
+use reqwest::{Client as ReqwestClient, ClientBuilder as ReqwestClientBuilder};
+use serde::de::DeserializeOwned;
+use std::time::Duration;
+use url::Url;
+
+/// Builder for [`AptosClient`]
+#[derive(Debug)]
+pub struct AptosClientBuilder {
+    base_url: Url,
+    inner: ReqwestClientBuilder,
+}
+
+impl AptosClientBuilder {
+    pub fn new(base_url: Url) -> Self {
+        let inner = ReqwestClient::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent(USER_AGENT)
+            .cookie_store(true);
+        Self { base_url, inner }
+    }
+
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.timeout(timeout);
+        self
+    }
+
+    pub fn build(self) -> Result<AptosClient> {
+        Ok(AptosClient {
+            base_url: self.base_url,
+            inner: self.inner.build()?,
+        })
+    }
+}
+
+/// A client for the Aptos REST API
+#[derive(Clone, Debug)]
+pub struct AptosClient {
+    base_url: Url,
+    inner: ReqwestClient,
+}
+
+impl AptosClient {
+    /// Make a GET request for a URL
+    async fn get_url<T: DeserializeOwned>(&self, url: Url) -> Result<LedgerResponse<T>> {
+        LedgerResponse::from_response(self.inner.get(url).send().await?).await
+    }
+
+    /// Make a POST request for a URL
+    async fn post_url<T: DeserializeOwned, Body: Into<reqwest::Body>>(
+        &self,
+        url: Url,
+        body: Body,
+    ) -> Result<LedgerResponse<T>> {
+        LedgerResponse::from_response(self.inner.post(url).body(body).send().await?).await
+    }
+
+    // -- General APIs --
+    /// Get `LedgerInfo`
+    async fn get_ledger_info(&self) -> Result<LedgerResponse<LedgerInfo>> {
+        self.get_url(self.base_url.clone()).await
+    }
+
+    // -- Account APIs --
+}

--- a/crates/aptos-rest-client/src/v2/client.rs
+++ b/crates/aptos-rest-client/src/v2/client.rs
@@ -1,19 +1,33 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{v2::types::LedgerResponse, USER_AGENT};
-use anyhow::Result;
-use aptos_api_types::LedgerInfo;
-use reqwest::{Client as ReqwestClient, ClientBuilder as ReqwestClientBuilder};
-use serde::de::DeserializeOwned;
+use crate::{
+    v2::types::{LedgerResponse, Page},
+    Account, AccountAddress, AptosVersion, Balance, Resource, BCS_CONTENT_TYPE, USER_AGENT,
+};
+use anyhow::{anyhow, Result};
+use aptos_api_types::{LedgerInfo, MoveModuleBytecode, Transaction};
+use aptos_crypto::HashValue;
+use aptos_types::account_config::aptos_root_address;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use reqwest::{
+    header::CONTENT_TYPE, Client as ReqwestClient, ClientBuilder as ReqwestClientBuilder,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::{json, Value};
 use std::time::Duration;
 use url::Url;
+
+const DEFAULT_TXN_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_TXN_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// Builder for [`AptosClient`]
 #[derive(Debug)]
 pub struct AptosClientBuilder {
     base_url: Url,
     inner: ReqwestClientBuilder,
+    txn_timeout: Duration,
+    txn_retry_delay: Duration,
 }
 
 impl AptosClientBuilder {
@@ -22,7 +36,12 @@ impl AptosClientBuilder {
             .timeout(Duration::from_secs(10))
             .user_agent(USER_AGENT)
             .cookie_store(true);
-        Self { base_url, inner }
+        Self {
+            base_url,
+            inner,
+            txn_timeout: DEFAULT_TXN_TIMEOUT,
+            txn_retry_delay: DEFAULT_TXN_RETRY_DELAY,
+        }
     }
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
@@ -34,6 +53,8 @@ impl AptosClientBuilder {
         Ok(AptosClient {
             base_url: self.base_url,
             inner: self.inner.build()?,
+            txn_timeout: self.txn_timeout,
+            txn_retry_delay: self.txn_retry_delay,
         })
     }
 }
@@ -43,6 +64,8 @@ impl AptosClientBuilder {
 pub struct AptosClient {
     base_url: Url,
     inner: ReqwestClient,
+    txn_timeout: Duration,
+    txn_retry_delay: Duration,
 }
 
 impl AptosClient {
@@ -51,20 +74,266 @@ impl AptosClient {
         LedgerResponse::from_response(self.inner.get(url).send().await?).await
     }
 
-    /// Make a POST request for a URL
-    async fn post_url<T: DeserializeOwned, Body: Into<reqwest::Body>>(
+    /// Make a POST request for a URL in JSON
+    async fn post_url_json<T: DeserializeOwned, Body: Serialize>(
         &self,
         url: Url,
-        body: Body,
+        body: &Body,
     ) -> Result<LedgerResponse<T>> {
-        LedgerResponse::from_response(self.inner.post(url).body(body).send().await?).await
+        LedgerResponse::from_response(self.inner.post(url).json(body).send().await?).await
+    }
+
+    /// Make a POST request for a URL in BCS
+    async fn post_url_bcs<T: DeserializeOwned, Body: Serialize>(
+        &self,
+        url: Url,
+        body: &Body,
+    ) -> Result<LedgerResponse<T>> {
+        LedgerResponse::from_response(
+            self.inner
+                .post(url)
+                .header(CONTENT_TYPE, BCS_CONTENT_TYPE)
+                .body(bcs::to_bytes(body)?)
+                .send()
+                .await?,
+        )
+        .await
     }
 
     // -- General APIs --
-    /// Get `LedgerInfo`
-    async fn get_ledger_info(&self) -> Result<LedgerResponse<LedgerInfo>> {
+    /// Get the `LedgerInfo` current state of the network
+    pub async fn get_ledger_info(&self) -> Result<LedgerResponse<LedgerInfo>> {
         self.get_url(self.base_url.clone()).await
     }
 
+    pub async fn get_aptos_version(&self, version: Option<u64>) -> Result<AptosVersion> {
+        self.get_typed_resource::<AptosVersion>(
+            aptos_root_address(),
+            "0x1::Version::Version",
+            version,
+        )
+        .await
+    }
+
+    /// Health check the endpoint
+    pub async fn health_check(&self, seconds: u64) -> Result<()> {
+        let response = self
+            .inner
+            .get(self.base_url.join("-/healthy")?)
+            .query(&[("duration_secs", seconds)])
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(anyhow::anyhow!("health check failed"));
+        }
+
+        Ok(())
+    }
+
     // -- Account APIs --
+    /// Get an [`Account`]'s attributes
+    pub async fn get_account(
+        &self,
+        account_address: AccountAddress,
+    ) -> Result<LedgerResponse<Account>> {
+        self.get_url(
+            self.base_url
+                .join(&format!("/accounts/{}", account_address.to_hex_literal()))?,
+        )
+        .await
+    }
+
+    /// Get all [`Resource`]s associated with an account at a version
+    ///
+    /// If no version is provided, it will grab the latest version
+    pub async fn get_account_resources(
+        &self,
+        account_address: AccountAddress,
+        version: Option<u64>,
+    ) -> Result<LedgerResponse<Vec<Resource>>> {
+        let path = with_version(
+            format!("/accounts/{}/resources", account_address.to_hex_literal()),
+            version,
+        );
+        self.get_url(self.base_url.join(&path)?).await
+    }
+
+    /// Get a specific [`Resource`] associated with an account at a version
+    ///
+    /// If no version is provided, it will grab the latest version
+    pub async fn get_account_resource(
+        &self,
+        account_address: AccountAddress,
+        resource_type: &str,
+        version: Option<u64>,
+    ) -> Result<LedgerResponse<Option<Resource>>> {
+        const ENCODING_CHARS: &AsciiSet = &CONTROLS.add(b'<').add(b'>');
+        let resource_type = utf8_percent_encode(resource_type, ENCODING_CHARS).to_string();
+
+        let path = with_version(
+            format!(
+                "/accounts/{}/resource/{}",
+                account_address.to_hex_literal(),
+                resource_type
+            ),
+            version,
+        );
+        self.get_url(self.base_url.join(&path)?).await
+    }
+
+    /// Get an account's [`Resource`] and convert it to the typed `T`
+    ///
+    /// TODO: This should probably be BCS encoded as well
+    pub async fn get_typed_resource<T: DeserializeOwned>(
+        &self,
+        account_address: AccountAddress,
+        resource_type: &str,
+        version: Option<u64>,
+    ) -> Result<T> {
+        let response = self
+            .get_account_resource(account_address, resource_type, version)
+            .await?;
+        if let Some(resource) = response.into_inner() {
+            serde_json::from_value(resource.data)
+                .map_err(|e| anyhow!("deserializing {} failed: {}", resource_type, e))
+        } else {
+            Err(anyhow!(
+                "Failed to find resource {} in account {}",
+                resource_type,
+                account_address
+            ))
+        }
+    }
+
+    /// Get all [`MoveModuleBytecode`]s associated with an account at a version
+    ///
+    /// If no version is provided, it will grab the latest version
+    pub async fn get_account_modules(
+        &self,
+        account_address: AccountAddress,
+        version: Option<u64>,
+    ) -> Result<LedgerResponse<Vec<MoveModuleBytecode>>> {
+        let path = with_version(
+            format!("/accounts/{}/modules", account_address.to_hex_literal()),
+            version,
+        );
+        self.get_url(self.base_url.join(&path)?).await
+    }
+
+    /// Retrieves transactions associated with an account
+    ///
+    /// Takes optional paging information, that can be used to page through transactions
+    pub async fn get_account_transactions(
+        &self,
+        account_address: AccountAddress,
+        page: Option<Page>,
+    ) -> Result<LedgerResponse<Vec<Transaction>>> {
+        let path = with_page(
+            format!(
+                "/accounts/{}/transactions",
+                account_address.to_hex_literal()
+            ),
+            page,
+        );
+        self.get_url(self.base_url.join(&path)?).await
+    }
+
+    pub async fn get_account_balance(
+        &self,
+        account_address: AccountAddress,
+        version: Option<u64>,
+    ) -> Result<Balance> {
+        self.get_typed_resource(
+            account_address,
+            "0x1::Coin::CoinStore<0x1::TestCoin::TestCoin>",
+            version,
+        )
+        .await
+    }
+
+    // -- Transaction APIs --
+    /// Get a transaction by it's hash value
+    pub async fn get_transaction_by_hash(
+        &self,
+        hash: HashValue,
+    ) -> Result<LedgerResponse<Transaction>> {
+        self.get_transaction(hash.to_hex_literal()).await
+    }
+
+    /// Get a transaction by it's ledger version
+    pub async fn get_transaction_by_version(
+        &self,
+        version: u64,
+    ) -> Result<LedgerResponse<Transaction>> {
+        self.get_transaction(version.to_string()).await
+    }
+
+    async fn get_transaction(
+        &self,
+        version_or_hash: String,
+    ) -> Result<LedgerResponse<Transaction>> {
+        self.get_url(
+            self.base_url
+                .join(&format!("transactions/{}", version_or_hash))?,
+        )
+        .await
+    }
+
+    // -- Table APIs --
+    pub async fn get_table_item<K: Serialize>(
+        &self,
+        table_handle: u128,
+        key_type: &str,
+        value_type: &str,
+        key: K,
+    ) -> Result<LedgerResponse<Value>> {
+        let data = json!({
+            "key_type": key_type,
+            "value_type": value_type,
+            "key": json!(key),
+        });
+
+        self.post_url_json(
+            self.base_url
+                .join(&format!("tables/{}/item", table_handle))?,
+            &data,
+        )
+        .await
+    }
+
+    // -- Submit APIs --
+}
+
+/// Appends version query arg if applicable
+fn with_version(path: String, version: Option<u64>) -> String {
+    if let Some(version) = version {
+        format!("{}?version={}", path, version)
+    } else {
+        path
+    }
+}
+
+/// Appends page query args if applicable
+fn with_page(path: String, page: Option<Page>) -> String {
+    let query_params = match page {
+        Some(Page {
+            start: Some(start),
+            limit: Some(limit),
+        }) => Some(format!("start={}&limit={}", start, limit)),
+        Some(Page {
+            start: None,
+            limit: Some(limit),
+        }) => Some(format!("limit={}", limit)),
+        Some(Page {
+            start: Some(start),
+            limit: None,
+        }) => Some(format!("start={}", start)),
+        _ => None,
+    };
+    if let Some(query_params) = query_params {
+        format!("{}?{}", path, query_params)
+    } else {
+        path
+    }
 }

--- a/crates/aptos-rest-client/src/v2/mod.rs
+++ b/crates/aptos-rest-client/src/v2/mod.rs
@@ -1,0 +1,26 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod client;
+pub mod types;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::v2::client::{AptosClient, AptosClientBuilder};
+
+    // TODO: Make these tests against a running server
+    fn setup_client() -> AptosClient {
+        AptosClientBuilder::new("http://localhost:8080".parse().unwrap())
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_ledger_info() {
+        let client = setup_client();
+        let response = client.get_ledger_info().await.unwrap();
+        let ledger_info = response.ledger_info();
+        assert_eq!(ledger_info, response.inner());
+    }
+}

--- a/crates/aptos-rest-client/src/v2/mod.rs
+++ b/crates/aptos-rest-client/src/v2/mod.rs
@@ -6,8 +6,15 @@ pub mod types;
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::v2::client::{AptosClient, AptosClientBuilder};
+    use crate::{
+        v2::{
+            client::{AptosClient, AptosClientBuilder},
+            types::Page,
+        },
+        AccountAddress,
+    };
+    use aptos_types::account_config::aptos_root_address;
+    use std::str::FromStr;
 
     // TODO: Make these tests against a running server
     fn setup_client() -> AptosClient {
@@ -22,5 +29,142 @@ mod test {
         let response = client.get_ledger_info().await.unwrap();
         let ledger_info = response.ledger_info();
         assert_eq!(ledger_info, response.inner());
+    }
+
+    #[tokio::test]
+    async fn health_check() {
+        let client = setup_client();
+        client.health_check(5).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_account() {
+        let client = setup_client();
+        client.get_account(AccountAddress::ONE).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_account_resources() {
+        let client = setup_client();
+        let one_response = client
+            .get_account_resources(AccountAddress::ONE, Some(1))
+            .await
+            .unwrap();
+        let zero_response = client
+            .get_account_resources(AccountAddress::ONE, Some(0))
+            .await
+            .unwrap();
+        let now_response = client
+            .get_account_resources(AccountAddress::ONE, None)
+            .await
+            .unwrap();
+
+        assert_eq!(zero_response.inner(), one_response.inner());
+        assert_eq!(zero_response.inner(), now_response.inner());
+    }
+
+    #[tokio::test]
+    async fn test_account_resource() {
+        let client = setup_client();
+        let one_response = client
+            .get_account_resource(
+                AccountAddress::ONE,
+                "0x1::Coin::CoinInfo<0x1::TestCoin::TestCoin>",
+                Some(1),
+            )
+            .await
+            .unwrap();
+        let zero_response = client
+            .get_account_resource(
+                AccountAddress::ONE,
+                "0x1::Coin::CoinInfo<0x1::TestCoin::TestCoin>",
+                Some(0),
+            )
+            .await
+            .unwrap();
+        let now_response = client
+            .get_account_resource(
+                AccountAddress::ONE,
+                "0x1::Coin::CoinInfo<0x1::TestCoin::TestCoin>",
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(zero_response.inner(), one_response.inner());
+        assert_eq!(zero_response.inner(), now_response.inner());
+    }
+
+    #[tokio::test]
+    async fn test_account_modules() {
+        let client = setup_client();
+        let one_response = client
+            .get_account_modules(AccountAddress::ONE, Some(1))
+            .await
+            .unwrap();
+        let zero_response = client
+            .get_account_modules(AccountAddress::ONE, Some(0))
+            .await
+            .unwrap();
+        let now_response = client
+            .get_account_modules(AccountAddress::ONE, None)
+            .await
+            .unwrap();
+
+        assert_eq!(zero_response.inner(), one_response.inner());
+        assert_eq!(zero_response.inner(), now_response.inner());
+    }
+
+    #[tokio::test]
+    async fn test_account_transactions() {
+        let client = setup_client();
+        let response = client
+            .get_account_transactions(aptos_root_address(), None)
+            .await
+            .unwrap();
+
+        assert!(!response.inner().is_empty());
+        let txn = response.inner().first().unwrap();
+        let response = client
+            .get_account_transactions(aptos_root_address(), Some(Page::new(Some(0), Some(1))))
+            .await
+            .unwrap();
+
+        assert_eq!(response.inner().first().unwrap(), txn);
+    }
+
+    #[tokio::test]
+    async fn test_account_transaction() {
+        let client = setup_client();
+        let response = client
+            .get_account_transactions(aptos_root_address(), None)
+            .await
+            .unwrap();
+        let txn = response.inner().first().unwrap();
+        let txn_info = txn.transaction_info().unwrap();
+        let by_version = client
+            .get_transaction_by_version(txn_info.version.0)
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(&by_version, txn);
+
+        let by_hash = client
+            .get_transaction_by_hash(txn_info.hash.into())
+            .await
+            .unwrap()
+            .into_inner();
+        assert_eq!(&by_hash, txn);
+    }
+
+    #[tokio::test]
+    async fn get_account_balance() {
+        let client = setup_client();
+        let account = AccountAddress::from_str(
+            "cb48471868293a5feb8fac3871775b62a671b7c405b43e7755f368901df9ec8c",
+        )
+        .unwrap();
+        let balance = client.get_account_balance(account, None).await.unwrap();
+        assert!(balance.coin.value.0 > 0);
     }
 }

--- a/crates/aptos-rest-client/src/v2/types.rs
+++ b/crates/aptos-rest-client/src/v2/types.rs
@@ -1,0 +1,101 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::RestError;
+use anyhow::anyhow;
+use aptos_api_types::{
+    mime_types::{BCS, JSON},
+    LedgerInfo, X_APTOS_CHAIN_ID, X_APTOS_EPOCH, X_APTOS_LEDGER_OLDEST_VERSION,
+    X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
+};
+use reqwest::{header::CONTENT_TYPE, Response};
+use serde::de::DeserializeOwned;
+
+/// Ledger response, containing the ledger state and the inner type
+#[derive(Clone, Debug)]
+pub struct LedgerResponse<T> {
+    pub(crate) inner: T,
+    pub(crate) ledger_info: LedgerInfo,
+}
+
+impl<T: DeserializeOwned> LedgerResponse<T> {
+    pub async fn from_response(response: Response) -> anyhow::Result<LedgerResponse<T>> {
+        if !response.status().is_success() {
+            let error_response = response.json::<RestError>().await?;
+            return Err(anyhow::anyhow!("Request failed: {:?}", error_response));
+        }
+        let ledger_info = ledger_info_from_headers(response.headers())?;
+
+        let encoding = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .map(|inner| inner.to_str());
+
+        let inner: T = match encoding {
+            Some(Ok(BCS)) => bcs::from_bytes(&response.bytes().await?)?,
+            Some(Ok(JSON)) => serde_json::from_str(&response.text().await?)?,
+            _ => return Err(anyhow!("Invalid encoding type {:?}", encoding)),
+        };
+
+        Ok(LedgerResponse { inner, ledger_info })
+    }
+
+    pub fn ledger_info(&self) -> &LedgerInfo {
+        &self.ledger_info
+    }
+
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+fn ledger_info_from_headers(headers: &reqwest::header::HeaderMap) -> anyhow::Result<LedgerInfo> {
+    let maybe_chain_id = headers
+        .get(X_APTOS_CHAIN_ID)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse().ok());
+    let maybe_version = headers
+        .get(X_APTOS_LEDGER_VERSION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse().ok());
+    let maybe_timestamp = headers
+        .get(X_APTOS_LEDGER_TIMESTAMP)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse().ok());
+    let maybe_epoch = headers
+        .get(X_APTOS_EPOCH)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse().ok());
+    let maybe_oldest_ledger_version = headers
+        .get(X_APTOS_LEDGER_OLDEST_VERSION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.parse().ok());
+
+    if let (
+        Some(chain_id),
+        Some(ledger_version),
+        Some(ledger_timestamp),
+        Some(epoch),
+        Some(oldest_ledger_version),
+    ) = (
+        maybe_chain_id,
+        maybe_version,
+        maybe_timestamp,
+        maybe_epoch,
+        maybe_oldest_ledger_version,
+    ) {
+        Ok(LedgerInfo {
+            chain_id,
+            epoch,
+            ledger_version,
+            ledger_timestamp,
+            oldest_ledger_version,
+        })
+    } else {
+        Err(anyhow!("Failed to parse LedgerInfo from headers"))
+    }
+}

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -18,7 +18,7 @@ use crate::{
 };
 use aptos_crypto::HashValue;
 use aptos_logger::{debug, trace};
-use aptos_rest_client::{aptos::Balance, aptos_api_types::U64};
+use aptos_rest_client::{aptos::Balance, aptos_api_types::U64, v2::client::AptosClient};
 use aptos_sdk::move_types::{identifier::Identifier, language_storage::TypeTag};
 use aptos_types::account_address::AccountAddress;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
@@ -104,7 +104,7 @@ async fn account_balance(
 }
 
 async fn get_block_index_from_request(
-    rest_client: &aptos_rest_client::Client,
+    rest_client: &AptosClient,
     partial_block_identifier: Option<PartialBlockIdentifier>,
     block_size: u64,
 ) -> ApiResult<u64> {
@@ -159,7 +159,7 @@ async fn get_block_index_from_request(
 }
 
 async fn get_balances(
-    rest_client: &aptos_rest_client::Client,
+    rest_client: &AptosClient,
     address: AccountAddress,
     version: u64,
 ) -> ApiResult<HashMap<TypeTag, Balance>> {
@@ -204,7 +204,7 @@ impl CoinCache {
     /// Retrieve a currency and cache it if applicable
     pub async fn get_currency(
         &self,
-        rest_client: &aptos_rest_client::Client,
+        rest_client: &AptosClient,
         coin: TypeTag,
         version: u64,
     ) -> ApiResult<Option<Currency>> {
@@ -228,7 +228,7 @@ impl CoinCache {
     /// Pulls currency information from onchain
     pub async fn get_currency_inner(
         &self,
-        rest_client: &aptos_rest_client::Client,
+        rest_client: &AptosClient,
         coin: TypeTag,
         version: u64,
     ) -> ApiResult<Option<Currency>> {

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use aptos_crypto::HashValue;
 use aptos_logger::{debug, trace};
-use aptos_rest_client::Transaction;
+use aptos_rest_client::{v2::client::AptosClient, Transaction};
 use std::str::FromStr;
 use warp::Filter;
 
@@ -55,7 +55,7 @@ async fn block(request: BlockRequest, server_context: RosettaContext) -> ApiResu
             // Allow 0x in front of hash
             let hash = HashValue::from_str(strip_hex_prefix(hash))
                 .map_err(|err| ApiError::AptosError(err.to_string()))?;
-            let response = rest_client.get_transaction(hash).await?;
+            let response = rest_client.get_transaction_by_hash(hash).await?;
             let txn = response.into_inner();
             let version = txn.version().unwrap();
             let block_index = version_to_block_index(server_context.block_size, version);
@@ -113,7 +113,7 @@ async fn block(request: BlockRequest, server_context: RosettaContext) -> ApiResu
 }
 
 async fn get_block_by_index(
-    rest_client: &aptos_rest_client::Client,
+    rest_client: &AptosClient,
     block_size: u64,
     block_index: u64,
 ) -> ApiResult<(Transaction, Vec<Transaction>)> {

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use aptos_crypto::ValidCryptoMaterial;
 use aptos_logger::debug;
-use aptos_rest_client::{aptos::Balance, Account, Response};
+use aptos_rest_client::{aptos::Balance, v2::client::AptosClient, Account, Response};
 use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use futures::future::BoxFuture;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -92,7 +92,7 @@ where
 }
 
 pub async fn get_account(
-    rest_client: &aptos_rest_client::Client,
+    rest_client: &AptosClient,
     address: AccountAddress,
 ) -> ApiResult<Response<Account>> {
     rest_client
@@ -102,7 +102,7 @@ pub async fn get_account(
 }
 
 pub async fn get_account_balance(
-    rest_client: &aptos_rest_client::Client,
+    rest_client: &AptosClient,
     address: AccountAddress,
 ) -> ApiResult<Response<Balance>> {
     rest_client

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -9,7 +9,7 @@ use crate::{account::CoinCache, error::ApiError};
 use aptos_api::runtime::WebServer;
 use aptos_config::config::ApiConfig;
 use aptos_logger::debug;
-use aptos_rest_client::aptos_api_types::Error;
+use aptos_rest_client::{aptos_api_types::Error, v2::client::AptosClient};
 use aptos_types::chain_id::ChainId;
 use std::{convert::Infallible, sync::Arc};
 use tokio::task::JoinHandle;
@@ -39,7 +39,7 @@ pub const ROSETTA_VERSION: &str = "1.4.12";
 #[derive(Clone, Debug)]
 pub struct RosettaContext {
     /// A rest client to connect to a fullnode
-    rest_client: Option<aptos_rest_client::Client>,
+    rest_client: Option<AptosClient>,
     /// ChainId of the chain to connect to
     pub chain_id: ChainId,
 
@@ -48,7 +48,7 @@ pub struct RosettaContext {
 }
 
 impl RosettaContext {
-    fn rest_client(&self) -> Result<&aptos_rest_client::Client, ApiError> {
+    fn rest_client(&self) -> Result<&AptosClient, ApiError> {
         if let Some(ref client) = self.rest_client {
             Ok(client)
         } else {
@@ -62,7 +62,7 @@ pub fn bootstrap(
     block_size: u64,
     chain_id: ChainId,
     api_config: ApiConfig,
-    rest_client: Option<aptos_rest_client::Client>,
+    rest_client: Option<AptosClient>,
 ) -> anyhow::Result<tokio::runtime::Runtime> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .thread_name("rosetta")
@@ -88,7 +88,7 @@ pub fn bootstrap(
 pub async fn bootstrap_async(
     chain_id: ChainId,
     api_config: ApiConfig,
-    rest_client: Option<aptos_rest_client::Client>,
+    rest_client: Option<AptosClient>,
 ) -> anyhow::Result<JoinHandle<()>> {
     debug!("Starting up Rosetta server with {:?}", api_config);
     let api = WebServer::from(api_config);

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use aptos_config::config::ApiConfig;
+use aptos_rest_client::v2::client::{AptosClient, AptosClientBuilder};
 use aptos_rosetta::bootstrap;
 use aptos_types::chain_id::ChainId;
 use clap::Parser;
@@ -42,7 +43,7 @@ trait ServerArgs {
     fn api_config(&self) -> ApiConfig;
 
     /// Retrieve the optional rest client for the local server
-    fn rest_client(&self) -> Option<aptos_rest_client::Client>;
+    fn rest_client(&self) -> Option<AptosClient>;
 
     /// Retrieve the chain id
     fn chain_id(&self) -> ChainId;
@@ -70,7 +71,7 @@ impl ServerArgs for CommandArgs {
         }
     }
 
-    fn rest_client(&self) -> Option<aptos_rest_client::Client> {
+    fn rest_client(&self) -> Option<AptosClient> {
         match self {
             CommandArgs::Online(args) => args.rest_client(),
             CommandArgs::Offline(args) => args.rest_client(),
@@ -125,7 +126,7 @@ impl ServerArgs for OfflineArgs {
         }
     }
 
-    fn rest_client(&self) -> Option<aptos_rest_client::Client> {
+    fn rest_client(&self) -> Option<AptosClient> {
         None
     }
 
@@ -152,8 +153,12 @@ impl ServerArgs for OnlineArgs {
         self.offline_args.api_config()
     }
 
-    fn rest_client(&self) -> Option<aptos_rest_client::Client> {
-        Some(aptos_rest_client::Client::new(self.rest_api_url.clone()))
+    fn rest_client(&self) -> Option<AptosClient> {
+        Some(
+            AptosClientBuilder::new(self.rest_api_url.clone())
+                .build()
+                .unwrap(),
+        )
     }
 
     fn chain_id(&self) -> ChainId {

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -79,7 +79,7 @@ impl BlockIdentifier {
         } else {
             BlockIdentifier {
                 index: version_to_block_index(block_size, info.version.0),
-                hash: info.accumulator_root_hash.to_string(),
+                hash: info.hash.to_string(),
             }
         }
     }


### PR DESCRIPTION
### Description
I spent time trying to get the rest client to support BCS, until I decided it wasn't worth my immediate time, but this lays the foundation for a simpler CLI.  It does not support sending txns at this moment, and is a WIP.

The tests I need to remove, they were run against my local node.


### Test Plan
Local testing, E2E tbd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1730)
<!-- Reviewable:end -->
