### PR TITLE
[consensus] fix flaky twins test

### DIFF
--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -302,6 +302,8 @@ impl NetworkPlayground {
         match msg {
             ConsensusMsg::ProposalMsg(proposal_msg) => Some(proposal_msg.proposal().round()),
             ConsensusMsg::VoteMsg(vote_msg) => Some(vote_msg.vote().vote_data().proposed().round()),
+            ConsensusMsg::SyncInfo(sync_info) => Some(sync_info.highest_certified_round()),
+            ConsensusMsg::CommitVoteMsg(commit_vote) => Some(commit_vote.commit_info().round()),
             _ => None,
         }
     }


### PR DESCRIPTION
The network is partitioned by round, but it missed a few types of message so it results in weird failures some times (safety violations in the twins_proposer test).

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1788)
<!-- Reviewable:end -->
