### PR TITLE
[helm][genesis] use updated layout fields

### DIFF
--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -18,7 +18,7 @@ data:
     min_lockup_duration_secs: {{ .Values.chain.min_lockup_duration_secs | int }}
     max_lockup_duration_secs: {{ .Values.chain.max_lockup_duration_secs | int }}
     epoch_duration_secs: {{ .Values.chain.epoch_duration_secs | int }}
-    initial_lockup_timestamp: {{ now | date_modify (printf "+%s" .Values.chain.initial_lockup_duration) | unixEpoch }}
+    initial_lockup_timestamp: {{ .Values.chain.initial_lockup_timestamp | int }}
     min_price_per_gas_unit: {{ .Values.chain.min_price_per_gas_unit }}
     allow_new_validators: {{ .Values.chain.allow_new_validators }}
 

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -6,11 +6,9 @@ chain:
   min_stake: 0
   max_stake: 100000
   min_lockup_duration_secs: 0
-  max_lockup_duration_secs: 2592000 # 1 month
+  max_lockup_duration_secs: 86400 # 1 day
   epoch_duration_secs: 86400 # 1 day
-  # instead of specifying "initial_lockup_timestamp", just take the delta between
-  # the current timestamp
-  initial_lockup_duration: 1d
+  initial_lockup_timestamp: 0
   min_price_per_gas_unit: 1
   allow_new_validators: false
 


### PR DESCRIPTION
Following https://github.com/aptos-labs/aptos-core/commit/4a514bbb16cde6f8325f85d924424213e19465a1 to set some sane defaults in genesis helm chart `values.yaml`

Deprecate helm value `initial_lockup_duration` in favor of just directly setting `initial_lockup_timestamp`

Previously failing with 
```
thread 'main' panicked at 'Error calling Genesis.create_initialize_validators: status ABORTED of type Execution with sub status 3591', aptos-move/vm-genesis/src/lib.rs:179:13
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1973)
<!-- Reviewable:end -->


