### PR TITLE
[Storage] Increase the # of background threads for Rocksdb.

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -15,6 +15,7 @@ use std::{
 pub struct RocksdbConfig {
     pub max_open_files: i32,
     pub max_total_wal_size: u64,
+    pub max_background_jobs: i32,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -33,6 +34,9 @@ impl Default for RocksdbConfigs {
                 // For now we set the max total WAL size to be 1G. This config can be useful when column
                 // families are updated at non-uniform frequencies.
                 max_total_wal_size: 1u64 << 30,
+                // This includes threads for flashing and compaction. Rocksdb will decide the # of
+                // threads to use internally.
+                max_background_jobs: 16,
             },
             state_merkle_db_config: RocksdbConfig {
                 // Allow db to close old sst files, saving memory.
@@ -40,6 +44,9 @@ impl Default for RocksdbConfigs {
                 // For now we set the max total WAL size to be 1G. This config can be useful when column
                 // families are updated at non-uniform frequencies.
                 max_total_wal_size: 1u64 << 30,
+                // This includes threads for flashing and compaction. Rocksdb will decide the # of
+                // threads to use internally.
+                max_background_jobs: 16,
             },
         }
     }

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -44,6 +44,7 @@ pub(super) fn gen_rocksdb_options(config: &RocksdbConfig, readonly: bool) -> Opt
     let mut db_opts = Options::default();
     db_opts.set_max_open_files(config.max_open_files);
     db_opts.set_max_total_wal_size(config.max_total_wal_size);
+    db_opts.set_max_background_jobs(config.max_background_jobs);
     if !readonly {
         db_opts.create_if_missing(true);
         db_opts.create_missing_column_families(true);

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -54,6 +54,8 @@ pub struct RocksdbOpt {
     state_merkle_db_max_open_files: i32,
     #[structopt(long, default_value = "1073741824")] // 1GB
     state_merkle_db_max_total_wal_size: u64,
+    #[structopt(long, default_value = "16")]
+    max_background_jobs: i32,
 }
 
 impl From<RocksdbOpt> for RocksdbConfigs {
@@ -62,10 +64,12 @@ impl From<RocksdbOpt> for RocksdbConfigs {
             ledger_db_config: RocksdbConfig {
                 max_open_files: opt.ledger_db_max_open_files,
                 max_total_wal_size: opt.ledger_db_max_total_wal_size,
+                max_background_jobs: opt.max_background_jobs,
             },
             state_merkle_db_config: RocksdbConfig {
                 max_open_files: opt.state_merkle_db_max_open_files,
                 max_total_wal_size: opt.state_merkle_db_max_total_wal_size,
+                max_background_jobs: opt.max_background_jobs,
             },
         }
     }


### PR DESCRIPTION
### Description
When db is huge, we sometimes see the compaction cannot catch up, and stalls/stops the write. The log shows the CPU time used for compaction is large, so increasing the # of threads should help.

e.g. Before this change we can see
```2022/07/15-03:54:04.092403 7f95747fb700 [WARN] [db/column_family.cc:917] [jellyfish_merkle_node] Stopping writes because of estimated pending compaction bytes 611474697013``` and 
```2022/07/15-04:34:35.750367 7f9571bff700 [WARN] [db/column_family.cc:895] [jellyfish_merkle_node] Stopping writes because we have 2 immutable memtables (waiting for flush), max_write_buffer_number is set to 2```,
which completely stopped writes for several minutes.
After this change they are gone.

### Test Plan
Manually tested on large DB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2087)
<!-- Reviewable:end -->
