### PR TITLE
[forge] Default to port forwarding when using operator resize command

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -141,9 +141,9 @@ struct Resize {
     move_modules_dir: Option<String>,
     #[structopt(
         long,
-        help = "If set, uses kubectl port-forward instead of assuming k8s DNS access"
+        help = "If set, dont use kubectl port forward to access the cluster"
     )]
-    port_forward: bool,
+    connect_directly: bool,
 }
 
 fn main() -> Result<()> {
@@ -224,7 +224,7 @@ fn main() -> Result<()> {
                     resize.validator_image_tag,
                     resize.testnet_image_tag,
                     resize.move_modules_dir,
-                    resize.port_forward,
+                    !resize.connect_directly,
                 ))?;
                 Ok(())
             }


### PR DESCRIPTION
Currently the default for forge is not to have direct access to k8s, so the command would fail to connect to nodes even though they are set up successfully. That makes port forward not really optional, and should be the default unless you're specifically configured network access which most people will not.

This inverts the flag and allows you to not port forward if you have direct connection.

Test Plan:

Run the resize command locally and ensure cluster works

```
$ cargo run -p forge-cli -- operator resize --namespace forge-banana --num-validators 10 --validator-image-tag 880bc32441e94ba39f8b2e93c2a1e1b7a0f5dd2d --testnet-image-tag 880bc32441e94ba39f8b2e93c2a1e1b7a0f5dd2d
```
