### PR TITLE
[community] Update leaderboard/it2 for new schema.

### DIFF
--- a/ecosystem/platform/server/app/components/table_header_column_component.rb
+++ b/ecosystem/platform/server/app/components/table_header_column_component.rb
@@ -1,10 +1,10 @@
+# frozen_string_literal: true
+
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
-# frozen_string_literal: true
 
 class TableHeaderColumnComponent < ViewComponent::Base
   include ApplicationHelper
-  include Memery
 
   renders_one :tooltip, IconTooltipComponent
 
@@ -26,7 +26,7 @@ class TableHeaderColumnComponent < ViewComponent::Base
 
   private
 
-  memoize def sort_direction
+  def sort_direction
     sort = parse_sort(request.params).find do |key, _direction|
       key == @id.to_s
     end

--- a/ecosystem/platform/server/app/controllers/application_controller.rb
+++ b/ecosystem/platform/server/app/controllers/application_controller.rb
@@ -23,10 +23,8 @@ class ApplicationController < ActionController::Base
 
     if user.email.nil? || user.username.nil?
       onboarding_email_path
-    elsif Flipper.enabled?(:it2_registration_open)
-      it2_path
     else
-      leaderboard_it2_path
+      it2_path
     end
   end
 

--- a/ecosystem/platform/server/app/controllers/leaderboard_controller.rb
+++ b/ecosystem/platform/server/app/controllers/leaderboard_controller.rb
@@ -8,7 +8,7 @@ class LeaderboardController < ApplicationController
   IT1_RESULTS = File.read(File.join(Rails.root, 'public/it1_leaderboard_final.json'))
   It1Metric = Struct.new(*IT1_METRIC_KEYS)
 
-  IT2_METRIC_KEYS = %i[rank validator liveness participation num_votes last_metrics_update].freeze
+  IT2_METRIC_KEYS = %i[rank validator liveness participation num_votes latest_reported_timestamp].freeze
   It2Metric = Struct.new(*IT2_METRIC_KEYS)
 
   def it1
@@ -43,11 +43,12 @@ class LeaderboardController < ApplicationController
 
   def it2
     expires_in 1.minute, public: true
-    default_sort = [[:num_votes, -1], [:participation, -1], [:liveness, -1], [:last_metrics_update, -1]]
+    default_sort = [[:num_votes, -1], [:participation, -1], [:liveness, -1], [:latest_reported_timestamp, -1]]
     @metrics, @last_updated = Rails.cache.fetch(:it2_leaderboard, expires_in: 1.minute) do
       response = HTTParty.get(ENV.fetch('LEADERBOARD_IT2_URL'))
       metrics = JSON.parse(response.body).map do |metric|
-        timestamp = if metric['latest_reported_timestamp'].blank?
+        timestamp = if metric['latest_reported_timestamp'].blank? ||
+                       metric['latest_reported_timestamp'] == '1970-01-01 00:00:00+00:00'
                       nil
                     else
                       DateTime.parse(metric['latest_reported_timestamp']).to_f
@@ -69,7 +70,7 @@ class LeaderboardController < ApplicationController
       [metrics, Time.now]
     end
 
-    @sort_columns = %w[rank liveness participation num_votes last_metrics_update]
+    @sort_columns = %w[rank liveness participation num_votes latest_reported_timestamp]
     sort = sort_params(@sort_columns)
     sort_metrics!(@metrics, sort) if sort.present?
   end

--- a/ecosystem/platform/server/app/views/leaderboard/it2.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it2.html.erb
@@ -32,7 +32,7 @@
       <%= content_tag :div, class: 'overflow-x-auto' do %>
         <%= render TableComponent.new(class: 'w-full table-auto') do |t| %>
           <%= t.with_column(:rank, '#', align: 'right') %>
-          <%= t.with_column(:validator, 'Account Address', align: 'left') %>
+          <%= t.with_column('Account Address', align: 'left') %>
           <%= t.with_column(:liveness, 'Liveness', align: 'left') do |column| %>
             <%= column.with_tooltip(:info) do |tooltip| %>
               <%= tooltip.with_header do %>
@@ -98,7 +98,7 @@
             <% end %>
           <% end %>
           <%= t.with_column(:num_votes, 'Votes', align: 'left') %>
-          <%= t.with_column(:last_metrics_update, 'Last Metrics Update', align: 'right') %>
+          <%= t.with_column(:latest_reported_timestamp, 'Last Metrics Update', align: 'right') %>
 
           <%= t.with_body do %>
             <% @metrics.each_with_index do |metric, i| %>
@@ -125,8 +125,8 @@
                   <%= metric.num_votes %>
                 <% end %>
                 <%= tr.with_column(align: 'right') do %>
-                  <% if metric.last_metrics_update %>
-                    <%= Time.at(metric.last_metrics_update).utc.to_fs(:db) %>
+                  <% if metric.latest_reported_timestamp %>
+                    <%= Time.at(metric.latest_reported_timestamp).utc.to_fs(:db) %>
                   <% end %>
                 <% end %>
               <% end %>
@@ -135,5 +135,7 @@
         <% end %>
       <% end %>
     <% end %>
+    <p class="text-neutral-400 text-xs mt-6 font-light">This page refreshes every 15 minutes.</p>
+    <p class="text-neutral-400 text-xs font-light">Data last updated <%= @last_updated.utc.to_fs(:db) %> UTC</p>
   </div>
 </div>

--- a/ecosystem/platform/server/public/it2_leaderboard_example.json
+++ b/ecosystem/platform/server/public/it2_leaderboard_example.json
@@ -1,121 +1,121 @@
 [{
-  "proposer": "e259c83edfdbe5b1b833faf45408f3ce48dc64de77b1aa744cad1ebe54ca6609",
+  "validator": "e259c83edfdbe5b1b833faf45408f3ce48dc64de77b1aa744cad1ebe54ca6609",
   "liveness": "97.0",
   "participation": "92.0",
   "num_votes": "5184",
-  "last_metrics_update": "2022-07-07T17:24:46Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:46Z"
 }, {
-  "proposer": "83424ccb8c69982802c35f656a381ea4ee641aa431a8a24d9d1c3134ac697dd9",
+  "validator": "83424ccb8c69982802c35f656a381ea4ee641aa431a8a24d9d1c3134ac697dd9",
   "liveness": "99.0",
   "participation": "97.0",
   "num_votes": "4698",
-  "last_metrics_update": "2022-07-07T05:24:46Z"
+  "latest_reported_timestamp": "2022-07-07T05:24:46Z"
 }, {
-  "proposer": "e93f2087bf380836825efbd683aaca87e109c7f8c1da8e90c218b250e22bc17e",
+  "validator": "e93f2087bf380836825efbd683aaca87e109c7f8c1da8e90c218b250e22bc17e",
   "liveness": "92.0",
   "participation": "95.0",
   "num_votes": "4577",
-  "last_metrics_update": "2022-07-07T17:24:38Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:38Z"
 }, {
-  "proposer": "4e5a325c29780ebbd924628d559c2577532ca79bea5e6d6451b6c45a426d90e7",
+  "validator": "4e5a325c29780ebbd924628d559c2577532ca79bea5e6d6451b6c45a426d90e7",
   "liveness": "98.0",
   "participation": "96.0",
   "num_votes": "4428",
-  "last_metrics_update": "2022-07-07T17:24:41Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:41Z"
 }, {
-  "proposer": "f8b54c48c2b0eebe2d4c376efff3273c0fdf0d640563db6b354aed824b2a4323",
+  "validator": "f8b54c48c2b0eebe2d4c376efff3273c0fdf0d640563db6b354aed824b2a4323",
   "liveness": "95.0",
   "participation": "91.0",
   "num_votes": "3214",
-  "last_metrics_update": "2022-07-07T17:24:47Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:47Z"
 }, {
-  "proposer": "871f63bc252b7428754c4c924d62e25a112790931f7ce82d13418fdae9b73ee3",
+  "validator": "871f63bc252b7428754c4c924d62e25a112790931f7ce82d13418fdae9b73ee3",
   "liveness": "96.0",
   "participation": "91.0",
   "num_votes": "1735",
-  "last_metrics_update": "2022-07-07T17:24:44Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:44Z"
 }, {
-  "proposer": "1958fae48dae3cf9ed4f92e8308ee213401f2a41ca312980138a06a9b94e541f",
+  "validator": "1958fae48dae3cf9ed4f92e8308ee213401f2a41ca312980138a06a9b94e541f",
   "liveness": "90.0",
   "participation": "98.0",
   "num_votes": "1335",
-  "last_metrics_update": "2022-07-07T17:24:42Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:42Z"
 }, {
-  "proposer": "242bf2bb0c9d3afeea4d5e15c14608dade0903b383ef0def954e2091343cdc5",
+  "validator": "242bf2bb0c9d3afeea4d5e15c14608dade0903b383ef0def954e2091343cdc5",
   "liveness": "99.0",
   "participation": "95.0",
   "num_votes": "1214",
-  "last_metrics_update": "2022-07-07T17:24:49Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:49Z"
 }, {
-  "proposer": "700816b23b55467f76ce87c0dba228c7c564b61ec173a9f4788ca985c1957b00",
+  "validator": "700816b23b55467f76ce87c0dba228c7c564b61ec173a9f4788ca985c1957b00",
   "liveness": "96.0",
   "participation": "97.0",
   "num_votes": "1138",
-  "last_metrics_update": "2022-07-07T06:33:57Z"
+  "latest_reported_timestamp": "2022-07-07T06:33:57Z"
 }, {
-  "proposer": "6f409c8b73a18cdeea4546c1df1e93594c07740cc609d93a99ca55c4920beb32",
+  "validator": "6f409c8b73a18cdeea4546c1df1e93594c07740cc609d93a99ca55c4920beb32",
   "liveness": "91.0",
   "participation": "92.0",
   "num_votes": "1123",
-  "last_metrics_update": "2022-07-07T17:24:47Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:47Z"
 }, {
-  "proposer": "ff1edbd3e4fd10617261d8f8f9176d77e2093ddada51b248b461a65475e839dd",
+  "validator": "ff1edbd3e4fd10617261d8f8f9176d77e2093ddada51b248b461a65475e839dd",
   "liveness": "91.0",
   "participation": "97.0",
   "num_votes": "946",
-  "last_metrics_update": "2022-07-07T17:24:45Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:45Z"
 }, {
-  "proposer": "28c0c0b575af75d0ddac1eb5c17af7a8cf3208a8372415219a7e317264b8f4de",
+  "validator": "28c0c0b575af75d0ddac1eb5c17af7a8cf3208a8372415219a7e317264b8f4de",
   "liveness": "96.0",
   "participation": "98.0",
   "num_votes": "938",
-  "last_metrics_update": "2022-07-07T17:24:45Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:45Z"
 }, {
-  "proposer": "618aabd73e7eea9511853b3b73ccd479584a40282936cdf3cf82c04d4b085ffb",
+  "validator": "618aabd73e7eea9511853b3b73ccd479584a40282936cdf3cf82c04d4b085ffb",
   "liveness": "97.0",
   "participation": "100.0",
   "num_votes": "927",
-  "last_metrics_update": "2022-07-07T17:24:44Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:44Z"
 }, {
-  "proposer": "c493bb36ac19d800640b32eb2844da802d6530773b01eeaa4886ad25196d7210",
+  "validator": "c493bb36ac19d800640b32eb2844da802d6530773b01eeaa4886ad25196d7210",
   "liveness": "96.0",
   "participation": "90.0",
   "num_votes": "911",
-  "last_metrics_update": "2022-07-07T17:24:43Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:43Z"
 }, {
-  "proposer": "938348b7c0d3fa132af43767c46eec9cdf4f726d0bb02e566b61abb11ac62e3a",
+  "validator": "938348b7c0d3fa132af43767c46eec9cdf4f726d0bb02e566b61abb11ac62e3a",
   "liveness": "92.0",
   "participation": "97.0",
   "num_votes": "901",
-  "last_metrics_update": "2022-07-07T17:24:48Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:48Z"
 }, {
-  "proposer": "a541da2b986ba92d57f20a2de298895273f9601f3eab2cbf4029e0f3b9d45235",
+  "validator": "a541da2b986ba92d57f20a2de298895273f9601f3eab2cbf4029e0f3b9d45235",
   "liveness": "99.0",
   "participation": "92.0",
   "num_votes": "862",
-  "last_metrics_update": "2022-07-07T17:22:02Z"
+  "latest_reported_timestamp": "2022-07-07T17:22:02Z"
 }, {
-  "proposer": "b8587a0616068db6ac7bab5a64ac1b474b5c3ff90a5caf61fe67608eb6749441",
+  "validator": "b8587a0616068db6ac7bab5a64ac1b474b5c3ff90a5caf61fe67608eb6749441",
   "liveness": "91.0",
   "participation": "98.0",
   "num_votes": "857",
-  "last_metrics_update": "2022-07-07T17:24:35Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:35Z"
 }, {
-  "proposer": "ffdabcdd88d12ea0681e2667ca5ec85a573dbbe6d5fa527dfd2bca11eb5a7837",
+  "validator": "ffdabcdd88d12ea0681e2667ca5ec85a573dbbe6d5fa527dfd2bca11eb5a7837",
   "liveness": "100.0",
   "participation": "91.0",
   "num_votes": "852",
-  "last_metrics_update": "2022-07-07T17:24:47Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:47Z"
 }, {
-  "proposer": "f5c22558b436a274913e750d91b55f06c52f84bdef6612ecdc221669e0171328",
+  "validator": "f5c22558b436a274913e750d91b55f06c52f84bdef6612ecdc221669e0171328",
   "liveness": "99.0",
   "participation": "92.0",
   "num_votes": "803",
-  "last_metrics_update": "2022-07-07T17:24:49Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:49Z"
 }, {
-  "proposer": "ce0a5f973a9b70169db96a7e69ba7167dfa453923022de26119f8ae3cdab8172",
+  "validator": "ce0a5f973a9b70169db96a7e69ba7167dfa453923022de26119f8ae3cdab8172",
   "liveness": "93.0",
   "participation": "93.0",
   "num_votes": "493",
-  "last_metrics_update": "2022-07-07T17:24:27Z"
+  "latest_reported_timestamp": "2022-07-07T17:24:27Z"
 }]


### PR DESCRIPTION
### Description

- `last_metrics_update` is now `latest_reported_timestamp`
- `validator` should not be sortable
- null timestamps are now received as '1970-01-01' instead of an empty string
- increase cache timeout to get more hits (since source data is now updated every 15 minutes instead of every minute)
- adds "this page refreshes every 15 minutes" disclaimer

### Test Plan
Manual testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1911)
<!-- Reviewable:end -->
