### PR TITLE
refactor: replace json txn with bcs txn for token client

### DIFF
--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
@@ -45,3 +45,9 @@ export function bcsSerializeStr(value: string): Bytes {
   serializer.serializeStr(value);
   return serializer.getBytes();
 }
+
+export function bcsSerializeBool(value: boolean): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeBool(value);
+  return serializer.getBytes();
+}


### PR DESCRIPTION
### Description
Get rid of the JSON transaction payloads in the token client. BCS is more secure and should be used.

### Test Plan
yarn test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1839)
<!-- Reviewable:end -->
