### PR TITLE
[consensus] remove help_remote option for sync up

### DIFF
--- a/consensus/src/logging.rs
+++ b/consensus/src/logging.rs
@@ -18,7 +18,6 @@ pub struct LogSchema {
 pub enum LogEvent {
     CommitViaBlock,
     CommitViaSync,
-    HelpPeerSync,
     NewEpoch,
     NewRound,
     Propose,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -212,15 +212,6 @@ impl NetworkSender {
         self.send(msg, recipients).await
     }
 
-    /// Sends the given sync info to the given author.
-    /// The future is fulfilled as soon as the message is added to the internal network channel
-    /// (does not indicate whether the message is delivered or sent out).
-    pub async fn send_sync_info(&self, sync_info: SyncInfo, recipient: Author) {
-        fail_point!("consensus::send_sync_info", |_| ());
-        let msg = ConsensusMsg::SyncInfo(Box::new(sync_info));
-        self.send(msg, vec![recipient]).await
-    }
-
     pub async fn send_proposal(&self, proposal_msg: ProposalMsg, recipients: Vec<Author>) {
         fail_point!("consensus::send_proposal", |_| ());
         let msg = ConsensusMsg::ProposalMsg(Box::new(proposal_msg));

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -27,7 +27,7 @@ use std::{
 #[derive(Debug, PartialEq)]
 pub enum VoteReceptionResult {
     /// The vote has been added but QC has not been formed yet. Return the amount of voting power
-    /// the given (proposal, execution) pair.
+    /// QC currently has.
     VoteAdded(u64),
     /// The very same vote message has been processed in past.
     DuplicateVote,
@@ -41,6 +41,8 @@ pub enum VoteReceptionResult {
     ErrorAddingVote(VerifyError),
     /// The vote is not for the current round.
     UnexpectedRound(u64, u64),
+    /// Receive f+1 timeout to trigger a local timeout, return the amount of voting power TC currently has.
+    EchoTimeout(u64),
 }
 
 /// A PendingVotes structure keep track of votes
@@ -53,6 +55,8 @@ pub struct PendingVotes {
     maybe_partial_2chain_tc: Option<TwoChainTimeoutCertificate>,
     /// Map of Author to vote. This is useful to discard multiple votes.
     author_to_vote: HashMap<Author, Vote>,
+    /// Whether we have echoed timeout for this round.
+    echo_timeout: bool,
 }
 
 impl PendingVotes {
@@ -62,6 +66,7 @@ impl PendingVotes {
             li_digest_to_votes: HashMap::new(),
             maybe_partial_2chain_tc: None,
             author_to_vote: HashMap::new(),
+            echo_timeout: false,
         }
     }
 
@@ -153,19 +158,31 @@ impl PendingVotes {
                 .maybe_partial_2chain_tc
                 .get_or_insert_with(|| TwoChainTimeoutCertificate::new(timeout.clone()));
             partial_tc.add(vote.author(), timeout.clone(), signature.clone());
-            match validator_verifier.check_voting_power(partial_tc.signers()) {
+            let tc_voting_power = match validator_verifier.check_voting_power(partial_tc.signers())
+            {
                 Ok(_) => {
                     return VoteReceptionResult::New2ChainTimeoutCertificate(Arc::new(
                         partial_tc.clone(),
                     ))
                 }
-                Err(VerifyError::TooLittleVotingPower { .. }) => (),
+                Err(VerifyError::TooLittleVotingPower { voting_power, .. }) => voting_power,
                 Err(error) => {
                     error!(
                         "MUST_FIX: 2-chain timeout vote received could not be added: {}, vote: {}",
                         error, vote
                     );
                     return VoteReceptionResult::ErrorAddingVote(error);
+                }
+            };
+
+            // Echo timeout if receive f+1 timeout message.
+            if !self.echo_timeout {
+                let f_plus_one = validator_verifier.total_voting_power()
+                    - validator_verifier.quorum_voting_power()
+                    + 1;
+                if tc_voting_power >= f_plus_one {
+                    self.echo_timeout = true;
+                    return VoteReceptionResult::EchoTimeout(tc_voting_power);
                 }
             }
         }
@@ -313,48 +330,66 @@ mod tests {
         ::aptos_logger::Logger::init_for_testing();
 
         // set up 4 validators
-        let (signers, validator) = random_validator_verifier(4, Some(2), false);
+        let (signers, validator) = random_validator_verifier(4, None, false);
         let mut pending_votes = PendingVotes::new();
 
         // submit a new vote from validator[0] -> VoteAdded
-        let li1 = random_ledger_info();
-        let vote1 = random_vote_data();
-        let mut vote1_author_0 = Vote::new(vote1, signers[0].author(), li1, &signers[0]);
+        let li0 = random_ledger_info();
+        let vote0 = random_vote_data();
+        let mut vote0_author_0 = Vote::new(vote0, signers[0].author(), li0, &signers[0]);
 
         assert_eq!(
-            pending_votes.insert_vote(&vote1_author_0, &validator),
+            pending_votes.insert_vote(&vote0_author_0, &validator),
             VoteReceptionResult::VoteAdded(1)
         );
 
         // submit the same vote but enhanced with a timeout -> VoteAdded
-        let timeout = vote1_author_0.generate_2chain_timeout(certificate_for_genesis());
+        let timeout = vote0_author_0.generate_2chain_timeout(certificate_for_genesis());
         let signature = timeout.sign(&signers[0]);
-        vote1_author_0.add_2chain_timeout(timeout, signature);
+        vote0_author_0.add_2chain_timeout(timeout, signature);
 
         assert_eq!(
-            pending_votes.insert_vote(&vote1_author_0, &validator),
+            pending_votes.insert_vote(&vote0_author_0, &validator),
             VoteReceptionResult::VoteAdded(1)
         );
 
         // another vote for a different block cannot form a TC if it doesn't have a timeout signature
-        let li2 = random_ledger_info();
-        let vote2 = random_vote_data();
-        let mut vote2_author_1 = Vote::new(vote2, signers[1].author(), li2, &signers[1]);
+        let li1 = random_ledger_info();
+        let vote1 = random_vote_data();
+        let mut vote1_author_1 = Vote::new(vote1, signers[1].author(), li1, &signers[1]);
         assert_eq!(
-            pending_votes.insert_vote(&vote2_author_1, &validator),
+            pending_votes.insert_vote(&vote1_author_1, &validator),
             VoteReceptionResult::VoteAdded(1)
         );
 
-        // if that vote is now enhanced with a timeout signature -> NewTimeoutCertificate
-        let timeout = vote2_author_1.generate_2chain_timeout(certificate_for_genesis());
+        // if that vote is now enhanced with a timeout signature -> EchoTimeout.
+        let timeout = vote1_author_1.generate_2chain_timeout(certificate_for_genesis());
         let signature = timeout.sign(&signers[1]);
-        vote2_author_1.add_2chain_timeout(timeout, signature);
-        match pending_votes.insert_vote(&vote2_author_1, &validator) {
+        vote1_author_1.add_2chain_timeout(timeout, signature);
+        match pending_votes.insert_vote(&vote1_author_1, &validator) {
+            VoteReceptionResult::EchoTimeout(voting_power) => {
+                assert_eq!(voting_power, 2);
+            }
+            _ => {
+                panic!("Should echo timeout");
+            }
+        };
+
+        let li2 = random_ledger_info();
+        let vote2 = random_vote_data();
+        let mut vote2_author_2 = Vote::new(vote2, signers[2].author(), li2, &signers[2]);
+
+        // if that vote is now enhanced with a timeout signature -> NewTimeoutCertificate.
+        let timeout = vote2_author_2.generate_2chain_timeout(certificate_for_genesis());
+        let signature = timeout.sign(&signers[2]);
+        vote2_author_2.add_2chain_timeout(timeout, signature);
+
+        match pending_votes.insert_vote(&vote2_author_2, &validator) {
             VoteReceptionResult::New2ChainTimeoutCertificate(tc) => {
                 assert!(validator.check_voting_power(tc.signers()).is_ok());
             }
             _ => {
-                panic!("No TC formed.");
+                panic!("Should form TC");
             }
         };
     }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -293,7 +293,6 @@ impl RoundManager {
                 proposal_msg.proposal().round(),
                 proposal_msg.sync_info(),
                 proposal_msg.proposer(),
-                true,
             )
             .await
             .context("[RoundManager] Process proposal")?
@@ -308,26 +307,9 @@ impl RoundManager {
         }
     }
 
-    /// Sync to the sync info sending from peer if it has newer certificates, if we have newer certificates
-    /// and help_remote is set, send it back the local sync info.
-    async fn sync_up(
-        &mut self,
-        sync_info: &SyncInfo,
-        author: Author,
-        help_remote: bool,
-    ) -> anyhow::Result<()> {
+    /// Sync to the sync info sending from peer if it has newer certificates.
+    async fn sync_up(&mut self, sync_info: &SyncInfo, author: Author) -> anyhow::Result<()> {
         let local_sync_info = self.block_store.sync_info();
-        if help_remote && local_sync_info.has_newer_certificates(sync_info) {
-            // TODO: we don't need to send them back if we're going to broadcast proposal with newer certificate
-            counters::SYNC_INFO_MSGS_SENT_COUNT.inc();
-            debug!(
-                self.new_log(LogEvent::HelpPeerSync).remote_peer(author),
-                "Remote peer has stale state {}, send it back {}", sync_info, local_sync_info,
-            );
-            self.network
-                .send_sync_info(local_sync_info.clone(), author)
-                .await;
-        }
         if sync_info.has_newer_certificates(&local_sync_info) {
             info!(
                 self.new_log(LogEvent::ReceiveNewCertificate)
@@ -370,12 +352,11 @@ impl RoundManager {
         message_round: Round,
         sync_info: &SyncInfo,
         author: Author,
-        help_remote: bool,
     ) -> anyhow::Result<bool> {
         if message_round < self.round_state.current_round() {
             return Ok(false);
         }
-        self.sync_up(sync_info, author, help_remote).await?;
+        self.sync_up(sync_info, author).await?;
         ensure!(
             message_round == self.round_state.current_round(),
             "After sync, round {} doesn't match local {}",
@@ -398,15 +379,9 @@ impl RoundManager {
             self.new_log(LogEvent::ReceiveSyncInfo).remote_peer(peer),
             "{}", sync_info
         );
-        // To avoid a ping-pong cycle between two peers that move forward together.
-        self.ensure_round_and_sync_up(
-            checked!((sync_info.highest_round()) + 1)?,
-            &sync_info,
-            peer,
-            false,
-        )
-        .await
-        .context("[RoundManager] Failed to process sync info msg")?;
+        self.ensure_round_and_sync_up(checked!((sync_info.highest_round()) + 1)?, &sync_info, peer)
+            .await
+            .context("[RoundManager] Failed to process sync info msg")?;
         Ok(())
     }
 
@@ -632,7 +607,6 @@ impl RoundManager {
                 vote_msg.vote().vote_data().proposed().round(),
                 vote_msg.sync_info(),
                 vote_msg.vote().author(),
-                true,
             )
             .await
             .context("[RoundManager] Stop processing vote")?

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -673,6 +673,7 @@ impl RoundManager {
             VoteReceptionResult::New2ChainTimeoutCertificate(tc) => {
                 self.new_2chain_tc_aggregated(tc).await
             }
+            VoteReceptionResult::EchoTimeout(_) => self.process_local_timeout(round).await,
             _ => Ok(()),
         }
     }

--- a/types/src/validator_verifier.rs
+++ b/types/src/validator_verifier.rs
@@ -19,13 +19,13 @@ pub enum VerifyError {
     /// The author for this signature is unknown by this validator.
     UnknownAuthor,
     #[error(
-        "The voting power ({}) is less than quorum voting power ({})",
+        "The voting power ({}) is less than expected voting power ({})",
         voting_power,
-        quorum_voting_power
+        expected_voting_power
     )]
     TooLittleVotingPower {
         voting_power: u64,
-        quorum_voting_power: u64,
+        expected_voting_power: u64,
     },
     #[error(
         "The number of signatures ({}) is greater than total number of authors ({})",
@@ -215,6 +215,7 @@ impl ValidatorVerifier {
         }
         Ok(())
     }
+
     /// Ensure there is at least quorum_voting_power in the provided signatures and there
     /// are only known authors. According to the threshold verification policy,
     /// invalid public keys are not allowed.
@@ -234,7 +235,7 @@ impl ValidatorVerifier {
         if aggregated_voting_power < self.quorum_voting_power {
             return Err(VerifyError::TooLittleVotingPower {
                 voting_power: aggregated_voting_power,
-                quorum_voting_power: self.quorum_voting_power,
+                expected_voting_power: self.quorum_voting_power,
             });
         }
         Ok(())
@@ -274,6 +275,11 @@ impl ValidatorVerifier {
     /// Returns quorum voting power.
     pub fn quorum_voting_power(&self) -> u64 {
         self.quorum_voting_power
+    }
+
+    /// Returns total voting power.
+    pub fn total_voting_power(&self) -> u64 {
+        self.total_voting_power
     }
 }
 
@@ -390,7 +396,7 @@ mod tests {
                 .unwrap_err(),
             VerifyError::TooLittleVotingPower {
                 voting_power: 0,
-                quorum_voting_power: 2,
+                expected_voting_power: 2,
             }
         );
 
@@ -514,7 +520,7 @@ mod tests {
                 .batch_verify_aggregated_signatures(&dummy_struct, &author_to_signature_map),
             Err(VerifyError::TooLittleVotingPower {
                 voting_power: 4,
-                quorum_voting_power: 5
+                expected_voting_power: 5
             })
         );
 
@@ -641,7 +647,7 @@ mod tests {
                 .batch_verify_aggregated_signatures(&dummy_struct, &author_to_signature_map),
             Err(VerifyError::TooLittleVotingPower {
                 voting_power: 3,
-                quorum_voting_power: 5
+                expected_voting_power: 5
             })
         );
 


### PR DESCRIPTION
This change removes the help_remote behavior and adds echo timeout instead.

The problem of help_remote is during vote or timeout, the first 2f+1 messages will advance the round by 1 and we'll bounce off a sync info message back for the rest f messages unnecessarily.G

Echo timeout is part of the bracha broadcast protocol that we immediately timeout if receive f+1 timeout messages (at least 1 honest).

This can help the scenario that node A is behind and everyone else is timing out, when node A receive the timeout, it'll first enter the round and wait for the whole timeout period to actually timeout the round. With echo timeout, node A would immediately timeout after receive f+1 timeout message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2095)
<!-- Reviewable:end -->
