### PR TITLE
observability: add honeycomb sink to vector

### DIFF
--- a/terraform/helm/vector-daemonset/example-values/honeycomb-sink.yaml
+++ b/terraform/helm/vector-daemonset/example-values/honeycomb-sink.yaml
@@ -1,0 +1,17 @@
+logging_sinks:
+  honeycomb:
+    type: honeycomb
+    inputs:
+      - k8s_logs
+    api_key: ${HONEYCOMB_API_KEY:?err}
+    dataset: k8s
+
+### PREREQUESITE: create a kubernetes secret via
+### kubectl create secret generic honeycomb-credentials --namespace vector --from-literal=HONEYCOMB_API_KEY=<YOUR_HONEYCOMB_API_KEY>
+env:
+  honeycomb:
+    - name: HONEYCOMB_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: honeycomb-credentials
+          key: HONEYCOMB_API_KEY


### PR DESCRIPTION
### Description

Adds a honeycomb sink to the vector daemonset.
Also some improvements to run_forge.sh which previously implicitly expected the kubectl context to be on the `default` namespace. Now it also works when the kubectl context is set to a different namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2097)
<!-- Reviewable:end -->
