### PR TITLE
[bug] Incorrect in-mem accumulator placeholder_hash

### DIFF
--- a/types/src/proof/accumulator/mod.rs
+++ b/types/src/proof/accumulator/mod.rs
@@ -20,9 +20,7 @@ use super::MerkleTreeInternalNode;
 use crate::proof::definition::{LeafCount, MAX_ACCUMULATOR_LEAVES};
 use anyhow::{ensure, format_err, Result};
 use aptos_crypto::{
-    hash::{
-        CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH, SPARSE_MERKLE_PLACEHOLDER_HASH,
-    },
+    hash::{CryptoHash, CryptoHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
 use serde::{Deserialize, Serialize};
@@ -86,7 +84,7 @@ where
         Self {
             frozen_subtree_roots: Vec::new(),
             num_leaves: 0,
-            root_hash: *SPARSE_MERKLE_PLACEHOLDER_HASH,
+            root_hash: *ACCUMULATOR_PLACEHOLDER_HASH,
             phantom: PhantomData,
         }
     }


### PR DESCRIPTION
### Description
`new_empty` function was introduced in https://github.com/aptos-labs/aptos-core/commit/a50eac3dd8132441d5b3d14d501aac23e23163c7.
I don't know who reviewed this in Feb.

It should be `ACCUMULATOR_PLACEHOLDER_HASH`


### Test Plan
my new change can catch this bug in aptosdb_test.
