### PR TITLE
[Token] [1/2]Separate the token package from core-framework

### DIFF
--- a/aptos-move/framework/aptos-token/Move.toml
+++ b/aptos-move/framework/aptos-token/Move.toml
@@ -1,0 +1,14 @@
+[package]
+name = "AptosToken"
+version = "1.0.0"
+
+[addresses]
+Std = "0x1"
+AptosFramework = "0x1"
+CoreResources = "0xA550C18"
+VMReserved = "0x0"
+AptosToken = "0x2"
+
+[dependencies]
+MoveStdlib = { local = "../move-stdlib" }
+AptosFramework = { local = "../aptos-framework"}

--- a/aptos-move/framework/aptos-token/sources/PropertyMap.move
+++ b/aptos-move/framework/aptos-token/sources/PropertyMap.move
@@ -1,6 +1,6 @@
 /// PropertyMap is a specialization of SimpleMap for Tokens.
-/// It maps a String key to a PropertyValue that consists of a String type and a vec value
-module AptosFramework::PropertyMap {
+/// It maps a String key to a PropertyValue that consists of type (string) and value (vecotr<u8>)
+module AptosToken::PropertyMap {
     use Std::Vector;
     use Std::ASCII::{Self, String};
     use AptosFramework::SimpleMap::{Self, SimpleMap};

--- a/aptos-move/framework/aptos-token/sources/TokenCoinSwap.move
+++ b/aptos-move/framework/aptos-token/sources/TokenCoinSwap.move
@@ -1,15 +1,15 @@
 /// A module for
-/// 1. hold tokens escrow to prevent token been transferred
-/// 2. list token for swapping with a targeted CoinType.
-/// 3. execute the swapping
-module AptosFramework::TokenCoinSwap {
+/// 1. Hold tokens escrow to prevent token been transferred
+/// 2. List token for swapping with a targeted CoinType.
+/// 3. Execute the swapping
+module AptosToken::TokenCoinSwap {
     use Std::Event::{Self, EventHandle};
     use Std::Signer;
     use AptosFramework::Table::{Self, Table};
-    use AptosFramework::TokenV1::{Self, Token, TokenId, deposit_token, withdraw_token, merge, split};
     use AptosFramework::Coin;
     use AptosFramework::Timestamp;
     use AptosFramework::TypeInfo::{Self, TypeInfo};
+    use AptosToken::TokenV1::{Self, Token, TokenId, deposit_token, withdraw_token, merge, split};
 
     const ETOKEN_ALREADY_LISTED: u64 = 1;
     const ETOKEN_LISTING_NOT_EXIST: u64 = 2;

--- a/aptos-move/framework/aptos-token/sources/TokenV1.move
+++ b/aptos-move/framework/aptos-token/sources/TokenV1.move
@@ -1,5 +1,5 @@
 /// This module provides the foundation for Tokens.
-module AptosFramework::TokenV1 {
+module AptosToken::TokenV1 {
     use Std::ASCII::{String, Self};
     use Std::Errors;
     use Std::Event::{Self, EventHandle};
@@ -7,7 +7,7 @@ module AptosFramework::TokenV1 {
     use Std::Vector;
 
     use AptosFramework::Table::{Self, Table};
-    use AptosFramework::PropertyMap::{Self, PropertyMap};
+    use AptosToken::PropertyMap::{Self, PropertyMap};
 
     const TOKEN_MAX_MUTABLE_IND: u64 = 0;
     const TOKEN_URI_MUTABLE_IND: u64 = 1;

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -10,15 +10,14 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+aptos-types = { path = "../../../types" }
 bcs = "0.1.3"
+framework = { path = ".." }
 include_dir = { version = "0.7.2", features = ["glob"] }
+move-deps = { path = "../../move-deps", features = ["address32"] }
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
-
-aptos-types = { path = "../../../types" }
-
-move-deps = { path = "../../move-deps", features = ["address32"] }
 
 [build-dependencies]
 framework = { path = ".." }

--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -3,6 +3,9 @@
 
 use std::path::PathBuf;
 
+use framework::release::CORE_FRAMEWORK_RELEASE_SUFFIX;
+use framework::release::TOKEN_RELEASE_SUFFIX;
+
 fn main() {
     println!("cargo:rerun-if-changed=../aptos-framework/sources");
     println!("cargo:rerun-if-changed=../move-stdlib/sources");
@@ -14,7 +17,28 @@ fn main() {
         script_abis: false,
         errmap: false,
         package: PathBuf::from("aptos-framework"),
-        output: PathBuf::from(std::env::var("OUT_DIR").unwrap()),
+        output: PathBuf::from(format!(
+            "{}/{}",
+            std::env::var("OUT_DIR").unwrap(),
+            CORE_FRAMEWORK_RELEASE_SUFFIX
+        )),
     };
     release.create_release();
+
+    println!("cargo:rerun-if-changed=../aptos-token/sources");
+    let token_release = framework::release::ReleaseOptions {
+        check_layout_compatibility: false,
+        build_docs: true,
+        with_diagram: true,
+        script_builder: false,
+        script_abis: false,
+        errmap: false,
+        package: PathBuf::from("aptos-token"),
+        output: PathBuf::from(format!(
+            "{}/{}",
+            std::env::var("OUT_DIR").unwrap(),
+            TOKEN_RELEASE_SUFFIX
+        )),
+    };
+    token_release.create_release();
 }

--- a/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_stdlib.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(unused_imports)]
-include!(concat!(env!("OUT_DIR"), "/transaction_script_builder.rs"));
+
+include!(concat!(
+    concat!(env!("OUT_DIR"), "/framework"),
+    "/transaction_script_builder.rs"
+));
 
 use aptos_types::utility_coin::TEST_COIN_TYPE;
 use move_deps::move_core_types::language_storage::{StructTag, TypeTag};

--- a/aptos-move/framework/cached-packages/src/aptos_token_stdlib.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_token_stdlib.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(unused_imports)]
+
+include!(concat!(
+    concat!(env!("OUT_DIR"), "/token"),
+    "/transaction_script_builder.rs"
+));

--- a/aptos-move/framework/cached-packages/src/lib.rs
+++ b/aptos-move/framework/cached-packages/src/lib.rs
@@ -9,8 +9,9 @@ use move_deps::{
 use once_cell::sync::Lazy;
 
 pub mod aptos_stdlib;
+pub mod aptos_token_stdlib;
 
-static PACKAGE: Dir<'static> = include_dir!("$OUT_DIR");
+static PACKAGE: Dir<'static> = include_dir!("$OUT_DIR/framework");
 
 static MODULE_BLOBS: Lazy<Vec<Vec<u8>>> = Lazy::new(|| load_modules("build"));
 
@@ -87,8 +88,23 @@ pub fn module_blobs() -> &'static [Vec<u8>] {
 }
 
 #[test]
-fn verify_load() {
+fn verify_load_framework() {
     module_blobs();
     error_map();
-    std::fs::read(concat!(env!("OUT_DIR"), "/transaction_script_builder.rs")).unwrap();
+    std::fs::read(concat!(
+        env!("OUT_DIR"),
+        "/framework/transaction_script_builder.rs"
+    ))
+    .unwrap();
+}
+
+#[test]
+fn verify_load_token() {
+    module_blobs();
+    error_map();
+    std::fs::read(concat!(
+        env!("OUT_DIR"),
+        "/token/transaction_script_builder.rs"
+    ))
+    .unwrap();
 }

--- a/aptos-move/framework/src/release.rs
+++ b/aptos-move/framework/src/release.rs
@@ -18,6 +18,9 @@ use std::{
 };
 use structopt::*;
 
+pub const CORE_FRAMEWORK_RELEASE_SUFFIX: &str = "framework";
+pub const TOKEN_RELEASE_SUFFIX: &str = "token";
+
 /// Options to configure the generation of a release.
 #[derive(Debug, StructOpt, Clone)]
 #[structopt(

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -40,3 +40,8 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
 fn move_unit_tests() {
     run_tests_for_pkg("aptos-framework");
 }
+
+#[test]
+fn move_token_unit_tests() {
+    run_tests_for_pkg("aptos-token");
+}


### PR DESCRIPTION
### Description
1. create a new package for token related modules
2. update the cached framework to have two compiled package and transaction_script

will modify genesis to deploy the token package to 0x2 in the next PR

### Test Plan
use default tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2008)
<!-- Reviewable:end -->
