### PR TITLE
[community] Remove HTTP caching.

### DIFF
--- a/ecosystem/platform/server/app/controllers/leaderboard_controller.rb
+++ b/ecosystem/platform/server/app/controllers/leaderboard_controller.rb
@@ -12,7 +12,6 @@ class LeaderboardController < ApplicationController
   It2Metric = Struct.new(*IT2_METRIC_KEYS)
 
   def it1
-    expires_in 1.minute, public: true
     default_sort = [[:participation, -1], [:liveness, -1], [:latest_reported_timestamp, -1]]
     @metrics, @last_updated = Rails.cache.fetch(:it1_leaderboard, expires_in: 1.minute) do
       metrics = JSON.parse(IT1_RESULTS).map do |metric|
@@ -42,7 +41,6 @@ class LeaderboardController < ApplicationController
   end
 
   def it2
-    expires_in 1.minute, public: true
     default_sort = [[:num_votes, -1], [:participation, -1], [:liveness, -1], [:latest_reported_timestamp, -1]]
     @metrics, @last_updated = Rails.cache.fetch(:it2_leaderboard, expires_in: 1.minute) do
       response = HTTParty.get(ENV.fetch('LEADERBOARD_IT2_URL'))

--- a/ecosystem/platform/server/app/controllers/static_page_controller.rb
+++ b/ecosystem/platform/server/app/controllers/static_page_controller.rb
@@ -3,25 +3,10 @@
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
 
-# This controller is for pages that are completely static (i.e. they render the
-# same HTML every time regardless of session state). These pages can therefore
-# be cached and served from the CDN.
-#
-# If a page does need limited dynamic content (e.g. log in / log out button),
-# the page should render the common case (e.g. log in button) and load the
-# correct content via turbo-frame.
 class StaticPageController < ApplicationController
   layout 'it2', only: [:community]
-  before_action :set_cache_headers
 
   def community
     @login_dialog = DialogComponent.new(id: 'login_dialog')
-  end
-
-  private
-
-  def set_cache_headers
-    # Disabling this temporarily to unblock flash on main page
-    # expires_in 1.hour, public: true
   end
 end

--- a/ecosystem/platform/server/app/helpers/application_helper.rb
+++ b/ecosystem/platform/server/app/helpers/application_helper.rb
@@ -12,8 +12,4 @@ module ApplicationHelper
       [attr, SORT_ORDER[sort_sign]]
     end
   end
-
-  def cached_page?
-    !!response.cache_control[:public]
-  end
 end

--- a/ecosystem/platform/server/app/views/layouts/_application.html.erb
+++ b/ecosystem/platform/server/app/views/layouts/_application.html.erb
@@ -16,7 +16,7 @@
 
   <body class="flex flex-col h-screen justify-between bg-neutral-900 antialiased">
     <div class="flex flex-col flex-1">
-      <%= render HeaderComponent.new(user: cached_page? ? nil : current_user) %>
+      <%= render HeaderComponent.new(user: current_user) %>
 
       <main class="flex-1">
         <%= yield %>

--- a/ecosystem/platform/server/test/controllers/static_page_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/static_page_controller_test.rb
@@ -13,18 +13,15 @@ class SettingsControllerTest < ActionDispatch::IntegrationTest
   end.reject(&:internal?)
 
   ROUTES.select { |route| route.controller == 'static_page' }.each do |route|
-    test "static_page##{route.action} is static" do
-      skip('Disabling this temporarily to unblock flash on main page') and return nil
+    test "static_page##{route.action} renders ok" do
       sign_out @controller.current_user if @controller&.current_user
       get route.path
-      signed_out = @response.body
+      assert_response :success
 
       user = FactoryBot.create(:user)
       sign_in user
       get route.path
-      signed_in = @response.body
-
-      assert_equal signed_out, signed_in
+      assert_response :success
     end
   end
 end


### PR DESCRIPTION
### Description

The point was to reduce latency for page loads in combination with a CDN. However, we don't have a CDN so let's remove the HTTP caching to simplify things.

### Test Plan
Existing tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1970)
<!-- Reviewable:end -->
