### PR TITLE
[Telemetry] Allow fetching of build information from the crate.

### DIFF
--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -8,6 +8,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 edition = "2018"
+build = "build.rs"
 
 [build-dependencies]
 shadow-rs = "0.11.0"

--- a/crates/aptos-telemetry/src/build_information.rs
+++ b/crates/aptos-telemetry/src/build_information.rs
@@ -1,32 +1,98 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate as aptos_telemetry;
 use crate::{service::TelemetryEvent, utils};
-use shadow_rs::shadow;
 use std::collections::BTreeMap;
 
 /// Build information event name
 const APTOS_NODE_BUILD_INFORMATION: &str = "APTOS_NODE_BUILD_INFORMATION";
 
 /// Build information keys
-const BUILD_BRANCH: &str = "build_branch";
-const BUILD_CARGO_VERSION: &str = "build_cargo_version";
-const BUILD_CHAIN_ID: &str = "build_chain_id";
-const BUILD_CLAP_VERSION: &str = "build_clap_version";
-const BUILD_COMMIT_HASH: &str = "build_commit_hash";
-const BUILD_OS: &str = "build_os";
-const BUILD_PKG_VERSION: &str = "build_pkg_version";
-const BUILD_PROJECT_NAME: &str = "build_project_name";
-const BUILD_RUST_CHANNEL: &str = "build_rust_channel";
-const BUILD_RUST_VERSION: &str = "build_rust_version";
-const BUILD_TAG: &str = "build_tag";
-const BUILD_TARGET: &str = "build_target";
-const BUILD_TARGET_ARCH: &str = "build_target_arch";
-const BUILD_TIME: &str = "build_time";
-const BUILD_VERSION: &str = "build_version";
+pub const BUILD_BRANCH: &str = "build_branch";
+pub const BUILD_CARGO_VERSION: &str = "build_cargo_version";
+pub const BUILD_CHAIN_ID: &str = "build_chain_id";
+pub const BUILD_CLAP_VERSION: &str = "build_clap_version";
+pub const BUILD_COMMIT_HASH: &str = "build_commit_hash";
+pub const BUILD_OS: &str = "build_os";
+pub const BUILD_PKG_VERSION: &str = "build_pkg_version";
+pub const BUILD_PROJECT_NAME: &str = "build_project_name";
+pub const BUILD_RUST_CHANNEL: &str = "build_rust_channel";
+pub const BUILD_RUST_VERSION: &str = "build_rust_version";
+pub const BUILD_TAG: &str = "build_tag";
+pub const BUILD_TARGET: &str = "build_target";
+pub const BUILD_TARGET_ARCH: &str = "build_target_arch";
+pub const BUILD_TIME: &str = "build_time";
+pub const BUILD_VERSION: &str = "build_version";
 
-// Get access to BUILD information
-shadow!(build);
+// Used by external crates to collect crate specific build information
+#[macro_export]
+macro_rules! collect_build_information {
+    () => {{
+        // Get access to shadow BUILD information
+        shadow_rs::shadow!(build);
+
+        // Collect and return the build information
+        let mut build_information: std::collections::BTreeMap<String, String> = BTreeMap::new();
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_BRANCH.into(),
+            build::BRANCH.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_CARGO_VERSION.into(),
+            build::CARGO_VERSION.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_CLAP_VERSION.into(),
+            build::CLAP_LONG_VERSION.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_COMMIT_HASH.into(),
+            build::COMMIT_HASH.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_OS.into(),
+            build::BUILD_OS.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_PKG_VERSION.into(),
+            build::PKG_VERSION.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_PROJECT_NAME.into(),
+            build::PROJECT_NAME.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_RUST_CHANNEL.into(),
+            build::RUST_CHANNEL.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_RUST_VERSION.into(),
+            build::RUST_VERSION.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_TAG.into(),
+            build::TAG.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_TARGET.into(),
+            build::BUILD_TARGET.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_TARGET_ARCH.into(),
+            build::BUILD_TARGET_ARCH.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_TIME.into(),
+            build::BUILD_TIME.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_VERSION.into(),
+            build::VERSION.into(),
+        );
+        build_information
+    }};
+}
 
 /// Collects and sends the build information via telemetry
 pub(crate) async fn create_build_info_telemetry_event(chain_id: String) -> TelemetryEvent {
@@ -42,29 +108,7 @@ pub(crate) async fn create_build_info_telemetry_event(chain_id: String) -> Telem
 
 /// Used to collect build information
 pub(crate) fn get_build_information(chain_id: Option<String>) -> BTreeMap<String, String> {
-    let mut build_information: BTreeMap<String, String> = BTreeMap::new();
-    collect_build_info(chain_id, &mut build_information);
+    let mut build_information = collect_build_information!();
+    utils::insert_optional_value(&mut build_information, BUILD_CHAIN_ID, chain_id);
     build_information
-}
-
-/// Collects the build info and appends it to the given map
-pub(crate) fn collect_build_info(
-    chain_id: Option<String>,
-    build_information: &mut BTreeMap<String, String>,
-) {
-    build_information.insert(BUILD_BRANCH.into(), build::BRANCH.into());
-    build_information.insert(BUILD_CARGO_VERSION.into(), build::CARGO_VERSION.into());
-    utils::insert_optional_value(build_information, BUILD_CHAIN_ID, chain_id);
-    build_information.insert(BUILD_CLAP_VERSION.into(), build::CLAP_LONG_VERSION.into());
-    build_information.insert(BUILD_COMMIT_HASH.into(), build::COMMIT_HASH.into());
-    build_information.insert(BUILD_OS.into(), build::BUILD_OS.into());
-    build_information.insert(BUILD_PKG_VERSION.into(), build::PKG_VERSION.into());
-    build_information.insert(BUILD_PROJECT_NAME.into(), build::PROJECT_NAME.into());
-    build_information.insert(BUILD_RUST_CHANNEL.into(), build::RUST_CHANNEL.into());
-    build_information.insert(BUILD_RUST_VERSION.into(), build::RUST_VERSION.into());
-    build_information.insert(BUILD_TAG.into(), build::TAG.into());
-    build_information.insert(BUILD_TARGET.into(), build::BUILD_TARGET.into());
-    build_information.insert(BUILD_TARGET_ARCH.into(), build::BUILD_TARGET_ARCH.into());
-    build_information.insert(BUILD_TIME.into(), build::BUILD_TIME.into());
-    build_information.insert(BUILD_VERSION.into(), build::VERSION.into());
 }

--- a/crates/aptos-telemetry/src/cli_metrics.rs
+++ b/crates/aptos-telemetry/src/cli_metrics.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{build_information::get_build_information, service, service::TelemetryEvent, utils};
+use crate::{service, service::TelemetryEvent, utils};
 use aptos_logger::error;
 use std::{collections::BTreeMap, time::Duration};
 
@@ -16,21 +16,19 @@ const ERROR: &str = "error";
 
 /// Collects and sends the build information via telemetry
 pub async fn send_cli_telemetry_event(
+    mut build_information: BTreeMap<String, String>,
     command: String,
     latency: Duration,
     success: bool,
     error: Option<String>,
 ) {
-    // Collect the build information
-    let mut cli_information = get_build_information(None);
-
     // Collection information about the cli command
-    collect_cli_info(command, latency, success, error, &mut cli_information);
+    collect_cli_info(command, latency, success, error, &mut build_information);
 
     // Create a new telemetry event
     let telemetry_event = TelemetryEvent {
         name: APTOS_CLI_METRICS.into(),
-        params: cli_information,
+        params: build_information,
     };
 
     // TODO(joshlind): can we find a better way of identifying each CLI user?

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-mod build_information;
+pub mod build_information;
 pub mod cli_metrics;
 mod constants;
 mod core_metrics;

--- a/crates/aptos-telemetry/src/utils.rs
+++ b/crates/aptos-telemetry/src/utils.rs
@@ -3,16 +3,15 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{build_information::collect_build_info, system_information::collect_system_info};
+use crate::{build_information::get_build_information, system_information::collect_system_info};
 use prometheus::proto::MetricFamily;
 use std::collections::BTreeMap;
 
 /// Used to expose system and build information
 pub fn get_system_and_build_information(chain_id: Option<String>) -> BTreeMap<String, String> {
-    let mut information: BTreeMap<String, String> = BTreeMap::new();
-    collect_build_info(chain_id, &mut information);
-    collect_system_info(&mut information);
-    information
+    let mut system_and_build_information = get_build_information(chain_id);
+    collect_system_info(&mut system_and_build_information);
+    system_and_build_information
 }
 
 /// Inserts an optional value into the given map iff the value exists


### PR DESCRIPTION
### Description
This PR updates the telemetry crate to allow clients (e.g., the Aptos CLI) to fetch build specific information relevant to the client crate. See https://github.com/aptos-labs/aptos-core/pull/1814 for discussion.

### Test Plan
Tested manually by running the Aptos CLI and inspecting the telemetry event:
```
Sending Telemetry event: TelemetryEvent { name: "APTOS_CLI_METRICS", params: {"build_branch": "test_devnet",
 "build_cargo_version": "cargo 1.61.0 (a028ae42f 2022-04-29)", "build_clap_version": 
"0.2.0\nbranch:test_devnet\ncommit_hash:21d0ff6c\nbuild_time:2022-07-08 10:46:32 -04:00\nbuild_env:rustc 1.61.0 
(fe5b13d68 2022-05-18),1.61.0-aarch64-apple-darwin", "build_commit_hash": 
"21d0ff6c8ab589c00ff5abd431a5672fa87e3084", "build_os": "macos-aarch64", "build_pkg_version": "0.2.0", 
"build_project_name": "aptos", "build_rust_channel": "1.61.0-aarch64-apple-darwin", "build_rust_version": "rustc 1.61.0 
(fe5b13d68 2022-05-18)", "build_tag": "", "build_target": "aarch64-apple-darwin", "build_target_arch": "aarch64", 
"build_time": "2022-07-08 10:46:32 -04:00", "build_version": 
"\npkg_version:0.2.0\nbranch:test_devnet\ncommit_hash:21d0ff6c\nbuild_time:2022-07-08 10:46:32 
-04:00\nbuild_env:rustc 1.61.0 (fe5b13d68 2022-05-18),1.61.0-aarch64-apple-darwin", "command": "ListAccount", 
"error": "Unable to find config /Users/joshlind/.../Code/aptos/clone/aptos-core/crates/.aptos/config.yaml, have you 
run `aptos init`?", "latency": "0", "success": "false"} }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1831)
<!-- Reviewable:end -->
