### PR TITLE
cicd: disable fail-fast for copy images to dockerhub job to make debugging which job actually failed easier

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   copy-images:
     strategy:
+      fail-fast: false
       matrix:
         IMAGE_NAME: [validator, forge, init, validator_tcb, tools, faucet, txn-emitter, indexer, node-checker]
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1818)
<!-- Reviewable:end -->
