### PR TITLE
[aptos-move] update to latest version to support K,V table indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1655,7 +1655,7 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4634,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4642,7 +4642,7 @@ dependencies = [
  "log",
  "move-bytecode-verifier",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-model",
  "serde 1.0.137",
 ]
@@ -4650,10 +4650,10 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -4665,18 +4665,18 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
  "move-binary-format",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-types",
  "move-symbol-pool",
  "serde 1.0.137",
@@ -4685,11 +4685,11 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "move-binary-format",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "petgraph 0.5.1",
  "serde-reflection 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -4697,19 +4697,19 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-borrow-graph",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "petgraph 0.5.1",
 ]
 
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "clap 3.2.11",
@@ -4726,7 +4726,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4742,7 +4742,7 @@ dependencies = [
  "move-bytecode-viewer",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-coverage",
  "move-disassembler",
  "move-errmapgen",
@@ -4767,12 +4767,12 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "difference",
  "hex",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "num-bigint 0.4.3",
  "serde 1.0.137",
  "sha2 0.9.9",
@@ -4782,7 +4782,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4795,7 +4795,7 @@ dependencies = [
  "move-bytecode-source-map",
  "move-bytecode-verifier",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-to-bytecode",
  "move-ir-types",
  "move-symbol-pool",
@@ -4806,23 +4806,6 @@ dependencies = [
  "sha3",
  "tempfile",
  "walkdir",
-]
-
-[[package]]
-name = "move-core-types"
-version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
-dependencies = [
- "anyhow",
- "bcs",
- "hex",
- "once_cell",
- "proptest",
- "proptest-derive",
- "rand 0.8.5",
- "ref-cast",
- "serde 1.0.137",
- "serde_bytes",
 ]
 
 [[package]]
@@ -4841,9 +4824,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-core-types"
+version = "0.0.4"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "hex",
+ "once_cell",
+ "proptest",
+ "proptest-derive",
+ "rand 0.8.5",
+ "ref-cast",
+ "serde 1.0.137",
+ "serde_bytes",
+]
+
+[[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4853,7 +4853,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
@@ -4871,7 +4871,7 @@ dependencies = [
  "move-cli",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-docgen",
  "move-errmapgen",
  "move-ir-compiler",
@@ -4894,7 +4894,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "clap 3.2.11",
@@ -4904,7 +4904,7 @@ dependencies = [
  "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-coverage",
  "move-ir-types",
 ]
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "codespan",
@@ -4930,13 +4930,13 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
  "log",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-model",
  "serde 1.0.137",
 ]
@@ -4955,7 +4955,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4964,7 +4964,7 @@ dependencies = [
  "move-bytecode-source-map",
  "move-bytecode-verifier",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-to-bytecode",
  "move-ir-types",
  "move-symbol-pool",
@@ -4974,7 +4974,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4982,7 +4982,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-to-bytecode-syntax",
  "move-ir-types",
  "move-symbol-pool",
@@ -4993,12 +4993,12 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "hex",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-types",
  "move-symbol-pool",
 ]
@@ -5006,12 +5006,12 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "hex",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-symbol-pool",
  "once_cell",
  "serde 1.0.137",
@@ -5020,7 +5020,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5033,7 +5033,7 @@ dependencies = [
  "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-disassembler",
  "move-ir-types",
  "move-symbol-pool",
@@ -5046,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5059,7 +5059,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-docgen",
  "move-model",
  "move-symbol-pool",
@@ -5079,7 +5079,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5095,7 +5095,7 @@ dependencies = [
  "move-binary-format",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-docgen",
  "move-errmapgen",
  "move-ir-types",
@@ -5116,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5127,7 +5127,7 @@ dependencies = [
  "log",
  "move-binary-format",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-model",
  "move-stackless-bytecode",
  "num 0.4.0",
@@ -5144,25 +5144,25 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "move-binary-format",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "serde 1.0.137",
 ]
 
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
  "hex",
  "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "once_cell",
  "serde 1.0.137",
 ]
@@ -5170,7 +5170,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -5183,7 +5183,7 @@ dependencies = [
  "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-to-bytecode",
  "move-model",
  "move-read-write-set-types",
@@ -5197,7 +5197,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -5205,7 +5205,7 @@ dependencies = [
  "codespan-reporting",
  "itertools",
  "move-binary-format",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-model",
  "move-stackless-bytecode",
  "num 0.4.0",
@@ -5215,14 +5215,14 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "log",
  "move-binary-format",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-docgen",
  "move-errmapgen",
  "move-prover",
@@ -5237,7 +5237,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "once_cell",
  "serde 1.0.137",
@@ -5246,13 +5246,13 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "bcs",
  "better_any",
  "move-binary-format",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",
@@ -5263,7 +5263,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "better_any",
@@ -5275,7 +5275,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-ir-types",
  "move-model",
  "move-resource-viewer",
@@ -5294,13 +5294,13 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "better_any",
  "fail 0.4.0",
  "move-binary-format",
  "move-bytecode-verifier",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-vm-types",
  "once_cell",
  "parking_lot 0.11.2",
@@ -5311,21 +5311,21 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-table-extension",
 ]
 
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "bcs",
  "move-binary-format",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "once_cell",
  "proptest",
  "serde 1.0.137",
@@ -6793,12 +6793,12 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-model",
  "move-read-write-set-types",
  "move-stackless-bytecode",
@@ -6808,12 +6808,12 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731#c51b11589554c6acfef15c74fca211def4ea0731"
+source = "git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c#f3c921433758340cb95075ae9918095878686d3c"
 dependencies = [
  "anyhow",
  "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=c51b11589554c6acfef15c74fca211def4ea0731)",
+ "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=f3c921433758340cb95075ae9918095878686d3c)",
  "move-read-write-set-types",
 ]
 

--- a/aptos-move/framework/aptos-framework/sources/table.move
+++ b/aptos-move/framework/aptos-framework/sources/table.move
@@ -23,7 +23,7 @@ module aptos_framework::table {
     /// Create a new Table.
     public fun new<K: copy + drop, V: store>(): Table<K, V> {
         Table{
-            handle: new_table_handle(),
+            handle: new_table_handle<K, V>(),
             length: 0,
         }
     }
@@ -103,7 +103,7 @@ module aptos_framework::table {
 
     // Primitives which take as an additional type parameter `Box<V>`, so the implementation
     // can use this to determine serialization layout.
-    native fun new_table_handle(): u128;
+    native fun new_table_handle<K, V>(): u128;
     native fun add_box<K: copy + drop, V, B>(table: &mut Table<K, V>, key: K, val: Box<V>);
     native fun borrow_box<K: copy + drop, V, B>(table: &Table<K, V>, key: K): &Box<V>;
     native fun borrow_box_mut<K: copy + drop, V, B>(table: &mut Table<K, V>, key: K): &mut Box<V>;

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -9,31 +9,31 @@ publish = false
 edition = "2018"
 
 [dependencies]
-move-abigen = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-cli = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-model = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-package = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-prover = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c51b11589554c6acfef15c74fca211def4ea0731" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-cli = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-model = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-package = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-prover = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "f3c921433758340cb95075ae9918095878686d3c" }
 
 [features]
 default = []


### PR DESCRIPTION
Per the title, this takes in the latest move so that we can record the K, V types in the new_tables and add that to an indexer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2102)
<!-- Reviewable:end -->
