### PR TITLE
Revert "[smoke test] use on disk storage in smoke tests"

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -10,8 +10,7 @@ use anyhow::ensure;
 use aptos_config::{
     config::{
         DiscoveryMethod, Identity, IdentityBlob, InitialSafetyRulesConfig, NetworkConfig,
-        NodeConfig, OnDiskStorageConfig, PeerRole, RoleType, SafetyRulesService, SecureBackend,
-        WaypointConfig,
+        NodeConfig, PeerRole, RoleType, SafetyRulesService, WaypointConfig,
     },
     generator::build_seed_for_network,
     network_id::NetworkId,
@@ -39,7 +38,6 @@ const VFN_IDENTITY: &str = "vfn-identity.yaml";
 const PRIVATE_IDENTITY: &str = "private-identity.yaml";
 const CONFIG_FILE: &str = "node.yaml";
 const GENESIS_BLOB: &str = "genesis.blob";
-const SECURE_DATA: &str = "secure-data.json";
 
 /// Configuration to run a local validator node
 #[derive(Debug, Clone)]
@@ -545,9 +543,6 @@ impl Builder {
 
         // Ensure safety rules runs in a thread
         config.consensus.safety_rules.service = SafetyRulesService::Thread;
-        let mut storage = OnDiskStorageConfig::default();
-        storage.set_data_dir(validator.dir.join(SECURE_DATA));
-        config.consensus.safety_rules.backend = SecureBackend::OnDiskStorage(storage);
 
         if index > 0 || self.randomize_first_validator_ports {
             config.randomize_ports();


### PR DESCRIPTION
### Description
This reverts commit c136780d702b7519b7b16d218c04fe54133cbbd3.
The reverted commit moves all testnet and other usages of the builder
in genesis to use on disk storage.  Let's put it back to be in memory.

We should re-evaluate what the tradeoffs of moving it to on disk are.

### Test Plan
E2E tests & `cargo run -p aptos-node -- --test` succeeds