### PR TITLE
[consensus] buffer manager cleanups and spawn_blocking

### DIFF
--- a/consensus/src/consensus_provider.rs
+++ b/consensus/src/consensus_provider.rs
@@ -51,7 +51,7 @@ pub fn start_consensus(
     ));
 
     let state_computer = Arc::new(ExecutionProxy::new(
-        Box::new(BlockExecutor::<AptosVM>::new(aptos_db)),
+        Arc::new(BlockExecutor::<AptosVM>::new(aptos_db)),
         txn_notifier,
         state_sync_notifier,
         commit_notifier.clone(),

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -291,12 +291,6 @@ impl BufferManager {
                 return;
             }
         };
-        // if this batch of blocks are all suffix blocks (reconfiguration block is in one of previous batch)
-        // we pause the execution from here and wait for the reconfiguration to be committed.
-        if executed_blocks.first().unwrap().is_reconfiguration_suffix() {
-            debug!("Ignore reconfiguration suffix execution, waiting for epoch to be committed");
-            return;
-        }
         debug!(
             "Receive executed response {}",
             executed_blocks.last().unwrap().block_info()

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -145,6 +145,20 @@ impl BufferManager {
         CountedRequest::new(req, self.ongoing_tasks.clone())
     }
 
+    fn spawn_retry_request<T: Send + 'static>(
+        mut sender: Sender<T>,
+        request: T,
+        duration: Duration,
+    ) {
+        tokio::spawn(async move {
+            tokio::time::sleep(duration).await;
+            sender
+                .send(request)
+                .await
+                .expect("Failed to send retry request");
+        });
+    }
+
     /// process incoming ordered blocks
     /// push them into the buffer and update the roots if they are none.
     fn process_ordered_blocks(&mut self, ordered_blocks: OrderedBlocks) {
@@ -170,10 +184,16 @@ impl BufferManager {
         );
         if self.execution_root.is_some() {
             let ordered_blocks = self.buffer.get(&self.execution_root).get_blocks().clone();
-            self.execution_phase_tx
-                .send(self.create_new_request(ExecutionRequest { ordered_blocks }))
-                .await
-                .expect("Failed to send execution request")
+            let request = self.create_new_request(ExecutionRequest { ordered_blocks });
+            if cursor == self.execution_root {
+                let sender = self.execution_phase_tx.clone();
+                Self::spawn_retry_request(sender, request, Duration::from_millis(100));
+            } else {
+                self.execution_phase_tx
+                    .send(request)
+                    .await
+                    .expect("Failed to send execution request")
+            }
         }
     }
 
@@ -191,13 +211,19 @@ impl BufferManager {
         if self.signing_root.is_some() {
             let item = self.buffer.get(&self.signing_root);
             let executed_item = item.unwrap_executed_ref();
-            self.signing_phase_tx
-                .send(self.create_new_request(SigningRequest {
-                    ordered_ledger_info: executed_item.ordered_proof.clone(),
-                    commit_ledger_info: executed_item.commit_proof.ledger_info().clone(),
-                }))
-                .await
-                .expect("Failed to send signing request");
+            let request = self.create_new_request(SigningRequest {
+                ordered_ledger_info: executed_item.ordered_proof.clone(),
+                commit_ledger_info: executed_item.commit_proof.ledger_info().clone(),
+            });
+            if cursor == self.signing_root {
+                let sender = self.signing_phase_tx.clone();
+                Self::spawn_retry_request(sender, request, Duration::from_millis(100));
+            } else {
+                self.signing_phase_tx
+                    .send(request)
+                    .await
+                    .expect("Failed to send signing request");
+            }
         }
     }
 
@@ -253,6 +279,9 @@ impl BufferManager {
         unreachable!("Aggregated item not found in the list");
     }
 
+    /// Reset any request in buffer manager, this is important to avoid race condition with state sync.
+    /// Internal requests are managed with ongoing_tasks.
+    /// Incoming ordered blocks are pulled, it should only have existing blocks but no new blocks until reset finishes.
     async fn reset(&mut self) {
         self.buffer = Buffer::new();
         self.execution_root = None;

--- a/consensus/src/experimental/tests/buffer_manager_tests.rs
+++ b/consensus/src/experimental/tests/buffer_manager_tests.rs
@@ -45,7 +45,7 @@ use network::{
     protocols::network::{Event, NewNetworkSender},
 };
 use safety_rules::{PersistentSafetyStorage, SafetyRulesManager};
-use std::{sync::Arc, thread::sleep, time::Duration};
+use std::sync::Arc;
 use tokio::runtime::Runtime;
 
 pub fn prepare_buffer_manager() -> (
@@ -303,7 +303,7 @@ fn buffer_manager_sync_test() {
     ) = launch_buffer_manager();
 
     let genesis_qc = certificate_for_genesis();
-    let num_batches = 5;
+    let num_batches = 100;
     let blocks_per_batch = 5;
     let mut init_round = 0;
 
@@ -327,15 +327,10 @@ fn buffer_manager_sync_test() {
         last_proposal = Some(proposal.last().unwrap().clone());
     }
 
-    // message proxy
-    runtime.spawn(async move {
-        loop {
-            loopback_commit_vote(&mut self_loop_rx, &msg_tx, &verifier).await;
-        }
-    });
+    let dropped_batches = 42;
 
     timed_block_on(&mut runtime, async move {
-        for i in 0..2 {
+        for i in 0..dropped_batches {
             block_tx
                 .send(OrderedBlocks {
                     ordered_blocks: batches[i].clone(),
@@ -345,9 +340,6 @@ fn buffer_manager_sync_test() {
                 .await
                 .ok();
         }
-
-        // make sure the messages are processed
-        sleep(Duration::from_millis(100));
 
         // reset
         let (tx, rx) = oneshot::channel::<ResetAck>();
@@ -355,7 +347,14 @@ fn buffer_manager_sync_test() {
         reset_tx.send(ResetRequest { tx, stop: false }).await.ok();
         rx.await.ok();
 
-        for i in 2..num_batches {
+        // start sending back commit vote after reset, to avoid [0..dropped_batches] being sent to result_rx
+        tokio::spawn(async move {
+            loop {
+                loopback_commit_vote(&mut self_loop_rx, &msg_tx, &verifier).await;
+            }
+        });
+
+        for i in dropped_batches..num_batches {
             block_tx
                 .send(OrderedBlocks {
                     ordered_blocks: batches[i].clone(),
@@ -366,8 +365,8 @@ fn buffer_manager_sync_test() {
                 .ok();
         }
 
-        // we should only see batches[0..num_batches]
-        assert_results(batches.drain(..2).collect(), &mut result_rx).await;
+        // we should only see batches[dropped_batches..num_batches]
+        assert_results(batches.drain(dropped_batches..).collect(), &mut result_rx).await;
 
         assert!(matches!(result_rx.next().now_or_never(), None));
     });


### PR DESCRIPTION
1. execute reconfiguration suffix to avoid rare race condition
2. add delay for retry requests to avoid busy looping
3. spawn_blocking for execution and commit to free cooperative threads

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2082)
<!-- Reviewable:end -->
