### PR TITLE
[Aptos Ecosystem] update wallet fetch nfts field

### DIFF
--- a/ecosystem/web-wallet/src/pages/Gallery.tsx
+++ b/ecosystem/web-wallet/src/pages/Gallery.tsx
@@ -150,7 +150,7 @@ function Gallery() {
                 galleryItems?.map((item) => (
                   <GalleryItem
                     key={`${item.name}`}
-                    imageSrc={item.metadata?.image || 'https://www.publicdomainpictures.net/pictures/280000/nahled/not-found-image-15383864787lu.jpg'}
+                    imageSrc={item.uri || 'https://www.publicdomainpictures.net/pictures/280000/nahled/not-found-image-15383864787lu.jpg'}
                   />
                 ))
               )


### PR DESCRIPTION
### Description

Currently, wallet is fetching from `metadata.image`, which is the wrong Token's field and showing not found for all the NFTs in the wallet. 
![Screen Shot 2022-07-09 at 3 14 34 PM](https://user-images.githubusercontent.com/11470615/178124557-185b025b-ee24-4863-9a26-80d3171af630.png)

This updates wallet to fetch from `uri`instead

![Screen Shot 2022-07-09 at 3 16 01 PM](https://user-images.githubusercontent.com/11470615/178124580-9af88869-d4b6-4de2-91c0-e6526b72af0b.png)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1866)
<!-- Reviewable:end -->
