### PR TITLE
[Storage] let StateStore maintain InMemoryState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-proptest-helpers",
+ "aptos-state-view",
  "aptos-temppath",
  "aptos-types",
  "aptos-workspace-hack",

--- a/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
@@ -68,20 +68,20 @@ fn main() -> Result<()> {
     .with_context(|| format_err!("Failed to open DB."))?;
     let db = DbReaderWriter::new(db);
 
-    let tree_state = db
+    let executed_trees = db
         .reader
-        .get_latest_tree_state()
+        .get_latest_executed_trees()
         .with_context(|| format_err!("Failed to get latest tree state."))?;
     if let Some(waypoint) = opt.waypoint_to_verify {
         ensure!(
-            waypoint.version() == tree_state.num_transactions,
+            waypoint.version() == executed_trees.num_transactions(),
             "Trying to generate waypoint at version {}, but DB has {} transactions.",
             waypoint.version(),
-            tree_state.num_transactions,
+            executed_trees.num_transactions(),
         )
     }
 
-    let committer = calculate_genesis::<AptosVM>(&db, tree_state, &genesis_txn)
+    let committer = calculate_genesis::<AptosVM>(&db, executed_trees, &genesis_txn)
         .with_context(|| format_err!("Failed to calculate genesis."))?;
     println!(
         "Successfully calculated genesis. Got waypoint: {}",

--- a/execution/executor/src/components/block_tree/mod.rs
+++ b/execution/executor/src/components/block_tree/mod.rs
@@ -15,7 +15,7 @@ use aptos_types::{
     ledger_info::LedgerInfo, proof::definition::LeafCount, state_store::state_value::StateValue,
 };
 use consensus_types::block::Block as ConsensusBlock;
-use executor_types::{in_memory_state_calculator::IntoLedgerView, Error, ExecutedChunk};
+use executor_types::{Error, ExecutedChunk};
 use scratchpad::SparseMerkleTree;
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -219,10 +219,7 @@ impl BlockTree {
             ledger_info.consensus_block_id()
         };
 
-        let result_view = startup_info
-            .committed_tree_state
-            .clone()
-            .into_ledger_view(db)?;
+        let result_view = startup_info.committed_trees;
         block_lookup.fetch_or_add_block(id, ExecutedChunk::new_empty(result_view), None)
     }
 

--- a/execution/executor/src/components/chunk_commit_queue.rs
+++ b/execution/executor/src/components/chunk_commit_queue.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{anyhow, Result};
 
-use executor_types::{in_memory_state_calculator::IntoLedgerView, ExecutedChunk};
+use executor_types::ExecutedChunk;
 use std::{collections::VecDeque, sync::Arc};
 use storage_interface::{DbReader, ExecutedTrees};
 
@@ -19,8 +19,7 @@ impl ChunkCommitQueue {
         let persisted_view = db
             .get_startup_info()?
             .ok_or_else(|| anyhow!("DB not bootstrapped."))?
-            .into_latest_tree_state()
-            .into_ledger_view(db)?;
+            .into_latest_executed_trees();
         Ok(Self::new(persisted_view))
     }
 

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -23,10 +23,7 @@ use aptos_types::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use aptosdb::AptosDB;
-use executor_types::{
-    in_memory_state_calculator::IntoLedgerView, BlockExecutorTrait, ChunkExecutorTrait,
-    TransactionReplayer,
-};
+use executor_types::{BlockExecutorTrait, ChunkExecutorTrait, TransactionReplayer};
 use storage_interface::{DbReaderWriter, ExecutedTrees};
 
 use crate::{
@@ -363,12 +360,7 @@ fn apply_transaction_by_writeset(
     db: &DbReaderWriter,
     transactions_and_writesets: Vec<(Transaction, WriteSet)>,
 ) {
-    let ledger_view: ExecutedTrees = db
-        .reader
-        .get_latest_tree_state()
-        .unwrap()
-        .into_ledger_view(&db.reader)
-        .unwrap();
+    let ledger_view: ExecutedTrees = db.reader.get_latest_executed_trees().unwrap();
 
     let transactions_and_outputs = transactions_and_writesets
         .iter()
@@ -528,12 +520,7 @@ impl TestBlock {
 fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
     let executor = TestExecutor::new();
     let db = &executor.db;
-    let mut ledger_view: ExecutedTrees = db
-        .reader
-        .get_latest_tree_state()
-        .unwrap()
-        .into_ledger_view(&db.reader)
-        .unwrap();
+    let mut ledger_view: ExecutedTrees = db.reader.get_latest_executed_trees().unwrap();
 
     for txn in transactions {
         let out = ChunkOutput::by_transaction_execution::<MockVM>(

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -13,7 +13,7 @@ use aptos_types::{
     move_resource::MoveStorage, transaction::TransactionListWithProof,
 };
 use event_notifications::{EventNotificationSender, EventSubscriptionService};
-use executor_types::{in_memory_state_calculator::IntoLedgerView, ChunkExecutorTrait};
+use executor_types::ChunkExecutorTrait;
 use std::sync::Arc;
 use storage_interface::DbReader;
 
@@ -85,19 +85,9 @@ impl<C: ChunkExecutorTrait> ExecutorProxyTrait for ExecutorProxy<C> {
         let current_epoch_state = storage_info.get_epoch_state().clone();
         let latest_ledger_info = storage_info.latest_ledger_info.clone();
 
-        let synced_trees = storage_info
-            .into_latest_tree_state()
-            .into_ledger_view(&self.storage)
-            .map_err(|error| {
-                Error::UnexpectedError(format!(
-                    "Failed to construct latest ledger view from storage: {}",
-                    error
-                ))
-            })?;
-
         Ok(SyncState::new(
             latest_ledger_info,
-            synced_trees,
+            storage_info.into_latest_executed_trees(),
             current_epoch_state,
         ))
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -38,7 +38,7 @@ use mockall::mock;
 use scratchpad::SparseMerkleTree;
 use std::sync::Arc;
 use storage_interface::{
-    DbReader, DbReaderWriter, DbWriter, Order, StartupInfo, StateSnapshotReceiver, TreeState,
+    DbReader, DbReaderWriter, DbWriter, ExecutedTrees, Order, StartupInfo, StateSnapshotReceiver,
 };
 use tokio::task::JoinHandle;
 
@@ -249,7 +249,7 @@ mock! {
             version: Version,
         ) -> Result<(Option<StateValue>, SparseMerkleProof)>;
 
-        fn get_latest_tree_state(&self) -> Result<TreeState>;
+        fn get_latest_executed_trees(&self) -> Result<ExecutedTrees>;
 
         fn get_epoch_ending_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -37,7 +37,7 @@ use futures::StreamExt;
 use mempool_notifications::{CommittedTransaction, MempoolNotificationListener};
 use move_deps::move_core_types::language_storage::TypeTag;
 use std::collections::BTreeMap;
-use storage_interface::{StartupInfo, TreeState};
+use storage_interface::{ExecutedTrees, StartupInfo};
 use storage_service_types::CompleteDataRange;
 
 /// Creates a new data stream listener and notification sender pair
@@ -124,7 +124,7 @@ pub fn create_startup_info() -> StartupInfo {
     StartupInfo::new(
         create_epoch_ending_ledger_info(),
         Some(EpochState::empty()),
-        TreeState::new_at_state_checkpoint(0, vec![], HashValue::random()),
+        ExecutedTrees::new_empty(),
         None,
     )
 }

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -50,7 +50,7 @@ use network::{
     },
 };
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
-use storage_interface::{DbReader, Order, StartupInfo, TreeState};
+use storage_interface::{DbReader, ExecutedTrees, Order, StartupInfo};
 use storage_service_types::{
     CompleteDataRange, DataSummary, Epoch, EpochEndingLedgerInfoRequest,
     NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest, ProtocolMetadata,
@@ -1513,7 +1513,7 @@ mock! {
             version: Version,
         ) -> Result<(Option<StateValue>, SparseMerkleProof)>;
 
-        fn get_latest_tree_state(&self) -> Result<TreeState>;
+        fn get_latest_executed_trees(&self) -> Result<ExecutedTrees>;
 
         fn get_epoch_ending_ledger_info(&self, known_version: u64) -> Result<LedgerInfoWithSignatures>;
 

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -31,10 +31,11 @@ aptos-jellyfish-merkle = { path = "../jellyfish-merkle" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers", optional = true }
+aptos-state-view = { path = "../state-view" }
 aptos-temppath = { path = "../../crates/aptos-temppath", optional = true }
 aptos-types = { path = "../../types" }
 aptos-workspace-hack = { path = "../../crates/aptos-workspace-hack" }
-executor-types = { path = "../../execution/executor-types", optional = true }
+executor-types = { path = "../../execution/executor-types" }
 move-deps = { path = "../../aptos-move/move-deps", features = ["address32"] }
 num-variants = { path = "../../crates/num-variants" }
 schemadb = { path = "../schemadb" }

--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -122,7 +122,7 @@ fn test_get_latest_executed_trees() {
 
     // entirely emtpy db
     let empty = db.get_latest_executed_trees().unwrap();
-    assert_eq!(empty, ExecutedTrees::new_empty());
+    assert!(empty.is_same_view(&ExecutedTrees::new_empty()));
 
     // bootstrapped db (any transaction info is in)
     let key = StateKey::Raw(String::from("test_key").into_bytes());
@@ -140,13 +140,12 @@ fn test_get_latest_executed_trees() {
     put_transaction_info(&db, 0, &txn_info);
 
     let bootstrapped = db.get_latest_executed_trees().unwrap();
-    assert_eq!(
-        bootstrapped,
-        ExecutedTrees::new_at_state_checkpoint(
+    assert!(
+        bootstrapped.is_same_view(&ExecutedTrees::new_at_state_checkpoint(
             txn_info.state_checkpoint_hash().unwrap(),
             vec![txn_info.hash()],
             1,
-        ),
+        ))
     );
 }
 

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -11,13 +11,13 @@ use aptos_jellyfish_merkle::restore::StateSnapshotRestore;
 use aptos_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
-    proof::definition::LeafCount,
+    proof::{accumulator::InMemoryAccumulator, definition::LeafCount},
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{Transaction, TransactionInfo, Version},
 };
 use schemadb::DB;
 use std::sync::Arc;
-use storage_interface::{DbReader, TreeState};
+use storage_interface::{in_memory_state::InMemoryState, DbReader, ExecutedTrees};
 
 /// Provides functionalities for AptosDB data restore.
 #[derive(Clone)]
@@ -101,19 +101,26 @@ impl RestoreHandler {
         )
     }
 
-    pub fn get_tree_state(&self, version: Option<Version>) -> Result<TreeState> {
+    pub fn get_executed_trees(&self, version: Option<Version>) -> Result<ExecutedTrees> {
         let num_transactions: LeafCount = version.map_or(0, |v| v + 1);
         let frozen_subtrees = self
             .ledger_store
             .get_frozen_subtree_hashes(num_transactions)?;
-        let state_root_hash = match version {
-            None => *SPARSE_MERKLE_PLACEHOLDER_HASH,
-            Some(ver) => self.state_store.get_root_hash(ver)?,
+        // For now, we know there must be a state snapshot at `committed_version`. We need to recover checkpoint after make commit async.
+        let (committed_version, committed_root_hash) = if let Some((version, hash)) = self
+            .state_store
+            .get_state_snapshot_before(num_transactions)?
+        {
+            (Some(version), hash)
+        } else {
+            (None, *SPARSE_MERKLE_PLACEHOLDER_HASH)
         };
-        Ok(TreeState::new_at_state_checkpoint(
-            num_transactions,
-            frozen_subtrees,
-            state_root_hash,
+
+        let transaction_accumulator =
+            Arc::new(InMemoryAccumulator::new(frozen_subtrees, num_transactions)?);
+        Ok(ExecutedTrees::new(
+            InMemoryState::new_at_checkpoint(committed_root_hash, committed_version),
+            transaction_accumulator,
         ))
     }
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -66,8 +66,8 @@ use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     nibble::nibble_path::NibblePath,
     proof::{
-        definition::LeafCount, AccumulatorConsistencyProof, SparseMerkleProof,
-        TransactionInfoListWithProof,
+        accumulator::InMemoryAccumulator, definition::LeafCount, AccumulatorConsistencyProof,
+        SparseMerkleProof, TransactionInfoListWithProof,
     },
     state_proof::StateProof,
     state_store::{
@@ -96,8 +96,8 @@ use std::{
     time::{Duration, Instant},
 };
 use storage_interface::{
-    jmt_update_refs, jmt_updates, DbReader, DbWriter, Order, StartupInfo, StateSnapshotReceiver,
-    TreeState,
+    in_memory_state::InMemoryState, jmt_update_refs, jmt_updates, DbReader, DbWriter,
+    ExecutedTrees, Order, StartupInfo, StateSnapshotReceiver,
 };
 
 pub const LEDGER_DB_NAME: &str = "ledger_db";
@@ -265,6 +265,7 @@ impl AptosDB {
         ledger_rocksdb: DB,
         state_merkle_rocksdb: DB,
         storage_pruner_config: StoragePrunerConfig,
+        hack_for_tests: bool,
     ) -> Self {
         let arc_ledger_rocksdb = Arc::new(ledger_rocksdb);
         let arc_state_merkle_rocksdb = Arc::new(state_merkle_rocksdb);
@@ -285,10 +286,11 @@ impl AptosDB {
             state_merkle_db: Arc::clone(&arc_state_merkle_rocksdb),
             event_store: Arc::new(EventStore::new(Arc::clone(&arc_ledger_rocksdb))),
             ledger_store: Arc::new(LedgerStore::new(Arc::clone(&arc_ledger_rocksdb))),
-            state_store: Arc::new(StateStore::new(
+            state_store: StateStore::new(
                 Arc::clone(&arc_ledger_rocksdb),
                 Arc::clone(&arc_state_merkle_rocksdb),
-            )),
+                hack_for_tests,
+            ),
             system_store: Arc::new(SystemStore::new(Arc::clone(&arc_ledger_rocksdb))),
             transaction_store: Arc::new(TransactionStore::new(Arc::clone(&arc_ledger_rocksdb))),
             pruner_config,
@@ -348,7 +350,7 @@ impl AptosDB {
             )
         };
 
-        let ret = Self::new_with_dbs(ledger_db, state_merkle_db, storage_pruner_config);
+        let ret = Self::new_with_dbs(ledger_db, state_merkle_db, storage_pruner_config, readonly);
         info!(
             ledger_db_path = ledger_db_path,
             state_merkle_db_path = state_merkle_db_path,
@@ -389,19 +391,31 @@ impl AptosDB {
                 state_merkle_db_column_families(),
             )?,
             NO_OP_STORAGE_PRUNER_CONFIG,
+            true,
         ))
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    fn new_without_pruner<P: AsRef<Path> + Clone>(db_root_path: P, readonly: bool) -> Self {
+        Self::open(
+            db_root_path,
+            readonly,
+            NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
+            RocksdbConfigs::default(),
+        )
+        .expect("Unable to open AptosDB")
     }
 
     /// This opens db in non-readonly mode, without the pruner.
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn new_for_test<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
-        Self::open(
-            db_root_path,
-            false,                       /* readonly */
-            NO_OP_STORAGE_PRUNER_CONFIG, /* pruner */
-            RocksdbConfigs::default(),
-        )
-        .expect("Unable to open AptosDB")
+        Self::new_without_pruner(db_root_path, false)
+    }
+
+    /// This opens db in non-readonly mode, without the pruner.
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn new_readonly_for_test<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
+        Self::new_without_pruner(db_root_path, true)
     }
 
     /// This force the db to update rocksdb properties immediately.
@@ -503,30 +517,6 @@ impl AptosDB {
             events,
             proof,
         })
-    }
-
-    fn get_tree_state(&self, version: Option<Version>) -> Result<TreeState> {
-        let num_transactions = version.map_or(0, |v| v + 1);
-
-        let frozen_subtrees = self
-            .ledger_store
-            .get_frozen_subtree_hashes(num_transactions)?;
-
-        let (checkpoint_version, checkpoint_root_hash) = if let Some((version, hash)) = self
-            .state_store
-            .get_state_snapshot_before(num_transactions)?
-        {
-            (Some(version), hash)
-        } else {
-            (None, *SPARSE_MERKLE_PLACEHOLDER_HASH)
-        };
-
-        Ok(TreeState::new(
-            num_transactions,
-            frozen_subtrees,
-            checkpoint_root_hash,
-            checkpoint_version,
-        ))
     }
 
     // ================================== Backup APIs ===================================
@@ -1104,18 +1094,48 @@ impl DbReader for AptosDB {
                 .get_startup_info()?
                 .map(
                     |(latest_ledger_info, latest_epoch_state_if_not_in_li, synced_version_opt)| {
-                        let committed_tree_state =
-                            self.get_tree_state(Some(latest_ledger_info.ledger_info().version()))?;
-                        let synced_tree_state = synced_version_opt
-                            .map(|v| self.get_tree_state(Some(v)))
-                            .transpose()?;
+                        let executed_trees = self.get_latest_executed_trees()?;
+                        let committed_version = latest_ledger_info.ledger_info().version();
+                        Ok(if synced_version_opt.is_none() {
+                            assert_eq!(
+                            Some(committed_version), executed_trees.version(),
+                            "ledger_info_version {:?} doesn't match with committed_executed_trees version {:?}",
+                            Some(committed_version),
+                            executed_trees.version()
+                            );
+                            StartupInfo::new(
+                                latest_ledger_info,
+                                latest_epoch_state_if_not_in_li,
+                                executed_trees,
+                                None
+                            )
+                        } else {
+                            let num_txns = committed_version + 1;
+                            let frozen_subtrees = self
+                                .ledger_store
+                                .get_frozen_subtree_hashes(num_txns)?;
+                            let transaction_accumulator = Arc::new(InMemoryAccumulator::new(
+                                frozen_subtrees,
+                                num_txns,
+                            )?);
+                            // For now, we know there must be a state snapshot at `committed_version`. We need to recover checkpoint after make commit async.
+                            let (committed_version, committed_root_hash) = if let Some((version, hash)) = self
+                                .state_store
+                                .get_state_snapshot_before(num_txns)?
+                            {
+                                (Some(version), hash)
+                            } else {
+                                (None, *SPARSE_MERKLE_PLACEHOLDER_HASH)
+                            };
 
-                        Ok(StartupInfo::new(
-                            latest_ledger_info,
-                            latest_epoch_state_if_not_in_li,
-                            committed_tree_state,
-                            synced_tree_state,
-                        ))
+                            let committed_trees = ExecutedTrees::new(InMemoryState::new_at_checkpoint(committed_root_hash, committed_version), transaction_accumulator);
+                            StartupInfo::new(
+                                latest_ledger_info,
+                                latest_epoch_state_if_not_in_li,
+                                committed_trees,
+                                Some(executed_trees)
+                            )
+                        })
                     },
                 )
                 .transpose()
@@ -1140,17 +1160,16 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_latest_tree_state(&self) -> Result<TreeState> {
-        gauged_api("get_latest_tree_state", || {
-            let latest_version = self
-                .ledger_store
-                .get_latest_transaction_info_option()?
-                .map(|(version, _)| version);
-            let tree_state = self.get_tree_state(latest_version)?;
+    fn get_latest_executed_trees(&self) -> Result<ExecutedTrees> {
+        gauged_api("get_latest_executed_trees", || {
+            let in_memory_state = self.state_store.in_memory_state().lock().clone();
+            let num_txns = in_memory_state.current_version.map_or(0, |v| v + 1);
 
-            debug!(tree_state = tree_state, "Got latest TreeState.");
-
-            Ok(tree_state)
+            let frozen_subtrees = self.ledger_store.get_frozen_subtree_hashes(num_txns)?;
+            let transaction_accumulator =
+                Arc::new(InMemoryAccumulator::new(frozen_subtrees, num_txns)?);
+            let executed_trees = ExecutedTrees::new(in_memory_state, transaction_accumulator);
+            Ok(executed_trees)
         })
     }
 
@@ -1275,7 +1294,7 @@ impl DbWriter for AptosDB {
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         version: Version,
         base_version: Option<Version>,
-        _state_tree_at_snapshot: SparseMerkleTree<StateValue>,
+        state_tree_at_snapshot: SparseMerkleTree<StateValue>,
     ) -> Result<()> {
         gauged_api("save_state_snapshot", || {
             let root_hash = self.state_store.merklize_value_set(
@@ -1290,6 +1309,14 @@ impl DbWriter for AptosDB {
                 root_hash = root_hash,
                 "State snapshot committed."
             );
+            {
+                let mut in_memory_state = self.state_store.in_memory_state().lock();
+                in_memory_state.checkpoint = state_tree_at_snapshot.clone();
+                in_memory_state.checkpoint_version = Some(version);
+                in_memory_state.current = state_tree_at_snapshot;
+                in_memory_state.current_version = Some(version);
+                in_memory_state.updated_since_checkpoint.clear();
+            }
             Ok(())
         })
     }
@@ -1325,11 +1352,13 @@ impl DbWriter for AptosDB {
                 "txns_to_commit is empty while ledger_info_with_sigs is None.",
             );
 
+            let last_version = first_version + num_txns - 1;
+
             if let Some(x) = ledger_info_with_sigs {
                 let claimed_last_version = x.ledger_info().version();
                 ensure!(
-                    claimed_last_version + 1 == first_version + num_txns,
-                    "Transaction batch not applicable: first_version {}, num_txns {}, last_version {}",
+                    claimed_last_version  == last_version,
+                    "Transaction batch not applicable: first_version {}, num_txns {}, last_version_in_ledger_info {}",
                     first_version,
                     num_txns,
                     claimed_last_version,
@@ -1389,6 +1418,12 @@ impl DbWriter for AptosDB {
                     .with_label_values(&["save_transactions_commit"])
                     .start_timer();
                 self.commit(sealed_cs)?;
+            }
+            // update the InMemoryState in StateStore.
+            {
+                let mut in_memory_state = self.state_store.in_memory_state().lock();
+                in_memory_state.current = state_tree;
+                in_memory_state.current_version = Some(last_version);
             }
 
             // Only increment counter if commit succeeds and there are at least one transaction written
@@ -1491,7 +1526,9 @@ impl DbWriter for AptosDB {
                 self.transaction_store.clone(),
                 version,
                 outputs,
-            )
+            )?;
+            self.state_store.maybe_reset(version);
+            Ok(())
         })
     }
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1098,10 +1098,10 @@ impl DbReader for AptosDB {
                         let committed_version = latest_ledger_info.ledger_info().version();
                         Ok(if synced_version_opt.is_none() {
                             assert_eq!(
-                            Some(committed_version), executed_trees.version(),
-                            "ledger_info_version {:?} doesn't match with committed_executed_trees version {:?}",
-                            Some(committed_version),
-                            executed_trees.version()
+                                Some(committed_version), executed_trees.version(),
+                                "ledger_info_version {:?} doesn't match with committed_executed_trees version {:?}",
+                                Some(committed_version),
+                                executed_trees.version()
                             );
                             StartupInfo::new(
                                 latest_ledger_info,

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -64,6 +64,7 @@ fn test_state_store_pruner() {
     let state_store = &StateStore::new(
         Arc::clone(&aptos_db.ledger_db),
         Arc::clone(&aptos_db.state_merkle_db),
+        false, /* hack_for_tests */
     );
     let pruner = Pruner::new(
         Arc::clone(&aptos_db.ledger_db),
@@ -150,6 +151,7 @@ fn test_state_store_pruner_disabled() {
     let state_store = &StateStore::new(
         Arc::clone(&aptos_db.ledger_db),
         Arc::clone(&aptos_db.state_merkle_db),
+        false, /* hack_for_tests */
     );
     let pruner = Pruner::new(
         Arc::clone(&aptos_db.ledger_db),
@@ -221,7 +223,11 @@ fn test_worker_quit_eagerly() {
     let tmp_dir = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp_dir);
     let db = aptos_db.ledger_db;
-    let state_store = &StateStore::new(Arc::clone(&db), Arc::clone(&aptos_db.state_merkle_db));
+    let state_store = &StateStore::new(
+        Arc::clone(&db),
+        Arc::clone(&aptos_db.state_merkle_db),
+        false, /* hack_for_tests */
+    );
 
     let _root0 = put_value_set(
         &db,

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -3,27 +3,23 @@
 
 //! This file defines state store APIs that are related account state Merkle tree.
 
-#[cfg(test)]
-mod state_store_test;
+use std::{collections::HashMap, sync::Arc};
 
-use crate::{
-    change_set::ChangeSet,
-    schema::{
-        jellyfish_merkle_node::JellyfishMerkleNodeSchema, stale_node_index::StaleNodeIndexSchema,
-        state_value::StateValueSchema,
-    },
-    state_merkle_db::{add_node_batch, StateMerkleDb},
-    AptosDbError, OTHER_TIMERS_SECONDS,
-};
 use anyhow::{anyhow, ensure, format_err, Result};
-use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_jellyfish_merkle::{
-    iterator::JellyfishMerkleIterator, node_type::NodeKey, restore::StateSnapshotRestore,
-    StateValueWriter,
+
+use aptos_crypto::{
+    hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
+    HashValue,
 };
+use aptos_infallible::Mutex;
+use aptos_jellyfish_merkle::{
+    iterator::JellyfishMerkleIterator, restore::StateSnapshotRestore, StateValueWriter,
+};
+use aptos_logger::debug;
+use aptos_state_view::StateViewId;
 use aptos_types::{
     nibble::nibble_path::NibblePath,
-    proof::{SparseMerkleProof, SparseMerkleRangeProof},
+    proof::{definition::LeafCount, SparseMerkleProof, SparseMerkleRangeProof},
     state_store::{
         state_key::StateKey,
         state_key_prefix::StateKeyPrefix,
@@ -31,18 +27,33 @@ use aptos_types::{
     },
     transaction::Version,
 };
+use executor_types::in_memory_state_calculator::InMemoryStateCalculator;
 use schemadb::{ReadOptions, SchemaBatch, DB};
-use std::{collections::HashMap, sync::Arc};
-use storage_interface::{DbReader, StateSnapshotReceiver};
+use storage_interface::{
+    cached_state_view::CachedStateView, in_memory_state::InMemoryState,
+    sync_proof_fetcher::SyncProofFetcher, DbReader, StateSnapshotReceiver,
+};
+
+use crate::{
+    change_set::ChangeSet,
+    schema::{stale_node_index::StaleNodeIndexSchema, state_value::StateValueSchema},
+    state_merkle_db::{add_node_batch, StateMerkleDb},
+    AptosDbError, LedgerStore, TransactionStore, OTHER_TIMERS_SECONDS,
+};
+
+#[cfg(test)]
+mod state_store_test;
 
 type StateValueBatch = aptos_jellyfish_merkle::StateValueBatch<StateKey, StateValue>;
 
 pub const MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX: usize = 10_000;
+const MAX_WRITE_SETS_AFTER_CHECKPOINT: LeafCount = 200_000;
 
 #[derive(Debug)]
 pub(crate) struct StateStore {
     ledger_db: Arc<DB>,
     pub state_merkle_db: Arc<StateMerkleDb>,
+    in_memory_state: Mutex<InMemoryState>,
 }
 
 // "using an Arc<dyn DbReader> as an Arc<dyn StateReader>" is not allowed in stable Rust. Actually we
@@ -55,7 +66,8 @@ impl DbReader for StateStore {
         &self,
         next_version: Version,
     ) -> Result<Option<(Version, HashValue)>> {
-        self.get_state_snapshot_version_before(next_version)?
+        self.state_merkle_db
+            .get_state_snapshot_version_before(next_version)?
             .map(|ver| Ok((ver, self.get_root_hash(ver)?)))
             .transpose()
     }
@@ -107,28 +119,110 @@ impl DbReader for StateStore {
 }
 
 impl StateStore {
-    pub fn new(ledger_db: Arc<DB>, state_merkle_db: Arc<DB>) -> Self {
-        Self {
+    pub fn new(ledger_db: Arc<DB>, state_merkle_db: Arc<DB>, hack_for_tests: bool) -> Arc<Self> {
+        let state_merkle_db = Arc::new(StateMerkleDb::new(state_merkle_db));
+        let store = Arc::new(Self {
             ledger_db,
-            state_merkle_db: Arc::new(StateMerkleDb::new(state_merkle_db)),
+            state_merkle_db,
+            in_memory_state: Mutex::new(InMemoryState::new_empty()),
+        });
+        store
+            .initialize(hack_for_tests)
+            .expect("StateStore initialization failed.");
+        store
+    }
+
+    pub fn maybe_reset(self: &Arc<Self>, version: Version) {
+        if self
+            .in_memory_state
+            .lock()
+            .checkpoint_version
+            .map_or(0, |v| v + 1)
+            < version
+        {
+            self.initialize(false)
+                .expect("StateStore initialization failed.")
         }
     }
 
-    fn get_state_snapshot_version_before(&self, next_version: Version) -> Result<Option<Version>> {
-        if next_version > 0 {
-            let max_possible_version = next_version - 1;
-            let mut iter = self
-                .state_merkle_db
-                .rev_iter::<JellyfishMerkleNodeSchema>(Default::default())?;
-            iter.seek_for_prev(&NodeKey::new_empty_path(max_possible_version))?;
-            if let Some((key, _node)) = iter.next().transpose()? {
-                // TODO: If we break up a single update batch to multiple commits, we would need to
-                // deal with a partial version, which hasn't got the root committed.
-                return Ok(Some(key.version()));
-            }
+    fn initialize(self: &Arc<Self>, hack_for_tests: bool) -> Result<()> {
+        let latest_snapshot_version = self
+            .state_merkle_db
+            .get_state_snapshot_version_before(Version::MAX)
+            .expect("Failed to query latest node on initialization.");
+        let latest_snapshot_root_hash = if let Some(version) = latest_snapshot_version {
+            self.state_merkle_db
+                .get_root_hash(version)
+                .expect("Failed to query latest checkpoint root hash on initialization.")
+        } else {
+            *SPARSE_MERKLE_PLACEHOLDER_HASH
+        };
+
+        // Make sure the committed transactions is ahead of the latest snapshot.
+        let snapshot_next_version = latest_snapshot_version.map_or(0, |v| v + 1);
+        // Initialize the state store before replaying write sets.
+        *self.in_memory_state.lock() =
+            InMemoryState::new_at_checkpoint(latest_snapshot_root_hash, latest_snapshot_version);
+
+        // If we , we don't ensure the consistency.
+        if hack_for_tests {
+            return Ok(());
         }
-        // No version before genesis.
-        Ok(None)
+
+        let num_transactions = LedgerStore::new(Arc::clone(&self.ledger_db))
+            .get_latest_transaction_info_option()?
+            .map(|(version, _)| version + 1)
+            .unwrap_or(0);
+        ensure!(
+            snapshot_next_version <= num_transactions,
+            "snapshot is after latest version. snapshot_next_version: {}, num_transactions: {}",
+            snapshot_next_version,
+            num_transactions,
+        );
+
+        // Replaying the committed write sets after the latest snapshot.
+        if snapshot_next_version != num_transactions {
+            ensure!(
+                num_transactions - snapshot_next_version <= MAX_WRITE_SETS_AFTER_CHECKPOINT,
+                "Too many versions after state snapshot. snapshot_next_version: {}, num_transactions: {}",
+                snapshot_next_version,
+                num_transactions,
+            );
+            let mut in_memory_state = self.in_memory_state.lock();
+            let latest_snapshot_state_view = CachedStateView::new(
+                StateViewId::Miscellaneous,
+                self.clone(),
+                num_transactions,
+                in_memory_state.current.clone(),
+                Arc::new(SyncProofFetcher::new(self.clone())),
+            )?;
+            let write_sets = TransactionStore::new(Arc::clone(&self.ledger_db))
+                .get_write_sets(snapshot_next_version, num_transactions)?;
+            latest_snapshot_state_view.prime_cache_by_write_set(&write_sets)?;
+            let calculator = InMemoryStateCalculator::new(
+                &in_memory_state,
+                latest_snapshot_state_view.into_state_cache(),
+            );
+            *in_memory_state = calculator.calculate_for_write_sets_after_checkpoint(&write_sets)?;
+        }
+
+        let (latest_version, root_hash) = {
+            let in_memory_state = self.in_memory_state.lock();
+            (
+                in_memory_state.current_version,
+                in_memory_state.current.root_hash(),
+            )
+        };
+        debug!(
+            latest_version = latest_version,
+            root_hash = root_hash,
+            "StateStore initialization finished.",
+        );
+        Ok(())
+    }
+
+    pub fn in_memory_state(&self) -> &Mutex<InMemoryState> {
+        &self.in_memory_state
     }
 
     /// Returns the key, value pairs for a particular state key prefix at at desired version. This

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -28,9 +28,9 @@ fn end_to_end() {
     backup_dir.create_as_dir().unwrap();
     let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
 
-    let latest_tree_state = src_db.get_latest_tree_state().unwrap();
-    let version = latest_tree_state.num_transactions - 1;
-    let state_root_hash = latest_tree_state.state_checkpoint_hash;
+    let latest_executed_trees = src_db.get_latest_executed_trees().unwrap();
+    let version = latest_executed_trees.version().unwrap();
+    let state_root_hash = latest_executed_trees.state().checkpoint_root_hash();
 
     let (rt, port) = start_local_backup_service(src_db);
     let client = Arc::new(BackupServiceClient::new(format!(
@@ -75,7 +75,7 @@ fn end_to_end() {
     )
     .unwrap();
 
-    let tgt_db = AptosDB::new_for_test(&tgt_db_dir);
+    let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
     assert_eq!(
         tgt_db
             .get_latest_state_checkpoint()

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -160,7 +160,7 @@ fn test_end_to_end_impl(d: TestData) {
     .unwrap();
 
     // Check
-    let tgt_db = AptosDB::new_for_test(&tgt_db_dir);
+    let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
     assert_eq!(
         d.db.get_transactions(
             d.txn_start_ver,

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -30,7 +30,7 @@ use aptos_types::{
 use aptos_vm::AptosVM;
 use aptosdb::backup::restore_handler::RestoreHandler;
 use executor::chunk_executor::ChunkExecutor;
-use executor_types::{in_memory_state_calculator::IntoLedgerView, TransactionReplayer};
+use executor_types::TransactionReplayer;
 use futures::{
     future,
     future::TryFutureExt,
@@ -407,9 +407,7 @@ impl TransactionRestoreBatchController {
         let replay_start = Instant::now();
         let first_version = self.replay_from_version.unwrap();
         let db = DbReaderWriter::from_arc(Arc::clone(&restore_handler.aptosdb));
-        let persisted_view = restore_handler
-            .get_tree_state(first_version.checked_sub(1))?
-            .into_ledger_view(&db.reader)?;
+        let persisted_view = restore_handler.get_executed_trees(first_version.checked_sub(1))?;
         let chunk_replayer = Arc::new(ChunkExecutor::<AptosVM>::new_with_view(db, persisted_view));
 
         let db_commit_stream = txns_to_execute_stream

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -96,7 +96,7 @@ fn end_to_end() {
     // We don't write down any ledger infos when recovering transactions. State-sync needs to take
     // care of it before running consensus. The latest transactions are deemed "synced" instead of
     // "committed" most likely.
-    let tgt_db = AptosDB::new_for_test(&tgt_db_dir);
+    let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
     assert_eq!(
         tgt_db
             .get_latest_transaction_info_option()

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -287,6 +287,17 @@ pub struct SparseMerkleTree<V> {
     inner: Arc<Inner<V>>,
 }
 
+impl<V> Eq for SparseMerkleTree<V> where V: Clone + CryptoHash + Send + Sync {}
+
+impl<V> PartialEq for SparseMerkleTree<V>
+where
+    V: Clone + CryptoHash + Send + Sync,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.root_hash() == other.root_hash()
+    }
+}
+
 impl<V> SparseMerkleTree<V>
 where
     V: Clone + CryptoHash + Send + Sync,

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -287,17 +287,6 @@ pub struct SparseMerkleTree<V> {
     inner: Arc<Inner<V>>,
 }
 
-impl<V> Eq for SparseMerkleTree<V> where V: Clone + CryptoHash + Send + Sync {}
-
-impl<V> PartialEq for SparseMerkleTree<V>
-where
-    V: Clone + CryptoHash + Send + Sync,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.root_hash() == other.root_hash()
-    }
-}
-
 impl<V> SparseMerkleTree<V>
 where
     V: Clone + CryptoHash + Send + Sync,
@@ -321,6 +310,10 @@ where
         Self {
             inner: Inner::new(SubTree::new_empty()),
         }
+    }
+
+    pub fn has_same_root_hash(&self, other: &Self) -> bool {
+        self.root_hash() == other.root_hash()
     }
 
     fn get_oldest_ancestor(&self) -> Self {

--- a/storage/storage-interface/src/executed_trees.rs
+++ b/storage/storage-interface/src/executed_trees.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 
 /// A wrapper of the in-memory state sparse merkle tree and the transaction accumulator that
 /// represent a specific state collectively. Usually it is a state after executing a block.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct ExecutedTrees {
     /// The in-memory representation of state after execution.
     state: InMemoryState,
@@ -91,7 +91,8 @@ impl ExecutedTrees {
     }
 
     pub fn is_same_view(&self, rhs: &Self) -> bool {
-        self.transaction_accumulator.root_hash() == rhs.transaction_accumulator.root_hash()
+        self.state().has_same_current_state(rhs.state())
+            && self.transaction_accumulator.root_hash() == rhs.transaction_accumulator.root_hash()
     }
 
     pub fn verified_state_view(

--- a/storage/storage-interface/src/in_memory_state.rs
+++ b/storage/storage-interface/src/in_memory_state.rs
@@ -25,6 +25,14 @@ pub struct InMemoryState {
     pub updated_since_checkpoint: HashSet<StateKey>,
 }
 
+impl PartialEq for InMemoryState {
+    fn eq(&self, other: &InMemoryState) -> bool {
+        self.current_version == other.current_version && self.current == other.current
+    }
+}
+
+impl Eq for InMemoryState {}
+
 impl InMemoryState {
     pub fn new(
         checkpoint: SparseMerkleTree<StateValue>,
@@ -33,6 +41,7 @@ impl InMemoryState {
         current_version: Option<Version>,
         updated_since_checkpoint: HashSet<StateKey>,
     ) -> Self {
+        assert!(checkpoint_version.map_or(0, |v| v + 1) <= current_version.map_or(0, |v| v + 1));
         Self {
             checkpoint,
             checkpoint_version,

--- a/storage/storage-interface/src/in_memory_state.rs
+++ b/storage/storage-interface/src/in_memory_state.rs
@@ -25,14 +25,6 @@ pub struct InMemoryState {
     pub updated_since_checkpoint: HashSet<StateKey>,
 }
 
-impl PartialEq for InMemoryState {
-    fn eq(&self, other: &InMemoryState) -> bool {
-        self.current_version == other.current_version && self.current == other.current
-    }
-}
-
-impl Eq for InMemoryState {}
-
 impl InMemoryState {
     pub fn new(
         checkpoint: SparseMerkleTree<StateValue>,
@@ -65,6 +57,11 @@ impl InMemoryState {
             checkpoint_version,
             HashSet::new(),
         )
+    }
+
+    pub fn has_same_current_state(&self, other: &InMemoryState) -> bool {
+        self.current_version == other.current_version
+            && self.current.has_same_root_hash(&other.current)
     }
 
     pub fn checkpoint_root_hash(&self) -> HashValue {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -48,7 +48,7 @@ pub mod sync_proof_fetcher;
 pub use executed_trees::ExecutedTrees;
 use scratchpad::SparseMerkleTree;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct StartupInfo {
     /// The latest ledger info.
     pub latest_ledger_info: LedgerInfoWithSignatures,

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -11,7 +11,6 @@ use aptos_types::{
     transaction::{SignedTransaction, VMValidatorResult},
 };
 use aptos_vm::AptosVM;
-use executor_types::in_memory_state_calculator::IntoLedgerView;
 use fail::fail_point;
 use std::sync::Arc;
 use storage_interface::{
@@ -37,9 +36,7 @@ pub trait TransactionValidation: Send + Sync + Clone {
 
 fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> CachedStateView {
     let ledger_view = db_reader
-        .get_latest_tree_state()
-        .expect("Should not fail.")
-        .into_ledger_view(db_reader)
+        .get_latest_executed_trees()
         .expect("Should not fail.");
 
     ledger_view


### PR DESCRIPTION
### Description

As a half-way milestone of lazy state commit, this PR implements

1. A skeleton of `StateStore`-maintained `InMemoryState` which cached all the uncommitted in-memory state data, which will be used later by async commit.
2. Replace `TreeState` with `ExecutedTrees`. Basically `TreeState` in an simplified serializable version of `ExecutedTrees` and after our change, we can directly replace it with `ExecutedTrees`.


### Test Plan
ut

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1787)
<!-- Reviewable:end -->
