### PR TITLE
[Aptos Framework] Give AptosGovernance the signer capability for AptosFramework account

### DIFF
--- a/api/goldens/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -33,5 +33,13 @@
         "dummy_field": false
       }
     }
+  },
+  {
+    "type": "0x1::AptosGovernance::GovernanceResponsbility",
+    "data": {
+      "signer_cap": {
+        "account": "0x1"
+      }
+    }
   }
 ]

--- a/aptos-move/framework/aptos-framework/sources/Account.move
+++ b/aptos-move/framework/aptos-framework/sources/Account.move
@@ -370,9 +370,11 @@ module AptosFramework::Account {
     }
 
     /// Create the account for @AptosFramework to help module upgrades on testnet.
-    public(friend) fun create_core_framework_account(): signer {
+    public(friend) fun create_core_framework_account(): (signer, SignerCapability) {
         Timestamp::assert_genesis();
-        create_account_unchecked(@AptosFramework)
+        let signer = create_account_unchecked(@AptosFramework);
+        let signer_cap = SignerCapability { account: @AptosFramework };
+        (signer, signer_cap)
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/aptos-move/framework/aptos-framework/sources/Genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/Genesis.move
@@ -5,6 +5,7 @@ module AptosFramework::Genesis {
     use Std::Vector;
 
     use AptosFramework::Account;
+    use AptosFramework::AptosGovernance;
     use AptosFramework::Coin;
     use AptosFramework::ConsensusConfig;
     use AptosFramework::TransactionPublishingOption;
@@ -102,7 +103,10 @@ module AptosFramework::Genesis {
         Account::create_account_internal(Signer::address_of(core_resource_account));
         Account::rotate_authentication_key_internal(core_resource_account, copy core_resource_account_auth_key);
         // initialize the core framework account
-        let core_framework_account = Account::create_core_framework_account();
+        let (core_framework_account, framework_signer_cap) = Account::create_core_framework_account();
+
+        // Give the decentralized on-chain governance control over the core framework account.
+        AptosGovernance::store_signer_cap(&core_framework_account, framework_signer_cap);
 
         // Consensus config setup
         ConsensusConfig::initialize(core_resource_account);


### PR DESCRIPTION
### Description

So proposal resolution can obtain the signer to create resources, deploy new modules or upgrade existing modules at 0x1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1990)
<!-- Reviewable:end -->
