### PR TITLE
[gha] fix forge default report condition

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -116,7 +116,7 @@ jobs:
           # parse the JSON report
           cat $FORGE_OUTPUT | awk '/====json-report-begin===/{f=1;next} /====json-report-end===/{f=0} f' > "${FORGE_REPORT}"
           # If no report was generated, fill with default report
-          if [ -s "${FORGE_REPORT}" ]; then
+          if [ ! -s "${FORGE_REPORT}" ]; then
             echo '{"text": "Forge test runner terminated"}' > "${FORGE_REPORT}"
           fi
 


### PR DESCRIPTION
if there's no forge report (`! -s "${FORGE_REPORT}"`), then add a default report with failure text. Previously the condition was flipped 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1837)
<!-- Reviewable:end -->
