### PR TITLE
[storage] limit the lifetime of CacheStateView<SyncProofFetcher>

### DIFF
--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -17,6 +17,7 @@ use executor_types::{BlockExecutorTrait, Error, StateComputeResult, StateSnapsho
 use fail::fail_point;
 use scratchpad::SparseMerkleTree;
 use std::marker::PhantomData;
+use std::ops::Deref;
 
 use crate::{
     components::{block_tree::BlockTree, chunk_output::ChunkOutput},
@@ -108,7 +109,7 @@ where
             let _timer = APTOS_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
             let state_view = parent_view.verified_state_view(
                 StateViewId::BlockExecution { block_id },
-                self.db.reader.clone(),
+                self.db.reader.deref(),
             )?;
 
             let chunk_output = {

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -31,6 +31,7 @@ use executor_types::{
 };
 use fail::fail_point;
 use std::{marker::PhantomData, sync::Arc};
+use storage_interface::sync_proof_fetcher::SyncProofFetcher;
 use storage_interface::{cached_state_view::CachedStateView, DbReaderWriter, ExecutedTrees};
 
 pub struct ChunkExecutor<V> {
@@ -58,12 +59,12 @@ impl<V> ChunkExecutor<V> {
         }
     }
 
-    fn state_view(&self, latest_view: &ExecutedTrees) -> Result<CachedStateView> {
+    fn state_view(&self, latest_view: &ExecutedTrees) -> Result<CachedStateView<SyncProofFetcher>> {
         latest_view.verified_state_view(
             StateViewId::ChunkExecution {
                 first_version: latest_view.txn_accumulator().num_leaves(),
             },
-            Arc::clone(&self.db.reader),
+            &*self.db.reader,
         )
     }
 

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -12,6 +12,7 @@ use aptos_vm::VMExecutor;
 use executor_types::ExecutedChunk;
 use fail::fail_point;
 use std::collections::HashSet;
+use storage_interface::sync_proof_fetcher::SyncProofFetcher;
 use storage_interface::{
     cached_state_view::{CachedStateView, StateCache},
     ExecutedTrees,
@@ -31,7 +32,7 @@ pub struct ChunkOutput {
 impl ChunkOutput {
     pub fn by_transaction_execution<V: VMExecutor>(
         transactions: Vec<Transaction>,
-        state_view: CachedStateView,
+        state_view: CachedStateView<SyncProofFetcher>,
     ) -> Result<Self> {
         let transaction_outputs = V::execute_block(transactions.clone(), &state_view)?;
 
@@ -44,7 +45,7 @@ impl ChunkOutput {
 
     pub fn by_transaction_output(
         transactions_and_outputs: Vec<(Transaction, TransactionOutput)>,
-        state_view: CachedStateView,
+        state_view: CachedStateView<SyncProofFetcher>,
     ) -> Result<Self> {
         let (transactions, transaction_outputs): (Vec<_>, Vec<_>) =
             transactions_and_outputs.into_iter().unzip();

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ops::Deref;
 use std::{collections::BTreeMap, iter::once};
 
 use proptest::prelude::*;
@@ -387,7 +388,7 @@ fn apply_transaction_by_writeset(
         .collect();
 
     let state_view = ledger_view
-        .verified_state_view(StateViewId::Miscellaneous, db.reader.clone())
+        .verified_state_view(StateViewId::Miscellaneous, db.reader.deref())
         .unwrap();
 
     let chunk_output =
@@ -526,7 +527,7 @@ fn run_transactions_naive(transactions: Vec<Transaction>) -> HashValue {
         let out = ChunkOutput::by_transaction_execution::<MockVM>(
             vec![txn],
             ledger_view
-                .verified_state_view(StateViewId::Miscellaneous, db.reader.clone())
+                .verified_state_view(StateViewId::Miscellaneous, db.reader.deref())
                 .unwrap(),
         )
         .unwrap();

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -3,6 +3,7 @@
 
 //! This file defines state store APIs that are related account state Merkle tree.
 
+use std::ops::Deref;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, ensure, format_err, Result};
@@ -191,10 +192,10 @@ impl StateStore {
             let mut buffered_state = self.buffered_state.lock();
             let latest_snapshot_state_view = CachedStateView::new(
                 StateViewId::Miscellaneous,
-                self.clone(),
+                self.deref(),
                 num_transactions,
                 buffered_state.current.clone(),
-                Arc::new(SyncProofFetcher::new(self.clone())),
+                SyncProofFetcher::new(self.deref()),
             )?;
             let write_sets = TransactionStore::new(Arc::clone(&self.ledger_db))
                 .get_write_sets(snapshot_next_version, num_transactions)?;

--- a/storage/storage-interface/src/no_proof_fetcher.rs
+++ b/storage/storage-interface/src/no_proof_fetcher.rs
@@ -8,7 +8,8 @@ use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
+use std::sync::Arc;
 
 /// An implementation of proof fetcher, which just reads the state value without fetching the proof.
 /// This can be useful for mempool validation, when we don't need to fetch the proof.

--- a/storage/storage-interface/src/sync_proof_fetcher.rs
+++ b/storage/storage-interface/src/sync_proof_fetcher.rs
@@ -9,17 +9,17 @@ use aptos_types::{
     transaction::Version,
 };
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 /// An implementation of proof fetcher, which synchronously fetches proofs from the underlying persistent
 /// storage.
-pub struct SyncProofFetcher {
-    reader: Arc<dyn DbReader>,
+pub struct SyncProofFetcher<'a> {
+    reader: &'a dyn DbReader,
     state_proof_cache: RwLock<HashMap<HashValue, SparseMerkleProof>>,
 }
 
-impl SyncProofFetcher {
-    pub fn new(reader: Arc<dyn DbReader>) -> Self {
+impl<'a> SyncProofFetcher<'a> {
+    pub fn new(reader: &'a dyn DbReader) -> Self {
         Self {
             reader,
             state_proof_cache: RwLock::new(HashMap::new()),
@@ -27,7 +27,7 @@ impl SyncProofFetcher {
     }
 }
 
-impl ProofFetcher for SyncProofFetcher {
+impl<'a> ProofFetcher for SyncProofFetcher<'a> {
     fn fetch_state_value_and_proof(
         &self,
         state_key: &StateKey,

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -13,6 +13,7 @@ use aptos_types::{
 use aptos_vm::AptosVM;
 use fail::fail_point;
 use std::sync::Arc;
+use storage_interface::no_proof_fetcher::NoProofFetcher;
 use storage_interface::{
     cached_state_view::CachedStateView, state_view::LatestDbStateCheckpointView, DbReader,
 };
@@ -34,7 +35,7 @@ pub trait TransactionValidation: Send + Sync + Clone {
     fn notify_commit(&mut self);
 }
 
-fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> CachedStateView {
+fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> CachedStateView<NoProofFetcher> {
     let ledger_view = db_reader
         .get_latest_executed_trees()
         .expect("Should not fail.");
@@ -44,14 +45,14 @@ fn latest_state_view(db_reader: &Arc<dyn DbReader>) -> CachedStateView {
             StateViewId::TransactionValidation {
                 base_version: ledger_view.version().expect("Must be bootstrapped."),
             },
-            db_reader.clone(),
+            db_reader,
         )
         .expect("failed to get latest state view.")
 }
 
 pub struct VMValidator {
     db_reader: Arc<dyn DbReader>,
-    cached_state_view: CachedStateView,
+    cached_state_view: CachedStateView<NoProofFetcher>,
     vm: AptosVM,
 }
 


### PR DESCRIPTION
### Description

The use cases of verified_state_view are always ephemeral which is not the case for `CacheStateView<NoProofFetcher>`. So we should not pass `Arc<DbReader>` in. It may help the initialization of `StateStore` too.

### Test Plan
ut

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2064)
<!-- Reviewable:end -->
