### PR TITLE
[CP] User profile dropdown on :hover due to Safari :focus

### DIFF
--- a/ecosystem/platform/server/app/components/header_component.html.erb
+++ b/ecosystem/platform/server/app/components/header_component.html.erb
@@ -21,7 +21,7 @@
         <% end %>
         </span>
       </button>
-      <div class="-translate-y-4 pt-8 absolute right-0 z-10 scale-0 opacity-0 group-focus:scale-100 group-focus-within:scale-100 group-focus:opacity-100 group-focus-within:opacity-100 origin-top-right transition-opacity duration-150 cursor-default">
+      <div class="-translate-y-4 pt-8 absolute right-0 z-10 scale-0 opacity-0 group-hover:scale-100 group-focus-within:scale-100 group-hover:opacity-100 group-focus-within:opacity-100 origin-top-right transition-opacity duration-150 cursor-default">
         <div class="text-gray-700 p-2 bg-black/95 border-neutral-800 border-t rounded-b-lg min-w-fit shadow-xl whitespace-nowrap w-48 flex flex-col gap-2">
         <% if @user&.username? %>
           <div class="text-teal-400 px-3 py-2 font-mono"><%= @user.username %></div>


### PR DESCRIPTION
### Description
Buttons are not click focusable in Safari - on click they don’t match `:focus`. This renders the `group-focus` tailwind class unusable in this situation which was dependent on `:focus` for displaying the dropdown. 

Revert back to `:hover` for now until dropdown display is driven by JS, or consider something other than `<button>`.

### Test Plan
Manual test on Safari / iOS clicking user profile icon to view dropdown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1863)
<!-- Reviewable:end -->
