### PR TITLE
Do not broadcast client transactions in validator network

### DIFF
--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -272,12 +272,13 @@ async fn handle_network_event<V>(
                 } => {
                     let smp_clone = smp.clone();
                     let peer = PeerNetworkId::new(network_id, peer_id);
-                    let timeline_state = match (smp.validator_broadcast()
+                    let ineligible_for_broadcast = (!smp.broadcast_within_validator_network()
                         && smp.network_interface.is_validator())
-                        || smp.network_interface.is_upstream_peer(&peer, None)
-                    {
-                        true => TimelineState::NonQualified,
-                        false => TimelineState::NotReady,
+                        || smp.network_interface.is_upstream_peer(&peer, None);
+                    let timeline_state = if ineligible_for_broadcast {
+                        TimelineState::NonQualified
+                    } else {
+                        TimelineState::NotReady
                     };
                     // This timer measures how long it took for the bounded executor to
                     // *schedule* the task.

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -77,7 +77,7 @@ impl<V: TransactionValidation + 'static> SharedMempool<V> {
         }
     }
 
-    pub fn validator_broadcast(&self) -> bool {
+    pub fn broadcast_within_validator_network(&self) -> bool {
         self.config.shared_mempool_validator_broadcast
     }
 }


### PR DESCRIPTION
### Description

Transactions directly submitted to validators were still being broadcast. Also cherry-pick bug fix from #1954 

### Test Plan

Previously, we could see the same transactions in every validator. Not anymore.

Run `cargo x test -p smoke-test -- test_basic_state_synchronization --nocapture` with an injected panic to preserve logs.

```
% grep "get_block" 0/log 1/log 2/log 3/log | grep -v '"txns":""'
0/log:2022-07-13T23:48:47.738494Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":1,"seen_consensus":0,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:0 ","walked":1}
0/log:2022-07-13T23:48:48.789123Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":2,"seen_consensus":1,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:1 ","walked":1}
0/log:2022-07-13T23:48:54.488900Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":3,"seen_consensus":2,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:2 ","walked":1}
0/log:2022-07-13T23:48:56.638923Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":4,"seen_consensus":3,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:3 ","walked":1}
0/log:2022-07-13T23:48:59.738834Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":5,"seen_consensus":4,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:4 ","walked":1}
0/log:2022-07-13T23:49:00.289087Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":6,"seen_consensus":5,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:5 ","walked":1}
0/log:2022-07-13T23:49:03.438463Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":5,"seen_consensus":4,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:6 ","walked":1}
0/log:2022-07-13T23:49:03.987797Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":6,"seen_consensus":5,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:7 ","walked":1}
0/log:2022-07-13T23:49:04.538445Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":7,"seen_consensus":6,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:8 ","walked":1}
0/log:2022-07-13T23:49:05.038902Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":8,"seen_consensus":7,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:9 ","walked":1}
0/log:2022-07-13T23:49:05.588575Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":9,"seen_consensus":8,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:10 ","walked":1}
0/log:2022-07-13T23:49:06.138549Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":9,"seen_consensus":8,"txns":"D012E1AB072A101E76EF2C6FDC73D930596F29238E70E265E26E8C9C732E3C6D:11 ","walked":1}
2/log:2022-07-13T23:48:43.187820Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":1,"seen_consensus":0,"txns":"000000000000000000000000000000000000000000000000000000000A550C18:0 ","walked":1}
2/log:2022-07-13T23:48:44.487680Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":2,"seen_consensus":1,"txns":"000000000000000000000000000000000000000000000000000000000A550C18:1 ","walked":1}
2/log:2022-07-13T23:48:45.537894Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":3,"seen_consensus":2,"txns":"000000000000000000000000000000000000000000000000000000000A550C18:2 ","walked":1}
2/log:2022-07-13T23:48:46.589132Z [shared-mem] DEBUG mempool/src/core_mempool/mempool.rs:250 {"block_size":1,"name":"get_block","result_size":1,"seen_after":4,"seen_consensus":3,"txns":"000000000000000000000000000000000000000000000000000000000A550C18:3 ","walked":1}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1958)
<!-- Reviewable:end -->
