### PR TITLE
[Aptos Node] Improve error message around config file loading failure.

### DIFF
--- a/aptos-node/src/main.rs
+++ b/aptos-node/src/main.rs
@@ -72,8 +72,17 @@ fn main() {
             rng,
         );
     } else {
-        let config = NodeConfig::load(args.config.unwrap()).expect("Failed to load node config");
+        // Load the config file
+        let config_path = args.config.unwrap();
+        let config = NodeConfig::load(config_path.clone()).unwrap_or_else(|error| {
+            panic!(
+                "Failed to load node config file! Given file path: {:?}. Error: {:?}",
+                config_path, error
+            )
+        });
         println!("Using node config {:?}", &config);
+
+        // Start the node
         aptos_node::start(config, None);
     };
 }


### PR DESCRIPTION
### Description

This PR improves the error message displayed to users when `aptos-node` is unable to start due to failing to find the node configuration file. Some users are struggling with the error, e.g., https://github.com/aptos-labs/aptos-core/issues/1744

New error message:
```
% cargo run -p aptos-node -- -f this_file_doesnt_exist 
    Finished dev [unoptimized + debuginfo] target(s) in 0.55s
     Running `target/debug/aptos-node -f this_file_doesnt_exist`
thread 'main' panicked at 'Failed to load node config file! Given file path: "this_file_doesnt_exist". Error: IO("this_file_doesnt_exist", Os { code: 2, kind: NotFound, message: "No such file or directory" })', aptos-node/src/main.rs:78:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

### Test Plan

Manual verification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1748)
<!-- Reviewable:end -->
