### PR TITLE
[bug-fix] read snapshot version before latest txn version at initialization

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1210,7 +1210,12 @@ impl DbReader for AptosDB {
 
     fn get_latest_state_checkpoint(&self) -> Result<Option<(Version, HashValue)>> {
         gauged_api("get_latest_state_checkpoint_version", || {
-            self.state_store.get_state_snapshot_before(Version::MAX)
+            let num_txns = self
+                .ledger_store
+                .get_latest_transaction_info_option()?
+                .map(|(version, _)| version + 1)
+                .unwrap_or(0);
+            self.state_store.get_state_snapshot_before(num_txns)
         })
     }
 


### PR DESCRIPTION
…StatStore initialization

### Description
Currently we commit `state_merkle_db` before `ledger_db` when saving txn outputs. So if a node gets killed in between, state_merkle_db state can be ahead of ledger_db. While when we restart db, state store read from latest snapshot while ledger db doesn't have its corresponding data at the version of the latest snapshot (because node crashes before the ledger db commit).

Soon we will move state_merkle_db commit later than ledger_db so the issue will disappear implicitly.

### Test Plan
cargo x test -p smoke-test -- test_validator_bootstrap_outputs --nocapture

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1852)
<!-- Reviewable:end -->
