### PR TITLE
devinfra: add missing feature dependencies and add script to automati… …cally find them in future

### DIFF
--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -1,0 +1,14 @@
+name: "Find Packages with undeclared feature dependencies"
+on:
+  workflow_dispatch:
+  schedule:
+    # every day at 3am PST
+    - cron: "0 10 * * *"
+
+jobs:
+  find-packages-with-undeclared-feature-dependencies:
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/rust-setup
+      - run: scripts/find-packages-with-undeclared-feature-dependencies.sh

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 anyhow = "1.0.57"
 async-trait = "0.1.53"
 bcs = "0.1.3"
-byteorder = { version = "1.4.3", default-features = false }
+byteorder = { version = "1.4.3" }
 bytes = "1.1.0"
 fail = "0.5.0"
 futures = "0.3.21"

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -17,7 +17,7 @@ dpn = []
 anyhow = "1.0.57"
 bcs = "0.1.3"
 hex = "0.4.3"
-reqwest = { version = "0.11.10", features = ["json", "cookies"] }
+reqwest = { version = "0.11.10", features = ["json", "cookies", "blocking"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 tokio = { version = "1.18.2", features = ["full"] }

--- a/crates/bounded-executor/Cargo.toml
+++ b/crates/bounded-executor/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.21"
-tokio = { version = "1.18.2", features = ["sync"] }
+tokio = { version = "1.18.2", features = ["sync", "rt"] }
 
 [dev-dependencies]
 tokio = { version = "1.18.2", features = ["full"] }

--- a/scripts/find-packages-with-undeclared-dependencies.sh
+++ b/scripts/find-packages-with-undeclared-dependencies.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+# This script builds all packages in the repo individually in order to find packages that may depend on features that they didn't declare in their Cargo.toml .
+# Since in CI and for production we usually only build the entire workspace, some these undeclared features may not appear immediately.
+# See also https://github.com/rust-lang/cargo/issues/4463
+
+# Example usage:
+# $ ./scripts/cargo_update_outdated.sh
+# $ git commit --all -m "Update dependencies"
+set -ex
+
+cargo install cargo-workspaces && for package in $(cargo workspaces list --all --json | jq ".[].name" -r); do cargo build -p $package || true; done


### PR DESCRIPTION
This PR adds missing feature dependencies to some of our rust packages. This is a follow up to some problems that surfaced once we removed the aptos-workspace-hack.

It also adds a script that we'll run every night at 3am to automatically find missing feature declarations in future.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1923)
<!-- Reviewable:end -->
