### PR TITLE
[testnet] Make iterating on terraform testnet much more simple

### DIFF
--- a/terraform/aptos-node-testnet/addons.tf
+++ b/terraform/aptos-node-testnet/addons.tf
@@ -178,6 +178,11 @@ resource "helm_release" "testnet-addons" {
         acm_certificate          = length(aws_acm_certificate.ingress) > 0 ? aws_acm_certificate.ingress[0].arn : null
         loadBalancerSourceRanges = var.client_sources_ipv4
       }
+      load_test = {
+        image = {
+          tag = var.image_tag
+        }
+      }
     }),
     jsonencode(var.testnet_addons_helm_values)
   ]

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -1,3 +1,4 @@
+{{- $imageTag := .Values.genesis.image.tag | default .Values.imageTag }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -68,7 +69,7 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "aptos-genesis.fullname" . }}-e{{ .Values.chain.era }}
+  name: {{ include "aptos-genesis.fullname" . }}-e{{ .Values.chain.era }}-{{ $imageTag | substr 0 4 }}
   labels:
     {{- include "aptos-genesis.labels" . | nindent 4 }}
     app.kubernetes.io/name: genesis
@@ -84,7 +85,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: genesis
-        image: {{ .Values.genesis.image.repo }}:{{ .Values.genesis.image.tag | default .Values.imageTag }}
+        image: {{ .Values.genesis.image.repo }}:{{ $imageTag }}
         imagePullPolicy: {{ .Values.genesis.image.pullPolicy }}
         workingDir: /tmp
         command:


### PR DESCRIPTION
This change makes it so that you can simply run terraform apply to update image

This is because genesis job name is constant for era, however job are
immutable, simply add the image string into the genesis name to make sure that
genesis job is created new for new image

Additionally use the image_tag by default for testnet addons txn emitter,
otherwise you have to specify image tag in two place

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1817)
<!-- Reviewable:end -->
