### PR TITLE
[aptos-rosetta] Fix Warp paths so that they don't conflict

### DIFF
--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -14,16 +14,16 @@ use warp::Filter;
 
 const Y2K_SECS: u64 = 946713600000;
 
-pub fn routes(
+pub fn block_route(
     server_context: RosettaContext,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    warp::post().and(
-        warp::path!("block")
-            .and(warp::body::json())
-            .and(with_context(server_context))
-            .and_then(handle_request(block)),
-    )
+    warp::path!("block")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(block))
 }
+
 /// Retrieves a block (in this case a single transaction) given it's identifier.
 ///
 /// Our implementation allows for by `index`, which is the ledger `version` or by

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -25,44 +25,84 @@ use aptos_types::transaction::{
 use std::{convert::TryFrom, str::FromStr};
 use warp::Filter;
 
-pub fn routes(
+pub fn combine_route(
     server_context: RosettaContext,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    warp::post()
-        .and(
-            warp::path!("construction" / "combine")
-                .and(warp::body::json())
-                .and(with_context(server_context.clone()))
-                .and_then(handle_request(construction_combine)),
-        )
-        .or(warp::path!("construction" / "derive")
-            .and(warp::body::json())
-            .and(with_context(server_context.clone()))
-            .and_then(handle_request(construction_derive)))
-        .or(warp::path!("construction" / "hash")
-            .and(warp::body::json())
-            .and(with_context(server_context.clone()))
-            .and_then(handle_request(construction_hash)))
-        .or(warp::path!("construction" / "metadata")
-            .and(warp::body::json())
-            .and(with_context(server_context.clone()))
-            .and_then(handle_request(construction_metadata)))
-        .or(warp::path!("construction" / "parse")
-            .and(warp::body::json())
-            .and(with_context(server_context.clone()))
-            .and_then(handle_request(construction_parse)))
-        .or(warp::path!("construction" / "payloads")
-            .and(warp::body::json())
-            .and(with_context(server_context.clone()))
-            .and_then(handle_request(construction_payloads)))
-        .or(warp::path!("construction" / "preprocess")
-            .and(warp::body::json())
-            .and(with_context(server_context.clone()))
-            .and_then(handle_request(construction_preprocess)))
-        .or(warp::path!("construction" / "submit")
-            .and(warp::body::json())
-            .and(with_context(server_context))
-            .and_then(handle_request(construction_submit)))
+    warp::path!("construction" / "combine")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_combine))
+}
+
+pub fn derive_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("construction" / "derive")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_derive))
+}
+
+pub fn hash_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("construction" / "hash")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_hash))
+}
+
+pub fn metadata_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("construction" / "metadata")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_metadata))
+}
+
+pub fn parse_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("construction" / "parse")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_parse))
+}
+
+pub fn payloads_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("construction" / "payloads")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_payloads))
+}
+
+pub fn preprocess_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("construction" / "preprocess")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_preprocess))
+}
+
+pub fn submit_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("construction" / "submit")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(construction_submit))
 }
 
 /// Construction combine command (OFFLINE)

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -109,9 +109,18 @@ pub fn routes(
     context: RosettaContext,
 ) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
     account::routes(context.clone())
-        .or(block::routes(context.clone()))
-        .or(construction::routes(context.clone()))
-        .or(network::routes(context))
+        .or(block::block_route(context.clone()))
+        .or(construction::combine_route(context.clone()))
+        .or(construction::derive_route(context.clone()))
+        .or(construction::hash_route(context.clone()))
+        .or(construction::metadata_route(context.clone()))
+        .or(construction::parse_route(context.clone()))
+        .or(construction::payloads_route(context.clone()))
+        .or(construction::preprocess_route(context.clone()))
+        .or(construction::submit_route(context.clone()))
+        .or(network::list_route(context.clone()))
+        .or(network::options_route(context.clone()))
+        .or(network::status_route(context))
         // TODO: Add health check?
         .with(
             warp::cors()

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -17,24 +17,34 @@ use crate::{
 use aptos_logger::{debug, trace};
 use warp::Filter;
 
-pub fn routes(
+pub fn list_route(
     server_context: RosettaContext,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-    warp::post()
-        .and(
-            warp::path!("network" / "list")
-                .and(with_empty_request())
-                .and(with_context(server_context.clone()))
-                .and_then(handle_request(network_list)),
-        )
-        .or(warp::path!("network" / "options")
-            .and(warp::body::json())
-            .and(with_context(server_context.clone()))
-            .and_then(handle_request(network_options)))
-        .or(warp::path!("network" / "status")
-            .and(warp::body::json())
-            .and(with_context(server_context))
-            .and_then(handle_request(network_status)))
+    warp::path!("network" / "list")
+        .and(warp::post())
+        .and(with_empty_request())
+        .and(with_context(server_context))
+        .and_then(handle_request(network_list))
+}
+
+pub fn options_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("network" / "options")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(network_options))
+}
+
+pub fn status_route(
+    server_context: RosettaContext,
+) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    warp::path!("network" / "status")
+        .and(warp::post())
+        .and(warp::body::json())
+        .and(with_context(server_context))
+        .and_then(handle_request(network_status))
 }
 
 /// List [`NetworkIdentifier`]s supported by this proxy aka [`ChainId`]s


### PR DESCRIPTION
### Description
All construction paths were being executed at the same time
which caused all APIs to fail with deserialization issues.
This fixes it by making them all separate.

Honestly, I'm amazed this didn't cause issues with the network APIs earlier.  This is copying the general flow from the REST API.

### Test Plan
Local testing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1776)
<!-- Reviewable:end -->
