### PR TITLE
[smoke-tests] Minimizing node restarts in local swarm smoke tests

### DIFF
--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::{Factory, GenesisConfig, Result, Swarm, Version};
 use anyhow::{bail, Context};
+use aptos_genesis::builder::InitConfigFn;
 use rand::rngs::StdRng;
 use std::{
     collections::HashMap,
@@ -112,7 +113,7 @@ impl LocalFactory {
         R: ::rand::RngCore + ::rand::CryptoRng,
     {
         let version = self.versions.keys().max().unwrap();
-        self.new_swarm_with_version(rng, number_of_validators, version, None, 1)
+        self.new_swarm_with_version(rng, number_of_validators, version, None, 1, None)
             .await
     }
 
@@ -123,6 +124,7 @@ impl LocalFactory {
         version: &Version,
         genesis_modules: Option<Vec<Vec<u8>>>,
         min_price_per_gas_unit: u64,
+        init_config: Option<InitConfigFn>,
     ) -> Result<LocalSwarm>
     where
         R: ::rand::RngCore + ::rand::CryptoRng,
@@ -130,7 +132,8 @@ impl LocalFactory {
         let mut builder = LocalSwarm::builder(self.versions.clone())
             .number_of_validators(number_of_validators)
             .initial_version(version.clone())
-            .min_price_per_gas_unit(min_price_per_gas_unit);
+            .min_price_per_gas_unit(min_price_per_gas_unit)
+            .with_init_config(init_config);
         if let Some(genesis_modules) = genesis_modules {
             builder = builder.genesis_modules(genesis_modules);
         }
@@ -169,7 +172,7 @@ impl Factory for LocalFactory {
             None => None,
         };
         let swarm = self
-            .new_swarm_with_version(rng, node_num, version, genesis_modules, 1)
+            .new_swarm_with_version(rng, node_num, version, genesis_modules, 1, None)
             .await?;
 
         Ok(Box::new(swarm))

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{FullNode, HealthCheckError, LocalVersion, Node, NodeExt, Validator, Version};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use aptos_config::config::NodeConfig;
 use aptos_logger::debug;
 use aptos_sdk::types::{account_address::AccountAddress, PeerId};
@@ -81,6 +81,8 @@ impl LocalNode {
     }
 
     pub fn start(&mut self) -> Result<()> {
+        ensure!(self.process.is_none(), "node {} already running", self.name);
+
         // Ensure log file exists
         let log_file = OpenOptions::new()
             .create(true)

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_genesis::builder::InitConfigFn;
 use forge::{Factory, LocalFactory, LocalSwarm};
 use once_cell::sync::Lazy;
 use rand::rngs::OsRng;
@@ -9,6 +10,7 @@ use std::num::NonZeroUsize;
 pub async fn new_local_swarm(
     num_validators: usize,
     genesis_modules: Option<Vec<Vec<u8>>>,
+    init_config: Option<InitConfigFn>,
 ) -> LocalSwarm {
     static FACTORY: Lazy<LocalFactory> = Lazy::new(|| LocalFactory::from_workspace().unwrap());
 
@@ -23,6 +25,7 @@ pub async fn new_local_swarm(
             genesis_modules,
             // TODO: migrate to > 0
             0,
+            init_config,
         )
         .await
         .unwrap()
@@ -33,6 +36,33 @@ pub async fn new_local_swarm_with_aptos(num_validators: usize) -> LocalSwarm {
     new_local_swarm(
         num_validators,
         Some(cached_framework_packages::module_blobs().to_vec()),
+        None,
     )
     .await
+}
+
+// Gas is not enabled with this setup, it's enabled via forge instance.
+pub async fn new_local_swarm_with_aptos_and_config(
+    num_validators: usize,
+    init_config: InitConfigFn,
+) -> LocalSwarm {
+    new_local_swarm(
+        num_validators,
+        Some(cached_framework_packages::module_blobs().to_vec()),
+        Some(init_config),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn test_prevent_starting_nodes_twice() {
+    // Create a validator swarm of 1 validator node
+    let mut swarm = new_local_swarm_with_aptos(1).await;
+
+    assert!(swarm.launch().await.is_err());
+    let validator = swarm.validators_mut().next().unwrap();
+    assert!(validator.start().is_err());
+    validator.stop();
+    assert!(validator.start().is_ok());
+    assert!(validator.start().is_err());
 }

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    smoke_test_environment::new_local_swarm_with_aptos,
+    smoke_test_environment::{new_local_swarm_with_aptos, new_local_swarm_with_aptos_and_config},
     test_utils::{create_and_fund_account, transfer_and_reconfig, transfer_coins},
 };
 use aptos_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
@@ -14,6 +14,7 @@ use aptosdb::{LEDGER_DB_NAME, STATE_MERKLE_DB_NAME};
 use forge::{LocalSwarm, NodeExt, Swarm, SwarmExt};
 use std::{
     fs,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -195,17 +196,17 @@ async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_c
 #[tokio::test]
 async fn test_validator_bootstrap_outputs() {
     // Create a swarm of 4 validators with state sync v2 enabled (output syncing)
-    let mut swarm = new_local_swarm_with_aptos(4).await;
-    for validator in swarm.validators_mut() {
-        let mut config = validator.config().clone();
-        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
-        config.state_sync.state_sync_driver.bootstrapping_mode =
-            BootstrappingMode::ApplyTransactionOutputsFromGenesis;
-        config.state_sync.state_sync_driver.continuous_syncing_mode =
-            ContinuousSyncingMode::ApplyTransactionOutputs;
-        config.save(validator.config_path()).unwrap();
-        validator.restart().await.unwrap();
-    }
+    let swarm = new_local_swarm_with_aptos_and_config(
+        4,
+        Arc::new(|_, config| {
+            config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::ApplyTransactionOutputsFromGenesis;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ApplyTransactionOutputs;
+        }),
+    )
+    .await;
 
     // Test the ability of the validators to sync
     test_validator_sync(swarm).await;
@@ -214,17 +215,17 @@ async fn test_validator_bootstrap_outputs() {
 #[tokio::test]
 async fn test_validator_bootstrap_transactions() {
     // Create a swarm of 4 validators with state sync v2 enabled (transaction syncing)
-    let mut swarm = new_local_swarm_with_aptos(4).await;
-    for validator in swarm.validators_mut() {
-        let mut config = validator.config().clone();
-        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
-        config.state_sync.state_sync_driver.bootstrapping_mode =
-            BootstrappingMode::ExecuteTransactionsFromGenesis;
-        config.state_sync.state_sync_driver.continuous_syncing_mode =
-            ContinuousSyncingMode::ExecuteTransactions;
-        config.save(validator.config_path()).unwrap();
-        validator.restart().await.unwrap();
-    }
+    let swarm = new_local_swarm_with_aptos_and_config(
+        4,
+        Arc::new(|_, config| {
+            config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::ExecuteTransactionsFromGenesis;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ExecuteTransactions;
+        }),
+    )
+    .await;
 
     // Test the ability of the validators to sync
     test_validator_sync(swarm).await;
@@ -233,9 +234,6 @@ async fn test_validator_bootstrap_transactions() {
 /// A helper method that tests that a validator can sync after a failure and
 /// continue to stay up-to-date.
 async fn test_validator_sync(mut swarm: LocalSwarm) {
-    // Launch the swarm and wait for it to be ready
-    swarm.launch().await.unwrap();
-
     // Execute multiple transactions through validator 0
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let validator_client_0 = swarm
@@ -285,17 +283,17 @@ async fn test_validator_sync(mut swarm: LocalSwarm) {
 async fn test_validator_failure_bootstrap_outputs() {
     // Create a swarm of 4 validators with state sync v2 enabled (account
     // bootstrapping and transaction output application).
-    let mut swarm = new_local_swarm_with_aptos(4).await;
-    for validator in swarm.validators_mut() {
-        let mut config = validator.config().clone();
-        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
-        config.state_sync.state_sync_driver.bootstrapping_mode =
-            BootstrappingMode::DownloadLatestStates;
-        config.state_sync.state_sync_driver.continuous_syncing_mode =
-            ContinuousSyncingMode::ApplyTransactionOutputs;
-        config.save(validator.config_path()).unwrap();
-        validator.restart().await.unwrap();
-    }
+    let swarm = new_local_swarm_with_aptos_and_config(
+        4,
+        Arc::new(|_, config| {
+            config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::DownloadLatestStates;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ApplyTransactionOutputs;
+        }),
+    )
+    .await;
 
     // Test the ability of the validators to sync
     test_all_validator_failures(swarm).await;
@@ -305,17 +303,17 @@ async fn test_validator_failure_bootstrap_outputs() {
 async fn test_validator_failure_bootstrap_execution() {
     // Create a swarm of 4 validators with state sync v2 enabled (account
     // bootstrapping and transaction execution).
-    let mut swarm = new_local_swarm_with_aptos(4).await;
-    for validator in swarm.validators_mut() {
-        let mut config = validator.config().clone();
-        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
-        config.state_sync.state_sync_driver.bootstrapping_mode =
-            BootstrappingMode::DownloadLatestStates;
-        config.state_sync.state_sync_driver.continuous_syncing_mode =
-            ContinuousSyncingMode::ExecuteTransactions;
-        config.save(validator.config_path()).unwrap();
-        validator.restart().await.unwrap();
-    }
+    let swarm = new_local_swarm_with_aptos_and_config(
+        4,
+        Arc::new(|_, config| {
+            config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::DownloadLatestStates;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ExecuteTransactions;
+        }),
+    )
+    .await;
 
     // Test the ability of the validators to sync
     test_all_validator_failures(swarm).await;
@@ -324,9 +322,6 @@ async fn test_validator_failure_bootstrap_execution() {
 /// A helper method that tests that all validators can sync after a failure and
 /// continue to stay up-to-date.
 async fn test_all_validator_failures(mut swarm: LocalSwarm) {
-    // Launch the swarm and wait for it to be ready
-    swarm.launch().await.unwrap();
-
     // Execute multiple transactions through validator 0
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let validator_0 = validator_peer_ids[0];
@@ -384,16 +379,13 @@ async fn test_all_validator_failures(mut swarm: LocalSwarm) {
 #[ignore]
 async fn test_single_validator_failure() {
     // Create a swarm of 1 validator
-    let mut swarm = new_local_swarm_with_aptos(1).await;
-    swarm.launch().await.unwrap();
-
-    // Enable state sync v2 and reboot the node
-    let validator = swarm.validators_mut().next().unwrap();
-    let mut config = validator.config().clone();
-    config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
-    config.save(validator.config_path()).unwrap();
-    validator.stop();
-    swarm.launch().await.unwrap();
+    let mut swarm = new_local_swarm_with_aptos_and_config(
+        1,
+        Arc::new(|_, mut config| {
+            config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+        }),
+    )
+    .await;
 
     // Execute multiple transactions
     let validator = swarm.validators_mut().next().unwrap();
@@ -411,7 +403,8 @@ async fn test_single_validator_failure() {
     // Restart the validator
     let validator = swarm.validators_mut().next().unwrap();
     validator.stop();
-    swarm.launch().await.unwrap();
+    validator.start().unwrap();
+    swarm.wait_all_alive(Duration::from_secs(20)).await.unwrap();
 
     // Execute more transactions
     execute_transactions(


### PR DESCRIPTION
### Description
    - Allowing setting (per-node) validator configuration,
      so that we don't need to restart the node to do so
    - disallowing starting already running nodes (which restarts them silently)
    
### Test Plan
    - all smoke tests. added test for not starting a node twice

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2098)
<!-- Reviewable:end -->
