### PR TITLE
[State Sync] Harden against all consensus/state sync race conditions (from the state sync side).

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
@@ -125,6 +125,8 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
 
     /// Processes a request for terminating the stream that sent a specific
     /// notification ID.
+    /// TODO(joshlind): once this is exposed to the wild, we'll need automatic
+    /// garbage collection for misbehaving clients.
     fn process_terminate_stream_request(
         &mut self,
         terminate_request: &TerminateStreamRequest,

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -414,7 +414,7 @@ impl<
     }
 
     /// Resets the currently active data stream and speculative state
-    fn reset_active_stream(&mut self) {
+    pub fn reset_active_stream(&mut self) {
         self.speculative_stream_state = None;
         self.active_data_stream = None;
     }


### PR DESCRIPTION
### Description

This PR explicitly hardens state sync from ever handing over to consensus until all pending data has been flushed out of the execute-commit pipeline. Right now, there's only a single case where this is possible and it requires: (i) malicious peers to construct a precise set of malicious data chunks that pass the streaming service's validation; and (ii) perfect timing between checking the current synced version, handing over to consensus, and processing another chunk. Both of these are conditions are *incredibly* unlikely, but this let's play it safe and avoid the race condition entirely.

### Test Plan
Existing unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1937)
<!-- Reviewable:end -->
