### PR TITLE
[aptos-genesis] Fix Validator builder secure storage path

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -39,7 +39,6 @@ const VFN_IDENTITY: &str = "vfn-identity.yaml";
 const PRIVATE_IDENTITY: &str = "private-identity.yaml";
 const CONFIG_FILE: &str = "node.yaml";
 const GENESIS_BLOB: &str = "genesis.blob";
-const SECURE_DATA: &str = "secure-data.json";
 
 /// Configuration to run a local validator node
 #[derive(Debug, Clone)]
@@ -546,7 +545,8 @@ impl Builder {
         // Ensure safety rules runs in a thread
         config.consensus.safety_rules.service = SafetyRulesService::Thread;
         let mut storage = OnDiskStorageConfig::default();
-        storage.set_data_dir(validator.dir.join(SECURE_DATA));
+        storage.set_data_dir(validator.dir.clone());
+
         config.consensus.safety_rules.backend = SecureBackend::OnDiskStorage(storage);
 
         if index > 0 || self.randomize_first_validator_ports {


### PR DESCRIPTION
### Description
The path was wrong, which was making it crash when safety
rules finally tried to write or load from storage.  This
now ensures that it can write to an existing path that is
in the correct place.

### Test Plan
E2E tests should still pass
 
Local testnet mode works now and makes a secure storage file

```
$ cargo run -p aptos-node -- --test                                            

Entering test mode, this should never be used in production!
Completed generating configuration:
        Log file: "/private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/6ea35ced629f07f1f20987db0c503141/validator.log"
        Config path: "/private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/6ea35ced629f07f1f20987db0c503141"
        Aptos root key path: "/private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/6ea35ced629f07f1f20987db0c503141/mint.key"
        Waypoint: 0:36a88c36a7362c0bd495b813ff2ea3c468b012cddbb13ed5f35bf2a0b9deffe4
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit
```

```
$ ls /private/var/folders/1c/n_v_74m52fn50xf0y2c46byh0000gn/T/6ea35ced629f07f1f20987db0c503141/0
db                      node.yaml               secure_storage.json     vfn-identity.yaml
genesis.blob            private-identity.yaml   validator-identity.yaml
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2059)
<!-- Reviewable:end -->
