### PR TITLE
observability: add k8s.cluster field to logs to identify the cluster it came from

### DIFF
--- a/terraform/helm/vector-daemonset/files/vector-config.yaml
+++ b/terraform/helm/vector-daemonset/files/vector-config.yaml
@@ -24,6 +24,7 @@ transforms:
       - kubernetes_logs
     source: |-
       .k8s = del(.kubernetes)
+      .k8s.cluster = "${K8S_CLUSTER:?err}"
 sinks:
   prom_exporter:
     type: prometheus_exporter

--- a/terraform/helm/vector-daemonset/templates/vector-daemonset.yaml
+++ b/terraform/helm/vector-daemonset/templates/vector-daemonset.yaml
@@ -166,8 +166,9 @@ spec:
             - --watch-config
             - --config-dir
             - /etc/vector/
-            - -v
           env:
+            - name: K8S_CLUSTER
+              value: "{{ .Values.k8s_cluster }}"
             - name: VECTOR_SELF_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/terraform/helm/vector-daemonset/values.schema.json
+++ b/terraform/helm/vector-daemonset/values.schema.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "required": ["k8s_cluster", "logging_sinks", "env"],
+  "properties": {
+    "k8s_cluster": {
+      "description": "A human readable name for the k8s cluster. This will be added as field 'k8s_cluster' to each log event.",
+      "type": "string"
+    },
+    "logging_sinks": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "type": "object" }
+    },
+    "env": {
+      "type": "object",
+      "additionalProperties": { "type": "array" }
+    }
+  }
+}

--- a/terraform/helm/vector-daemonset/values.yaml
+++ b/terraform/helm/vector-daemonset/values.yaml
@@ -15,3 +15,5 @@ logging_sinks:
 #         key: MY_CUSTOM_SECRET
 
 env:
+
+# k8s_cluster: my_blockchain_cluster

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -53,14 +53,16 @@ FORGE_NAMESPACE=${FORGE_NAMESPACE:0:64}
 [ "$FORGE_ENABLE_HAPROXY" = "true" ] && ENABLE_HAPROXY_ARGS="--enable-haproxy"
 
 if [ -z "$IMAGE_TAG" ]; then
-    echo "IMAGE_TAG not set"
-    exit 1
+    IMAGE_TAG_DEFAULT=$(git rev-parse HEAD)
+    echo "IMAGE_TAG not set, defaulting to current HEAD commit as tag: ${IMAGE_TAG_DEFAULT}"
+    IMAGE_TAG=${IMAGE_TAG_DEFAULT}
 fi
 
 echo "Ensure image exists"
 img=$(aws ecr describe-images --repository-name="aptos/validator" --image-ids=imageTag=$IMAGE_TAG)
 if [ $? != 0 ]; then
-    echo "IMAGE_TAG does not exist: ${IMAGE_TAG}"
+    echo "IMAGE_TAG does not exist in ECR: ${IMAGE_TAG}. Make sure your commit has been pushed to GitHub previously."
+    echo "If you're trying to run the code from your PR, apply the label 'CICD:build-images' and wait for the builds to finish."
     exit 1
 fi
 


### PR DESCRIPTION
also: improving run_forge.sh DX when running it locally

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2074)
<!-- Reviewable:end -->
