### PR TITLE
[gha] report forge test runner pod status

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -55,6 +55,7 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         shell: bash
         run: |
+          set -ex
           # replace non alphanumeric chars with dash
           FORGE_NAMESPACE="${FORGE_NAMESPACE_BASE//[^[:alnum:]]/-}"
           # use the first 64 chars only for namespace, as it is the maximum for k8s resources
@@ -68,13 +69,14 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         shell: bash
         run: |
+          set -ex
           kubectl delete $FORGE_POD_NAME || true
           kubectl wait --for=delete "pod/${FORGE_POD_NAME}"
       - name: Run Forge
         if: env.FORGE_ENABLED == 'true'
         shell: bash
         run: |
-          set +e
+          set -ex
           FORGE_START_TIME_MS="$(date '+%s')000"
 
           # Run forge with test runner in k8s
@@ -87,8 +89,17 @@ jobs:
           # tail the logs to get them in GHA runner. tee them for further parsing
           kubectl wait --for=condition=Ready "pod/${FORGE_POD_NAME}"
           kubectl logs -f $FORGE_POD_NAME | tee $FORGE_OUTPUT
+
           FORGE_END_TIME_MS="$(date '+%s')000"
-          FORGE_EXIT_CODE=$?
+
+          # parse the pod status: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase
+          forge_pod_status=$(kubectl get pod $FORGE_POD_NAME -o jsonpath="{.status.phase}")
+          if [ "$forge_pod_status" = "Succeeded" ]; then
+            FORGE_EXIT_CODE=0
+          else
+            FORGE_EXIT_CODE=1
+          fi
+
           # export env vars for next step
           echo "FORGE_EXIT_CODE=$FORGE_EXIT_CODE" >> $GITHUB_ENV
           echo "FORGE_START_TIME_MS=$FORGE_START_TIME_MS" >> $GITHUB_ENV
@@ -107,7 +118,21 @@ jobs:
           # parse the JSON report
           cat $FORGE_OUTPUT | awk '/====json-report-begin===/{f=1;next} /====json-report-end===/{f=0} f' > "${FORGE_REPORT}"
           # If no report was generated, fill with default report
-          [ ! -s "${FORGE_REPORT}" ] && echo '{"text": "Forge test runner terminated"}' > "${FORGE_REPORT}"
+          if [ -s "${FORGE_REPORT}" ]; then
+            echo '{"text": "Forge test runner terminated"}' > "${FORGE_REPORT}"
+          fi
+
+          # If no report text was generated, fill with default text
+          FORGE_REPORT_TXT=$(cat $FORGE_REPORT | jq -r .text)
+          if [ -z "$FORGE_REPORT_TXT" ]; then
+            FORGE_REPORT_TXT="Forge report text empty. See test runner output."
+          fi
+
+          if [ "$FORGE_EXIT_CODE" == "0" ]; then
+            FORGE_COMMENT_HEADER='### :white_check_mark: Forge test success'
+          else
+            FORGE_COMMENT_HEADER='### :x: Forge test failure'
+          fi
 
           # remove the "aptos-" prefix to get the chain name as reported to Prometheus
           FORGE_CHAIN_NAME=${FORGE_CLUSTER_NAME#"aptos-"} 
@@ -119,7 +144,8 @@ jobs:
 
           # export env vars for next step
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-          echo "FORGE_REPORT_TXT=$(cat $FORGE_REPORT | jq -r .text)" >> $GITHUB_ENV
+          echo "FORGE_COMMENT_HEADER=$FORGE_COMMENT_HEADER" >> $GITHUB_ENV
+          echo "FORGE_REPORT_TXT=$FORGE_REPORT_TXT" >> $GITHUB_ENV
           echo "FORGE_DASHBOARD_LINK=$FORGE_DASHBOARD_LINK" >> $GITHUB_ENV
 
           # report metrics to pushgateway
@@ -130,9 +156,9 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Forge run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            Grafana dashboard: ${{ env.FORGE_DASHBOARD_LINK }}
-            Forge test result: 
+            ${{ env.FORGE_COMMENT_HEADER }}
+            * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            * [Grafana dashboard](${{ env.FORGE_DASHBOARD_LINK }})
             ```
             ${{ env.FORGE_REPORT_TXT }}
             ```


### PR DESCRIPTION
Get the Forge test runner pod status and use it as the exit code. Exit code is not currently being used now though since Forge is non-blocking. Also make the GH comment prettier and handle the case when the test report is not generated.

Since Forge and all our builds are triggered on `pull_request_target`, the below run on `CICD:run-e2e-tests` gets the workflow config from `main` rather than this PR, so the comment isn't accurate. But it shows that forge is working now -- we just need to clean up some rough edges. After this PR lands, the below forge run comment will look like the following:

___

### :white_check_mark: Forge test success
  * [Test runner output](https://github.com/aptos-labs/aptos-core/actions/runs/2633453227)
  * [Grafana dashboard](http://o11y.aptosdev.com/grafana/d/overview/overview?orgId=1&var-Datasource=Remote%20Prometheus%20Devinfra&var-namespace=forge-pr-1822&var-chain_name=forge-0&from=1657246959000&to=1657247320000)
```
all up : 1665 TPS, 2598 ms latency, 3450 ms p99 latency,no expired txns
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1822)
<!-- Reviewable:end -->
