### PR TITLE
[state store] rename in_memory_state to buffered_state

### DIFF
--- a/storage/aptosdb/src/backup/test.rs
+++ b/storage/aptosdb/src/backup/test.rs
@@ -18,7 +18,7 @@ proptest! {
     fn test_get_transaction_iter(input in arb_blocks_to_commit()) {
         let tmp_dir = TempPath::new();
         let db = AptosDB::new_for_test(&tmp_dir);
-        let mut in_memory_state = (*db.state_store.in_memory_state().lock()).clone();
+        let mut in_memory_state = (*db.state_store.buffered_state().lock()).clone();
         let _ancester = in_memory_state.current.clone().freeze();
         let mut cur_ver: Version = 0;
         for (txns_to_commit, ledger_info_with_sigs) in input.iter() {

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -207,7 +207,7 @@ pub fn test_save_blocks_impl(input: Vec<(Vec<TransactionToCommit>, LedgerInfoWit
     let tmp_dir = TempPath::new();
     let db = AptosDB::new_for_test(&tmp_dir);
 
-    let mut in_memory_state = (*db.state_store.in_memory_state().lock()).clone();
+    let mut in_memory_state = (*db.state_store.buffered_state().lock()).clone();
     let _ancester = in_memory_state.current.clone();
     let num_batches = input.len();
     let mut cur_ver: Version = 0;
@@ -626,7 +626,7 @@ pub fn put_as_state_root(db: &AptosDB, version: Version, key: StateKey, value: S
     db.ledger_db
         .put::<StateValueSchema>(&(key.clone(), version), &value)
         .unwrap();
-    let mut in_memory_state = db.state_store.in_memory_state().lock();
+    let mut in_memory_state = db.state_store.buffered_state().lock();
     in_memory_state.current = smt;
     in_memory_state.current_version = Some(version);
     in_memory_state.updated_since_checkpoint.insert(key, value);
@@ -638,7 +638,7 @@ pub fn test_sync_transactions_impl(
     let tmp_dir = TempPath::new();
     let db = AptosDB::new_for_test(&tmp_dir);
 
-    let mut in_memory_state = (*db.state_store.in_memory_state().lock()).clone();
+    let mut in_memory_state = (*db.state_store.buffered_state().lock()).clone();
     let _ancester = in_memory_state.current.clone().freeze();
     let num_batches = input.len();
     let mut cur_ver: Version = 0;

--- a/storage/backup/backup-cli/src/utils/test_utils.rs
+++ b/storage/backup/backup-cli/src/utils/test_utils.rs
@@ -34,7 +34,7 @@ pub fn tmp_db_with_random_content() -> (
 ) {
     let (tmpdir, db) = tmp_db_empty();
     let mut cur_ver: Version = 0;
-    let mut in_memory_state = db.cached_state();
+    let mut in_memory_state = db.buffered_state();
     let _ancester = in_memory_state.current.clone().freeze();
     let blocks = ValueGenerator::new().generate(arb_blocks_to_commit());
     for (txns_to_commit, ledger_info_with_sigs) in &blocks {


### PR DESCRIPTION
### Description

Just rename `in_memory_state` to `buffered_state` as it is a special in_memory_state maintained by state store and its checkpoint is actually the latest snapshot (persisted checkpoint).

### Test Plan
ut

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1998)
<!-- Reviewable:end -->
