### PR TITLE
[aptos-rosetta] Make block info API, and get reconciliation working for Rosetta

### DIFF
--- a/api/src/blocks.rs
+++ b/api/src/blocks.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{context::Context, failpoint::fail_point, metrics::metrics, param::LedgerVersionParam};
+use anyhow::Result;
+use aptos_api_types::{Error, LedgerInfo, Response, TransactionId};
+use warp::{filters::BoxedFilter, Filter, Rejection, Reply};
+
+// GET /blocks/<version>
+pub fn get_block_info(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("blocks" / LedgerVersionParam)
+        .and(warp::get())
+        .and(context.filter())
+        .and_then(handle_get_block_info)
+        .with(metrics("get_block_info"))
+        .boxed()
+}
+
+async fn handle_get_block_info(
+    ledger_version: LedgerVersionParam,
+    context: Context,
+) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_block_info")?;
+    Ok(Block::new(Some(ledger_version), context)?.find_block()?)
+}
+
+pub(crate) struct Block {
+    version: u64,
+    latest_ledger_info: LedgerInfo,
+    context: Context,
+}
+
+impl Block {
+    pub fn new(
+        ledger_version: Option<LedgerVersionParam>,
+        context: Context,
+    ) -> Result<Self, Error> {
+        let latest_ledger_info = context.get_latest_ledger_info()?;
+        let ledger_version = ledger_version
+            .map(|v| v.parse("ledger version"))
+            .unwrap_or_else(|| Ok(latest_ledger_info.version()))?;
+
+        if ledger_version > latest_ledger_info.version() {
+            return Err(Error::not_found(
+                "ledger",
+                TransactionId::Version(ledger_version),
+                latest_ledger_info.version(),
+            ));
+        }
+
+        Ok(Self {
+            version: ledger_version,
+            latest_ledger_info,
+            context,
+        })
+    }
+
+    /// Scans the DB for block boundaries, then retrieves all the transactions associated
+    pub fn find_block(self) -> Result<Response, Error> {
+        let ledger_version = self.latest_ledger_info.version();
+        Response::new(
+            self.latest_ledger_info,
+            &self.context.get_block_info(self.version, ledger_version)?,
+        )
+    }
+}

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -133,7 +133,7 @@ impl Context {
     /// Retrieves information about a block
     pub fn get_block_info(&self, version: u64, ledger_version: u64) -> Result<Option<BlockInfo>> {
         // We scan the DB to get the block boundaries
-        let (start, end) = match self.db.get_block_boundaries(version) {
+        let (start, end) = match self.db.get_block_boundaries(version, ledger_version) {
             Ok(inner) => inner,
             Err(error) => {
                 debug!("Failed to get block boundaries {}", error);

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1,32 +1,34 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_api_types::{Error, LedgerInfo, TransactionOnChainData};
+use anyhow::{anyhow, ensure, format_err, Result};
+use aptos_api_types::{AsConverter, BlockInfo, Error, LedgerInfo, TransactionOnChainData, U64};
 use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::HashValue;
+use aptos_logger::debug;
 use aptos_mempool::{MempoolClientRequest, MempoolClientSender, SubmissionStatus};
+use aptos_state_view::StateView;
 use aptos_types::{
+    access_path::Path,
     account_address::AccountAddress,
+    account_config::aptos_root_address,
     account_state::AccountState,
     chain_id::ChainId,
     contract_event::ContractEvent,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{SignedTransaction, TransactionWithProof},
-};
-use storage_interface::{DbReader, Order};
-
-use anyhow::{anyhow, ensure, format_err, Result};
-use aptos_state_view::StateView;
-use aptos_types::{
     state_store::{state_key::StateKey, state_key_prefix::StateKeyPrefix},
-    transaction::Version,
+    transaction::{SignedTransaction, TransactionWithProof, Version},
+    write_set::WriteOp,
 };
 use aptos_vm::data_cache::{IntoMoveResolver, RemoteStorageOwned};
 use futures::{channel::oneshot, SinkExt};
+use move_deps::move_core_types::ident_str;
+use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, sync::Arc};
-use storage_interface::state_view::{
-    DbStateView, DbStateViewAtVersion, LatestDbStateCheckpointView,
+use storage_interface::{
+    state_view::{DbStateView, DbStateViewAtVersion, LatestDbStateCheckpointView},
+    DbReader, Order,
 };
 use warp::{filters::BoxedFilter, Filter, Reply};
 
@@ -126,6 +128,109 @@ impl Context {
 
     pub fn get_block_timestamp(&self, version: u64) -> Result<u64> {
         self.db.get_block_timestamp(version)
+    }
+
+    /// Retrieves information about a block
+    pub fn get_block_info(&self, version: u64, ledger_version: u64) -> Result<Option<BlockInfo>> {
+        // We scan the DB to get the block boundaries
+        let (start, end) = match self.db.get_block_boundaries(version) {
+            Ok(inner) => inner,
+            Err(error) => {
+                debug!("Failed to get block boundaries {}", error);
+                // None means we can't find the block
+                return Ok(None);
+            }
+        };
+
+        let txn_with_proof = self
+            .db
+            .get_transaction_by_version(start, ledger_version, false)?;
+
+        // Retrieve block timestamp and hash
+        let timestamp;
+        let block_hash;
+        use aptos_types::transaction::Transaction::*;
+        match &txn_with_proof.transaction {
+            GenesisTransaction(_) => {
+                timestamp = 0;
+                block_hash = txn_with_proof.proof.transaction_info.transaction_hash();
+            }
+            BlockMetadata(inner) => {
+                timestamp = inner.timestamp_usecs();
+                block_hash = inner.id();
+            }
+            _ => {
+                return Err(anyhow!(
+                    "Failed to retrieve BlockMetadata or Genesis transaction"
+                ));
+            }
+        }
+
+        // If timestamp is 0, it's the genesis transaction, and we can stop now
+        if timestamp == 0 {
+            return Ok(Some(BlockInfo {
+                block_height: 0,
+                start_version: start,
+                end_version: end,
+                block_hash: block_hash.into(),
+                block_timestamp: timestamp,
+                num_transactions: end.saturating_sub(start).saturating_add(1) as u16,
+            }));
+        }
+
+        // Retrieve block height from the transaction outputs
+        let height_id = ident_str!("height");
+        let block_metadata_type = move_deps::move_core_types::language_storage::StructTag {
+            address: AccountAddress::ONE,
+            module: ident_str!("Block").into(),
+            name: ident_str!("BlockMetadata").into(),
+            type_params: vec![],
+        };
+
+        let resolver = self.move_resolver()?;
+        let converter = resolver.as_converter();
+        let txn = self.get_transaction_by_version(start, ledger_version)?;
+
+        // Parse the resources and find the block metadata resource update
+        let maybe_block_height = txn.changes.iter().find_map(|(key, op)| {
+            if let StateKey::AccessPath(path) = key {
+                if let Path::Resource(typ) = path.get_path() {
+                    // If it's block metadata, we can convert it to get the block height
+                    // And it must be the root address
+                    if path.address == aptos_root_address() && typ == block_metadata_type {
+                        if let WriteOp::Value(value) = op {
+                            if let Ok(mut resource) = converter.try_into_resource(&typ, value) {
+                                if let Some(value) = resource.data.0.remove(height_id) {
+                                    if let Ok(height) = serde_json::from_value::<U64>(value) {
+                                        return Some(height.0);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            None
+        });
+
+        // This should always work unless there's something unexpected in the block format
+        if let Some(block_height) = maybe_block_height {
+            Ok(Some(BlockInfo {
+                block_height,
+                start_version: start,
+                end_version: end,
+                block_hash: block_hash.into(),
+                block_timestamp: timestamp,
+                num_transactions: end.saturating_sub(start).saturating_add(1) as u16,
+            }))
+        } else {
+            Err(anyhow!(
+                "Unable to find block height in metadata transaction {}:{}",
+                start,
+                end
+            ))
+        }
     }
 
     pub fn get_transactions(
@@ -266,4 +371,10 @@ impl Context {
     pub fn health_check_route(&self) -> BoxedFilter<(impl Reply,)> {
         super::health_check::health_check_route(self.db.clone())
     }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BlockMetadataState {
+    epoch_internal: U64,
+    height: U64,
 }

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    accounts,
+    accounts, blocks,
     context::Context,
     events,
     failpoint::fail_point,
@@ -30,6 +30,7 @@ pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Inf
         .or(accounts::get_account(context.clone()))
         .or(accounts::get_account_resources(context.clone()))
         .or(accounts::get_account_modules(context.clone()))
+        .or(blocks::get_block_info(context.clone()))
         .or(transactions::get_bcs_transaction(context.clone()))
         .or(transactions::get_json_transaction(context.clone()))
         .or(transactions::get_bcs_transactions(context.clone()))

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -16,6 +16,7 @@ mod state;
 mod transactions;
 pub(crate) mod version;
 
+mod blocks;
 mod failpoint;
 #[cfg(any(test))]
 pub(crate) mod tests;

--- a/api/types/src/block.rs
+++ b/api/types/src/block.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::HashValue;
+use serde::{Deserialize, Serialize};
+
+/// A description of a block
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+pub struct BlockInfo {
+    pub block_height: u64,
+    pub block_hash: HashValue,
+    pub block_timestamp: u64,
+    pub start_version: u64,
+    pub end_version: u64,
+    pub num_transactions: u16,
+}

--- a/api/types/src/hash.rs
+++ b/api/types/src/hash.rs
@@ -4,7 +4,7 @@
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str::FromStr};
 
-#[derive(Clone, Debug, PartialEq, Copy)]
+#[derive(Debug, Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct HashValue(aptos_crypto::hash::HashValue);
 
 impl From<aptos_crypto::hash::HashValue> for HashValue {

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod account;
 mod address;
+mod block;
 mod bytecode;
 mod convert;
 mod error;
@@ -18,6 +19,7 @@ mod transaction;
 
 pub use account::AccountData;
 pub use address::Address;
+pub use block::BlockInfo;
 pub use bytecode::Bytecode;
 pub use convert::{new_vm_ascii_string, AsConverter, MoveConverter};
 pub use error::Error;

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -12,7 +12,7 @@ use aptos_config::{
 };
 use aptos_data_client::aptosnet::AptosNetDataClient;
 use aptos_infallible::RwLock;
-use aptos_logger::prelude::*;
+use aptos_logger::{prelude::*, Level};
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_time_service::TimeService;
 use aptos_types::{
@@ -150,7 +150,7 @@ pub fn load_test_environment<R>(
         maybe_config.push("validator_node_template.yaml");
         let mut template = NodeConfig::load_config(maybe_config)
             .unwrap_or_else(|_| NodeConfig::default_for_validator());
-
+        template.logger.level = Level::Debug;
         // enable REST and JSON-RPC API
         template.api.address = format!("0.0.0.0:{}", template.api.address.port())
             .parse()

--- a/crates/aptos-rosetta/rosetta_cli.json
+++ b/crates/aptos-rosetta/rosetta_cli.json
@@ -3,12 +3,12 @@
         "blockchain": "aptos",
         "network": "TESTING"
     },
-    "online_url": "http://192.168.1.126:8082",
-    "data_directory": "",
+    "online_url": "http://localhost:8082",
+    "data_directory": "data",
     "http_timeout": 30,
     "max_retries": 5,
     "retry_elapsed_time": 0,
-    "max_online_connections": 500,
+    "max_online_connections": 100,
     "max_sync_concurrency": 64,
     "tip_delay": 120,
     "max_reorg_depth": 100,
@@ -18,9 +18,9 @@
     "error_stack_trace_disabled": false,
     "coin_supported": false,
     "construction": {
-        "offline_url": "http://192.168.1.126:8083",
-        "max_offline_connections": 500,
-        "stale_depth": 100000,
+        "offline_url": "http://localhost:8083",
+        "max_offline_connections": 100,
+        "stale_depth": 1000,
         "broadcast_limit": 5,
         "ignore_broadcast_failures": false,
         "clear_broadcasts": false,
@@ -29,10 +29,13 @@
         "rebroadcast_all": false,
         "constructor_dsl_file": "aptos.ros",
         "status_port": 9090,
+        "force_retry": true,
         "end_conditions": {
             "create_account": 10,
             "transfer": 20
-        }
+        },
+        "prefunded_accounts": [
+        ]
     },
     "data": {
         "active_reconciliation_concurrency": 16,
@@ -60,7 +63,6 @@
             "tip": true,
             "reconciliation_coverage": {
                 "coverage": 0.95,
-                "from_tip": true,
                 "tip": true
             }
         }

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -241,7 +241,7 @@ async fn construction_metadata(
 
     let rest_client = server_context.rest_client()?;
     let address = request.options.internal_operation.sender();
-    let response = get_account(rest_client, address).await?;
+    let response = get_account(&rest_client, address).await?;
 
     // Ensure this network really is the one we expect it to be
     if server_context.chain_id.id() != response.state().chain_id {

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -21,13 +21,8 @@ async fn main() {
     let args: CommandArgs = CommandArgs::parse();
 
     // Ensure runtime for Rosetta is up and running
-    let _runtime = bootstrap(
-        args.block_size(),
-        args.chain_id(),
-        args.api_config(),
-        args.rest_client(),
-    )
-    .expect("Should bootstrap");
+    let _runtime = bootstrap(args.chain_id(), args.api_config(), args.rest_client())
+        .expect("Should bootstrap");
 
     // Run until there is an interrupt
     let term = Arc::new(AtomicBool::new(false));
@@ -46,9 +41,6 @@ trait ServerArgs {
 
     /// Retrieve the chain id
     fn chain_id(&self) -> ChainId;
-
-    /// Size of the imaginary blocks made up for this system
-    fn block_size(&self) -> u64;
 }
 
 /// Aptos Rosetta API Server
@@ -84,13 +76,6 @@ impl ServerArgs for CommandArgs {
             CommandArgs::Offline(args) => args.chain_id(),
         }
     }
-
-    fn block_size(&self) -> u64 {
-        match self {
-            CommandArgs::Online(args) => args.block_size(),
-            CommandArgs::Offline(args) => args.block_size(),
-        }
-    }
 }
 
 #[derive(Debug, Parser)]
@@ -110,9 +95,6 @@ pub struct OfflineArgs {
     /// ChainId to be used for the server e.g. TESTNET
     #[clap(long, default_value = "TESTING")]
     chain_id: ChainId,
-    /// Block size to emulate blocks
-    #[clap(long, default_value_t = 1000)]
-    block_size: u64,
 }
 
 impl ServerArgs for OfflineArgs {
@@ -132,10 +114,6 @@ impl ServerArgs for OfflineArgs {
 
     fn chain_id(&self) -> ChainId {
         self.chain_id
-    }
-
-    fn block_size(&self) -> u64 {
-        self.block_size
     }
 }
 
@@ -159,9 +137,5 @@ impl ServerArgs for OnlineArgs {
 
     fn chain_id(&self) -> ChainId {
         self.offline_args.chain_id
-    }
-
-    fn block_size(&self) -> u64 {
-        self.offline_args.block_size
     }
 }

--- a/ecosystem/indexer/src/indexer/fetcher.rs
+++ b/ecosystem/indexer/src/indexer/fetcher.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 // TODO: make this configurable
 const RETRY_TIME_MILLIS: u64 = 5000;
-const TRANSACTION_FETCH_BATCH_SIZE: u64 = 500;
+const TRANSACTION_FETCH_BATCH_SIZE: u16 = 500;
 
 #[derive(Debug)]
 pub struct TransactionFetcher {

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1184,6 +1184,12 @@ impl DbReader for AptosDB {
         })
     }
 
+    fn get_block_boundaries(&self, version: u64) -> Result<(u64, u64)> {
+        gauged_api("get_block_boundaries", || {
+            self.transaction_store.get_block_boundaries(version)
+        })
+    }
+
     fn get_last_version_before_timestamp(
         &self,
         timestamp: u64,

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1184,9 +1184,10 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_block_boundaries(&self, version: u64) -> Result<(u64, u64)> {
+    fn get_block_boundaries(&self, version: u64, latest_ledger_version: u64) -> Result<(u64, u64)> {
         gauged_api("get_block_boundaries", || {
-            self.transaction_store.get_block_boundaries(version)
+            self.transaction_store
+                .get_block_boundaries(version, latest_ledger_version)
         })
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -266,7 +266,7 @@ pub trait DbReader: Send + Sync {
     ///
     /// [AptosDB::get_block_boundaries]:
     /// ../aptosdb/struct.AptosDB.html#method.get_block_boundaries
-    fn get_block_boundaries(&self, version: u64) -> Result<(u64, u64)> {
+    fn get_block_boundaries(&self, version: u64, latest_ledger_version: u64) -> Result<(u64, u64)> {
         unimplemented!()
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -262,6 +262,14 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
+    /// See [AptosDB::get_block_boundaries].
+    ///
+    /// [AptosDB::get_block_boundaries]:
+    /// ../aptosdb/struct.AptosDB.html#method.get_block_boundaries
+    fn get_block_boundaries(&self, version: u64) -> Result<(u64, u64)> {
+        unimplemented!()
+    }
+
     /// Gets the version of the last transaction committed before timestamp,
     /// a committed block at or after the required timestamp must exist (otherwise it's possible
     /// the next block committed as a timestamp smaller than the one in the request).

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -37,7 +37,6 @@ pub async fn setup_test(
 
     // Start the server
     let _rosetta = aptos_rosetta::bootstrap_async(
-        10,
         swarm.chain_id(),
         api_config,
         Some(aptos_rest_client::Client::new(


### PR DESCRIPTION
### Description
To get Rosetta working, I had to reconstruct the blocks from ledger versions.  This currently doesn't handle any proper on disk storage, which is another step on this.  But, it does work entirely in memory if there is continually blocks being searched for.

This does a scan for the BlockMetadata transaction, and for the StateCheckpoint to figure out the boundaries for the block, and exposes this as an API with the block hash and other information needed.

There are a ton of performance things that could be updated, but this is an MVP.  Still need to work through the testing for the transfer APIs.


### Test Plan

```
$ rosetta-cli check:data --configuration-file rosetta_cli.json

[STATS] Blocks: 2600 (Orphaned: 0) Transactions: 5184 Operations: 36 Accounts: 5 Reconciliations: 49 (Inactive: 27, Exempt: 0, Skipped: 0, Coverage: 100.000000%)

Success: Reconciliation Coverage End Condition [Coverage: 100.000000%]

+--------------------+--------------------------------+--------+
|  CHECK:DATA TESTS  |          DESCRIPTION           | STATUS |
+--------------------+--------------------------------+--------+
| Request/Response   | Rosetta implementation         | PASSED |
|                    | serviced all requests          |        |
+--------------------+--------------------------------+--------+
| Response Assertion | All responses are correctly    | PASSED |
|                    | formatted                      |        |
+--------------------+--------------------------------+--------+
| Block Syncing      | Blocks are connected into a    | PASSED |
|                    | single canonical chain         |        |
+--------------------+--------------------------------+--------+
| Balance Tracking   | Account balances did not go    | PASSED |
|                    | negative                       |        |
+--------------------+--------------------------------+--------+
| Reconciliation     | No balance discrepancies were  | PASSED |
|                    | found between computed and     |        |
|                    | live balances                  |        |
+--------------------+--------------------------------+--------+

+--------------------------+--------------------------------+-------------+
|     CHECK:DATA STATS     |          DESCRIPTION           |    VALUE    |
+--------------------------+--------------------------------+-------------+
| Blocks                   | # of blocks synced             |        2600 |
+--------------------------+--------------------------------+-------------+
| Orphans                  | # of blocks orphaned           |           0 |
+--------------------------+--------------------------------+-------------+
| Transactions             | # of transaction processed     |        5184 |
+--------------------------+--------------------------------+-------------+
| Operations               | # of operations processed      |          36 |
+--------------------------+--------------------------------+-------------+
| Accounts                 | # of accounts seen             |           5 |
+--------------------------+--------------------------------+-------------+
| Active Reconciliations   | # of reconciliations performed |          22 |
|                          | after seeing an account in a   |             |
|                          | block                          |             |
+--------------------------+--------------------------------+-------------+
| Inactive Reconciliations | # of reconciliations performed |          27 |
|                          | on randomly selected accounts  |             |
+--------------------------+--------------------------------+-------------+
| Exempt Reconciliations   | # of reconciliation failures   |           0 |
|                          | considered exempt              |             |
+--------------------------+--------------------------------+-------------+
| Failed Reconciliations   | # of reconciliation failures   |           0 |
+--------------------------+--------------------------------+-------------+
| Skipped Reconciliations  | # of reconciliations skipped   |           0 |
+--------------------------+--------------------------------+-------------+
| Reconciliation Coverage  | % of accounts that have been   | 100.000000% |
|                          | reconciled                     |             |
+--------------------------+--------------------------------+-------------+

badger 2022/07/10 00:59:36 INFO: Storing value log head: {Fid:0 Len:32 Offset:3606533}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1867)
<!-- Reviewable:end -->
