### PR TITLE
[consensus] properly guard the buffer manager requests

### DIFF
--- a/consensus/src/experimental/pipeline_phase.rs
+++ b/consensus/src/experimental/pipeline_phase.rs
@@ -16,34 +16,59 @@ pub trait StatelessPipeline: Send + Sync {
     async fn process(&self, req: Self::Request) -> Self::Response;
 }
 
+struct TaskGuard {
+    counter: Arc<AtomicU64>,
+}
+
+impl TaskGuard {
+    fn new(counter: Arc<AtomicU64>) -> Self {
+        counter.fetch_add(1, Ordering::SeqCst);
+        Self { counter }
+    }
+}
+
+impl Drop for TaskGuard {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+pub struct CountedRequest<Request> {
+    req: Request,
+    guard: TaskGuard,
+}
+
+impl<Request> CountedRequest<Request> {
+    pub fn new(req: Request, counter: Arc<AtomicU64>) -> Self {
+        let guard = TaskGuard::new(counter);
+        Self { req, guard }
+    }
+}
+
 pub struct PipelinePhase<T: StatelessPipeline> {
-    rx: Receiver<T::Request>,
+    rx: Receiver<CountedRequest<T::Request>>,
     maybe_tx: Option<Sender<T::Response>>,
     processor: Box<T>,
-    ongoing_tasks: Arc<AtomicU64>,
 }
 
 impl<T: StatelessPipeline> PipelinePhase<T> {
     pub fn new(
-        rx: Receiver<T::Request>,
+        rx: Receiver<CountedRequest<T::Request>>,
         maybe_tx: Option<Sender<T::Response>>,
         processor: Box<T>,
-        ongoing_tasks: Arc<AtomicU64>,
     ) -> Self {
         Self {
             rx,
             maybe_tx,
             processor,
-            ongoing_tasks,
         }
     }
 
     pub async fn start(mut self) {
         // main loop
-        while let Some(req) = self.rx.next().await {
-            self.ongoing_tasks.fetch_add(1, Ordering::SeqCst);
+        while let Some(counted_req) = self.rx.next().await {
+            let CountedRequest { req, guard: _guard } = counted_req;
             let response = self.processor.process(req).await;
-            self.ongoing_tasks.fetch_sub(1, Ordering::SeqCst);
             if let Some(tx) = &mut self.maybe_tx {
                 if tx.send(response).await.is_err() {
                     break;


### PR DESCRIPTION
Previous implementation only guards the `process` function, this commit changes it to guard the whole `request` life cycle to avoid the race condition that the request is created but not dequeued and the counter is 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1951)
<!-- Reviewable:end -->
