### PR TITLE
[docker] Fix Rosetta git command

### DIFF
--- a/docker/rosetta/rosetta.Dockerfile
+++ b/docker/rosetta/rosetta.Dockerfile
@@ -12,7 +12,7 @@ FROM rust-base as builder
 ARG GIT_REPO=https://github.com/aptos-labs/aptos-core.git
 ARG GIT_REF
 
-RUN git clone $GIT_REPO ./ && git reset origin/$GIT_REF --hard
+RUN git clone $GIT_REPO ./ && git reset $GIT_REF --hard
 RUN --mount=type=cache,target=/aptos/target --mount=type=cache,target=$CARGO_HOME/registry \
   cargo build --release \
   -p aptos-rosetta \


### PR DESCRIPTION
### Description
The git command doesn't work with origin/<hash>, because it doesn't know that it's a hash.  Since it always pulls from source, I just changed it to checkout the hash or branch, since it's the latest state anyways.

### Test Plan

Ran the docker command locally and it built and started
```
 ./docker/rosetta/docker-build-rosetta.sh && \
mkdir -p data && \
cp config/src/config/test_data/public_full_node.yaml data/fullnode.yaml && \
curl -o data/genesis.blob https://devnet.aptoslabs.com/genesis.blob && \
curl -o data/waypoint.txt https://devnet.aptoslabs.com/waypoint.txt && \
docker run -p 8082:8082 --rm -v $(pwd)/data:/opt/aptos/data aptos-core:rosetta-latest online --test
+ export GIT_REPO=https://github.com/aptos-labs/aptos-core.git
+ GIT_REPO=https://github.com/aptos-labs/aptos-core.git
++ git rev-parse HEAD
+ export GIT_REF=5b14f2d3b45cb7e514311cc857c924744b6b94b9
+ GIT_REF=5b14f2d3b45cb7e514311cc857c924744b6b94b9
+ docker buildx build --file docker/rosetta/rosetta.Dockerfile --build-arg=GIT_REPO=https://github.com/aptos-labs/aptos-core.git --build-arg=GIT_REF=5b14f2d3b45cb7e514311cc857c924744b6b94b9 -t aptos-core:rosetta-5b14f2d3b45cb7e514311cc857c924744b6b94b9 -t aptos-core:rosetta-latest --load .
[+] Building 1.3s (16/16) FINISHED
 => [internal] load build definition from rosetta.Dockerfile                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 1.13kB                                                                                                                                                                                                       0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                            0.0s
 => => transferring context: 35B                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/rust:1.61-buster                                                                                                                                                                          1.2s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                                                                              1.2s
 => [auth] library/rust:pull token for registry-1.docker.io                                                                                                                                                                                  0.0s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                                                                                0.0s
 => [rust-base 1/3] FROM docker.io/library/rust:1.61-buster@sha256:3c7cc70ad77bdcd8b79b2621a509324ad595899eaffe755fe8e7187cc007f2cf                                                                                                          0.0s
 => [ubuntu-base 1/1] FROM docker.io/library/ubuntu:20.04@sha256:fd92c36d3cb9b1d027c4d2a72c6bf0125da82425fc2ca37c414d4f010180dc19                                                                                                            0.0s
 => CACHED [rosetta 1/3] RUN apt-get update && apt-get install -y libssl-dev ca-certificates && apt-get clean && rm -r /var/lib/apt/lists/*                                                                                                  0.0s
 => CACHED [rust-base 2/3] WORKDIR /aptos                                                                                                                                                                                                    0.0s
 => CACHED [rust-base 3/3] RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev                                                                                                                     0.0s
 => CACHED [builder 1/2] RUN git clone https://github.com/aptos-labs/aptos-core.git ./ && git reset 5b14f2d3b45cb7e514311cc857c924744b6b94b9 --hard                                                                                          0.0s
 => CACHED [builder 2/2] RUN --mount=type=cache,target=/aptos/target --mount=type=cache,target=/usr/local/cargo/registry   cargo build --release   -p aptos-rosetta   && mkdir dist   && cp target/release/aptos-rosetta dist/aptos-rosetta  0.0s
 => CACHED [rosetta 2/3] COPY --from=builder /aptos/dist/aptos-rosetta /usr/local/bin/aptos-rosetta                                                                                                                                          0.0s
 => CACHED [rosetta 3/3] WORKDIR /opt/aptos/data                                                                                                                                                                                             0.0s
 => exporting to image                                                                                                                                                                                                                       0.0s
 => => exporting layers                                                                                                                                                                                                                      0.0s
 => => writing image sha256:75a10b7780084318aff127cae03e17e25c4b216bf351da1d95227ddc9aa770b5                                                                                                                                                 0.0s
 => => naming to docker.io/library/aptos-core:rosetta-5b14f2d3b45cb7e514311cc857c924744b6b94b9                                                                                                                                               0.0s
 => => naming to docker.io/library/aptos-core:rosetta-latest                                                                                                                                                                                 0.0s
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  134k  100  134k    0     0   606k      0 --:--:-- --:--:-- --:--:--  618k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    66  100    66    0     0    507      0 --:--:-- --:--:-- --:--:--   536
aptos-rosetta: Starting Rosetta in Online (with local full node) mode
aptos-rosetta: Starting local full node
Entering test mode, this should never be used in production!
Completed generating configuration:
	Log file: "/tmp/1e44d5cc14707ef3f3e0cdacad272613/validator.log"
	Config path: "/tmp/1e44d5cc14707ef3f3e0cdacad272613"
	Aptos root key path: "/tmp/1e44d5cc14707ef3f3e0cdacad272613/mint.key"
	Waypoint: 0:2acd049a7dd386a423965f60a957fb0bb4f44089777f6c1d01427627bf2313dd
	ChainId: TESTING
	REST API endpoint: 0.0.0.0:8080
	FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit

aptos-rosetta: Local full node started successfully
aptos-rosetta: Starting rosetta
aptos-rosetta: Rosetta started
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2060)
<!-- Reviewable:end -->
