### PR TITLE
[storage] add back computing jf_node_hashes and recover batch commit

### DIFF
--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -184,12 +184,13 @@ where
             fail_point!("executor::commit_blocks", |_| {
                 Err(anyhow::anyhow!("Injected error in commit_blocks.").into())
             });
-            let checkpoint = self
+            let result_in_memory_state = self
                 .block_tree
                 .get_block(block_id_to_commit)?
                 .output
                 .result_view
-                .state_tree();
+                .state()
+                .clone();
             self.db.writer.save_transactions_ext(
                 &txns_to_commit,
                 first_version,
@@ -200,7 +201,7 @@ where
                     .checkpoint_version,
                 Some(&ledger_info_with_sigs),
                 save_state_snapshots,
-                checkpoint,
+                result_in_memory_state,
             )?;
             self.block_tree
                 .prune(ledger_info_with_sigs.ledger_info())

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -98,7 +98,7 @@ impl<V> ChunkExecutor<V> {
                 base_view.txn_accumulator().num_leaves(),
                 base_view.state().checkpoint_version,
                 ledger_info,
-                to_commit.result_view.state_tree(),
+                to_commit.result_view.state().clone(),
             )?;
         }
 

--- a/execution/executor/src/db_bootstrapper.rs
+++ b/execution/executor/src/db_bootstrapper.rs
@@ -102,7 +102,7 @@ impl GenesisCommitter {
             self.output.result_view.txn_accumulator().version(),
             self.base_state_version,
             self.output.ledger_info.as_ref(),
-            self.output.result_view.state_tree(),
+            self.output.result_view.state().clone(),
         )?;
         info!("Genesis commited.");
         // DB bootstrapped, avoid anything that could fail after this.

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -7,7 +7,6 @@ use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
 use aptos_state_view::StateView;
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
-    state_store::state_value::StateValue,
     transaction::{
         Transaction, TransactionListWithProof, TransactionOutput, TransactionToCommit, Version,
     },
@@ -15,8 +14,9 @@ use aptos_types::{
 };
 use aptos_vm::VMExecutor;
 use executor_types::{BlockExecutorTrait, ChunkExecutorTrait};
-use scratchpad::SparseMerkleTree;
-use storage_interface::{DbReader, DbReaderWriter, DbWriter, StartupInfo};
+use storage_interface::{
+    in_memory_state::InMemoryState, DbReader, DbReaderWriter, DbWriter, StartupInfo,
+};
 
 fn create_test_executor() -> BlockExecutor<FakeVM> {
     // setup fake db
@@ -90,7 +90,7 @@ impl DbWriter for FakeDb {
         _first_version: Version,
         _base_state_version: Option<Version>,
         _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
-        _state_tree: SparseMerkleTree<StateValue>,
+        _in_memory_state: InMemoryState,
     ) -> Result<()> {
         Ok(())
     }

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -401,7 +401,7 @@ fn apply_transaction_by_writeset(
             ledger_view.txn_accumulator().num_leaves(),
             ledger_view.state().checkpoint_version,
             None,
-            executed.result_view.state_tree(),
+            executed.result_view.state().clone(),
         )
         .unwrap();
 }
@@ -537,7 +537,7 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
                 ledger_view.txn_accumulator().num_leaves(),
                 ledger_view.state().checkpoint_version,
                 None,
-                executed.result_view.state_tree(),
+                executed.result_view.state().clone(),
             )
             .unwrap();
         ledger_view = executed.result_view;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -35,10 +35,10 @@ use data_streaming_service::{
 };
 use executor_types::{ChunkCommitNotification, ChunkExecutorTrait};
 use mockall::mock;
-use scratchpad::SparseMerkleTree;
 use std::sync::Arc;
 use storage_interface::{
-    DbReader, DbReaderWriter, DbWriter, ExecutedTrees, Order, StartupInfo, StateSnapshotReceiver,
+    in_memory_state::InMemoryState, DbReader, DbReaderWriter, DbWriter, ExecutedTrees, Order,
+    StartupInfo, StateSnapshotReceiver,
 };
 use tokio::task::JoinHandle;
 
@@ -305,7 +305,7 @@ mock! {
             first_version: Version,
             base_state_version: Option<Version>,
             ledger_info_with_sigs: Option<&'a LedgerInfoWithSignatures>,
-            state_tree: SparseMerkleTree<StateValue>,
+            in_memory_state: InMemoryState,
         ) -> Result<()>;
 
         fn delete_genesis(&self) -> Result<()>;

--- a/storage/aptosdb/src/backup/test.rs
+++ b/storage/aptosdb/src/backup/test.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    test_helper::{arb_blocks_to_commit, update_smt},
+    test_helper::{arb_blocks_to_commit, update_in_memory_state},
     AptosDB,
 };
 use anyhow::Result;
 use aptos_temppath::TempPath;
-use aptos_types::{state_store::state_value::StateValue, transaction::Version};
+use aptos_types::transaction::Version;
 use proptest::prelude::*;
-use scratchpad::SparseMerkleTree;
 use storage_interface::DbWriter;
 
 proptest! {
@@ -19,12 +18,12 @@ proptest! {
     fn test_get_transaction_iter(input in arb_blocks_to_commit()) {
         let tmp_dir = TempPath::new();
         let db = AptosDB::new_for_test(&tmp_dir);
-        let mut smt = SparseMerkleTree::<StateValue>::default().freeze();
-
+        let mut in_memory_state = (*db.state_store.in_memory_state().lock()).clone();
+        let _ancester = in_memory_state.current.clone().freeze();
         let mut cur_ver: Version = 0;
         for (txns_to_commit, ledger_info_with_sigs) in input.iter() {
-            smt = update_smt(&smt, txns_to_commit.as_slice());
-            db.save_transactions(txns_to_commit, cur_ver, cur_ver.checked_sub(1), Some(ledger_info_with_sigs), smt.clone().unfreeze())
+            update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
+            db.save_transactions(txns_to_commit, cur_ver, cur_ver.checked_sub(1), Some(ledger_info_with_sigs), in_memory_state.clone())
                 .unwrap();
             cur_ver += txns_to_commit.len() as u64;
         }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -132,14 +132,8 @@ impl StateStore {
         store
     }
 
-    pub fn maybe_reset(self: &Arc<Self>, version: Version) {
-        if self
-            .in_memory_state
-            .lock()
-            .checkpoint_version
-            .map_or(0, |v| v + 1)
-            <= version
-        {
+    pub fn maybe_reset(self: &Arc<Self>, latest_snapshot_version: Option<Version>) {
+        if self.in_memory_state.lock().checkpoint_version < latest_snapshot_version {
             self.initialize(false)
                 .expect("StateStore initialization failed.")
         }

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -17,19 +17,57 @@ use aptos_types::{
 };
 use executor_types::ProofReader;
 use proptest::{collection::vec, prelude::*};
-use scratchpad::{FrozenSparseMerkleTree, SparseMerkleTree};
 
-pub fn update_smt(
-    smt: &FrozenSparseMerkleTree<StateValue>,
-    txns_to_commit: &[TransactionToCommit],
-) -> FrozenSparseMerkleTree<StateValue> {
-    let updates = txns_to_commit
-        .iter()
-        .flat_map(|x| x.state_updates())
-        .map(|(key, value)| (key.hash(), value))
-        .collect();
-    smt.batch_update(updates, &ProofReader::new_empty())
-        .unwrap()
+pub fn update_in_memory_state(state: &mut InMemoryState, txns_to_commit: &[TransactionToCommit]) {
+    let mut next_version = state.current_version.map_or(0, |v| v + 1);
+    for txn_to_commit in txns_to_commit {
+        txn_to_commit
+            .state_updates()
+            .iter()
+            .for_each(|(key, value)| {
+                state
+                    .updated_since_checkpoint
+                    .insert(key.clone(), value.clone());
+            });
+        next_version += 1;
+        if txn_to_commit.is_state_checkpoint() {
+            state.current = state
+                .current
+                .clone()
+                .freeze()
+                .batch_update(
+                    state
+                        .updated_since_checkpoint
+                        .iter()
+                        .map(|(k, v)| (k.hash(), v))
+                        .collect(),
+                    &ProofReader::new_empty(),
+                )
+                .unwrap()
+                .unfreeze();
+            state.current_version = next_version.checked_sub(1);
+            state.checkpoint = state.current.clone();
+            state.checkpoint_version = state.current_version;
+            state.updated_since_checkpoint.clear();
+        }
+    }
+    if next_version.checked_sub(1) != state.current_version {
+        state.current = state
+            .current
+            .clone()
+            .freeze()
+            .batch_update(
+                state
+                    .updated_since_checkpoint
+                    .iter()
+                    .map(|(k, v)| (k.hash(), v))
+                    .collect(),
+                &ProofReader::new_empty(),
+            )
+            .unwrap()
+            .unfreeze();
+        state.current_version = next_version.checked_sub(1);
+    }
 }
 
 prop_compose! {
@@ -50,12 +88,16 @@ prop_compose! {
         type EventAccumulator = InMemoryAccumulator<EventAccumulatorHasher>;
         type TxnAccumulator = InMemoryAccumulator<TransactionAccumulatorHasher>;
 
-        let mut smt = SparseMerkleTree::<StateValue>::default().freeze();
         let mut txn_accumulator = TxnAccumulator::new_empty();
         let mut result = Vec::new();
 
+    let mut in_memory_state = InMemoryState::new_empty();
+    let _ancester = in_memory_state.current.clone().freeze();
+
         for block_gen in block_gens {
             let (mut txns_to_commit, mut ledger_info) = block_gen.materialize(&mut universe);
+            update_in_memory_state(&mut in_memory_state, &txns_to_commit);
+            let state_checkpoint_root_hash = in_memory_state.root_hash();
 
             // make real txn_info's
             for txn in txns_to_commit.iter_mut() {
@@ -65,14 +107,11 @@ prop_compose! {
                 let event_hashes: Vec<_> = txn.events().iter().map(CryptoHash::hash).collect();
                 let event_root_hash = EventAccumulator::from_leaves(&event_hashes).root_hash();
 
-                // calculate state checkpoint hash
-                let state_checkpoint_hash = if txn.state_updates().is_empty() {
-                    None
+                // calculate state checkpoint hash and this must be the last txn
+                let state_checkpoint_hash = if txn.is_state_checkpoint() {
+                    Some(state_checkpoint_root_hash)
                 } else {
-                    let updates = txn.state_updates().iter().map(|(key, value)| {(key.hash(), value)}).collect();
-                    smt = smt.batch_update(updates, &ProofReader::new_empty()).unwrap();
-
-                    Some(smt.root_hash())
+                    None
                 };
 
                 let txn_info = TransactionInfo::new(
@@ -168,18 +207,19 @@ pub fn test_save_blocks_impl(input: Vec<(Vec<TransactionToCommit>, LedgerInfoWit
     let tmp_dir = TempPath::new();
     let db = AptosDB::new_for_test(&tmp_dir);
 
-    let mut smt = SparseMerkleTree::<StateValue>::default().freeze();
+    let mut in_memory_state = (*db.state_store.in_memory_state().lock()).clone();
+    let _ancester = in_memory_state.current.clone();
     let num_batches = input.len();
     let mut cur_ver: Version = 0;
     let mut all_committed_txns = vec![];
     for (batch_idx, (txns_to_commit, ledger_info_with_sigs)) in input.iter().enumerate() {
-        smt = update_smt(&smt, txns_to_commit.as_slice());
+        update_in_memory_state(&mut in_memory_state, txns_to_commit.as_slice());
         db.save_transactions(
             txns_to_commit,
             cur_ver,                /* first_version */
             cur_ver.checked_sub(1), /* base_state_version */
             Some(ledger_info_with_sigs),
-            smt.clone().unfreeze(),
+            in_memory_state.clone(),
         )
         .unwrap();
 
@@ -453,6 +493,7 @@ pub fn verify_committed_transactions(
     );
 
     let mut cur_ver = first_version;
+    let mut updates = HashMap::new();
     for txn_to_commit in txns_to_commit {
         let txn_info = db.ledger_store.get_transaction_info(cur_ver).unwrap();
 
@@ -461,82 +502,94 @@ pub fn verify_committed_transactions(
             txn_info.transaction_hash(),
             txn_to_commit.transaction().hash()
         );
-        if matches!(txn_to_commit.transaction(), Transaction::StateCheckpoint(_)) {
-            continue;
-        }
-
-        // Fetch and verify transaction itself.
-        let txn = txn_to_commit.transaction().as_signed_user_txn().unwrap();
-        let txn_with_proof = db
-            .get_transaction_by_hash(txn_to_commit.transaction().hash(), ledger_version, true)
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            txn_with_proof.transaction.hash(),
-            txn_to_commit.transaction().hash()
-        );
-        txn_with_proof
-            .verify_user_txn(ledger_info, cur_ver, txn.sender(), txn.sequence_number())
-            .unwrap();
-        let txn_with_proof = db
-            .get_transaction_with_proof(cur_ver, ledger_version, true)
-            .unwrap();
-        txn_with_proof
-            .verify_user_txn(ledger_info, cur_ver, txn.sender(), txn.sequence_number())
-            .unwrap();
-
-        let txn_with_proof = db
-            .get_account_transaction(txn.sender(), txn.sequence_number(), true, ledger_version)
-            .unwrap()
-            .expect("Should exist.");
-        txn_with_proof
-            .verify_user_txn(ledger_info, cur_ver, txn.sender(), txn.sequence_number())
-            .unwrap();
-
-        let acct_txns_with_proof = db
-            .get_account_transactions(txn.sender(), txn.sequence_number(), 1, true, ledger_version)
-            .unwrap();
-        acct_txns_with_proof
-            .verify(
-                ledger_info,
-                txn.sender(),
-                txn.sequence_number(),
-                1,
-                true,
-                ledger_version,
-            )
-            .unwrap();
-        assert_eq!(acct_txns_with_proof.len(), 1);
-
-        let txn_list_with_proof = db
-            .get_transactions(cur_ver, 1, ledger_version, true /* fetch_events */)
-            .unwrap();
-        txn_list_with_proof
-            .verify(ledger_info, Some(cur_ver))
-            .unwrap();
-        assert_eq!(txn_list_with_proof.transactions.len(), 1);
-
-        let txn_output_list_with_proof = db
-            .get_transaction_outputs(cur_ver, 1, ledger_version)
-            .unwrap();
-        txn_output_list_with_proof
-            .verify(ledger_info, Some(cur_ver))
-            .unwrap();
-        assert_eq!(txn_output_list_with_proof.transactions_and_outputs.len(), 1);
 
         // Fetch and verify account states.
         for (state_key, state_value) in txn_to_commit.state_updates() {
-            let (state_value_in_db, proof) = db
-                .get_state_value_with_proof_by_version(state_key, cur_ver)
-                .unwrap();
+            updates.insert(state_key, state_value);
+            let state_value_in_db = db.get_state_value_by_version(state_key, cur_ver).unwrap();
             assert_eq!(state_value_in_db, Some(state_value.clone()));
-            proof
-                .verify(
-                    txn_info.state_checkpoint_hash().unwrap(),
-                    state_key.hash(),
-                    state_value_in_db.as_ref(),
+        }
+
+        if txn_to_commit.is_state_checkpoint() {
+            for (state_key, state_value) in &updates {
+                let (state_value_in_db, proof) = db
+                    .get_state_value_with_proof_by_version(state_key, cur_ver)
+                    .unwrap();
+                assert_eq!(state_value_in_db, Some((*state_value).clone()));
+                proof
+                    .verify(
+                        txn_info.state_checkpoint_hash().unwrap(),
+                        state_key.hash(),
+                        state_value_in_db.as_ref(),
+                    )
+                    .unwrap();
+            }
+            updates.clear();
+        } else {
+            // Fetch and verify transaction itself.
+            let txn = txn_to_commit.transaction().as_signed_user_txn().unwrap();
+            let txn_with_proof = db
+                .get_transaction_by_hash(txn_to_commit.transaction().hash(), ledger_version, true)
+                .unwrap()
+                .unwrap();
+            assert_eq!(
+                txn_with_proof.transaction.hash(),
+                txn_to_commit.transaction().hash()
+            );
+            txn_with_proof
+                .verify_user_txn(ledger_info, cur_ver, txn.sender(), txn.sequence_number())
+                .unwrap();
+            let txn_with_proof = db
+                .get_transaction_with_proof(cur_ver, ledger_version, true)
+                .unwrap();
+            txn_with_proof
+                .verify_user_txn(ledger_info, cur_ver, txn.sender(), txn.sequence_number())
+                .unwrap();
+
+            let txn_with_proof = db
+                .get_account_transaction(txn.sender(), txn.sequence_number(), true, ledger_version)
+                .unwrap()
+                .expect("Should exist.");
+            txn_with_proof
+                .verify_user_txn(ledger_info, cur_ver, txn.sender(), txn.sequence_number())
+                .unwrap();
+
+            let acct_txns_with_proof = db
+                .get_account_transactions(
+                    txn.sender(),
+                    txn.sequence_number(),
+                    1,
+                    true,
+                    ledger_version,
                 )
                 .unwrap();
+            acct_txns_with_proof
+                .verify(
+                    ledger_info,
+                    txn.sender(),
+                    txn.sequence_number(),
+                    1,
+                    true,
+                    ledger_version,
+                )
+                .unwrap();
+            assert_eq!(acct_txns_with_proof.len(), 1);
+
+            let txn_list_with_proof = db
+                .get_transactions(cur_ver, 1, ledger_version, true /* fetch_events */)
+                .unwrap();
+            txn_list_with_proof
+                .verify(ledger_info, Some(cur_ver))
+                .unwrap();
+            assert_eq!(txn_list_with_proof.transactions.len(), 1);
+
+            let txn_output_list_with_proof = db
+                .get_transaction_outputs(cur_ver, 1, ledger_version)
+                .unwrap();
+            txn_output_list_with_proof
+                .verify(ledger_info, Some(cur_ver))
+                .unwrap();
+            assert_eq!(txn_output_list_with_proof.transactions_and_outputs.len(), 1);
         }
 
         cur_ver += 1;
@@ -585,7 +638,8 @@ pub fn test_sync_transactions_impl(
     let tmp_dir = TempPath::new();
     let db = AptosDB::new_for_test(&tmp_dir);
 
-    let mut smt = SparseMerkleTree::<StateValue>::default().freeze();
+    let mut in_memory_state = (*db.state_store.in_memory_state().lock()).clone();
+    let _ancester = in_memory_state.current.clone().freeze();
     let num_batches = input.len();
     let mut cur_ver: Version = 0;
     for (batch_idx, (txns_to_commit, ledger_info_with_sigs)) in input.iter().enumerate() {
@@ -593,23 +647,23 @@ pub fn test_sync_transactions_impl(
         let batch1_len = txns_to_commit.len() / 2;
         let base_state_version = cur_ver.checked_sub(1);
         if batch1_len > 0 {
-            smt = update_smt(&smt, &txns_to_commit[..batch1_len]);
+            update_in_memory_state(&mut in_memory_state, &txns_to_commit[..batch1_len]);
             db.save_transactions(
                 &txns_to_commit[..batch1_len],
                 cur_ver, /* first_version */
                 base_state_version,
                 None,
-                smt.clone().unfreeze(),
+                in_memory_state.clone(),
             )
             .unwrap();
         }
-        smt = update_smt(&smt, &txns_to_commit[batch1_len..]);
+        update_in_memory_state(&mut in_memory_state, &txns_to_commit[batch1_len..]);
         db.save_transactions(
             &txns_to_commit[batch1_len..],
             cur_ver + batch1_len as u64, /* first_version */
             base_state_version,
             Some(ledger_info_with_sigs),
-            smt.clone().unfreeze(),
+            in_memory_state.clone(),
         )
         .unwrap();
 

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -78,7 +78,7 @@ fn end_to_end() {
     let tgt_db = AptosDB::new_readonly_for_test(&tgt_db_dir);
     assert_eq!(
         tgt_db
-            .get_latest_state_snapshot()
+            .get_state_snapshot_before(version + 1) // We cannot use get_latest_snapshot() because it searches backward from the latest txn_info version
             .unwrap()
             .map(|(_, hash)| hash)
             .unwrap(),

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -165,7 +165,7 @@ impl RestoreRunMode {
     pub fn finish(&self, version: Version) {
         match self {
             Self::Restore { restore_handler } => {
-                restore_handler.maybe_reset_state_store(version);
+                restore_handler.maybe_reset_state_store(Some(version));
             }
             Self::Verify => (),
         }

--- a/storage/storage-interface/src/executed_trees.rs
+++ b/storage/storage-interface/src/executed_trees.rs
@@ -8,11 +8,7 @@ use crate::{
 use anyhow::Result;
 use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
 use aptos_state_view::StateViewId;
-use aptos_types::{
-    proof::accumulator::InMemoryAccumulator, state_store::state_value::StateValue,
-    transaction::Version,
-};
-use scratchpad::SparseMerkleTree;
+use aptos_types::{proof::accumulator::InMemoryAccumulator, transaction::Version};
 use std::sync::Arc;
 
 /// A wrapper of the in-memory state sparse merkle tree and the transaction accumulator that
@@ -30,10 +26,6 @@ pub struct ExecutedTrees {
 impl ExecutedTrees {
     pub fn state(&self) -> &InMemoryState {
         &self.state
-    }
-
-    pub fn state_tree(&self) -> SparseMerkleTree<StateValue> {
-        self.state().current.clone()
     }
 
     pub fn txn_accumulator(&self) -> &Arc<InMemoryAccumulator<TransactionAccumulatorHasher>> {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -45,6 +45,7 @@ pub mod proof_fetcher;
 pub mod state_view;
 pub mod sync_proof_fetcher;
 
+use crate::in_memory_state::InMemoryState;
 pub use executed_trees::ExecutedTrees;
 use scratchpad::SparseMerkleTree;
 
@@ -622,7 +623,7 @@ pub trait DbWriter: Send + Sync {
         base_state_version: Option<Version>,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
         save_state_snapshots: bool,
-        state_tree: SparseMerkleTree<StateValue>,
+        latest_in_memory_state: InMemoryState,
     ) -> Result<()> {
         unimplemented!()
     }
@@ -633,7 +634,7 @@ pub trait DbWriter: Send + Sync {
         first_version: Version,
         base_state_version: Option<Version>,
         ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
-        state_tree: SparseMerkleTree<StateValue>,
+        latest_in_memory_state: InMemoryState,
     ) -> Result<()> {
         self.save_transactions_ext(
             txns_to_commit,
@@ -641,7 +642,7 @@ pub trait DbWriter: Send + Sync {
             base_state_version,
             ledger_info_with_sigs,
             true, /* save_state_snapshots */
-            state_tree,
+            latest_in_memory_state,
         )
     }
 
@@ -660,12 +661,7 @@ pub trait DbWriter: Send + Sync {
     /// See [`AptosDB::save_state_snapshot`].
     ///
     /// [`AptosDB::save_state_snapshot`]: ../aptosdb/struct.AptosDB.html#method.save_state_snapshot
-    fn save_state_snapshot(
-        &self,
-        version: Version,
-        base_version: Option<Version>,
-        state_tree_at_snapshot: SparseMerkleTree<StateValue>,
-    ) -> Result<()> {
+    fn save_state_snapshot(&self) -> Result<()> {
         unimplemented!()
     }
 

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -979,12 +979,16 @@ impl TransactionInfo {
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
-    pub fn new_placeholder(gas_used: u64, status: ExecutionStatus) -> Self {
+    pub fn new_placeholder(
+        gas_used: u64,
+        state_checkpoint_hash: Option<HashValue>,
+        status: ExecutionStatus,
+    ) -> Self {
         Self::new(
             HashValue::default(),
             HashValue::default(),
             HashValue::default(),
-            Some(HashValue::default()),
+            state_checkpoint_hash,
             gas_used,
             status,
         )


### PR DESCRIPTION
### Description
This PR has two major changes:
1. We add back the optimizations computing the JMT node hashes before committing JMT.
2. Batch committing the blocks into one state_merkle_db writes instead of one write per block. This will recover the state-sync speed.

Also, fix a lot of tests issue when the aforementioned changes have been made.

### Test Plan
cargo xtest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1983)
<!-- Reviewable:end -->
