### PR TITLE
Updated aptos-cli version in Readme

### DIFF
--- a/crates/aptos/README.md
+++ b/crates/aptos/README.md
@@ -35,7 +35,7 @@ source $HOME/.cargo/env
 2. Install the `aptos` CLI tool by running the below command.  You can run this command from any directory.  The `aptos`
    CLI tool will be installed into your `CARGO_HOME`, usually `~/.cargo`:
 ```bash
-cargo install --git https://github.com/aptos-labs/aptos-core.git aptos --tag aptos-cli-latest
+cargo install --git https://github.com/aptos-labs/aptos-core.git aptos --tag aptos-cli-v0.2.0
 ```
 3. Confirm that the `aptos` CLI tool is installed successfully by running the below command.  The terminal will display
    the path to the `aptos` CLI's location.


### PR DESCRIPTION
### Description
Since aptos-cli-latest still points to 0.1.2 and IT2 is requiring 0.2.0, I think it makes sense to update the version in the guide to avoid errors in the future that are hard to debug (You can check in discord that users are facing "[VM] Unexpected verifier/deserialization error! This likely means there is code stored on chain that is unverifiable!" because of this version discrepancy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1746)
<!-- Reviewable:end -->
