### PR TITLE
[Storage] Prevent log spamming.

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1284,7 +1284,7 @@ impl DbWriter for AptosDB {
                 version,
                 base_version,
             )?;
-            debug!(
+            trace!(
                 version = version,
                 base_version = base_version,
                 root_hash = root_hash,


### PR DESCRIPTION
### Description

This log is producing a bunch of spam on our nodes. The PR reduces the log from `debug` to `trace`. If this is not good enough, perhaps we should consider sampling?

<img width="1625" alt="Screen Shot 2022-07-07 at 12 47 22 PM" src="https://user-images.githubusercontent.com/4578587/177827365-2c01c64d-5e12-4efa-a7b4-7728ff8bf300.png">


### Test Plan
None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1796)
<!-- Reviewable:end -->
