### PR TITLE
[rosetta] fix rosetta after event update

### DIFF
--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -720,10 +720,8 @@ fn parse_operations_from_write_set(
                 if id == &withdraw_events_identifier() {
                     serde_json::from_value::<CoinEventId>(value.clone()).unwrap();
                     if let Ok(event) = serde_json::from_value::<CoinEventId>(value.clone()) {
-                        let withdraw_event = EventKey::new(
-                            event.guid.guid.id.creation_num.0,
-                            event.guid.guid.id.addr,
-                        );
+                        let withdraw_event =
+                            EventKey::new(event.guid.id.creation_num.0, event.guid.id.addr);
                         if let Some(amount) = get_amount_from_event(events, withdraw_event) {
                             operations.push(Operation::withdraw(
                                 operation_index,
@@ -738,10 +736,8 @@ fn parse_operations_from_write_set(
                 } else if id == &deposit_events_identifier() {
                     serde_json::from_value::<CoinEventId>(value.clone()).unwrap();
                     if let Ok(event) = serde_json::from_value::<CoinEventId>(value.clone()) {
-                        let withdraw_event = EventKey::new(
-                            event.guid.guid.id.creation_num.0,
-                            event.guid.guid.id.addr,
-                        );
+                        let withdraw_event =
+                            EventKey::new(event.guid.id.creation_num.0, event.guid.id.addr);
                         if let Some(amount) = get_amount_from_event(events, withdraw_event) {
                             operations.push(Operation::deposit(
                                 operation_index,
@@ -941,11 +937,6 @@ pub struct CoinEvent {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct CoinEventId {
-    guid: Guid,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Guid {
     guid: Id,
 }
 

--- a/developer-docs-site/static/examples/python/first_transaction.py
+++ b/developer-docs-site/static/examples/python/first_transaction.py
@@ -11,8 +11,6 @@ from typing import Any, Dict, Optional
 
 TESTNET_URL = "https://fullnode.devnet.aptoslabs.com"
 FAUCET_URL = "https://faucet.devnet.aptoslabs.com"
-TESTNET_URL = "http://127.0.0.1:8080"
-FAUCET_URL = "http://127.0.0.1:8081"
 
 #:!:>section_1
 class Account:


### PR DESCRIPTION
event's no longer are guids inside of guids
just an id inside a guid, see

```{'counter': '1', 'guid': {'id': {'addr':
'0xfe30dec34daa1ba55d661905cdcc579018563316231b52f3c17505b93da99018',
'creation_num': '1'}}}```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2039)
<!-- Reviewable:end -->
