### PR TITLE
observability: introduce vector daemonset for log collection

### DIFF
--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -47,9 +47,9 @@ module "validator" {
   image_tag      = var.image_tag
   validator_name = "aptos-node"
 
-  num_validators       = var.num_validators
-  num_fullnode_groups  = var.num_fullnode_groups
-  helm_values          = var.aptos_node_helm_values
+  num_validators      = var.num_validators
+  num_fullnode_groups = var.num_fullnode_groups
+  helm_values         = var.aptos_node_helm_values
 
   # allow all nodegroups to surge to 2x their size, in case of total nodes replacement
   validator_instance_num = var.num_validator_instance > 0 ? 2 * var.num_validator_instance : var.num_validators
@@ -60,10 +60,12 @@ module "validator" {
   validator_instance_type = var.validator_instance_type
 
   # addons
-  enable_monitoring      = true
-  enable_logger          = true
-  monitoring_helm_values = var.monitoring_helm_values
-  logger_helm_values     = var.logger_helm_values
+  enable_monitoring              = true
+  enable_logger                  = true
+  monitoring_helm_values         = var.monitoring_helm_values
+  logger_helm_values             = var.logger_helm_values
+  enable_vector_daemonset_logger = var.enable_vector_daemonset_logger
+  vector_daemonset_helm_values   = var.vector_daemonset_helm_values
 }
 
 locals {

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -102,6 +102,17 @@ variable "logger_helm_values" {
   default     = {}
 }
 
+variable "enable_vector_daemonset_logger" {
+  description = "Enable vector-daemonset logger"
+  default     = false
+}
+
+variable "vector_daemonset_helm_values" {
+  description = "Map of helm values to pass to vector-daemonset chart"
+  type        = list(string)
+  default     = []
+}
+
 variable "monitoring_helm_values" {
   description = "Map of values to pass to monitoring helm chart"
   type        = any

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -194,6 +194,28 @@ resource "helm_release" "logger" {
   }
 }
 
+locals {
+  vector_daemonset_chart_path = "${path.module}/../../helm/vector-daemonset"
+}
+
+resource "helm_release" "vector_daemonset" {
+  count            = var.enable_vector_daemonset_logger ? 1 : 0
+  name             = "${local.helm_release_name}-vector-daemonset"
+  chart            = local.vector_daemonset_chart_path
+  max_history      = 5
+  namespace        = "vector"
+  create_namespace = true
+  wait             = false
+
+  values = var.vector_daemonset_helm_values
+
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
+  set {
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.vector_daemonset_chart_path, "**") : filesha1("${local.vector_daemonset_chart_path}/${f}")]))
+  }
+}
+
 resource "helm_release" "monitoring" {
   count       = var.enable_monitoring ? 1 : 0
   name        = "${local.helm_release_name}-mon"
@@ -210,7 +232,7 @@ resource "helm_release" "monitoring" {
         name = var.validator_name
       }
       service = {
-        domain   = local.domain
+        domain = local.domain
       }
       monitoring = {
         prometheus = {

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -196,6 +196,17 @@ variable "logger_helm_values" {
   default     = {}
 }
 
+variable "enable_vector_daemonset_logger" {
+  description = "Enable vector daemonset logger helm chart"
+  default     = false
+}
+
+variable "vector_daemonset_helm_values" {
+  description = "Map of helm values to pass to vector-daemonset chart"
+  type        = list(string)
+  default     = []
+}
+
 variable "enable_monitoring" {
   description = "Enable monitoring helm chart"
   default     = false

--- a/terraform/helm/vector-daemonset/Chart.yaml
+++ b/terraform/helm/vector-daemonset/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: aptos-vector-daemonset
+version: 0.1.0

--- a/terraform/helm/vector-daemonset/README.md
+++ b/terraform/helm/vector-daemonset/README.md
@@ -1,0 +1,26 @@
+Vector DaemonSet
+===
+
+This Helm chart deploys a k8s DaemonSet that collects ALL logs of a k8s cluster via [Vector](https://vector.dev/).
+The logger then sends the logs to any destination [Vector Sink](https://vector.dev/docs/reference/configuration/sinks) of your choice.
+
+We also provide some recommended values for the sink configuration of _some_ sinks.
+
+## General instructions
+
+1. Install Helm v3: https://helm.sh/docs/intro/install/
+2. Create a `my-values.yaml` to configure your sink
+3. Deploy it via `helm upgrade vector --install --namespace vector --create-namespace ./ --values my-values.yaml`
+
+
+## Sink specific instructions
+
+### [Humio](https://www.humio.com/) Sink
+
+1. Create a humio ingest token and follow the instructions under [humio-sink.yaml](./example-values/humio-sink.yaml) to create a corresponding k8s Secret.
+2. Deploy it via `helm upgrade vector --install --namespace vector --create-namespace --values ./example-values/humio-sink.yaml ./`
+
+
+## Troubleshooting
+
+- `kubectl exec -it <name_of_a_vector_pod> -- vector top`

--- a/terraform/helm/vector-daemonset/example-values/humio-sink.yaml
+++ b/terraform/helm/vector-daemonset/example-values/humio-sink.yaml
@@ -1,0 +1,28 @@
+# This provides a values example for a humio sink with some recommended settings.
+# For docs on availabe config options check https://vector.dev/docs/reference/configuration/sinks/humio_logs/ .
+# The TLDR is:
+# most defaults are fine as baseline config.
+# - set compression: gzip. Typically this will save you 90-95% in Network Egress at the cost of some (negligible amount) of CPU to handle the compression.
+# - set rate_limit_num: 100 or something higher than the default. The default is `10` which is a bit too conservative and can easily lead backpressure for high-volume sources.
+logging_sinks:
+  humio:
+    type: humio_logs
+    inputs:
+      - k8s_logs
+    token: ${HUMIO_TOKEN:?err}
+    endpoint: https://cloud.community.humio.com
+    encoding:
+      codec: json
+    compression: gzip
+    request:
+      rate_limit_num: 100
+
+### PREREQUESITE: create a kubernetes secret via
+### kubectl create secret generic humio-token --namespace vector --from-literal=HUMIO_TOKEN=<YOUR_HUMIO_INGEST_TOKEN>
+env:
+  humio:
+    - name: HUMIO_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: humio-token
+          key: HUMIO_TOKEN

--- a/terraform/helm/vector-daemonset/example-values/observe-sink.yaml
+++ b/terraform/helm/vector-daemonset/example-values/observe-sink.yaml
@@ -1,0 +1,28 @@
+logging_sinks:
+  observe:
+    type: http
+    inputs:
+      - k8s_logs
+    uri: https://collect.observeinc.com/v1/http
+    compression: gzip
+    auth:
+      strategy: basic
+      user: ${OBSERVE_CUSTOMER_ID:?err}
+      password: ${OBSERVE_TOKEN:?err}
+    encoding:
+      codec: json
+
+### PREREQUESITE: create a kubernetes secret via
+### kubectl create secret generic observe-credentials --namespace vector --from-literal=OBSERVE_CUSTOMER_ID=<YOUR_OBSERVE_CUSTOMER_ID> --from-literal=OBSERVE_TOKEN=<OBSERVE_TOKEN>
+env:
+  observe:
+    - name: OBSERVE_CUSTOMER_ID
+      valueFrom:
+        secretKeyRef:
+          name: observe-credentials
+          key: OBSERVE_CUSTOMER_ID
+    - name: OBSERVE_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: observe-credentials
+          key: OBSERVE_TOKEN

--- a/terraform/helm/vector-daemonset/files/vector-config.yaml
+++ b/terraform/helm/vector-daemonset/files/vector-config.yaml
@@ -1,0 +1,34 @@
+data_dir: /vector-data-dir
+api:
+  enabled: true
+  address: 127.0.0.1:8686
+  playground: false
+sources:
+  kubernetes_logs:
+    type: kubernetes_logs
+  host_metrics:
+    filesystem:
+      devices:
+        excludes: [binfmt_misc]
+      filesystems:
+        excludes: [binfmt_misc]
+      mountPoints:
+        excludes: ["*/proc/sys/fs/binfmt_misc"]
+    type: host_metrics
+  internal_metrics:
+    type: internal_metrics
+transforms:
+  k8s_logs:
+    type: remap
+    inputs:
+      - kubernetes_logs
+    source: |-
+      .k8s = del(.kubernetes)
+sinks:
+  prom_exporter:
+    type: prometheus_exporter
+    inputs: [host_metrics, internal_metrics]
+    address: 0.0.0.0:9090
+    # HACK ALARM: need to replace the observe customer id expression with a 'quoted' version of it here, otherwise vector's environment
+    # variable substitution will treat the customer id as an integer value which will fail vector's config 
+  {{- toYaml .Values.logging_sinks | nindent 2 | replace "${OBSERVE_CUSTOMER_ID:?err}" "'${OBSERVE_CUSTOMER_ID:?err}'"}}

--- a/terraform/helm/vector-daemonset/templates/vector-daemonset.yaml
+++ b/terraform/helm/vector-daemonset/templates/vector-daemonset.yaml
@@ -1,0 +1,233 @@
+# These templates originate / are inspired from https://github.com/vectordotdev/vector/tree/master/distribution/kubernetes/vector-agent
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: vector
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: Agent
+    app.kubernetes.io/version: "0.23.0-distroless-libc"
+automountServiceAccountToken: true
+---
+# Permissions to use Kubernetes API.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: vector
+  namespace: {{ .Release.Namespace }}  
+  labels:
+    app.kubernetes.io/name: vector
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: Agent
+    app.kubernetes.io/version: "0.23.0-distroless-libc"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+      - nodes
+      - pods
+    verbs:
+      - list
+      - watch
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+    - vector
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vector
+  labels:
+    app.kubernetes.io/name: vector
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: Agent
+    app.kubernetes.io/version: "0.23.0-distroless-libc"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: vector
+subjects:
+  - kind: ServiceAccount
+    name: vector
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: vector
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: Agent
+    app.kubernetes.io/version: "0.23.0-distroless-libc"
+data:
+  vector-config.yaml: |-
+{{ (tpl (.Files.Get "files/vector-config.yaml") .) | indent 4 }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: vector
+  labels:
+    app.kubernetes.io/name: vector
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: Agent
+    app.kubernetes.io/version: "0.23.0-distroless-libc"
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'hostPath'
+    - 'configMap'
+    - 'emptyDir'
+    - 'secret'
+    - 'projected'
+  allowedHostPaths:
+    - pathPrefix: "/var/log"
+      readOnly: true
+    - pathPrefix: "/var/lib"
+      readOnly: true
+    - pathPrefix: "/var/lib/vector"
+      readOnly: false
+    - pathPrefix: "/sys"
+      readOnly: true
+    - pathPrefix: "/proc"
+      readOnly: true
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: vector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: vector
+    app.kubernetes.io/instance: vector
+    app.kubernetes.io/component: Agent
+    app.kubernetes.io/version: "0.23.0-distroless-libc"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: vector
+      app.kubernetes.io/instance: vector
+      app.kubernetes.io/component: Agent
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: "33%"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: vector
+        app.kubernetes.io/instance: vector
+        app.kubernetes.io/component: Agent
+        vector.dev/exclude: "true"
+      annotations:
+        checksum/vector.yaml: {{ tpl (.Files.Get "files/vector-config.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: vector
+      dnsPolicy: ClusterFirst
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      containers:
+        - name: vector
+          image: "timberio/vector:0.23.0-distroless-libc"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --watch-config
+            - --config-dir
+            - /etc/vector/
+            - -v
+          env:
+            - name: VECTOR_SELF_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: VECTOR_SELF_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: VECTOR_SELF_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: PROCFS_ROOT
+              value: "/host/proc"
+            - name: SYSFS_ROOT
+              value: "/host/sys"
+            {{- range $k, $v := .Values.env }}
+              {{- toYaml $v | nindent 12 }}
+            {{ end }}
+          ports:
+            - name: prom-exporter
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: data
+              mountPath: "/vector-data-dir"
+            - name: config
+              mountPath: "/etc/vector/"
+              readOnly: true
+            - name: var-log
+              mountPath: "/var/log/"
+              readOnly: true
+            - name: var-lib
+              mountPath: "/var/lib"
+              readOnly: true
+            - name: procfs
+              mountPath: "/host/proc"
+              readOnly: true
+            - name: sysfs
+              mountPath: "/host/sys"
+              readOnly: true
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: vector
+        - name: data
+          hostPath:
+            path: "/var/lib/vector"
+        - name: var-log
+          hostPath:
+            path: "/var/log/"
+        - name: var-lib
+          hostPath:
+            path: "/var/lib/"
+        - name: procfs
+          hostPath:
+            path: "/proc"
+        - name: sysfs
+          hostPath:
+            path: "/sys"

--- a/terraform/helm/vector-daemonset/values.yaml
+++ b/terraform/helm/vector-daemonset/values.yaml
@@ -1,0 +1,17 @@
+logging_sinks:
+# this creates a `stdout` sink which writes all logs (again) to stdout. This is almost certainly not what you want in production - only useful for debugging.
+# For production choose any (you can choose multiple) logging sinks supported by vector as found here https://vector.dev/docs/reference/configuration/sinks/
+# stdout:
+#   type: console
+#   inputs: [kubernetes_logs]
+#   encoding:
+#     codec: json
+
+# env:
+#   - name: MY_CUSTOM_SECRET
+#     valueFrom:
+#       secretKeyRef:
+#         name: custom-secret
+#         key: MY_CUSTOM_SECRET
+
+env:


### PR DESCRIPTION
This introduces a new helm chart to collect logs as k8s daemonset via vector + corresponding example sink configurations for Humio and Observe.
The previous vector deployment was running as "aggregator" deployment and required containers to use remote writes to send logs to it which in turn it forwarded to the sink (AWS OpenSearch).

With this new setup (daemonset) we collect all cluster logs on the node level from logfiles that the container runtime creates and rotates. This is generally the best practice for k8s and has a number of advantages:
- applications/containers don't need to explicitly support some kind of remote write, instead they simply need to write to stdout. So it's easy to collect logs from _everything_ that runs in the cluster.
- Much higher chance of collecting crash logs, as long as the crash situation (such as a panic) writes something to stdout/stderr. Remote writes usually can't capture these situations since the process itself will be unable to send a log event to a remote destination after a panic occurs.
- Each log line is annotated with a _very_ rich set of k8s metadata, such as k8s labels, annotations, k8s node name etc. etc.

The chart itself is written to be somewhat sink agnostic, although I've only tried it out with Humio and Observe for now.

## Open Questions

The vector config currently also collects a bunch of rich host metrics (see the `host_metrics` config in the vector config) and exposes them via prometheus-style endpoint.
I'm not sure if we want/need that (i.e. do we collect rich host metrics already in another way)? cc @rustielin 
Might be good to also start using the vector daemonset for stuff like this since vector is for more than just logs, but I can remove it if it's unnecessary.

## Caveats

When using the humio sink, the chart expects the operator to manually create a secret right now via:
```
kubectl create secret generic humio-token --namespace vector --from-literal=HUMIO_TOKEN=<HUMIO_INGEST_TOKEN>
```
Wasn't really sure how to securely create a secret in our current setup, so I opted to do this manually for now.

## Test Plan

Deployed the chart into Rustienet via TF.
Observed logs in the Humio UI.

Below is an example of how the logs look in the UI.
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/1221897/179432032-e59bdb61-00f6-4872-9c0a-9eea4b047638.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2013)
<!-- Reviewable:end -->
