### PR TITLE
[aptos-rosetta] Run aptos-node alongside aptos-rosetta

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -367,7 +367,6 @@ name = "aptos-faucet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "aptos",
  "aptos-config",
  "aptos-crypto",
  "aptos-infallible",
@@ -377,13 +376,13 @@ dependencies = [
  "aptos-sdk",
  "bcs",
  "bytes",
+ "clap 3.2.10",
  "futures",
  "hex",
  "rand 0.7.3",
  "reqwest",
  "serde 1.0.137",
  "serde_json",
- "structopt",
  "tempfile",
  "tokio",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,6 +886,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-logger",
  "aptos-metrics-core",
+ "aptos-node",
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-transaction-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,7 +82,7 @@ dependencies = [
  "aptos-vm",
  "bcs",
  "cached-framework-packages",
- "clap 3.1.18",
+ "clap 3.2.10",
  "datatest-stable",
  "move-deps",
 ]
@@ -161,7 +161,7 @@ dependencies = [
  "base64",
  "bcs",
  "cached-framework-packages",
- "clap 3.1.18",
+ "clap 3.2.10",
  "executor",
  "framework",
  "hex",
@@ -405,7 +405,7 @@ dependencies = [
  "aptos-sdk",
  "bcs",
  "bytes",
- "clap 3.1.18",
+ "clap 3.2.10",
  "futures",
  "hex",
  "rand 0.7.3",
@@ -525,7 +525,7 @@ dependencies = [
  "aptos-rest-client",
  "async-trait",
  "chrono",
- "clap 3.1.18",
+ "clap 3.2.10",
  "diesel",
  "diesel_migrations",
  "futures",
@@ -706,6 +706,7 @@ dependencies = [
  "backup-service",
  "bcs",
  "cached-framework-packages",
+ "clap 3.2.10",
  "consensus",
  "consensus-notifications",
  "crash-handler",
@@ -728,7 +729,6 @@ dependencies = [
  "storage-interface",
  "storage-service-client",
  "storage-service-server",
- "structopt",
  "tokio",
  "tokio-stream",
 ]
@@ -745,7 +745,7 @@ dependencies = [
  "aptos-rest-client",
  "aptos-sdk",
  "async-trait",
- "clap 3.1.18",
+ "clap 3.2.10",
  "const_format",
  "env_logger 0.8.4",
  "futures",
@@ -892,7 +892,7 @@ dependencies = [
  "aptos-types",
  "async-trait",
  "bcs",
- "clap 3.1.18",
+ "clap 3.2.10",
  "framework",
  "futures",
  "hex",
@@ -920,7 +920,7 @@ dependencies = [
  "aptos-logger",
  "aptos-rosetta",
  "aptos-types",
- "clap 3.1.18",
+ "clap 3.2.10",
  "hex",
  "serde 1.0.137",
  "serde_json",
@@ -1875,16 +1875,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static 1.4.0",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1905,9 +1905,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -2621,7 +2621,7 @@ dependencies = [
  "diesel_derives",
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.1.43",
+ "num-traits 0.2.15",
  "pq-sys",
  "r2d2",
  "serde_json",
@@ -3199,7 +3199,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "bcs",
- "clap 3.1.18",
+ "clap 3.2.10",
  "include_dir 0.7.2",
  "log",
  "move-deps",
@@ -4612,7 +4612,7 @@ version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd85b73af4287210e7#ece13ae276e3925111bf48cd85b73af4287210e7"
 dependencies = [
  "anyhow",
- "clap 3.1.18",
+ "clap 3.2.10",
  "crossterm 0.21.0",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4630,7 +4630,7 @@ source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.18",
+ "clap 3.2.10",
  "codespan-reporting",
  "colored",
  "difference",
@@ -4686,7 +4686,7 @@ source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.18",
+ "clap 3.2.10",
  "codespan-reporting",
  "difference",
  "hex",
@@ -4732,7 +4732,7 @@ source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.18",
+ "clap 3.2.10",
  "codespan",
  "colored",
  "move-binary-format",
@@ -4782,7 +4782,7 @@ version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd85b73af4287210e7#ece13ae276e3925111bf48cd85b73af4287210e7"
 dependencies = [
  "anyhow",
- "clap 3.1.18",
+ "clap 3.2.10",
  "colored",
  "move-binary-format",
  "move-bytecode-source-map",
@@ -4832,7 +4832,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-types",
  "aptos-vm",
- "clap 3.1.18",
+ "clap 3.2.10",
  "move-deps",
  "tempfile",
 ]
@@ -4844,7 +4844,7 @@ source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.18",
+ "clap 3.2.10",
  "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
@@ -4935,7 +4935,7 @@ source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd
 dependencies = [
  "anyhow",
  "bcs",
- "clap 3.1.18",
+ "clap 3.2.10",
  "colored",
  "dirs-next",
  "move-abigen",
@@ -4969,7 +4969,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "clap 3.1.18",
+ "clap 3.2.10",
  "codespan",
  "codespan-reporting",
  "futures",
@@ -5086,7 +5086,7 @@ source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
- "clap 3.1.18",
+ "clap 3.2.10",
  "codespan-reporting",
  "itertools",
  "move-binary-format",
@@ -5150,7 +5150,7 @@ version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=ece13ae276e3925111bf48cd85b73af4287210e7#ece13ae276e3925111bf48cd85b73af4287210e7"
 dependencies = [
  "anyhow",
- "clap 3.1.18",
+ "clap 3.2.10",
  "codespan-reporting",
  "colored",
  "itertools",
@@ -5698,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "oorandom"
@@ -8555,7 +8555,7 @@ dependencies = [
  "anyhow",
  "aptos-logger",
  "aptos-sdk",
- "clap 3.1.18",
+ "clap 3.2.10",
  "futures",
  "itertools",
  "rand 0.7.3",
@@ -8578,7 +8578,7 @@ dependencies = [
  "aptos-rest-client",
  "aptos-sdk",
  "aptos-transaction-builder",
- "clap 3.1.18",
+ "clap 3.2.10",
  "futures",
  "itertools",
  "once_cell",
@@ -8659,7 +8659,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -11,12 +11,12 @@ edition = "2018"
 
 [dependencies]
 bcs = "0.1.3"
+clap = "3.1.8"
 fail = "0.5.0"
 futures = "0.3.21"
 hex = "0.4.3"
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 rand = "0.7.3"
-structopt = "0.3.21"
 tokio = { version = "1.18.2", features = ["full"] }
 tokio-stream = "0.1.8"
 

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -67,7 +67,7 @@ const INTRA_NODE_CHANNEL_BUFFER_SIZE: usize = 1;
 const MEMPOOL_NETWORK_CHANNEL_BUFFER_SIZE: usize = 1_024;
 
 /// Runs an aptos fullnode or validator
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 #[clap(name = "Aptos Node", author, version)]
 pub struct AptosNodeArgs {
     /// Path to node configuration file

--- a/aptos-node/src/main.rs
+++ b/aptos-node/src/main.rs
@@ -2,87 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-use aptos_config::config::NodeConfig;
-use hex::FromHex;
-use rand::{rngs::StdRng, SeedableRng};
-use std::path::PathBuf;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
-#[structopt(about = "Aptos Node")]
-struct Args {
-    #[structopt(
-        short = "f",
-        long,
-        required_unless = "test",
-        help = "Path to NodeConfig"
-    )]
-    config: Option<PathBuf>,
-    #[structopt(long, help = "Enable a single validator testnet")]
-    test: bool,
-
-    #[structopt(
-        long,
-        help = "RNG Seed to use when starting single validator testnet",
-        parse(try_from_str = FromHex::from_hex),
-        requires("test")
-    )]
-    seed: Option<[u8; 32]>,
-
-    #[structopt(long, help = "Enabling random ports for testnet", requires("test"))]
-    random_ports: bool,
-
-    #[structopt(
-        long,
-        help = "Paths to module blobs to be included in genesis. Can include both files and directories",
-        requires("test")
-    )]
-    genesis_modules: Option<Vec<PathBuf>>,
-
-    #[structopt(
-        long,
-        help = "Lazy mode, set this flag will set `consensus#mempool_poll_count` config to `u64::MAX` and only commit a block when there is user transaction in mempool",
-        requires("test")
-    )]
-    lazy: bool,
-}
+use aptos_node::AptosNodeArgs;
+use clap::Parser;
 
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
-    let args = Args::from_args();
-
-    if args.test {
-        println!("Entering test mode, this should never be used in production!");
-        let rng = args
-            .seed
-            .map(StdRng::from_seed)
-            .unwrap_or_else(StdRng::from_entropy);
-        let genesis_modules = if let Some(module_paths) = args.genesis_modules {
-            framework::load_modules_from_paths(&module_paths)
-        } else {
-            cached_framework_packages::module_blobs().to_vec()
-        };
-        aptos_node::load_test_environment(
-            args.config,
-            args.random_ports,
-            args.lazy,
-            genesis_modules,
-            rng,
-        );
-    } else {
-        // Load the config file
-        let config_path = args.config.unwrap();
-        let config = NodeConfig::load(config_path.clone()).unwrap_or_else(|error| {
-            panic!(
-                "Failed to load node config file! Given file path: {:?}. Error: {:?}",
-                config_path, error
-            )
-        });
-        println!("Using node config {:?}", &config);
-
-        // Start the node
-        aptos_node::start(config, None);
-    };
+    AptosNodeArgs::parse().run()
 }

--- a/crates/aptos-faucet/Cargo.toml
+++ b/crates/aptos-faucet/Cargo.toml
@@ -13,18 +13,17 @@ edition = "2018"
 anyhow = "1.0.57"
 bcs = "0.1.3"
 bytes = "1.1.0"
+clap = "3.1.8"
 futures = "0.3.21"
 hex = "0.4.3"
 rand = "0.7.3"
 reqwest = { version = "0.11.10", features = ["blocking"], default-features = false }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-structopt = "0.3.21"
 tokio = { version = "1.18.2", features = ["full"] }
 url = "2.2.2"
 warp = "0.3.2"
 
-aptos = { path = "../aptos" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
 aptos-keygen = { path = "../aptos-keygen" }

--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -20,7 +20,6 @@
 //! ```
 
 use anyhow::Result;
-use aptos::common::types::EncodingType;
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_logger::info;
@@ -32,55 +31,57 @@ use aptos_sdk::{
         LocalAccount,
     },
 };
+use clap::Parser;
 use futures::lock::Mutex;
 use reqwest::StatusCode;
-use std::{convert::Infallible, fmt, path::Path, sync::Arc};
-use structopt::StructOpt;
+use std::{convert::Infallible, fmt, path::PathBuf, sync::Arc};
 use url::Url;
 use warp::{http, Filter, Rejection, Reply};
 
 pub mod mint;
 
-#[derive(Debug, StructOpt)]
-#[structopt(
-    name = "Aptos Faucet",
-    author = "Aptos",
-    about = "Aptos Testnet utility service for creating test accounts and minting test coins"
-)]
+/// Aptos Testnet utility service for creating test accounts and minting test coins
+#[derive(Clone, Debug, Parser)]
+#[clap(name = "Aptos Faucet", author, version)]
 pub struct FaucetArgs {
     /// Faucet service listen address
-    #[structopt(short = "a", long, default_value = "127.0.0.1")]
+    #[clap(short = 'a', long, default_value = "127.0.0.1")]
     pub address: String,
     /// Faucet service listen port
-    #[structopt(short = "p", long, default_value = "80")]
+    #[clap(short = 'p', long, default_value = "80")]
     pub port: u16,
     /// Aptos fullnode/validator server URL
-    #[structopt(short = "s", long, default_value = "https://testnet.aptoslabs.com/")]
-    pub server_url: String,
+    #[clap(short = 's', long, default_value = "https://testnet.aptoslabs.com/")]
+    pub server_url: Url,
     /// Path to the private key for creating test account and minting coins.
     /// To keep Testnet simple, we used one private key for aptos root account
     /// To manually generate a keypair, use generate-key:
     /// `cargo run -p generate-keypair -- -o <output_file_path>`
-    #[structopt(short = "m", long, default_value = "/opt/aptos/etc/mint.key")]
-    pub mint_key_file_path: String,
+    #[clap(
+        short = 'm',
+        long,
+        default_value = "/opt/aptos/etc/mint.key",
+        parse(from_os_str)
+    )]
+    pub mint_key_file_path: PathBuf,
     /// Ed25519PrivateKey for minting coins
-    #[structopt(long, parse(try_from_str = ConfigKey::from_encoded_string))]
+    #[clap(long, parse(try_from_str = ConfigKey::from_encoded_string))]
     pub mint_key: Option<ConfigKey<Ed25519PrivateKey>>,
     /// Address of the account to send transactions from.
     /// On Testnet, for example, this is a550c18.
     /// If not present, the mint key's address is used
-    #[structopt(short = "t", long, parse(try_from_str = AccountAddress::from_hex_literal))]
+    #[clap(short = 't', long, parse(try_from_str = AccountAddress::from_hex_literal))]
     pub mint_account_address: Option<AccountAddress>,
     /// Chain ID of the network this client is connecting to.
     /// For mainnet: "MAINNET" or 1, testnet: "TESTNET" or 2, devnet: "DEVNET" or 3,
     /// local swarm: "TESTING" or 4
     /// Note: Chain ID of 0 is not allowed; Use number if chain id is not predefined.
-    #[structopt(short = "c", long, default_value = "2")]
+    #[clap(short = 'c', long, default_value = "2")]
     pub chain_id: ChainId,
     /// Maximum amount of coins to mint.
-    #[structopt(long)]
+    #[clap(long)]
     pub maximum_amount: Option<u64>,
-    #[structopt(long)]
+    #[clap(long)]
     pub do_not_delegate: bool,
 }
 
@@ -100,9 +101,11 @@ impl FaucetArgs {
         let key = if let Some(ref key) = self.mint_key {
             key.private_key()
         } else {
-            EncodingType::BCS
-                .load_key::<Ed25519PrivateKey>("mint key", Path::new(&self.mint_key_file_path))
-                .unwrap()
+            bcs::from_bytes(
+                &std::fs::read(self.mint_key_file_path.as_path())
+                    .expect("Failed to read mint key file"),
+            )
+            .expect("Failed to deserialize mint key file")
         };
 
         let faucet_address: AccountAddress =
@@ -127,13 +130,8 @@ impl FaucetArgs {
         let actual_service = if self.do_not_delegate {
             service
         } else {
-            delegate_mint_account(
-                service,
-                self.server_url.clone(),
-                self.chain_id,
-                self.maximum_amount,
-            )
-            .await
+            delegate_mint_account(service, self.server_url, self.chain_id, self.maximum_amount)
+                .await
         };
 
         info!(
@@ -149,18 +147,18 @@ pub struct Service {
     pub faucet_account: Mutex<LocalAccount>,
     pub transaction_factory: TransactionFactory,
     client: Client,
-    endpoint: String,
+    endpoint: Url,
     maximum_amount: Option<u64>,
 }
 
 impl Service {
     pub fn new(
-        endpoint: String,
+        endpoint: Url,
         chain_id: ChainId,
         faucet_account: LocalAccount,
         maximum_amount: Option<u64>,
     ) -> Self {
-        let client = Client::new(Url::parse(&endpoint).expect("Invalid rest endpoint"));
+        let client = Client::new(endpoint.clone());
         Service {
             faucet_account: Mutex::new(faucet_account),
             transaction_factory: TransactionFactory::new(chain_id)
@@ -172,7 +170,7 @@ impl Service {
         }
     }
 
-    pub fn endpoint(&self) -> &String {
+    pub fn endpoint(&self) -> &Url {
         &self.endpoint
     }
 }
@@ -249,7 +247,7 @@ impl<T: fmt::Display> fmt::Display for OptFmt<T> {
 /// succeed and the other will hit an unwrap. Eventually all faucets should get online.
 pub async fn delegate_mint_account(
     service: Arc<Service>,
-    server_url: String,
+    server_url: Url,
     chain_id: ChainId,
     maximum_amount: Option<u64>,
 ) -> Arc<Service> {

--- a/crates/aptos-rest-client/src/faucet.rs
+++ b/crates/aptos-rest-client/src/faucet.rs
@@ -7,21 +7,21 @@ use move_deps::move_core_types::account_address::AccountAddress;
 use reqwest::Url;
 
 pub struct FaucetClient {
-    faucet_url: String,
+    faucet_url: Url,
     rest_client: Client,
 }
 
 impl FaucetClient {
-    pub fn new(faucet_url: String, rest_url: String) -> Self {
+    pub fn new(faucet_url: Url, rest_url: Url) -> Self {
         Self {
             faucet_url,
-            rest_client: Client::new(Url::parse(&rest_url).expect("Unable to parse rest url")),
+            rest_client: Client::new(rest_url),
         }
     }
 
     pub fn create_account(&self, address: AccountAddress) -> Result<()> {
         let client = reqwest::blocking::Client::new();
-        let mut url = Url::parse(&self.faucet_url).map_err(Error::request)?;
+        let mut url = self.faucet_url.clone();
         url.set_path("mint");
         let query = format!("auth_key={}&amount=0&return_txns=true", address);
         url.set_query(Some(&query));
@@ -46,7 +46,7 @@ impl FaucetClient {
 
     pub fn fund(&self, address: AccountAddress, amount: u64) -> Result<()> {
         let client = reqwest::blocking::Client::new();
-        let mut url = Url::parse(&self.faucet_url).map_err(Error::request)?;
+        let mut url = self.faucet_url.clone();
         url.set_path("mint");
         let query = format!("auth_key={}&amount={}&return_txns=true", address, amount);
         url.set_query(Some(&query));

--- a/crates/aptos-rosetta/Cargo.toml
+++ b/crates/aptos-rosetta/Cargo.toml
@@ -32,6 +32,7 @@ aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-metrics-core = { path = "../aptos-metrics-core" }
+aptos-node = { path = "../../aptos-node" }
 aptos-rest-client = { path = "../aptos-rest-client" }
 aptos-sdk = { path = "../../sdk" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use aptos_config::config::ApiConfig;
+use aptos_node::AptosNodeArgs;
 use aptos_rosetta::bootstrap;
 use aptos_types::chain_id::ChainId;
 use clap::Parser;
@@ -13,15 +14,58 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
+    thread,
+    time::Duration,
 };
+use tokio::time::Instant;
+
+const REST_API_WAIT_DURATION_MS: u64 = 60;
+const TOTAL_REST_API_WAIT_DURATION_S: u64 = 300;
 
 #[tokio::main]
 async fn main() {
-    aptos_logger::Logger::new().init();
     let args: CommandArgs = CommandArgs::parse();
 
+    // If we're in online mode, we run a full node side by side
+    let _maybe_node = if let CommandArgs::Online(OnlineLocalArgs {
+        ref node_args,
+        ref online_args,
+    }) = args
+    {
+        let node_args = node_args.clone();
+        let runtime = thread::spawn(move || node_args.run());
+
+        // Wait and ensure the node is running on the URL
+        let client = aptos_rest_client::Client::new(online_args.rest_api_url.clone());
+        let mut successful = false;
+        let total_wait_duration = Duration::from_secs(TOTAL_REST_API_WAIT_DURATION_S);
+        let start = Instant::now();
+        while start.elapsed() < total_wait_duration {
+            if client.get_index().await.is_ok() {
+                successful = true;
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(REST_API_WAIT_DURATION_MS)).await;
+        }
+
+        // If it didn't start up, we need to crash
+        if !successful {
+            panic!(
+                "Node didn't start up on time after {} seconds",
+                TOTAL_REST_API_WAIT_DURATION_S
+            )
+        }
+
+        Some(runtime)
+    } else {
+        // Offline mode we just need to start up the logger
+        aptos_logger::Logger::new().init();
+        None
+    };
+
     // Ensure runtime for Rosetta is up and running
-    let _runtime = bootstrap(args.chain_id(), args.api_config(), args.rest_client())
+    let _rosetta = bootstrap(args.chain_id(), args.api_config(), args.rest_client())
         .expect("Should bootstrap");
 
     // Run until there is an interrupt
@@ -50,7 +94,9 @@ trait ServerArgs {
 #[clap(name = "aptos-rosetta", author, version, propagate_version = true)]
 pub enum CommandArgs {
     /// Run a local online server that connects to a fullnode endpoint
-    Online(OnlineArgs),
+    OnlineRemote(OnlineRemoteArgs),
+    /// Run a local online server and a node that connects
+    Online(OnlineLocalArgs),
     /// Run a local online server that doesn't connect to a fullnode endpoint
     Offline(OfflineArgs),
 }
@@ -58,22 +104,25 @@ pub enum CommandArgs {
 impl ServerArgs for CommandArgs {
     fn api_config(&self) -> ApiConfig {
         match self {
-            CommandArgs::Online(args) => args.api_config(),
+            CommandArgs::OnlineRemote(args) => args.api_config(),
             CommandArgs::Offline(args) => args.api_config(),
+            CommandArgs::Online(args) => args.api_config(),
         }
     }
 
     fn rest_client(&self) -> Option<aptos_rest_client::Client> {
         match self {
-            CommandArgs::Online(args) => args.rest_client(),
+            CommandArgs::OnlineRemote(args) => args.rest_client(),
             CommandArgs::Offline(args) => args.rest_client(),
+            CommandArgs::Online(args) => args.rest_client(),
         }
     }
 
     fn chain_id(&self) -> ChainId {
         match self {
-            CommandArgs::Online(args) => args.chain_id(),
+            CommandArgs::OnlineRemote(args) => args.chain_id(),
             CommandArgs::Offline(args) => args.chain_id(),
+            CommandArgs::Online(args) => args.chain_id(),
         }
     }
 }
@@ -118,15 +167,15 @@ impl ServerArgs for OfflineArgs {
 }
 
 #[derive(Debug, Parser)]
-pub struct OnlineArgs {
+pub struct OnlineRemoteArgs {
     #[clap(flatten)]
     offline_args: OfflineArgs,
     /// URL for the Aptos REST API. e.g. https://fullnode.devnet.aptoslabs.com
-    #[clap(long, default_value = "https://fullnode.devnet.aptoslabs.com")]
+    #[clap(long, default_value = "https://localhost:8080")]
     rest_api_url: url::Url,
 }
 
-impl ServerArgs for OnlineArgs {
+impl ServerArgs for OnlineRemoteArgs {
     fn api_config(&self) -> ApiConfig {
         self.offline_args.api_config()
     }
@@ -137,5 +186,29 @@ impl ServerArgs for OnlineArgs {
 
     fn chain_id(&self) -> ChainId {
         self.offline_args.chain_id
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct OnlineLocalArgs {
+    #[clap(flatten)]
+    online_args: OnlineRemoteArgs,
+    #[clap(flatten)]
+    node_args: AptosNodeArgs,
+}
+
+impl ServerArgs for OnlineLocalArgs {
+    fn api_config(&self) -> ApiConfig {
+        self.online_args.offline_args.api_config()
+    }
+
+    fn rest_client(&self) -> Option<aptos_rest_client::Client> {
+        Some(aptos_rest_client::Client::new(
+            self.online_args.rest_api_url.clone(),
+        ))
+    }
+
+    fn chain_id(&self) -> ChainId {
+        self.online_args.offline_args.chain_id
     }
 }

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -26,7 +26,7 @@ const TOTAL_REST_API_WAIT_DURATION_S: u64 = 300;
 async fn main() {
     let args: CommandArgs = CommandArgs::parse();
 
-    // If we're in online mode, we run a full node side by side
+    // If we're in online mode, we run a full node side by side, the fullnode sets up the logger
     let _maybe_node = if let CommandArgs::Online(OnlineLocalArgs {
         ref node_args,
         ref online_args,
@@ -59,7 +59,7 @@ async fn main() {
 
         Some(runtime)
     } else {
-        // Offline mode we just need to start up the logger
+        // If we aren't running a full node, set up the logger now
         aptos_logger::Logger::new().init();
         None
     };
@@ -95,7 +95,7 @@ trait ServerArgs {
 pub enum CommandArgs {
     /// Run a local online server that connects to a fullnode endpoint
     OnlineRemote(OnlineRemoteArgs),
-    /// Run a local online server and a node that connects
+    /// Run a local full node in tandem with Rosetta
     Online(OnlineLocalArgs),
     /// Run a local online server that doesn't connect to a fullnode endpoint
     Offline(OfflineArgs),

--- a/testsuite/smoke-test/src/aptos_cli.rs
+++ b/testsuite/smoke-test/src/aptos_cli.rs
@@ -8,6 +8,7 @@ use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_faucet::FaucetArgs;
 use aptos_types::{account_config::aptos_root_address, chain_id::ChainId};
 use forge::{LocalSwarm, Node};
+use std::path::PathBuf;
 use tokio::task::JoinHandle;
 
 pub async fn setup_cli_test(num_nodes: usize) -> (LocalSwarm, CliTestFramework, JoinHandle<()>) {
@@ -39,8 +40,8 @@ pub fn launch_faucet(
     let faucet = FaucetArgs {
         address: "127.0.0.1".to_string(),
         port,
-        server_url: endpoint.to_string(),
-        mint_key_file_path: "".to_string(),
+        server_url: endpoint,
+        mint_key_file_path: PathBuf::new(),
         mint_key: Some(ConfigKey::new(mint_key)),
         mint_account_address: Some(aptos_root_address()),
         chain_id,


### PR DESCRIPTION
### Description
To make it easier to make the dockerfile, I've made the aptos node main thread run in a thread alongside the Rosetta implementation.  It's required by rosetta to run the docker

With this, we may be able to improve the performance better later by not using the REST API.

### Test Plan
```
$ cargo run -p aptos-rosetta -- online --test --seed 0000000000000000000000000000000000000000000000000000000000000000
    Finished dev [unoptimized + debuginfo] target(s) in 0.29s
     Running `target/debug/aptos-rosetta online --test --seed 0000000000000000000000000000000000000000000000000000000000000000`
Entering test mode, this should never be used in production!
Completed generating configuration:
        Log file: "/tmp/31d462a28b5fb41e16a1c88228a90a1a/validator.log"
        Config path: "/tmp/31d462a28b5fb41e16a1c88228a90a1a"
        Aptos root key path: "/tmp/31d462a28b5fb41e16a1c88228a90a1a/mint.key"
        Waypoint: 0:9833a6b7a8fa71a844351ec052f5162d80d8e2bcc38b097905b4ff3e8d994602
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1934)
<!-- Reviewable:end -->
