### PR TITLE
[aptos-cli] Fix profiles as inputs to function inputs

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -23,7 +23,6 @@ use move_deps::{
     move_cli::package::cli::UnitTestResult,
     move_command_line_common::env::get_bytecode_version_from_env,
     move_core_types::{
-        account_address::AccountAddress,
         identifier::Identifier,
         language_storage::{ModuleId, TypeTag},
     },
@@ -344,7 +343,7 @@ impl FunctionArgType {
     fn parse_arg(&self, arg: &str) -> CliTypedResult<Vec<u8>> {
         match self {
             FunctionArgType::Address => bcs::to_bytes(
-                &AccountAddress::from_str(arg)
+                &load_account_arg(arg)
                     .map_err(|err| CliError::UnableToParse("address", err.to_string()))?,
             ),
             FunctionArgType::Bool => bcs::to_bytes(


### PR DESCRIPTION
### Description
I noticed that the Aptos cli doesn't handle the address aliases in the run function args, which is inconsistent with the rest of the code.

### Test Plan
TBD

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1981)
<!-- Reviewable:end -->
