### PR TITLE
[forge] logs link and fix metrics parsing

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -34,7 +34,6 @@ env:
   FORGE_REPORT: forge_report.json
   FORGE_RUNNER_MODE: k8s
   FORGE_NAMESPACE: ${{ inputs.FORGE_NAMESPACE }}
-  GRAFANA_BASE_URL: ${{ secrets.GRAFANA_BASE_URL }}
 
 jobs:
   forge:
@@ -76,6 +75,8 @@ jobs:
           echo "FORGE_COMMENT_HEADER=$FORGE_COMMENT_HEADER" >> $GITHUB_ENV
           echo "FORGE_DASHBOARD_LINK=$FORGE_DASHBOARD_LINK" >> $GITHUB_ENV
           echo "FORGE_REPORT_TXT=$FORGE_REPORT_TXT" >> $GITHUB_ENV
+          echo "FORGE_DASHBOARD_LINK=$FORGE_DASHBOARD_LINK" >> $GITHUB_ENV
+          echo "VALIDATOR_LOGS_LINK=$VALIDATOR_LOGS_LINK" >> $GITHUB_ENV
 
       - name: Post result as PR comment
         if: env.FORGE_ENABLED == 'true' && env.PR_NUMBER != null
@@ -86,6 +87,7 @@ jobs:
             ${{ env.FORGE_BLOCKING == 'true' && 'Forge is land-blocking' || 'Forge is not land-blocking' }}
             * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
             * [Grafana dashboard](${{ env.FORGE_DASHBOARD_LINK }})
+            * [Validator 0 logs](${{ env.VALIDATOR_LOGS_LINK }})
             ```
             ${{ env.FORGE_REPORT_TXT }}
             ```


### PR DESCRIPTION
### Description

* Generate a link to the validator logs in the Github comment. 
* Default to the o11y resources (Grafana, Opensearch) hosted by Aptos Labs in the `run_forge.sh` script, depending on the cluster name. They are used to generate the links in the Github comment and this just moving them from GHA environment variables to be hard-coded in the script.
* Also fix a bug in metrics parsing and report to PushGateway

### Test Plan

Run Forge

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2016)
<!-- Reviewable:end -->
