### PR TITLE
[aptos-rosetta] Chain Construction APIs together via testing and add better errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ name = "aptos-rosetta-cli"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "aptos",
  "aptos-api",
  "aptos-config",
  "aptos-crypto",

--- a/crates/aptos-rosetta-cli/Cargo.toml
+++ b/crates/aptos-rosetta-cli/Cargo.toml
@@ -24,9 +24,10 @@ tokio = { version = "1.18.2", features = ["full", "time"] }
 url = "2.2.2"
 warp = "0.3.2"
 
+aptos = { path = "../aptos" }
 aptos-api = { path = "../../api" }
 aptos-config = { path = "../../config" }
-aptos-crypto = { path = "../aptos-crypto" }
+aptos-crypto = { path = "../aptos-crypto", features = ["fuzzing"] }
 aptos-logger = { path = "../aptos-logger" }
 aptos-metrics-core = { path = "../aptos-metrics-core" }
 aptos-rest-client = { path = "../aptos-rest-client" }

--- a/crates/aptos-rosetta-cli/src/account.rs
+++ b/crates/aptos-rosetta-cli/src/account.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::{format_output, NetworkArgs, UrlArgs};
-use aptos_rosetta::types::{AccountBalanceRequest, AccountBalanceResponse};
+use crate::common::{format_output, BlockArgs, NetworkArgs, UrlArgs};
+use aptos_rosetta::types::{AccountBalanceRequest, AccountBalanceResponse, Currency};
 use aptos_types::account_address::AccountAddress;
 use clap::{Parser, Subcommand};
 
@@ -29,22 +29,34 @@ impl AccountCommand {
 pub struct AccountBalanceCommand {
     #[clap(flatten)]
     network_args: NetworkArgs,
-    /// Account to list the balance
-    #[clap(long)]
-    account: AccountAddress,
     #[clap(flatten)]
     url_args: UrlArgs,
+    #[clap(flatten)]
+    block_args: BlockArgs,
+    #[clap(long)]
+    filter_currency: bool,
+    /// Account to list the balance
+    #[clap(long, parse(try_from_str=aptos::common::types::load_account_arg))]
+    account: AccountAddress,
 }
 
 impl AccountBalanceCommand {
     pub async fn execute(self) -> anyhow::Result<AccountBalanceResponse> {
         let client = self.url_args.client();
-        let request = AccountBalanceRequest {
-            network_identifier: self.network_args.network_identifier(),
-            account_identifier: self.account.into(),
-            block_identifier: None,
-            currencies: None,
-        };
-        client.account_balance(&request).await
+        client
+            .account_balance(&AccountBalanceRequest {
+                network_identifier: self.network_args.network_identifier(),
+                account_identifier: self.account.into(),
+                block_identifier: self.block_args.into(),
+                currencies: if self.filter_currency {
+                    Some(vec![Currency {
+                        symbol: "TC".to_string(),
+                        decimals: 6,
+                    }])
+                } else {
+                    None
+                },
+            })
+            .await
     }
 }

--- a/crates/aptos-rosetta-cli/src/block.rs
+++ b/crates/aptos-rosetta-cli/src/block.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::{format_output, NetworkArgs, UrlArgs};
-use aptos_rosetta::types::{BlockRequest, BlockResponse, PartialBlockIdentifier};
+use crate::common::{format_output, BlockArgs, NetworkArgs, UrlArgs};
+use aptos_rosetta::types::{BlockRequest, BlockResponse};
 use clap::{Parser, Subcommand};
 
 /// Block APIs
@@ -26,10 +26,8 @@ impl BlockCommand {
 /// [API Spec](https://www.rosetta-api.org/docs/BlockApi.html#block)
 #[derive(Debug, Parser)]
 pub struct GetBlockCommand {
-    #[clap(long)]
-    version: Option<u64>,
-    #[clap(long)]
-    txn_hash: Option<String>,
+    #[clap(flatten)]
+    block_args: BlockArgs,
     #[clap(flatten)]
     network_args: NetworkArgs,
     #[clap(flatten)]
@@ -40,10 +38,7 @@ impl GetBlockCommand {
     pub async fn execute(self) -> anyhow::Result<BlockResponse> {
         let request = BlockRequest {
             network_identifier: self.network_args.network_identifier(),
-            block_identifier: PartialBlockIdentifier {
-                index: self.version,
-                hash: self.txn_hash,
-            },
+            block_identifier: self.block_args.into(),
         };
         self.url_args.client().block(&request).await
     }

--- a/crates/aptos-rosetta-cli/src/common.rs
+++ b/crates/aptos-rosetta-cli/src/common.rs
@@ -4,7 +4,7 @@
 use crate::{account, block, construction, network};
 use aptos_rosetta::{
     client::RosettaClient,
-    types::{NetworkIdentifier, NetworkRequest},
+    types::{NetworkIdentifier, NetworkRequest, PartialBlockIdentifier},
 };
 use aptos_types::chain_id::ChainId;
 use clap::Parser;
@@ -44,7 +44,7 @@ pub fn format_output<T: Serialize>(input: anyhow::Result<T>) -> anyhow::Result<S
 
 #[derive(Debug, Parser)]
 pub struct UrlArgs {
-    /// URL for the Aptos Rosetta API. e.g. http://localhost:8080
+    /// URL for the Aptos Rosetta API. e.g. http://localhost:8082
     #[clap(long, default_value = "http://localhost:8082")]
     rosetta_api_url: url::Url,
 }
@@ -78,4 +78,27 @@ impl NetworkArgs {
 #[derive(Serialize)]
 pub struct ErrorWrapper {
     pub error: String,
+}
+
+#[derive(Debug, Parser)]
+pub struct BlockArgs {
+    #[clap(long)]
+    block_index: Option<u64>,
+    #[clap(long)]
+    block_hash: Option<String>,
+}
+
+impl From<BlockArgs> for Option<PartialBlockIdentifier> {
+    fn from(args: BlockArgs) -> Self {
+        Some(args.into())
+    }
+}
+
+impl From<BlockArgs> for PartialBlockIdentifier {
+    fn from(args: BlockArgs) -> Self {
+        PartialBlockIdentifier {
+            index: args.block_index,
+            hash: args.block_hash,
+        }
+    }
 }

--- a/crates/aptos-rosetta-cli/src/common.rs
+++ b/crates/aptos-rosetta-cli/src/common.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account, block, network};
+use crate::{account, block, construction, network};
 use aptos_rosetta::{
     client::RosettaClient,
     types::{NetworkIdentifier, NetworkRequest},
@@ -21,6 +21,8 @@ pub enum RosettaCliArgs {
     #[clap(subcommand)]
     Block(block::BlockCommand),
     #[clap(subcommand)]
+    Construction(construction::ConstructionCommand),
+    #[clap(subcommand)]
     Network(network::NetworkCommand),
 }
 
@@ -29,6 +31,7 @@ impl RosettaCliArgs {
         match self {
             RosettaCliArgs::Account(inner) => inner.execute().await,
             RosettaCliArgs::Block(inner) => inner.execute().await,
+            RosettaCliArgs::Construction(inner) => inner.execute().await,
             RosettaCliArgs::Network(inner) => inner.execute().await,
         }
     }
@@ -42,7 +45,7 @@ pub fn format_output<T: Serialize>(input: anyhow::Result<T>) -> anyhow::Result<S
 #[derive(Debug, Parser)]
 pub struct UrlArgs {
     /// URL for the Aptos Rosetta API. e.g. http://localhost:8080
-    #[clap(long, default_value = "http://localhost:8080")]
+    #[clap(long, default_value = "http://localhost:8082")]
     rosetta_api_url: url::Url,
 }
 

--- a/crates/aptos-rosetta-cli/src/construction.rs
+++ b/crates/aptos-rosetta-cli/src/construction.rs
@@ -1,0 +1,318 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::{format_output, NetworkArgs, UrlArgs};
+use anyhow::anyhow;
+use aptos::common::types::{EncodingOptions, PrivateKeyInputOptions, ProfileOptions};
+use aptos_crypto::{
+    ed25519::Ed25519PrivateKey, PrivateKey, SigningKey, ValidCryptoMaterialStringExt,
+};
+use aptos_rosetta::{
+    client::RosettaClient,
+    types::{
+        AccountIdentifier, Amount, ConstructionCombineRequest, ConstructionDeriveRequest,
+        ConstructionDeriveResponse, ConstructionMetadata, ConstructionMetadataRequest,
+        ConstructionMetadataResponse, ConstructionParseRequest, ConstructionPayloadsRequest,
+        ConstructionPayloadsResponse, ConstructionPreprocessRequest, ConstructionSubmitRequest,
+        Currency, NetworkIdentifier, Operation, OperationIdentifier, OperationType, PublicKey,
+        Signature, SignatureType, TransactionIdentifier,
+    },
+};
+use aptos_types::account_address::AccountAddress;
+use clap::{Parser, Subcommand};
+use std::convert::TryInto;
+
+#[derive(Debug, Subcommand)]
+pub enum ConstructionCommand {
+    CreateAccount(CreateAccountCommand),
+    Transfer(TransferCommand),
+}
+
+impl ConstructionCommand {
+    pub async fn execute(self) -> anyhow::Result<String> {
+        use ConstructionCommand::*;
+        match self {
+            CreateAccount(inner) => format_output(inner.execute().await),
+            Transfer(inner) => format_output(inner.execute().await),
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct CreateAccountCommand {
+    #[clap(flatten)]
+    network_args: NetworkArgs,
+    #[clap(flatten)]
+    url_args: UrlArgs,
+    #[clap(flatten)]
+    encoding_options: EncodingOptions,
+    #[clap(flatten)]
+    profile_options: ProfileOptions,
+    #[clap(flatten)]
+    private_key_options: PrivateKeyInputOptions,
+    #[clap(long, parse(try_from_str=aptos::common::types::load_account_arg))]
+    new_account: AccountAddress,
+}
+
+impl CreateAccountCommand {
+    pub async fn execute(self) -> anyhow::Result<TransactionIdentifier> {
+        let client = self.url_args.client();
+        let network_identifier = self.network_args.network_identifier();
+        let account = self.new_account.into();
+        let private_key = self.private_key_options.extract_private_key(
+            self.encoding_options.encoding,
+            &self.profile_options.profile,
+        )?;
+
+        let operations = vec![Operation {
+            operation_identifier: OperationIdentifier {
+                index: 0,
+                network_index: None,
+            },
+            related_operations: None,
+            operation_type: OperationType::CreateAccount.to_string(),
+            status: None,
+            account: Some(account),
+            amount: None,
+        }];
+
+        submit_operations(&client, network_identifier, private_key, operations).await
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct TransferCommand {
+    #[clap(flatten)]
+    network_args: NetworkArgs,
+    #[clap(flatten)]
+    url_args: UrlArgs,
+    #[clap(flatten)]
+    encoding_options: EncodingOptions,
+    #[clap(flatten)]
+    profile_options: ProfileOptions,
+    #[clap(flatten)]
+    private_key_options: PrivateKeyInputOptions,
+    #[clap(long, parse(try_from_str=aptos::common::types::load_account_arg))]
+    receiver: AccountAddress,
+    #[clap(long)]
+    amount: u64,
+}
+
+impl TransferCommand {
+    pub async fn execute(self) -> anyhow::Result<TransactionIdentifier> {
+        let client = self.url_args.client();
+        let network_identifier = self.network_args.network_identifier();
+        let private_key = self.private_key_options.extract_private_key(
+            self.encoding_options.encoding,
+            &self.profile_options.profile,
+        )?;
+        let account = derive_account(
+            &client,
+            network_identifier.clone(),
+            private_key.public_key().try_into()?,
+        )
+        .await?;
+
+        let operations = vec![
+            Operation {
+                operation_identifier: OperationIdentifier {
+                    index: 0,
+                    network_index: None,
+                },
+                related_operations: None,
+                operation_type: OperationType::Withdraw.to_string(),
+                status: None,
+                account: Some(account),
+                amount: Some(val_to_amount(self.amount, true)),
+            },
+            Operation {
+                operation_identifier: OperationIdentifier {
+                    index: 1,
+                    network_index: None,
+                },
+                related_operations: None,
+                operation_type: OperationType::Deposit.to_string(),
+                status: None,
+                account: Some(self.receiver.into()),
+                amount: Some(val_to_amount(self.amount, false)),
+            },
+        ];
+
+        submit_operations(&client, network_identifier, private_key, operations).await
+    }
+}
+
+async fn submit_operations(
+    client: &RosettaClient,
+    network_identifier: NetworkIdentifier,
+    private_key: Ed25519PrivateKey,
+    operations: Vec<Operation>,
+) -> anyhow::Result<TransactionIdentifier> {
+    let public_key: PublicKey = private_key.public_key().try_into()?;
+
+    let metadata = metadata(
+        client,
+        network_identifier.clone(),
+        operations.clone(),
+        10000,
+        1,
+        public_key.clone(),
+    )
+    .await?;
+
+    let response = unsigned_transaction(
+        client,
+        network_identifier.clone(),
+        operations,
+        metadata.metadata,
+        public_key,
+    )
+    .await?;
+    let signed_txn =
+        sign_transaction(client, network_identifier.clone(), &private_key, response).await?;
+    submit_transaction(client, network_identifier, signed_txn).await
+}
+
+async fn derive_account(
+    client: &RosettaClient,
+    network_identifier: NetworkIdentifier,
+    public_key: PublicKey,
+) -> anyhow::Result<AccountIdentifier> {
+    // TODO: If it's not derivable then what?
+    if let ConstructionDeriveResponse {
+        account_identifier: Some(account_id),
+    } = client
+        .derive(&ConstructionDeriveRequest {
+            network_identifier,
+            public_key,
+        })
+        .await?
+    {
+        Ok(account_id)
+    } else {
+        return Err(anyhow!("Failed to find account address for key"));
+    }
+}
+
+async fn metadata(
+    client: &RosettaClient,
+    network_identifier: NetworkIdentifier,
+    operations: Vec<Operation>,
+    max_fee: u64,
+    fee_multiplier: u32,
+    public_key: PublicKey,
+) -> anyhow::Result<ConstructionMetadataResponse> {
+    // TODO: Pull gas currency a better way
+    let amount = val_to_amount(max_fee, true);
+
+    let preprocess_response = client
+        .preprocess(&ConstructionPreprocessRequest {
+            network_identifier: network_identifier.clone(),
+            operations,
+            max_fee: Some(vec![amount]),
+            suggested_fee_multiplier: Some(fee_multiplier as f64),
+        })
+        .await?;
+    client
+        .metadata(&ConstructionMetadataRequest {
+            network_identifier,
+            options: preprocess_response.options.unwrap(),
+            public_keys: vec![public_key],
+        })
+        .await
+}
+
+async fn unsigned_transaction(
+    client: &RosettaClient,
+    network_identifier: NetworkIdentifier,
+    operations: Vec<Operation>,
+    metadata: ConstructionMetadata,
+    public_key: PublicKey,
+) -> anyhow::Result<ConstructionPayloadsResponse> {
+    let payloads = client
+        .payloads(&ConstructionPayloadsRequest {
+            network_identifier: network_identifier.clone(),
+            operations,
+            metadata: Some(metadata),
+            public_keys: Some(vec![public_key]),
+        })
+        .await?;
+
+    // Verify
+    client
+        .parse(&ConstructionParseRequest {
+            network_identifier,
+            signed: false,
+            transaction: payloads.unsigned_transaction.clone(),
+        })
+        .await?;
+
+    Ok(payloads)
+}
+
+async fn sign_transaction(
+    client: &RosettaClient,
+    network_identifier: NetworkIdentifier,
+    private_key: &Ed25519PrivateKey,
+    mut unsigned_response: ConstructionPayloadsResponse,
+) -> anyhow::Result<String> {
+    // TODO: Support more than one payload
+    let signing_payload = unsigned_response.payloads.pop().unwrap();
+    let unsigned_transaction = unsigned_response.unsigned_transaction;
+
+    let unsigned_bytes = unsigned_transaction.as_bytes();
+    let txn_signature = private_key.sign_arbitrary_message(unsigned_bytes);
+    let signature = Signature {
+        signing_payload,
+        public_key: private_key.public_key().try_into()?,
+        signature_type: SignatureType::Ed25519,
+        hex_bytes: txn_signature.to_encoded_string()?,
+    };
+    let signed_response = client
+        .combine(&ConstructionCombineRequest {
+            network_identifier: network_identifier.clone(),
+            unsigned_transaction,
+            signatures: vec![signature],
+        })
+        .await?;
+
+    // Verify
+    client
+        .parse(&ConstructionParseRequest {
+            network_identifier,
+            signed: true,
+            transaction: signed_response.signed_transaction.clone(),
+        })
+        .await?;
+
+    Ok(signed_response.signed_transaction)
+}
+
+async fn submit_transaction(
+    client: &RosettaClient,
+    network_identifier: NetworkIdentifier,
+    signed_transaction: String,
+) -> anyhow::Result<TransactionIdentifier> {
+    Ok(client
+        .submit(&ConstructionSubmitRequest {
+            network_identifier,
+            signed_transaction,
+        })
+        .await?
+        .transaction_identifier)
+}
+
+fn val_to_amount(amount: u64, withdraw: bool) -> Amount {
+    let value = if withdraw {
+        format!("-{}", amount)
+    } else {
+        amount.to_string()
+    };
+    Amount {
+        value,
+        currency: Currency {
+            symbol: "TC".to_string(),
+            decimals: 6,
+        },
+    }
+}

--- a/crates/aptos-rosetta-cli/src/main.rs
+++ b/crates/aptos-rosetta-cli/src/main.rs
@@ -20,6 +20,7 @@
 mod account;
 mod block;
 mod common;
+mod construction;
 mod network;
 
 use crate::common::{ErrorWrapper, RosettaCliArgs};

--- a/crates/aptos-rosetta-cli/src/main.rs
+++ b/crates/aptos-rosetta-cli/src/main.rs
@@ -24,10 +24,19 @@ mod construction;
 mod network;
 
 use crate::common::{ErrorWrapper, RosettaCliArgs};
+use aptos_logger::Level;
 use clap::Parser;
 
 #[tokio::main]
 async fn main() {
+    let mut logger = aptos_logger::Logger::new();
+    logger
+        .channel_size(1000)
+        .is_async(false)
+        .level(Level::Warn)
+        .read_env();
+    logger.build();
+
     let args: RosettaCliArgs = RosettaCliArgs::parse();
 
     let result = args.execute().await;

--- a/crates/aptos-rosetta/rosetta_cli.json
+++ b/crates/aptos-rosetta/rosetta_cli.json
@@ -43,7 +43,7 @@
         "log_balance_changes": false,
         "log_reconciliations": false,
         "ignore_reconciliation_error": false,
-        "historical_balance_disabled": true,
+        "historical_balance_disabled": false,
         "exempt_accounts": "",
         "bootstrap_balances": "",
         "interesting_accounts": "",

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -154,12 +154,12 @@ async fn get_block_index_from_request(
             } else {
                 // Lookup by hash doesn't work since we're faking blocks, need to verify that it's a
                 // block
-                let response = rest_client
-                    .get_transaction(
-                        HashValue::from_str(&hash)
-                            .map_err(|err| ApiError::DeserializationFailed(err.to_string()))?,
-                    )
-                    .await?;
+                let response =
+                    rest_client
+                        .get_transaction(HashValue::from_str(&hash).map_err(|err| {
+                            ApiError::DeserializationFailed(Some(err.to_string()))
+                        })?)
+                        .await?;
                 let version = response.inner().version();
 
                 if let Some(version) = version {
@@ -301,10 +301,10 @@ impl CoinCache {
         // At this point if we've retrieved it and it's bad, we error out
         if let Some(resource) = response.into_inner() {
             let coin_info = serde_json::from_value::<CoinInfo>(resource.data).map_err(|_| {
-                ApiError::DeserializationFailed(format!(
+                ApiError::DeserializationFailed(Some(format!(
                     "CoinInfo failed to deserialize for {}",
                     coin
-                ))
+                )))
             })?;
 
             Ok(Some(Currency {
@@ -312,10 +312,10 @@ impl CoinCache {
                 decimals: coin_info.decimals.0,
             }))
         } else {
-            Err(ApiError::DeserializationFailed(format!(
+            Err(ApiError::DeserializationFailed(Some(format!(
                 "Currency {} not found",
                 coin
-            )))
+            ))))
         }
     }
 }

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -56,7 +56,7 @@ async fn block(request: BlockRequest, server_context: RosettaContext) -> ApiResu
         (None, Some(hash)) => {
             // Allow 0x in front of hash
             let hash = HashValue::from_str(strip_hex_prefix(hash))
-                .map_err(|err| ApiError::DeserializationFailed(err.to_string()))?;
+                .map_err(|err| ApiError::DeserializationFailed(Some(err.to_string())))?;
             let response = rest_client.get_transaction(hash).await?;
             let txn = response.into_inner();
             let version = txn.version().unwrap();

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -81,12 +81,14 @@ impl RosettaClient {
     ) -> anyhow::Result<ConstructionParseResponse> {
         self.make_call("construction/parse", request).await
     }
+
     pub async fn payloads(
         &self,
         request: &ConstructionPayloadsRequest,
     ) -> anyhow::Result<ConstructionPayloadsResponse> {
         self.make_call("construction/payloads", request).await
     }
+
     pub async fn preprocess(
         &self,
         request: &ConstructionPreprocessRequest,

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -92,20 +92,6 @@ impl RosettaClient {
             .send()
             .await?;
 
-        self.json(response).await
-    }
-
-    async fn json<T: serde::de::DeserializeOwned>(
-        &self,
-        response: reqwest::Response,
-    ) -> anyhow::Result<T> {
-        if !response.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "Request failed: {:?}",
-                response.error_for_status()
-            ));
-        }
-
         Ok(response.json().await?)
     }
 }

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -5,11 +5,18 @@ use crate::{
     common::EmptyRequest,
     types::{
         AccountBalanceRequest, AccountBalanceResponse, BlockRequest, BlockResponse,
+        ConstructionCombineRequest, ConstructionCombineResponse, ConstructionDeriveRequest,
+        ConstructionDeriveResponse, ConstructionHashRequest, ConstructionMetadataRequest,
+        ConstructionMetadataResponse, ConstructionParseRequest, ConstructionParseResponse,
+        ConstructionPayloadsRequest, ConstructionPayloadsResponse, ConstructionPreprocessRequest,
+        ConstructionPreprocessResponse, ConstructionSubmitRequest, ConstructionSubmitResponse,
         NetworkListResponse, NetworkOptionsResponse, NetworkRequest, NetworkStatusResponse,
+        TransactionIdentifierResponse,
     },
 };
 use aptos_rest_client::aptos_api_types::mime_types::JSON;
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient};
+use serde::{de::DeserializeOwned, Serialize};
 use url::Url;
 
 /// Client for testing & interacting with a Rosetta service
@@ -30,63 +37,93 @@ impl RosettaClient {
         &self,
         request: &AccountBalanceRequest,
     ) -> anyhow::Result<AccountBalanceResponse> {
-        let response = self
-            .inner
-            .post(self.address.join("account/balance").unwrap())
-            .header(CONTENT_TYPE, JSON)
-            .body(serde_json::to_string(request)?)
-            .send()
-            .await?;
-
-        self.json(response).await
+        self.make_call("account/balance", request).await
     }
 
     pub async fn block(&self, request: &BlockRequest) -> anyhow::Result<BlockResponse> {
-        let response = self
-            .inner
-            .post(self.address.join("block").unwrap())
-            .header(CONTENT_TYPE, JSON)
-            .body(serde_json::to_string(request)?)
-            .send()
-            .await?;
+        self.make_call("block", request).await
+    }
 
-        self.json(response).await
+    pub async fn combine(
+        &self,
+        request: &ConstructionCombineRequest,
+    ) -> anyhow::Result<ConstructionCombineResponse> {
+        self.make_call("construction/combine", request).await
+    }
+
+    pub async fn derive(
+        &self,
+        request: &ConstructionDeriveRequest,
+    ) -> anyhow::Result<ConstructionDeriveResponse> {
+        self.make_call("construction/derive", request).await
+    }
+
+    pub async fn hash(
+        &self,
+        request: &ConstructionHashRequest,
+    ) -> anyhow::Result<TransactionIdentifierResponse> {
+        self.make_call("construction/hash", request).await
+    }
+
+    pub async fn metadata(
+        &self,
+        request: &ConstructionMetadataRequest,
+    ) -> anyhow::Result<ConstructionMetadataResponse> {
+        self.make_call("construction/hash", request).await
+    }
+
+    pub async fn parse(
+        &self,
+        request: &ConstructionParseRequest,
+    ) -> anyhow::Result<ConstructionParseResponse> {
+        self.make_call("construction/parse", request).await
+    }
+    pub async fn payloads(
+        &self,
+        request: &ConstructionPayloadsRequest,
+    ) -> anyhow::Result<ConstructionPayloadsResponse> {
+        self.make_call("construction/payloads", request).await
+    }
+    pub async fn preprocess(
+        &self,
+        request: &ConstructionPreprocessRequest,
+    ) -> anyhow::Result<ConstructionPreprocessResponse> {
+        self.make_call("construction/preprocess", request).await
+    }
+
+    pub async fn submit(
+        &self,
+        request: &ConstructionSubmitRequest,
+    ) -> anyhow::Result<ConstructionSubmitResponse> {
+        self.make_call("construction/submit", request).await
     }
 
     pub async fn network_list(&self) -> anyhow::Result<NetworkListResponse> {
-        let response = self
-            .inner
-            .post(self.address.join("network/list").unwrap())
-            .header(CONTENT_TYPE, JSON)
-            .body(serde_json::to_string(&EmptyRequest)?)
-            .send()
-            .await?;
-
-        self.json(response).await
+        self.make_call("network/list", &EmptyRequest).await
     }
 
     pub async fn network_options(
         &self,
         request: &NetworkRequest,
     ) -> anyhow::Result<NetworkOptionsResponse> {
-        let response = self
-            .inner
-            .post(self.address.join("network/options").unwrap())
-            .header(CONTENT_TYPE, JSON)
-            .body(serde_json::to_string(request)?)
-            .send()
-            .await?;
-
-        self.json(response).await
+        self.make_call("network/options", request).await
     }
 
     pub async fn network_status(
         &self,
         request: &NetworkRequest,
     ) -> anyhow::Result<NetworkStatusResponse> {
+        self.make_call("network/status", request).await
+    }
+
+    async fn make_call<'a, I: Serialize, O: DeserializeOwned>(
+        &'a self,
+        path: &'static str,
+        request: &'a I,
+    ) -> anyhow::Result<O> {
         let response = self
             .inner
-            .post(self.address.join("network/status").unwrap())
+            .post(self.address.join(path)?)
             .header(CONTENT_TYPE, JSON)
             .body(serde_json::to_string(request)?)
             .send()

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -15,9 +15,11 @@ use crate::{
     },
 };
 use anyhow::anyhow;
+use aptos_logger::debug;
 use aptos_rest_client::aptos_api_types::mime_types::JSON;
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient};
 use serde::{de::DeserializeOwned, Serialize};
+use std::fmt::Debug;
 use url::Url;
 
 /// Client for testing & interacting with a Rosetta service
@@ -117,11 +119,12 @@ impl RosettaClient {
         self.make_call("network/status", request).await
     }
 
-    async fn make_call<'a, I: Serialize, O: DeserializeOwned>(
+    async fn make_call<'a, I: Serialize + Debug, O: DeserializeOwned>(
         &'a self,
         path: &'static str,
         request: &'a I,
     ) -> anyhow::Result<O> {
+        debug!("Rosetta Client path:{} request:{:?}", path, request);
         let response = self
             .inner
             .post(self.address.join(path)?)

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -95,7 +95,7 @@ pub async fn get_account(
     rest_client
         .get_account(address)
         .await
-        .map_err(|_| ApiError::AccountNotFound(address.to_string()))
+        .map_err(|_| ApiError::AccountNotFound(Some(address.to_string())))
 }
 
 /// Retrieve the timestamp according ot the Rosetta spec (milliseconds)
@@ -140,6 +140,6 @@ pub fn is_native_coin(currency: &Currency) -> ApiResult<()> {
     if currency == &native_coin() {
         Ok(())
     } else {
-        Err(ApiError::UnsupportedCurrency(currency.symbol.clone()))
+        Err(ApiError::UnsupportedCurrency(Some(currency.symbol.clone())))
     }
 }

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -40,7 +40,7 @@ pub fn with_context(
     warp::any().map(move || context.clone())
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy)]
 pub struct EmptyRequest;
 
 pub fn with_empty_request() -> impl Filter<Extract = (EmptyRequest,), Error = Infallible> + Clone {

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -1,6 +1,29 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+//! Construction APIs
+//!
+//! The construction APIs break down transactions into composable parts that are
+//! used to be generic across blockchains.  A flow of operations can be found
+//! in the [specifications](https://www.rosetta-api.org/docs/construction_api_introduction.html)
+//!
+//! This is broken down in the following flow:
+//!
+//! * Preprocess (based on operations) gets information to fetch from metadata (onchchain)
+//! * Metadata fetches onchain information e.g. sequence number
+//! * Payloads generates an unsigned transaction
+//! * Application outside signs the payload from the transactino
+//! * Combine puts the signed transaction payload with the unsigned transaction
+//! * Submit submits the signed transaciton to the blockchain
+//!
+//! There are also 2 other sometimes used APIs
+//! * Derive (get an account from the private key)
+//! * Hash (get a hash of the transaction to lookup in mempool)
+//!
+//! Note: there is an "online" mode and an "offline" mode.  The offline APIs can run without
+//! a connection to a full node.  The online ones need a connection to a full node.
+//!
+
 use crate::{
     common::{
         check_network, decode_bcs, decode_key, encode_bcs, get_account, handle_request,

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -123,9 +123,9 @@ async fn construction_combine(
     // Single signer only supported for now
     // TODO: Support multi-agent / multi-signer?
     if request.signatures.len() != 1 {
-        return Err(ApiError::UnsupportedSignatureCount(
+        return Err(ApiError::UnsupportedSignatureCount(Some(
             request.signatures.len(),
-        ));
+        )));
     }
 
     let signature = &request.signatures[0];
@@ -291,7 +291,9 @@ async fn construction_payloads(
         ),
         InternalOperation::Transfer(transfer) => {
             if transfer.currency != native_coin() {
-                return Err(ApiError::UnsupportedCurrency(transfer.currency.symbol));
+                return Err(ApiError::UnsupportedCurrency(Some(
+                    transfer.currency.symbol,
+                )));
             }
             (
                 aptos_stdlib::encode_test_coin_transfer(transfer.receiver, transfer.amount),

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -310,7 +310,7 @@ async fn construction_payloads(
     let unsigned_transaction = transaction_factory
         .payload(txn_payload)
         .sender(sender)
-        .sequence_number(sequence_number + 1)
+        .sequence_number(sequence_number)
         .build();
 
     let signing_message = hex::encode(signing_message(&unsigned_transaction));

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -12,35 +12,39 @@ pub type ApiResult<T> = Result<T, ApiError>;
 
 #[derive(Debug, Deserialize, Serialize, Error)]
 pub enum ApiError {
-    #[error("Aptos error {0}")]
+    #[error("Aptos error: {0}")]
     AptosError(String),
-    #[error("bad block request")]
-    BadBlockRequest,
-    #[error("bad network")]
-    BadNetwork,
-    #[error("deserialization failed: {0}")]
+    #[error("Must provide either hash or index but not both")]
+    BlockParameterConflict,
+    #[error("Transaction is pending")]
+    TransactionIsPending,
+    #[error("Network identifier doesn't match the supported network")]
+    NetworkIdentifierMismatch,
+    #[error("ChainId doesn't match the on-chain state")]
+    ChainIdMismatch,
+    #[error("Deserialization failed {0}")]
     DeserializationFailed(String),
-    #[error("bad transfer operations")]
-    BadTransferOperations(String),
-    #[error("account not found")]
-    AccountNotFound,
-    #[error("bad signature")]
-    BadSignature,
-    #[error("bad signature type")]
-    BadSignatureType,
-    #[error("bad transaction script")]
-    BadTransactionScript,
-    #[error("bad transaction payload")]
-    BadTransactionPayload,
-    #[error("bad coin")]
-    BadCoin,
-    #[error("bad signature count")]
-    BadSignatureCount,
-    #[error("historic balances unsupported")]
-    HistoricBalancesUnsupported,
-    #[error("node is offline")]
+    #[error("Transfer operations failed {0}")]
+    InvalidTransferOperations(String),
+    #[error("Account not found {0}")]
+    AccountNotFound(String),
+    #[error("Invalid signature type, only Ed25519 is supported")]
+    InvalidSignatureType,
+    #[error("Invalid max gas fees, only one native gas fee is allowed")]
+    InvalidMaxGasFees,
+    #[error("Invalid fee multiplier, only integers are allowed")]
+    InvalidGasMultiplier,
+    #[error("Operations don't map to a supported internal operation")]
+    InvalidOperations,
+    #[error("Missing payload metadata containing the internal transaction")]
+    MissingPayloadMetadata,
+    #[error("Unsupported currency {0}")]
+    UnsupportedCurrency(String),
+    #[error("Unsupported signature count {0}")]
+    UnsupportedSignatureCount(usize),
+    #[error("Node is offline, and this API is not supported in offline mode")]
     NodeIsOffline,
-    #[error("block incomplete")]
+    #[error("Block is not yet complete, request will need to be retried")]
     BlockIncomplete,
 }
 
@@ -49,53 +53,61 @@ impl ApiError {
         use ApiError::*;
         vec![
             AptosError(String::new()),
-            BadBlockRequest,
-            BadNetwork,
+            TransactionIsPending,
             DeserializationFailed(String::new()),
-            BadTransferOperations(String::new()),
-            AccountNotFound,
-            BadSignature,
-            BadSignatureType,
-            BadTransactionScript,
-            BadTransactionPayload,
-            BadCoin,
-            BadSignatureCount,
-            HistoricBalancesUnsupported,
+            InvalidTransferOperations(String::new()),
+            InvalidSignatureType,
             NodeIsOffline,
             BlockIncomplete,
+            BlockParameterConflict,
+            NetworkIdentifierMismatch,
+            ChainIdMismatch,
+            AccountNotFound(String::new()),
+            InvalidMaxGasFees,
+            InvalidGasMultiplier,
+            InvalidOperations,
+            MissingPayloadMetadata,
+            UnsupportedCurrency(String::new()),
+            UnsupportedSignatureCount(0),
         ]
     }
 
     pub fn code(&self) -> u64 {
         use ApiError::*;
         match self {
-            AptosError(_) => 10,
-            BadBlockRequest => 20,
-            BadNetwork => 40,
-            DeserializationFailed(_) => 50,
-            BadTransferOperations(_) => 70,
-            AccountNotFound => 80,
-            BadSignature => 110,
-            BadSignatureType => 120,
-            BadTransactionScript => 130,
-            BadTransactionPayload => 140,
-            BadCoin => 150,
-            BadSignatureCount => 160,
-            HistoricBalancesUnsupported => 170,
-            NodeIsOffline => 180,
-            BlockIncomplete => 181,
+            AptosError(_) => 1,
+            TransactionIsPending => 2,
+            DeserializationFailed(_) => 3,
+            InvalidTransferOperations(_) => 4,
+            InvalidSignatureType => 5,
+            NodeIsOffline => 6,
+            BlockIncomplete => 7,
+            BlockParameterConflict => 8,
+            NetworkIdentifierMismatch => 9,
+            ChainIdMismatch => 10,
+            AccountNotFound(_) => 11,
+            InvalidMaxGasFees => 12,
+            InvalidGasMultiplier => 13,
+            InvalidOperations => 14,
+            MissingPayloadMetadata => 15,
+            UnsupportedCurrency(_) => 16,
+            UnsupportedSignatureCount(_) => 17,
         }
     }
 
     pub fn retriable(&self) -> bool {
-        matches!(self, ApiError::AccountNotFound | ApiError::BlockIncomplete)
+        matches!(
+            self,
+            ApiError::AccountNotFound(_) | ApiError::BlockIncomplete
+        )
     }
 
     pub fn status_code(&self) -> StatusCode {
         use ApiError::*;
         match self {
-            AccountNotFound => StatusCode::NOT_FOUND,
+            AccountNotFound(_) => StatusCode::NOT_FOUND,
             BlockIncomplete => StatusCode::PRECONDITION_FAILED,
+            NodeIsOffline => StatusCode::METHOD_NOT_ALLOWED,
             _ => StatusCode::BAD_REQUEST,
         }
     }
@@ -129,19 +141,19 @@ impl From<&ApiError> for types::Error {
 
 impl From<AccountAddressParseError> for ApiError {
     fn from(err: AccountAddressParseError) -> Self {
-        ApiError::AptosError(err.to_string())
+        ApiError::DeserializationFailed(err.to_string())
     }
 }
 
 impl From<FromHexError> for ApiError {
     fn from(err: FromHexError) -> Self {
-        ApiError::AptosError(err.to_string())
+        ApiError::DeserializationFailed(err.to_string())
     }
 }
 
 impl From<bcs::Error> for ApiError {
     fn from(err: bcs::Error) -> Self {
-        ApiError::AptosError(err.to_string())
+        ApiError::DeserializationFailed(err.to_string())
     }
 }
 
@@ -153,7 +165,7 @@ impl From<anyhow::Error> for ApiError {
 
 impl From<std::num::ParseIntError> for ApiError {
     fn from(err: std::num::ParseIntError) -> Self {
-        ApiError::AptosError(err.to_string())
+        ApiError::DeserializationFailed(err.to_string())
     }
 }
 

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -46,6 +46,8 @@ pub enum ApiError {
     NodeIsOffline,
     #[error("Block is not yet complete, request will need to be retried")]
     BlockIncomplete,
+    #[error("Transaction cannot be parsed")]
+    TransactionParseError(Option<&'static str>),
 }
 
 impl ApiError {
@@ -69,6 +71,7 @@ impl ApiError {
             MissingPayloadMetadata,
             UnsupportedCurrency(None),
             UnsupportedSignatureCount(None),
+            TransactionParseError(None),
         ]
     }
 
@@ -92,6 +95,7 @@ impl ApiError {
             MissingPayloadMetadata => 15,
             UnsupportedCurrency(_) => 16,
             UnsupportedSignatureCount(_) => 17,
+            TransactionParseError(_) => 18,
         }
     }
 
@@ -136,6 +140,7 @@ impl From<&ApiError> for types::Error {
             ApiError::AccountNotFound(details) => details.clone(),
             ApiError::UnsupportedCurrency(details) => details.clone(),
             ApiError::UnsupportedSignatureCount(details) => details.map(|inner| inner.to_string()),
+            ApiError::TransactionParseError(details) => details.map(|inner| inner.to_string()),
             _ => None,
         }
         .map(|details| ErrorDetails { details });

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -130,7 +130,6 @@ pub fn routes(
         )
         .with(aptos_api::log::logger())
         .recover(handle_rejection)
-    // TODO Logger?
     // TODO metrics?
 }
 
@@ -139,7 +138,7 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
     let code;
     let body;
 
-    debug!("Failed with: {:?}", err);
+    println!("Failed with: {:?}", err);
 
     if err.is_not_found() {
         code = StatusCode::NOT_FOUND;

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -95,7 +95,7 @@ impl ServerArgs for CommandArgs {
 #[derive(Debug, Parser)]
 pub struct OfflineArgs {
     /// Listen address for the server. e.g. 127.0.0.1:8080
-    #[clap(long, default_value = "127.0.0.1:8080")]
+    #[clap(long, default_value = "127.0.0.1:8082")]
     listen_address: SocketAddr,
     /// Path to TLS cert for HTTPS support
     #[clap(long)]

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -41,7 +41,7 @@ impl TryFrom<&AccountIdentifier> for AccountAddress {
             Ok(address)
         } else {
             Ok(AccountAddress::from_str(&account.address)
-                .map_err(|_| ApiError::AptosError("Invalid account address".to_string()))?)
+                .map_err(|_| ApiError::AptosError(Some("Invalid account address".to_string())))?)
         }
     }
 }
@@ -90,7 +90,7 @@ impl BlockIdentifier {
     pub fn from_transaction(block_size: u64, txn: &Transaction) -> ApiResult<BlockIdentifier> {
         let txn_info = txn
             .transaction_info()
-            .map_err(|err| ApiError::AptosError(err.to_string()))?;
+            .map_err(|err| ApiError::AptosError(Some(err.to_string())))?;
         Ok(Self::from_transaction_info(block_size, txn_info))
     }
 }
@@ -119,7 +119,7 @@ impl TryFrom<&NetworkIdentifier> for ChainId {
 
     fn try_from(network_identifier: &NetworkIdentifier) -> Result<Self, Self::Error> {
         ChainId::from_str(network_identifier.network.trim())
-            .map_err(|err| ApiError::AptosError(err.to_string()))
+            .map_err(|err| ApiError::AptosError(Some(err.to_string())))
     }
 }
 

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     block::version_to_block_index,
-    common::{strip_hex_prefix, BLOCKCHAIN},
+    common::BLOCKCHAIN,
     error::{ApiError, ApiResult},
 };
 use aptos_rest_client::{aptos_api_types::TransactionInfo, Transaction};
@@ -37,9 +37,12 @@ impl TryFrom<&AccountIdentifier> for AccountAddress {
 
     fn try_from(account: &AccountIdentifier) -> Result<Self, Self::Error> {
         // Allow 0x in front of account address
-        Ok(AccountAddress::from_str(strip_hex_prefix(
-            &account.address,
-        ))?)
+        if let Ok(address) = AccountAddress::from_hex_literal(&account.address) {
+            Ok(address)
+        } else {
+            Ok(AccountAddress::from_str(&account.address)
+                .map_err(|_| ApiError::AptosError("Invalid account address".to_string()))?)
+        }
     }
 }
 

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -31,8 +31,8 @@ pub struct Error {
 /// Error details that are specific to the instance
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ErrorDetails {
-    /// Detailed error message
-    pub error: String,
+    /// Related error details
+    pub details: String,
 }
 
 /// Status of an operation
@@ -106,10 +106,10 @@ impl FromStr for OperationType {
             Self::CREATE_ACCOUNT => Ok(OperationType::CreateAccount),
             Self::DEPOSIT => Ok(OperationType::Deposit),
             Self::WITHDRAW => Ok(OperationType::Withdraw),
-            _ => Err(ApiError::DeserializationFailed(format!(
+            _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
                 s
-            ))),
+            )))),
         }
     }
 }
@@ -168,10 +168,10 @@ impl FromStr for OperationStatusType {
         match s.to_lowercase().trim() {
             Self::SUCCESS => Ok(OperationStatusType::Success),
             Self::FAILURE => Ok(OperationStatusType::Failure),
-            _ => Err(ApiError::DeserializationFailed(format!(
+            _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationStatusType: {}",
                 s
-            ))),
+            )))),
         }
     }
 }

--- a/crates/aptos-rosetta/src/types/mod.rs
+++ b/crates/aptos-rosetta/src/types/mod.rs
@@ -3,10 +3,12 @@
 
 mod identifiers;
 mod misc;
+mod move_types;
 mod objects;
 mod requests;
 
 pub use identifiers::*;
 pub use misc::*;
+pub use move_types::*;
 pub use objects::*;
 pub use requests::*;

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -25,21 +25,27 @@ pub fn create_account_identifier() -> Identifier {
 pub fn test_coin_identifier() -> Identifier {
     ident_str!("TestCoin").into()
 }
+
 pub fn sequence_number_identifier() -> Identifier {
     ident_str!("sequence_number").into()
 }
+
 pub fn deposit_events_identifier() -> Identifier {
     ident_str!("deposit_events").into()
 }
+
 pub fn withdraw_events_identifier() -> Identifier {
     ident_str!("withdraw_events").into()
 }
+
 pub fn transfer_identifier() -> Identifier {
     ident_str!("transfer").into()
 }
+
 pub fn decimals_identifier() -> Identifier {
     ident_str!("decimals").into()
 }
+
 pub fn symbol_identifier() -> Identifier {
     ident_str!("symbol").into()
 }

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_sdk::move_types::{ident_str, identifier::Identifier};
+
+pub fn account_identifier() -> Identifier {
+    ident_str!("Account").into()
+}
+
+pub fn coin_identifier() -> Identifier {
+    ident_str!("Coin").into()
+}
+
+pub fn coin_info_identifier() -> Identifier {
+    ident_str!("CoinInfo").into()
+}
+pub fn coin_store_identifier() -> Identifier {
+    ident_str!("CoinStore").into()
+}
+
+pub fn create_account_identifier() -> Identifier {
+    ident_str!("create_account").into()
+}
+
+pub fn test_coin_identifier() -> Identifier {
+    ident_str!("TestCoin").into()
+}
+pub fn sequence_number_identifier() -> Identifier {
+    ident_str!("sequence_number").into()
+}
+pub fn deposit_events_identifier() -> Identifier {
+    ident_str!("deposit_events").into()
+}
+pub fn withdraw_events_identifier() -> Identifier {
+    ident_str!("withdraw_events").into()
+}
+pub fn transfer_identifier() -> Identifier {
+    ident_str!("transfer").into()
+}
+pub fn decimals_identifier() -> Identifier {
+    ident_str!("decimals").into()
+}
+pub fn symbol_identifier() -> Identifier {
+    ident_str!("symbol").into()
+}

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -522,10 +522,10 @@ impl Transaction {
                                             deposit_event_key: deposit_event,
                                         });
                                     } else {
-                                        return Err(ApiError::UnsupportedCurrency(format!(
+                                        return Err(ApiError::UnsupportedCurrency(Some(format!(
                                             "Currency {} is not supported",
                                             coin_type
-                                        )));
+                                        ))));
                                     }
                                 }
                             }
@@ -650,9 +650,9 @@ impl Transaction {
                     metadata: None,
                 });
             } else {
-                return Err(ApiError::AptosError(
+                return Err(ApiError::AptosError(Some(
                     "Failed to load gas currency".to_string(),
-                ));
+                )));
             }
         }
 
@@ -743,9 +743,9 @@ impl Transfer {
                     == OperationType::Withdraw
             }))
         {
-            return Err(ApiError::InvalidTransferOperations(
-                "Must have exactly 1 withdraw and 1 deposit".to_string(),
-            ));
+            return Err(ApiError::InvalidTransferOperations(Some(
+                "Must have exactly 1 withdraw and 1 deposit",
+            )));
         }
 
         let mut op_map = HashMap::new();
@@ -755,9 +755,9 @@ impl Transfer {
         }
         let mut keys = op_map.keys();
         if !keys.contains(&OperationType::Withdraw) || !keys.contains(&OperationType::Deposit) {
-            return Err(ApiError::InvalidTransferOperations(
-                "Must have exactly 1 withdraw and 1 deposit".to_string(),
-            ));
+            return Err(ApiError::InvalidTransferOperations(Some(
+                "Must have exactly 1 withdraw and 1 deposit",
+            )));
         }
 
         // Verify accounts and amounts
@@ -765,18 +765,18 @@ impl Transfer {
         let sender = if let Some(ref account) = withdraw.account {
             account.try_into()?
         } else {
-            return Err(ApiError::InvalidTransferOperations(
-                "Invalid withdraw account provided".to_string(),
-            ));
+            return Err(ApiError::InvalidTransferOperations(Some(
+                "Invalid withdraw account provided",
+            )));
         };
 
         let deposit = op_map.get(&OperationType::Deposit).unwrap();
         let receiver = if let Some(ref account) = deposit.account {
             account.try_into()?
         } else {
-            return Err(ApiError::InvalidTransferOperations(
-                "Invalid deposit account provided".to_string(),
-            ));
+            return Err(ApiError::InvalidTransferOperations(Some(
+                "Invalid deposit account provided",
+            )));
         };
 
         let (amount, currency): (u64, Currency) =
@@ -785,9 +785,9 @@ impl Transfer {
             {
                 // Currencies have to be the same
                 if withdraw_amount.currency != deposit_amount.currency {
-                    return Err(ApiError::InvalidTransferOperations(
-                        "Currency mismatch between withdraw and deposit".to_string(),
-                    ));
+                    return Err(ApiError::InvalidTransferOperations(Some(
+                        "Currency mismatch between withdraw and deposit",
+                    )));
                 }
 
                 // Check that the currency is supported
@@ -795,24 +795,24 @@ impl Transfer {
                 let _ = is_native_coin(&withdraw_amount.currency)?;
 
                 let withdraw_value = i64::from_str(&withdraw_amount.value).map_err(|_| {
-                    ApiError::InvalidTransferOperations("Withdraw amount is invalid".to_string())
+                    ApiError::InvalidTransferOperations(Some("Withdraw amount is invalid"))
                 })?;
                 let deposit_value = i64::from_str(&deposit_amount.value).map_err(|_| {
-                    ApiError::InvalidTransferOperations("Deposit amount is invalid".to_string())
+                    ApiError::InvalidTransferOperations(Some("Deposit amount is invalid"))
                 })?;
 
                 // We can't create or destroy coins, they must be negatives of each other
                 if -withdraw_value != deposit_value {
-                    return Err(ApiError::InvalidTransferOperations(
-                        "Withdraw amount must be equal to negative of deposit amount".to_string(),
-                    ));
+                    return Err(ApiError::InvalidTransferOperations(Some(
+                        "Withdraw amount must be equal to negative of deposit amount",
+                    )));
                 }
 
                 (deposit_value as u64, deposit_amount.currency.clone())
             } else {
-                return Err(ApiError::InvalidTransferOperations(
-                    "Must have exactly 1 withdraw and 1 deposit with amounts".to_string(),
-                ));
+                return Err(ApiError::InvalidTransferOperations(Some(
+                    "Must have exactly 1 withdraw and 1 deposit with amounts",
+                )));
             };
 
         Ok(Transfer {

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -218,7 +218,7 @@ pub struct ConstructionPayloadsResponse {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ConstructionPreprocessRequest {
     pub network_identifier: NetworkIdentifier,
-    /// TODO: Operations expected to occur from the transaction?
+    /// Operations that make up an `InternalOperation`
     pub operations: Vec<Operation>,
     /// Max gas price
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -342,7 +342,6 @@ pub struct NetworkStatusResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sync_status: Option<SyncStatus>,
     /// Connected peers
-    /// TODO: This doesn't seem to really be used anywhere, is it necessary?
     pub peers: Vec<Peer>,
 }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -6,7 +6,8 @@ use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_config::{config::ApiConfig, utils::get_available_port};
 use aptos_rosetta::{
     client::RosettaClient,
-    types::{AccountBalanceRequest, BlockRequest, Currency, SupportedCurrencies},
+    common::native_coin,
+    types::{AccountBalanceRequest, BlockRequest},
 };
 use forge::{LocalSwarm, Node};
 use std::{future::Future, str::FromStr, time::Duration};
@@ -73,10 +74,7 @@ async fn test_account_balance() {
     assert_eq!(1, response.balances.len());
     let balance = response.balances.first().unwrap();
     assert_eq!(DEFAULT_FUNDED_COINS, u64::from_str(&balance.value).unwrap());
-    assert_eq!(
-        &Currency::from(SupportedCurrencies::NativeCoin),
-        &balance.currency
-    );
+    assert_eq!(&native_coin(), &balance.currency);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Description
This gets Construct working for both CreateAccount and Transfer operations to the Rosetta spec.

Additionally, I cleaned up the errors for Rosetta in general, fixed some bugs, added parsing for operations.

There are a few TODOs leftover for getting the genesis hash and adding peers.  Otherwise, the entire system does work with my test framework.  Additionally, I'll need to build the Rosetta DSL to finish the testing.


Built on top of https://github.com/aptos-labs/aptos-core/pull/1776

### Test Plan
Create flow:

```
$ aptos account fund --profile local --account local --num-coins 100000000
{
  "Result": "Added 100000000 coins to account CB48471868293A5FEB8FAC3871775B62A671B7C405B43E7755F368901DF9EC8C"
}

$ curl localhost:8080/accounts/0xcb48471868293a5feb8fac3871775b62a671b7c405b43e7755f368901df9ec8c/resources 2> /dev/null | jq | grep -A 1 coin
      "coin": {
        "value": "100000000"

$ cargo run -p aptos-rosetta-cli -- construction create-account --new-account 0x1337 --profile local --sender local                                           
    Finished dev [unoptimized + debuginfo] target(s) in 0.30s
     Running `target/debug/aptos-rosetta-cli construction create-account --new-account 0x1337 --profile local --sender local`
{
  "hash": "0xbd5433448fa3c761c2be3f6527713caa293572f42036789d8a177d8ce04a7c31"
}

$ curl localhost:8080/accounts/0xcb48471868293a5feb8fac3871775b62a671b7c405b43e7755f368901df9ec8c/resources 2> /dev/null | jq | grep -A 1 coin
      "coin": {
        "value": "99999861"
$ curl localhost:8080/accounts/0x1337
{"sequence_number":"0","authentication_key":"0x0000000000000000000000000000000000000000000000000000000000001337"}%             
```

Transfer flow:
```
$ ./target/debug/aptos-rosetta-cli construction transfer --profile local --sender local --receiver 0x1337 --amount 10000
{
  "hash": "0xb534a43fe98c0d43883bf8ac90f06c9749434a241e42930a97f82918b9c68b48"
}

$ curl localhost:8080/accounts/0x1337
{"sequence_number":"0","authentication_key":"0x0000000000000000000000000000000000000000000000000000000000001337"}% 

$ curl localhost:8080/accounts/0xcb48471868293a5feb8fac3871775b62a671b7c405b43e7755f368901df9ec8c/resources 2> /dev/null | jq | grep -A 1 coin
      "coin": {
        "value": "99989788"
        
$ curl localhost:8080/accounts/0x1337/resources 2> /dev/null | jq | grep -A 1 coin
      "coin": {
        "value": "10000"
```



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1781)
<!-- Reviewable:end -->
