### PR TITLE
[community] Fix deleting accounts with it1_profile.

### DIFF
--- a/ecosystem/platform/server/app/models/user.rb
+++ b/ecosystem/platform/server/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   validates :terms_accepted, acceptance: true
 
   has_many :authorizations, dependent: :destroy
-  has_one :it1_profile
+  has_one :it1_profile, dependent: :destroy
   has_one :it2_profile, dependent: :destroy
   has_one :it2_survey, dependent: :destroy
   has_many :nfts, dependent: :destroy

--- a/ecosystem/platform/server/spec/factories/it1_profiles.rb
+++ b/ecosystem/platform/server/spec/factories/it1_profiles.rb
@@ -1,18 +1,21 @@
+# frozen_string_literal: true
+
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
-# frozen_string_literal: true
 
 FactoryBot.define do
   factory :it1_profile do
     user { nil }
-    consensus_key { 'MyString' }
-    account_key { 'MyString' }
-    network_key { 'MyString' }
-    validator_address { 'MyString' }
-    validator_port { 1 }
-    validator_metrics_port { 1 }
-    fullnode_address { 'MyString' }
-    fullnode_port { 1 }
-    fullnode_network_key { 'MyString' }
+    consensus_key { "0x#{Faker::Crypto.sha256}" }
+    account_key { "0x#{Faker::Crypto.sha256}" }
+    network_key { "0x#{Faker::Crypto.sha256}" }
+    validator_address { "0x#{Faker::Crypto.sha256}" }
+    validator_port { 6180 }
+    validator_api_port { 8080 }
+    validator_metrics_port { 9101 }
+    terms_accepted { true }
+    fullnode_address { nil }
+    fullnode_port { nil }
+    fullnode_network_key { nil }
   end
 end

--- a/ecosystem/platform/server/spec/factories/it2_profiles.rb
+++ b/ecosystem/platform/server/spec/factories/it2_profiles.rb
@@ -6,13 +6,16 @@
 FactoryBot.define do
   factory :it2_profile do
     user { nil }
-    consensus_key { '0xbcaa0d44b821a745bc29767713cd78dbc88da73679e3ccdf5c145a2b4f7b17ac' }
-    account_key { '0x7964a378e4c6d387d900c6e02430b7ee8263a977ace368484fc72c3b8469f520' }
-    network_key { '0x2b0ebca9776bd79dcd3c0551e784965e87e8a1551d52c4a48758e1df2122064b' }
-    validator_address { '127.0.0.1' }
+    consensus_key { "0x#{Faker::Crypto.sha256}" }
+    account_key { "0x#{Faker::Crypto.sha256}" }
+    network_key { "0x#{Faker::Crypto.sha256}" }
+    validator_address { "0x#{Faker::Crypto.sha256}" }
     validator_port { 6180 }
-    validator_metrics_port { 9101 }
     validator_api_port { 8080 }
+    validator_metrics_port { 9101 }
     terms_accepted { true }
+    fullnode_address { nil }
+    fullnode_port { nil }
+    fullnode_network_key { nil }
   end
 end

--- a/ecosystem/platform/server/spec/factories/it2_surveys.rb
+++ b/ecosystem/platform/server/spec/factories/it2_surveys.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+FactoryBot.define do
+  factory :it2_survey do
+    user { nil }
+    persona { 'Node Operator' }
+    participate_reason { Faker::Quote.yoda }
+    qualified_reason { Faker::Quote.yoda }
+    website { Faker::Internet.url }
+    interest_reason { Faker::Quote.yoda }
+  end
+end

--- a/ecosystem/platform/server/test/controllers/settings_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/settings_controller_test.rb
@@ -56,6 +56,9 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'deletes account successfully' do
+    @user.it1_profile = FactoryBot.create(:it1_profile, user: @user)
+    @user.it2_profile = FactoryBot.create(:it2_profile, user: @user)
+    @user.it2_survey = FactoryBot.create(:it2_survey, user: @user)
     delete settings_delete_account_url,
            params: { user: { verification_text: 'delete my account 55555', verification_number: 55_555 } }
     follow_redirect!


### PR DESCRIPTION
### Description

Fixes this error:

```
PG::ForeignKeyViolation: ERROR:  update or delete on table "users" violates foreign key constraint "fk_rails_4650fd3769" on table "it1_profiles"
DETAIL:  Key (id)=(17392) is still referenced from table "it1_profiles".
```

### Test Plan
I wrote automated tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1840)
<!-- Reviewable:end -->
