### PR TITLE
[mempool] Improve transaction already in mempool messaging

### DIFF
--- a/api/goldens/aptos_api__tests__transactions_test__test_post_transaction_rejected_by_mempool.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_post_transaction_rejected_by_mempool.json
@@ -1,4 +1,4 @@
 {
   "code": 400,
-  "message": "transaction is rejected: InvalidUpdate - Transaction already in mempool"
+  "message": "transaction is rejected: InvalidUpdate - Transaction already in mempool with different payload"
 }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -128,7 +128,6 @@ impl Mempool {
     pub(crate) fn add_txn(
         &mut self,
         txn: SignedTransaction,
-        gas_amount: u64,
         ranking_score: u64,
         crsn_or_seqno: AccountSequenceInfo,
         timeline_state: TimelineState,
@@ -168,7 +167,6 @@ impl Mempool {
         let txn_info = MempoolTransaction::new(
             txn,
             expiration_time,
-            gas_amount,
             ranking_score,
             timeline_state,
             sequence_number,

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -14,7 +14,6 @@ pub struct MempoolTransaction {
     pub txn: SignedTransaction,
     // System expiration time of the transaction. It should be removed from mempool by that time.
     pub expiration_time: Duration,
-    pub gas_amount: u64,
     pub ranking_score: u64,
     pub timeline_state: TimelineState,
     pub sequence_info: SequenceInfo,
@@ -24,7 +23,6 @@ impl MempoolTransaction {
     pub(crate) fn new(
         txn: SignedTransaction,
         expiration_time: Duration,
-        gas_amount: u64,
         ranking_score: u64,
         timeline_state: TimelineState,
         seqno_type: AccountSequenceInfo,
@@ -36,7 +34,6 @@ impl MempoolTransaction {
             },
             txn,
             expiration_time,
-            gas_amount,
             ranking_score,
             timeline_state,
         }

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -296,11 +296,9 @@ where
             if let Ok(validation_result) = &validation_results[idx] {
                 match validation_result.status() {
                     None => {
-                        let gas_amount = transaction.max_gas_amount();
                         let ranking_score = validation_result.score();
                         let mempool_status = mempool.add_txn(
                             transaction.clone(),
-                            gas_amount,
                             ranking_score,
                             crsn_or_seqno,
                             timeline_state,

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -115,7 +115,6 @@ pub(crate) fn add_txns_to_mempool(
         let txn = transaction.make_signed_transaction();
         pool.add_txn(
             txn.clone(),
-            0,
             txn.gas_unit_price(),
             transaction.account_seqno_type,
             TimelineState::NotReady,
@@ -133,7 +132,6 @@ pub(crate) fn add_signed_txn(pool: &mut CoreMempool, transaction: SignedTransact
     match pool
         .add_txn(
             transaction.clone(),
-            0,
             transaction.gas_unit_price(),
             AccountSequenceInfo::Sequential(0),
             TimelineState::NotReady,

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -554,7 +554,6 @@ fn test_gc_ready_transaction() {
     let txn = TestTransaction::new(1, 1, 1).make_signed_transaction_with_expiration_time(0);
     pool.add_txn(
         txn,
-        0,
         1,
         AccountSequenceInfo::Sequential(0),
         TimelineState::NotReady,
@@ -592,7 +591,6 @@ fn test_clean_stuck_transactions() {
     let txn = TestTransaction::new(0, db_sequence_number, 1).make_signed_transaction();
     pool.add_txn(
         txn,
-        0,
         1,
         AccountSequenceInfo::Sequential(db_sequence_number),
         TimelineState::NotReady,
@@ -633,7 +631,6 @@ fn test_get_transaction_by_hash() {
     let txn = TestTransaction::new(0, db_sequence_number, 1).make_signed_transaction();
     pool.add_txn(
         txn.clone(),
-        0,
         1,
         AccountSequenceInfo::Sequential(db_sequence_number),
         TimelineState::NotReady,
@@ -653,7 +650,6 @@ fn test_get_transaction_by_hash_after_the_txn_is_updated() {
     let txn = TestTransaction::new(0, db_sequence_number, 1).make_signed_transaction();
     pool.add_txn(
         txn.clone(),
-        0,
         1,
         AccountSequenceInfo::Sequential(db_sequence_number),
         TimelineState::NotReady,
@@ -664,7 +660,6 @@ fn test_get_transaction_by_hash_after_the_txn_is_updated() {
     let new_txn = TestTransaction::new(0, db_sequence_number, 100).make_signed_transaction();
     pool.add_txn(
         new_txn.clone(),
-        0,
         1,
         AccountSequenceInfo::Sequential(db_sequence_number),
         TimelineState::NotReady,

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -147,7 +147,6 @@ impl MockSharedMempool {
                 if pool
                     .add_txn(
                         txn.clone(),
-                        0,
                         txn.gas_unit_price(),
                         AccountSequenceInfo::Sequential(0),
                         TimelineState::NotReady,

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -374,7 +374,6 @@ impl Node {
             let transaction = txn.make_signed_transaction_with_max_gas_amount(5);
             mempool.add_txn(
                 transaction.clone(),
-                0,
                 transaction.gas_unit_price(),
                 AccountSequenceInfo::Sequential(0),
                 TimelineState::NotReady,


### PR DESCRIPTION
### Description
"Transaction already in mempool" is not very helpful of a message, because it doesn't tell you why it failed.  It's also not hiding anything since you can lookup the pending transaction via the API.

So, I've added a breakdown that tells you if the message matches accordingly.

### Test Plan
E2E tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1952)
<!-- Reviewable:end -->
