### PR TITLE
[Genesis] [Aptos Framework] Fix an issue with validator lockup validation when timestamp has not been set (happens during genesis)

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/configs/Stake.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/Stake.move
@@ -1016,6 +1016,12 @@ module AptosFramework::Stake {
     /// Validate that the lockup time is at least more than the minimum required.
     fun validate_lockup_time(locked_until_secs: u64, validator_set_config: &ValidatorSetConfiguration) {
         let current_time = Timestamp::now_seconds();
+        // Short-circuit early if current_time is 0. This only happens during Genesis before a first block
+        // is produced.
+        if (current_time == 0) {
+            return
+        };
+
         assert!(
             current_time + validator_set_config.min_lockup_duration_secs <= locked_until_secs,
             Errors::invalid_argument(ELOCK_TIME_TOO_SHORT),

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -170,8 +170,7 @@ pub fn load_test_environment<R>(
             .with_randomize_first_validator_ports(random_ports)
             .with_initial_lockup_timestamp(now_secs + EPOCH_LENGTH_SECS)
             .with_min_lockup_duration_secs(0)
-            .with_max_lockup_duration_secs(86400)
-            .with_initial_lockup_timestamp(0);
+            .with_max_lockup_duration_secs(86400);
 
         let (root_key, _genesis, genesis_waypoint, validators) = builder.build(rng).unwrap();
 


### PR DESCRIPTION
### Description

During genesis, there has been no block so timestamp stored on chain is set to 0. This means that if the initial lockup time provided by the initial validators as part of genesis cannot be validated correctly. This PR allows skipping this validation (trusting the genesis configurations are generated correctly).

### Test Plan
E2e tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1978)
<!-- Reviewable:end -->
