### PR TITLE
Return error in error path when determining State from API headers

### DIFF
--- a/crates/aptos-rest-client/src/state.rs
+++ b/crates/aptos-rest-client/src/state.rs
@@ -49,7 +49,15 @@ impl State {
                 oldest_ledger_version,
             }
         } else {
-            todo!()
+            anyhow::bail!(
+                "Failed to build State from headers due to missing values in response. \
+                Chain ID: {:?}, Version: {:?}, Timestamp: {:?}, Epoch: {:?}, Oldest Ledger Version: {:?}",
+                maybe_chain_id,
+                maybe_version,
+                maybe_timestamp,
+                maybe_epoch,
+                oldest_ledger_version,
+            )
         };
 
         Ok(state)


### PR DESCRIPTION
## Description
I hit this path while testing something else, it would be nice to have a real error message to see what value is missing.

## Test Plan
From `crates/aptos-rest-client`:
```
cargo test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1763)
<!-- Reviewable:end -->
