### PR TITLE
[aptos-cli] Return correct exit code if any of the unittests failed

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -72,8 +72,8 @@ pub enum CliError {
     IO(String, #[source] std::io::Error),
     #[error("Move compilation failed: {0}")]
     MoveCompilationError(String),
-    #[error("Move unit tests failed: {0}")]
-    MoveTestError(String),
+    #[error("Move unit tests failed")]
+    MoveTestError,
     #[error("Unable to parse '{0}': error: {1}")]
     UnableToParse(&'static str, String),
     #[error("Unable to read file '{0}', error: {1}")]
@@ -93,7 +93,7 @@ impl CliError {
             CliError::ConfigNotFoundError(_) => "ConfigNotFoundError",
             CliError::IO(_, _) => "IO",
             CliError::MoveCompilationError(_) => "MoveCompilationError",
-            CliError::MoveTestError(_) => "MoveTestError",
+            CliError::MoveTestError => "MoveTestError",
             CliError::UnableToParse(_, _) => "UnableToParse",
             CliError::UnableToReadFile(_, _) => "UnableToReadFile",
             CliError::UnexpectedError(_) => "UnexpectedError",

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -212,12 +212,12 @@ impl CliCommand<&'static str> for TestPackage {
             aptos_debug_natives::aptos_debug_natives(),
             false,
         )
-        .map_err(|err| CliError::MoveTestError(err.to_string()))?;
+        .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
 
         // TODO: commit back up to the move repo
         match result {
             UnitTestResult::Success => Ok("Success"),
-            UnitTestResult::Failure => Ok("Failure"),
+            UnitTestResult::Failure => Err(CliError::MoveTestError),
         }
     }
 }


### PR DESCRIPTION
### Description
Fixes https://github.com/aptos-labs/aptos-core/issues/1207. 

I've removed the string parameter from the `MoveTestError` as it doesn't have any in the context.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
I haven't found any tests for the `aptos-cli` itself, I don't want to increase a number of changes by adding new ones. But it should be pretty easy to test for the correct exit code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1794)
<!-- Reviewable:end -->
