### PR TITLE
[mempool] on direct client txn submission to a validator, only broadcast if configured to do so

### DIFF
--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -108,7 +108,14 @@ pub(crate) async fn process_client_transaction_submission<V>(
 {
     timer.stop_and_record();
     let _timer = counters::process_txn_submit_latency_timer_client();
-    let statuses = process_incoming_transactions(&smp, vec![transaction], TimelineState::NotReady);
+    let ineligible_for_broadcast =
+        !smp.broadcast_within_validator_network() && smp.network_interface.is_validator();
+    let timeline_state = if ineligible_for_broadcast {
+        TimelineState::NonQualified
+    } else {
+        TimelineState::NotReady
+    };
+    let statuses = process_incoming_transactions(&smp, vec![transaction], timeline_state);
     log_txn_process_results(&statuses, None);
 
     if let Some(status) = statuses.get(0) {


### PR DESCRIPTION
### Description

#1954 only applies to transactions coming from a VFN. This covers the case when we submit directly to validators, which happens in some of our tests (e.g., perf tests).

### Test Plan

Smoke tests added in #2249.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1957)
<!-- Reviewable:end -->
