### PR TITLE
[State Sync] Add simple metric for the active validator set.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -308,11 +308,7 @@ impl<
             .reconfiguration_events
             .is_empty()
         {
-            metrics::increment_gauge(
-                &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
-                metrics::StorageSynchronizerOperations::SyncedEpoch.get_label(),
-                1,
-            );
+            utils::update_new_epoch_metrics(self.storage.clone());
         }
     }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/metrics.rs
@@ -82,6 +82,16 @@ pub static DRIVER_COUNTERS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Gauges related to the current epoch state
+pub static EPOCH_STATE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_state_sync_epoch_state_gauges",
+        "Gauges related to the storage synchronizer",
+        &["epoch", "validator_address", "validator_weight"]
+    )
+    .unwrap()
+});
+
 /// Counters related to the currently executing component
 pub static EXECUTING_COMPONENT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
@@ -139,7 +149,19 @@ pub fn decrement_gauge(gauge: &Lazy<IntGaugeVec>, label: &str, delta: u64) {
     gauge.with_label_values(&[label]).sub(delta as i64);
 }
 
+/// Reads the gauge with the specific label
+pub fn read_gauge(gauge: &Lazy<IntGaugeVec>, label: &str) -> i64 {
+    gauge.with_label_values(&[label]).get()
+}
+
 /// Sets the gauge with the specific label to the given value
 pub fn set_gauge(gauge: &Lazy<IntGaugeVec>, label: &str, value: u64) {
     gauge.with_label_values(&[label]).set(value as i64);
+}
+
+/// Sets the gauge for the epoch state
+pub fn set_epoch_state_gauge(epoch: &str, validator_address: &str, validator_weight: &str) {
+    EPOCH_STATE
+        .with_label_values(&[epoch, validator_address, validator_weight])
+        .set(1);
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -461,12 +461,7 @@ fn spawn_committer<
                                 notification.committed_transactions.len() as u64,
                             );
                             if notification.reconfiguration_occurred {
-                                metrics::increment_gauge(
-                                    &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
-                                    metrics::StorageSynchronizerOperations::SyncedEpoch
-                                        .get_label(),
-                                    1,
-                                );
+                                utils::update_new_epoch_metrics(storage.clone());
                             }
 
                             // Handle the committed transaction notification (e.g., notify mempool).

--- a/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
@@ -288,3 +288,40 @@ pub async fn handle_committed_transactions<M: MempoolNotificationSender>(
             .message("Failed to handle a transaction commit notification!"));
     }
 }
+
+/// Updates the metrics to handle an epoch change event
+pub fn update_new_epoch_metrics(storage: Arc<dyn DbReader>) {
+    // Increment the epoch
+    metrics::increment_gauge(
+        &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+        metrics::StorageSynchronizerOperations::SyncedEpoch.get_label(),
+        1,
+    );
+
+    // Update the validator set accounts in the epoch
+    match fetch_latest_epoch_state(storage) {
+        Ok(latest_epoch_state) => {
+            let epoch = metrics::read_gauge(
+                &metrics::STORAGE_SYNCHRONIZER_OPERATIONS,
+                metrics::StorageSynchronizerOperations::SyncedEpoch.get_label(),
+            );
+            let validator_verifier = latest_epoch_state.verifier;
+            for validator_address in validator_verifier.get_ordered_account_addresses_iter() {
+                let validator_weight = validator_verifier
+                    .get_voting_power(&validator_address)
+                    .unwrap_or(0);
+                metrics::set_epoch_state_gauge(
+                    &epoch.to_string(),
+                    &validator_address.to_string(),
+                    &validator_weight.to_string(),
+                );
+            }
+        }
+        Err(error) => {
+            error!(LogSchema::new(LogEntry::Driver).message(&format!(
+                "Failed to get the latest epoch state from storage! Error: {:?}",
+                error
+            )));
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR adds a simple metric for displaying the addresses and weights of the active validator set at each epoch change. Using these metrics we can create a nice dashboard. This will be helpful for testing and general use.

### Test Plan
Manual verification of a fullnode, e.g., for the first epoch change:
```
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="0444E008A5C7EFC78787BA48923A7AAD221993243E7C31AE8EFF190B5F68CB1B",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="0CE74FB3F6A29948847D82D3D784CECB6CDC75980B745FB03491CDA0F13E6FE3",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="15A8033113D5FCAB18544C84070B1CFCA8B637A5382E1005E477D8D59DA79E01",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="181E3ECC391E6371B4F386278E9136CDA1D76F5BF183419C306637EF84F4FF92",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="1B204217398810604940C89297419DCB4C7FEC9F4685784833B30199DA174448",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="2520DF729C08D2669053CD0201AC31574D4866FA3D9B4C158697E0515CB0A4BA",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="2EBA9D724D6CD9B43A024D20AA7231528FD05C50E55146908B6F7891656FBF07",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="3741AFCDC9FDA7630D929043EDEBF09EC83891FF154E08DFA3B74C900ACBC3D3",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="41BA278097869D0DD8609128FBB3047A6A66A874B5E27BED32D47C10514BA9E6",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="4567DD36589CE91F1B7B19F95D70BF888D483F55B9B346EA519AC6B464723402",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="48E6F65BC826AFE7452DE6AEE888FE866333629D327F89842884DB9C7C955BE7",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="64D462705D5AD40CA270305E660C7E1C869042085D62ECFA3DA9DF3C2C8BD402",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="6D7EE047488DFEBF2C60158C36BC09956ED392120C605FBAC3898A6C6D3AAC46",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="8BF7F74435E13CA6188FB51DD0153B68E73DD77AABC3B1C80E126FB9F0813879",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="8D65609A2C83DE0E61C9A8D3C6A8CE8450CCCE7E7B5C092DD2B68A4EF94F1522",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="8D6596FF47158E38D58E1B950327BF89D2DE05E67C22A6F27526C7A8ADBF85FE",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="8E5F11418FDF44CDADED1C1CC96A7C067DDD066D2005E1DC1CDF24575EA3BE5C",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="9849E0D17EBB9583FADF8155B892109DA07D2B372D822F5DE73AFFA58777694D",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="9F0EF6E529F5CDC60D90730885FA7CAF2EA8EEB2FA1796D0837C3C1DEBCA370D",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="A4FD8D6796E715F2EBCDB1EB83F6D22C79B1AAB4E8B46D3AE00935F41800C2C2",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="D7982886B2EDE5080D8E685D7F49EE78074782DCC15D97B3400B15640859E02D",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="E2609B0B091C13F7A62966FF9EA11BF9F44ED6C54D4C42CB8E6FD2213ED9F792",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="EB61EF88AB8D37A3DE920F7936E30CC5CFBBC2B4F52F699625D712FCB036FD80",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="F83A789D6179589FF37BEFF7517CA51DAC630873456579AC8CD5A9F7DAA1432E",validator_weight="1"} 1
aptos_state_sync_epoch_state_gauges{epoch="2",validator_address="FD98B2733DC5B6F84D91554580AEC539EC3F53321A8A392FBC32C647FD258B35",validator_weight="1"} 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1808)
<!-- Reviewable:end -->
