### PR TITLE
Rosetta fixes

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -54,7 +54,7 @@ impl Client {
             .await
     }
 
-    pub async fn get_block_info(&self, version: u64) -> Result<Response<Option<BlockInfo>>> {
+    pub async fn get_block_info(&self, version: u64) -> Result<Response<BlockInfo>> {
         self.get(self.base_url.join(&format!("blocks/{}", version))?)
             .await
     }

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -4,8 +4,8 @@
 use crate::{
     error::{ApiError, ApiResult},
     types::{
-        test_coin_identifier, BlockIdentifier, Currency, MetadataRequest, NetworkIdentifier,
-        PartialBlockIdentifier,
+        test_coin_identifier, BlockIdentifier, Currency, CurrencyMetadata, MetadataRequest,
+        NetworkIdentifier, PartialBlockIdentifier,
     },
     RosettaContext,
 };
@@ -143,6 +143,9 @@ pub fn native_coin() -> Currency {
     Currency {
         symbol: DEFAULT_COIN.to_string(),
         decimals: DEFAULT_DECIMALS,
+        metadata: Some(CurrencyMetadata {
+            move_type: native_coin_tag().to_string(),
+        }),
     }
 }
 

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -52,7 +52,7 @@ impl TryFrom<&AccountIdentifier> for AccountAddress {
 impl From<AccountAddress> for AccountIdentifier {
     fn from(address: AccountAddress) -> Self {
         AccountIdentifier {
-            address: format!("{:#x}", address),
+            address: format!("{:x}", address),
             sub_account: None,
         }
     }
@@ -207,7 +207,7 @@ pub struct TransactionIdentifier {
 impl From<&TransactionInfo> for TransactionIdentifier {
     fn from(txn: &TransactionInfo) -> Self {
         TransactionIdentifier {
-            hash: txn.accumulator_root_hash.to_string(),
+            hash: strip_hex_prefix(&txn.hash.to_string()).to_string(),
         }
     }
 }

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -177,6 +177,12 @@ pub struct Currency {
     pub symbol: String,
     /// Number of decimals to be considered in the currency
     pub decimals: u64,
+    pub metadata: Option<CurrencyMetadata>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct CurrencyMetadata {
+    pub move_type: String,
 }
 
 /// Various signing curves supported by Rosetta.  We only use [`CurveType::Edwards25519`]

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -486,6 +486,7 @@ impl Transaction {
         let status = if txn_info.success {
             OperationStatusType::Success
         } else {
+            // TODO: Pull failed operations from transaction payload
             OperationStatusType::Failure
         };
 
@@ -642,7 +643,8 @@ impl Transaction {
         if let Some(sender) = maybe_sender {
             operations.push(Operation::withdraw(
                 operation_index,
-                Some(status),
+                // Gas charging is always successful if it's been committed
+                Some(OperationStatusType::Success),
                 *sender.inner(),
                 native_coin(),
                 txn_info.gas_used.0,

--- a/storage/aptosdb/src/transaction_store/mod.rs
+++ b/storage/aptosdb/src/transaction_store/mod.rs
@@ -208,14 +208,15 @@ impl TransactionStore {
         }
 
         // If we've found both, we have the whole block
-        if let (Some(start), Some(end)) = (start_version, end_version) {
-            Ok((start, end))
-        } else {
-            Err(AptosDbError::NotFound(format!(
+        match (start_version, end_version) {
+            (Some(start), Some(end)) => Ok((start, end)),
+            // If we didn't find the end, it's a single transaction block (reconfig)
+            (Some(start), None) => Ok((start, start)),
+            _ => Err(AptosDbError::NotFound(format!(
                 "Block boundaries not found for version {}",
                 version
             ))
-            .into())
+            .into()),
         }
     }
 


### PR DESCRIPTION
### Description
0xs were inconsistent across types. Coins didn't have the associated move type, so it made it confusing.  Now its' added.

Also, gas wasn't always charged so it caused issues during failed transactions.  Now, all gas is always charged all the time.

### Test Plan
```
$ rosetta-cli check:data --configuration-file rosetta_config.json

Success: Reconciliation Coverage End Condition [Coverage: 100.000000%]

+--------------------+--------------------------------+--------+
|  CHECK:DATA TESTS  |          DESCRIPTION           | STATUS |
+--------------------+--------------------------------+--------+
| Request/Response   | Rosetta implementation         | PASSED |
|                    | serviced all requests          |        |
+--------------------+--------------------------------+--------+
| Response Assertion | All responses are correctly    | PASSED |
|                    | formatted                      |        |
+--------------------+--------------------------------+--------+
| Block Syncing      | Blocks are connected into a    | PASSED |
|                    | single canonical chain         |        |
+--------------------+--------------------------------+--------+
| Balance Tracking   | Account balances did not go    | PASSED |
|                    | negative                       |        |
+--------------------+--------------------------------+--------+
| Reconciliation     | No balance discrepancies were  | PASSED |
|                    | found between computed and     |        |
|                    | live balances                  |        |
+--------------------+--------------------------------+--------+

+--------------------------+--------------------------------+-------------+
|     CHECK:DATA STATS     |          DESCRIPTION           |    VALUE    |
+--------------------------+--------------------------------+-------------+
| Blocks                   | # of blocks synced             |       14482 |
+--------------------------+--------------------------------+-------------+
| Orphans                  | # of blocks orphaned           |           0 |
+--------------------------+--------------------------------+-------------+
| Transactions             | # of transaction processed     |       28825 |
+--------------------------+--------------------------------+-------------+
| Operations               | # of operations processed      |          44 |
+--------------------------+--------------------------------+-------------+
| Accounts                 | # of accounts seen             |           6 |
+--------------------------+--------------------------------+-------------+
| Active Reconciliations   | # of reconciliations performed |          31 |
|                          | after seeing an account in a   |             |
|                          | block                          |             |
+--------------------------+--------------------------------+-------------+
| Inactive Reconciliations | # of reconciliations performed |         314 |
|                          | on randomly selected accounts  |             |
+--------------------------+--------------------------------+-------------+
| Exempt Reconciliations   | # of reconciliation failures   |           0 |
|                          | considered exempt              |             |
+--------------------------+--------------------------------+-------------+
| Failed Reconciliations   | # of reconciliation failures   |           0 |
+--------------------------+--------------------------------+-------------+
| Skipped Reconciliations  | # of reconciliations skipped   |           0 |
+--------------------------+--------------------------------+-------------+
| Reconciliation Coverage  | % of accounts that have been   | 100.000000% |
|                          | reconciled                     |             |
+--------------------------+--------------------------------+-------------+

badger 2022/07/11 16:15:36 INFO: Storing value log head: {Fid:0 Len:33 Offset:19906543}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1892)
<!-- Reviewable:end -->
