### PR TITLE
[aptos-telemetry] Fix build metrics to come from the correct place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4232,6 +4232,7 @@ dependencies = [
  "reqwest",
  "rusty-fork",
  "serde_json",
+ "shadow-rs",
  "sysinfo",
  "tokio",
 ]

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
+build = "build.rs"
 
 [build-dependencies]
 shadow-rs = "0.11.0"

--- a/crates/aptos-telemetry/src/build_information.rs
+++ b/crates/aptos-telemetry/src/build_information.rs
@@ -9,21 +9,21 @@ use std::collections::BTreeMap;
 const APTOS_NODE_BUILD_INFORMATION: &str = "APTOS_NODE_BUILD_INFORMATION";
 
 /// Build information keys
-const BUILD_BRANCH: &str = "build_branch";
-const BUILD_CARGO_VERSION: &str = "build_cargo_version";
-const BUILD_CHAIN_ID: &str = "build_chain_id";
-const BUILD_CLAP_VERSION: &str = "build_clap_version";
-const BUILD_COMMIT_HASH: &str = "build_commit_hash";
-const BUILD_OS: &str = "build_os";
-const BUILD_PKG_VERSION: &str = "build_pkg_version";
-const BUILD_PROJECT_NAME: &str = "build_project_name";
-const BUILD_RUST_CHANNEL: &str = "build_rust_channel";
-const BUILD_RUST_VERSION: &str = "build_rust_version";
-const BUILD_TAG: &str = "build_tag";
-const BUILD_TARGET: &str = "build_target";
-const BUILD_TARGET_ARCH: &str = "build_target_arch";
-const BUILD_TIME: &str = "build_time";
-const BUILD_VERSION: &str = "build_version";
+pub const BUILD_BRANCH: &str = "build_branch";
+pub const BUILD_CARGO_VERSION: &str = "build_cargo_version";
+pub const BUILD_CHAIN_ID: &str = "build_chain_id";
+pub const BUILD_CLAP_VERSION: &str = "build_clap_version";
+pub const BUILD_COMMIT_HASH: &str = "build_commit_hash";
+pub const BUILD_OS: &str = "build_os";
+pub const BUILD_PKG_VERSION: &str = "build_pkg_version";
+pub const BUILD_PROJECT_NAME: &str = "build_project_name";
+pub const BUILD_RUST_CHANNEL: &str = "build_rust_channel";
+pub const BUILD_RUST_VERSION: &str = "build_rust_version";
+pub const BUILD_TAG: &str = "build_tag";
+pub const BUILD_TARGET: &str = "build_target";
+pub const BUILD_TARGET_ARCH: &str = "build_target_arch";
+pub const BUILD_TIME: &str = "build_time";
+pub const BUILD_VERSION: &str = "build_version";
 
 // Get access to BUILD information
 shadow!(build);
@@ -31,7 +31,9 @@ shadow!(build);
 /// Collects and sends the build information via telemetry
 pub(crate) async fn create_build_info_telemetry_event(chain_id: String) -> TelemetryEvent {
     // Collect the build information
-    let build_information = get_build_information(Some(chain_id));
+    // Note: This is giving the build information of the telemetry crate and not the aptos node
+    let mut build_information = crate::build_information_internal!();
+    add_chain_id(&mut build_information, Some(chain_id));
 
     // Create and return a new telemetry event
     TelemetryEvent {
@@ -40,31 +42,42 @@ pub(crate) async fn create_build_info_telemetry_event(chain_id: String) -> Telem
     }
 }
 
-/// Used to collect build information
-pub(crate) fn get_build_information(chain_id: Option<String>) -> BTreeMap<String, String> {
-    let mut build_information: BTreeMap<String, String> = BTreeMap::new();
-    collect_build_info(chain_id, &mut build_information);
-    build_information
+/// Adds chain id to build information
+pub fn add_chain_id(build_information: &mut BTreeMap<String, String>, chain_id: Option<String>) {
+    utils::insert_optional_value(build_information, BUILD_CHAIN_ID, chain_id);
 }
 
-/// Collects the build info and appends it to the given map
-pub(crate) fn collect_build_info(
-    chain_id: Option<String>,
-    build_information: &mut BTreeMap<String, String>,
-) {
-    build_information.insert(BUILD_BRANCH.into(), build::BRANCH.into());
-    build_information.insert(BUILD_CARGO_VERSION.into(), build::CARGO_VERSION.into());
-    utils::insert_optional_value(build_information, BUILD_CHAIN_ID, chain_id);
-    build_information.insert(BUILD_CLAP_VERSION.into(), build::CLAP_LONG_VERSION.into());
-    build_information.insert(BUILD_COMMIT_HASH.into(), build::COMMIT_HASH.into());
-    build_information.insert(BUILD_OS.into(), build::BUILD_OS.into());
-    build_information.insert(BUILD_PKG_VERSION.into(), build::PKG_VERSION.into());
-    build_information.insert(BUILD_PROJECT_NAME.into(), build::PROJECT_NAME.into());
-    build_information.insert(BUILD_RUST_CHANNEL.into(), build::RUST_CHANNEL.into());
-    build_information.insert(BUILD_RUST_VERSION.into(), build::RUST_VERSION.into());
-    build_information.insert(BUILD_TAG.into(), build::TAG.into());
-    build_information.insert(BUILD_TARGET.into(), build::BUILD_TARGET.into());
-    build_information.insert(BUILD_TARGET_ARCH.into(), build::BUILD_TARGET_ARCH.into());
-    build_information.insert(BUILD_TIME.into(), build::BUILD_TIME.into());
-    build_information.insert(BUILD_VERSION.into(), build::VERSION.into());
+// Note, this cannot be moved into a central crate, it has to be run in the crate being measured
+// This is a hack around that the constants need to be imported
+#[macro_export]
+macro_rules! build_information {
+    () => {{
+        use aptos_telemetry::build_information::*;
+        build_information_internal!()
+    }};
+}
+
+#[macro_export]
+macro_rules! build_information_internal {
+    () => {{
+        use std::collections::BTreeMap;
+        shadow_rs::shadow!(build);
+
+        let mut build_information: BTreeMap<String, String> = BTreeMap::new();
+        build_information.insert(BUILD_BRANCH.into(), build::BRANCH.into());
+        build_information.insert(BUILD_CARGO_VERSION.into(), build::CARGO_VERSION.into());
+        build_information.insert(BUILD_CLAP_VERSION.into(), build::CLAP_LONG_VERSION.into());
+        build_information.insert(BUILD_COMMIT_HASH.into(), build::COMMIT_HASH.into());
+        build_information.insert(BUILD_OS.into(), build::BUILD_OS.into());
+        build_information.insert(BUILD_PKG_VERSION.into(), build::PKG_VERSION.into());
+        build_information.insert(BUILD_PROJECT_NAME.into(), build::PROJECT_NAME.into());
+        build_information.insert(BUILD_RUST_CHANNEL.into(), build::RUST_CHANNEL.into());
+        build_information.insert(BUILD_RUST_VERSION.into(), build::RUST_VERSION.into());
+        build_information.insert(BUILD_TAG.into(), build::TAG.into());
+        build_information.insert(BUILD_TARGET.into(), build::BUILD_TARGET.into());
+        build_information.insert(BUILD_TARGET_ARCH.into(), build::BUILD_TARGET_ARCH.into());
+        build_information.insert(BUILD_TIME.into(), build::BUILD_TIME.into());
+        build_information.insert(BUILD_VERSION.into(), build::VERSION.into());
+        build_information
+    }};
 }

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-mod build_information;
+pub mod build_information;
 pub mod cli_metrics;
 mod constants;
 mod core_metrics;

--- a/crates/aptos-telemetry/src/utils.rs
+++ b/crates/aptos-telemetry/src/utils.rs
@@ -3,24 +3,21 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{build_information::collect_build_info, system_information::collect_system_info};
+use crate::{build_information::add_chain_id, system_information::collect_system_info};
 use prometheus::proto::MetricFamily;
 use std::collections::BTreeMap;
 
 /// Used to expose system and build information
-pub fn get_system_and_build_information(chain_id: Option<String>) -> BTreeMap<String, String> {
-    let mut information: BTreeMap<String, String> = BTreeMap::new();
-    collect_build_info(chain_id, &mut information);
-    collect_system_info(&mut information);
-    information
+pub fn get_system_and_build_information(
+    information: &mut BTreeMap<String, String>,
+    chain_id: Option<String>,
+) {
+    add_chain_id(information, chain_id);
+    collect_system_info(information);
 }
 
 /// Inserts an optional value into the given map iff the value exists
-pub(crate) fn insert_optional_value(
-    map: &mut BTreeMap<String, String>,
-    key: &str,
-    value: Option<String>,
-) {
+pub fn insert_optional_value(map: &mut BTreeMap<String, String>, key: &str, value: Option<String>) {
     if let Some(value) = value {
         map.insert(key.to_string(), value);
     }

--- a/crates/inspection-service/Cargo.toml
+++ b/crates/inspection-service/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
+build = "build.rs"
 
 [dependencies]
 anyhow = "1.0.57"
@@ -17,6 +18,7 @@ once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }
 reqwest = { version = "0.11.10", features = ["blocking", "json"], default_features = false }
 serde_json = "1.0.81"
+shadow-rs = "0.11.0"
 sysinfo = "0.24.2"
 tokio = { version = "1.18.2", features = ["full"] }
 
@@ -30,3 +32,6 @@ aptos-workspace-hack = { path = "../aptos-workspace-hack" }
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 rusty-fork = "0.3.0"
+
+[build-dependencies]
+shadow-rs = "0.11.0"

--- a/crates/inspection-service/build.rs
+++ b/crates/inspection-service/build.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}

--- a/crates/inspection-service/src/inspection_service.rs
+++ b/crates/inspection-service/src/inspection_service.rs
@@ -3,6 +3,7 @@
 
 use crate::{gather_metrics, json_encoder::JsonEncoder, NUM_METRICS};
 use aptos_config::config::NodeConfig;
+use aptos_telemetry::{build_information, build_information_internal};
 use hyper::{
     service::{make_service_fn, service_fn},
     Body, Method, Request, Response, Server, StatusCode,
@@ -120,8 +121,11 @@ async fn serve_requests(
         // Expose the system and build information
         (&Method::GET, "/system_information") => {
             if node_config.inspection_service.expose_system_information {
-                let system_information =
-                    aptos_telemetry::utils::get_system_and_build_information(None);
+                let mut system_information = build_information!();
+                let system_information = aptos_telemetry::utils::get_system_and_build_information(
+                    &mut system_information,
+                    None,
+                );
                 let encoded_information = serde_json::to_string(&system_information).unwrap();
                 *resp.body_mut() = Body::from(encoded_information);
             } else {


### PR DESCRIPTION
### Description
Shadow RS is a build time collection of build artifacts.  Therefore,
it's collected on a per crate level.  So, now there are macros
to ensure that there isn't duplicated code, but the proper measurement
can be taken

Note the telemetry service still doesn't record the correct versions, it should be recorded in aptos node or whatever is running.

### Test Plan
I ran this manually for the CLI, and it changed the output to the correct version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1814)
<!-- Reviewable:end -->
