### PR TITLE
observability: temp fix to log panic when aptos-node crashes

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+# config file for https://github.com/nektos/act
+-P ubuntu-latest=catthehacker/ubuntu:full-latest

--- a/.github/workflows/sdk-integration-test.yaml
+++ b/.github/workflows/sdk-integration-test.yaml
@@ -46,3 +46,8 @@ jobs:
       - run: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install && yarn test
       # Run example code in javascript
       - run: cd ./ecosystem/typescript/sdk/examples/javascript && yarn install && yarn test
+
+      - name: print docker-compose testnet logs when previous steps failed
+        if: ${{ failure() }}
+        working-directory: docker/compose/validator-testnet
+        run: docker-compose logs

--- a/crates/crash-handler/src/lib.rs
+++ b/crates/crash-handler/src/lib.rs
@@ -35,7 +35,11 @@ fn handle_panic(panic_info: &PanicInfo<'_>) {
     let backtrace = format!("{:#?}", Backtrace::new());
 
     let info = CrashInfo { details, backtrace };
-    error!("{}", crash_info = toml::to_string_pretty(&info).unwrap());
+    let crash_info = toml::to_string_pretty(&info).unwrap();
+    error!("{}", crash_info);
+    // TODO / HACK ALARM: Write crash info synchronously via eprintln! to ensure it is written before the process exits which error! doesn't guarantee.
+    // This is a workaround until https://github.com/aptos-labs/aptos-core/issues/2038 is resolved.
+    eprintln!("{}", crash_info);
 
     // Wait till the logs have been flushed
     aptos_logger::flush();

--- a/secure/storage/src/on_disk.rs
+++ b/secure/storage/src/on_disk.rs
@@ -33,7 +33,8 @@ impl OnDiskStorage {
 
     fn new_with_time_service(file_path: PathBuf, time_service: TimeService) -> Self {
         if !file_path.exists() {
-            File::create(&file_path).expect("Unable to create storage");
+            File::create(&file_path)
+                .unwrap_or_else(|_| panic!("Unable to create storage at path: {:?}", file_path));
         }
 
         // The parent will be one when only a filename is supplied. Therefore use the current

--- a/x.toml
+++ b/x.toml
@@ -185,7 +185,7 @@ mark-changed = "all"
 
 # Core devtools files.
 [[determinator.path-rule]]
-globs = [".config/nextest.toml", "scripts/dev_setup.sh", "x.toml", ".node-version", ".prettierrc"]
+globs = [".config/nextest.toml", "scripts/dev_setup.sh", "x.toml", ".node-version", ".prettierrc", ".actrc"]
 mark-changed = "all"
 
 [[determinator.path-rule]]


### PR DESCRIPTION
### Description

This PR originally was intented to just fix the sdk integration tests.
To figure out what's going on I had to make the crash reason more observable by:
- print docker-compose logs when sdk integration test failed
- make sure aptos-node actually prints the crash reason
- enhance the error message in `.expect` to give more details on why we are crashing.

So this PR is basically fixing these 3 things.
The SDK integration tests themselves already have been fixed by #2059 after we printed the crash reason in this PR.

TODO: follow up on #2038 for a cleaner fix to lacking crash logging.

### Test Plan
Let the node crash a few times before #2059 was merged and observed the crash reason being printed in CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2035)
<!-- Reviewable:end -->
