### PR TITLE
[blockchain] make state-checkpoint-transaction hash unique

### DIFF
--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -229,7 +229,7 @@ impl TestContext {
                     .cloned()
                     .map(Transaction::UserTransaction),
             )
-            .chain(once(Transaction::StateCheckpoint))
+            .chain(once(Transaction::StateCheckpoint(metadata.id())))
             .collect();
 
         // Check that txn execution was successful.

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -99,7 +99,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
                 (info, payload, events).into()
             }
             BlockMetadata(txn) => (&txn, info, events).into(),
-            StateCheckpoint => {
+            StateCheckpoint(_) => {
                 Transaction::StateCheckpointTransaction(StateCheckpointTransaction {
                     info,
                     timestamp: timestamp.into(),

--- a/aptos-move/aptos-vm/src/adapter_common.rs
+++ b/aptos-move/aptos-vm/src/adapter_common.rs
@@ -269,7 +269,7 @@ pub(crate) fn preprocess_transaction<A: VMAdapter>(txn: Transaction) -> Preproce
                 _ => PreprocessedTransaction::UserTransaction(Box::new(checked_txn)),
             }
         }
-        Transaction::StateCheckpoint => PreprocessedTransaction::StateCheckpoint,
+        Transaction::StateCheckpoint(_) => PreprocessedTransaction::StateCheckpoint,
     }
 }
 

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -341,7 +341,7 @@ impl Block {
                 .into_iter()
                 .map(Transaction::UserTransaction),
         )
-        .chain(once(Transaction::StateCheckpoint))
+        .chain(once(Transaction::StateCheckpoint(self.id)))
         .collect()
     }
 

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_generator::{AccountCache, AccountGenerator};
-use aptos_crypto::ed25519::Ed25519PrivateKey;
+use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue};
 use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_types::{
@@ -279,7 +279,7 @@ impl TransactionGenerator {
                     vec![create, mint]
                 })
                 .map(Transaction::UserTransaction)
-                .chain(once(Transaction::StateCheckpoint))
+                .chain(once(Transaction::StateCheckpoint(HashValue::random())))
                 .collect();
             self.version += transactions.len() as Version;
             bar.inc(transactions.len() as u64 - 1);
@@ -331,7 +331,7 @@ impl TransactionGenerator {
                         )
                 })
                 .map(Transaction::UserTransaction)
-                .chain(once(Transaction::StateCheckpoint))
+                .chain(once(Transaction::StateCheckpoint(HashValue::random())))
                 .collect();
             self.version += transactions.len() as Version;
             if let Some(sender) = &self.block_sender {
@@ -366,7 +366,7 @@ impl TransactionGenerator {
                     )
                 })
                 .map(Transaction::UserTransaction)
-                .chain(once(Transaction::StateCheckpoint))
+                .chain(once(Transaction::StateCheckpoint(HashValue::random())))
                 .collect();
             self.version += transactions.len() as Version;
 

--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -127,7 +127,7 @@ impl ExecutedChunk {
                 || self
                     .to_commit
                     .last()
-                    .map_or(true, |(t, _)| matches!(t, Transaction::StateCheckpoint)),
+                    .map_or(true, |(t, _)| matches!(t, Transaction::StateCheckpoint(_))),
             "Chunk not ending with a state checkpoint.",
         );
         Ok(())

--- a/execution/executor-types/src/in_memory_state_calculator.rs
+++ b/execution/executor-types/src/in_memory_state_calculator.rs
@@ -150,7 +150,7 @@ impl InMemoryStateCalculator {
                 Transaction::BlockMetadata(_) | Transaction::UserTransaction(_) => {
                     Ok((HashMap::new(), HashMap::new(), None))
                 }
-                Transaction::GenesisTransaction(_) | Transaction::StateCheckpoint => {
+                Transaction::GenesisTransaction(_) | Transaction::StateCheckpoint(_) => {
                     self.checkpoint()
                 }
             }
@@ -340,7 +340,7 @@ fn ensure_txn_valid_for_vacant_entry(transaction: &Transaction) -> Result<()> {
             }
             TransactionPayload::WriteSet(_) => (),
         },
-        Transaction::StateCheckpoint => {}
+        Transaction::StateCheckpoint(_) => {}
     }
     Ok(())
 }

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -84,7 +84,7 @@ impl VMExecutor for MockVM {
         let mut outputs = vec![];
 
         for txn in transactions {
-            if matches!(txn, Transaction::StateCheckpoint) {
+            if matches!(txn, Transaction::StateCheckpoint(_)) {
                 outputs.push(TransactionOutput::new(
                     WriteSet::default(),
                     vec![],

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -285,7 +285,7 @@ fn create_transaction_chunks(
         let txn = encode_mint_transaction(gen_address(i), 100);
         txns.push(txn);
     }
-    txns.push(Transaction::StateCheckpoint);
+    txns.push(Transaction::StateCheckpoint(HashValue::random()));
     let id = gen_block_id(1);
 
     let output = executor
@@ -376,7 +376,7 @@ fn apply_transaction_by_writeset(
             )
         })
         .chain(once((
-            Transaction::StateCheckpoint,
+            Transaction::StateCheckpoint(HashValue::random()),
             TransactionOutput::new(
                 WriteSet::default(),
                 Vec::new(),

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -461,7 +461,7 @@ pub fn verify_committed_transactions(
             txn_info.transaction_hash(),
             txn_to_commit.transaction().hash()
         );
-        if matches!(txn_to_commit.transaction(), Transaction::StateCheckpoint) {
+        if matches!(txn_to_commit.transaction(), Transaction::StateCheckpoint(_)) {
             continue;
         }
 

--- a/storage/backup/backup-cli/src/backup_types/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/tests.rs
@@ -47,7 +47,7 @@ fn test_data_strategy() -> impl Strategy<Value = TestData> {
         .into_iter()
         .enumerate()
         .filter_map(|(idx, txn)| match txn {
-            Transaction::GenesisTransaction(..) | Transaction::StateCheckpoint => {
+            Transaction::GenesisTransaction(_) | Transaction::StateCheckpoint(_) => {
                 Some(idx as Version)
             }
             _ => None,

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -167,7 +167,9 @@ Transaction:
         NEWTYPE:
           TYPENAME: BlockMetadata
     3:
-      StateCheckpoint: UNIT
+      StateCheckpoint:
+        NEWTYPE:
+          TYPENAME: HashValue
 TransactionArgument:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -375,7 +375,9 @@ Transaction:
         NEWTYPE:
           TYPENAME: BlockMetadata
     3:
-      StateCheckpoint: UNIT
+      StateCheckpoint:
+        NEWTYPE:
+          TYPENAME: HashValue
 TransactionArgument:
   ENUM:
     0:

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -1138,7 +1138,7 @@ impl BlockGen {
             })
             .collect();
         txns_to_commit.push(TransactionToCommit::new(
-            Transaction::StateCheckpoint,
+            Transaction::StateCheckpoint(HashValue::random()),
             TransactionInfo::new_placeholder(0, ExecutionStatus::Success),
             state_updates,
             None,

--- a/types/src/test_helpers/transaction_test_helpers.rs
+++ b/types/src/test_helpers/transaction_test_helpers.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     write_set::WriteSet,
 };
-use aptos_crypto::{ed25519::*, traits::*};
+use aptos_crypto::{ed25519::*, traits::*, HashValue};
 
 const MAX_GAS_AMOUNT: u64 = 1_000_000;
 const TEST_GAS_PRICE: u64 = 0;
@@ -253,6 +253,6 @@ pub fn get_write_set_txn(
 }
 
 pub fn block(mut user_txns: Vec<Transaction>) -> Vec<Transaction> {
-    user_txns.push(Transaction::StateCheckpoint);
+    user_txns.push(Transaction::StateCheckpoint(HashValue::random()));
     user_txns
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1492,7 +1492,8 @@ pub enum Transaction {
 
     /// Transaction to let the executor update the global state tree and record the root hash
     /// in the TransactionInfo
-    StateCheckpoint,
+    /// The hash value inside is unique block id which can generate unique hash of state checkpoint transaction
+    StateCheckpoint(HashValue),
 }
 
 impl Transaction {
@@ -1513,7 +1514,7 @@ impl Transaction {
             // TODO: display proper information for client
             Transaction::BlockMetadata(_block_metadata) => String::from("block_metadata"),
             // TODO: display proper information for client
-            Transaction::StateCheckpoint => String::from("state_checkpoint"),
+            Transaction::StateCheckpoint(_) => String::from("state_checkpoint"),
         }
     }
 }


### PR DESCRIPTION
### Description
@CapCap and @gregnazario want unique txn hash for each txn for external requirements but our state checkpoint txns are always the same (empty). So we agreed to add block_id, a hash, into it to produce unique hash.

### Test Plan
cargo xtest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1853)
<!-- Reviewable:end -->
