### PR TITLE
[Storage] Add functions to read proof by key and version.

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1078,6 +1078,25 @@ impl DbReader for AptosDB {
         })
     }
 
+    /// Returns the proof of the given state key and version.
+    fn get_state_proof_by_version(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<SparseMerkleProof> {
+        gauged_api("get_proof_by_version", || {
+            error_if_version_is_pruned(
+                &self.pruner,
+                PrunerIndex::StateStorePrunerIndex,
+                "State",
+                version,
+            )?;
+
+            self.state_store
+                .get_state_proof_by_version(state_key, version)
+        })
+    }
+
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         gauged_api("get_startup_info", || {
             self.ledger_store

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -79,6 +79,16 @@ impl DbReader for StateStore {
             .transpose()
     }
 
+    /// Returns the proof of the given state key and version.
+    fn get_state_proof_by_version(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<SparseMerkleProof> {
+        let (_, proof) = self.state_merkle_db.get_with_proof(state_key, version)?;
+        Ok(proof)
+    }
+
     /// Get the state value with proof given the state key and version
     fn get_state_value_with_proof_by_version(
         &self,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -458,6 +458,15 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
+    /// Returns the proof of the given state key and version.
+    fn get_state_proof_by_version(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<SparseMerkleProof> {
+        unimplemented!()
+    }
+
     /// Gets a state value by state key along with the proof, out of the ledger state indicated by the state
     /// Merkle tree root with a sparse merkle proof proving state tree root.
     /// See [AptosDB::get_account_state_with_proof_by_version].


### PR DESCRIPTION
### Description
Add functions to read proof by key and version. This will be used later so that we can separate value/proof read in execution, and put proof read into background thread.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Existing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1775)
<!-- Reviewable:end -->
