### PR TITLE
[helm][aptos-node] make haproxy work with ClusterIP

### DIFF
--- a/terraform/helm/aptos-node/templates/haproxy.yaml
+++ b/terraform/helm/aptos-node/templates/haproxy.yaml
@@ -46,7 +46,10 @@ spec:
     targetPort: 8180
   {{- end }}
   type: {{ $.Values.service.validator.external.type }}
-  externalTrafficPolicy: Local
+  # Use externalTrafficPolicy if service type is LoadBalancer or Nodeport
+  {{- if and (ne "ClusterIP" $.Values.service.validator.external.type) $.Values.service.validator.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $.Values.service.validator.externalTrafficPolicy }}
+  {{- end }}
   {{- with $.Values.service.validator.loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}
@@ -91,7 +94,10 @@ spec:
   {{- end }}
   {{- end }}
   type: {{ $.Values.service.fullnode.external.type }}
-  externalTrafficPolicy: Local
+  # Use externalTrafficPolicy if service type is LoadBalancer or Nodeport
+  {{- if and (ne "ClusterIP" $.Values.service.fullnode.external.type) $.Values.service.fullnode.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ $.Values.service.fullnode.externalTrafficPolicy }}
+  {{- end }}  
   {{- with (index $.Values.service $config.name).loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -92,6 +92,7 @@ service:
   validator:
     external: 
       type: LoadBalancer
+    externalTrafficPolicy: Local
     loadBalancerSourceRanges:
     enableRestApi: true
     enableMetricsPort: true
@@ -99,6 +100,7 @@ service:
   fullnode:
     external: 
       type: LoadBalancer
+    externalTrafficPolicy: Local
     loadBalancerSourceRanges:
     enableRestApi: true
     enableMetricsPort: true


### PR DESCRIPTION
Only set `externalTrafficPolicy` if it's specified and the service type is not `ClusterIP` ( it's `NodePort` or `LoadBalancer`). This makes it possible to override the service type to `ClusterIP` and have everything work for internal testnets like Forge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1780)
<!-- Reviewable:end -->
