### PR TITLE
[CP] Sync forum SSO information

### DIFF
--- a/ecosystem/platform/server/app/controllers/discourse_controller.rb
+++ b/ecosystem/platform/server/app/controllers/discourse_controller.rb
@@ -11,8 +11,6 @@ class DiscourseController < ApplicationController
   before_action :ensure_confirmed!
 
   def sso
-    secret = ENV.fetch('DISCOURSE_SECRET', nil)
-
     query_str = cookies['FORUM-SSO'] || request.query_string
 
     # This allows hitting this sso for the first time from our side, we redirect to forum, which redirects back to us
@@ -24,13 +22,13 @@ class DiscourseController < ApplicationController
       return
     end
 
-    sso = DiscourseApi::SingleSignOn.parse(query_str, secret)
+    sso = DiscourseApi::SingleSignOn.parse(query_str, DiscourseHelper.sso_secret)
     cookies.delete 'FORUM-SSO'
 
     sso.email = current_user.email
-    sso.username = current_user.username.presence || current_user.authorizations.pluck(:username).first
+    sso.username = current_user.username
     sso.external_id = current_user.external_id # unique id for each user of your application
-    sso.sso_secret = secret
+    sso.sso_secret = DiscourseHelper.sso_secret
 
     sso.admin = current_user.is_root?
 

--- a/ecosystem/platform/server/app/controllers/onboarding_controller.rb
+++ b/ecosystem/platform/server/app/controllers/onboarding_controller.rb
@@ -14,13 +14,13 @@ class OnboardingController < ApplicationController
   layout 'it2'
 
   def email
-    redirect_to it2_path if current_user.email_confirmed? && !current_user.username.nil?
+    redirect_to it2_path if current_user.registration_completed?
   end
 
   def email_success; end
 
   def email_update
-    return redirect_to it2_path if current_user.email_confirmed? && !current_user.username.nil?
+    return redirect_to it2_path if current_user.registration_completed?
 
     recaptcha_v3_success = verify_recaptcha(action: 'onboarding/email', minimum_score: 0.5,
                                             secret_key: ENV.fetch('RECAPTCHA_V3_SECRET_KEY', nil), model: current_user)

--- a/ecosystem/platform/server/app/helpers/discourse_helper.rb
+++ b/ecosystem/platform/server/app/helpers/discourse_helper.rb
@@ -8,6 +8,10 @@ module DiscourseHelper
     ENV.fetch('DISCOURSE_URL_BASE', 'https://forum.aptoslabs.com')
   end
 
+  def self.sso_secret
+    ENV.fetch('DISCOURSE_SECRET', nil)
+  end
+
   # @return DiscourseApi::Client
   def self.system_client
     client = DiscourseApi::Client.new(DiscourseHelper.base_url)

--- a/ecosystem/platform/server/app/jobs/discourse_job.rb
+++ b/ecosystem/platform/server/app/jobs/discourse_job.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class DiscourseJob < ApplicationJob
+  memoize def discourse_user_id
+    return @user.discourse_id if @user.discourse_id.present?
+
+    id = @client.by_external_id(@user.external_id)['id']
+    Rails.logger.debug("Fetched forum user id #{id} for user #{@user.id} - #{@user.external_id}")
+    if id.present?
+      @user.discourse_id = id
+      @user.save
+    end
+    id
+  rescue DiscourseApi::NotFoundError
+    Rails.logger.debug("Forum account does not exist yet for user #{@user.id} - #{@user.external_id}")
+  end
+end

--- a/ecosystem/platform/server/app/jobs/discourse_sync_sso_job.rb
+++ b/ecosystem/platform/server/app/jobs/discourse_sync_sso_job.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class DiscourseSyncSsoJob < DiscourseJob
+  # Ex args: { user_id: 32 }
+  def perform(args)
+    @args = args
+    @user = User.find(args[:user_id])
+
+    unless @user.registration_completed?
+      return Rails.logger.debug("User not confirmed: #{@user.id} - #{@user.external_id}")
+    end
+
+    @client = DiscourseHelper.system_client
+
+    sync_sso
+  end
+
+  def sync_sso
+    return if discourse_user_id.nil?
+
+    res = @client.sync_sso(
+      sso_secret: DiscourseHelper.sso_secret,
+      username: @user.username,
+      email: @user.email,
+      external_id: @user.external_id,
+      admin: @user.is_root?
+    )
+    Rails.logger.debug("User SSO synced to discourse: #{@user.id} - #{@user.external_id}")
+    res
+  end
+end
+
+# DiscourseSyncSsoJob.perform_now({ user_id: 5 })

--- a/ecosystem/platform/server/app/models/authorization.rb
+++ b/ecosystem/platform/server/app/models/authorization.rb
@@ -8,8 +8,14 @@ class Authorization < ApplicationRecord
 
   validates_uniqueness_of :uid, scope: [:provider]
 
+  PROVIDER_NAME_MAP = { github: 'GitHub', google: 'Google', discord: 'Discord' }.with_indifferent_access.freeze
+
+  def display_provider
+    PROVIDER_NAME_MAP[provider] || provider
+  end
+
   def display_name
-    "#{provider} [#{full_name || username || email || uid}]"
+    "#{provider} [#{username || email || full_name || uid}]"
   end
 
   def display_shortname

--- a/ecosystem/platform/server/app/views/onboarding/email.html.erb
+++ b/ecosystem/platform/server/app/views/onboarding/email.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 
   <%= form_with(model: current_user, url: onboarding_email_path, method: :post, data: { turbo: !@show_recaptcha_v2, controller: 'recaptcha', action: 'recaptcha#validate' }, builder: AptosFormBuilder) do |f| %>
-    <% if !current_user.email %>
+    <% if !current_user.email_confirmed? %>
       <div class="mb-6">
         <%= f.label :email, class: 'font-mono uppercase block mb-2' %>
         <%= f.email_field :email, placeholder: 'ENTER YOUR EMAIL ADDRESS', autofocus: true, autocomplete: 'email', spellcheck: false, required: true, value: current_user.unconfirmed_email || @oauth_email, class: 'md:w-96' %>

--- a/ecosystem/platform/server/db/migrate/20220707015905_add_discourse_id_to_users.rb
+++ b/ecosystem/platform/server/db/migrate/20220707015905_add_discourse_id_to_users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class AddDiscourseIdToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :discourse_id, :integer, null: true, index: { unique: true }
+  end
+end

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_01_031008) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_07_015905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -241,6 +241,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_01_031008) do
     t.uuid "external_id", default: -> { "gen_random_uuid()" }, null: false
     t.boolean "kyc_exempt", default: false
     t.string "completed_persona_inquiry_id"
+    t.integer "discourse_id"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["current_sign_in_ip"], name: "index_users_on_current_sign_in_ip"
     t.index ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
### Description
Syncs various SSO status items whenever they are updated in complat, automagically to the forum.

The only thing missing is syncing avatars... but that first requires avatars on complat :-P

### Test Plan
Tested manually; locally -> discourse via 
```
irb(main):016:0> DiscourseSyncSsoJob.perform_now({ user_id: 5 })
Performing DiscourseSyncSsoJob (Job ID: eab878a3-aa5d-4801-8f41-d65055851335) from Delayed(default) enqueued at  with arguments: {:user_id=>5}
  User Load (8.3ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 LIMIT $2  [["id", 5], ["LIMIT", 1]]
User SSO synced to discourse: 5 - 68...4f
Performed DiscourseSyncSsoJob (Job ID: eab878a3-aa5d-4801-8f41-d65055851335) from Delayed(default) in 842.77ms
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1789)
<!-- Reviewable:end -->
