### PR TITLE
[storage] support reading per-version state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,7 +3214,6 @@ dependencies = [
  "bcs",
  "itertools",
  "once_cell",
- "rayon",
  "scratchpad",
  "serde 1.0.137",
  "storage-interface",

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -182,6 +182,29 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         .unwrap();
     verify_committed_txn_status(t6.as_ref(), &block1[8]).unwrap();
 
+    // test the initial balance.
+    let db_state_view = db.reader.state_view_at_version(Some(6)).unwrap();
+    let account1_state_view = db_state_view.as_account_with_state_view(&account1_address);
+    verify_account_balance(get_account_balance(&account1_state_view), |x| {
+        x == 2_000_000
+    })
+    .unwrap();
+
+    let account2_state_view = db_state_view.as_account_with_state_view(&account2_address);
+
+    verify_account_balance(get_account_balance(&account2_state_view), |x| {
+        x == 1_200_000
+    })
+    .unwrap();
+
+    let account3_state_view = db_state_view.as_account_with_state_view(&account3_address);
+
+    verify_account_balance(get_account_balance(&account3_state_view), |x| {
+        x == 1_000_000
+    })
+    .unwrap();
+
+    // test the final balance.
     let db_state_view = db
         .reader
         .state_view_at_version(Some(current_version))

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 itertools = "0.10.0"
 once_cell = "1.10.0"
-rayon = "1.5.2"
 serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 

--- a/execution/executor-types/src/in_memory_state_calculator.rs
+++ b/execution/executor-types/src/in_memory_state_calculator.rs
@@ -5,7 +5,6 @@ use std::collections::{hash_map, HashMap, HashSet};
 
 use anyhow::{anyhow, bail, Result};
 use once_cell::sync::Lazy;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 
 use crate::{ParsedTransactionOutput, ProofReader};
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -32,7 +31,7 @@ pub static NEW_EPOCH_EVENT_KEY: Lazy<EventKey> = Lazy::new(on_chain_config::new_
 ///   2. a transaction chunk or block ended (where `finish()` is called)
 ///
 /// | ------------------------------------------ | -------------------------- |
-/// |  (updated_between_checkpoint_and_latest)   |  (updated_after_latest)    |
+/// |  (updated_between_checkpoint_and_latest)   |  (updates_after_latest)    |
 /// \                                            \                            |
 ///  checkpoint SMT                               latest SMT                  |
 ///                                                                          /
@@ -54,7 +53,7 @@ pub struct InMemoryStateCalculator {
 
     next_version: Version,
     updated_between_checkpoint_and_latest: HashSet<StateKey>,
-    updated_after_latest: HashSet<StateKey>,
+    updates_after_latest: HashMap<StateKey, StateValue>,
 }
 
 impl InMemoryStateCalculator {
@@ -81,7 +80,7 @@ impl InMemoryStateCalculator {
             latest: current.freeze(),
             next_version: current_version.map_or(0, |v| v + 1),
             updated_between_checkpoint_and_latest: updated_since_checkpoint,
-            updated_after_latest: HashSet::new(),
+            updates_after_latest: HashMap::new(),
         }
     }
 
@@ -134,13 +133,12 @@ impl InMemoryStateCalculator {
         HashMap<NibblePath, HashValue>,
         Option<HashValue>,
     )> {
-        let updated_state_keys = process_write_set(
+        let updated_state_kvs = process_write_set(
             Some(txn),
             &mut self.state_cache,
             txn_output.write_set().clone(),
         )?;
-        self.updated_after_latest
-            .extend(updated_state_keys.into_iter());
+        self.updates_after_latest.extend(updated_state_kvs.clone());
         self.next_version += 1;
 
         if txn_output.is_reconfig() {
@@ -148,7 +146,7 @@ impl InMemoryStateCalculator {
         } else {
             match txn {
                 Transaction::BlockMetadata(_) | Transaction::UserTransaction(_) => {
-                    Ok((HashMap::new(), HashMap::new(), None))
+                    Ok((updated_state_kvs, HashMap::new(), None))
                 }
                 Transaction::GenesisTransaction(_) | Transaction::StateCheckpoint => {
                     self.checkpoint()
@@ -165,8 +163,8 @@ impl InMemoryStateCalculator {
         Option<HashValue>,
     )> {
         // Update SMT.
-        let updates_after_latest = self.updates_after_latest()?;
-        let smt_updates: Vec<_> = updates_after_latest
+        let smt_updates: Vec<_> = self
+            .updates_after_latest
             .iter()
             .map(|(key, value)| (key.hash(), value))
             .collect();
@@ -178,7 +176,14 @@ impl InMemoryStateCalculator {
         // Calculate the set of state items that got changed since last checkpoint.
         let updated_between_checkpoint_and_latest: Vec<_> = self
             .updated_between_checkpoint_and_latest
-            .difference(&self.updated_after_latest)
+            .difference(
+                &self
+                    .updates_after_latest
+                    .keys()
+                    .cloned()
+                    .into_iter()
+                    .collect(),
+            )
             .map(|key| match self.latest.get(key.hash()) {
                 StateStoreStatus::ExistsInScratchPad(value) => Ok((key.clone(), value)),
                 _ => Err(anyhow!(
@@ -188,7 +193,7 @@ impl InMemoryStateCalculator {
             })
             .collect::<Result<_>>()?;
 
-        let mut state_updates = updates_after_latest;
+        let mut state_updates = self.updates_after_latest.clone();
         state_updates.extend(updated_between_checkpoint_and_latest.into_iter());
 
         // Move self to the new checkpoint.
@@ -196,7 +201,7 @@ impl InMemoryStateCalculator {
         self.checkpoint = new_checkpoint.unfreeze();
         self.checkpoint_version = self.next_version.checked_sub(1);
         self.updated_between_checkpoint_and_latest = HashSet::new();
-        self.updated_after_latest = HashSet::new();
+        self.updates_after_latest = HashMap::new();
 
         Ok((state_updates, new_node_hashes, Some(root_hash)))
     }
@@ -217,34 +222,16 @@ impl InMemoryStateCalculator {
         })
     }
 
-    fn updates_after_latest(&self) -> Result<HashMap<StateKey, StateValue>> {
-        self.updated_after_latest
-            .iter()
-            .collect::<Vec<_>>()
-            .par_iter()
-            .with_min_len(100)
-            .map(|key| {
-                Ok((
-                    (**key).clone(),
-                    self.state_cache
-                        .get(key)
-                        .ok_or_else(|| anyhow!("State value should exist."))?
-                        .clone(),
-                ))
-            })
-            .collect::<Result<_>>()
-    }
-
     fn finish(self) -> Result<(InMemoryState, HashMap<StateKey, StateValue>)> {
-        let updates_after_latest = self.updates_after_latest()?;
-        let smt_updates: Vec<_> = updates_after_latest
+        let smt_updates: Vec<_> = self
+            .updates_after_latest
             .iter()
             .map(|(key, value)| (key.hash(), value))
             .collect();
         let latest = self.latest.batch_update(smt_updates, &self.proof_reader)?;
 
         let mut updated_since_checkpoint = self.updated_between_checkpoint_and_latest;
-        updated_since_checkpoint.extend(updates_after_latest.keys().cloned());
+        updated_since_checkpoint.extend(self.updates_after_latest.keys().cloned());
 
         let result_state = InMemoryState::new(
             self.checkpoint,
@@ -264,7 +251,7 @@ impl InMemoryStateCalculator {
         for write_set in write_sets {
             let state_updates =
                 process_write_set(None, &mut self.state_cache, (*write_set).clone())?;
-            self.updated_after_latest.extend(state_updates.into_iter());
+            self.updates_after_latest.extend(state_updates.into_iter());
             self.next_version += 1;
         }
         let (result_state, _) = self.finish()?;
@@ -274,53 +261,43 @@ impl InMemoryStateCalculator {
 
 // Checks the write set is a subset of the read set.
 // Updates the `state_cache` to reflect the latest value.
-// Returns all state keys touched.
+// Returns all state key-value pair touched.
 pub fn process_write_set(
     transaction: Option<&Transaction>,
     state_cache: &mut HashMap<StateKey, StateValue>,
     write_set: WriteSet,
-) -> Result<HashSet<StateKey>> {
+) -> Result<HashMap<StateKey, StateValue>> {
     // Find all keys this transaction touches while processing each write op.
-    let mut updated_keys = HashSet::new();
-    for (state_key, write_op) in write_set.into_iter() {
-        process_state_key_write_op(
-            transaction,
-            state_cache,
-            &mut updated_keys,
-            state_key,
-            write_op,
-        )?;
-    }
-
-    Ok(updated_keys)
+    write_set
+        .into_iter()
+        .map(|(state_key, write_op)| {
+            process_state_key_write_op(transaction, state_cache, state_key, write_op)
+        })
+        .collect::<Result<_>>()
 }
 
 fn process_state_key_write_op(
     transaction: Option<&Transaction>,
     state_cache: &mut HashMap<StateKey, StateValue>,
-    updated_keys: &mut HashSet<StateKey>,
     state_key: StateKey,
     write_op: WriteOp,
-) -> Result<()> {
+) -> Result<(StateKey, StateValue)> {
+    let state_value = match write_op {
+        WriteOp::Value(new_value) => StateValue::from(new_value),
+        WriteOp::Deletion => StateValue::empty(),
+    };
     match state_cache.entry(state_key.clone()) {
         hash_map::Entry::Occupied(mut entry) => {
-            match write_op {
-                WriteOp::Value(new_value) => entry.insert(StateValue::from(new_value)),
-                WriteOp::Deletion => entry.insert(StateValue::empty()),
-            };
+            entry.insert(state_value.clone());
         }
         hash_map::Entry::Vacant(entry) => {
             if let Some(txn) = transaction {
                 ensure_txn_valid_for_vacant_entry(txn)?;
             }
-            match write_op {
-                WriteOp::Value(new_value) => entry.insert(StateValue::from(new_value)),
-                WriteOp::Deletion => entry.insert(StateValue::empty()),
-            };
+            entry.insert(state_value.clone());
         }
     }
-    updated_keys.insert(state_key);
-    Ok(())
+    Ok((state_key, state_value))
 }
 
 fn ensure_txn_valid_for_vacant_entry(transaction: &Transaction) -> Result<()> {

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -654,7 +654,9 @@ impl AptosDB {
 
             let state_updates_vec = txns_to_commit
                 .iter()
-                .map(|txn_to_commit| txn_to_commit.state_updates())
+                .map(|txn_to_commit| {
+                    txn_to_commit.state_updates()
+                })
                 .collect::<Vec<_>>();
             self.state_store
                 .put_value_sets(state_updates_vec, first_version, cs)?;
@@ -1377,7 +1379,7 @@ impl DbWriter for AptosDB {
                 for (idx, jmt_updates, jf_node_hashes) in txns_to_commit
                     .iter()
                     .enumerate()
-                    .filter(|(_idx, txn_to_commit)| !txn_to_commit.state_updates().is_empty())
+                    .filter(|(_idx, txn_to_commit)| txn_to_commit.is_state_checkpoint())
                     .map(|(idx, txn_to_commit)| {
                         (
                             idx,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1125,6 +1125,10 @@ impl TransactionToCommit {
         &self.transaction_info
     }
 
+    pub fn is_state_checkpoint(&self) -> bool {
+        self.transaction_info().state_checkpoint_hash.is_some()
+    }
+
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn set_transaction_info(&mut self, txn_info: TransactionInfo) {
         self.transaction_info = txn_info


### PR DESCRIPTION
### Description
Because of checkpoint txns, all the resource state is available after checkpoint txn commit and the version at which they are availble is the version of checkpoint txn but not the version of the original txn that made the state updates. This PR solves this issue.

### Test Plan
add a couple of lines in executor-storage integration test.
Also verified that before this PR, these lines of testing fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1816)
<!-- Reviewable:end -->
