### PR TITLE
[Docs] mention intellij-move plugin in the "Getting Started"

### DIFF
--- a/developer-docs-site/docs/guides/getting-started.md
+++ b/developer-docs-site/docs/guides/getting-started.md
@@ -65,6 +65,7 @@ Now your basic Aptos development environment is ready.
 
 - [Syntax hightlighting for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=damirka.move-syntax).
 - [Move analyzer for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer) - supports advanced code navigation and syntax highlighting.
+- [Move language plugin for Jetbrains IDEs](https://plugins.jetbrains.com/plugin/14721-move-language) - supports syntax highlighting, code navigation, renames, formatting, type checks and code generation
 
 ## Aptos CLI
 

--- a/developer-docs-site/docs/guides/getting-started.md
+++ b/developer-docs-site/docs/guides/getting-started.md
@@ -65,7 +65,7 @@ Now your basic Aptos development environment is ready.
 
 - [Syntax hightlighting for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=damirka.move-syntax).
 - [Move analyzer for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=move.move-analyzer) - supports advanced code navigation and syntax highlighting.
-- [Move language plugin for Jetbrains IDEs](https://plugins.jetbrains.com/plugin/14721-move-language) - supports syntax highlighting, code navigation, renames, formatting, type checks and code generation
+- [Move language plugin for Jetbrains IDEs](https://plugins.jetbrains.com/plugin/14721-move-language) - supports syntax highlighting, code navigation, renames, formatting, type checks and code generation.
 
 ## Aptos CLI
 


### PR DESCRIPTION
### Description

Adds a reference to the Intellij-Move plugin to the `Getting Started` section of the documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2047)
<!-- Reviewable:end -->
