### PR TITLE
[NHC] Extract API index query functionality out of evaluator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ name = "aptos-api-types"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "aptos-config",
  "aptos-crypto",
  "aptos-state-view",
  "aptos-transaction-builder",

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -10,9 +10,7 @@ use crate::{
     metrics::{metrics, status_metrics},
     state, transactions,
 };
-use aptos_api_types::{Error, LedgerInfo, Response};
-use aptos_config::config::RoleType;
-use serde::Serialize;
+use aptos_api_types::{Error, IndexResponse, Response};
 use std::convert::Infallible;
 use warp::{
     body::BodyDeserializeError,
@@ -25,25 +23,6 @@ use warp::{
 
 const OPEN_API_HTML: &str = include_str!("../doc/spec.html");
 const OPEN_API_SPEC: &str = include_str!("../doc/openapi.yaml");
-
-/// The struct holding all data returned to the client by the
-/// index endpoint (i.e., GET "/"). The data is flattened into
-/// a single JSON map to offer easier parsing for clients.
-#[derive(Serialize)]
-pub struct IndexResponse {
-    #[serde(flatten)]
-    ledger_info: LedgerInfo,
-    node_role: RoleType,
-}
-
-impl IndexResponse {
-    pub fn new(ledger_info: LedgerInfo, node_role: RoleType) -> IndexResponse {
-        Self {
-            ledger_info,
-            node_role,
-        }
-    }
-}
 
 pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
     index(context.clone())

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.137", default-features = false }
 serde_json = "1.0.81"
 warp = { version = "0.3.2", features = ["default"] }
 
+aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }

--- a/api/types/src/index.rs
+++ b/api/types/src/index.rs
@@ -1,0 +1,25 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::LedgerInfo;
+use aptos_config::config::RoleType;
+use serde::{Deserialize, Serialize};
+
+/// The struct holding all data returned to the client by the
+/// index endpoint (i.e., GET "/"). The data is flattened into
+/// a single JSON map to offer easier parsing for clients.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct IndexResponse {
+    #[serde(flatten)]
+    pub ledger_info: LedgerInfo,
+    pub node_role: RoleType,
+}
+
+impl IndexResponse {
+    pub fn new(ledger_info: LedgerInfo, node_role: RoleType) -> IndexResponse {
+        Self {
+            ledger_info,
+            node_role,
+        }
+    }
+}

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -8,6 +8,7 @@ mod convert;
 mod error;
 mod event_key;
 mod hash;
+mod index;
 mod ledger_info;
 pub mod mime_types;
 mod move_types;
@@ -22,6 +23,7 @@ pub use convert::{new_vm_ascii_string, AsConverter, MoveConverter};
 pub use error::Error;
 pub use event_key::EventKey;
 pub use hash::HashValue;
+pub use index::IndexResponse;
 pub use ledger_info::LedgerInfo;
 pub use move_types::{
     HexEncodedBytes, MoveFunction, MoveModule, MoveModuleBytecode, MoveModuleId, MoveResource,

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -3,7 +3,9 @@
 
 use anyhow::{anyhow, Result};
 use aptos_api_types::mime_types::BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE;
-pub use aptos_api_types::{self, MoveModuleBytecode, PendingTransaction, Transaction};
+pub use aptos_api_types::{
+    self, IndexResponse, MoveModuleBytecode, PendingTransaction, Transaction,
+};
 use aptos_crypto::HashValue;
 use aptos_types::{
     account_address::AccountAddress, account_config::aptos_root_address,
@@ -63,6 +65,11 @@ impl Client {
                 Err(anyhow!("No data returned"))
             }
         })
+    }
+
+    pub async fn get_index(&self) -> Result<Response<IndexResponse>> {
+        self.json(self.inner.get(self.base_url.clone()).send().await?)
+            .await
     }
 
     pub async fn get_ledger_information(&self) -> Result<Response<State>> {

--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -5,7 +5,7 @@ use crate::{
     evaluators::{
         direct::{
             get_node_identity, LatencyEvaluatorArgs, NodeIdentityEvaluatorArgs, TpsEvaluatorArgs,
-            TransactionPresenceEvaluatorArgs,
+            TransactionAvailabilityEvaluatorArgs,
         },
         metrics::{
             ConsensusProposalsEvaluatorArgs, ConsensusRoundEvaluatorArgs,
@@ -18,11 +18,13 @@ use crate::{
 };
 use anyhow::{bail, format_err, Result};
 use aptos_config::config::RoleType;
+use aptos_rest_client::Client as AptosRestClient;
 use aptos_sdk::types::chain_id::ChainId;
 use clap::Parser;
 use once_cell::sync::Lazy;
 use poem_openapi::{types::Example, Object as PoemObject};
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use url::Url;
 
 pub const DEFAULT_METRICS_PORT: u16 = 9101;
@@ -87,14 +89,12 @@ pub struct NodeConfiguration {
 // It'd be better to have an enum with two variants, e.g. unfetched and fetched.
 impl NodeConfiguration {
     /// Only call this after fetch_additional_configuration has been called.
-    #[allow(dead_code)]
     pub fn get_chain_id(&self) -> ChainId {
         self.chain_id
             .expect("get_chain_id called before fetch_additional_configuration")
     }
 
     /// Only call this after fetch_additional_configuration has been called.
-    #[allow(dead_code)]
     pub fn get_role_type(&self) -> RoleType {
         self.role_type
             .expect("get_role_type called before fetch_additional_configuration")
@@ -105,12 +105,14 @@ impl NodeConfiguration {
     /// match up. If they're not set, we set them using the values we find.
     pub async fn fetch_additional_configuration(&mut self) -> Result<()> {
         let (reported_chain_id, reported_role_type) =
-            get_node_identity(&self.node_address).await.map_err(|e| {
-                format_err!(
+            get_node_identity(&self.node_address, Duration::from_secs(5))
+                .await
+                .map_err(|e| {
+                    format_err!(
                     "Failed to fetch chain ID and role type for baseline node configuration: {}",
                     e
                 )
-            })?;
+                })?;
         if let Some(configured_chain_id) = self.chain_id {
             if configured_chain_id != reported_chain_id {
                 bail!("Chain ID mismatch: The baseline configuration {} says the chain ID is {} but the node reports chain ID {}", self.configuration_name, configured_chain_id, reported_chain_id);
@@ -161,7 +163,7 @@ pub struct EvaluatorArgs {
     pub tps_args: TpsEvaluatorArgs,
 
     #[clap(flatten)]
-    pub transaction_presence_args: TransactionPresenceEvaluatorArgs,
+    pub transaction_availability_args: TransactionAvailabilityEvaluatorArgs,
 }
 
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
@@ -214,6 +216,15 @@ impl NodeAddress {
         let mut url = self.url.clone();
         url.set_port(Some(self.api_port)).unwrap();
         url
+    }
+
+    pub fn get_api_client(&self, timeout: Duration) -> AptosRestClient {
+        let client = reqwest::ClientBuilder::new()
+            .timeout(timeout)
+            .build()
+            .unwrap();
+
+        AptosRestClient::from((client, self.get_api_url()))
     }
 }
 

--- a/ecosystem/node-checker/src/evaluators/build_evaluators.rs
+++ b/ecosystem/node-checker/src/evaluators/build_evaluators.rs
@@ -7,7 +7,7 @@ use crate::{
     evaluators::{
         direct::{
             ApiEvaluatorError, DirectEvaluatorInput, LatencyEvaluator, TpsEvaluator,
-            TpsEvaluatorError, TransactionPresenceEvaluator,
+            TpsEvaluatorError, TransactionAvailabilityEvaluator,
         },
         metrics::{
             ConsensusProposalsEvaluator, ConsensusRoundEvaluator, ConsensusTimeoutsEvaluator,
@@ -143,7 +143,7 @@ pub fn build_evaluators(
         &mut evaluator_identifiers,
         evaluator_args,
     )?;
-    TransactionPresenceEvaluator::add_from_evaluator_args(
+    TransactionAvailabilityEvaluator::add_from_evaluator_args(
         &mut evaluators,
         &mut evaluator_identifiers,
         evaluator_args,

--- a/ecosystem/node-checker/src/evaluators/direct/api/mod.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/mod.rs
@@ -3,15 +3,21 @@
 
 mod latency;
 mod node_identity;
-mod transaction_presence;
+mod transaction_availability;
 
-use anyhow::Error;
+use anyhow::{Error, Result};
+use aptos_rest_client::IndexResponse;
 pub use latency::{LatencyEvaluator, LatencyEvaluatorArgs};
 pub use node_identity::{
     get_node_identity, NodeIdentityEvaluator, NodeIdentityEvaluatorArgs, NodeIdentityEvaluatorError,
 };
+use std::time::Duration;
 use thiserror::Error as ThisError;
-pub use transaction_presence::{TransactionPresenceEvaluator, TransactionPresenceEvaluatorArgs};
+pub use transaction_availability::{
+    TransactionAvailabilityEvaluator, TransactionAvailabilityEvaluatorArgs,
+};
+
+use crate::{configuration::NodeAddress, evaluator::EvaluationResult};
 
 pub const API_CATEGORY: &str = "api";
 
@@ -19,4 +25,32 @@ pub const API_CATEGORY: &str = "api";
 pub enum ApiEvaluatorError {
     #[error("API returned an error for endpoint {0}: {1}")]
     EndpointError(String, Error),
+}
+
+pub async fn get_index_response(
+    node_address: &NodeAddress,
+    timeout: Duration,
+) -> Result<IndexResponse> {
+    Ok(node_address
+        .get_api_client(timeout)
+        .get_index()
+        .await?
+        .into_inner())
+}
+
+pub async fn get_index_response_or_evaluation_result(
+    node_address: &NodeAddress,
+    timeout: Duration,
+) -> Result<IndexResponse, EvaluationResult> {
+    match get_index_response(node_address, timeout).await {
+        Ok(index_response) => Ok(index_response),
+        Err(error) => Err(EvaluationResult {
+            headline: "Failed to read response from / on API".to_string(),
+            score: 0,
+            explanation: format!("We received an error response hitting / (the index) of the API of your node, make sure your API port ({}) is publicly accessible: {}.", node_address.api_port, error),
+            category: API_CATEGORY.to_string(),
+            evaluator_name: "index_response".to_string(),
+            links: vec![],
+        })
+    }
 }

--- a/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
@@ -6,64 +6,30 @@ use crate::{
     evaluator::{EvaluationResult, Evaluator},
     evaluators::EvaluatorType,
 };
-use anyhow::{anyhow, format_err, Result};
+use anyhow::{format_err, Result};
 use aptos_config::config::RoleType;
 use aptos_sdk::types::chain_id::ChainId;
 use clap::Parser;
 use poem_openapi::Object as PoemObject;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display, str::FromStr};
+use std::{fmt::Display, time::Duration};
 use thiserror::Error as ThisError;
 
-use super::{super::DirectEvaluatorInput, API_CATEGORY};
+use super::{super::DirectEvaluatorInput, get_index_response, API_CATEGORY};
 
 /// This function hits the `/` endpoint of the API and returns the chain ID
 /// and role type, extracted from the IndexResponse.
-pub async fn get_node_identity(node_address: &NodeAddress) -> Result<(ChainId, RoleType)> {
-    let mut url = node_address.url.clone();
-    url.set_port(Some(node_address.api_port))
-        .map_err(|_| format_err!("Failed to set port for URL"))?;
-
-    let client = reqwest::ClientBuilder::new()
-        .timeout(std::time::Duration::from_secs(4))
-        .build()
-        .unwrap();
-
-    let response = client
-        .get(url)
-        .send()
+pub async fn get_node_identity(
+    node_address: &NodeAddress,
+    timeout: Duration,
+) -> Result<(ChainId, RoleType)> {
+    let index_response = get_index_response(node_address, timeout)
         .await
-        .map_err(|e| format_err!("Failed to get node identity {}", e))?;
-    let response_body = response
-        .text()
-        .await
-        .map_err(|e| format_err!("Failed to get body of node identity response {}", e))?;
-
-    let data: HashMap<String, serde_json::Value> =
-        serde_json::from_str(&response_body).map_err(|e| {
-            format_err!(
-                "Failed to process response body as valid JSON with string key/values {}",
-                e
-            )
-        })?;
-
-    let chain_id_raw: u8 = data
-        .get("chain_id")
-        .ok_or_else(|| format_err!("Failed to get chain_id from node identity"))?
-        .as_u64()
-        .ok_or_else(|| anyhow!("Failed to read chain ID from node identity as u8"))?
-        as u8;
-    let chain_id = ChainId::new(chain_id_raw);
-
-    let role_type_raw = data
-        .get("node_role")
-        .ok_or_else(|| format_err!("Failed to get node_role from node identity"))?
-        .as_str()
-        .ok_or_else(|| anyhow!("Failed to read node_role from node identity as str"))?;
-    let role_type = RoleType::from_str(role_type_raw)
-        .map_err(|e| format_err!("Failed to parse node_role {}", e))?;
-
-    Ok((chain_id, role_type))
+        .map_err(|e| format_err!("Failed to get response from index (/) of API. Make sure your API port ({}) is open: {}", node_address.api_port, e))?;
+    Ok((
+        ChainId::new(index_response.ledger_info.chain_id),
+        index_response.node_role,
+    ))
 }
 
 #[derive(Debug, ThisError)]
@@ -126,32 +92,15 @@ impl Evaluator for NodeIdentityEvaluator {
 
     /// Assert that the node identity (role type and chain ID) of the two nodes match.
     async fn evaluate(&self, input: &Self::Input) -> Result<Vec<EvaluationResult>, Self::Error> {
-        let (target_chain_id, target_role_type) =
-            match get_node_identity(&input.target_node_address).await {
-                Ok((chain_id, role_type)) => (chain_id, role_type),
-                Err(e) => {
-                    return Ok(vec![self.build_evaluation_result(
-                        "Failed to get node identity from target node".to_string(),
-                        0,
-                        format!(
-                            "Failed to get node identity from target node, \
-                        make sure your API port ({}) is open and you're running \
-                        the correct node version: {}",
-                            input.target_node_address.api_port, e
-                        ),
-                    )])
-                }
-            };
-
         let evaluation_results = vec![
             self.help_build_evaluation_result(
-                input.baseline_node_information.chain_id,
-                target_chain_id,
+                input.get_baseline_chain_id(),
+                input.get_target_chain_id(),
                 "Chain ID",
             ),
             self.help_build_evaluation_result(
                 input.baseline_node_information.role_type,
-                target_role_type,
+                input.target_index_response.node_role,
                 "Role Type",
             ),
         ];

--- a/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
@@ -18,18 +18,18 @@ use std::time::Duration;
 const TRANSACTIONS_ENDPOINT: &str = "/transactions";
 
 #[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
-pub struct TransactionPresenceEvaluatorArgs {
+pub struct TransactionAvailabilityEvaluatorArgs {
     #[clap(long, default_value_t = 5)]
     pub transaction_fetch_delay_secs: u64,
 }
 
 #[derive(Debug)]
-pub struct TransactionPresenceEvaluator {
-    args: TransactionPresenceEvaluatorArgs,
+pub struct TransactionAvailabilityEvaluator {
+    args: TransactionAvailabilityEvaluatorArgs,
 }
 
-impl TransactionPresenceEvaluator {
-    pub fn new(args: TransactionPresenceEvaluatorArgs) -> Self {
+impl TransactionAvailabilityEvaluator {
+    pub fn new(args: TransactionAvailabilityEvaluatorArgs) -> Self {
         Self { args }
     }
 
@@ -96,7 +96,7 @@ impl TransactionPresenceEvaluator {
 }
 
 #[async_trait::async_trait]
-impl Evaluator for TransactionPresenceEvaluator {
+impl Evaluator for TransactionAvailabilityEvaluator {
     type Input = DirectEvaluatorInput;
     type Error = ApiEvaluatorError;
 
@@ -195,11 +195,13 @@ impl Evaluator for TransactionPresenceEvaluator {
     }
 
     fn get_evaluator_name() -> String {
-        "transaction_presence".to_string()
+        "transaction_availability".to_string()
     }
 
     fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
-        Ok(Self::new(evaluator_args.transaction_presence_args.clone()))
+        Ok(Self::new(
+            evaluator_args.transaction_availability_args.clone(),
+        ))
     }
 
     fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {

--- a/ecosystem/node-checker/src/evaluators/direct/types.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/types.rs
@@ -1,15 +1,32 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_rest_client::IndexResponse;
+use aptos_sdk::types::chain_id::ChainId;
+
 use crate::{configuration::NodeAddress, server::NodeInformation};
 
 /// This type of evaluator just takes in the target node address and then
 /// directly fetches whatever information it needs to perform the evaluation.
 /// This is different to other evaluators, where the information they need is
 /// fetched earlier and then passed in, so all they have to do is process it.
+/// It also takes in the response from the API index, which we know we have in
+/// all cases since it is necessary for the mandatory node identity evaluator.
 
 #[derive(Debug)]
 pub struct DirectEvaluatorInput {
     pub baseline_node_information: NodeInformation,
     pub target_node_address: NodeAddress,
+    pub baseline_index_response: IndexResponse,
+    pub target_index_response: IndexResponse,
+}
+
+impl DirectEvaluatorInput {
+    pub fn get_baseline_chain_id(&self) -> ChainId {
+        self.baseline_node_information.chain_id
+    }
+
+    pub fn get_target_chain_id(&self) -> ChainId {
+        ChainId::new(self.target_index_response.ledger_info.chain_id)
+    }
 }

--- a/ecosystem/node-checker/src/runner/traits.rs
+++ b/ecosystem/node-checker/src/runner/traits.rs
@@ -21,6 +21,9 @@ pub enum RunnerError {
     #[error("Failed to evaluate API: {0}")]
     ApiEvaluatorError(#[from] ApiEvaluatorError),
 
+    #[error("Data was missing from the baseline node: {0}")]
+    BaselineMissingDataError(Error),
+
     /// We failed to collect metrics for some reason.
     #[error("Failed to collect metrics: {0}")]
     MetricCollectorError(#[from] MetricCollectorError),


### PR DESCRIPTION
## Description
For future evaluators, it would be handy if we could hit the index endpoint just once and then pass that in to future API based evaluators. We already hit this endpoint as part of node configuration / determining node chain ID + role type, which is an evaluator we always run, so it makes sense to pull this out and do it always too.

As part of this I enhance the rest client to be able to just hit the index and deserialize exactly what it returns, vs the existing `get_ledger_information` which throws some info out and changes the type.

## Test Plan
```
cargo run -- configuration create --configuration-name test --configuration-name-pretty 'testing' --url http://localhost/ --evaluators network_minimum_peers > /tmp/test.yaml
```
```
cargo run -- server run --baseline-node-config-paths /tmp/test.yaml --listen-address 0.0.0.0
```
```
curl 'http://localhost:20121/check_node?node_url=http://localhost&baseline_configuration_name=test'
```
```
{
  "evaluation_results": [
    {
      "headline": "Chain ID reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Chain ID 18 as is reported by the baseline node",
      "evaluator_name": "node_identity",
      "category": "api",
      "links": []
    },
    {
      "headline": "Role Type reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Role Type full_node as is reported by the baseline node",
      "evaluator_name": "node_identity",
      "category": "api",
      "links": []
    },
    {
      "headline": "There are sufficient inbound connections from the target node",
      "score": 100,
      "explanation": "There are 0 inbound connections from other nodes to the target node (the minimum is 0).",
      "evaluator_name": "minimum_peers",
      "category": "network",
      "links": []
    },
    {
      "headline": "There are sufficient outbound connections to the target node",
      "score": 100,
      "explanation": "There are 2 outbound connections to other nodes from the target node (the minimum is 1).",
      "evaluator_name": "minimum_peers",
      "category": "network",
      "links": []
    }
  ],
  "summary_score": 100,
  "summary_explanation": "100: Awesome!"
}
```
Error if the baseline shut down after NHC startup:
```
Data was missing from the baseline node: Failed to read index response from baseline node, make sure its API is open (port 8080)
```
Results if target unreachable:
```
{
  "evaluation_results": [
    {
      "headline": "Failed to read response from / on API",
      "score": 0,
      "explanation": "We received an error response hitting / (the index) of the API of your node, make sure your API port (8080) is publicly accessible: error sending request for url (http://fake:8080/): error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known",
      "evaluator_name": "index_response",
      "category": "api",
      "links": []
    }
  ],
  "summary_score": 0,
  "summary_explanation": "0: Not good enough :("
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1774)
<!-- Reviewable:end -->
