### PR TITLE
[Token] Enable VecBytes in TransactionBuilder and Modify Token to Take Vec<Vec<u8>> as parameters

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/PropertyMap.move
+++ b/aptos-move/framework/aptos-framework/sources/PropertyMap.move
@@ -2,7 +2,7 @@
 /// It maps a String key to a PropertyValue that consists of a String type and a vec value
 module AptosFramework::PropertyMap {
     use Std::Vector;
-    use Std::ASCII::String;
+    use Std::ASCII::{Self, String};
     use AptosFramework::SimpleMap::{Self, SimpleMap};
 
     const MAX_PROPERTY_MAP_SIZE: u64 = 1000;
@@ -104,6 +104,16 @@ module AptosFramework::PropertyMap {
             update_property_value(list, key, *value);
             i = i + 1;
         };
+    }
+
+    public fun generate_string_vector(values: vector<vector<u8>>): vector<String> {
+        let vals: vector<String> = Vector::empty<String>();
+        let i = 0;
+        while (i < Vector::length(&values)) {
+            Vector::push_back(&mut vals, ASCII::string(*Vector::borrow(&mut values, i )));
+            i = i + 1;
+        };
+        vals
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-framework/sources/TokenV1.move
+++ b/aptos-move/framework/aptos-framework/sources/TokenV1.move
@@ -229,9 +229,9 @@ module AptosFramework::TokenV1 {
         royalty_points_denominator: u64,
         royalty_points_nominator: u64,
         token_mutate_setting: vector<bool>,
-        property_keys: vector<String>,
+        property_keys: vector<vector<u8>>,
         property_values: vector<vector<u8>>,
-        property_types: vector<String>,
+        property_types: vector<vector<u8>>,
     ) acquires Collections, TokenStore {
         create_token(
             creator,
@@ -245,9 +245,9 @@ module AptosFramework::TokenV1 {
             royalty_points_denominator,
             royalty_points_nominator,
             token_mutate_setting,
-            property_keys,
+            PropertyMap::generate_string_vector(property_keys),
             property_values,
-            property_types,
+            PropertyMap::generate_string_vector(property_types),
         );
     }
 

--- a/aptos-move/transaction-builder-generator/src/rust.rs
+++ b/aptos-move/transaction-builder-generator/src/rust.rs
@@ -218,6 +218,11 @@ impl ScriptFunctionCall {
             .with_external_definitions(external_definitions)
             .with_serialization(!self.local_types);
         rust::CodeGenerator::new(&config)
+            .with_derive_macros(vec![
+                "Clone".to_string(),
+                "Debug".to_string(),
+                "PartialEq".to_string(),
+            ])
             .with_custom_derive_block(custom_derive_block)
             .output(&mut self.out, &script_registry)
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, format!("{}", err)))?;

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -23,7 +23,7 @@ once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", default-features = false, optional = true }
 rand = "0.7.3"
-serde = { version = "1.0.137", default-features = false }
+serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_bytes = "0.11.6"
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -20,7 +20,7 @@ use crate::{
         ChangeSet, ExecutionStatus, Module, ModuleBundle, RawTransaction, Script,
         SignatureCheckedTransaction, SignedTransaction, Transaction, TransactionArgument,
         TransactionInfo, TransactionListWithProof, TransactionPayload, TransactionStatus,
-        TransactionToCommit, Version, WriteSetPayload,
+        TransactionToCommit, VecBytes, Version, WriteSetPayload,
     },
     validator_info::ValidatorInfo,
     validator_signer::ValidatorSigner,
@@ -1209,4 +1209,16 @@ pub fn arb_json_value() -> impl Strategy<Value = Value> {
             ]
         },
     )
+}
+
+// this function generate arbitrary vec<vec<u8>> value
+impl Arbitrary for VecBytes {
+    type Parameters = ();
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        prop::collection::vec(any::<[u8; 32]>().prop_map(|e| e.to_vec()), 1..32)
+            .prop_map(VecBytes::from)
+            .boxed()
+    }
+
+    type Strategy = BoxedStrategy<Self>;
 }

--- a/types/src/transaction/transaction_argument.rs
+++ b/types/src/transaction/transaction_argument.rs
@@ -1,7 +1,61 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
+use move_deps::move_core_types::transaction_argument::VecBytes as MoveVecBytes;
+use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+use serde_bytes::ByteBuf;
+use std::fmt::{Debug, Formatter};
 
 pub use move_deps::move_core_types::{
-    parser::parse_transaction_argument,
-    transaction_argument::{TransactionArgument, VecBytes},
+    parser::parse_transaction_argument, transaction_argument::TransactionArgument,
 };
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub struct VecBytes(MoveVecBytes);
+
+impl Debug for VecBytes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&self.clone().into_vec(), f)
+    }
+}
+
+impl Serialize for VecBytes {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let data = self.0.clone().into_vec();
+        let length = data.len();
+        let mut seq = serializer.serialize_seq(Some(length))?;
+        for e in data {
+            seq.serialize_element(&ByteBuf::from(&e[..]))?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for VecBytes {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(::serde::Deserialize)]
+        #[serde(rename = "VecBytes")]
+        struct Value(Vec<ByteBuf>);
+
+        let value = Value::deserialize(deserializer)?;
+
+        Ok(VecBytes::from(
+            value.0.iter().map(|e| e.clone().into_vec()).collect(),
+        ))
+    }
+}
+
+impl VecBytes {
+    pub fn from(vec_bytes: Vec<Vec<u8>>) -> Self {
+        VecBytes(MoveVecBytes::from(vec_bytes))
+    }
+
+    pub fn into_vec(self) -> Vec<Vec<u8>> {
+        self.0.into_vec()
+    }
+}


### PR DESCRIPTION
### Description

1. currently script function still cannot take String as a parameter. 
modify the script function parameter back to vec<vec<u8>> and do conversion inside the script function

2. vec<vec<u8>> is represented as VecBytes in Aptos transaction builder. This type was imported from move and not implemented proptest. I created a Aptos VecBytes type and implemented the Arbitrary trait for this type. 

### Test Plan

following tests passed: 
cargo test -p aptos-types
cargo xclippy --all-targets
cargo test -p generate-format


<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1815)
<!-- Reviewable:end -->
