### PR TITLE
[Cherry-pick] [Consensus] Get metrics for leader reputation metrics across all validators

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -3,8 +3,8 @@
 
 use aptos_metrics_core::{
     op_counters::DurationHistogram, register_histogram, register_histogram_vec,
-    register_int_counter, register_int_counter_vec, register_int_gauge, Histogram, HistogramVec,
-    IntCounter, IntCounterVec, IntGauge,
+    register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
+    Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -81,37 +81,40 @@ pub static VOTE_NIL_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Committed proposals from this validator when using LeaderReputation as the ProposerElection
-pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
+/// Committed proposals map when using LeaderReputation as the ProposerElection
+pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
         "aptos_committed_proposals_in_window",
-        "Total number of this validator's committed proposals in the current reputation window"
+        "Total number committed proposals in the current reputation window",
+        &["address"]
     )
     .unwrap()
 });
 
-/// Failed proposals from this validator when using LeaderReputation as the ProposerElection
-pub static FAILED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
+/// Failed proposals map when using LeaderReputation as the ProposerElection
+pub static FAILED_PROPOSALS_IN_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
         "aptos_failed_proposals_in_window",
-        "Total number of this validator's committed proposals in the current reputation window"
+        "Total number of failed proposals in the current reputation window",
+        &["address"]
     )
     .unwrap()
 });
 
-/// Committed votes from this validator when using LeaderReputation as the ProposerElection
-pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
-    register_int_gauge!(
+/// Committed votes map when using LeaderReputation as the ProposerElection
+pub static COMMITTED_VOTES_IN_WINDOW: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
         "aptos_committed_votes_in_window",
-        "Total number of this validator's committed votes in the current reputation window"
+        "Total number of committed votes in the current reputation window",
+        &["address"]
     )
     .unwrap()
 });
 
 /// The number of block events the LeaderReputation uses
-pub static LEADER_REPUTATION_HISTORY_SIZE: Lazy<IntGauge> = Lazy::new(|| {
+pub static LEADER_REPUTATION_ROUND_HISTORY_SIZE: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_leader_reputation_history_size",
+        "aptos_leader_reputation_round_history_size",
         "Total number of new block events in the current reputation window"
     )
     .unwrap()

--- a/consensus/src/liveness/leader_reputation.rs
+++ b/consensus/src/liveness/leader_reputation.rs
@@ -4,7 +4,7 @@
 use crate::{
     counters::{
         COMMITTED_PROPOSALS_IN_WINDOW, COMMITTED_VOTES_IN_WINDOW, FAILED_PROPOSALS_IN_WINDOW,
-        LEADER_REPUTATION_HISTORY_SIZE,
+        LEADER_REPUTATION_ROUND_HISTORY_SIZE,
     },
     liveness::proposer_election::{next, ProposerElection},
 };
@@ -12,6 +12,7 @@ use aptos_infallible::{Mutex, MutexGuard};
 use aptos_logger::prelude::*;
 use aptos_types::block_metadata::{new_block_event_key, NewBlockEvent};
 use consensus_types::common::{Author, Round};
+use short_hex_str::AsShortHexStr;
 use std::{cmp::Ordering, collections::HashMap, convert::TryFrom, sync::Arc};
 use storage_interface::{DbReader, Order};
 
@@ -217,6 +218,38 @@ impl NewBlockEventAggregation {
             .filter(move |&meta| meta.epoch() == epoch)
     }
 
+    pub fn get_aggregated_metrics(
+        &self,
+        epoch: u64,
+        candidates: &[Author],
+        history: &[NewBlockEvent],
+    ) -> (
+        HashMap<Author, u32>,
+        HashMap<Author, u32>,
+        HashMap<Author, u32>,
+    ) {
+        let votes = self.count_votes(epoch, candidates, history);
+        let proposals = self.count_proposals(epoch, history);
+        let failed_proposals = self.count_failed_proposals(epoch, candidates, history);
+
+        for candidate in candidates {
+            COMMITTED_PROPOSALS_IN_WINDOW
+                .with_label_values(&[candidate.short_str().as_str()])
+                .set(*proposals.get(candidate).unwrap_or(&0) as i64);
+            FAILED_PROPOSALS_IN_WINDOW
+                .with_label_values(&[candidate.short_str().as_str()])
+                .set(*failed_proposals.get(candidate).unwrap_or(&0) as i64);
+            COMMITTED_VOTES_IN_WINDOW
+                .with_label_values(&[candidate.short_str().as_str()])
+                .set(*votes.get(candidate).unwrap_or(&0) as i64);
+        }
+
+        LEADER_REPUTATION_ROUND_HISTORY_SIZE.set(
+            proposals.values().sum::<u32>() as i64 + failed_proposals.values().sum::<u32>() as i64,
+        );
+        (votes, proposals, failed_proposals)
+    }
+
     pub fn count_votes(
         &self,
         epoch: u64,
@@ -320,12 +353,9 @@ impl ReputationHeuristic for ActiveInactiveHeuristic {
         candidates: &[Author],
         history: &[NewBlockEvent],
     ) -> Vec<u64> {
-        let votes = self.aggregation.count_votes(epoch, candidates, history);
-        let proposals = self.aggregation.count_proposals(epoch, history);
-
-        COMMITTED_PROPOSALS_IN_WINDOW.set(*proposals.get(&self.author).unwrap_or(&0) as i64);
-        COMMITTED_VOTES_IN_WINDOW.set(*votes.get(&self.author).unwrap_or(&0) as i64);
-        LEADER_REPUTATION_HISTORY_SIZE.set(proposals.values().sum::<u32>() as i64);
+        let (votes, proposals, _) = self
+            .aggregation
+            .get_aggregated_metrics(epoch, candidates, history);
 
         candidates
             .iter()
@@ -399,16 +429,9 @@ impl ReputationHeuristic for ProposerAndVoterHeuristic {
         candidates: &[Author],
         history: &[NewBlockEvent],
     ) -> Vec<u64> {
-        let votes = self.aggregation.count_votes(epoch, candidates, history);
-        let proposals = self.aggregation.count_proposals(epoch, history);
-        let failed_proposals = self
+        let (votes, proposals, failed_proposals) = self
             .aggregation
-            .count_failed_proposals(epoch, candidates, history);
-
-        COMMITTED_PROPOSALS_IN_WINDOW.set(*proposals.get(&self.author).unwrap_or(&0) as i64);
-        FAILED_PROPOSALS_IN_WINDOW.set(*proposals.get(&self.author).unwrap_or(&0) as i64);
-        COMMITTED_VOTES_IN_WINDOW.set(*votes.get(&self.author).unwrap_or(&0) as i64);
-        LEADER_REPUTATION_HISTORY_SIZE.set(proposals.values().sum::<u32>() as i64);
+            .get_aggregated_metrics(epoch, candidates, history);
 
         candidates
             .iter()


### PR DESCRIPTION
Description

The metrics were being populated only for the author - changing them to be populated for all validators instead - that way we can get a view of all the validator's voting/proposing activity from our node.

Test Plan

Existing UTs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1966)
<!-- Reviewable:end -->
