### PR TITLE
[Aptos Data Client] Reduce error log to warning.

### DIFF
--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -58,7 +58,7 @@ const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 5;
 const GLOBAL_DATA_METRIC_FREQ_SECS: u64 = 1;
 const IN_FLIGHT_METRICS_SAMPLE_FREQ: u64 = 5;
 const PEER_LOG_FREQ_SECS: u64 = 10;
-const POLLER_LOG_FREQ_SECS: u64 = 1;
+const POLLER_LOG_FREQ_SECS: u64 = 2;
 const REGULAR_PEER_SAMPLE_FREQ: u64 = 3;
 
 /// An [`AptosDataClient`] that fulfills requests from remote peers' Storage Service
@@ -685,7 +685,7 @@ impl DataSummaryPoller {
 fn log_poller_error(error: Error) {
     sample!(
         SampleRate::Duration(Duration::from_secs(POLLER_LOG_FREQ_SECS)),
-        error!(
+        warn!(
             (LogSchema::new(LogEntry::StorageSummaryRequest)
                 .event(LogEvent::PeerPollingError)
                 .message("Unable to fetch peers to poll!")


### PR DESCRIPTION
### Description

This reduces an `error` log to a `warn` as there are a very small number of edge cases where the error message is acceptable (see https://github.com/aptos-labs/aptos-core/issues/1880). Likewise, we reduce the frequency of the log (from 1 to 2 seconds). I don't think we should reduce it further as it might hide other (more important) errors.

### Test Plan
None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1881)
<!-- Reviewable:end -->
