### PR TITLE
[docs] Update the example dapp for wallet updates

### DIFF
--- a/developer-docs-site/docs/tutorials/first-dapp.md
+++ b/developer-docs-site/docs/tutorials/first-dapp.md
@@ -58,7 +58,7 @@ You will now have a basic React app up and running in your browser.
 
 ## Step 2: Integrate the Aptos Wallet Web3 API
 
-The Aptos Wallet provides a Web3 API for dapps at `window.aptos`. You can see how it works by opening up the browser console and running `await window.aptos.account()`. It will print out the address corresponding to the account you set up in the Aptos Wallet.
+The Aptos Wallet provides a Web3 API for dapps at `window.aptos`. You can see how it works by opening up the browser console and running `await window.aptos.connect()`. It will print out the address corresponding to the account you set up in the Aptos Wallet.
 
 Next we will update our app to use this API to display the Wallet account's address.
 
@@ -102,9 +102,24 @@ declare global {
 
 This lets us use the `window.aptos` API without having to do `(window as any).aptos`.
 
+### Connecting to the wallet
+Our app is now ready to use the `window.aptos` API. Lets establish a connection to the wallet before load. Add the following to `src/index.tsx`:
+
+```typescript
+window.addEventListener('load', async () => {
+  await window.aptos.connect();
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+});
+```
+
+
 ### Display `window.aptos.account()` in the app
 
-Our app is now ready to use the `window.aptos` API. We will change `src/App.tsx` to retrieve the value of `window.aptos.account()` (the wallet account) on initial render, store it in state, and then display it:
+Now we will change `src/App.tsx` to retrieve the value of `window.aptos.account()` (the wallet account) on initial render, store it in state, and then display it:
 
 ```typescript
 import React from 'react';

--- a/developer-docs-site/static/examples/typescript/dapp-example/src/index.tsx
+++ b/developer-docs-site/static/examples/typescript/dapp-example/src/index.tsx
@@ -13,7 +13,8 @@ const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 
-window.addEventListener("load", () => {
+window.addEventListener("load", async () => {
+  await window.aptos.connect();
   root.render(
     <React.StrictMode>
       <App />


### PR DESCRIPTION
### Description
We updated the wallet recently and this example was not working - https://aptos.dev/guides/building-wallet-extension

I think that we should likely re-think this example at some point now that the dapp api is more stable. But let's get it working for now.

### Test Plan
The dapp works and prompts the user to connect the wallet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1811)
<!-- Reviewable:end -->
