### PR TITLE
[Storage] Add a new API call: `get_latest_epoch_state`

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
@@ -11,10 +11,10 @@ use crate::{
             MockStorageSynchronizer, MockStreamingClient,
         },
         utils::{
-            create_data_stream_listener, create_full_node_driver_configuration,
-            create_global_summary, create_output_list_with_proof,
-            create_random_epoch_ending_ledger_info, create_startup_info, create_transaction_info,
-            create_transaction_list_with_proof,
+            create_data_stream_listener, create_empty_epoch_state, create_epoch_ending_ledger_info,
+            create_full_node_driver_configuration, create_global_summary,
+            create_output_list_with_proof, create_random_epoch_ending_ledger_info,
+            create_transaction_info, create_transaction_list_with_proof,
         },
     },
 };
@@ -570,8 +570,11 @@ fn create_bootstrapper(
     // Create the mock db reader with only genesis loaded
     let mut mock_database_reader = create_mock_db_reader();
     mock_database_reader
-        .expect_get_startup_info()
-        .returning(|| Ok(Some(create_startup_info())));
+        .expect_get_latest_epoch_state()
+        .returning(|| Ok(create_empty_epoch_state()));
+    mock_database_reader
+        .expect_get_latest_ledger_info()
+        .returning(|| Ok(create_epoch_ending_ledger_info()));
     mock_database_reader
         .expect_get_latest_transaction_info_option()
         .returning(|| Ok(Some((0, create_transaction_info()))));

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
@@ -12,9 +12,8 @@ use crate::{
             MockStorageSynchronizer, MockStreamingClient,
         },
         utils::{
-            create_data_stream_listener, create_epoch_ending_ledger_info,
-            create_full_node_driver_configuration, create_startup_info_at_version_epoch,
-            create_transaction_info,
+            create_data_stream_listener, create_epoch_ending_ledger_info, create_epoch_state,
+            create_full_node_driver_configuration, create_transaction_info,
         },
     },
 };
@@ -289,13 +288,8 @@ fn create_continuous_syncer(
         .expect_get_latest_transaction_info_option()
         .returning(move || Ok(Some((synced_version, create_transaction_info()))));
     mock_database_reader
-        .expect_get_startup_info()
-        .returning(move || {
-            Ok(Some(create_startup_info_at_version_epoch(
-                synced_version,
-                current_epoch,
-            )))
-        });
+        .expect_get_latest_epoch_state()
+        .returning(move || Ok(create_epoch_state(current_epoch)));
 
     ContinuousSyncer::new(
         driver_configuration,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -1,12 +1,13 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::tests::utils::{create_empty_epoch_state, create_epoch_ending_ledger_info};
 use crate::{
-    storage_synchronizer::StorageSynchronizerInterface,
-    tests::utils::{create_startup_info, create_transaction_info},
+    storage_synchronizer::StorageSynchronizerInterface, tests::utils::create_transaction_info,
 };
 use anyhow::Result;
 use aptos_crypto::HashValue;
+use aptos_types::epoch_state::EpochState;
 use aptos_types::{
     account_address::AccountAddress,
     contract_event::EventWithVersion,
@@ -70,8 +71,11 @@ pub fn create_mock_reader_writer(
         .expect_get_latest_transaction_info_option()
         .returning(|| Ok(Some((0, create_transaction_info()))));
     reader
-        .expect_get_startup_info()
-        .returning(|| Ok(Some(create_startup_info())));
+        .expect_get_latest_epoch_state()
+        .returning(|| Ok(create_empty_epoch_state()));
+    reader
+        .expect_get_latest_ledger_info()
+        .returning(|| Ok(create_epoch_ending_ledger_info()));
 
     let writer = writer.unwrap_or_else(create_mock_db_writer);
     DbReaderWriter {
@@ -205,6 +209,8 @@ mock! {
         ) -> Result<Version>;
 
         fn get_latest_state_value(&self, state_key: StateKey) -> Result<Option<StateValue>>;
+
+        fn get_latest_epoch_state(&self) -> Result<EpochState>;
 
         fn get_latest_ledger_info_option(&self) -> Result<Option<LedgerInfoWithSignatures>>;
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -10,12 +10,12 @@ use crate::{
     storage_synchronizer::{StorageSynchronizer, StorageSynchronizerInterface},
     tests::{
         mocks::{
-            create_mock_db_reader, create_mock_db_writer, create_mock_executor,
-            create_mock_reader_writer, create_mock_receiver, MockChunkExecutor,
+            create_mock_db_writer, create_mock_executor, create_mock_reader_writer,
+            create_mock_receiver, MockChunkExecutor,
         },
         utils::{
             create_epoch_ending_ledger_info, create_event, create_output_list_with_proof,
-            create_startup_info, create_state_value_chunk_with_proof, create_transaction,
+            create_state_value_chunk_with_proof, create_transaction,
             create_transaction_list_with_proof, verify_mempool_and_event_notification,
         },
     },
@@ -58,18 +58,9 @@ async fn test_apply_transaction_outputs() {
         .expect_commit_chunk()
         .return_once(move || expected_commit_return);
 
-    // Set up the mock db reader
-    let mut db_reader = create_mock_db_reader();
-    db_reader
-        .expect_get_startup_info()
-        .returning(|| Ok(Some(create_startup_info())));
-
     // Create the storage synchronizer
     let (_, _, event_subscription_service, mut mempool_listener, mut storage_synchronizer, _, _) =
-        create_storage_synchronizer(
-            chunk_executor,
-            create_mock_reader_writer(Some(db_reader), None),
-        );
+        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Subscribe to the expected event
     let mut event_listener = event_subscription_service
@@ -180,18 +171,9 @@ async fn test_execute_transactions() {
         .expect_commit_chunk()
         .return_once(move || expected_commit_return);
 
-    // Set up the mock db reader
-    let mut db_reader = create_mock_db_reader();
-    db_reader
-        .expect_get_startup_info()
-        .returning(|| Ok(Some(create_startup_info())));
-
     // Create the storage synchronizer
     let (_, _, event_subscription_service, mut mempool_listener, mut storage_synchronizer, _, _) =
-        create_storage_synchronizer(
-            chunk_executor,
-            create_mock_reader_writer(Some(db_reader), None),
-        );
+        create_storage_synchronizer(chunk_executor, create_mock_reader_writer(None, None));
 
     // Subscribe to the expected event
     let mut event_listener = event_subscription_service
@@ -377,12 +359,6 @@ async fn test_save_states_completion() {
     let mut chunk_executor = create_mock_executor();
     chunk_executor.expect_reset().returning(|| Ok(()));
 
-    // Set up the mock db reader
-    let mut db_reader = create_mock_db_reader();
-    db_reader
-        .expect_get_startup_info()
-        .returning(|| Ok(Some(create_startup_info())));
-
     // Setup the mock db writer
     let mut db_writer = create_mock_db_writer();
     db_writer
@@ -409,7 +385,7 @@ async fn test_save_states_completion() {
     let (mut commit_listener, _, _, _, mut storage_synchronizer, _, _) =
         create_storage_synchronizer(
             chunk_executor,
-            create_mock_reader_writer(Some(db_reader), Some(db_writer)),
+            create_mock_reader_writer(None, Some(db_writer)),
         );
 
     // Subscribe to the expected event

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -8,6 +8,7 @@ use aptos_crypto::{
     HashValue, PrivateKey, Uniform,
 };
 use aptos_data_client::GlobalDataSummary;
+use aptos_types::on_chain_config::ValidatorSet;
 use aptos_types::{
     account_address::AccountAddress,
     block_info::BlockInfo,
@@ -37,7 +38,6 @@ use futures::StreamExt;
 use mempool_notifications::{CommittedTransaction, MempoolNotificationListener};
 use move_deps::move_core_types::language_storage::TypeTag;
 use std::collections::BTreeMap;
-use storage_interface::{ExecutedTrees, StartupInfo};
 use storage_service_types::CompleteDataRange;
 
 /// Creates a new data stream listener and notification sender pair
@@ -51,7 +51,7 @@ pub fn create_data_stream_listener() -> (Sender<(), DataNotification>, DataStrea
 
 /// Creates a test epoch ending ledger info
 pub fn create_epoch_ending_ledger_info() -> LedgerInfoWithSignatures {
-    let ledger_info = LedgerInfo::new(BlockInfo::random(0), HashValue::zero());
+    let ledger_info = LedgerInfo::genesis(HashValue::zero(), ValidatorSet::empty());
     LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
 }
 
@@ -119,39 +119,16 @@ pub fn create_random_epoch_ending_ledger_info(
     LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
 }
 
-/// Creates a test startup info
-pub fn create_startup_info() -> StartupInfo {
-    StartupInfo::new(
-        create_epoch_ending_ledger_info(),
-        Some(EpochState::empty()),
-        ExecutedTrees::new_empty(),
-        None,
-    )
+/// Returns an empty epoch state
+pub fn create_empty_epoch_state() -> EpochState {
+    EpochState::empty()
 }
 
-/// Creates a test startup info at the given version and epoch
-pub fn create_startup_info_at_version_epoch(version: Version, epoch: Epoch) -> StartupInfo {
-    let mut startup_info = create_startup_info();
-
-    // Set the latest ledger info
-    let block_info = BlockInfo::new(
-        epoch,
-        0,
-        HashValue::zero(),
-        HashValue::random(),
-        version,
-        0,
-        None,
-    );
-    let ledger_info = LedgerInfo::new(block_info, HashValue::random());
-    startup_info.latest_ledger_info = LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new());
-
-    // Set the latest epoch state
-    let mut latest_epoch_state = EpochState::empty();
-    latest_epoch_state.epoch = epoch;
-    startup_info.latest_epoch_state = Some(latest_epoch_state);
-
-    startup_info
+/// Returns an epoch state at the specified epoch
+pub fn create_epoch_state(epoch: u64) -> EpochState {
+    let mut epoch_state = create_empty_epoch_state();
+    epoch_state.epoch = epoch;
+    epoch_state
 }
 
 /// Creates a test state value chunk with proof

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -290,6 +290,11 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
+    /// Gets the latest epoch state currently held in storage.
+    fn get_latest_epoch_state(&self) -> Result<EpochState> {
+        unimplemented!()
+    }
+
     /// Returns the key, value pairs for a particular state key prefix at at desired version. This
     /// API can be used to get all resources of an account by passing the account address as the
     /// key prefix.


### PR DESCRIPTION
### Description

This PR updates storage to add a new API call: `get_latest_epoch_state`. In addition, it updates state sync to use this new API instead of `get_startup_info()`, which fetches a bit more data and requires locking.

### Test Plan
Existing unit tests have been updated and should cover this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2003)
<!-- Reviewable:end -->
