### PR TITLE
[Consensus] Get metrics for leader reputation metrics across all validators

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -112,9 +112,9 @@ pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
 });
 
 /// The number of block events the LeaderReputation uses
-pub static LEADER_REPUTATION_HISTORY_SIZE: Lazy<IntGauge> = Lazy::new(|| {
+pub static LEADER_REPUTATION_ROUND_HISTORY_SIZE: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_leader_reputation_history_size",
+        "aptos_leader_reputation_round_history_size",
         "Total number of new block events in the current reputation window"
     )
     .unwrap()

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -3,8 +3,8 @@
 
 use aptos_metrics_core::{
     op_counters::DurationHistogram, register_histogram, register_histogram_vec,
-    register_int_counter, register_int_counter_vec, register_int_gauge, Histogram, HistogramVec,
-    IntCounter, IntCounterVec, IntGauge,
+    register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -81,29 +81,32 @@ pub static VOTE_NIL_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Committed proposals from this validator when using LeaderReputation as the ProposerElection
-pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
+/// Committed proposals map when using LeaderReputation as the ProposerElection
+pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
         "aptos_committed_proposals_in_window",
-        "Total number of this validator's committed proposals in the current reputation window"
+        "Total number committed proposals in the current reputation window",
+        &["address"]
     )
     .unwrap()
 });
 
-/// Failed proposals from this validator when using LeaderReputation as the ProposerElection
-pub static FAILED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
+/// Failed proposals map when using LeaderReputation as the ProposerElection
+pub static FAILED_PROPOSALS_IN_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
         "aptos_failed_proposals_in_window",
-        "Total number of this validator's failed proposals in the current reputation window"
+        "Total number of failed proposals in the current reputation window",
+        &["address"]
     )
     .unwrap()
 });
 
-/// Committed votes from this validator when using LeaderReputation as the ProposerElection
-pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
+/// Committed votes map when using LeaderReputation as the ProposerElection
+pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
         "aptos_committed_votes_in_window",
-        "Total number of this validator's committed votes in the current reputation window"
+        "Total number of committed votes in the current reputation window",
+        &["address"]
     )
     .unwrap()
 });

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -4,7 +4,7 @@
 use crate::{
     counters::{
         COMMITTED_PROPOSALS_IN_WINDOW, COMMITTED_VOTES_IN_WINDOW, FAILED_PROPOSALS_IN_WINDOW,
-        LEADER_REPUTATION_HISTORY_SIZE,
+        LEADER_REPUTATION_ROUND_HISTORY_SIZE,
     },
     liveness::proposer_election::{next, ProposerElection},
 };
@@ -244,7 +244,7 @@ impl NewBlockEventAggregation {
                 .set(*votes.get(candidate).unwrap_or(&0) as i64);
         }
 
-        LEADER_REPUTATION_HISTORY_SIZE.set(
+        LEADER_REPUTATION_ROUND_HISTORY_SIZE.set(
             proposals.values().sum::<u32>() as i64 + failed_proposals.values().sum::<u32>() as i64,
         );
         (votes, proposals, failed_proposals)


### PR DESCRIPTION
### Description

The metrics were being populated only for the author - changing them to be populated for all validators instead - that way we can get a view of all the validator's voting/proposing activity from our node. 

### Test Plan
Existing UTs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1963)
<!-- Reviewable:end -->
