### PR TITLE
[Execution] Add AsyncProofFetcher.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c07dab4369547dbe5114677b33fbbf724971019f3818172d59a97a61c774ffd"
 
 [[package]]
+name = "assert_unordered"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89464e809410174509672bc79d06dec8cde36332819c9bfd0e6eee2b4e0b50e0"
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7923,9 +7929,14 @@ dependencies = [
  "aptos-secure-net",
  "aptos-state-view",
  "aptos-types",
+ "aptos-vm",
+ "assert_unordered",
  "bcs",
+ "crossbeam-channel",
  "move-deps",
+ "once_cell",
  "parking_lot 0.12.0",
+ "rayon",
  "scratchpad",
  "serde 1.0.137",
  "thiserror",

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -64,6 +64,7 @@ use std::{
 };
 
 static EXECUTION_CONCURRENCY_LEVEL: OnceCell<usize> = OnceCell::new();
+static NUM_PROOF_READING_THREADS: OnceCell<usize> = OnceCell::new();
 
 #[derive(Clone)]
 pub struct AptosVM(pub(crate) AptosVMImpl);
@@ -109,6 +110,23 @@ impl AptosVM {
         match EXECUTION_CONCURRENCY_LEVEL.get() {
             Some(concurrency_level) => *concurrency_level,
             None => 1,
+        }
+    }
+
+    /// Sets the # of async proof reading threads.
+    pub fn set_num_proof_reading_threads_once(mut num_threads: usize) {
+        // TODO(grao): Do more analysis to tune this magic number.
+        num_threads = min(num_threads, 256);
+        // Only the first call succeeds, due to OnceCell semantics.
+        NUM_PROOF_READING_THREADS.set(num_threads).ok();
+    }
+
+    /// Returns the # of async proof reading threads if already set, otherwise return default value
+    /// (32).
+    pub fn get_num_proof_reading_threads() -> usize {
+        match NUM_PROOF_READING_THREADS.get() {
+            Some(num_threads) => *num_threads,
+            None => 32,
         }
     }
 

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -496,6 +496,9 @@ pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle>
         info!("Genesis txn not provided, it's fine if you don't expect to apply it otherwise please double check config");
     }
     AptosVM::set_concurrency_level_once(node_config.execution.concurrency_level as usize);
+    AptosVM::set_num_proof_reading_threads_once(
+        node_config.execution.num_proof_reading_threads as usize,
+    );
 
     debug!(
         "Storage service started in {} ms",

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -20,6 +20,7 @@ pub struct ExecutionConfig {
     pub genesis_file_location: PathBuf,
     pub network_timeout_ms: u64,
     pub concurrency_level: u16,
+    pub num_proof_reading_threads: u16,
 }
 
 impl std::fmt::Debug for ExecutionConfig {
@@ -47,6 +48,7 @@ impl Default for ExecutionConfig {
             network_timeout_ms: 30_000,
             // Sequential execution by default.
             concurrency_level: 1,
+            num_proof_reading_threads: 32,
         }
     }
 }

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -11,8 +11,12 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.57"
+assert_unordered = "0.1.1"
 bcs = "0.1.3"
+crossbeam-channel = "0.5.4"
+once_cell = "1.10.0"
 parking_lot = "0.12.0"
+rayon = "1.5.2"
 serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 
@@ -20,6 +24,7 @@ aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-state-view = { path = "../state-view" }
 aptos-types = { path = "../../types" }
+aptos-vm = { path = "../../aptos-move/aptos-vm" }
 
 move-deps = { path = "../../aptos-move/move-deps", features = ["address32"] }
 scratchpad = { path = "../scratchpad" }

--- a/storage/storage-interface/src/async_proof_fetcher.rs
+++ b/storage/storage-interface/src/async_proof_fetcher.rs
@@ -1,0 +1,140 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{proof_fetcher::ProofFetcher, DbReader};
+
+use anyhow::Result;
+use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_types::{
+    proof::SparseMerkleProof,
+    state_store::{state_key::StateKey, state_value::StateValue},
+    transaction::Version,
+};
+use aptos_vm::AptosVM;
+use crossbeam_channel::{unbounded, Receiver, Sender};
+use once_cell::sync::Lazy;
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+static IO_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(AptosVM::get_num_proof_reading_threads())
+        .thread_name(|index| format!("proof_reader_{}", index))
+        .build()
+        .unwrap()
+});
+
+struct Proof {
+    state_key_hash: HashValue,
+    proof: SparseMerkleProof,
+}
+
+pub struct AsyncProofFetcher {
+    reader: Arc<dyn DbReader>,
+    data_sender: Sender<Proof>,
+    data_receiver: Receiver<Proof>,
+    num_proofs_to_read: AtomicUsize,
+}
+
+impl AsyncProofFetcher {
+    pub fn new(reader: Arc<dyn DbReader>) -> Self {
+        let (data_sender, data_receiver) = unbounded();
+
+        Self {
+            reader,
+            data_sender,
+            data_receiver,
+            num_proofs_to_read: AtomicUsize::new(0),
+        }
+    }
+
+    // Waits scheduled proof read to finish, and returns all read proofs.
+    //
+    // This is only expected to be called in a single thread, after all reads being scheduled.
+    fn wait(&self) -> HashMap<HashValue, SparseMerkleProof> {
+        // TODO(grao): Find a way to verify the proof.
+        let mut proofs = HashMap::new();
+        for _ in 0..self.num_proofs_to_read.load(Ordering::SeqCst) {
+            let data = self
+                .data_receiver
+                .recv()
+                .expect("Failed to receive proof on the channel.");
+            let Proof {
+                state_key_hash,
+                proof,
+            } = data;
+            proofs.insert(state_key_hash, proof);
+        }
+        self.num_proofs_to_read.store(0, Ordering::SeqCst);
+        proofs
+    }
+
+    // Schedules proof reading work in a background running thread pool.
+    fn schedule_proof_read(&self, state_key: StateKey, version: Version) {
+        self.num_proofs_to_read.fetch_add(1, Ordering::SeqCst);
+        let reader = self.reader.clone();
+        let data_sender = self.data_sender.clone();
+        IO_POOL.spawn(move || {
+            let proof = reader
+                .get_state_proof_by_version(&state_key, version)
+                .expect("Proof reading should succeed.");
+            data_sender
+                .send(Proof {
+                    state_key_hash: state_key.hash(),
+                    proof,
+                })
+                .expect("Sending proof should succeed.");
+        });
+    }
+}
+
+impl ProofFetcher for AsyncProofFetcher {
+    fn fetch_state_value_and_proof(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<(Option<StateValue>, Option<SparseMerkleProof>)> {
+        self.schedule_proof_read(state_key.clone(), version);
+        let value = self.reader.get_state_value_by_version(state_key, version)?;
+        Ok((value, None))
+    }
+
+    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProof> {
+        self.wait()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mock::MockDbReaderWriter;
+    use assert_unordered::assert_eq_unordered;
+
+    #[test]
+    fn test_fetch() {
+        let fetcher = AsyncProofFetcher::new(Arc::new(MockDbReaderWriter));
+        let mut expected_key_hashes = vec![];
+        for i in 0..10 {
+            let state_key = StateKey::Raw(format!("test_key_{}", i).into_bytes());
+            expected_key_hashes.push(state_key.hash());
+            let result = fetcher
+                .fetch_state_value_and_proof(&state_key, 0)
+                .expect("Should not fail.");
+            let expected_value = StateValue::from(match state_key {
+                StateKey::Raw(key) => key,
+                _ => unreachable!(),
+            });
+            assert_eq!(result.0, Some(expected_value));
+            assert!(result.1.is_none());
+        }
+
+        let proofs = fetcher.get_proof_cache();
+        assert_eq!(proofs.len(), 10);
+        assert_eq_unordered!(proofs.into_keys().collect::<Vec<_>>(), expected_key_hashes);
+    }
+}

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -35,9 +35,9 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
+pub mod async_proof_fetcher;
 pub mod cached_state_view;
 mod executed_trees;
-#[cfg(any(feature = "testing", feature = "fuzzing"))]
 pub mod mock;
 pub mod no_proof_fetcher;
 pub mod proof_fetcher;

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -10,6 +10,7 @@ use aptos_types::{
     account_address::AccountAddress,
     account_config::AccountResource,
     account_state::AccountState,
+    proof::SparseMerkleProof,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
@@ -28,6 +29,7 @@ impl DbReader for MockDbReaderWriter {
                     .cloned()
                     .map(StateValue::from))
             }
+            StateKey::Raw(raw_key) => Ok(Some(StateValue::from(raw_key))),
             _ => Err(anyhow!("Not supported state key type {:?}", state_key)),
         }
     }
@@ -49,6 +51,14 @@ impl DbReader for MockDbReaderWriter {
     ) -> Result<Option<StateValue>> {
         // dummy proof which is not used
         Ok(self.get_latest_state_value(state_key.clone()).unwrap())
+    }
+
+    fn get_state_proof_by_version(
+        &self,
+        _state_key: &StateKey,
+        _version: Version,
+    ) -> Result<SparseMerkleProof> {
+        Ok(SparseMerkleProof::new(None, vec![]))
     }
 }
 


### PR DESCRIPTION
### Description
Implement AsyncProofFetcher. Will use this in execution to only get state value in foreground, and put proof reading to background, to reduce latency.

### Test Plan
New UT, and manually tested on large DBs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2093)
<!-- Reviewable:end -->
