### PR TITLE
[gha/docker] fix tools image usage in forge

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -84,8 +84,10 @@ jobs:
             --image="${AWS_ACCOUNT_NUM}.dkr.ecr.${AWS_REGION}.amazonaws.com/aptos/forge:$IMAGE_TAG" \
             --command -- forge test k8s-swarm --image-tag $IMAGE_TAG --namespace $FORGE_NAMESPACE
 
+          # wait for enough time for the pod to start and potentially new nodes to come online
+          kubectl wait --timeout=5m --for=condition=Ready "pod/${FORGE_POD_NAME}"
+
           # tail the logs to get them in GHA runner. tee them for further parsing
-          kubectl wait --for=condition=Ready "pod/${FORGE_POD_NAME}"
           kubectl logs -f $FORGE_POD_NAME | tee $FORGE_OUTPUT
 
           FORGE_END_TIME_MS="$(date '+%s')000"

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -148,13 +148,13 @@ jobs:
 
           # report metrics to pushgateway
           echo "forge_job_status {FORGE_EXIT_CODE=\"$FORGE_EXIT_CODE\",FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\"} $GITHUB_RUN_ID" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
-
       - name: Post result as PR comment
         if: env.FORGE_ENABLED == 'true' && env.PR_NUMBER != null
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
             ${{ env.FORGE_COMMENT_HEADER }}
+            ${{ env.FORGE_BLOCKING == 'true' && 'Forge is land-blocking' || 'Forge is not land-blocking' }}
             * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             * [Grafana dashboard](${{ env.FORGE_DASHBOARD_LINK }})
             ```
@@ -167,6 +167,6 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         shell: bash
         run: |
-          if [ -n "$FORGE_BLOCKING" ]; then
+          if [ "$FORGE_BLOCKING" = "true" ]; then
             exit $FORGE_EXIT_CODE
           fi

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -80,6 +80,7 @@ RUN ln -s /usr/bin/python3 /usr/local/bin/python
 COPY --link docker/tools/boto.cfg /etc/boto.cfg
 
 RUN wget https://storage.googleapis.com/pub/gsutil.tar.gz -O- | tar --gzip --directory /opt --extract && ln -s /opt/gsutil/gsutil /usr/local/bin
+RUN cd /usr/local/bin && wget "https://storage.googleapis.com/kubernetes-release/release/v1.18.6/bin/linux/amd64/kubectl" -O kubectl && chmod +x kubectl
 
 COPY --link --from=builder /aptos/dist/db-bootstrapper /usr/local/bin/db-bootstrapper
 COPY --link --from=builder /aptos/dist/db-backup /usr/local/bin/db-backup


### PR DESCRIPTION
install `kubectl` in `tools` image since genesis ceremony uses it to create secrets. Here's a forge failure on main: https://github.com/aptos-labs/aptos-core/runs/7260707689?check_suite_focus=true

also make the Forge comment show if it's land-blocking or not

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1857)
<!-- Reviewable:end -->
