### PR TITLE
cicd: add Datadog CI visibility

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -142,7 +142,7 @@ jobs:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/rust-setup
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
-      - run: cargo nextest --nextest-profile ci --test-threads 16 --retries 2 --unit --exclude backup-cli --changed-since "origin/main"
+      - run: cargo nextest --nextest-profile ci --unit --exclude backup-cli --changed-since "origin/main"
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 
@@ -158,6 +158,14 @@ jobs:
           key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
 
+      - uses: datadog/junit-upload-github-action@v1
+        if: "!cancelled()"
+        with:
+          api-key: ${{ secrets.DD_API_KEY }}
+          datadog-site: us5.datadoghq.com
+          service: rust-unit-nextest
+          files: target/nextest/ci/junit.xml
+
   rust-e2e-test:
     runs-on: high-perf-docker
     steps:
@@ -169,6 +177,27 @@ jobs:
         env:
           RUST_BACKTRACE: full
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+
+      - name: Upload test results to BuildPulse for flaky test detection
+        # Only run this step for branches where where we have access to secrets.
+        # Run this step even when the tests fail. Skip if the workflow is cancelled.
+        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled()
+        uses: Workshop64/buildpulse-action@main
+        with:
+          account: 99841612
+          repository: 462597790
+          path: target/nextest/ci/junit.xml
+          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+
+      - uses: datadog/junit-upload-github-action@v1
+        if: "!cancelled()"
+        with:
+          api-key: ${{ secrets.DD_API_KEY }}
+          datadog-site: us5.datadoghq.com
+          service: rust-e2e-test
+          files: target/nextest/ci/junit.xml
+
       - name: Upload smoke test logs for failures
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
### Description

this adds Datadog CI visibility - sharing link to reports internally.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2063)
<!-- Reviewable:end -->
