### PR TITLE
[storage][pruner] Add capability of incremental pruning

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -71,7 +71,8 @@ pub struct StorageConfig {
 pub const NO_OP_STORAGE_PRUNER_CONFIG: StoragePrunerConfig = StoragePrunerConfig {
     state_store_prune_window: None,
     ledger_prune_window: None,
-    pruning_batch_size: 10_000,
+    ledger_pruning_batch_size: 10_000,
+    state_store_pruning_batch_size: 10_000,
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -84,21 +85,27 @@ pub struct StoragePrunerConfig {
     /// being big in size, we might want to configure a smaller window for state store vs other
     /// store.
     pub ledger_prune_window: Option<u64>,
-    /// Batch size of the versions to be sent to the pruner - this is to avoid slowdown due to
-    /// issuing too many DB calls and batch prune instead.
-    pub pruning_batch_size: usize,
+    /// Batch size of the versions to be sent to the ledger pruner - this is to avoid slowdown due to
+    /// issuing too many DB calls and batch prune instead. For ledger pruner, this means the number
+    /// of versions to prune a time.
+    pub ledger_pruning_batch_size: usize,
+    /// Similar to the variable above but for state store pruner. It means the number of stale
+    /// nodes to prune a time.
+    pub state_store_pruning_batch_size: usize,
 }
 
 impl StoragePrunerConfig {
     pub fn new(
         state_store_prune_window: Option<u64>,
         ledger_store_prune_window: Option<u64>,
-        pruning_batch_size: usize,
+        ledger_pruning_batch_size: usize,
+        state_store_pruning_batch_size: usize,
     ) -> Self {
         StoragePrunerConfig {
             state_store_prune_window,
             ledger_prune_window: ledger_store_prune_window,
-            pruning_batch_size,
+            ledger_pruning_batch_size,
+            state_store_pruning_batch_size,
         }
     }
 }
@@ -119,7 +126,10 @@ impl Default for StorageConfig {
             storage_pruner_config: StoragePrunerConfig {
                 state_store_prune_window: Some(1_000_000),
                 ledger_prune_window: Some(10_000_000),
-                pruning_batch_size: 500,
+                ledger_pruning_batch_size: 500,
+                // A 10k transaction block (touching 60k state values, in the case of the account
+                // creation benchmark) on a 4B items DB (or 1.33B accounts) yields 300k JMT nodes
+                state_store_pruning_batch_size: 1_000,
             },
             data_dir: PathBuf::from("/opt/aptos/data"),
             // Default read/write/connection timeout, in milliseconds

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -19,7 +19,10 @@ struct PrunerOpt {
     ledger_prune_window: i64,
 
     #[structopt(long, default_value = "500")]
-    pruning_batch_size: usize,
+    ledger_pruning_batch_size: usize,
+
+    #[structopt(long, default_value = "500")]
+    state_store_pruning_batch_size: usize,
 }
 
 impl PrunerOpt {
@@ -35,7 +38,8 @@ impl PrunerOpt {
             } else {
                 Some(self.ledger_prune_window as u64)
             },
-            pruning_batch_size: self.pruning_batch_size,
+            ledger_pruning_batch_size: self.ledger_pruning_batch_size,
+            state_store_pruning_batch_size: self.state_store_pruning_batch_size,
         }
     }
 }

--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -89,7 +89,8 @@ fn test_error_if_version_is_pruned() {
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
-            pruning_batch_size: 1,
+            ledger_pruning_batch_size: 1,
+            state_store_pruning_batch_size: 1,
         },
     );
     pruner.testonly_update_min_version(&[Some(5), Some(10)]);

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -84,8 +84,19 @@ pub static PRUNER_LEAST_READABLE_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static PRUNER_BATCH_SIZE: Lazy<IntGauge> =
-    Lazy::new(|| register_int_gauge!("pruner_batch_size", "Aptos pruner batch size").unwrap());
+/// Pruner batch size. For ledger pruner, this means the number of versions to be pruned at a time.
+/// For state store pruner, this means the number of stale nodes to be pruned at a time.
+pub static PRUNER_BATCH_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        // metric name
+        "pruner_batch_size",
+        // metric description
+        "Aptos pruner batch size",
+        // metric labels (dimensions)
+        &["pruner_name",]
+    )
+    .unwrap()
+});
 
 pub static API_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(

--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -37,7 +37,7 @@ pub trait DBPruner {
 
     /// Performs the actual pruning, a target version is passed, which is the target the pruner
     /// tries to prune.
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version>;
+    fn prune(&self, batch_size: usize) -> anyhow::Result<Version>;
 
     /// Initializes the least readable version stored in underlying DB storage
     fn initialize_min_readable_version(&self) -> anyhow::Result<Version>;

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -61,7 +61,8 @@ fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
-            pruning_batch_size: 1,
+            ledger_pruning_batch_size: 1,
+            state_store_pruning_batch_size: 100,
         },
     );
 
@@ -108,7 +109,8 @@ fn verify_event_store_pruner_disabled(events: Vec<Vec<ContractEvent>>) {
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: None,
-            pruning_batch_size: 1,
+            ledger_pruning_batch_size: 1,
+            state_store_pruning_batch_size: 100,
         },
     );
 

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -36,7 +36,7 @@ impl DBPruner for LedgerPruner {
         LEDGER_PRUNER_NAME
     }
 
-    fn prune(&self, max_versions: u64) -> anyhow::Result<Version> {
+    fn prune(&self, max_versions: usize) -> anyhow::Result<Version> {
         if !self.is_pruning_pending() {
             return Ok(self.min_readable_version());
         }
@@ -44,7 +44,7 @@ impl DBPruner for LedgerPruner {
         let min_readable_version = self.min_readable_version();
         // Current target version might be less than the target version to ensure we don't prune
         // more than max_version in one go.
-        let current_target_version = self.get_currrent_batch_target(max_versions);
+        let current_target_version = self.get_currrent_batch_target(max_versions as Version);
 
         self.transaction_store_pruner.prune(
             &mut db_batch,

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -92,7 +92,13 @@ impl Pruner {
             .with_label_values(&["ledger_pruner"])
             .set((storage_pruner_config.ledger_prune_window.unwrap_or(0)) as i64);
 
-        PRUNER_BATCH_SIZE.set(storage_pruner_config.pruning_batch_size as i64);
+        PRUNER_BATCH_SIZE
+            .with_label_values(&["ledger_pruner"])
+            .set(storage_pruner_config.ledger_pruning_batch_size as i64);
+
+        PRUNER_BATCH_SIZE
+            .with_label_values(&["state_store_pruner"])
+            .set(storage_pruner_config.state_store_pruning_batch_size as i64);
 
         let worker = Worker::new(
             ledger_rocksdb,
@@ -113,7 +119,7 @@ impl Pruner {
             command_sender: Mutex::new(command_sender),
             min_readable_versions: worker_progress_clone,
             last_version_sent_to_pruners: Arc::new(Mutex::new(0)),
-            pruning_batch_size: storage_pruner_config.pruning_batch_size,
+            pruning_batch_size: storage_pruner_config.ledger_pruning_batch_size,
             latest_version: Arc::new(Mutex::new(0)),
         }
     }
@@ -139,6 +145,10 @@ impl Pruner {
     /// Sends pruning command to the worker thread when necessary.
     pub fn maybe_wake_pruner(&self, latest_version: Version) {
         *self.latest_version.lock() = latest_version;
+        // TODO(zcc): Right now we will still wake up the state store pruner once per pruning batch
+        // size even though state store pruner not necessarily prune one single version of nodes
+        // each time. We should make ledger pruner and state store separate and wake up them
+        // separately.
         if latest_version
             >= *self.last_version_sent_to_pruners.as_ref().lock() + self.pruning_batch_size as u64
         {

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -6,8 +6,10 @@ use std::collections::HashMap;
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
 use aptos_types::state_store::{state_key::StateKey, state_value::StateValue};
+use schemadb::ReadOptions;
 use storage_interface::{jmt_update_refs, jmt_updates, DbReader};
 
+use crate::stale_node_index::StaleNodeIndexSchema;
 use crate::{change_set::ChangeSet, pruner::*, state_store::StateStore, AptosDB};
 
 fn put_value_set(
@@ -72,7 +74,8 @@ fn test_state_store_pruner() {
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
-            pruning_batch_size: prune_batch_size,
+            ledger_pruning_batch_size: prune_batch_size,
+            state_store_pruning_batch_size: prune_batch_size,
         },
     );
 
@@ -141,6 +144,149 @@ fn test_state_store_pruner() {
 }
 
 #[test]
+fn test_state_store_pruner_partial_version() {
+    // ```text
+    // | batch    | 0      | 1             | 2             |
+    // | address1 | value1 |               |               |
+    // | address2 | value2 | value2_update |               |
+    // | address3 |        | value3        | value3_update |
+    // ```
+    // The stale node indexes will have 4 entries in total.
+    // ```
+    // index: StaleNodeIndex { stale_since_version: 1, node_key: NodeKey { version: 0, nibble_path:  } }
+    // index: StaleNodeIndex { stale_since_version: 1, node_key: NodeKey { version: 0, nibble_path: 2 } }
+    // index: StaleNodeIndex { stale_since_version: 2, node_key: NodeKey { version: 1, nibble_path:  } }
+    // index: StaleNodeIndex { stale_since_version: 2, node_key: NodeKey { version: 1, nibble_path: d } }
+    // ```
+    // On version 1, there are two entries, one changes address2 and the other changes the root node.
+    // On version 2, there are two entries, one changes address3 and the other changes the root node.
+    let key1 = StateKey::Raw(String::from("test_key1").into_bytes());
+    let key2 = StateKey::Raw(String::from("test_key2").into_bytes());
+    let key3 = StateKey::Raw(String::from("test_key3").into_bytes());
+
+    let value1 = StateValue::from(String::from("test_val1").into_bytes());
+    let value2 = StateValue::from(String::from("test_val2").into_bytes());
+    let value2_update = StateValue::from(String::from("test_val2_update").into_bytes());
+    let value3 = StateValue::from(String::from("test_val3").into_bytes());
+    let value3_update = StateValue::from(String::from("test_val3_update").into_bytes());
+
+    let prune_batch_size = 1;
+    let tmp_dir = TempPath::new();
+    let aptos_db = AptosDB::new_for_test(&tmp_dir);
+    let state_store = &StateStore::new(
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
+        false, /* hack_for_tests */
+    );
+    let pruner = Pruner::new(
+        Arc::clone(&aptos_db.ledger_db),
+        Arc::clone(&aptos_db.state_merkle_db),
+        StoragePrunerConfig {
+            state_store_prune_window: Some(0),
+            ledger_prune_window: Some(0),
+            ledger_pruning_batch_size: prune_batch_size,
+            state_store_pruning_batch_size: prune_batch_size,
+        },
+    );
+
+    let _root0 = put_value_set(
+        &aptos_db.ledger_db,
+        state_store,
+        vec![(key1.clone(), value1.clone()), (key2.clone(), value2)],
+        0, /* version */
+    );
+    let _root1 = put_value_set(
+        &aptos_db.ledger_db,
+        state_store,
+        vec![
+            (key2.clone(), value2_update.clone()),
+            (key3.clone(), value3.clone()),
+        ],
+        1, /* version */
+    );
+    let _root2 = put_value_set(
+        &aptos_db.ledger_db,
+        state_store,
+        vec![(key3.clone(), value3_update.clone())],
+        2, /* version */
+    );
+
+    // Prune till version=0. This should basically be a no-op
+    {
+        pruner
+            .wake_and_wait(
+                0, /* latest_version */
+                PrunerIndex::StateStorePrunerIndex as usize,
+            )
+            .unwrap();
+        verify_state_in_store(state_store, key1.clone(), Some(&value1), 1);
+        verify_state_in_store(state_store, key2.clone(), Some(&value2_update), 1);
+        verify_state_in_store(state_store, key3.clone(), Some(&value3), 1);
+    }
+
+    // Test for batched pruning, since we use a batch size of 1, updating the latest version to 1
+    // should prune 1 stale node with the version 0.
+    {
+        assert!(pruner
+            .wake_and_wait(
+                1, /* latest_version */
+                PrunerIndex::StateStorePrunerIndex as usize,
+            )
+            .is_ok());
+        assert!(state_store
+            .get_state_value_with_proof_by_version(&key1, 0_u64)
+            .is_err());
+        // root1 is still there.
+        verify_state_in_store(state_store, key1.clone(), Some(&value1), 1);
+        verify_state_in_store(state_store, key2.clone(), Some(&value2_update), 1);
+        verify_state_in_store(state_store, key3.clone(), Some(&value3), 1);
+    }
+    // Prune 3 more times. All version 0 and 1 stale nodes should be gone.
+    {
+        assert!(pruner
+            .wake_and_wait(
+                2, /* latest_version */
+                PrunerIndex::StateStorePrunerIndex as usize,
+            )
+            .is_ok());
+        assert!(pruner
+            .wake_and_wait(
+                2, /* latest_version */
+                PrunerIndex::StateStorePrunerIndex as usize,
+            )
+            .is_ok());
+
+        assert!(pruner
+            .wake_and_wait(
+                2, /* latest_version */
+                PrunerIndex::StateStorePrunerIndex as usize,
+            )
+            .is_ok());
+        assert!(state_store
+            .get_state_value_with_proof_by_version(&key1, 0_u64)
+            .is_err());
+        assert!(state_store
+            .get_state_value_with_proof_by_version(&key2, 1_u64)
+            .is_err());
+        // root2 is still there.
+        verify_state_in_store(state_store, key1, Some(&value1), 2);
+        verify_state_in_store(state_store, key2, Some(&value2_update), 2);
+        verify_state_in_store(state_store, key3, Some(&value3_update), 2);
+    }
+
+    // Make sure all stale indices are gone.
+    assert_eq!(
+        aptos_db
+            .state_merkle_db
+            .iter::<StaleNodeIndexSchema>(ReadOptions::default())
+            .unwrap()
+            .collect::<Vec<_>>()
+            .len(),
+        0
+    );
+}
+
+#[test]
 fn test_state_store_pruner_disabled() {
     let key = StateKey::Raw(String::from("test_key1").into_bytes());
 
@@ -159,7 +305,8 @@ fn test_state_store_pruner_disabled() {
         StoragePrunerConfig {
             state_store_prune_window: None,
             ledger_prune_window: Some(0),
-            pruning_batch_size: prune_batch_size,
+            ledger_pruning_batch_size: prune_batch_size,
+            state_store_pruning_batch_size: prune_batch_size,
         },
     );
 
@@ -258,7 +405,8 @@ fn test_worker_quit_eagerly() {
             StoragePrunerConfig {
                 state_store_prune_window: Some(1),
                 ledger_prune_window: Some(1),
-                pruning_batch_size: 100,
+                ledger_pruning_batch_size: 100,
+                state_store_pruning_batch_size: 100,
             },
         );
         command_sender

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -53,7 +53,8 @@ fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
-            pruning_batch_size: 1,
+            ledger_pruning_batch_size: 1,
+            state_store_pruning_batch_size: 100,
         },
     );
 
@@ -102,7 +103,8 @@ fn verify_txn_store_pruner(
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
             ledger_prune_window: Some(0),
-            pruning_batch_size: 1,
+            ledger_pruning_batch_size: 1,
+            state_store_pruning_batch_size: 100,
         },
     );
 

--- a/storage/aptosdb/src/pruner/utils.rs
+++ b/storage/aptosdb/src/pruner/utils.rs
@@ -13,7 +13,7 @@ use crate::{
 use aptos_config::config::StoragePrunerConfig;
 use aptos_infallible::Mutex;
 use schemadb::DB;
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 /// A useful utility function to instantiate all db pruners.
 pub fn create_db_pruners(
@@ -23,11 +23,9 @@ pub fn create_db_pruners(
 ) -> Vec<Option<Mutex<Arc<dyn DBPruner + Send + Sync>>>> {
     vec![
         if storage_pruner_config.state_store_prune_window.is_some() {
-            Some(Mutex::new(Arc::new(StateStorePruner::new(
-                Arc::clone(&state_merkle_db),
-                0,
-                Instant::now(),
-            ))))
+            Some(Mutex::new(Arc::new(StateStorePruner::new(Arc::clone(
+                &state_merkle_db,
+            )))))
         } else {
             None
         },

--- a/storage/aptosdb/src/pruner/worker.rs
+++ b/storage/aptosdb/src/pruner/worker.rs
@@ -4,6 +4,7 @@ use aptos_types::transaction::Version;
 use schemadb::DB;
 
 use crate::pruner::{db_pruner::DBPruner, utils};
+use crate::PrunerIndex;
 use aptos_config::config::StoragePrunerConfig;
 use aptos_infallible::Mutex;
 use itertools::zip_eq;
@@ -24,7 +25,10 @@ pub struct Worker {
     /// Indicates if there's NOT any pending work to do currently, to hint
     /// `Self::receive_commands()` to `recv()` blocking-ly.
     blocking_recv: bool,
-    max_version_to_prune_per_batch: u64,
+    /// Max items to prune per batch. For the ledger pruner, this means the max versions to prune
+    /// and for the state pruner, this means the max stale nodes to prune.
+    ledger_store_max_versions_to_prune_per_batch: u64,
+    state_store_max_nodes_to_prune_per_batch: u64,
 }
 
 impl Worker {
@@ -42,26 +46,51 @@ impl Worker {
             command_receiver,
             min_readable_versions,
             blocking_recv: true,
-            max_version_to_prune_per_batch: storage_pruner_config.pruning_batch_size as u64,
+            ledger_store_max_versions_to_prune_per_batch: storage_pruner_config
+                .ledger_pruning_batch_size
+                as u64,
+            state_store_max_nodes_to_prune_per_batch: storage_pruner_config
+                .state_store_pruning_batch_size
+                as u64,
         }
     }
 
     pub(crate) fn work(mut self) {
+        assert_eq!(self.db_pruners.len(), 2);
         while self.receive_commands() {
             // Process a reasonably small batch of work before trying to receive commands again,
             // in case `Command::Quit` is received (that's when we should quit.)
             let mut error_in_pruning = false;
-            for db_pruner in self.db_pruners.iter().flatten() {
-                let result = db_pruner.lock().prune(self.max_version_to_prune_per_batch);
-                result.map_err(|_| error_in_pruning = true).ok();
-            }
             let mut pruning_pending = false;
-            for db_pruner in self.db_pruners.iter().flatten() {
-                // if any of the pruner has pending pruning, then we don't block on receive
-                if db_pruner.lock().is_pruning_pending() {
+
+            if let Some(state_store_pruner_locked) =
+                &self.db_pruners[PrunerIndex::StateStorePrunerIndex as usize]
+            {
+                let state_store_pruner = state_store_pruner_locked.lock();
+                state_store_pruner
+                    .prune(self.state_store_max_nodes_to_prune_per_batch as usize)
+                    .map_err(|_| error_in_pruning = true)
+                    .ok();
+
+                if state_store_pruner.is_pruning_pending() {
                     pruning_pending = true;
                 }
             }
+
+            if let Some(ledger_pruner_locked) =
+                &self.db_pruners[PrunerIndex::LedgerPrunerIndex as usize]
+            {
+                let ledger_pruner = ledger_pruner_locked.lock();
+                ledger_pruner
+                    .prune(self.ledger_store_max_versions_to_prune_per_batch as usize)
+                    .map_err(|_| error_in_pruning = true)
+                    .ok();
+
+                if ledger_pruner.is_pruning_pending() {
+                    pruning_pending = true;
+                }
+            }
+
             if !pruning_pending || error_in_pruning {
                 self.blocking_recv = true;
             } else {


### PR DESCRIPTION
### Description
Add a capability to only prune a partial version for state pruner
Context: https://linear.app/aptoslabs/issue/BLK-19/[db]-state-pruner-smaller-commits
### Changes
- Previously, max version in prune_state_store means the max number of versions to prune. In each version, there can be multiple stale nodes. Now, the same parameter means the max number of stale nodes to prune.
- Previously, we don't immediately delete the stale node index after pruning the node from DB but only do it periodically. After this change, we will delete the stale node indexes immediately after pruning the stale node.
  - Previously, if deleting the stale node index, we will just print a warning. Now we treat failures of deleting the stale node index the same as that of deleting the node.
- Split config `pruning_batch_size` into `ledger_pruning_batch_size` and `state_store_pruning_batch_size`. We still only wake up the state store pruner only when we have at least `ledger_pruning_batch_size` pending versions to keep this PR smaller. In the next PR, we will refactor pruners so that we will wake up pruners independently.
- Changed the is_pending logic of state pruner to `target_version > min_readable_version || min_readable_version_has_more_items_to_prune`
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
- Added UTs.
- Cargo xtest, nextest
- Performance test is TBD
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2004)
<!-- Reviewable:end -->
