### PR TITLE
[api] use more correct bcs type

### DIFF
--- a/api/src/accept_type.rs
+++ b/api/src/accept_type.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+#[derive(PartialEq)]
 pub enum AcceptType {
     Json,
     Bcs,

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -140,12 +140,13 @@ impl Events {
             self.ledger_info.version(),
         )?;
 
-        let resolver = self.context.move_resolver()?;
-        let events = resolver.as_converter().try_into_events(&contract_events)?;
-
         match accept_type {
-            AcceptType::Json => Response::new(self.ledger_info, &events),
-            AcceptType::Bcs => Response::new_bcs(self.ledger_info, &events),
+            AcceptType::Json => {
+                let resolver = self.context.move_resolver()?;
+                let events = resolver.as_converter().try_into_events(&contract_events)?;
+                Response::new(self.ledger_info, &events)
+            }
+            AcceptType::Bcs => Response::new_bcs(self.ledger_info, &contract_events),
         }
     }
 }

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -30,7 +30,7 @@ use std::{
     str::FromStr,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum TransactionData {
     OnChain(TransactionOnChainData),
     Pending(Box<SignedTransaction>),
@@ -48,7 +48,7 @@ impl From<SignedTransaction> for TransactionData {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TransactionOnChainData {
     pub version: u64,
     pub transaction: aptos_types::transaction::Transaction,


### PR DESCRIPTION
The goal of the original PR was to take the state from the DB and
present it to the user without any additional coding. In the ideal case,
we wouldn't even have to deserialize and then reserialize. We would just
be shipping bytes around.

The original code was re-encoding a human readable version into bcs.
That made it effectively unparseable.

The newer version does slightly better by using the types in the api
side, which are wrappers around the original types, which are also
native.

We should evaluate if for a bcs interface we want to just return back
these data types or massage it to be more of a wrapper around storage.
I'm inclined toward the former for now.

original pr: https://github.com/aptos-labs/aptos-core/pull/1716

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1738)
<!-- Reviewable:end -->
