### PR TITLE
[logger] add optional namespace field

### DIFF
--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -116,7 +116,7 @@ locals {
         value  = "validators"
         effect = "NoExecute"
       }]
-      remoteLogAddress = var.enable_logger ? "${helm_release.logger[0].name}-aptos-logger:5044" : null
+      remoteLogAddress = var.enable_logger ? "${helm_release.logger[0].name}-aptos-logger.${helm_release.logger[0].namespace}.svc:5044" : null
     }
     fullnode = {
       storage = {

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -83,6 +83,10 @@ spec:
         - name: STRUCT_LOG_TCP_ADDR
           value: {{ $.Values.validator.remoteLogAddress }}
         {{- end }}
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: RUST_BACKTRACE
           value: "0"
         volumeMounts:

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -87,6 +87,10 @@ spec:
           value: {{ .remoteLogAddress }}
         {{- end }}
       {{- end }}
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: RUST_BACKTRACE
           value: "0"
         volumeMounts:

--- a/terraform/helm/fullnode/templates/fullnode.yaml
+++ b/terraform/helm/fullnode/templates/fullnode.yaml
@@ -38,6 +38,10 @@ spec:
           value: {{ .Values.rust_log }}
         - name: RUST_LOG_REMOTE
           value: {{ .Values.rust_log_remote }}
+        - name: KUBERNETES_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: RUST_BACKTRACE
           value: "0"
         volumeMounts:


### PR DESCRIPTION
Stacked on https://github.com/aptos-labs/aptos-core/pull/1847

Add an optional `namespace` field to structured logs, which is set by `KUBERNETES_NAMESPACE` environment variable. This lets us filter logs in Forge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1849)
<!-- Reviewable:end -->
