### PR TITLE
 [cli][smoke-tests] Add command and test to update validator network addresses

### DIFF
--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -129,6 +129,7 @@ impl LocalFactory {
     where
         R: ::rand::RngCore + ::rand::CryptoRng,
     {
+        println!("Preparing a new swarm");
         let mut builder = LocalSwarm::builder(self.versions.clone())
             .number_of_validators(number_of_validators)
             .initial_version(version.clone())

--- a/testsuite/forge/src/interface/chain_info.rs
+++ b/testsuite/forge/src/interface/chain_info.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::AptosPublicInfo;
+use anyhow::Result;
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     transaction_builder::TransactionFactory,
@@ -31,6 +32,15 @@ impl<'t> ChainInfo<'t> {
 
     pub fn root_account(&mut self) -> &mut LocalAccount {
         self.root_account
+    }
+
+    pub async fn resync_root_account_seq_num(&mut self, client: &RestClient) -> Result<()> {
+        let account = client
+            .get_account(self.root_account.address())
+            .await?
+            .into_inner();
+        *self.root_account.sequence_number_mut() = account.sequence_number;
+        Ok(())
     }
 
     pub fn rest_api(&self) -> &str {

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -176,7 +176,7 @@ async fn test_file_discovery() {
 
     // Now when we clear the file, we shouldn't be able to connect
     write_peerset_to_file((*discovery_file).as_ref(), HashMap::new());
-    std::thread::sleep(Duration::from_millis(300));
+    tokio::time::sleep(Duration::from_millis(300)).await;
 
     assert_eq!(
         false,

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -61,7 +61,16 @@ pub async fn reconfig(
     let txn = root_account.sign_with_transaction_builder(
         transaction_factory.payload(aptos_stdlib::version_set_version(current_version + 1)),
     );
-    client.submit_and_wait(&txn).await.unwrap();
+    client
+        .submit_and_wait(&txn)
+        .await
+        .map_err(|e| {
+            panic!(
+                "Couldn't execute {:?}, for account {:?}, error {:?}",
+                txn, root_account, e
+            )
+        })
+        .unwrap();
 
     println!("Changing aptos version to {}", current_version + 1,);
 }

--- a/types/src/network_address/mod.rs
+++ b/types/src/network_address/mod.rs
@@ -380,6 +380,14 @@ impl NetworkAddress {
         })
     }
 
+    /// Retrieves the port from the network address
+    pub fn find_port(&self) -> Option<u16> {
+        self.0.iter().find_map(|proto| match proto {
+            Protocol::Tcp(port) => Some(*port),
+            _ => None,
+        })
+    }
+
     /// A temporary, hacky function to parse out the first `/noise-ik/<pubkey>` from
     /// a `NetworkAddress`. We can remove this soon, when we move to the interim
     /// "monolithic" transport model.

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -31,7 +31,7 @@ pub use self::{
         ConsensusConfigV1, LeaderReputationType, OnChainConsensusConfig, ProposerElectionType,
     },
     registered_currencies::RegisteredCurrencies,
-    validator_set::ValidatorSet,
+    validator_set::{ConsensusScheme, ValidatorSet},
     vm_config::VMConfig,
     vm_publishing_option::VMPublishingOption,
 };


### PR DESCRIPTION
extracted the same config from registering a new validator and used for the new command.
Seems like registering a new validator is broken on main, as bls proof of availability is missing,
but since I want to merge this to testnet branch (I assume?) that cannot be part of this diff.


### Description

### Test Plan
how should I test this properly?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1946)
<!-- Reviewable:end -->
