### PR TITLE
[community] Keep icon SVGs in memory.

### DIFF
--- a/ecosystem/platform/server/app/components/icon_component.rb
+++ b/ecosystem/platform/server/app/components/icon_component.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
-# frozen_string_literal: true
 
 class IconComponent < ViewComponent::Base
   SIZE_CLASSES = {
@@ -11,7 +12,7 @@ class IconComponent < ViewComponent::Base
 
   ICONS = Dir[File.join(Rails.root, 'app/assets/images/icons/*.svg')].to_h do |icon_path|
     icon_name, _ext = File.basename(icon_path).split('.')
-    [icon_name.to_sym, icon_path]
+    [icon_name.to_sym, File.read(icon_path).html_safe]
   end
 
   def initialize(icon, size: :unspecified, **rest)
@@ -26,8 +27,7 @@ class IconComponent < ViewComponent::Base
   end
 
   def svg
-    path = ICONS[@icon]
-    Rails.cache.fetch(icon: @icon) { File.read(path).html_safe }
+    ICONS[@icon]
   end
 
   def call


### PR DESCRIPTION
### Description

Now that we're switching to redis for caching, this avoids making a network call to redis every time an icon is rendered.

### Test Plan
Tested manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1930)
<!-- Reviewable:end -->
