### PR TITLE
[forge] Tune transaction emitter config for forge to send up to 10k TPS

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -32,7 +32,7 @@ pub struct ConsensusConfig {
 impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
-            max_block_size: 3000,
+            max_block_size: 6000,
             max_pruned_blocks_in_mem: 100,
             mempool_executed_txn_timeout_ms: 1000,
             mempool_txn_pull_timeout_ms: 1000,

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -95,7 +95,7 @@ impl Default for EmitJobRequest {
     fn default() -> Self {
         Self {
             rest_clients: Vec::new(),
-            accounts_per_client: 20,
+            accounts_per_client: 15,
             workers_per_endpoint: None,
             thread_params: EmitThreadParams::default(),
             gas_price: 0,
@@ -240,7 +240,7 @@ impl<'t> TxnEmitter<'t> {
         let workers_per_endpoint = match req.workers_per_endpoint {
             Some(x) => x,
             None => {
-                let target_threads = 500;
+                let target_threads = 600;
                 // Trying to create somewhere between target_threads/2..target_threads threads
                 // We want to have equal numbers of threads for each endpoint, so that they are equally loaded
                 // Otherwise things like flamegrap/perf going to show different numbers depending on which endpoint is chosen

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -95,7 +95,7 @@ impl Default for EmitJobRequest {
     fn default() -> Self {
         Self {
             rest_clients: Vec::new(),
-            accounts_per_client: 15,
+            accounts_per_client: 20,
             workers_per_endpoint: None,
             thread_params: EmitThreadParams::default(),
             gas_price: 0,
@@ -240,12 +240,12 @@ impl<'t> TxnEmitter<'t> {
         let workers_per_endpoint = match req.workers_per_endpoint {
             Some(x) => x,
             None => {
-                let target_threads = 300;
+                let target_threads = 500;
                 // Trying to create somewhere between target_threads/2..target_threads threads
                 // We want to have equal numbers of threads for each endpoint, so that they are equally loaded
                 // Otherwise things like flamegrap/perf going to show different numbers depending on which endpoint is chosen
                 // Also limiting number of threads as max 10 per endpoint for use cases with very small number of nodes or use --peers
-                min(10, max(1, target_threads / req.rest_clients.len()))
+                min(30, max(1, target_threads / req.rest_clients.len()))
             }
         };
         let num_clients = req.rest_clients.len() * workers_per_endpoint;

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -240,12 +240,12 @@ impl<'t> TxnEmitter<'t> {
         let workers_per_endpoint = match req.workers_per_endpoint {
             Some(x) => x,
             None => {
-                let target_threads = 600;
+                let target_threads = 1200;
                 // Trying to create somewhere between target_threads/2..target_threads threads
                 // We want to have equal numbers of threads for each endpoint, so that they are equally loaded
                 // Otherwise things like flamegrap/perf going to show different numbers depending on which endpoint is chosen
                 // Also limiting number of threads as max 10 per endpoint for use cases with very small number of nodes or use --peers
-                min(30, max(1, target_threads / req.rest_clients.len()))
+                min(60, max(1, target_threads / req.rest_clients.len()))
             }
         };
         let num_clients = req.rest_clients.len() * workers_per_endpoint;

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -13,7 +13,7 @@
 pwd | grep -qE 'aptos-core$' || (echo "Please run from aptos-core root directory" && exit 1)
 
 # for calculating regression
-TPS_THRESHOLD=1500
+TPS_THRESHOLD=4000
 P99_LATENCY_MS_THRESHOLD=5000
 
 FORGE_OUTPUT=${FORGE_OUTPUT:-forge_output.txt}

--- a/testsuite/testcases/src/performance_test.rs
+++ b/testsuite/testcases/src/performance_test.rs
@@ -15,7 +15,7 @@ impl Test for PerformanceBenchmark {
 
 impl NetworkTest for PerformanceBenchmark {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = Duration::from_secs(180);
+        let duration = Duration::from_secs(300);
         let all_validators = ctx
             .swarm()
             .validators()


### PR DESCRIPTION
### Description

Tuning the transaction emitter configurations to send up to 10k TPS.

### Test Plan

Run forge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2020)
<!-- Reviewable:end -->
