### PR TITLE
Remove spammy log line in case of failing to send the log

### DIFF
--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -358,7 +358,10 @@ impl AptosData {
         }
 
         if let Some(sender) = &self.sender {
-            if let Err(_) = sender.try_send(LoggerServiceEvent::LogEntry(entry)) {
+            if sender
+                .try_send(LoggerServiceEvent::LogEntry(entry))
+                .is_err()
+            {
                 STRUCT_LOG_QUEUE_ERROR_COUNT.inc();
             }
         }

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -360,7 +360,6 @@ impl AptosData {
         if let Some(sender) = &self.sender {
             if let Err(e) = sender.try_send(LoggerServiceEvent::LogEntry(entry)) {
                 STRUCT_LOG_QUEUE_ERROR_COUNT.inc();
-                eprintln!("Failed to send structured log: {}", e);
             }
         }
     }

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -358,7 +358,7 @@ impl AptosData {
         }
 
         if let Some(sender) = &self.sender {
-            if let Err(e) = sender.try_send(LoggerServiceEvent::LogEntry(entry)) {
+            if let Err(_) = sender.try_send(LoggerServiceEvent::LogEntry(entry)) {
                 STRUCT_LOG_QUEUE_ERROR_COUNT.inc();
             }
         }


### PR DESCRIPTION
### Description

We see this log line spamming the validator logs in case of network error. Removing this log line. 


