### PR TITLE
[consensus] Add failpoints on sending and have all failpoints code be behind configuration

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -110,12 +110,10 @@ impl BlockStore {
             if qc.ends_epoch() {
                 retriever
                     .network
-                    .broadcast(ConsensusMsg::EpochChangeProof(Box::new(
-                        EpochChangeProof::new(
-                            vec![qc.ledger_info().clone()],
-                            /* more = */ false,
-                        ),
-                    )))
+                    .broadcast_epoch_change(EpochChangeProof::new(
+                        vec![qc.ledger_info().clone()],
+                        /* more = */ false,
+                    ))
                     .await;
             }
         }

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -32,7 +32,6 @@ use crate::{
         signing_phase::{SigningRequest, SigningResponse},
     },
     network::NetworkSender,
-    network_interface::ConsensusMsg,
     round_manager::VerifiedEvent,
     state_replication::StateComputerCommitCallBackType,
 };
@@ -343,9 +342,7 @@ impl BufferManager {
 
                 self.buffer.set(&current_cursor, signed_item);
 
-                self.commit_msg_tx
-                    .broadcast(ConsensusMsg::CommitVoteMsg(Box::new(commit_vote)))
-                    .await;
+                self.commit_msg_tx.broadcast_commit_vote(commit_vote).await;
             } else {
                 self.buffer.set(&current_cursor, item);
             }
@@ -419,9 +416,7 @@ impl BufferManager {
                 }
                 let signed_item = item.unwrap_signed_ref();
                 self.commit_msg_tx
-                    .broadcast(ConsensusMsg::CommitVoteMsg(Box::new(
-                        signed_item.commit_vote.clone(),
-                    )))
+                    .broadcast_commit_vote(signed_item.commit_vote.clone())
                     .await;
             }
             cursor = self.buffer.get_next(&cursor);

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -640,9 +640,7 @@ mod tests {
                     _ => panic!("unexpected messages"),
                 }
             }
-            nodes[0]
-                .broadcast(ConsensusMsg::ProposalMsg(Box::new(proposal.clone())))
-                .await;
+            nodes[0].broadcast_proposal(proposal.clone()).await;
             playground
                 .wait_for_messages(4, NetworkPlayground::take_all)
                 .await;


### PR DESCRIPTION
- previously we only had failpoints on processing of the messages (i.e. on receiving the messages),
   making it hard to test things where one node is failing to send something. Adding failpints
   on all send messages (and for that separating different types of broadcasts into their own functions
- made sure all failpoints code is behind configuraiton. we had inject_reconfiguration_error always enabled
  whenever code was compiled with failpoints feature (which can lead to flaky tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2049)
<!-- Reviewable:end -->
