### PR TITLE
Add names to threads in parallel executor's thread pool.

### DIFF
--- a/aptos-move/parallel-executor/src/executor.rs
+++ b/aptos-move/parallel-executor/src/executor.rs
@@ -27,6 +27,7 @@ use std::{
 static RAYON_EXEC_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
     rayon::ThreadPoolBuilder::new()
         .num_threads(num_cpus::get())
+        .thread_name(|index| format!("parallel_executor_{}", index))
         .build()
         .unwrap()
 });


### PR DESCRIPTION
### Description
Add names to threads, so it would be easier to track in debugger.
### Test Plan
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1756)
<!-- Reviewable:end -->
