### PR TITLE
[testnet] Decouple the fullnode count from the validator count

### DIFF
--- a/terraform/aptos-node-testnet/addons.tf
+++ b/terraform/aptos-node-testnet/addons.tf
@@ -178,6 +178,15 @@ resource "helm_release" "testnet-addons" {
         acm_certificate          = length(aws_acm_certificate.ingress) > 0 ? aws_acm_certificate.ingress[0].arn : null
         loadBalancerSourceRanges = var.client_sources_ipv4
       }
+      load_test = {
+        fullnodeGroups = try(var.aptos_node_helm_values.fullnode.groups, [])
+        config = {
+          numFullnodeGroups = var.num_fullnode_groups
+        }
+        image = {
+          tag = var.image_tag
+        }
+      }
     }),
     jsonencode(var.testnet_addons_helm_values)
   ]

--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -47,8 +47,9 @@ module "validator" {
   image_tag      = var.image_tag
   validator_name = "aptos-node"
 
-  num_validators = var.num_validators
-  helm_values    = var.aptos_node_helm_values
+  num_validators       = var.num_validators
+  num_fullnode_groups  = var.num_fullnode_groups
+  helm_values          = var.aptos_node_helm_values
 
   # allow all nodegroups to surge to 2x their size, in case of total nodes replacement
   validator_instance_num = var.num_validator_instance > 0 ? 2 * var.num_validator_instance : var.num_validators

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -118,7 +118,13 @@ variable "testnet_addons_helm_values" {
 ### EKS nodegroups
 
 variable "num_validators" {
-  default = 4
+  description = "The number of validator nodes to create"
+  default     = 4
+}
+
+variable "num_fullnode_groups" {
+  description = "The number of fullnode groups to create"
+  default     = 1
 }
 
 variable "num_utility_instance" {

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -95,8 +95,9 @@ resource "helm_release" "calico" {
 
 locals {
   helm_values = jsonencode({
-    numValidators = var.num_validators
-    imageTag      = var.image_tag
+    numValidators     = var.num_validators
+    numFullnodeGroups = var.num_fullnode_groups
+    imageTag          = var.image_tag
     chain = {
       era        = var.era
       chain_id   = var.chain_id

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -9,7 +9,13 @@ variable "k8s_api_sources" {
 }
 
 variable "num_validators" {
-  default = 1
+  description = "The number of validator nodes to create"
+  default     = 1
+}
+
+variable "num_fullnode_groups" {
+  description = "The number of fullnode groups to create"
+  default     = 1
 }
 
 variable "era" {

--- a/terraform/helm/aptos-node/files/haproxy.cfg
+++ b/terraform/helm/aptos-node/files/haproxy.cfg
@@ -67,6 +67,7 @@ backend validator-api
 {{- end }}
 
 {{- range $index, $config := $.Values.fullnode.groups }}
+{{- if lt $.Values.i (int $.Values.numFullnodeGroups) }}
 
 frontend {{ $config.name }}-aptosnet
     bind :{{ add 6182 $index }}
@@ -111,6 +112,7 @@ backend {{ $config.name }}-metrics
     default-server maxconn 1024
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }} {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }}:9101
 
+{{- end }}
 {{- end }}
 
 frontend stats

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -1,4 +1,4 @@
-{{- range $i, $e := until (int .Values.numValidators) }}
+{{- range $i, $e := until (int .Values.numFullnodeGroups) }}
 {{- range $.Values.fullnode.groups }}
 ---
 

--- a/terraform/helm/aptos-node/templates/haproxy.yaml
+++ b/terraform/helm/aptos-node/templates/haproxy.yaml
@@ -57,6 +57,7 @@ spec:
   {{- end }}
 
 {{- range $index, $config := $.Values.fullnode.groups }}
+{{- if lt $i (int $.Values.numFullnodeGroups) }}
 ---
 apiVersion: v1
 kind: Service
@@ -104,6 +105,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 
+{{- end }}
 {{- end }}
 
 ---

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -7,6 +7,7 @@ imageTag: testnet
 
 # Number of validators to deploy
 numValidators: 1
+numFullnodeGroups: 1
 
 validator:
   name:

--- a/terraform/helm/testnet-addons/templates/loadtest.yaml
+++ b/terraform/helm/testnet-addons/templates/loadtest.yaml
@@ -30,11 +30,29 @@ spec:
             - emit-tx
             - --mint-key={{ .Values.load_test.config.mint_key }}
             - --chain-id={{ .Values.genesis.chain_id }}
-            {{- range $i := until (int $.Values.genesis.numValidators) }}
+            {{- $numTargets := 0 }}
+            {{- $targetSuffix := "" }}
+            {{- $targetGroups := list }}
+            {{- if $.Values.load_test.config.use_validators }}
+              {{- $numTargets = $.Values.genesis.numValidators }}
+              {{- $targetSuffix = "validator" }}
+              {{- $targetGroups = list }}
+            {{- else }}
+              {{- $numTargets = $.Values.load_test.config.numFullnodeGroups }}
+              {{- $targetSuffix = "fullnode" }}
+              {{- $targetGroups = $.Values.load_test.fullnodeGroups }}
+            {{- end }}
+            {{- range $i := until (int $numTargets) }}
               {{- $port := 80 }}
-              {{- $nodeType := ternary "validator" "fullnode" $.Values.load_test.config.use_validators }}
-              {{- $nodeName := join "-" (list $.Values.genesis.username_prefix $i $nodeType "lb") }}
+              {{- if $targetGroups }}
+              {{- range $group := $targetGroups }}
+              {{- $nodeName := join "-" (list $.Values.genesis.username_prefix $i $group.name "lb") }}
             - --targets=http://{{ $nodeName }}:{{ $port }}
+              {{- end }}
+              {{- else }}
+              {{- $nodeName := join "-" (list $.Values.genesis.username_prefix $i $targetSuffix "lb") }}
+            - --targets=http://{{ $nodeName }}:{{ $port }}
+              {{- end }}
             {{- end }}
           # This with terminates on line 77
           {{- with .Values.load_test }}

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -33,7 +33,11 @@ load_test:
   tolerations: []
   affinity: {}
   intervalMins: 15
+  fullnode:
+    groups:
+    - name: fullnode
   config:
+    numFullnodeGroups:
     mint_key:
     duration: 300
     accounts_per_client: 12


### PR DESCRIPTION
Decouple the number of desired fullnodes from desired validators. Coupling these is fine for small networks, but for large scale testing you may want vastly different number of validator and fullnodes to simulate different scenarios. This change attempt to make them separate numbers and expose the values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1893)
<!-- Reviewable:end -->
