### PR TITLE
[State Sync] Rename account state synchronization to state synchronization.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -56,12 +56,12 @@ impl Default for StateSyncConfig {
 }
 
 /// The bootstrapping mode determines how the node will bootstrap to the latest
-/// blockchain state, e.g., directly download the latest account states.
+/// blockchain state, e.g., directly download the latest states.
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub enum BootstrappingMode {
     ApplyTransactionOutputsFromGenesis, // Applies transaction outputs (starting at genesis)
-    DownloadLatestAccountStates,        // Downloads the account states (at the latest version)
-    ExecuteTransactionsFromGenesis,     // Executes transactions (starting at genesis)
+    DownloadLatestStates, // Downloads the state keys and values (at the latest version)
+    ExecuteTransactionsFromGenesis, // Executes transactions (starting at genesis)
 }
 
 impl BootstrappingMode {
@@ -70,7 +70,7 @@ impl BootstrappingMode {
             BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
                 "apply_transaction_outputs_from_genesis"
             }
-            BootstrappingMode::DownloadLatestAccountStates => "download_latest_account_states",
+            BootstrappingMode::DownloadLatestStates => "download_latest_states",
             BootstrappingMode::ExecuteTransactionsFromGenesis => {
                 "execute_transactions_from_genesis"
             }
@@ -129,13 +129,13 @@ impl Default for StateSyncDriverConfig {
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageServiceConfig {
-    pub max_account_states_chunk_sizes: u64, // Max num of accounts per chunk
-    pub max_concurrent_requests: u64,        // Max num of concurrent storage server tasks
-    pub max_epoch_chunk_size: u64,           // Max num of epoch ending ledger infos per chunk
-    pub max_lru_cache_size: u64,             // Max num of items in the lru cache before eviction
-    pub max_network_channel_size: u64,       // Max num of pending network messages
-    pub max_subscription_period_ms: u64,     // Max period (ms) of pending subscription requests
-    pub max_transaction_chunk_size: u64,     // Max num of transactions per chunk
+    pub max_concurrent_requests: u64, // Max num of concurrent storage server tasks
+    pub max_epoch_chunk_size: u64,    // Max num of epoch ending ledger infos per chunk
+    pub max_lru_cache_size: u64,      // Max num of items in the lru cache before eviction
+    pub max_network_channel_size: u64, // Max num of pending network messages
+    pub max_state_chunk_size: u64,    // Max num of state keys and values per chunk
+    pub max_subscription_period_ms: u64, // Max period (ms) of pending subscription requests
+    pub max_transaction_chunk_size: u64, // Max num of transactions per chunk
     pub max_transaction_output_chunk_size: u64, // Max num of transaction outputs per chunk
     pub storage_summary_refresh_interval_ms: u64, // The interval (ms) to refresh the storage summary
 }
@@ -143,11 +143,11 @@ pub struct StorageServiceConfig {
 impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
-            max_account_states_chunk_sizes: 1000,
             max_concurrent_requests: 4000,
             max_epoch_chunk_size: 100,
             max_lru_cache_size: 100,
             max_network_channel_size: 4000,
+            max_state_chunk_size: 1000,
             max_subscription_period_ms: 10000,
             max_transaction_chunk_size: 1000,
             max_transaction_output_chunk_size: 1000,

--- a/state-sync/aptos-data-client/src/aptosnet/metrics.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/metrics.rs
@@ -97,8 +97,8 @@ pub static OPTIMAL_CHUNK_SIZES: Lazy<IntGaugeVec> = Lazy::new(|| {
 /// An enum representing the various types of data that can be
 /// fetched via the data client.
 pub enum DataType {
-    AccountStates,
     LedgerInfos,
+    States,
     TransactionOutputs,
     Transactions,
 }
@@ -106,8 +106,8 @@ pub enum DataType {
 impl DataType {
     pub fn as_str(&self) -> &'static str {
         match self {
-            DataType::AccountStates => "account_states",
             DataType::LedgerInfos => "ledger_infos",
+            DataType::States => "states",
             DataType::TransactionOutputs => "transaction_outputs",
             DataType::Transactions => "transactions",
         }
@@ -115,8 +115,8 @@ impl DataType {
 
     pub fn get_all_types() -> Vec<DataType> {
         vec![
-            DataType::AccountStates,
             DataType::LedgerInfos,
+            DataType::States,
             DataType::TransactionOutputs,
             DataType::Transactions,
         ]

--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -37,8 +37,8 @@ use rand::seq::SliceRandom;
 use std::{convert::TryFrom, fmt, sync::Arc, time::Duration};
 use storage_service_client::StorageServiceClient;
 use storage_service_types::{
-    AccountStatesChunkWithProofRequest, Epoch, EpochEndingLedgerInfoRequest,
-    NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest, StorageServerSummary,
+    Epoch, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
+    NewTransactionsWithProofRequest, StateValuesWithProofRequest, StorageServerSummary,
     StorageServiceRequest, StorageServiceResponse, TransactionOutputsWithProofRequest,
     TransactionsWithProofRequest,
 };
@@ -460,22 +460,6 @@ impl AptosDataClient for AptosNetDataClient {
         self.global_summary_cache.read().clone()
     }
 
-    async fn get_account_states_with_proof(
-        &self,
-        version: u64,
-        start_account_index: u64,
-        end_account_index: u64,
-    ) -> Result<Response<StateValueChunkWithProof>> {
-        let request = StorageServiceRequest::GetAccountStatesChunkWithProof(
-            AccountStatesChunkWithProofRequest {
-                version,
-                start_account_index,
-                end_account_index,
-            },
-        );
-        self.send_request_and_decode(request).await
-    }
-
     async fn get_epoch_ending_ledger_infos(
         &self,
         start_epoch: Epoch,
@@ -519,8 +503,22 @@ impl AptosDataClient for AptosNetDataClient {
         self.send_request_and_decode(request).await
     }
 
-    async fn get_number_of_account_states(&self, version: Version) -> Result<Response<u64>> {
-        let request = StorageServiceRequest::GetNumberOfAccountsAtVersion(version);
+    async fn get_number_of_states(&self, version: Version) -> Result<Response<u64>> {
+        let request = StorageServiceRequest::GetNumberOfStatesAtVersion(version);
+        self.send_request_and_decode(request).await
+    }
+
+    async fn get_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> Result<Response<StateValueChunkWithProof>> {
+        let request = StorageServiceRequest::GetStateValuesWithProof(StateValuesWithProofRequest {
+            version,
+            start_index,
+            end_index,
+        });
         self.send_request_and_decode(request).await
     }
 
@@ -789,8 +787,8 @@ fn update_advertised_data_metrics(global_data_summary: GlobalDataSummary) {
     let optimal_chunk_sizes = &global_data_summary.optimal_chunk_sizes;
     for data_type in DataType::get_all_types() {
         let optimal_chunk_size = match data_type {
-            DataType::AccountStates => optimal_chunk_sizes.account_states_chunk_size,
             DataType::LedgerInfos => optimal_chunk_sizes.epoch_chunk_size,
+            DataType::States => optimal_chunk_sizes.state_chunk_size,
             DataType::TransactionOutputs => optimal_chunk_sizes.transaction_output_chunk_size,
             DataType::Transactions => optimal_chunk_sizes.transaction_chunk_size,
         };
@@ -819,8 +817,8 @@ fn update_advertised_data_metrics(global_data_summary: GlobalDataSummary) {
     // Update the lowest advertised data
     for data_type in DataType::get_all_types() {
         let lowest_advertised_version = match data_type {
-            DataType::AccountStates => advertised_data.lowest_account_states_version(),
             DataType::LedgerInfos => Some(0), // All nodes contain all epoch ending ledger infos
+            DataType::States => advertised_data.lowest_state_version(),
             DataType::TransactionOutputs => advertised_data.lowest_transaction_output_version(),
             DataType::Transactions => advertised_data.lowest_transaction_version(),
         };

--- a/state-sync/aptos-data-client/src/lib.rs
+++ b/state-sync/aptos-data-client/src/lib.rs
@@ -70,16 +70,6 @@ pub trait AptosDataClient {
     /// cached view of this data client's available data.
     fn get_global_data_summary(&self) -> GlobalDataSummary;
 
-    /// Returns a single account states chunk with proof, containing the accounts
-    /// from start to end index (inclusive) at the specified version. The proof
-    /// version is the same as the specified version.
-    async fn get_account_states_with_proof(
-        &self,
-        version: u64,
-        start_account_index: u64,
-        end_account_index: u64,
-    ) -> Result<Response<StateValueChunkWithProof>>;
-
     /// Returns all epoch ending ledger infos between start and end (inclusive).
     /// If the data cannot be fetched (e.g., the number of epochs is too large),
     /// an error is returned.
@@ -110,8 +100,18 @@ pub trait AptosDataClient {
         include_events: bool,
     ) -> Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>>;
 
-    /// Returns the number of account states at the specified version.
-    async fn get_number_of_account_states(&self, version: Version) -> Result<Response<u64>>;
+    /// Returns the number of states at the specified version.
+    async fn get_number_of_states(&self, version: Version) -> Result<Response<u64>>;
+
+    /// Returns a single state value chunk with proof, containing the values
+    /// from start to end index (inclusive) at the specified version. The proof
+    /// version is the same as the specified version.
+    async fn get_state_values_with_proof(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+    ) -> Result<Response<StateValueChunkWithProof>>;
 
     /// Returns a transaction output list with proof object, with transaction
     /// outputs from start to end versions (inclusive). The proof is relative to
@@ -209,11 +209,11 @@ impl<T> Response<T> {
 /// The different data client response payloads as an enum.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResponsePayload {
-    AccountStatesWithProof(StateValueChunkWithProof),
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
     NewTransactionOutputsWithProof((TransactionOutputListWithProof, LedgerInfoWithSignatures)),
     NewTransactionsWithProof((TransactionListWithProof, LedgerInfoWithSignatures)),
-    NumberOfAccountStates(u64),
+    NumberOfStates(u64),
+    StateValuesWithProof(StateValueChunkWithProof),
     TransactionOutputsWithProof(TransactionOutputListWithProof),
     TransactionsWithProof(TransactionListWithProof),
 }
@@ -221,11 +221,11 @@ pub enum ResponsePayload {
 impl ResponsePayload {
     pub fn get_label(&self) -> &'static str {
         match self {
-            Self::AccountStatesWithProof(_) => "account_states_with_proof",
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
             Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
             Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
-            Self::NumberOfAccountStates(_) => "number_of_account_states",
+            Self::NumberOfStates(_) => "number_of_states",
+            Self::StateValuesWithProof(_) => "state_values_with_proof",
             Self::TransactionOutputsWithProof(_) => "transaction_outputs_with_proof",
             Self::TransactionsWithProof(_) => "transactions_with_proof",
         }
@@ -236,7 +236,7 @@ impl ResponsePayload {
 
 impl From<StateValueChunkWithProof> for ResponsePayload {
     fn from(inner: StateValueChunkWithProof) -> Self {
-        Self::AccountStatesWithProof(inner)
+        Self::StateValuesWithProof(inner)
     }
 }
 
@@ -260,7 +260,7 @@ impl From<(TransactionListWithProof, LedgerInfoWithSignatures)> for ResponsePayl
 
 impl From<u64> for ResponsePayload {
     fn from(inner: u64) -> Self {
-        Self::NumberOfAccountStates(inner)
+        Self::NumberOfStates(inner)
     }
 }
 impl From<TransactionOutputListWithProof> for ResponsePayload {
@@ -302,8 +302,8 @@ impl GlobalDataSummary {
 /// requesting data. This makes the request *more likely* to succeed.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct OptimalChunkSizes {
-    pub account_states_chunk_size: u64,
     pub epoch_chunk_size: u64,
+    pub state_chunk_size: u64,
     pub transaction_chunk_size: u64,
     pub transaction_output_chunk_size: u64,
 }
@@ -311,8 +311,8 @@ pub struct OptimalChunkSizes {
 impl OptimalChunkSizes {
     pub fn empty() -> Self {
         OptimalChunkSizes {
-            account_states_chunk_size: 0,
             epoch_chunk_size: 0,
+            state_chunk_size: 0,
             transaction_chunk_size: 0,
             transaction_output_chunk_size: 0,
         }
@@ -322,15 +322,15 @@ impl OptimalChunkSizes {
 /// A summary of all data that is currently advertised in the network.
 #[derive(Clone, Eq, PartialEq)]
 pub struct AdvertisedData {
-    /// The ranges of account states advertised, e.g., if a range is
-    /// (X,Y), it means all account states are held for every version X->Y
-    /// (inclusive).
-    pub account_states: Vec<CompleteDataRange<Version>>,
-
     /// The ranges of epoch ending ledger infos advertised, e.g., if a range
     /// is (X,Y), it means all epoch ending ledger infos for epochs X->Y
     /// (inclusive) are available.
     pub epoch_ending_ledger_infos: Vec<CompleteDataRange<Epoch>>,
+
+    /// The ranges of states advertised, e.g., if a range is
+    /// (X,Y), it means all states are held for every version X->Y
+    /// (inclusive).
+    pub states: Vec<CompleteDataRange<Version>>,
 
     /// The ledger infos corresponding to the highest synced versions
     /// currently advertised.
@@ -355,8 +355,8 @@ impl fmt::Debug for AdvertisedData {
             .join(", ");
         write!(
             f,
-            "account_states: {:?}, epoch_ending_ledger_infos: {:?}, synced_ledger_infos: [{}], transactions: {:?}, transaction_outputs: {:?}",
-            &self.account_states, &self.epoch_ending_ledger_infos, sync_lis, &self.transactions, &self.transaction_outputs
+            "epoch_ending_ledger_infos: {:?}, states: {:?}, synced_ledger_infos: [{}], transactions: {:?}, transaction_outputs: {:?}",
+            &self.epoch_ending_ledger_infos, &self.states, sync_lis, &self.transactions, &self.transaction_outputs
         )
     }
 }
@@ -364,8 +364,8 @@ impl fmt::Debug for AdvertisedData {
 impl AdvertisedData {
     pub fn empty() -> Self {
         AdvertisedData {
-            account_states: vec![],
             epoch_ending_ledger_infos: vec![],
+            states: vec![],
             synced_ledger_infos: vec![],
             transactions: vec![],
             transaction_outputs: vec![],
@@ -421,9 +421,9 @@ impl AdvertisedData {
         }
     }
 
-    /// Returns the lowest advertised version containing all account states
-    pub fn lowest_account_states_version(&self) -> Option<Version> {
-        get_lowest_version_from_range_set(&self.account_states)
+    /// Returns the lowest advertised version containing all states
+    pub fn lowest_state_version(&self) -> Option<Version> {
+        get_lowest_version_from_range_set(&self.states)
     }
 
     /// Returns the lowest advertised transaction output version

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -24,11 +24,11 @@ pub struct DataNotification {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug)]
 pub enum DataPayload {
-    AccountStatesWithProof(StateValueChunkWithProof),
     ContinuousTransactionOutputsWithProof(LedgerInfoWithSignatures, TransactionOutputListWithProof),
     ContinuousTransactionsWithProof(LedgerInfoWithSignatures, TransactionListWithProof),
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
     EndOfStream,
+    StateValuesWithProof(StateValueChunkWithProof),
     TransactionOutputsWithProof(TransactionOutputListWithProof),
     TransactionsWithProof(TransactionListWithProof),
 }
@@ -36,11 +36,11 @@ pub enum DataPayload {
 /// A request that has been sent to the Aptos data client.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataClientRequest {
-    AccountsWithProof(AccountsWithProofRequest),
     EpochEndingLedgerInfos(EpochEndingLedgerInfosRequest),
     NewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest),
     NewTransactionsWithProof(NewTransactionsWithProofRequest),
-    NumberOfAccounts(NumberOfAccountsRequest),
+    NumberOfStates(NumberOfStatesRequest),
+    StateValuesWithProof(StateValuesWithProofRequest),
     TransactionsWithProof(TransactionsWithProofRequest),
     TransactionOutputsWithProof(TransactionOutputsWithProofRequest),
 }
@@ -49,20 +49,20 @@ impl DataClientRequest {
     /// Returns a summary label for the request
     pub fn get_label(&self) -> &'static str {
         match self {
-            Self::AccountsWithProof(_) => "accounts_with_proof",
             Self::EpochEndingLedgerInfos(_) => "epoch_ending_ledger_infos",
             Self::NewTransactionOutputsWithProof(_) => "new_transaction_outputs_with_proof",
             Self::NewTransactionsWithProof(_) => "new_transactions_with_proof",
-            Self::NumberOfAccounts(_) => "number_of_accounts",
+            Self::NumberOfStates(_) => "number_of_states",
+            Self::StateValuesWithProof(_) => "state_values_with_proof",
             Self::TransactionsWithProof(_) => "transactions_with_proof",
             Self::TransactionOutputsWithProof(_) => "transaction_outputs_with_proof",
         }
     }
 }
 
-/// A request for fetching account states.
+/// A request for fetching states values.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AccountsWithProofRequest {
+pub struct StateValuesWithProofRequest {
     pub version: Version,
     pub start_index: u64,
     pub end_index: u64,
@@ -90,9 +90,9 @@ pub struct NewTransactionOutputsWithProofRequest {
     pub known_epoch: Epoch,
 }
 
-/// A client request for fetching the number of accounts at a version.
+/// A client request for fetching the number of states at a version.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct NumberOfAccountsRequest {
+pub struct NumberOfStatesRequest {
     pub version: Version,
 }
 

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
@@ -29,12 +29,12 @@ pub type Epoch = u64;
 /// is the responsibility of the client to terminate the stream using this API.
 #[async_trait]
 pub trait DataStreamingClient {
-    /// Fetches the account states at the specified version. If `start_index`
-    /// is specified, the account states will be fetched starting at the
+    /// Fetches the state values at the specified version. If `start_index`
+    /// is specified, the state values will be fetched starting at the
     /// `start_index` (inclusive). Otherwise, the start index will 0.
     /// The specified version must be an epoch ending version, otherwise an
-    /// error will be returned. Account state proofs are at the same version.
-    async fn get_all_accounts(
+    /// error will be returned. State proofs are at the same version.
+    async fn get_all_state_values(
         &self,
         version: Version,
         start_index: Option<u64>,
@@ -133,8 +133,8 @@ pub struct StreamRequestMessage {
 /// The data streaming request from the client.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StreamRequest {
-    GetAllAccounts(GetAllAccountsRequest),
     GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest),
+    GetAllStates(GetAllStatesRequest),
     GetAllTransactions(GetAllTransactionsRequest),
     GetAllTransactionOutputs(GetAllTransactionOutputsRequest),
     ContinuouslyStreamTransactions(ContinuouslyStreamTransactionsRequest),
@@ -146,8 +146,8 @@ impl StreamRequest {
     /// Returns a summary label for the stream request
     pub fn get_label(&self) -> &'static str {
         match self {
-            Self::GetAllAccounts(_) => "get_all_accounts",
             Self::GetAllEpochEndingLedgerInfos(_) => "get_all_epoch_ending_ledger_infos",
+            Self::GetAllStates(_) => "get_all_states",
             Self::GetAllTransactions(_) => "get_all_transactions",
             Self::GetAllTransactionOutputs(_) => "get_all_transaction_outputs",
             Self::ContinuouslyStreamTransactions(_) => "continuously_stream_transactions",
@@ -159,17 +159,17 @@ impl StreamRequest {
     }
 }
 
-/// A client request for fetching all account states at a specified version.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GetAllAccountsRequest {
-    pub version: Version,
-    pub start_index: u64,
-}
-
 /// A client request for fetching all available epoch ending ledger infos.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GetAllEpochEndingLedgerInfosRequest {
     pub start_epoch: Epoch,
+}
+
+/// A client request for fetching all states at a specified version.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetAllStatesRequest {
+    pub version: Version,
+    pub start_index: u64,
 }
 
 /// A client request for fetching all transactions with proofs.
@@ -273,13 +273,13 @@ impl StreamingServiceClient {
 
 #[async_trait]
 impl DataStreamingClient for StreamingServiceClient {
-    async fn get_all_accounts(
+    async fn get_all_state_values(
         &self,
         version: u64,
         start_index: Option<u64>,
     ) -> Result<DataStreamListener, Error> {
         let start_index = start_index.unwrap_or(0);
-        let client_request = StreamRequest::GetAllAccounts(GetAllAccountsRequest {
+        let client_request = StreamRequest::GetAllStates(GetAllStatesRequest {
             version,
             start_index,
         });

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
@@ -328,7 +328,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
 /// Verifies that all optimal chunk sizes are valid (i.e., not zero). Returns an
 /// error if a chunk size is 0.
 fn verify_optimal_chunk_sizes(optimal_chunk_sizes: &OptimalChunkSizes) -> Result<(), Error> {
-    if optimal_chunk_sizes.account_states_chunk_size == 0
+    if optimal_chunk_sizes.state_chunk_size == 0
         || optimal_chunk_sizes.epoch_chunk_size == 0
         || optimal_chunk_sizes.transaction_chunk_size == 0
         || optimal_chunk_sizes.transaction_output_chunk_size == 0

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
@@ -7,8 +7,8 @@ use crate::{
     error::Error,
     streaming_client::{
         new_streaming_service_client_listener_pair, ContinuouslyStreamTransactionOutputsRequest,
-        ContinuouslyStreamTransactionsRequest, DataStreamingClient, GetAllAccountsRequest,
-        GetAllEpochEndingLedgerInfosRequest, GetAllTransactionOutputsRequest,
+        ContinuouslyStreamTransactionsRequest, DataStreamingClient,
+        GetAllEpochEndingLedgerInfosRequest, GetAllStatesRequest, GetAllTransactionOutputsRequest,
         GetAllTransactionsRequest, NotificationFeedback, StreamRequest, StreamingServiceListener,
         TerminateStreamRequest,
     },
@@ -36,23 +36,23 @@ fn test_client_service_error() {
 }
 
 #[test]
-fn test_get_all_accounts() {
+fn test_get_all_states() {
     // Create a new streaming service client and listener
     let (streaming_service_client, streaming_service_listener) =
         new_streaming_service_client_listener_pair();
 
     // Note the request we expect to receive on the streaming service side
     let request_version = 100;
-    let expected_request = StreamRequest::GetAllAccounts(GetAllAccountsRequest {
+    let expected_request = StreamRequest::GetAllStates(GetAllStatesRequest {
         version: request_version,
         start_index: 0,
     });
 
-    // Spawn a new server thread to handle any account stream requests
+    // Spawn a new server thread to handle any stream requests
     let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
 
-    // Send an account stream request and verify we get a data stream listener
-    let response = block_on(streaming_service_client.get_all_accounts(request_version, None));
+    // Send a state value stream request and verify we get a data stream listener
+    let response = block_on(streaming_service_client.get_all_state_values(request_version, None));
     assert_ok!(response);
 }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
@@ -17,7 +17,7 @@ pub enum StorageSynchronizerOperations {
     AppliedTransactionOutputs, // Applied a chunk of transactions outputs.
     ExecutedTransactions,      // Executed a chunk of transactions.
     Synced,                    // Wrote a chunk of transactions and outputs to storage.
-    SyncedAccounts,            // Wrote a chunk of accounts to storage.
+    SyncedStates,              // Wrote a chunk of state values to storage.
     SyncedEpoch, // Wrote a chunk of transactions and outputs to storage that resulted in a new epoch.
 }
 
@@ -29,8 +29,8 @@ impl StorageSynchronizerOperations {
             }
             StorageSynchronizerOperations::ExecutedTransactions => "executed_transactions",
             StorageSynchronizerOperations::Synced => "synced",
-            StorageSynchronizerOperations::SyncedAccounts => "synced_accounts",
             StorageSynchronizerOperations::SyncedEpoch => "synced_epoch",
+            StorageSynchronizerOperations::SyncedStates => "synced_states",
         }
     }
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
@@ -33,16 +33,16 @@ const MEMPOOL_COMMIT_ACK_TIMEOUT_MS: u64 = 5000; // 5 seconds
 /// A notification for new data that has been committed to storage
 #[derive(Clone, Debug)]
 pub enum CommitNotification {
-    CommittedAccounts(CommittedAccounts),
+    CommittedStates(CommittedStates),
 }
 
-/// A commit notification for new account states
+/// A commit notification for new state values
 #[derive(Clone, Debug)]
-pub struct CommittedAccounts {
-    pub all_accounts_synced: bool,
-    pub last_committed_account_index: u64,
+pub struct CommittedStates {
+    pub all_states_synced: bool,
+    pub last_committed_state_index: u64,
 
-    /// If `all_accounts_synced` is true, we expect a single committed
+    /// If `all_states_synced` is true, we expect a single committed
     /// transaction (as the node should have all required state at this version).
     pub committed_transaction: Option<CommittedTransactions>,
 }
@@ -55,17 +55,17 @@ pub struct CommittedTransactions {
 }
 
 impl CommitNotification {
-    pub fn new_committed_accounts(
-        all_accounts_synced: bool,
-        last_committed_account_index: u64,
+    pub fn new_committed_states(
+        all_states_synced: bool,
+        last_committed_state_index: u64,
         committed_transaction: Option<CommittedTransactions>,
     ) -> Self {
-        let committed_accounts = CommittedAccounts {
-            all_accounts_synced,
-            last_committed_account_index,
+        let committed_states = CommittedStates {
+            all_states_synced,
+            last_committed_state_index,
             committed_transaction,
         };
-        CommitNotification::CommittedAccounts(committed_accounts)
+        CommitNotification::CommittedStates(committed_states)
     }
 
     /// Handles the commit notification by notifying mempool and the event

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
@@ -188,15 +188,15 @@ async fn test_critical_timeout() {
 }
 
 #[tokio::test]
-async fn test_data_stream_accounts() {
+async fn test_data_stream_state_values() {
     // Create test data
     let notification_id = 50043;
     let highest_version = 10000;
     let highest_ledger_info = create_random_epoch_ending_ledger_info(highest_version, 1);
 
-    // Create a driver configuration with a genesis waypoint and account state syncing
+    // Create a driver configuration with a genesis waypoint and state syncing
     let mut driver_configuration = create_full_node_driver_configuration();
-    driver_configuration.config.bootstrapping_mode = BootstrappingMode::DownloadLatestAccountStates;
+    driver_configuration.config.bootstrapping_mode = BootstrappingMode::DownloadLatestStates;
 
     // Create the mock streaming client
     let mut mock_streaming_client = create_mock_streaming_client();
@@ -233,7 +233,7 @@ async fn test_data_stream_accounts() {
     let mut global_data_summary = create_global_summary(1);
     global_data_summary.advertised_data.synced_ledger_infos = vec![highest_ledger_info.clone()];
 
-    // Drive progress to initialize the account states stream
+    // Drive progress to initialize the state values stream
     drive_progress(&mut bootstrapper, &global_data_summary, false)
         .await
         .unwrap();
@@ -251,7 +251,7 @@ async fn test_data_stream_accounts() {
         .unwrap_err();
     assert_matches!(error, Error::VerificationError(_));
 
-    // Drive progress to initialize the account states stream
+    // Drive progress to initialize the state value stream
     drive_progress(&mut bootstrapper, &global_data_summary, false)
         .await
         .unwrap();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -327,7 +327,7 @@ mock! {
     pub StreamingClient {}
     #[async_trait]
     impl DataStreamingClient for StreamingClient {
-        async fn get_all_accounts(
+        async fn get_all_state_values(
             &self,
             version: Version,
             start_index: Option<u64>,
@@ -399,7 +399,7 @@ mock! {
             end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
         ) -> Result<(), crate::error::Error>;
 
-        fn initialize_account_synchronizer(
+        fn initialize_state_synchronizer(
             &mut self,
             epoch_change_proofs: Vec<LedgerInfoWithSignatures>,
             target_ledger_info: LedgerInfoWithSignatures,
@@ -408,10 +408,10 @@ mock! {
 
         fn pending_storage_data(&self) -> bool;
 
-        fn save_account_states(
+        fn save_state_values(
             &mut self,
             notification_id: NotificationId,
-            account_states_with_proof: StateValueChunkWithProof,
+            state_value_chunk_with_proof: StateValueChunkWithProof,
         ) -> Result<(), crate::error::Error>;
 
         fn reset_chunk_executor(&mut self) -> Result<(), crate::error::Error>;

--- a/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
@@ -216,7 +216,7 @@ fn fetch_startup_info(storage: Arc<dyn DbReader>) -> Result<StartupInfo, Error> 
 }
 
 /// Initializes all relevant metric gauges (e.g., after a reboot
-/// or after an account state snapshot has been restored).
+/// or after a state snapshot has been restored).
 pub fn initialize_sync_gauges(storage: Arc<dyn DbReader>) -> Result<(), Error> {
     // Update the latest synced versions
     let highest_synced_version = fetch_latest_synced_version(storage.clone())?;

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -27,7 +27,7 @@ async fn test_full_node_bootstrap_accounts() {
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
     vfn_config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
     vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
-        BootstrappingMode::DownloadLatestAccountStates;
+        BootstrappingMode::DownloadLatestStates;
 
     // Create (and stop) the fullnode
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
@@ -36,10 +36,7 @@ async fn test_full_node_bootstrap_accounts() {
     // Set at most 2 accounts per storage request for the validator
     let validator = swarm.validators_mut().next().unwrap();
     let mut config = validator.config().clone();
-    config
-        .state_sync
-        .storage_service
-        .max_account_states_chunk_sizes = 2;
+    config.state_sync.storage_service.max_state_chunk_size = 2;
     config.save(validator.config_path()).unwrap();
     validator.restart().await.unwrap();
     validator
@@ -292,7 +289,7 @@ async fn test_validator_failure_bootstrap_outputs() {
         let mut config = validator.config().clone();
         config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
         config.state_sync.state_sync_driver.bootstrapping_mode =
-            BootstrappingMode::DownloadLatestAccountStates;
+            BootstrappingMode::DownloadLatestStates;
         config.state_sync.state_sync_driver.continuous_syncing_mode =
             ContinuousSyncingMode::ApplyTransactionOutputs;
         config.save(validator.config_path()).unwrap();
@@ -312,7 +309,7 @@ async fn test_validator_failure_bootstrap_execution() {
         let mut config = validator.config().clone();
         config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
         config.state_sync.state_sync_driver.bootstrapping_mode =
-            BootstrappingMode::DownloadLatestAccountStates;
+            BootstrappingMode::DownloadLatestStates;
         config.state_sync.state_sync_driver.continuous_syncing_mode =
             ContinuousSyncingMode::ExecuteTransactions;
         config.save(validator.config_path()).unwrap();


### PR DESCRIPTION
Note: this PR simply renames things. There are no changes to execution logic.

### Description

With the introduction of [fine-grained storage](https://github.com/aptos-labs/aptos-core/issues/289), we renamed `account states` to `state values` (as states are no longer specific to accounts). This PR updates all remaining references of "account states" to "states" (or "state values", where appropriate) inside the state sync codebase.

### Test Plan
Existing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1747)
<!-- Reviewable:end -->
