### PR TITLE
[Aptos Framework] Update setters in stake and block modules to allow multiple actions in one governance proposal

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/block.move
+++ b/aptos-move/framework/aptos-framework/sources/block.move
@@ -52,7 +52,7 @@ module aptos_framework::block {
     /// Update the epoch interval.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_epoch_interval(
-        _gov_proposal: GovernanceProposal,
+        _gov_proposal: &GovernanceProposal,
         new_epoch_interval: u64,
     ) acquires BlockMetadata {
         let block_metadata = borrow_global_mut<BlockMetadata>(@aptos_framework);
@@ -114,5 +114,15 @@ module aptos_framework::block {
     public fun get_current_block_height(): u64 acquires BlockMetadata {
         assert!(is_initialized(), errors::not_published(EBLOCK_METADATA));
         borrow_global<BlockMetadata>(@aptos_framework).height
+    }
+
+    #[test(aptos_framework = @aptos_framework)]
+    public entry fun test_update_epoch_interval(aptos_framework: signer) acquires BlockMetadata {
+        use aptos_framework::governance_proposal;
+
+        initialize_block_metadata(&aptos_framework, 1);
+        assert!(borrow_global<BlockMetadata>(@aptos_framework).epoch_internal == 1, 0);
+        update_epoch_interval(&governance_proposal::create_test_proposal(), 2);
+        assert!(borrow_global<BlockMetadata>(@aptos_framework).epoch_internal == 2, 1);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/stake.move
@@ -314,7 +314,7 @@ module aptos_framework::stake {
     /// Update the min and max stake amounts.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_required_stake(
-        _gov_proposal: GovernanceProposal,
+        _gov_proposal: &GovernanceProposal,
         minimum_stake: u64,
         maximum_stake: u64,
     ) acquires ValidatorSetConfiguration {
@@ -328,7 +328,7 @@ module aptos_framework::stake {
     /// Update the min and max lockup duration.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_required_lockup(
-        _gov_proposal: GovernanceProposal,
+        _gov_proposal: &GovernanceProposal,
         min_lockup_duration_secs: u64,
         max_lockup_duration_secs: u64,
     ) acquires ValidatorSetConfiguration {
@@ -342,7 +342,7 @@ module aptos_framework::stake {
     /// Update the rewards rate.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_rewards_rate(
-        _gov_proposal: GovernanceProposal,
+        _gov_proposal: &GovernanceProposal,
         new_rewards_rate: u64,
         new_rewards_rate_denominator: u64,
     ) acquires ValidatorSetConfiguration {
@@ -1556,9 +1556,9 @@ module aptos_framework::stake {
 
         initialize_validator_set(&aptos_framework, 0, 1, 0, 1, false, 1, 1);
 
-        update_required_stake(governance_proposal::create_test_proposal(), 100, 1000);
-        update_required_lockup(governance_proposal::create_test_proposal(), 1000, 10000);
-        update_rewards_rate(governance_proposal::create_test_proposal(), 10, 100);
+        update_required_stake(&governance_proposal::create_test_proposal(), 100, 1000);
+        update_required_lockup(&governance_proposal::create_test_proposal(), 1000, 10000);
+        update_rewards_rate(&governance_proposal::create_test_proposal(), 10, 100);
         let config = borrow_global<ValidatorSetConfiguration>(@aptos_framework);
         assert!(config.minimum_stake == 100, 0);
         assert!(config.maximum_stake == 1000, 1);
@@ -1571,25 +1571,25 @@ module aptos_framework::stake {
     #[test]
     #[expected_failure(abort_code = 4359)]
     public entry fun test_update_required_stake_invalid_range_should_fail() acquires ValidatorSetConfiguration {
-        update_required_stake(governance_proposal::create_test_proposal(), 10, 5);
+        update_required_stake(&governance_proposal::create_test_proposal(), 10, 5);
     }
 
     #[test]
     #[expected_failure(abort_code = 4359)]
     public entry fun test_update_required_stake_zero_max_stake_should_fail() acquires ValidatorSetConfiguration {
-        update_required_stake(governance_proposal::create_test_proposal(), 0, 0);
+        update_required_stake(&governance_proposal::create_test_proposal(), 0, 0);
     }
 
     #[test]
     #[expected_failure(abort_code = 4615)]
     public entry fun test_update_required_lockup_invalid_range_should_fail() acquires ValidatorSetConfiguration {
-        update_required_lockup(governance_proposal::create_test_proposal(), 10, 5);
+        update_required_lockup(&governance_proposal::create_test_proposal(), 10, 5);
     }
 
     #[test]
     #[expected_failure(abort_code = 4615)]
     public entry fun test_update_required_lockup_zero_max_lockup_should_fail() acquires ValidatorSetConfiguration {
-        update_required_lockup(governance_proposal::create_test_proposal(), 0, 0);
+        update_required_lockup(&governance_proposal::create_test_proposal(), 0, 0);
     }
 
     #[test_only]


### PR DESCRIPTION
### Description

Currently setters such as stake::update_required_stake requires passing the GovernanceProposal object, which effectively consumes it in one call. This means that a governance proposal cannot invoke multiple setters in a single transaction script since the GovernanceProposal that voting::resolve returns can only used once.

This PR updates these functions to accept &GovernanceProposal instead so it can be reused in the same resolution script for multiple changes.

### Test Plan
Unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2101)
<!-- Reviewable:end -->
