### PR TITLE
[consensus] switch back to bcs for consensus messages

### DIFF
--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -87,11 +87,11 @@ pub struct ConsensusNetworkSender {
 }
 
 /// Supported protocols in preferred order (from highest priority to lowest).
-pub const RPC: &[ProtocolId] = &[ProtocolId::ConsensusRpcJson, ProtocolId::ConsensusRpcBcs];
+pub const RPC: &[ProtocolId] = &[ProtocolId::ConsensusRpcBcs, ProtocolId::ConsensusRpcJson];
 /// Supported protocols in preferred order (from highest priority to lowest).
 pub const DIRECT_SEND: &[ProtocolId] = &[
-    ProtocolId::ConsensusDirectSendJson,
     ProtocolId::ConsensusDirectSendBcs,
+    ProtocolId::ConsensusDirectSendJson,
 ];
 
 /// Configuration for the network endpoints to support consensus.


### PR DESCRIPTION
bcs is more compact and efficient than json, json is used for upgrading the messages

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1932)
<!-- Reviewable:end -->
