### PR TITLE
[tf/forge] use sha1 to trigger helm release

### DIFF
--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -79,11 +79,6 @@ variable "helm_values_file" {
   default     = ""
 }
 
-variable "helm_force_update" {
-  description = "Force Terraform to update the Helm deployment"
-  default     = true
-}
-
 variable "k8s_admins" {
   description = "List of AWS usernames to configure as Kubernetes administrators"
   type        = list(string)

--- a/terraform/aptos-node/azure/kubernetes.tf
+++ b/terraform/aptos-node/azure/kubernetes.tf
@@ -14,9 +14,16 @@ provider "helm" {
   }
 }
 
+locals {
+  # helm chart paths
+  monitoring_helm_chart_path = "${path.module}/../../helm/monitoring"
+  logger_helm_chart_path     = "${path.module}/../../helm/logger"
+  aptos_node_helm_chart_path = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
+}
+
 resource "helm_release" "validator" {
   name        = terraform.workspace
-  chart       = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
+  chart       = local.aptos_node_helm_chart_path
   max_history = 5
   wait        = false
 
@@ -60,16 +67,17 @@ resource "helm_release" "validator" {
     jsonencode(var.helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = var.helm_force_update ? timestamp() : ""
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.aptos_node_helm_chart_path, "**") : filesha1("${local.aptos_node_helm_chart_path}/${f}")]))
   }
 }
 
 resource "helm_release" "logger" {
   count       = var.enable_logger ? 1 : 0
   name        = "${terraform.workspace}-log"
-  chart       = "${path.module}/../../helm/logger"
+  chart       = local.logger_helm_chart_path
   max_history = 10
   wait        = false
 
@@ -83,22 +91,23 @@ resource "helm_release" "logger" {
       }
       serviceAccount = {
         create = false
-        name = "${terraform.workspace}-aptos-node-validator"
+        name   = "${terraform.workspace}-aptos-node-validator"
       }
     }),
     jsonencode(var.logger_helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = timestamp()
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.logger_helm_chart_path, "**") : filesha1("${local.logger_helm_chart_path}/${f}")]))
   }
 }
 
 resource "helm_release" "monitoring" {
   count       = var.enable_monitoring ? 1 : 0
   name        = "${terraform.workspace}-mon"
-  chart       = "${path.module}/../../helm/monitoring"
+  chart       = local.monitoring_helm_chart_path
   max_history = 10
   wait        = false
 
@@ -121,8 +130,9 @@ resource "helm_release" "monitoring" {
     jsonencode(var.monitoring_helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = timestamp()
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.monitoring_helm_chart_path, "**") : filesha1("${local.monitoring_helm_chart_path}/${f}")]))
   }
 }

--- a/terraform/aptos-node/azure/variables.tf
+++ b/terraform/aptos-node/azure/variables.tf
@@ -59,11 +59,6 @@ variable "helm_values_file" {
   default     = ""
 }
 
-variable "helm_force_update" {
-  description = "Force Terraform to update the Helm deployment"
-  default     = true
-}
-
 variable "k8s_api_sources" {
   description = "List of CIDR subnets which can access the Kubernetes API endpoint"
   default     = ["0.0.0.0/0"]

--- a/terraform/aptos-node/gcp/kubernetes.tf
+++ b/terraform/aptos-node/gcp/kubernetes.tf
@@ -23,9 +23,16 @@ provider "helm" {
   }
 }
 
+locals {
+  # helm chart paths
+  monitoring_helm_chart_path = "${path.module}/../../helm/monitoring"
+  logger_helm_chart_path     = "${path.module}/../../helm/logger"
+  aptos_node_helm_chart_path = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
+}
+
 resource "helm_release" "validator" {
   name        = terraform.workspace
-  chart       = var.helm_chart != "" ? var.helm_chart : "${path.module}/../../helm/aptos-node"
+  chart       = local.aptos_node_helm_chart_path
   max_history = 5
   wait        = false
 
@@ -33,9 +40,9 @@ resource "helm_release" "validator" {
     jsonencode({
       imageTag = var.image_tag
       chain = {
-      era        = var.era
-      chain_id   = var.chain_id
-      chain_name = var.chain_name
+        era        = var.era
+        chain_id   = var.chain_id
+        chain_name = var.chain_name
       }
       validator = {
         name = var.validator_name
@@ -69,16 +76,17 @@ resource "helm_release" "validator" {
     jsonencode(var.helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = var.helm_force_update ? timestamp() : ""
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.aptos_node_helm_chart_path, "**") : filesha1("${local.aptos_node_helm_chart_path}/${f}")]))
   }
 }
 
 resource "helm_release" "logger" {
   count       = var.enable_logger ? 1 : 0
   name        = "${terraform.workspace}-log"
-  chart       = "${path.module}/../../helm/logger"
+  chart       = local.logger_helm_chart_path
   max_history = 10
   wait        = false
 
@@ -92,22 +100,23 @@ resource "helm_release" "logger" {
       }
       serviceAccount = {
         create = false
-        name = "${terraform.workspace}-aptos-node-validator"
+        name   = "${terraform.workspace}-aptos-node-validator"
       }
     }),
     jsonencode(var.logger_helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = timestamp()
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.logger_helm_chart_path, "**") : filesha1("${local.logger_helm_chart_path}/${f}")]))
   }
 }
 
 resource "helm_release" "monitoring" {
   count       = var.enable_monitoring ? 1 : 0
   name        = "${terraform.workspace}-mon"
-  chart       = "${path.module}/../../helm/monitoring"
+  chart       = local.monitoring_helm_chart_path
   max_history = 10
   wait        = false
 
@@ -130,8 +139,9 @@ resource "helm_release" "monitoring" {
     jsonencode(var.monitoring_helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = timestamp()
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.monitoring_helm_chart_path, "**") : filesha1("${local.monitoring_helm_chart_path}/${f}")]))
   }
 }

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -69,11 +69,6 @@ variable "helm_values_file" {
   default     = ""
 }
 
-variable "helm_force_update" {
-  description = "Force Terraform to update the Helm deployment"
-  default     = true
-}
-
 variable "k8s_api_sources" {
   description = "List of CIDR subnets which can access the Kubernetes API endpoint"
   default     = ["0.0.0.0/0"]

--- a/terraform/fullnode/aws/main.tf
+++ b/terraform/fullnode/aws/main.tf
@@ -58,20 +58,26 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.aptos.token
 }
 
+locals {
+  pfn_helm_chart_path        = "${path.module}/fullnode"
+  pfn_logger_helm_chart_path = "${path.module}/../../helm/logger"
+  fullnode_helm_chart_path   = "${path.module}/../../helm/fullnode"
+}
+
 resource "helm_release" "pfn" {
   name        = "aptos"
-  chart       = "${path.module}/fullnode"
+  chart       = local.pfn_helm_chart_path
   max_history = 10
   wait        = false
 
   values = [
     jsonencode({
-      imageTag          = local.image_tag
+      imageTag = local.image_tag
       service = {
         domain   = local.domain
         aws_tags = local.aws_tags
         fullnode = {
-          numFullnodes = var.num_fullnodes
+          numFullnodes             = var.num_fullnodes
           loadBalancerSourceRanges = var.client_sources_ipv4
         }
         monitoring = {
@@ -100,23 +106,24 @@ resource "helm_release" "pfn" {
     jsonencode(var.pfn_helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = timestamp()
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.pfn_helm_chart_path, "**") : filesha1("${local.pfn_helm_chart_path}/${f}")]))
   }
 }
 
 resource "helm_release" "fullnode" {
   count       = var.num_fullnodes
   name        = "pfn${count.index}"
-  chart       = "${path.module}/../../helm/fullnode"
+  chart       = local.fullnode_helm_chart_path
   max_history = 10
   wait        = false
 
   values = [
     jsonencode({
       chain = {
-        era  = var.era
+        era = var.era
       }
       image = {
         tag = local.image_tag
@@ -135,9 +142,10 @@ resource "helm_release" "fullnode" {
     jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = timestamp()
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.fullnode_helm_chart_path, "**") : filesha1("${local.fullnode_helm_chart_path}/${f}")]))
   }
 }
 
@@ -145,7 +153,7 @@ resource "helm_release" "fullnode" {
 resource "helm_release" "pfn-logger" {
   count       = var.enable_pfn_logger ? 1 : 0
   name        = "pfn-logger"
-  chart       = "${path.module}/../../helm/logger"
+  chart       = local.pfn_logger_helm_chart_path
   max_history = 10
   wait        = false
 
@@ -161,8 +169,9 @@ resource "helm_release" "pfn-logger" {
     jsonencode(var.pfn_logger_helm_values),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = timestamp()
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.pfn_logger_helm_chart_path, "**") : filesha1("${local.pfn_logger_helm_chart_path}/${f}")]))
   }
 }

--- a/terraform/fullnode/digital_ocean/variables.tf
+++ b/terraform/fullnode/digital_ocean/variables.tf
@@ -26,11 +26,6 @@ variable "fullnode_helm_values_list" {
   default     = {}
 }
 
-variable "helm_force_update" {
-  description = "Force Terraform to update the Helm deployment"
-  default     = false
-}
-
 variable "k8s_namespace" {
   default     = "aptos"
   description = "Kubernetes namespace that the fullnode will be deployed into"

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -31,11 +31,6 @@ variable "fullnode_helm_values_list" {
   default     = {}
 }
 
-variable "helm_force_update" {
-  description = "Force Terraform to update the Helm deployment"
-  default     = false
-}
-
 variable "k8s_namespace" {
   default     = "aptos"
   description = "Kubernetes namespace that the fullnode will be deployed into"

--- a/terraform/fullnode/vultr/kubernetes.tf
+++ b/terraform/fullnode/vultr/kubernetes.tf
@@ -1,8 +1,8 @@
 provider "kubernetes" {
-  host = yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).clusters[0].cluster["server"]
+  host                   = yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).clusters[0].cluster["server"]
   cluster_ca_certificate = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).clusters[0].cluster["certificate-authority-data"])
-  client_certificate = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-certificate-data"])
-  client_key = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-key-data"])
+  client_certificate     = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-certificate-data"])
+  client_key             = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-key-data"])
 }
 
 resource "kubernetes_namespace" "aptos" {
@@ -13,17 +13,21 @@ resource "kubernetes_namespace" "aptos" {
 
 provider "helm" {
   kubernetes {
-    host = yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).clusters[0].cluster["server"]
+    host                   = yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).clusters[0].cluster["server"]
     cluster_ca_certificate = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).clusters[0].cluster["certificate-authority-data"])
-    client_certificate = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-certificate-data"])
-    client_key = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-key-data"])
+    client_certificate     = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-certificate-data"])
+    client_key             = base64decode(yamldecode(base64decode(vultr_kubernetes.k8.kube_config)).users[0].user["client-key-data"])
   }
+}
+
+locals {
+  fullnode_helm_chart_path = "${path.module}/../../helm/fullnode"
 }
 
 resource "helm_release" "fullnode" {
   count            = var.num_fullnodes
   name             = "${terraform.workspace}${count.index}"
-  chart            = "${path.module}/../../helm/fullnode"
+  chart            = local.fullnode_helm_chart_path
   max_history      = 100
   wait             = false
   namespace        = var.k8s_namespace
@@ -51,9 +55,10 @@ resource "helm_release" "fullnode" {
     jsonencode(var.fullnode_helm_values_list == {} ? {} : var.fullnode_helm_values_list[count.index]),
   ]
 
+  # inspired by https://stackoverflow.com/a/66501021 to trigger redeployment whenever any of the charts file contents change.
   set {
-    name  = "timestamp"
-    value = var.helm_force_update ? timestamp() : ""
+    name  = "chart_sha1"
+    value = sha1(join("", [for f in fileset(local.fullnode_helm_chart_path, "**") : filesha1("${local.fullnode_helm_chart_path}/${f}")]))
   }
 }
 

--- a/terraform/fullnode/vultr/variables.tf
+++ b/terraform/fullnode/vultr/variables.tf
@@ -16,11 +16,6 @@ variable "fullnode_helm_values_list" {
   default     = {}
 }
 
-variable "helm_force_update" {
-  description = "Force Terraform to update the Helm deployment"
-  default     = false
-}
-
 variable "k8s_namespace" {
   default     = "aptos"
   description = "Kubernetes namespace that the fullnode will be deployed into"

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -17,9 +17,6 @@ spec:
     - |
       ulimit -n 1048576
       forge test k8s-swarm --image-tag {IMAGE_TAG} --namespace {FORGE_NAMESPACE} {KEEP_ARGS} {ENABLE_HAPROXY_ARGS}
-    resources:
-      requests:
-        cpu: 15.5
   affinity:
     # avoid scheduling with other forge or validator/fullnode pods
     podAntiAffinity:


### PR DESCRIPTION
### Description

* Remove the resource requirement for Forge test runner to use 15.5 vCPU. This number will change anyways depending on the machine type. Instead, rely on the pod antiaffinity and have it use as much CPU as it needs on the node it's scheduled on
* Trigger helm_release using the chart's sha1, instead of relying on timestamp which will change every time. This makes the TF plan smarter! Applied the same change to all our TF configs that previously used timestamp for the `helm_release` resource 

### Test Plan

TF apply and create a new forge cluster 

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2083)
<!-- Reviewable:end -->
