### PR TITLE
[State Sync] Small tweaks to logic and logging

### DIFF
--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -54,7 +54,7 @@ mod tests;
 // and little separation between components.
 
 // Useful constants for the Aptos Data Client
-const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 5;
+const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 10;
 const GLOBAL_DATA_METRIC_FREQ_SECS: u64 = 1;
 const IN_FLIGHT_METRICS_SAMPLE_FREQ: u64 = 5;
 const PEER_LOG_FREQ_SECS: u64 = 10;
@@ -284,8 +284,8 @@ impl AptosNetDataClient {
                 (LogSchema::new(LogEntry::PeerStates)
                     .event(LogEvent::PriorityAndRegularPeers)
                     .message(&format!(
-                        "Current priority peers: {:?} and regular peers: {:?}",
-                        priority_peers, regular_peers,
+                        "Number of priority peers: {:?}. Number of regular peers: {:?}",
+                        priority_peers.len(), regular_peers.len(),
                     )))
             );
         );
@@ -760,7 +760,7 @@ pub(crate) fn poll_peer(
                 (LogSchema::new(LogEntry::PeerStates)
                     .event(LogEvent::AggregateSummary)
                     .message(&format!(
-                        "Global data summary: {:?}",
+                        "Global data summary: {}",
                         data_client.get_global_data_summary()
                     )))
             );

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -161,13 +161,14 @@ impl VerifiedEpochStates {
         &mut self,
         epoch_ending_ledger_info: LedgerInfoWithSignatures,
     ) {
+        let ledger_info = epoch_ending_ledger_info.ledger_info();
         info!(LogSchema::new(LogEntry::Bootstrapper).message(&format!(
-            "Adding a new epoch to the epoch ending ledger infos: {}",
-            &epoch_ending_ledger_info
+            "Adding a new epoch to the epoch ending ledger infos. Epoch: {:?}, Version: {:?}, Ends epoch: {:?}",
+            ledger_info.epoch(), ledger_info.version(), ledger_info.ends_epoch(),
         )));
 
         // Insert the version to ledger info mapping
-        let version = epoch_ending_ledger_info.ledger_info().version();
+        let version = ledger_info.version();
         if let Some(epoch_ending_ledger_info) = self
             .new_epoch_ending_ledger_infos
             .insert(version, epoch_ending_ledger_info)

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -253,7 +253,7 @@ impl<
                         self.storage_synchronizer.apply_transaction_outputs(
                             notification_id,
                             transaction_outputs_with_proof,
-                            ledger_info_with_signatures,
+                            ledger_info_with_signatures.clone(),
                             None,
                         )?;
                         num_transaction_outputs
@@ -274,7 +274,7 @@ impl<
                         self.storage_synchronizer.execute_transactions(
                             notification_id,
                             transaction_list_with_proof,
-                            ledger_info_with_signatures,
+                            ledger_info_with_signatures.clone(),
                             None,
                         )?;
                         num_transactions
@@ -294,8 +294,9 @@ impl<
             .checked_add(num_transactions_or_outputs as u64)
             .and_then(|version| version.checked_sub(1)) // synced_version = start + num txns/outputs - 1
             .ok_or_else(|| Error::IntegerOverflow("The synced version has overflown!".into()))?;
-        self.get_speculative_stream_state()
-            .update_synced_version(synced_version);
+        let speculative_stream_state = self.get_speculative_stream_state();
+        speculative_stream_state.update_synced_version(synced_version);
+        speculative_stream_state.maybe_update_epoch_state(ledger_info_with_signatures);
 
         Ok(())
     }


### PR DESCRIPTION
### Description

This PR makes several small tweaks to the state sync logic and logging:
1. We improve the logs (to prevent them from getting too large when we have a large number of peers and validators in each ledger info).
2. We remove the old and unnecessary yield code (this was resolved in a different PR, but never removed from the code, e.g., see https://github.com/aptos-labs/aptos-core/issues/623)
3. We fix a small bug in handling epoch state changes when the continuous syncer is running. The bug didn't have any practical impact other than forcing a speculative stream reset. But, it's a bug nonetheless :)

### Test Plan
Manual verification and existing unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2027)
<!-- Reviewable:end -->
