### PR TITLE
[Aptos CLI][Move Prover] Add the subcommand to run Move Prover in Aptos CLI

### DIFF
--- a/aptos-move/move-examples/hello_prover/Move.toml
+++ b/aptos-move/move-examples/hello_prover/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hello_prover"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "main" }
+
+[addresses]
+
+

--- a/aptos-move/move-examples/hello_prover/sources/prove.move
+++ b/aptos-move/move-examples/hello_prover/sources/prove.move
@@ -1,0 +1,17 @@
+module 0x42::prove {
+    fun plus1(x: u64): u64 {
+        x+1
+    }
+    spec plus1 {
+        ensures result == x+1;
+    }
+
+    fun abortsIf0(x: u64) {
+        if (x == 0) {
+            abort(0)
+        };
+    }
+    spec abortsIf0 {
+        aborts_if x == 0;
+    }
+}

--- a/aptos-move/move-examples/tests/move_prover_tests.rs
+++ b/aptos-move/move-examples/tests/move_prover_tests.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_types::account_address::AccountAddress;
+use move_deps::move_cli::base::prove::run_move_prover;
+use move_deps::move_prover;
+use std::{collections::BTreeMap, path::PathBuf};
+use tempfile::tempdir;
+
+pub fn path_in_crate<S>(relative: S) -> PathBuf
+where
+    S: Into<String>,
+{
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push(relative.into());
+    path
+}
+
+pub fn run_prover_for_pkg(
+    path_to_pkg: impl Into<String>,
+    named_addr: BTreeMap<String, AccountAddress>,
+) {
+    let pkg_path = path_in_crate(path_to_pkg);
+    let config = move_deps::move_package::BuildConfig {
+        additional_named_addresses: named_addr,
+        test_mode: true,
+        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+        ..Default::default()
+    };
+    run_move_prover(
+        config,
+        &pkg_path,
+        &None,
+        true,
+        move_prover::cli::Options::default(),
+    )
+    .unwrap();
+}
+
+#[ignore] // TODO: Ignored because Prover dependencies are not installed in CI.
+#[test]
+fn test_hello_prover() {
+    let named_address = BTreeMap::new();
+    run_prover_for_pkg("hello_prover", named_address);
+}

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -75,6 +75,8 @@ pub enum CliError {
     MoveCompilationError(String),
     #[error("Move unit tests failed")]
     MoveTestError,
+    #[error("Move Prover failed")]
+    MoveProverError,
     #[error("Unable to parse '{0}': error: {1}")]
     UnableToParse(&'static str, String),
     #[error("Unable to read file '{0}', error: {1}")]
@@ -95,6 +97,7 @@ impl CliError {
             CliError::IO(_, _) => "IO",
             CliError::MoveCompilationError(_) => "MoveCompilationError",
             CliError::MoveTestError => "MoveTestError",
+            CliError::MoveProverError => "MoveProverError",
             CliError::UnableToParse(_, _) => "UnableToParse",
             CliError::UnableToReadFile(_, _) => "UnableToReadFile",
             CliError::UnexpectedError(_) => "UnexpectedError",


### PR DESCRIPTION
### Description
- Enabled the Prover command in Aptos CLI (`$ aptos move prove`)
- Added a test package (`hello_prover`) and a test script in `move-examples`

### Test Plan
cargo test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2086)
<!-- Reviewable:end -->
