### PR TITLE
feat: add abi support to TS SDK

### DIFF
--- a/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
@@ -58,7 +58,7 @@ const {
     ),
   );
 
-  const [{ sequence_number: sequnceNumber }, chainId] = await Promise.all([
+  const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
     client.getAccount(account1.address()),
     client.getChainId(),
   ]);
@@ -68,7 +68,7 @@ const {
   const rawTxn = new RawTransaction(
     // Transaction sender account address
     AccountAddress.fromHex(account1.address()),
-    BigInt(sequnceNumber),
+    BigInt(sequenceNumber),
     scriptFunctionPayload,
     // Max gas unit to spend
     1000n,

--- a/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
@@ -73,7 +73,7 @@ type SigningMessage = TxnBuilderTypes.SigningMessage;
     ),
   );
 
-  const [{ sequence_number: sequnceNumber }, chainId] = await Promise.all([
+  const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
     client.getAccount(mutisigAccountAddress),
     client.getChainId(),
   ]);
@@ -83,7 +83,7 @@ type SigningMessage = TxnBuilderTypes.SigningMessage;
   const rawTxn = new TxnBuilderTypes.RawTransaction(
     // Transaction sender account address
     TxnBuilderTypes.AccountAddress.fromHex(mutisigAccountAddress),
-    BigInt(sequnceNumber),
+    BigInt(sequenceNumber),
     scriptFunctionPayload,
     // Max gas unit to spend
     1000n,

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -76,15 +76,19 @@ test("test raiseForStatus", async () => {
   // an error, oh no!
   fakeResponse.status = 500;
   expect(() => raiseForStatus(200, fakeResponse, testData)).toThrow(
+    // eslint-disable-next-line quotes
     'Status Text - "some string" @ host/path : {"hello":"wow"}',
   );
 
+  // eslint-disable-next-line quotes
   expect(() => raiseForStatus(200, fakeResponse)).toThrow('Status Text - "some string" @ host/path');
 
   // Just a wild test to make sure it doesn't break: request is `any`!
   delete fakeResponse.request;
+  // eslint-disable-next-line quotes
   expect(() => raiseForStatus(200, fakeResponse, testData)).toThrow('Status Text - "some string" : {"hello":"wow"}');
 
+  // eslint-disable-next-line quotes
   expect(() => raiseForStatus(200, fakeResponse)).toThrow('Status Text - "some string"');
 });
 
@@ -117,14 +121,14 @@ test(
       ),
     );
 
-    const [{ sequence_number: sequnceNumber }, chainId] = await Promise.all([
+    const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
       client.getAccount(account1.address()),
       client.getChainId(),
     ]);
 
     const rawTxn = new TxnBuilderTypes.RawTransaction(
       TxnBuilderTypes.AccountAddress.fromHex(account1.address()),
-      BigInt(sequnceNumber),
+      BigInt(sequenceNumber),
       scriptFunctionPayload,
       1000n,
       1n,
@@ -188,14 +192,14 @@ test(
       ),
     );
 
-    const [{ sequence_number: sequnceNumber }, chainId] = await Promise.all([
+    const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
       client.getAccount(mutisigAccountAddress),
       client.getChainId(),
     ]);
 
     const rawTxn = new TxnBuilderTypes.RawTransaction(
       TxnBuilderTypes.AccountAddress.fromHex(mutisigAccountAddress),
-      BigInt(sequnceNumber),
+      BigInt(sequenceNumber),
       scriptFunctionPayload,
       1000n,
       1n,
@@ -317,14 +321,14 @@ test(
       ),
     );
 
-    const [{ sequence_number: sequnceNumber }, chainId] = await Promise.all([
+    const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
       client.getAccount(account1.address()),
       client.getChainId(),
     ]);
 
     const rawTxn = new TxnBuilderTypes.RawTransaction(
       TxnBuilderTypes.AccountAddress.fromHex(account1.address()),
-      BigInt(sequnceNumber),
+      BigInt(sequenceNumber),
       scriptFunctionPayload,
       1000n,
       1n,
@@ -412,14 +416,14 @@ test(
       ),
     );
 
-    const [{ sequence_number: sequnceNumber }, chainId] = await Promise.all([
+    const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
       client.getAccount(alice.address()),
       client.getChainId(),
     ]);
 
     const rawTxn = new TxnBuilderTypes.RawTransaction(
       aliceAccountAddress,
-      BigInt(sequnceNumber),
+      BigInt(sequenceNumber),
       scriptFunctionPayload,
       1000n,
       1n,

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -555,7 +555,11 @@ export class AptosClient {
 
   // Only cache for a short period to avoid excessive amount of memory usage
   @MemoizeExpiring(2 * 60 * 1000) // Cache for 2min
-  private async getTransactionBuilder(accountFrom: AptosAccount): Promise<TransactionBuilderEd25519> {
+  async getTxnBuilderWithABI(accountFrom: AptosAccount): Promise<TransactionBuilderEd25519> {
+    if (this.abis.length === 0) {
+      throw new Error("ABIs are not provided.");
+    }
+
     const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
       this.getAccount(accountFrom.address()),
       this.getChainId(),
@@ -584,7 +588,7 @@ export class AptosClient {
     args: any[],
   ): Promise<Types.PendingTransaction> {
     const [txnBuilder, { sequence_number: sequenceNumber }] = await Promise.all([
-      this.getTransactionBuilder(accountFrom),
+      this.getTxnBuilderWithABI(accountFrom),
       this.getAccount(accountFrom.address()),
     ]);
     txnBuilder.rawTxnBuilder?.setSequenceNumber(sequenceNumber);

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.test.ts
@@ -1,0 +1,46 @@
+import { HexString } from '../../hex_string';
+import { Deserializer } from '../bcs';
+import { ScriptABI, ScriptFunctionABI, TransactionScriptABI } from './abi';
+import { TypeTagAddress, TypeTagU64 } from './type_tag';
+
+// eslint-disable-next-line operator-linebreak
+const SCRIPT_FUNCTION_ABI =
+  // eslint-disable-next-line max-len
+  '010E6372656174655F6163636F756E740000000000000000000000000000000000000000000000000000000000000001074163636F756E7420204261736963206163636F756E74206372656174696F6E206D6574686F64732E000108617574685F6B657904';
+
+// eslint-disable-next-line operator-linebreak
+const TRANSACTION_SCRIPT_ABI =
+  // eslint-disable-next-line max-len
+  '00046D61696E0F20412074657374207363726970742E8B01A11CEB0B050000000501000403040A050E0B071924083D200000000101020301000003010400020C0301050001060C0101074163636F756E74065369676E65720A616464726573735F6F66096578697374735F617400000000000000000000000000000000000000000000000000000000000000010000010A0E0011000C020B021101030705090B0127020001016902';
+
+describe('ABI', () => {
+  it('parses create_acount successfully', async () => {
+    const deserializer = new Deserializer(new HexString(SCRIPT_FUNCTION_ABI).toUint8Array());
+    const scriptFunctionABI = ScriptABI.deserialize(deserializer) as ScriptFunctionABI;
+    const { address: moduleAddress, name: moduleName } = scriptFunctionABI.module_name;
+    expect(scriptFunctionABI.name).toBe('create_account');
+    expect(HexString.fromUint8Array(moduleAddress.address).toShortString()).toBe('0x1');
+    expect(moduleName.value).toBe('Account');
+    expect(scriptFunctionABI.doc.trim()).toBe('Basic account creation methods.');
+
+    const arg = scriptFunctionABI.args[0];
+    expect(arg.name).toBe('auth_key');
+    expect(arg.type_tag instanceof TypeTagAddress).toBeTruthy();
+  });
+
+  it('parses script abi successfully', async () => {
+    const deserializer = new Deserializer(new HexString(TRANSACTION_SCRIPT_ABI).toUint8Array());
+    const transactionScriptABI = ScriptABI.deserialize(deserializer) as TransactionScriptABI;
+    expect(transactionScriptABI.name).toBe('main');
+    expect(transactionScriptABI.doc.trim()).toBe('A test script.');
+
+    expect(HexString.fromUint8Array(transactionScriptABI.code).hex()).toBe(
+      // eslint-disable-next-line max-len
+      '0xa11ceb0b050000000501000403040a050e0b071924083d200000000101020301000003010400020c0301050001060c0101074163636f756e74065369676e65720a616464726573735f6f66096578697374735f617400000000000000000000000000000000000000000000000000000000000000010000010a0e0011000c020b021101030705090b012702',
+    );
+
+    const arg = transactionScriptABI.args[0];
+    expect(arg.name).toBe('i');
+    expect(arg.type_tag instanceof TypeTagU64).toBeTruthy();
+  });
+});

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.test.ts
@@ -1,46 +1,46 @@
-import { HexString } from '../../hex_string';
-import { Deserializer } from '../bcs';
-import { ScriptABI, ScriptFunctionABI, TransactionScriptABI } from './abi';
-import { TypeTagAddress, TypeTagU64 } from './type_tag';
+import { HexString } from "../../hex_string";
+import { Deserializer } from "../bcs";
+import { ScriptABI, ScriptFunctionABI, TransactionScriptABI } from "./abi";
+import { TypeTagAddress, TypeTagU64 } from "./type_tag";
 
 // eslint-disable-next-line operator-linebreak
 const SCRIPT_FUNCTION_ABI =
   // eslint-disable-next-line max-len
-  '010E6372656174655F6163636F756E740000000000000000000000000000000000000000000000000000000000000001074163636F756E7420204261736963206163636F756E74206372656174696F6E206D6574686F64732E000108617574685F6B657904';
+  "010E6372656174655F6163636F756E740000000000000000000000000000000000000000000000000000000000000001074163636F756E7420204261736963206163636F756E74206372656174696F6E206D6574686F64732E000108617574685F6B657904";
 
 // eslint-disable-next-line operator-linebreak
 const TRANSACTION_SCRIPT_ABI =
   // eslint-disable-next-line max-len
-  '00046D61696E0F20412074657374207363726970742E8B01A11CEB0B050000000501000403040A050E0B071924083D200000000101020301000003010400020C0301050001060C0101074163636F756E74065369676E65720A616464726573735F6F66096578697374735F617400000000000000000000000000000000000000000000000000000000000000010000010A0E0011000C020B021101030705090B0127020001016902';
+  "00046D61696E0F20412074657374207363726970742E8B01A11CEB0B050000000501000403040A050E0B071924083D200000000101020301000003010400020C0301050001060C0101074163636F756E74065369676E65720A616464726573735F6F66096578697374735F617400000000000000000000000000000000000000000000000000000000000000010000010A0E0011000C020B021101030705090B0127020001016902";
 
-describe('ABI', () => {
-  it('parses create_acount successfully', async () => {
+describe("ABI", () => {
+  it("parses create_acount successfully", async () => {
     const deserializer = new Deserializer(new HexString(SCRIPT_FUNCTION_ABI).toUint8Array());
     const scriptFunctionABI = ScriptABI.deserialize(deserializer) as ScriptFunctionABI;
     const { address: moduleAddress, name: moduleName } = scriptFunctionABI.module_name;
-    expect(scriptFunctionABI.name).toBe('create_account');
-    expect(HexString.fromUint8Array(moduleAddress.address).toShortString()).toBe('0x1');
-    expect(moduleName.value).toBe('Account');
-    expect(scriptFunctionABI.doc.trim()).toBe('Basic account creation methods.');
+    expect(scriptFunctionABI.name).toBe("create_account");
+    expect(HexString.fromUint8Array(moduleAddress.address).toShortString()).toBe("0x1");
+    expect(moduleName.value).toBe("Account");
+    expect(scriptFunctionABI.doc.trim()).toBe("Basic account creation methods.");
 
     const arg = scriptFunctionABI.args[0];
-    expect(arg.name).toBe('auth_key');
+    expect(arg.name).toBe("auth_key");
     expect(arg.type_tag instanceof TypeTagAddress).toBeTruthy();
   });
 
-  it('parses script abi successfully', async () => {
+  it("parses script abi successfully", async () => {
     const deserializer = new Deserializer(new HexString(TRANSACTION_SCRIPT_ABI).toUint8Array());
     const transactionScriptABI = ScriptABI.deserialize(deserializer) as TransactionScriptABI;
-    expect(transactionScriptABI.name).toBe('main');
-    expect(transactionScriptABI.doc.trim()).toBe('A test script.');
+    expect(transactionScriptABI.name).toBe("main");
+    expect(transactionScriptABI.doc.trim()).toBe("A test script.");
 
     expect(HexString.fromUint8Array(transactionScriptABI.code).hex()).toBe(
       // eslint-disable-next-line max-len
-      '0xa11ceb0b050000000501000403040a050e0b071924083d200000000101020301000003010400020c0301050001060c0101074163636f756e74065369676e65720a616464726573735f6f66096578697374735f617400000000000000000000000000000000000000000000000000000000000000010000010a0e0011000c020b021101030705090b012702',
+      "0xa11ceb0b050000000501000403040a050e0b071924083d200000000101020301000003010400020c0301050001060c0101074163636f756e74065369676e65720a616464726573735f6f66096578697374735f617400000000000000000000000000000000000000000000000000000000000000010000010a0e0011000c020b021101030705090b012702",
     );
 
     const arg = transactionScriptABI.args[0];
-    expect(arg.name).toBe('i');
+    expect(arg.name).toBe("i");
     expect(arg.type_tag instanceof TypeTagU64).toBeTruthy();
   });
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.ts
@@ -1,0 +1,132 @@
+import { Deserializer, Serializer, Bytes, Seq, deserializeVector, serializeVector } from '../bcs';
+
+import { ModuleId } from './transaction';
+
+import { TypeTag } from './type_tag';
+
+export class TypeArgumentABI {
+  /**
+   * Constructs a TypeArgumentABI instance.
+   * @param name
+   */
+  constructor(public readonly name: string) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.name);
+  }
+
+  static deserialize(deserializer: Deserializer): TypeArgumentABI {
+    const name = deserializer.deserializeStr();
+    return new TypeArgumentABI(name);
+  }
+}
+
+export class ArgumentABI {
+  /**
+   * Constructs an ArgumentABI instance.
+   * @param name
+   * @param type_tag
+   */
+  constructor(public readonly name: string, public readonly type_tag: TypeTag) {}
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.name);
+    this.type_tag.serialize(serializer);
+  }
+
+  static deserialize(deserializer: Deserializer): TypeArgumentABI {
+    const name = deserializer.deserializeStr();
+    const typeTag = TypeTag.deserialize(deserializer);
+    return new ArgumentABI(name, typeTag);
+  }
+}
+
+export abstract class ScriptABI {
+  abstract serialize(serializer: Serializer): void;
+
+  static deserialize(deserializer: Deserializer): ScriptABI {
+    const index = deserializer.deserializeUleb128AsU32();
+    switch (index) {
+      case 0:
+        return TransactionScriptABI.load(deserializer);
+      case 1:
+        return ScriptFunctionABI.load(deserializer);
+      default:
+        throw new Error(`Unknown variant index for TransactionPayload: ${index}`);
+    }
+  }
+}
+
+export class TransactionScriptABI extends ScriptABI {
+  /**
+   * Constructs a TransactionScriptABI instance.
+   * @param name Entry function name
+   * @param doc
+   * @param code
+   * @param ty_args
+   * @param args
+   */
+  constructor(
+    public readonly name: string,
+    public readonly doc: string,
+    public readonly code: Bytes,
+    public readonly ty_args: Seq<TypeArgumentABI>,
+    public readonly args: Seq<ArgumentABI>,
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.name);
+    serializer.serializeStr(this.doc);
+    serializer.serializeBytes(this.code);
+    serializeVector<TypeArgumentABI>(this.ty_args, serializer);
+    serializeVector<ArgumentABI>(this.args, serializer);
+  }
+
+  static load(deserializer: Deserializer): TransactionScriptABI {
+    const name = deserializer.deserializeStr();
+    const doc = deserializer.deserializeStr();
+    const code = deserializer.deserializeBytes();
+    const tyArgs = deserializeVector(deserializer, TypeArgumentABI);
+    const args = deserializeVector(deserializer, ArgumentABI);
+    return new TransactionScriptABI(name, doc, code, tyArgs, args);
+  }
+}
+
+export class ScriptFunctionABI extends ScriptABI {
+  /**
+   * Constructs a ScriptFunctionABI instance
+   * @param name
+   * @param module_name Fully qualified module id
+   * @param doc
+   * @param ty_args
+   * @param args
+   */
+  constructor(
+    public readonly name: string,
+    public readonly module_name: ModuleId,
+    public readonly doc: string,
+    public readonly ty_args: Seq<TypeArgumentABI>,
+    public readonly args: Seq<ArgumentABI>,
+  ) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeStr(this.name);
+    this.module_name.serialize(serializer);
+    serializer.serializeStr(this.doc);
+    serializeVector<TypeArgumentABI>(this.ty_args, serializer);
+    serializeVector<ArgumentABI>(this.args, serializer);
+  }
+
+  static load(deserializer: Deserializer): ScriptFunctionABI {
+    const name = deserializer.deserializeStr();
+    const moduleName = ModuleId.deserialize(deserializer);
+    const doc = deserializer.deserializeStr();
+    const tyArgs = deserializeVector(deserializer, TypeArgumentABI);
+    const args = deserializeVector(deserializer, ArgumentABI);
+    return new ScriptFunctionABI(name, moduleName, doc, tyArgs, args);
+  }
+}

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.ts
@@ -1,8 +1,8 @@
-import { Deserializer, Serializer, Bytes, Seq, deserializeVector, serializeVector } from '../bcs';
+import { Deserializer, Serializer, Bytes, Seq, deserializeVector, serializeVector } from "../bcs";
 
-import { ModuleId } from './transaction';
+import { ModuleId } from "./transaction";
 
-import { TypeTag } from './type_tag';
+import { TypeTag } from "./type_tag";
 
 export class TypeArgumentABI {
   /**

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -79,8 +79,8 @@ export class TransactionBuilder<F extends SigningFn> {
 export class TransactionBuilderEd25519 extends TransactionBuilder<SigningFn> {
   private readonly publicKey: Uint8Array;
 
-  constructor(signingFunction: SigningFn, publicKey: Uint8Array) {
-    super(signingFunction);
+  constructor(signingFunction: SigningFn, publicKey: Uint8Array, rawTxnBuilder?: TransactionBuilderABI) {
+    super(signingFunction, rawTxnBuilder);
     this.publicKey = publicKey;
   }
 
@@ -200,6 +200,10 @@ export class TransactionBuilderABI {
     }
 
     return args.map((arg, i) => argToTransactionArgument(arg, abiArgs[i].type_tag));
+  }
+
+  setSequenceNumber(seqNumber: Uint64 | string) {
+    this.builderConfig.sequenceNumber = BigInt(seqNumber);
   }
 
   /**

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -38,8 +38,22 @@ export type SigningFn = (txn: SigningMessage) => Ed25519Signature | MultiEd25519
 export class TransactionBuilder<F extends SigningFn> {
   protected readonly signingFunction: F;
 
-  constructor(signingFunction: F) {
+  constructor(signingFunction: F, public readonly rawTxnBuilder?: TransactionBuilderABI) {
     this.signingFunction = signingFunction;
+  }
+
+  /**
+   * Builds a RawTransaction. Relays the call to TransactionBuilderABI.build
+   * @param func
+   * @param ty_tags
+   * @param args
+   */
+  build(func: string, ty_tags: string[], args: any[]): RawTransaction {
+    if (!this.rawTxnBuilder) {
+      throw new Error("this.rawTxnBuilder doesn't exist.");
+    }
+
+    return this.rawTxnBuilder.build(func, ty_tags, args);
   }
 
   /** Generates a Signing Message out of a raw transaction. */

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -22,7 +22,7 @@ import {
 import { bcsToBytes, Bytes, Deserializer, Serializer, Uint64, Uint8 } from "./bcs";
 import { ScriptABI, ScriptFunctionABI, TransactionScriptABI } from "./aptos_types/abi";
 import { HexString } from "../hex_string";
-import { argToTransactionArgument, parseTypeTag, serializeArg } from "./builder_utils";
+import { argToTransactionArgument, TypeTagParser, serializeArg } from "./builder_utils";
 
 const RAW_TRANSACTION_SALT = "APTOS::RawTransaction";
 const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";
@@ -226,7 +226,7 @@ export class TransactionBuilderABI {
 
     const senderAccount = sender instanceof HexString ? AccountAddress.fromHex(sender) : sender;
 
-    const typeTags = ty_tags.map((ty_arg) => parseTypeTag(ty_arg));
+    const typeTags = ty_tags.map((ty_arg) => new TypeTagParser(ty_arg).parseTypeTag());
 
     const expTimetampSec = BigInt(Math.floor(Date.now() / 1000) + Number(expSecFromNow));
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -11,32 +11,18 @@ import {
   TransactionAuthenticatorMultiEd25519,
   SigningMessage,
   MultiAgentRawTransaction,
-  TypeTag,
-  TypeTagBool,
-  TypeTagU8,
-  TypeTagU64,
-  TypeTagU128,
-  TypeTagAddress,
   AccountAddress,
-  TypeTagVector,
   ScriptFunction,
-  TypeTagStruct,
-  StructTag,
   Identifier,
   ChainId,
   Script,
-  TransactionArgument,
-  TransactionArgumentBool,
-  TransactionArgumentU64,
-  TransactionArgumentU128,
-  TransactionArgumentAddress,
-  TransactionArgumentU8,
-  TransactionArgumentU8Vector,
   TransactionPayload,
+  TransactionArgument,
 } from "./aptos_types";
 import { bcsToBytes, Bytes, Deserializer, Serializer, Uint64, Uint8 } from "./bcs";
 import { ScriptABI, ScriptFunctionABI, TransactionScriptABI } from "./aptos_types/abi";
 import { HexString } from "../hex_string";
+import { argToTransactionArgument, parseTypeTag, serializeArg } from "./builder_utils";
 
 const RAW_TRANSACTION_SALT = "APTOS::RawTransaction";
 const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";
@@ -182,105 +168,6 @@ export class TransactionBuilderABI {
     };
   }
 
-  /**
-   * Parses a tag string
-   * @param typeTagStr A string represented tag, e.g. bool
-   * @returns
-   */
-  static parseTypeTag(typeTagStr: string): TypeTag {
-    const typeTag = typeTagStr.trim();
-
-    if (typeTag.startsWith("vector")) {
-      return new TypeTagVector(
-        // 7 is the offset of the first char after "vector<".
-        TransactionBuilderABI.parseTypeTag(typeTag.substring(7, typeTag.length - 1)),
-      );
-    }
-    if (typeTag.includes("::")) {
-      if (!typeTag.includes("<")) {
-        return new TypeTagStruct(StructTag.fromString(typeTag));
-      }
-
-      const [structStr, tempStrNotTrimmed] = typeTag.split("<", 2);
-
-      if ((structStr.match(/::/g) || []).length !== 3) {
-        throw new Error("Invalid type arg.");
-      }
-
-      const [address, module, name] = structStr.split("::");
-
-      const pos = tempStrNotTrimmed.lastIndexOf(">");
-      if (pos === -1) {
-        throw new Error("Invalid type arg.");
-      }
-
-      const tempStr = tempStrNotTrimmed.substring(0, pos);
-
-      const tempStrParts = tempStr.split(",");
-
-      const typeArgs = tempStrParts.map((temp) => TransactionBuilderABI.parseTypeTag(temp));
-      const structTag = new StructTag(
-        AccountAddress.fromHex(address),
-        new Identifier(module),
-        new Identifier(name),
-        typeArgs,
-      );
-
-      return new TypeTagStruct(structTag);
-    }
-
-    switch (typeTag) {
-      case "bool":
-        return new TypeTagBool();
-      case "u8":
-        return new TypeTagU8();
-      case "u64":
-        return new TypeTagU64();
-      case "u128":
-        return new TypeTagU128();
-      case "address":
-        return new TypeTagAddress();
-      default:
-        throw new Error("Unknown type tag.");
-    }
-  }
-
-  private static serializeArg(argVal: any, argType: TypeTag, serializer: Serializer) {
-    if (argType instanceof TypeTagBool) {
-      serializer.serializeBool(argVal);
-    }
-    if (argType instanceof TypeTagU8) {
-      serializer.serializeU8(argVal);
-    }
-    if (argType instanceof TypeTagU64) {
-      serializer.serializeU64(argVal);
-    }
-    if (argType instanceof TypeTagU128) {
-      serializer.serializeU128(argVal);
-    }
-    if (argType instanceof TypeTagAddress) {
-      let addr: AccountAddress;
-      if (typeof argVal === "string") {
-        addr = AccountAddress.fromHex(argVal);
-      } else if (argVal instanceof AccountAddress) {
-        addr = argVal;
-      } else {
-        throw new Error("Invalid account address.");
-      }
-      addr.serialize(serializer);
-    }
-    if (argType instanceof TypeTagVector) {
-      if (!(argVal instanceof Array)) {
-        throw new Error("Invalid vector args.");
-      }
-
-      serializer.serializeU32AsUleb128(argVal.length);
-
-      argVal.forEach((arg) => TransactionBuilderABI.serializeArg(arg, argType, serializer));
-    }
-    throw new Error("Unsupported arg type.");
-  }
-
   private static toBCSArgs(abiArgs: any[], args: any[]): Bytes[] {
     if (abiArgs.length !== args.length) {
       throw new Error("Wrong number of args provided.");
@@ -288,40 +175,17 @@ export class TransactionBuilderABI {
 
     return args.map((arg, i) => {
       const serializer = new Serializer();
-      TransactionBuilderABI.serializeArg(arg, abiArgs[i].type_tag, serializer);
+      serializeArg(arg, abiArgs[i].type_tag, serializer);
       return serializer.getBytes();
     });
   }
 
-  private static argToTransactionArgument(argVal: any, argType: TypeTag): TransactionArgument {
-    if (argType instanceof TypeTagBool) {
-      return new TransactionArgumentBool(argVal);
-    }
-    if (argType instanceof TypeTagU8) {
-      return new TransactionArgumentU8(argVal);
-    }
-    if (argType instanceof TypeTagU64) {
-      return new TransactionArgumentU64(argVal);
-    }
-    if (argType instanceof TypeTagU128) {
-      return new TransactionArgumentU128(argVal);
-    }
-    if (argType instanceof TypeTagAddress) {
-      return new TransactionArgumentAddress(argVal);
-    }
-    if (argType instanceof Uint8Array) {
-      return new TransactionArgumentU8Vector(argVal);
-    }
-
-    throw new Error("Unknown type for TransactionArgument.");
-  }
-
-  private static toTransactionArgument(abiArgs: any[], args: any[]): TransactionArgument[] {
+  private static toTransactionArguments(abiArgs: any[], args: any[]): TransactionArgument[] {
     if (abiArgs.length !== args.length) {
       throw new Error("Wrong number of args provided.");
     }
 
-    return args.map((arg, i) => TransactionBuilderABI.argToTransactionArgument(arg, abiArgs[i].type_tag));
+    return args.map((arg, i) => argToTransactionArgument(arg, abiArgs[i].type_tag));
   }
 
   /**
@@ -348,7 +212,7 @@ export class TransactionBuilderABI {
 
     const senderAccount = sender instanceof HexString ? AccountAddress.fromHex(sender) : sender;
 
-    const typeTags = ty_tags.map((ty_arg) => TransactionBuilderABI.parseTypeTag(ty_arg));
+    const typeTags = ty_tags.map((ty_arg) => parseTypeTag(ty_arg));
 
     const expTimetampSec = BigInt(Math.floor(Date.now() / 1000) + Number(expSecFromNow));
 
@@ -368,7 +232,7 @@ export class TransactionBuilderABI {
 
     if (scriptABI instanceof TransactionScriptABI) {
       const funcABI = scriptABI as TransactionScriptABI;
-      const scriptArgs = TransactionBuilderABI.toTransactionArgument(funcABI.args, args);
+      const scriptArgs = TransactionBuilderABI.toTransactionArguments(funcABI.args, args);
 
       payload = new Script(funcABI.code, typeTags, scriptArgs);
     }

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
@@ -81,6 +81,7 @@ describe("BuilderUtils", () => {
     assertStruct(structTypeTag2 as TypeTagStruct, "0x1", "test_coin", "AptosCoin2");
 
     const coinComplex = new TypeTagParser(
+      // eslint-disable-next-line max-len
       "0x1::coin::CoinStore < 0x2::coin::LPCoin < 0x1::test_coin::AptosCoin1 <u8>, vector<0x1::test_coin::AptosCoin2 > > >",
     ).parseTypeTag();
 
@@ -198,6 +199,14 @@ describe("BuilderUtils", () => {
     let serializer = new Serializer();
     serializeArg([255], new TypeTagVector(new TypeTagU8()), serializer);
     expect(serializer.getBytes()).toEqual(new Uint8Array([0x1, 0xff]));
+
+    serializer = new Serializer();
+    serializeArg("abc", new TypeTagVector(new TypeTagU8()), serializer);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x3, 0x61, 0x62, 0x63]));
+
+    serializer = new Serializer();
+    serializeArg(new Uint8Array([0x61, 0x62, 0x63]), new TypeTagVector(new TypeTagU8()), serializer);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x3, 0x61, 0x62, 0x63]));
 
     serializer = new Serializer();
     expect(() => {

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
@@ -55,66 +55,66 @@ describe("BuilderUtils", () => {
       expect(struct.value.module_name.value).toBe(moduleName);
       expect(struct.value.name.value).toBe(structName);
     };
-    const coin = new TypeTagParser("0x1::TestCoin::Coin").parseTypeTag();
+    const coin = new TypeTagParser("0x1::test_coin::Coin").parseTypeTag();
     expect(coin instanceof TypeTagStruct).toBeTruthy();
-    assertStruct(coin as TypeTagStruct, "0x1", "TestCoin", "Coin");
+    assertStruct(coin as TypeTagStruct, "0x1", "test_coin", "Coin");
 
-    const testCoin = new TypeTagParser(
-      "0x1::Coin::CoinStore < 0x1::TestCoin::TestCoin1 ,  0x1::TestCoin::TestCoin2 > ",
+    const aptosCoin = new TypeTagParser(
+      "0x1::coin::CoinStore < 0x1::test_coin::AptosCoin1 ,  0x1::test_coin::AptosCoin2 > ",
     ).parseTypeTag();
-    expect(testCoin instanceof TypeTagStruct).toBeTruthy();
-    assertStruct(testCoin as TypeTagStruct, "0x1", "Coin", "CoinStore");
+    expect(aptosCoin instanceof TypeTagStruct).toBeTruthy();
+    assertStruct(aptosCoin as TypeTagStruct, "0x1", "coin", "CoinStore");
 
-    const testCoinTrailingComma = new TypeTagParser(
-      "0x1::Coin::CoinStore < 0x1::TestCoin::TestCoin1 ,  0x1::TestCoin::TestCoin2, > ",
+    const aptosCoinTrailingComma = new TypeTagParser(
+      "0x1::coin::CoinStore < 0x1::test_coin::AptosCoin1 ,  0x1::test_coin::AptosCoin2, > ",
     ).parseTypeTag();
-    expect(testCoinTrailingComma instanceof TypeTagStruct).toBeTruthy();
-    assertStruct(testCoinTrailingComma as TypeTagStruct, "0x1", "Coin", "CoinStore");
+    expect(aptosCoinTrailingComma instanceof TypeTagStruct).toBeTruthy();
+    assertStruct(aptosCoinTrailingComma as TypeTagStruct, "0x1", "coin", "CoinStore");
 
-    const structTypeTags = (testCoin as TypeTagStruct).value.type_args;
+    const structTypeTags = (aptosCoin as TypeTagStruct).value.type_args;
     expect(structTypeTags.length).toBe(2);
 
     const structTypeTag1 = structTypeTags[0];
-    assertStruct(structTypeTag1 as TypeTagStruct, "0x1", "TestCoin", "TestCoin1");
+    assertStruct(structTypeTag1 as TypeTagStruct, "0x1", "test_coin", "AptosCoin1");
 
     const structTypeTag2 = structTypeTags[1];
-    assertStruct(structTypeTag2 as TypeTagStruct, "0x1", "TestCoin", "TestCoin2");
+    assertStruct(structTypeTag2 as TypeTagStruct, "0x1", "test_coin", "AptosCoin2");
 
     const coinComplex = new TypeTagParser(
-      "0x1::Coin::CoinStore < 0x2::Coin::LPCoin < 0x1::TestCoin::TestCoin1 <u8>, vector<0x1::TestCoin::TestCoin2 > > >",
+      "0x1::coin::CoinStore < 0x2::coin::LPCoin < 0x1::test_coin::AptosCoin1 <u8>, vector<0x1::test_coin::AptosCoin2 > > >",
     ).parseTypeTag();
 
     expect(coinComplex instanceof TypeTagStruct).toBeTruthy();
-    assertStruct(coinComplex as TypeTagStruct, "0x1", "Coin", "CoinStore");
+    assertStruct(coinComplex as TypeTagStruct, "0x1", "coin", "CoinStore");
     const coinComplexTypeTag = (coinComplex as TypeTagStruct).value.type_args[0];
-    assertStruct(coinComplexTypeTag as TypeTagStruct, "0x2", "Coin", "LPCoin");
+    assertStruct(coinComplexTypeTag as TypeTagStruct, "0x2", "coin", "LPCoin");
 
     expect(() => {
-      new TypeTagParser("0x1::TestCoin").parseTypeTag();
+      new TypeTagParser("0x1::test_coin").parseTypeTag();
     }).toThrow("Invalid type tag.");
 
     expect(() => {
-      new TypeTagParser("0x1::TestCoin::CoinStore<0x1::TestCoin::TestCoin").parseTypeTag();
+      new TypeTagParser("0x1::test_coin::CoinStore<0x1::test_coin::AptosCoin").parseTypeTag();
     }).toThrow("Invalid type tag.");
 
     expect(() => {
-      new TypeTagParser("0x1::TestCoin::CoinStore<0x1::TestCoin>").parseTypeTag();
+      new TypeTagParser("0x1::test_coin::CoinStore<0x1::test_coin>").parseTypeTag();
     }).toThrow("Invalid type tag.");
 
     expect(() => {
-      new TypeTagParser("0x1:TestCoin::TestCoin").parseTypeTag();
+      new TypeTagParser("0x1:test_coin::AptosCoin").parseTypeTag();
     }).toThrow("Unrecognized token.");
 
     expect(() => {
-      new TypeTagParser("0x!::TestCoin::TestCoin").parseTypeTag();
+      new TypeTagParser("0x!::test_coin::AptosCoin").parseTypeTag();
     }).toThrow("Unrecognized token.");
 
     expect(() => {
-      new TypeTagParser("0x1::TestCoin::TestCoin<").parseTypeTag();
+      new TypeTagParser("0x1::test_coin::AptosCoin<").parseTypeTag();
     }).toThrow("Invalid type tag.");
 
     expect(() => {
-      new TypeTagParser("0x1::TestCoin::CoinStore<0x1::TestCoin::TestCoin,").parseTypeTag();
+      new TypeTagParser("0x1::test_coin::CoinStore<0x1::test_coin::AptosCoin,").parseTypeTag();
     }).toThrow("Invalid type tag.");
 
     expect(() => {
@@ -122,11 +122,11 @@ describe("BuilderUtils", () => {
     }).toThrow("Invalid type tag.");
 
     expect(() => {
-      new TypeTagParser("0x1::<::CoinStore<0x1::TestCoin::TestCoin,").parseTypeTag();
+      new TypeTagParser("0x1::<::CoinStore<0x1::test_coin::AptosCoin,").parseTypeTag();
     }).toThrow("Invalid type tag.");
 
     expect(() => {
-      new TypeTagParser("0x1::TestCoin::><0x1::TestCoin::TestCoin,").parseTypeTag();
+      new TypeTagParser("0x1::test_coin::><0x1::test_coin::AptosCoin,").parseTypeTag();
     }).toThrow("Invalid type tag.");
 
     expect(() => {

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
@@ -1,0 +1,229 @@
+import { HexString } from "../hex_string";
+import {
+  AccountAddress,
+  TransactionArgumentAddress,
+  TransactionArgumentBool,
+  TransactionArgumentU128,
+  TransactionArgumentU64,
+  TransactionArgumentU8,
+  TransactionArgumentU8Vector,
+  TypeTagAddress,
+  TypeTagBool,
+  TypeTagStruct,
+  TypeTagU128,
+  TypeTagU64,
+  TypeTagU8,
+  TypeTagVector,
+} from "./aptos_types";
+import { Serializer } from "./bcs";
+import { argToTransactionArgument, parseTypeTag, serializeArg } from "./builder_utils";
+
+describe("BuilderUtils", () => {
+  it("parses a bool TypeTag", async () => {
+    expect(parseTypeTag("bool") instanceof TypeTagBool).toBeTruthy();
+  });
+
+  it("parses a u8 TypeTag", async () => {
+    expect(parseTypeTag("u8") instanceof TypeTagU8).toBeTruthy();
+  });
+
+  it("parses a u64 TypeTag", async () => {
+    expect(parseTypeTag("u64") instanceof TypeTagU64).toBeTruthy();
+  });
+
+  it("parses a u128 TypeTag", async () => {
+    expect(parseTypeTag("u128") instanceof TypeTagU128).toBeTruthy();
+  });
+
+  it("parses a address TypeTag", async () => {
+    expect(parseTypeTag("address") instanceof TypeTagAddress).toBeTruthy();
+  });
+
+  it("parses a vector TypeTag", async () => {
+    const vectorAddress = parseTypeTag("vector<address>");
+    expect(vectorAddress instanceof TypeTagVector).toBeTruthy();
+    expect((vectorAddress as TypeTagVector).value instanceof TypeTagAddress).toBeTruthy();
+
+    const vectorU64 = parseTypeTag(" vector < u64 > ");
+    expect(vectorU64 instanceof TypeTagVector).toBeTruthy();
+    expect((vectorU64 as TypeTagVector).value instanceof TypeTagU64).toBeTruthy();
+  });
+
+  it("parses a sturct TypeTag", async () => {
+    const assertStruct = (struct: TypeTagStruct, accountAddress: string, moduleName: string, structName: string) => {
+      expect(HexString.fromUint8Array(struct.value.address.address).toShortString()).toBe(accountAddress);
+      expect(struct.value.module_name.value).toBe(moduleName);
+      expect(struct.value.name.value).toBe(structName);
+    };
+    const coin = parseTypeTag("0x1::TestCoin::Coin");
+    expect(coin instanceof TypeTagStruct).toBeTruthy();
+    assertStruct(coin as TypeTagStruct, "0x1", "TestCoin", "Coin");
+
+    const testCoin = parseTypeTag("0x1::Coin::CoinStore < 0x1::TestCoin::TestCoin1 ,  0x1::TestCoin::TestCoin2 > ");
+    expect(testCoin instanceof TypeTagStruct).toBeTruthy();
+    assertStruct(testCoin as TypeTagStruct, "0x1", "Coin", "CoinStore");
+
+    const structTypeTags = (testCoin as TypeTagStruct).value.type_args;
+    expect(structTypeTags.length).toBe(2);
+
+    const structTypeTag1 = structTypeTags[0];
+    assertStruct(structTypeTag1 as TypeTagStruct, "0x1", "TestCoin", "TestCoin1");
+
+    const structTypeTag2 = structTypeTags[1];
+    assertStruct(structTypeTag2 as TypeTagStruct, "0x1", "TestCoin", "TestCoin2");
+
+    expect(() => {
+      parseTypeTag("0x1::TestCoin");
+    }).toThrow("Invalid struct tag string literal.");
+
+    expect(() => {
+      parseTypeTag("0x1::TestCoin::CoinStore<0x1::TestCoin::TestCoin");
+    }).toThrow("Invalid struct tag string literal.");
+
+    expect(() => {
+      parseTypeTag("0x1::TestCoin::CoinStore<0x1::TestCoin>");
+    }).toThrow("Invalid struct tag string literal.");
+  });
+
+  it("serializes a boolean arg", async () => {
+    let serializer = new Serializer();
+    serializeArg(true, new TypeTagBool(), serializer);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x01]));
+    serializer = new Serializer();
+    expect(() => {
+      serializeArg(123, new TypeTagBool(), serializer);
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("serializes a u8 arg", async () => {
+    let serializer = new Serializer();
+    serializeArg(255, new TypeTagU8(), serializer);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0xff]));
+
+    serializer = new Serializer();
+    expect(() => {
+      serializeArg("u8", new TypeTagU8(), serializer);
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("serializes a u64 arg", async () => {
+    let serializer = new Serializer();
+    serializeArg(18446744073709551615n, new TypeTagU64(), serializer);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
+
+    serializer = new Serializer();
+    expect(() => {
+      serializeArg("u64", new TypeTagU64(), serializer);
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("serializes a u128 arg", async () => {
+    let serializer = new Serializer();
+    serializeArg(340282366920938463463374607431768211455n, new TypeTagU128(), serializer);
+    expect(serializer.getBytes()).toEqual(
+      new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+    );
+
+    serializer = new Serializer();
+    expect(() => {
+      serializeArg("u128", new TypeTagU128(), serializer);
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("serializes an AccountAddress arg", async () => {
+    let serializer = new Serializer();
+    serializeArg("0x1", new TypeTagAddress(), serializer);
+    expect(HexString.fromUint8Array(serializer.getBytes()).toShortString()).toEqual("0x1");
+
+    serializer = new Serializer();
+    serializeArg(AccountAddress.fromHex("0x1"), new TypeTagAddress(), serializer);
+    expect(HexString.fromUint8Array(serializer.getBytes()).toShortString()).toEqual("0x1");
+
+    serializer = new Serializer();
+    expect(() => {
+      serializeArg(123456, new TypeTagAddress(), serializer);
+    }).toThrow("Invalid account address.");
+  });
+
+  it("serializes a vector arg", async () => {
+    let serializer = new Serializer();
+    serializeArg([255], new TypeTagVector(new TypeTagU8()), serializer);
+    expect(serializer.getBytes()).toEqual(new Uint8Array([0x1, 0xff]));
+
+    serializer = new Serializer();
+    expect(() => {
+      serializeArg(123456, new TypeTagVector(new TypeTagU8()), serializer);
+    }).toThrow("Invalid vector args.");
+  });
+
+  it("throws at unrecognized arg types", async () => {
+    const serializer = new Serializer();
+    expect(() => {
+      // @ts-ignore
+      serializeArg(123456, "unknown_type", serializer);
+    }).toThrow("Unsupported arg type.");
+  });
+
+  it("converts a boolean TransactionArgument", async () => {
+    const res = argToTransactionArgument(true, new TypeTagBool());
+    expect((res as TransactionArgumentBool).value).toEqual(true);
+    expect(() => {
+      argToTransactionArgument(123, new TypeTagBool());
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("converts a u8 TransactionArgument", async () => {
+    const res = argToTransactionArgument(123, new TypeTagU8());
+    expect((res as TransactionArgumentU8).value).toEqual(123);
+    expect(() => {
+      argToTransactionArgument("u8", new TypeTagBool());
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("converts a u64 TransactionArgument", async () => {
+    const res = argToTransactionArgument(123, new TypeTagU64());
+    expect((res as TransactionArgumentU64).value).toEqual(123);
+    expect(() => {
+      argToTransactionArgument("u64", new TypeTagU64());
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("converts a u128 TransactionArgument", async () => {
+    const res = argToTransactionArgument(123, new TypeTagU128());
+    expect((res as TransactionArgumentU128).value).toEqual(123);
+    expect(() => {
+      argToTransactionArgument("u128", new TypeTagU128());
+    }).toThrow(/Invalid arg/);
+  });
+
+  it("converts an AccountAddress TransactionArgument", async () => {
+    let res = argToTransactionArgument("0x1", new TypeTagAddress()) as TransactionArgumentAddress;
+    expect(HexString.fromUint8Array(res.value.address).toShortString()).toEqual("0x1");
+
+    res = argToTransactionArgument(AccountAddress.fromHex("0x2"), new TypeTagAddress()) as TransactionArgumentAddress;
+    expect(HexString.fromUint8Array(res.value.address).toShortString()).toEqual("0x2");
+
+    expect(() => {
+      argToTransactionArgument(123456, new TypeTagAddress());
+    }).toThrow("Invalid account address.");
+  });
+
+  it("converts a vector TransactionArgument", async () => {
+    const res = argToTransactionArgument(
+      new Uint8Array([0x1]),
+      new TypeTagVector(new TypeTagU8()),
+    ) as TransactionArgumentU8Vector;
+    expect(res.value).toEqual(new Uint8Array([0x1]));
+
+    expect(() => {
+      argToTransactionArgument(123456, new TypeTagVector(new TypeTagU8()));
+    }).toThrow(/.*should be an instance of Uint8Array$/);
+  });
+
+  it("throws at unrecognized TransactionArgument types", async () => {
+    expect(() => {
+      // @ts-ignore
+      argToTransactionArgument(123456, "unknown_type");
+    }).toThrow("Unknown type for TransactionArgument.");
+  });
+});

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
@@ -243,6 +243,19 @@ export function serializeArg(argVal: any, argType: TypeTag, serializer: Serializ
     return;
   }
   if (argType instanceof TypeTagVector) {
+    // We are serializing a vector<u8>
+    if (argType.value instanceof TypeTagU8) {
+      if (argVal instanceof Uint8Array) {
+        serializer.serializeBytes(argVal);
+        return;
+      }
+
+      if (typeof argVal === "string") {
+        serializer.serializeStr(argVal);
+        return;
+      }
+    }
+
     if (!(argVal instanceof Array)) {
       throw new Error("Invalid vector args.");
     }

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
@@ -1,0 +1,179 @@
+import {
+  TypeTag,
+  TypeTagBool,
+  TypeTagU8,
+  TypeTagU64,
+  TypeTagU128,
+  TypeTagAddress,
+  AccountAddress,
+  TypeTagVector,
+  TypeTagStruct,
+  StructTag,
+  Identifier,
+  TransactionArgument,
+  TransactionArgumentBool,
+  TransactionArgumentU64,
+  TransactionArgumentU128,
+  TransactionArgumentAddress,
+  TransactionArgumentU8,
+  TransactionArgumentU8Vector,
+} from "./aptos_types";
+import { Serializer } from "./bcs";
+
+function assertType(val: any, types: string[] | string, message?: string) {
+  if (!types?.includes(typeof val)) {
+    throw new Error(
+      message || `Invalid arg: ${val} type should be ${types instanceof Array ? types.join(" or ") : types}`,
+    );
+  }
+}
+
+/**
+ * Parses a tag string
+ * @param typeTagStr A string represented tag, e.g. bool
+ * @returns
+ */
+export function parseTypeTag(typeTagStr: string): TypeTag {
+  const typeTag = typeTagStr.trim();
+
+  if (typeTag.startsWith("vector")) {
+    // Strips off 'vector'
+    let innerTagStr = typeTag.substring(6).trim();
+    // Strips off '<' and '>'
+    innerTagStr = innerTagStr.substring(1, innerTagStr.length - 1);
+    return new TypeTagVector(parseTypeTag(innerTagStr));
+  }
+
+  if (typeTag.includes("::")) {
+    if (!typeTag.includes("<")) {
+      return new TypeTagStruct(StructTag.fromString(typeTag));
+    }
+
+    const [structStr, tempStrNotEndTrimmed] = typeTag.split("<", 2);
+
+    // "0x1::Coin::CoinStore".match(/::/g) produces ['::', '::']
+    if ((structStr.match(/::/g) || []).length !== 2) {
+      throw new Error("Invalid struct tag string literal.");
+    }
+
+    const [address, module, name] = structStr.trim().split("::");
+
+    const pos = tempStrNotEndTrimmed.lastIndexOf(">");
+    if (pos === -1) {
+      throw new Error("Invalid struct tag string literal.");
+    }
+
+    const tempStr = tempStrNotEndTrimmed.trim().substring(0, pos - 1);
+
+    const tempStrParts = tempStr.split(",");
+
+    const typeArgs = tempStrParts.map((temp) => parseTypeTag(temp));
+    const structTag = new StructTag(
+      AccountAddress.fromHex(address),
+      new Identifier(module),
+      new Identifier(name),
+      typeArgs,
+    );
+
+    return new TypeTagStruct(structTag);
+  }
+
+  switch (typeTag) {
+    case "bool":
+      return new TypeTagBool();
+    case "u8":
+      return new TypeTagU8();
+    case "u64":
+      return new TypeTagU64();
+    case "u128":
+      return new TypeTagU128();
+    case "address":
+      return new TypeTagAddress();
+    default:
+      throw new Error("Unknown type tag.");
+  }
+}
+
+export function serializeArg(argVal: any, argType: TypeTag, serializer: Serializer) {
+  if (argType instanceof TypeTagBool) {
+    assertType(argVal, "boolean");
+    serializer.serializeBool(argVal);
+    return;
+  }
+  if (argType instanceof TypeTagU8) {
+    assertType(argVal, "number");
+    serializer.serializeU8(argVal);
+    return;
+  }
+  if (argType instanceof TypeTagU64) {
+    assertType(argVal, ["number", "bigint"]);
+    serializer.serializeU64(argVal);
+    return;
+  }
+  if (argType instanceof TypeTagU128) {
+    assertType(argVal, ["number", "bigint"]);
+    serializer.serializeU128(argVal);
+    return;
+  }
+  if (argType instanceof TypeTagAddress) {
+    let addr: AccountAddress;
+    if (typeof argVal === "string") {
+      addr = AccountAddress.fromHex(argVal);
+    } else if (argVal instanceof AccountAddress) {
+      addr = argVal;
+    } else {
+      throw new Error("Invalid account address.");
+    }
+    addr.serialize(serializer);
+    return;
+  }
+  if (argType instanceof TypeTagVector) {
+    if (!(argVal instanceof Array)) {
+      throw new Error("Invalid vector args.");
+    }
+
+    serializer.serializeU32AsUleb128(argVal.length);
+
+    argVal.forEach((arg) => serializeArg(arg, argType.value, serializer));
+    return;
+  }
+  throw new Error("Unsupported arg type.");
+}
+
+export function argToTransactionArgument(argVal: any, argType: TypeTag): TransactionArgument {
+  if (argType instanceof TypeTagBool) {
+    assertType(argVal, "boolean");
+    return new TransactionArgumentBool(argVal);
+  }
+  if (argType instanceof TypeTagU8) {
+    assertType(argVal, "number");
+    return new TransactionArgumentU8(argVal);
+  }
+  if (argType instanceof TypeTagU64) {
+    assertType(argVal, ["number", "bigint"]);
+    return new TransactionArgumentU64(argVal);
+  }
+  if (argType instanceof TypeTagU128) {
+    assertType(argVal, ["number", "bigint"]);
+    return new TransactionArgumentU128(argVal);
+  }
+  if (argType instanceof TypeTagAddress) {
+    let addr: AccountAddress;
+    if (typeof argVal === "string") {
+      addr = AccountAddress.fromHex(argVal);
+    } else if (argVal instanceof AccountAddress) {
+      addr = argVal;
+    } else {
+      throw new Error("Invalid account address.");
+    }
+    return new TransactionArgumentAddress(addr);
+  }
+  if (argType instanceof TypeTagVector && argType.value instanceof TypeTagU8) {
+    if (!(argVal instanceof Uint8Array)) {
+      throw new Error(`${argVal} should be an instance of Uint8Array`);
+    }
+    return new TransactionArgumentU8Vector(argVal);
+  }
+
+  throw new Error("Unknown type for TransactionArgument.");
+}

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
@@ -1,3 +1,4 @@
+import { HexString } from "../hex_string";
 import {
   TypeTag,
   TypeTagBool,
@@ -50,7 +51,7 @@ type TokenType = string;
 type TokenValue = string;
 type Token = [TokenType, TokenValue];
 
-// A simple tokenizer, we don't do special processing for cases like 0x...
+// Returns Token and Token byte size
 function nextToken(tagStr: string, pos: number): [Token, number] {
   const c = tagStr[pos];
   if (c === ":") {
@@ -231,7 +232,7 @@ export function serializeArg(argVal: any, argType: TypeTag, serializer: Serializ
   }
   if (argType instanceof TypeTagAddress) {
     let addr: AccountAddress;
-    if (typeof argVal === "string") {
+    if (typeof argVal === "string" || argVal instanceof HexString) {
       addr = AccountAddress.fromHex(argVal);
     } else if (argVal instanceof AccountAddress) {
       addr = argVal;


### PR DESCRIPTION
### Description
This PR aims to provide similar features as the [Ethereum web3 Contract interface](https://web3js.readthedocs.io/en/v1.2.11/web3-eth-contract.html). With Ethereum, developers are able to generate ABI in JSON format and provide the JSON object to the web3 JS. Web3 JS then converts the Javascript function calls to RPC calls.

In Aptos TS SDK, developers must manually construct the transaction payloads for BCS endpoints, which are verbose. With this PR, developers can provide ABI information to the SDK, and the SDK can use the type information in ABI to translate the plain javascript parameters to BCS payloads. This significantly reduces the burden on SDK developers.

The ABIs are generated when compiling Move modules. The ABI bytes can then be provided to the SDK by developers.

### Test Plan
Jest test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1891)
<!-- Reviewable:end -->
