### PR TITLE
[api] Add REST API to modify failpoints during execution

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -87,6 +87,10 @@ impl Context {
         self.node_config.api.content_length_limit()
     }
 
+    pub fn failpoints_enabled(&self) -> bool {
+        self.node_config.api.failpoints_enabled
+    }
+
     pub fn filter(self) -> impl Filter<Extract = (Context,), Error = Infallible> + Clone {
         warp::any().map(move || self.clone())
     }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -3,8 +3,10 @@
 
 mod accept_type;
 mod accounts;
+mod blocks;
 pub mod context;
 mod events;
+mod failpoint;
 mod health_check;
 mod index;
 pub mod log;
@@ -13,11 +15,9 @@ mod page;
 pub mod param;
 mod poem_backend;
 pub mod runtime;
+mod set_failpoints;
 mod state;
-mod transactions;
-pub(crate) mod version;
-
-mod blocks;
-mod failpoint;
 #[cfg(any(test))]
 pub(crate) mod tests;
+mod transactions;
+pub(crate) mod version;

--- a/api/src/set_failpoints.rs
+++ b/api/src/set_failpoints.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(unused_imports)]
+use anyhow::{format_err, Result};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "failpoints")]
+use crate::context::Context;
+#[cfg(feature = "failpoints")]
+use crate::metrics::metrics;
+#[cfg(feature = "failpoints")]
+use aptos_logger::prelude::*;
+#[cfg(feature = "failpoints")]
+use warp::{filters::BoxedFilter, http::Response, Filter, Rejection, Reply};
+
+#[derive(Deserialize, Serialize)]
+struct FailpointConf {
+    name: String,
+    actions: String,
+}
+
+// GET /set_failpoint?name=str&actions=str
+#[cfg(feature = "failpoints")]
+pub fn set_failpoint(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("set_failpoint")
+        .and(warp::get())
+        .and(warp::query::<FailpointConf>())
+        .and(context.filter())
+        .and_then(handle_set_failpoint)
+        .with(metrics("set_failpoint"))
+        .boxed()
+}
+
+#[allow(unused_variables)]
+#[inline]
+#[cfg(feature = "failpoints")]
+async fn handle_set_failpoint(
+    failpoint_conf: FailpointConf,
+    context: Context,
+) -> Result<impl Reply, Rejection> {
+    if context.failpoints_enabled() {
+        fail::cfg(&failpoint_conf.name, &failpoint_conf.actions)
+            .map_err(|e| warp::reject::reject())?;
+        info!(
+            "Configured failpoint {} to {}",
+            failpoint_conf.name, failpoint_conf.actions
+        );
+        Ok(Response::builder().body(""))
+    } else {
+        Err(warp::reject::reject())
+    }
+}

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -18,6 +18,8 @@ pub struct ApiConfig {
     // optional for compatible with old configuration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_length_limit: Option<u64>,
+    #[serde(default = "default_disabled")]
+    pub failpoints_enabled: bool,
 }
 
 pub const DEFAULT_ADDRESS: &str = "127.0.0.1";
@@ -26,6 +28,10 @@ pub const DEFAULT_REQUEST_CONTENT_LENGTH_LIMIT: u64 = 4 * 1024 * 1024; // 4mb
 
 fn default_enabled() -> bool {
     true
+}
+
+fn default_disabled() -> bool {
+    false
 }
 
 impl Default for ApiConfig {
@@ -38,6 +44,7 @@ impl Default for ApiConfig {
             tls_cert_path: None,
             tls_key_path: None,
             content_length_limit: None,
+            failpoints_enabled: default_disabled(),
         }
     }
 }

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -372,6 +372,26 @@ impl Client {
         self.json(response).await
     }
 
+    pub async fn set_failpoint(&self, name: String, actions: String) -> Result<String> {
+        let mut base = self.base_url.join("set_failpoint")?;
+        let url = base
+            .query_pairs_mut()
+            .append_pair("name", &name)
+            .append_pair("actions", &actions)
+            .finish();
+        let response = self.inner.get(url.clone()).send().await?;
+
+        if !response.status().is_success() {
+            let error_response = response.json::<RestError>().await?;
+            return Err(anyhow::anyhow!("Request failed: {:?}", error_response));
+        }
+
+        response
+            .text()
+            .await
+            .map_err(|e| anyhow::anyhow!("To text failed: {:?}", e))
+    }
+
     async fn check_response(
         &self,
         response: reqwest::Response,

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -168,6 +168,7 @@ impl ServerArgs for OfflineArgs {
             tls_cert_path: self.tls_cert_path.clone(),
             tls_key_path: self.tls_key_path.clone(),
             content_length_limit: self.content_length_limit,
+            failpoints_enabled: false,
         }
     }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -45,6 +45,7 @@ pub async fn setup_test(
         tls_cert_path: None,
         tls_key_path: None,
         content_length_limit: None,
+        failpoints_enabled: false,
     };
 
     // Start the server


### PR DESCRIPTION
### Description

Adding failpoints REST API (/failpoints?name=str&actions=str), to allow modifying failpoints during execution.
This will allow more targeted/surgical testing - both within smoke tests as well as forge/cluster tests

### Test Plan
Used in new smoke tests in the stacked diffs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2048)
<!-- Reviewable:end -->
