### PR TITLE
[consensus] another attempt to fix race condition in buffer manager

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -538,8 +538,8 @@ impl BlockRetriever {
 }
 
 // Max timeout is 16s=RETRIEVAL_INITIAL_TIMEOUT*(2^RETRIEVAL_MAX_EXP)
-const RETRIEVAL_INITIAL_TIMEOUT: Duration = Duration::from_millis(200);
-const RETRIEVAL_MAX_EXP: u32 = 4;
+const RETRIEVAL_INITIAL_TIMEOUT: Duration = Duration::from_millis(500);
+const RETRIEVAL_MAX_EXP: u32 = 2;
 
 /// Returns exponentially increasing timeout with
 /// limit of RETRIEVAL_INITIAL_TIMEOUT*(2^RETRIEVAL_MAX_EXP)


### PR DESCRIPTION
    Previously we protect three pipeline phases with atomic counters, but missed the incoming blocks from ordering phase.
    It's difficult to do the same with OrderedBlocks because processing that is in the same thread as reset, so we just pull until it's empty.

    The assumption is that upon reset request, there's no concurrent incoming blocks but only requests that're already in the queue.

    Another race condition is after committing the reconfiguration block, execution will create the new epoch's genesis and drop any leftover blocks.
    Continue to execute reconfiguration suffix blocks will result in BlockNotFound error.
    
    Also relaxed the block retrieval timeout from 200ms to 500ms

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1976)
<!-- Reviewable:end -->
