### PR TITLE
[tf][aptos-node] use logger full service name

### DIFF
--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -115,7 +115,7 @@ locals {
         value  = "validators"
         effect = "NoExecute"
       }]
-      remoteLogAddress = var.enable_logger ? "${helm_release.logger[0].name}-aptos-logger:5044" : null
+      remoteLogAddress = var.enable_logger ? "${helm_release.logger[0].name}-aptos-logger.${helm_release.logger[0].namespace}.svc:5044" : null
     }
     fullnode = {
       storage = {


### PR DESCRIPTION
Use the full logger service name (with the namespace specified), instead of assuming that `aptos-node` and `logger` are installed in the same k8s namespace.

This gets us Forge logs from all validators across all namespaces, though there are no structlog fields that specify namespace, so you can't filter them really yet. We probably should be pulling logs from stdout rather than having `aptos-node` binary itself shipping logs 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1847)
<!-- Reviewable:end -->
