### PR TITLE
[forge] uninstall if failure in swarm setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,7 +2318,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.2",
  "subtle",
- "time 0.3.11",
+ "time 0.3.9",
  "version_check",
 ]
 
@@ -2802,7 +2802,7 @@ dependencies = [
  "diesel_derives",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.2.15",
+ "num-traits 0.1.43",
  "pq-sys",
  "r2d2",
  "serde_json",
@@ -4187,12 +4187,12 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.1",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -6456,7 +6456,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
- "time 0.3.11",
+ "time 0.3.9",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
@@ -6659,12 +6659,11 @@ dependencies = [
 
 [[package]]
 name = "prometheus-parse"
-version = "0.2.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7a8ed15bcffc55fe0328931ef20d393bb89ad704756a37bd20cffb4804f306"
+checksum = "c996f3caea1c51aa034c0d2dfd8447a12c555f4567b02677ef8a865ac4cce712"
 dependencies = [
  "chrono",
- "itertools",
  "lazy_static 1.4.0",
  "regex",
 ]
@@ -7711,7 +7710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bcc41d18f7a1d50525d080fd3e953be87c4f9f1a974f3c21798ca00d54ec15"
 dependencies = [
  "lazy_static 1.4.0",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -8646,9 +8645,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
 dependencies = [
  "itoa 1.0.2",
  "libc",
@@ -9111,7 +9110,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "static_assertions",
 ]
 

--- a/crates/aptos-workspace-hack/Cargo.toml
+++ b/crates/aptos-workspace-hack/Cargo.toml
@@ -32,6 +32,7 @@ futures-io = { version = "0.3.21", features = ["std"] }
 futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.21", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14.18", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
@@ -84,6 +85,7 @@ futures-io = { version = "0.3.21", features = ["std"] }
 futures-sink = { version = "0.3.21", features = ["alloc", "std"] }
 futures-util = { version = "0.3.21", features = ["alloc", "async-await", "async-await-macro", "channel", "futures-channel", "futures-io", "futures-macro", "futures-sink", "io", "memchr", "sink", "slab", "std"] }
 generic-array = { version = "0.14.5", default-features = false, features = ["more_lengths"] }
+hashbrown = { version = "0.11.2", features = ["ahash", "inline-more", "raw"] }
 hyper = { version = "0.14.18", features = ["client", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"] }
 include_dir = { version = "0.7.2", features = ["glob"] }
 itertools = { version = "0.10.3", features = ["use_alloc", "use_std"] }
@@ -115,22 +117,18 @@ url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.2", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 
 [target.x86_64-apple-darwin.dependencies]
-hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-hashbrown = { version = "0.11.2", features = ["ahash", "inline-more"] }
 standback = { version = "0.2.17", default-features = false, features = ["std"] }
 tokio-util-3b31131e45eafb45 = { package = "tokio-util", version = "0.6.10", features = ["codec", "io"] }
 


### PR DESCRIPTION
Make Forge fail-faster if the initial testnet setup does not complete. We now do forge cleanup:
* [this PR] if K8sSwarm setup does not complete
* when K8sSwarm is dropped
* on a cadence by `forge-auto-cleanup` job

Also re-generate some cargo workspace hack stuff to get linters happy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1806)
<!-- Reviewable:end -->
