### PR TITLE
[Storage] Delegate state updates caching to state store from InMemoryStateCalculator 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3022,7 +3022,6 @@ dependencies = [
  "bcs",
  "itertools",
  "once_cell",
- "rayon",
  "scratchpad",
  "serde 1.0.137",
  "storage-interface",

--- a/execution/executor-benchmark/src/state_committer.rs
+++ b/execution/executor-benchmark/src/state_committer.rs
@@ -101,7 +101,7 @@ impl StateCommitter {
             .freeze()
             .new_node_hashes_since(&self.committed_smt.clone().freeze());
         self.db
-            .save_state_snapshot(
+            .save_state_snapshot_for_bench(
                 to_commit,
                 Some(&node_hashes),
                 self.version,

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -182,6 +182,29 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
         .unwrap();
     verify_committed_txn_status(t6.as_ref(), &block1[8]).unwrap();
 
+    // test the initial balance.
+    let db_state_view = db.reader.state_view_at_version(Some(6)).unwrap();
+    let account1_state_view = db_state_view.as_account_with_state_view(&account1_address);
+    verify_account_balance(get_account_balance(&account1_state_view), |x| {
+        x == 2_000_000
+    })
+    .unwrap();
+
+    let account2_state_view = db_state_view.as_account_with_state_view(&account2_address);
+
+    verify_account_balance(get_account_balance(&account2_state_view), |x| {
+        x == 1_200_000
+    })
+    .unwrap();
+
+    let account3_state_view = db_state_view.as_account_with_state_view(&account3_address);
+
+    verify_account_balance(get_account_balance(&account3_state_view), |x| {
+        x == 1_000_000
+    })
+    .unwrap();
+
+    // test the final balance.
     let db_state_view = db
         .reader
         .state_view_at_version(Some(current_version))

--- a/execution/executor-types/Cargo.toml
+++ b/execution/executor-types/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 itertools = "0.10.0"
 once_cell = "1.10.0"
-rayon = "1.5.2"
 serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 

--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -51,7 +51,6 @@ impl ExecutedChunk {
                     txn.clone(),
                     txn_data.txn_info.clone(),
                     txn_data.state_updates().clone(),
-                    Some(txn_data.jf_node_hashes().clone()),
                     txn_data.write_set().clone(),
                     txn_data.events().to_vec(),
                 ))

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -16,7 +16,6 @@ use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
-    nibble::nibble_path::NibblePath,
     proof::{accumulator::InMemoryAccumulator, AccumulatorExtensionProof},
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
@@ -319,10 +318,6 @@ pub struct TransactionData {
     /// transaction.
     state_updates: HashMap<StateKey, StateValue>,
 
-    /// Each entry in this map represents the the hash of a newly generated jellyfish node
-    /// and its corresponding nibble path.
-    jf_node_hashes: HashMap<NibblePath, HashValue>,
-
     /// The writeset generated from this transaction.
     write_set: WriteSet,
 
@@ -351,7 +346,6 @@ pub struct TransactionData {
 impl TransactionData {
     pub fn new(
         state_updates: HashMap<StateKey, StateValue>,
-        jf_node_hashes: HashMap<NibblePath, HashValue>,
         write_set: WriteSet,
         events: Vec<ContractEvent>,
         reconfig_events: Vec<ContractEvent>,
@@ -363,7 +357,6 @@ impl TransactionData {
     ) -> Self {
         TransactionData {
             state_updates,
-            jf_node_hashes,
             write_set,
             events,
             reconfig_events,
@@ -377,10 +370,6 @@ impl TransactionData {
 
     pub fn state_updates(&self) -> &HashMap<StateKey, StateValue> {
         &self.state_updates
-    }
-
-    pub fn jf_node_hashes(&self) -> &HashMap<NibblePath, HashValue> {
-        &self.jf_node_hashes
     }
 
     pub fn write_set(&self) -> &WriteSet {

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -62,6 +62,10 @@ impl RestoreHandler {
         )
     }
 
+    pub fn maybe_reset_state_store(&self, version: Version) {
+        self.state_store.maybe_reset(version);
+    }
+
     pub fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()> {
         restore_utils::save_ledger_infos(
             self.ledger_db.clone(),

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1299,8 +1299,7 @@ impl DbWriter for AptosDB {
         })
     }
 
-    /// Snapshots are persisted checkpoints that merklize global state key-value pairs.
-    fn save_state_snapshot(
+    fn save_state_snapshot_for_bench(
         &self,
         jmt_updates: Vec<(HashValue, (HashValue, StateKey))>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
@@ -1329,6 +1328,36 @@ impl DbWriter for AptosDB {
                 in_memory_state.current_version = Some(version);
                 in_memory_state.updated_since_checkpoint.clear();
             }
+            Ok(())
+        })
+    }
+
+    /// Snapshots are persisted checkpoints that merklize global state key-value pairs.
+    fn save_state_snapshot(
+        &self,
+        version: Version,
+        base_version: Option<Version>,
+        state_tree_at_snapshot: SparseMerkleTree<StateValue>,
+    ) -> Result<()> {
+        gauged_api("save_state_snapshot", || {
+            let mut in_memory_state = self.state_store.in_memory_state().lock();
+            let root_hash = self.state_store.merklize_value_set(
+                jmt_update_refs(&jmt_updates(&in_memory_state.updated_since_checkpoint)),
+                None,
+                version,
+                base_version,
+            )?;
+            trace!(
+                version = version,
+                base_version = base_version,
+                root_hash = root_hash,
+                "State snapshot committed."
+            );
+            in_memory_state.checkpoint = state_tree_at_snapshot.clone();
+            in_memory_state.checkpoint_version = Some(version);
+            in_memory_state.current = state_tree_at_snapshot.clone();
+            in_memory_state.current_version = Some(version);
+            in_memory_state.updated_since_checkpoint.clear();
             Ok(())
         })
     }
@@ -1383,27 +1412,6 @@ impl DbWriter for AptosDB {
             let new_root_hash =
                 self.save_transactions_impl(txns_to_commit, first_version, &mut cs)?;
 
-            if save_state_snapshots {
-                let mut base_version = base_state_version;
-                // find all the checkpoint versions
-                for (idx, jmt_updates) in txns_to_commit
-                    .iter()
-                    .enumerate()
-                    .filter(|(_idx, txn_to_commit)| !txn_to_commit.state_updates().is_empty())
-                    .map(|(idx, txn_to_commit)| (idx, jmt_updates(txn_to_commit.state_updates())))
-                {
-                    let version = first_version + idx as LeafCount;
-                    self.save_state_snapshot(
-                        jmt_updates,
-                        None,
-                        version,
-                        base_version,
-                        state_tree.clone(),
-                    )?;
-                    base_version = Some(version);
-                }
-            }
-
             // If expected ledger info is provided, verify result root hash and save the ledger info.
             if let Some(x) = ledger_info_with_sigs {
                 let expected_root_hash = x.ledger_info().transaction_accumulator_hash();
@@ -1425,12 +1433,36 @@ impl DbWriter for AptosDB {
                     .start_timer();
                 self.commit(sealed_cs)?;
             }
+            if save_state_snapshots {
+                let checkpoint_version =
+                    self.state_store.in_memory_state().lock().checkpoint_version;
+                let mut base_version = base_state_version;
+                ensure!(
+                    base_version == checkpoint_version,
+                    "base_version {:?} does not match checkpoint_version {:?} in state_store",
+                    base_version,
+                    checkpoint_version
+                );
+                // find all the checkpoint versions
+                for (idx, txn_to_commit) in txns_to_commit.iter().enumerate() {
+                    self.state_store
+                        .in_memory_state()
+                        .lock()
+                        .updated_since_checkpoint
+                        .extend(txn_to_commit.state_updates().clone());
+                    if txn_to_commit.is_state_checkpoint() {
+                        let version = first_version + idx as LeafCount;
+                        self.save_state_snapshot(version, base_version, state_tree.clone())?;
+                        base_version = Some(version);
+                    }
+                }
+            }
             // update the InMemoryState in StateStore.
             {
                 let mut in_memory_state = self.state_store.in_memory_state().lock();
-                in_memory_state.current = state_tree;
+                in_memory_state.current = state_tree.clone();
                 in_memory_state.current_version = Some(last_version);
-            }
+            };
 
             // Only increment counter if commit succeeds and there are at least one transaction written
             // to the storage. That's also when we'd inform the pruner thread to work.

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1386,22 +1386,16 @@ impl DbWriter for AptosDB {
             if save_state_snapshots {
                 let mut base_version = base_state_version;
                 // find all the checkpoint versions
-                for (idx, jmt_updates, jf_node_hashes) in txns_to_commit
+                for (idx, jmt_updates) in txns_to_commit
                     .iter()
                     .enumerate()
                     .filter(|(_idx, txn_to_commit)| !txn_to_commit.state_updates().is_empty())
-                    .map(|(idx, txn_to_commit)| {
-                        (
-                            idx,
-                            jmt_updates(txn_to_commit.state_updates()),
-                            txn_to_commit.jf_node_hashes(),
-                        )
-                    })
+                    .map(|(idx, txn_to_commit)| (idx, jmt_updates(txn_to_commit.state_updates())))
                 {
                     let version = first_version + idx as LeafCount;
                     self.save_state_snapshot(
                         jmt_updates,
-                        jf_node_hashes,
+                        None,
                         version,
                         base_version,
                         state_tree.clone(),

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -177,10 +177,10 @@ impl StateStore {
         // For non-restore cases, always snapshot_next_version <= num_transactions.
         if snapshot_next_version > num_transactions {
             info!(
-            snapshot_next_version = snapshot_next_version,
+                snapshot_next_version = snapshot_next_version,
                 num_transactions = num_transactions,
-            "snapshot is after latest transaction version. It should only happen in restore mode",
-           );
+                "snapshot is after latest transaction version. It should only happen in restore mode",
+            );
         }
 
         // Replaying the committed write sets after the latest snapshot.

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -15,7 +15,7 @@ use aptos_infallible::Mutex;
 use aptos_jellyfish_merkle::{
     iterator::JellyfishMerkleIterator, restore::StateSnapshotRestore, StateValueWriter,
 };
-use aptos_logger::debug;
+use aptos_logger::{debug, info};
 use aptos_state_view::StateViewId;
 use aptos_types::{
     nibble::nibble_path::NibblePath,
@@ -138,7 +138,7 @@ impl StateStore {
             .lock()
             .checkpoint_version
             .map_or(0, |v| v + 1)
-            < version
+            <= version
         {
             self.initialize(false)
                 .expect("StateStore initialization failed.")
@@ -174,15 +174,17 @@ impl StateStore {
             return Ok(());
         }
 
-        ensure!(
-            snapshot_next_version <= num_transactions,
-            "snapshot is after latest version. snapshot_next_version: {}, num_transactions: {}",
-            snapshot_next_version,
-            num_transactions,
-        );
+        // For non-restore cases, always snapshot_next_version <= num_transactions.
+        if snapshot_next_version > num_transactions {
+            info!(
+            snapshot_next_version = snapshot_next_version,
+                num_transactions = num_transactions,
+            "snapshot is after latest transaction version. It should only happen in restore mode",
+           );
+        }
 
         // Replaying the committed write sets after the latest snapshot.
-        if snapshot_next_version != num_transactions {
+        if snapshot_next_version < num_transactions {
             ensure!(
                 num_transactions - snapshot_next_version <= MAX_WRITE_SETS_AFTER_CHECKPOINT,
                 "Too many versions after state snapshot. snapshot_next_version: {}, num_transactions: {}",
@@ -219,6 +221,7 @@ impl StateStore {
             root_hash = root_hash,
             "StateStore initialization finished.",
         );
+
         Ok(())
     }
 

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -576,7 +576,7 @@ pub fn put_as_state_root(db: &AptosDB, version: Version, key: StateKey, value: S
     let mut in_memory_state = db.state_store.in_memory_state().lock();
     in_memory_state.current = smt;
     in_memory_state.current_version = Some(version);
-    in_memory_state.updated_since_checkpoint.insert(key);
+    in_memory_state.updated_since_checkpoint.insert(key, value);
 }
 
 pub fn test_sync_transactions_impl(

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs
@@ -142,7 +142,9 @@ impl StateSnapshotRestoreController {
             leaf_idx.set(chunk.last_idx as i64);
         }
 
-        receiver.finish()
+        receiver.finish()?;
+        self.run_mode.finish(self.version);
+        Ok(())
     }
 
     async fn read_state_value(

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -161,6 +161,15 @@ impl RestoreRunMode {
             }
         }
     }
+
+    pub fn finish(&self, version: Version) {
+        match self {
+            Self::Restore { restore_handler } => {
+                restore_handler.maybe_reset_state_store(version);
+            }
+            Self::Verify => (),
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/storage/storage-interface/src/in_memory_state.rs
+++ b/storage/storage-interface/src/in_memory_state.rs
@@ -7,7 +7,7 @@ use aptos_types::{
     transaction::Version,
 };
 use scratchpad::SparseMerkleTree;
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 /// This represents the state at a certain version in memory.
 ///
@@ -22,7 +22,7 @@ pub struct InMemoryState {
     pub checkpoint_version: Option<Version>,
     pub current: SparseMerkleTree<StateValue>,
     pub current_version: Option<Version>,
-    pub updated_since_checkpoint: HashSet<StateKey>,
+    pub updated_since_checkpoint: HashMap<StateKey, StateValue>,
 }
 
 impl InMemoryState {
@@ -31,7 +31,7 @@ impl InMemoryState {
         checkpoint_version: Option<Version>,
         current: SparseMerkleTree<StateValue>,
         current_version: Option<Version>,
-        updated_since_checkpoint: HashSet<StateKey>,
+        updated_since_checkpoint: HashMap<StateKey, StateValue>,
     ) -> Self {
         assert!(checkpoint_version.map_or(0, |v| v + 1) <= current_version.map_or(0, |v| v + 1));
         Self {
@@ -45,7 +45,7 @@ impl InMemoryState {
 
     pub fn new_empty() -> Self {
         let smt = SparseMerkleTree::new_empty();
-        Self::new(smt.clone(), None, smt, None, HashSet::new())
+        Self::new(smt.clone(), None, smt, None, HashMap::new())
     }
 
     pub fn new_at_checkpoint(root_hash: HashValue, checkpoint_version: Option<Version>) -> Self {
@@ -55,7 +55,7 @@ impl InMemoryState {
             checkpoint_version,
             smt,
             checkpoint_version,
-            HashSet::new(),
+            HashMap::new(),
         )
     }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -645,14 +645,23 @@ pub trait DbWriter: Send + Sync {
         )
     }
 
+    fn save_state_snapshot_for_bench(
+        &self,
+        jmt_updates: Vec<(HashValue, (HashValue, StateKey))>,
+        node_hashes: Option<&HashMap<NibblePath, HashValue>>,
+        version: Version,
+        base_version: Option<Version>,
+        state_tree_at_snapshot: SparseMerkleTree<StateValue>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
     /// Persists merklized states as authenticated state checkpoint.
     /// See [`AptosDB::save_state_snapshot`].
     ///
     /// [`AptosDB::save_state_snapshot`]: ../aptosdb/struct.AptosDB.html#method.save_state_snapshot
     fn save_state_snapshot(
         &self,
-        jmt_updates: Vec<(HashValue, (HashValue, StateKey))>,
-        node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         version: Version,
         base_version: Option<Version>,
         state_tree_at_snapshot: SparseMerkleTree<StateValue>,
@@ -747,7 +756,7 @@ pub fn jmt_updates(
 ) -> Vec<(HashValue, (HashValue, StateKey))> {
     state_updates
         .iter()
-        .map(|(k, v)| (k.hash(), (v.hash(), k.clone())))
+        .map(|(k, v)| (k.hash(), (v.hash(), (*k).clone())))
         .collect()
 }
 

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -812,7 +812,6 @@ impl TransactionToCommitGen {
             TransactionInfo::new_placeholder(self.gas_used, self.status),
             // state updates will be dealt with in BlockGen at a state checkpoint
             HashMap::new(), /* state updates */
-            None,
             self.write_set,
             events,
         )
@@ -1141,7 +1140,6 @@ impl BlockGen {
             Transaction::StateCheckpoint(HashValue::random()),
             TransactionInfo::new_placeholder(0, ExecutionStatus::Success),
             state_updates,
-            None,
             WriteSet::default(),
             Vec::new(),
         ));

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -7,7 +7,6 @@ use crate::{
     chain_id::ChainId,
     contract_event::ContractEvent,
     ledger_info::LedgerInfo,
-    nibble::nibble_path::NibblePath,
     proof::{
         accumulator::InMemoryAccumulator, TransactionInfoListWithProof, TransactionInfoWithProof,
     },
@@ -1093,7 +1092,6 @@ pub struct TransactionToCommit {
     transaction: Transaction,
     transaction_info: TransactionInfo,
     state_updates: HashMap<StateKey, StateValue>,
-    jf_node_hashes: Option<HashMap<NibblePath, HashValue>>,
     write_set: WriteSet,
     events: Vec<ContractEvent>,
 }
@@ -1103,7 +1101,6 @@ impl TransactionToCommit {
         transaction: Transaction,
         transaction_info: TransactionInfo,
         state_updates: HashMap<StateKey, StateValue>,
-        jf_node_hashes: Option<HashMap<NibblePath, HashValue>>,
         write_set: WriteSet,
         events: Vec<ContractEvent>,
     ) -> Self {
@@ -1111,7 +1108,6 @@ impl TransactionToCommit {
             transaction,
             transaction_info,
             state_updates,
-            jf_node_hashes,
             write_set,
             events,
         }
@@ -1132,10 +1128,6 @@ impl TransactionToCommit {
 
     pub fn state_updates(&self) -> &HashMap<StateKey, StateValue> {
         &self.state_updates
-    }
-
-    pub fn jf_node_hashes(&self) -> Option<&HashMap<NibblePath, HashValue>> {
-        self.jf_node_hashes.as_ref()
     }
 
     pub fn write_set(&self) -> &WriteSet {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1121,6 +1121,10 @@ impl TransactionToCommit {
         &self.transaction_info
     }
 
+    pub fn is_state_checkpoint(&self) -> bool {
+        self.transaction_info().state_checkpoint_hash.is_some()
+    }
+
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn set_transaction_info(&mut self, txn_info: TransactionInfo) {
         self.transaction_info = txn_info


### PR DESCRIPTION
### Description
As title, we now cache the pending state updates in `state_store.in_memory_state` instead of in_memory_state_calculator.
Also, we commit only at checkpoints the data in `state_store.in_memory_state.updated_from_checkpoint`. 

It is the prep for lazy commit. later we're gonna make the commit function call async.

### Test Plan
ut

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1902)
<!-- Reviewable:end -->
