### PR TITLE
[cherry-pick][consensus] prevent commit and sync_to happen at the sam…

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1084,6 +1084,7 @@ impl DbReader for AptosDB {
 
     fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
         gauged_api("get_startup_info", || {
+            let _lock = self.ledger_commit_lock.lock();
             self.ledger_store
                 .get_startup_info()?
                 .map(
@@ -1294,10 +1295,7 @@ impl DbWriter for AptosDB {
             // Executing and committing from more than one threads not allowed -- consensus and
             // state sync must hand over to each other after all pending execution and committing
             // complete.
-            let _lock = self
-                .ledger_commit_lock
-                .try_lock()
-                .expect("Concurrent committing detected.");
+            let _lock = self.ledger_commit_lock.lock();
 
             let num_txns = txns_to_commit.len() as u64;
             // ledger_info_with_sigs could be None if we are doing state synchronization. In this case


### PR DESCRIPTION
…e time

This commit adds a mutex to provide commit and sync_to so they can't run concurrently.

Also we unwrap the storage commit result since we can't do anything if commits fail and we should fail fast.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1945)
<!-- Reviewable:end -->
