### PR TITLE
[forge] separate test runner template for customizations

### DIFF
--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {FORGE_POD_NAME}
+  labels:
+    app.kubernetes.io/name: forge
+spec:
+  restartPolicy: Never
+  serviceAccountName: forge
+  containers:
+  - name: main
+    image: {AWS_ACCOUNT_NUM}.dkr.ecr.{AWS_REGION}.amazonaws.com/aptos/forge:{IMAGE_TAG}
+    imagePullPolicy: Always
+    command:
+    - /bin/bash
+    - -c
+    - |
+      ulimit -n 1048576
+      forge test k8s-swarm --image-tag {IMAGE_TAG} --namespace {FORGE_NAMESPACE} {KEEP_ARGS} {ENABLE_HAPROXY_ARGS}
+    resources:
+      requests:
+        cpu: 15.5
+  affinity:
+    # avoid scheduling with other forge or validator/fullnode pods
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app.kubernetes.io/name
+            operator: In
+            values: ["validator", "fullnode", "forge"]
+          - key: run
+            operator: Exists
+        topologyKey: "kubernetes.io/hostname"
+  # schedule on a k8s worker node in the "validators" nodegroup
+  # to access more compute
+  nodeSelector:
+    eks.amazonaws.com/nodegroup: validators
+  tolerations:
+  - effect: NoExecute
+    key: aptos.org/nodepool
+    value: validators
+  

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -24,7 +24,7 @@ AWS_REGION=${AWS_REGION:-us-west-2}
 # forge test runner customization
 FORGE_RUNNER_MODE=${FORGE_RUNNER_MODE:-k8s}
 FORGE_NAMESPACE_KEEP=${FORGE_NAMESPACE_KEEP:-false}
-FORGE_ENABLE_HAPROXY=${FORGE_ENABLE_HAPROXY:-true}
+FORGE_ENABLE_HAPROXY=${FORGE_ENABLE_HAPROXY:-false}
 
 # if this script is not triggered in GHA, use a default value
 [ -z "$GITHUB_RUN_ID" ] && GITHUB_RUN_ID=0
@@ -89,7 +89,7 @@ elif [ "$FORGE_RUNNER_MODE" = "k8s" ]; then
     kubectl delete pod $FORGE_POD_NAME || true
     kubectl wait --for=delete "pod/${FORGE_POD_NAME}" || true
 
-    specfile=$(mktemp -t $FORGE_POD_NAME)
+    specfile=$(mktemp)
     echo "Forge test-runner pod Spec : ${specfile}"
 
     sed -e "s/{FORGE_POD_NAME}/${FORGE_POD_NAME}/g" \

--- a/x.toml
+++ b/x.toml
@@ -190,7 +190,12 @@ mark-changed = "all"
 
 [[determinator.path-rule]]
 # Ignore website and other ancillary files, and scripts not listed above.
-globs = ["CODEOWNERS","dashboards/**", "developer-docs-site/**/*", "documentation/**/*", "docker/**/*", "language/documentation/**/*", "specifications/**/*", "scripts/**/*", "terraform/**/*", "crowdin.yml", "testsuite/run_forge.sh"]
+globs = ["CODEOWNERS","dashboards/**", "developer-docs-site/**/*", "documentation/**/*", "docker/**/*", "language/documentation/**/*", "specifications/**/*", "scripts/**/*", "terraform/**/*", "crowdin.yml"]
+mark-changed = []
+
+[[determinator.path-rule]]
+# Ignore forge files and scripts
+globs = ["testsuite/run_forge.sh", "testsuite/forge-test-runner-template.yaml"]
 mark-changed = []
 
 [[determinator.path-rule]]


### PR DESCRIPTION
### Description

Makes Forge test results more consistent

Move the Forge test-runner pod config to a separate template, as it was getting too complex to use `kubectl run --override`. This allows us to set more granular pod affinities, nodeTolerations, and resources:
* Schedule Forge test-runner pod on its own machine using antiaffinity 
* Schedule it on a machine in the `validators` nodegroup so it has access to more CPU
* Guarantee 15.5 vCPU so we can push it to its limit, though in practice we only see under 6vCPU being used 
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/12578616/179363703-e2660a42-f8c7-4125-bce3-1ed82b011d8b.png">



### Test Plan

Run forge a few times in testing environment.

```
  "text": "all up : 3195 TPS, 1379 ms latency, 1750 ms p99 latency,no expired txns"
  "text": "all up : 3229 TPS, 1368 ms latency, 1650 ms p99 latency,no expired txns"
  "text": "all up : 3195 TPS, 1382 ms latency, 1800 ms p99 latency,no expired txns"
  "text": "all up : 3189 TPS, 1386 ms latency, 1750 ms p99 latency,no expired txns"
```
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2015)
<!-- Reviewable:end -->
