### PR TITLE
[gha/forge] report avg_tps and p99_latency to prometheus

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -77,6 +77,9 @@ jobs:
 
           # report metrics to pushgateway
           echo "forge_job_status {FORGE_EXIT_CODE=\"$FORGE_EXIT_CODE\",FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\"} $GITHUB_RUN_ID" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
+          echo "forge_job_avg_tps {FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\",GITHUB_RUN_ID=\"$GITHUB_RUN_ID\"} $AVG_TPS" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
+          echo "forge_job_p99_latency {FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\",GITHUB_RUN_ID=\"$GITHUB_RUN_ID\"} $P99_LATENCY" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
+
       - name: Post result as PR comment
         if: env.FORGE_ENABLED == 'true' && env.PR_NUMBER != null
         uses: thollander/actions-comment-pull-request@v1

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -124,14 +124,14 @@ fi
 
 # detect regressions
 # TODO(rustielin): do not block on perf regressions for now until Forge network performance stabilizes
-avg_tps=$(cat $FORGE_REPORT | grep -oE '\d+ TPS' | awk '{print $1}')
-p99_latency=$(cat $FORGE_REPORT | grep -oE '\d+ ms p99 latency' | awk '{print $1}')
-if [ -n "$avg_tps" ] && [ "$avg_tps" -lt "$TPS_THRESHOLD" ]; then
-    echo "(\!) AVG_TPS: ${avg_tps} < ${TPS_THRESHOLD} tps"
+AVG_TPS=$(cat $FORGE_REPORT | grep -oE '\d+ TPS' | awk '{print $1}')
+P99_LATENCY=$(cat $FORGE_REPORT | grep -oE '\d+ ms p99 latency' | awk '{print $1}')
+if [ -n "$AVG_TPS" ] && [ "$AVG_TPS" -lt "$TPS_THRESHOLD" ]; then
+    echo "(\!) AVG_TPS: ${AVG_TPS} < ${TPS_THRESHOLD} tps"
     # FORGE_EXIT_CODE=1
 fi
-if [ -n "$p99_latency" ] && [ "$p99_latency" -gt "$P99_LATENCY_MS_THRESHOLD" ]; then
-    echo "(\!) P99_LATENCY: ${p99_latency} > 5000 ms"
+if [ -n "$P99_LATENCY" ] && [ "$P99_LATENCY" -gt "$P99_LATENCY_MS_THRESHOLD" ]; then
+    echo "(\!) P99_LATENCY: ${P99_LATENCY} > 5000 ms"
     # FORGE_EXIT_CODE=1
 fi
 


### PR DESCRIPTION
so we can track regressions across runs with automation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/1999)
<!-- Reviewable:end -->
