### PR TITLE
rosetta: add rosetta compliant dockerfile and docs how to build+run it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ target-out-docker
 # Typescript
 *.env
 node_modules
+
+# local /data dir sometimes used for testing
+/data

--- a/docker/rosetta/README.md
+++ b/docker/rosetta/README.md
@@ -1,0 +1,58 @@
+# Rosetta API Dockerfile
+
+This directory contains a Dockerfile meant to build a [Rosetta compliant Docker image](https://www.rosetta-api.org/docs/node_deployment.html) of Aptos.
+
+## One-shot devnet deployment
+
+Run the following commands for testing only. For production make sure you read the remainder of this README and adjust the steps as necessary.
+
+```
+GIT_SHA=main ./docker/rosetta/docker-build-rosetta.sh && \
+mkdir -p data && \
+cp config/src/config/test_data/public_full_node.yaml data/fullnode.yaml && \
+curl -o data/genesis.blob https://devnet.aptoslabs.com/genesis.blob && \
+curl -o data/waypoint.txt https://devnet.aptoslabs.com/waypoint.txt && \
+docker run -p 8082:8082 -p 8083:8083 --rm -v $(pwd)/data:/opt/aptos/data aptos-core:rosetta-latest online --config /opt/aptos/data/fullnode.yaml
+```
+
+## How to build the image
+
+Use either option
+
+Option 1:
+
+```
+docker/rosetta/docker-build-rosetta.sh
+```
+
+Option 2:
+
+```
+docker buildx build --file docker/rosetta/rosetta.Dockerfile --build-arg=GIT_SHA=<GIT_SHA_YOU_WANT_TO_BUILD> -t aptos-core:rosetta-<GIT_SHA_YOU_WANT_TO_BUILD> -t aptos-core:rosetta-latest .
+```
+
+## How to run
+
+The rosetta docker image contains a single binary `aptos-rosetta` which is meant to run a fullnode and rosetta API:
+
+In order to run it, create a `data` directory and put a `fullnode.yaml`, `genesis.blob` and `waypoint.txt` into it.
+Since aptos-rosetta is essentially just a special fullnode with a rosetta API, you can follow these instructions to fetch or create these config files: https://aptos.dev/nodes/full-node/fullnode-source-code-and-docker.
+
+Once you've built the image and put all the config data in the `data` directory you can run aptos-rosetta via:
+
+**online mode**
+
+```
+docker run -p 8082:8082 -p 8083:8083 --rm -v $(pwd)/data:/opt/aptos aptos-core:rosetta-latest aptos-rosetta online --config /opt/aptos/fullnode.yaml
+```
+
+**offline mode**
+
+```
+docker run -p 8082:8082 -p 8083:8083 --rm -v $(pwd)/data:/opt/aptos aptos-core:rosetta-latest aptos-rosetta offline --config /opt/aptos/fullnode.yaml
+```
+
+The APIs are available under:
+
+- 8082 for online mode
+- 8083 for offline mode

--- a/docker/rosetta/docker-build-rosetta.sh
+++ b/docker/rosetta/docker-build-rosetta.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+# This script is meant to build the rosetta docker image.
+# Run it via `docker/rosetta/docker-build-rosetta.sh`
+set -ex
+
+export GIT_SHA="${GIT_SHA:-$(git rev-parse HEAD)}"
+
+docker buildx build --file docker/rosetta/rosetta.Dockerfile --build-arg=GIT_SHA=$GIT_SHA -t aptos-core:rosetta-$GIT_SHA -t aptos-core:rosetta-latest --load .

--- a/docker/rosetta/rosetta.Dockerfile
+++ b/docker/rosetta/rosetta.Dockerfile
@@ -1,0 +1,40 @@
+FROM debian:buster-20220228@sha256:fd510d85d7e0691ca551fe08e8a2516a86c7f24601a940a299b5fe5cdd22c03a AS debian-base
+
+## get rust build environment ready
+FROM rust:1.61-buster AS rust-base
+
+WORKDIR /aptos
+RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev
+
+### Build Rust code ###
+FROM rust-base as builder
+
+ARG GIT_SHA
+RUN git clone https://github.com/aptos-labs/aptos-core.git ./ && git reset $GIT_SHA --hard
+RUN --mount=type=cache,target=/aptos/target --mount=type=cache,target=$CARGO_HOME/registry \
+  cargo build --release \
+  -p aptos-node \
+  -p aptos-rosetta \
+  && mkdir dist \
+  && cp target/release/aptos-node dist/aptos-node \
+  && cp target/release/aptos-rosetta dist/aptos-rosetta
+
+### Create image with aptos-node and aptos-rosetta ###
+FROM debian-base AS rosetta
+
+RUN apt-get update && apt-get install -y libssl1.1 ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*
+
+COPY --from=builder /aptos/dist/aptos-rosetta /usr/local/bin/aptos-rosetta
+
+# Rosetta online API
+EXPOSE 8082
+# Rosetta offline API
+EXPOSE 8083
+
+# Capture backtrace on error
+ENV RUST_BACKTRACE 1
+
+WORKDIR /opt/aptos/data
+
+ENTRYPOINT ["/usr/local/bin/aptos-rosetta"]
+CMD ["online", "--config /opt/aptos/fullnode.yaml"]


### PR DESCRIPTION
### Description

This introduces a dockerfile file to run a fullnode with a rosetta API - https://www.rosetta-api.org/ .
The dockerfile tries to follow the conventions set here https://www.rosetta-api.org/docs/node_deployment.html#dockerfile-expectations.

### Test Plan
Ran this locally:
```
GIT_SHA=main ./docker/rosetta/docker-build-rosetta.sh && \
mkdir -p data && \
cp config/src/config/test_data/public_full_node.yaml data/fullnode.yaml && \
curl -o data/genesis.blob https://devnet.aptoslabs.com/genesis.blob && \
curl -o data/waypoint.txt https://devnet.aptoslabs.com/waypoint.txt && \
docker run -p 8082:8082 -p 8083:8083 --rm -v $(pwd)/data:/opt/aptos/data aptos-core:rosetta-latest online --config /opt/aptos/data/fullnode.yaml
```

and accessed the rosetta API on `localhost:8082` (that part is still TBD, waiting for some fixes in aptos-rosetta to be landed first).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1899)
<!-- Reviewable:end -->
