### PR TITLE
[state commit] Add a metric to check latency

### DIFF
--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -367,8 +367,10 @@ impl StateStore {
         }
 
         // commit jellyfish merkle nodes
+        let _timer = OTHER_TIMERS_SECONDS
+            .with_label_values(&["commit_jellyfish_merkle_nodes"])
+            .start_timer();
         self.state_merkle_db.write_schemas(batch)?;
-
         Ok(new_root_hash)
     }
 


### PR DESCRIPTION
### Description
Add a metric to check latency of state commits

### Test Plan
<img width="1225" alt="Screen Shot 2022-07-08 at 4 05 23 PM" src="https://user-images.githubusercontent.com/107430656/178080661-1bcc6a06-0701-457a-81a4-a48f02ab8070.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1842)
<!-- Reviewable:end -->
