### PR TITLE
[Txn-emitter] Optimize transaction emitter to reduce REST API call 

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -7,7 +7,7 @@ pub mod submission_worker;
 
 use ::aptos_logger::*;
 use again::RetryPolicy;
-use anyhow::{format_err, Result};
+use anyhow::{anyhow, format_err, Result};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
@@ -17,6 +17,7 @@ use aptos_sdk::{
 use futures::future::{try_join_all, FutureExt};
 use itertools::zip;
 use once_cell::sync::Lazy;
+use rand::prelude::SliceRandom;
 use rand_core::SeedableRng;
 use std::{
     cmp::{max, min},
@@ -404,6 +405,35 @@ impl<'t> TxnEmitter<'t> {
     }
 }
 
+async fn wait_for_single_account_sequence(
+    client: &RestClient,
+    account: &LocalAccount,
+    wait_timeout: Duration,
+) -> Result<()> {
+    let deadline = Instant::now() + wait_timeout;
+    while Instant::now() <= deadline {
+        time::sleep(Duration::from_millis(500)).await;
+        match query_sequence_numbers(client, &[account.address()]).await {
+            Ok(sequence_numbers) => {
+                if sequence_numbers[0] >= account.sequence_number() {
+                    return Ok(());
+                }
+            }
+            Err(e) => {
+                info!(
+                    "Failed to query sequence number for account {:?} for instance {:?} : {:?}",
+                    account, client, e
+                );
+            }
+        }
+    }
+    Err(anyhow!(
+        "Timed out waiting for single account {:?} sequence number for instance {:?}",
+        account,
+        client
+    ))
+}
+
 /// This function waits for the submitted transactions to be committed, up to
 /// a deadline. If some accounts still have uncommitted transactions when we
 /// hit the deadline, we return a map of account to the info about the number
@@ -420,10 +450,22 @@ async fn wait_for_accounts_sequence(
     client: &RestClient,
     accounts: &mut [LocalAccount],
     wait_timeout: Duration,
+    rng: &mut StdRng,
 ) -> Result<(), HashSet<AccountAddress>> {
     let deadline = Instant::now() + wait_timeout;
     let addresses: Vec<_> = accounts.iter().map(|d| d.address()).collect();
     let mut uncommitted = addresses.clone().into_iter().collect::<HashSet<_>>();
+
+    // Choose a random account and wait for its sequence number to be up to date. After that, we can
+    // query the all the accounts. This will help us ensure we don't hammer the REST API with too many
+    // query for all the accounts.
+    let account = accounts.choose(rng).expect("accounts can't be empty");
+    if wait_for_single_account_sequence(client, account, wait_timeout)
+        .await
+        .is_err()
+    {
+        return Err(uncommitted);
+    }
 
     while Instant::now() <= deadline {
         match query_sequence_numbers(client, &addresses).await {
@@ -445,8 +487,7 @@ async fn wait_for_accounts_sequence(
                 );
             }
         }
-
-        time::sleep(Duration::from_millis(250)).await;
+        time::sleep(Duration::from_millis(500)).await;
     }
 
     Err(uncommitted)

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -405,6 +405,7 @@ impl<'t> TxnEmitter<'t> {
     }
 }
 
+/// Waits for a single account to catch up to the expected sequence number
 async fn wait_for_single_account_sequence(
     client: &RestClient,
     account: &LocalAccount,

--- a/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
+++ b/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
@@ -149,6 +149,7 @@ impl SubmissionWorker {
             &self.client,
             &mut self.accounts,
             wait_for_accounts_sequence_timeout,
+            &mut self.rng,
         )
         .await
         {

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -19,7 +19,7 @@ use url::Url;
 #[derive(StructOpt, Debug)]
 struct Args {
     // general options
-    #[structopt(long, default_value = "15")]
+    #[structopt(long, default_value = "25")]
     accounts_per_client: usize,
     #[structopt(long)]
     workers_per_ac: Option<usize>,

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -19,7 +19,7 @@ use url::Url;
 #[derive(StructOpt, Debug)]
 struct Args {
     // general options
-    #[structopt(long, default_value = "25")]
+    #[structopt(long, default_value = "15")]
     accounts_per_client: usize,
     #[structopt(long)]
     workers_per_ac: Option<usize>,


### PR DESCRIPTION
### Description

This PR adds some optimizations to the transaction emitter to reduce the volume of the REST call made when waiting for transactions to be committed as follows

1. Instead of making REST call for all the accounts, use a random single account to wait for sequence number and once that is done, we can wait for all the accounts. This way, we don't need to make the REST calls for all the accounts when the transactions are waiting.
2. Increase the sleep time between calls from 250 ms to 500 ms
3. Add the sleep before the first call

### Test Plan

Ran forge and observed the CPU usage for the transaction emitter went down from 14 core to less than 4 core - http://o11y.aptosdev.com/grafana/explore?orgId=1&left=%7B%22datasource%22:%22Remote%20Prometheus%20Devinfra%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22sum%20(rate%20(container_cpu_usage_seconds_total%7Bpod%3D~%5C%22forge.*%5C%22%7D%5B1m%5D))%20by%20(container_name)%5Cn%22%7D%5D,%22range%22:%7B%22from%22:%221658105058217%22,%22to%22:%221658110048290%22%7D%7D.  This also helped push the performance of TPS test by around 10%.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2036)
<!-- Reviewable:end -->
