### PR TITLE
[aptos-cli] Add local testnet command to run a local testnet node and mint coins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "anyhow",
  "aptos-config",
  "aptos-crypto",
+ "aptos-faucet",
  "aptos-genesis",
  "aptos-github-client",
  "aptos-keygen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 dependencies = [
  "backtrace",
 ]
@@ -688,6 +688,7 @@ dependencies = [
 name = "aptos-node"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-api",
  "aptos-config",
  "aptos-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
  "aptos-keygen",
  "aptos-logger",
  "aptos-module-verifier",
+ "aptos-node",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-secure-storage",

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.58"
 bcs = "0.1.3"
 clap = "3.1.8"
 fail = "0.5.0"

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+use anyhow::anyhow;
 use aptos_api::runtime::bootstrap as bootstrap_api;
 use aptos_config::{
     config::{
@@ -126,10 +127,11 @@ impl AptosNodeArgs {
                 self.lazy,
                 genesis_modules,
                 rng,
-            );
+            )
+            .expect("Test mode should start correctly");
         } else {
             // Load the config file
-            let config_path = self.config.unwrap();
+            let config_path = self.config.expect("Config is required to launch node");
             let config = NodeConfig::load(config_path.clone()).unwrap_or_else(|error| {
                 panic!(
                     "Failed to load node config file! Given file path: {:?}. Error: {:?}",
@@ -139,7 +141,7 @@ impl AptosNodeArgs {
             println!("Using node config {:?}", &config);
 
             // Start the node
-            start(config, None);
+            start(config, None).expect("Node should start correctly");
         };
     }
 }
@@ -156,7 +158,7 @@ pub struct AptosHandle {
 }
 
 /// Start an aptos node
-pub fn start(config: NodeConfig, log_file: Option<PathBuf>) {
+pub fn start(config: NodeConfig, log_file: Option<PathBuf>) -> anyhow::Result<()> {
     crash_handler::setup_panic_handler();
 
     let mut logger = aptos_logger::Logger::new();
@@ -187,12 +189,13 @@ pub fn start(config: NodeConfig, log_file: Option<PathBuf>) {
         warn!("failpoints is set in config, but the binary doesn't compile with this feature");
     }
 
-    let _node_handle = setup_environment(config);
+    let _node_handle = setup_environment(config)?;
     let term = Arc::new(AtomicBool::new(false));
 
     while !term.load(Ordering::Acquire) {
         std::thread::park();
     }
+    Ok(())
 }
 
 const EPOCH_LENGTH_SECS: u64 = 60;
@@ -204,7 +207,8 @@ pub fn load_test_environment<R>(
     lazy: bool,
     genesis_modules: Vec<Vec<u8>>,
     rng: R,
-) where
+) -> anyhow::Result<()>
+where
     R: ::rand::RngCore + ::rand::CryptoRng,
 {
     // If there wasn't a testnet directory given, create a temp one
@@ -217,9 +221,8 @@ pub fn load_test_environment<R>(
     // Create the directories for the node
     std::fs::DirBuilder::new()
         .recursive(true)
-        .create(&test_dir)
-        .unwrap();
-    let test_dir = test_dir.canonicalize().unwrap();
+        .create(&test_dir)?;
+    let test_dir = test_dir.canonicalize()?;
 
     // The validator builder puts the first node in the 0 directory
     let validator_config_path = test_dir.join("0").join("node.yaml");
@@ -227,7 +230,8 @@ pub fn load_test_environment<R>(
 
     // If there's already a config, use it
     let config = if validator_config_path.exists() {
-        NodeConfig::load(&validator_config_path).expect("Unable to load config:")
+        NodeConfig::load(&validator_config_path)
+            .map_err(|err| anyhow!("Unable to load config: {}", err))?
     } else {
         // Build a single validator network with a generated config
         let mut template = NodeConfig::default_for_validator();
@@ -241,20 +245,14 @@ pub fn load_test_environment<R>(
 
         template.logger.level = Level::Debug;
         // enable REST and JSON-RPC API
-        template.api.address = format!("0.0.0.0:{}", template.api.address.port())
-            .parse()
-            .unwrap();
+        template.api.address = format!("0.0.0.0:{}", template.api.address.port()).parse()?;
         if lazy {
             template.consensus.quorum_store_poll_count = u64::MAX;
         }
 
         // Build genesis and validator node
-        let now_secs = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        let builder = aptos_genesis::builder::Builder::new(&test_dir, genesis_modules)
-            .unwrap()
+        let now_secs = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+        let builder = aptos_genesis::builder::Builder::new(&test_dir, genesis_modules)?
             .with_allow_new_validators(true)
             .with_epoch_duration_secs(EPOCH_LENGTH_SECS)
             .with_template(template)
@@ -263,20 +261,19 @@ pub fn load_test_environment<R>(
             .with_min_lockup_duration_secs(0)
             .with_max_lockup_duration_secs(86400);
 
-        let (root_key, _genesis, genesis_waypoint, validators) = builder.build(rng).unwrap();
+        let (root_key, _genesis, genesis_waypoint, validators) = builder.build(rng)?;
 
         // Write the mint key to disk
-        let serialized_keys = bcs::to_bytes(&root_key).unwrap();
-        let mut key_file = std::fs::File::create(&aptos_root_key_path).unwrap();
-        key_file.write_all(&serialized_keys).unwrap();
+        let serialized_keys = bcs::to_bytes(&root_key)?;
+        let mut key_file = std::fs::File::create(&aptos_root_key_path)?;
+        key_file.write_all(&serialized_keys)?;
 
         // Build a waypoint file so that clients / docker can grab it easily
         let waypoint_file_path = test_dir.join("waypoint.txt");
         std::io::Write::write_all(
-            &mut std::fs::File::create(&waypoint_file_path).unwrap(),
+            &mut std::fs::File::create(&waypoint_file_path)?,
             genesis_waypoint.to_string().as_bytes(),
-        )
-        .unwrap();
+        )?;
 
         validators[0].config.clone()
     };
@@ -305,17 +302,17 @@ pub fn load_test_environment<R>(
 }
 
 // Fetch chain ID from on-chain resource
-fn fetch_chain_id(db: &DbReaderWriter) -> ChainId {
+fn fetch_chain_id(db: &DbReaderWriter) -> anyhow::Result<ChainId> {
     let db_state_view = db
         .reader
         .latest_state_checkpoint_view()
-        .expect("[aptos-node] failed to create db state view");
-    db_state_view
+        .map_err(|err| anyhow!("[aptos-node] failed to create db state view {}", err))?;
+    Ok(db_state_view
         .as_account_with_state_view(&CORE_CODE_ADDRESS)
         .get_chain_id_resource()
-        .expect("[aptos-node] failed to get chain ID resource")
+        .map_err(|err| anyhow!("[aptos-node] failed to get chain id resource {}", err))?
         .expect("[aptos-node] missing chain ID resource")
-        .chain_id()
+        .chain_id())
 }
 
 fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
@@ -332,13 +329,13 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
     waypoint: Waypoint,
     event_subscription_service: EventSubscriptionService,
     db_rw: DbReaderWriter,
-) -> StateSyncRuntimes {
+) -> anyhow::Result<StateSyncRuntimes> {
     // Start the state sync storage service
     let storage_service_runtime = setup_state_sync_storage_service(
         node_config.state_sync.storage_service,
         storage_service_server_network_handles,
         &db_rw,
-    );
+    )?;
 
     // Start the data client
     let (aptos_data_client, aptos_data_client_runtime) = setup_aptos_data_client(
@@ -347,17 +344,18 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
         node_config.base.clone(),
         storage_service_client_network_handles,
         peer_metadata_storage,
-    );
+    )?;
 
     // Start the data streaming service
     let (streaming_service_client, streaming_service_runtime) = setup_data_streaming_service(
         node_config.state_sync.data_streaming_service,
         aptos_data_client.clone(),
-    );
+    )?;
 
     // Create the chunk executor
     let chunk_executor = Arc::new(
-        ChunkExecutor::<AptosVM>::new(db_rw.clone()).expect("Unable to create the chunk executor!"),
+        ChunkExecutor::<AptosVM>::new(db_rw.clone())
+            .map_err(|err| anyhow!("Failed to create chunk executor {}", err))?,
     );
 
     // Create the state sync multiplexer
@@ -375,18 +373,18 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
     );
 
     // Create and return the new state sync handle
-    StateSyncRuntimes::new(
+    Ok(StateSyncRuntimes::new(
         aptos_data_client_runtime,
         state_sync_multiplexer,
         storage_service_runtime,
         streaming_service_runtime,
-    )
+    ))
 }
 
 fn setup_data_streaming_service(
     config: DataStreamingServiceConfig,
     aptos_data_client: AptosNetDataClient,
-) -> (StreamingServiceClient, Runtime) {
+) -> anyhow::Result<(StreamingServiceClient, Runtime)> {
     // Create the data streaming service
     let (streaming_service_client, streaming_service_listener) =
         new_streaming_service_client_listener_pair();
@@ -398,10 +396,10 @@ fn setup_data_streaming_service(
         .thread_name("data-streaming-service")
         .enable_all()
         .build()
-        .expect("Failed to create data streaming service!");
+        .map_err(|err| anyhow!("Failed to create data streaming service {}", err))?;
     streaming_service_runtime.spawn(data_streaming_service.start_service());
 
-    (streaming_service_client, streaming_service_runtime)
+    Ok((streaming_service_client, streaming_service_runtime))
 }
 
 fn setup_aptos_data_client(
@@ -410,7 +408,7 @@ fn setup_aptos_data_client(
     base_config: BaseConfig,
     network_handles: HashMap<NetworkId, storage_service_client::StorageServiceNetworkSender>,
     peer_metadata_storage: Arc<PeerMetadataStorage>,
-) -> (AptosNetDataClient, Runtime) {
+) -> anyhow::Result<(AptosNetDataClient, Runtime)> {
     // Combine all storage service client handles
     let network_client = StorageServiceClient::new(
         StorageServiceMultiSender::new(network_handles),
@@ -422,7 +420,7 @@ fn setup_aptos_data_client(
         .thread_name("aptos-data-client")
         .enable_all()
         .build()
-        .expect("Failed to create aptos data client!");
+        .map_err(|err| anyhow!("Failed to create aptos data client {}", err))?;
 
     // Create the data client and spawn the data poller
     let (aptos_data_client, data_summary_poller) = AptosNetDataClient::new(
@@ -435,20 +433,20 @@ fn setup_aptos_data_client(
     );
     aptos_data_client_runtime.spawn(data_summary_poller.start_poller());
 
-    (aptos_data_client, aptos_data_client_runtime)
+    Ok((aptos_data_client, aptos_data_client_runtime))
 }
 
 fn setup_state_sync_storage_service(
     config: StorageServiceConfig,
     network_handles: Vec<StorageServiceNetworkEvents>,
     db_rw: &DbReaderWriter,
-) -> Runtime {
+) -> anyhow::Result<Runtime> {
     // Create a new state sync storage service runtime
     let storage_service_runtime = Builder::new_multi_thread()
         .thread_name("storage-service-server")
         .enable_all()
         .build()
-        .expect("Failed to start the AptosNet storage-service runtime.");
+        .map_err(|err| anyhow!("Failed to start state sync storage service {}", err))?;
 
     // Spawn all state sync storage service servers on the same runtime
     let storage_reader = StorageReader::new(config, Arc::clone(&db_rw.reader));
@@ -463,10 +461,10 @@ fn setup_state_sync_storage_service(
         storage_service_runtime.spawn(service.start());
     }
 
-    storage_service_runtime
+    Ok(storage_service_runtime)
 }
 
-pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
+pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle> {
     // Start the node inspection service
     let node_config_clone = node_config.clone();
     thread::spawn(move || {
@@ -482,7 +480,7 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
             node_config.storage.storage_pruner_config,
             node_config.storage.rocksdb_configs,
         )
-        .expect("DB should open."),
+        .map_err(|err| anyhow!("DB failed to open {}", err))?,
     );
     let backup_service = start_backup_service(
         node_config.storage.backup_service_address,
@@ -493,7 +491,7 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
     // if there's genesis txn and waypoint, commit it if the result matches.
     if let Some(genesis) = get_genesis_txn(&node_config) {
         maybe_bootstrap::<AptosVM>(&db_rw, genesis, genesis_waypoint)
-            .expect("Db-bootstrapper should not fail.");
+            .map_err(|err| anyhow!("DB failed to bootstrap {}", err))?;
     } else {
         info!("Genesis txn not provided, it's fine if you don't expect to apply it otherwise please double check config");
     }
@@ -504,7 +502,7 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
         instant.elapsed().as_millis()
     );
 
-    let chain_id = fetch_chain_id(&db_rw);
+    let chain_id = fetch_chain_id(&db_rw)?;
     let mut network_runtimes = vec![];
     let mut state_sync_network_handles = vec![];
     let mut mempool_network_handles = vec![];
@@ -517,17 +515,12 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
         ON_CHAIN_CONFIG_REGISTRY,
         Arc::new(RwLock::new(db_rw.clone())),
     );
-    let mempool_reconfig_subscription = event_subscription_service
-        .subscribe_to_reconfigurations()
-        .unwrap();
+    let mempool_reconfig_subscription =
+        event_subscription_service.subscribe_to_reconfigurations()?;
 
     // Create a consensus subscription for reconfiguration events (if this node is a validator).
     let consensus_reconfig_subscription = if node_config.base.role.is_validator() {
-        Some(
-            event_subscription_service
-                .subscribe_to_reconfigurations()
-                .unwrap(),
-        )
+        Some(event_subscription_service.subscribe_to_reconfigurations()?)
     } else {
         None
     };
@@ -563,9 +556,12 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
         if let Some(runtime_threads) = network_config.runtime_threads {
             runtime_builder.worker_threads(runtime_threads);
         }
-        let runtime = runtime_builder
-            .build()
-            .expect("Failed to start runtime. Won't be able to start networking.");
+        let runtime = runtime_builder.build().map_err(|err| {
+            anyhow!(
+                "Failed to start runtime.  Won't be able to start networking. {}",
+                err
+            )
+        })?;
 
         // Entering here gives us a runtime to instantiate all the pieces of the builder
         let _enter = runtime.enter();
@@ -652,11 +648,11 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
         genesis_waypoint,
         event_subscription_service,
         db_rw.clone(),
-    );
+    )?;
 
     let (mp_client_sender, mp_client_events) = channel(AC_SMP_CHANNEL_BUFFER_SIZE);
 
-    let api_runtime = bootstrap_api(&node_config, chain_id, aptos_db, mp_client_sender).unwrap();
+    let api_runtime = bootstrap_api(&node_config, chain_id, aptos_db, mp_client_sender)?;
 
     let mut consensus_runtime = None;
     let (consensus_to_mempool_sender, consensus_to_mempool_receiver) =
@@ -719,7 +715,7 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
         chain_id.to_string(),
     );
 
-    AptosHandle {
+    Ok(AptosHandle {
         _api: api_runtime,
         _backup: backup_service,
         _consensus_runtime: consensus_runtime,
@@ -727,5 +723,5 @@ pub fn setup_environment(node_config: NodeConfig) -> AptosHandle {
         _network_runtimes: network_runtimes,
         _state_sync_runtimes: state_sync_runtimes,
         _telemetry_runtime: telemetry_runtime,
-    }
+    })
 }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -40,6 +40,7 @@ aptos-github-client = { path = "../../secure/storage/github" }
 aptos-keygen = { path = "../aptos-keygen" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-module-verifier = { path = "../../aptos-move/aptos-module-verifier" }
+aptos-node = { path = "../../aptos-node" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-sdk = { path = "../../sdk" }
 aptos-secure-storage = { path = "../../secure/storage" }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -35,6 +35,7 @@ uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto", features = [] }
+aptos-faucet = { path = "../aptos-faucet" }
 aptos-genesis = { path = "../aptos-genesis" }
 aptos-github-client = { path = "../../secure/storage/github" }
 aptos-keygen = { path = "../aptos-keygen" }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::utils::start_logger;
 use crate::{
     common::{
         init::{DEFAULT_FAUCET_URL, DEFAULT_REST_URL},
@@ -753,12 +754,21 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
     /// Executes the command, and serializes it to the common JSON output type
     async fn execute_serialized(self) -> CliResult {
         let command_name = self.command_name();
+        start_logger();
+        let start_time = Instant::now();
+        to_common_result(command_name, start_time, self.execute().await).await
+    }
+
+    /// Same as execute serialized without setting up logging
+    async fn execute_serialized_without_logger(self) -> CliResult {
+        let command_name = self.command_name();
         let start_time = Instant::now();
         to_common_result(command_name, start_time, self.execute().await).await
     }
 
     /// Executes the command, and throws away Ok(result) for the string Success
     async fn execute_serialized_success(self) -> CliResult {
+        start_logger();
         let command_name = self.command_name();
         let start_time = Instant::now();
         to_common_success_result(command_name, start_time, self.execute().await).await

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -5,6 +5,7 @@ use crate::{
     common::types::{CliError, CliTypedResult, PromptOptions},
     CliResult,
 };
+use aptos_logger::Level;
 use aptos_rest_client::Client;
 use aptos_telemetry::collect_build_information;
 use aptos_types::chain_id::ChainId;
@@ -290,4 +291,14 @@ pub async fn fund_account(
             response.status()
         )))
     }
+}
+
+pub fn start_logger() {
+    let mut logger = aptos_logger::Logger::new();
+    logger
+        .channel_size(1000)
+        .is_async(false)
+        .level(Level::Warn)
+        .read_env();
+    logger.build();
 }

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -6,20 +6,11 @@
 #![forbid(unsafe_code)]
 
 use aptos::Tool;
-use aptos_logger::Level;
 use clap::Parser;
 use std::process::exit;
 
 #[tokio::main]
 async fn main() {
-    let mut logger = aptos_logger::Logger::new();
-    logger
-        .channel_size(1000)
-        .is_async(false)
-        .level(Level::Warn)
-        .read_env();
-    logger.build();
-
     // Run the corresponding tools
     let result = Tool::parse().execute().await;
 

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -568,7 +568,7 @@ impl CliCommand<()> for RunLocalTestnet {
             false,
             cached_framework_packages::module_blobs().to_vec(),
             rng,
-        );
+        )?;
 
         Ok(())
     }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -41,6 +41,7 @@ pub enum NodeTool {
     ShowValidatorConfig(ShowValidatorConfig),
     ShowValidatorSet(ShowValidatorSet),
     ShowValidatorStake(ShowValidatorStake),
+    RunLocalTestnet(RunLocalTestnet),
 }
 
 impl NodeTool {
@@ -57,6 +58,7 @@ impl NodeTool {
             ShowValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorStake(tool) => tool.execute_serialized().await,
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
+            RunLocalTestnet(tool) => tool.execute_serialized().await,
         }
     }
 }


### PR DESCRIPTION
### Description
Ever wanted to run a local testnet node that matches your CLI exactly, now you can!

This allows for running a local testnet node and minting coins with a faucet on that node.

(This is also a possible workaround for https://github.com/aptos-labs/aptos-core/issues/1700)


### Test Plan
```
$ aptos node run-local-testnet --help
aptos-node-run-local-testnet 0.2.0
Run local testnet

This local testnet will run it's own Genesis and run as a single node network locally.  Optionally,
a faucet can be added for minting coins.

USAGE:
    aptos node run-local-testnet [OPTIONS]

OPTIONS:
        --assume-no
            Assume no for all yes/no prompts

        --assume-yes
            Assume yes for all yes/no prompts

        --config-path <CONFIG_PATH>
            An overridable config template for the test node

        --faucet-port <FAUCET_PORT>
            Port to run the faucet on
            
            [default: 8081]

        --force-restart
            Clean the state and start with a new chain at genesis

    -h, --help
            Print help information

        --seed <SEED>
            Random seed for key generation in test mode

        --test-dir <TEST_DIR>
            The directory to save all files for the node
            
            [default: .aptos/testnet]

    -V, --version
            Print version information

        --with-faucet
            Run a faucet alongside the node

$ aptos node run-local-testnet --with-faucet
Completed generating configuration:
        Log file: "/opt/git/aptos-core/.aptos/testnet/validator.log"
        Test dir: "/opt/git/aptos-core/.aptos/testnet"
        Aptos root key path: "/opt/git/aptos-core/.aptos/testnet/mint.key"
        Waypoint: 0:401e26b3c160dbdb6e361d2503e037e245aedab1be2af36053a83cb0af3f627a
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit

$ curl localhost:8080 
{"chain_id":4,"epoch":4,"ledger_version":"207","oldest_ledger_version":"0","ledger_timestamp":"1658250521421168","node_role":"validator"}%

$ curl -X POST 'localhost:8081/mint?amount=100000&address=0x1337'
["8a49e5ae7bae1977ee9facb1322516734595a59b44c9a348019175e96beb2413","463d3de8b04befb2cc6fb9e9b71448ac500b70e8d01d38a9f824ded17a88424b"]%  
```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1873)
<!-- Reviewable:end -->
