### PR TITLE
[Aptos Framework] Update performance scores before on_new_epoch() and skip out-of-bounds validator indices

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/Block.move
+++ b/aptos-move/framework/aptos-framework/sources/Block.move
@@ -101,12 +101,13 @@ module AptosFramework::Block {
             }
         );
 
+        // Performance scores have to be updated before the epoch transition as the transaction that triggers the
+        // transition is the last the last in the previous epoch.
+        Stake::update_performance_statistics(missed_votes);
+
         if (timestamp - Reconfiguration::last_reconfiguration_time() > block_metadata_ref.epoch_internal) {
             Reconfiguration::reconfigure();
         };
-
-        // Update performance score after potential reconfigure, which resets all performance scores.
-        Stake::update_performance_statistics(missed_votes);
     }
 
     /// Get the current block height


### PR DESCRIPTION
### Description
Before reconfiguration, the missed votes still refer to the previous epoch's validator set. After reconfiguration, on_new_epoch resets the validator set so if the performance scores still refer to the previous validator set but is called after on_new_epoch, we can run into out of bounds errors.

### Tests
Unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1803)
<!-- Reviewable:end -->
