### PR TITLE
[crypto] fixed the (lack of) Ed25519 public key validation in Move

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,6 +3226,7 @@ dependencies = [
  "aptos-vm",
  "bcs",
  "clap 3.2.11",
+ "curve25519-dalek",
  "include_dir 0.7.2",
  "libsecp256k1",
  "log",

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 anyhow = "1.0.57"
 bcs = "0.1.3"
 clap = "3.1.8"
+curve25519-dalek = { version = "3", default-features = false }
 include_dir = "0.7.2"
 libsecp256k1 = "0.7.0"
 log = "0.4.17"

--- a/aptos-move/framework/aptos-framework/sources/signature.move
+++ b/aptos-move/framework/aptos-framework/sources/signature.move
@@ -3,8 +3,9 @@ module aptos_framework::signature {
 
     /// Return `true` if the bytes in `public_key` can be parsed as a valid Ed25519 public key.
     /// Returns `false` if `public_key` is not 32 bytes OR is 32 bytes, but does not pass
-    /// points-on-curve or small subgroup checks. See the Rust `aptos_crypto::Ed25519PublicKey` type
-    /// for more details.
+    /// points-on-curve or small subgroup checks. This function should NOT be needed for most users
+    /// since ed25519_verify already does all these checks. We leave it here just in case.
+    /// See the Rust `aptos_crypto::Ed25519PublicKey` type for more details.
     /// Does not abort.
     native public fun ed25519_validate_pubkey(public_key: vector<u8>): bool;
 


### PR DESCRIPTION
### Description

This [commit](https://github.com/aptos-labs/aptos-core/commit/e623f228d68f09141ff0b47c314777f0efce948a#diff-9c464e51b249d8512f7638ff80fd8b5bac5b725d1e6d45c1bbd1ef0bed89bd6c) removed the small subgroup check on  Ed25519 public keys when deserializing them.

As a result, our `ed25519_validate_pubkey` Move function does not actually check for small subgroups, which can lead to big problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2077)
<!-- Reviewable:end -->
