### PR TITLE
[aptos-cli] Usability fixes to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "aptos-config",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -25,6 +25,7 @@ pub enum ConfigTool {
     Init(crate::common::init::InitTool),
     GenerateShellCompletions(GenerateShellCompletions),
     SetGlobalConfig(SetGlobalConfig),
+    ShowGlobalConfig(ShowGlobalConfig),
 }
 
 impl ConfigTool {
@@ -33,6 +34,7 @@ impl ConfigTool {
             ConfigTool::Init(tool) => tool.execute_serialized_success().await,
             ConfigTool::GenerateShellCompletions(tool) => tool.execute_serialized_success().await,
             ConfigTool::SetGlobalConfig(tool) => tool.execute_serialized_success().await,
+            ConfigTool::ShowGlobalConfig(tool) => tool.execute_serialized().await,
         }
     }
 }
@@ -95,6 +97,22 @@ impl CliCommand<()> for SetGlobalConfig {
         }
 
         config.save()
+    }
+}
+
+/// Shows the properties in the global config
+#[derive(Parser, Debug)]
+pub struct ShowGlobalConfig {}
+
+#[async_trait]
+impl CliCommand<GlobalConfig> for ShowGlobalConfig {
+    fn command_name(&self) -> &'static str {
+        "ShowGlobalConfig"
+    }
+
+    async fn execute(self) -> CliTypedResult<GlobalConfig> {
+        // Load the global config
+        GlobalConfig::load()
     }
 }
 

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -12,8 +12,12 @@ pub mod node;
 pub mod op;
 pub mod test;
 
-use crate::common::types::{CliCommand, CliResult};
+use crate::common::types::{CliCommand, CliResult, CliTypedResult};
+use async_trait::async_trait;
 use clap::Parser;
+use std::collections::BTreeMap;
+
+shadow_rs::shadow!(build);
 
 /// CLI tool for interacting with the Aptos blockchain and nodes
 ///
@@ -26,6 +30,7 @@ pub enum Tool {
     Config(config::ConfigTool),
     #[clap(subcommand)]
     Genesis(genesis::GenesisTool),
+    Info(InfoTool),
     Init(common::init::InitTool),
     #[clap(subcommand)]
     Key(op::key::KeyTool),
@@ -42,6 +47,7 @@ impl Tool {
             Account(tool) => tool.execute().await,
             Config(tool) => tool.execute().await,
             Genesis(tool) => tool.execute().await,
+            Info(tool) => tool.execute_serialized().await,
             // TODO: Replace entirely with config init
             Init(tool) => tool.execute_serialized_success().await,
             Key(tool) => tool.execute().await,
@@ -49,4 +55,54 @@ impl Tool {
             Node(tool) => tool.execute().await,
         }
     }
+}
+
+/// Show information about the build of the CLI
+///
+/// This is useful for debugging as well as determining what versions are compatible with the CLI
+#[derive(Parser)]
+pub struct InfoTool {}
+
+#[async_trait]
+impl CliCommand<BTreeMap<String, String>> for InfoTool {
+    fn command_name(&self) -> &'static str {
+        "GetCLIInfo"
+    }
+
+    async fn execute(self) -> CliTypedResult<BTreeMap<String, String>> {
+        let mut build_information: std::collections::BTreeMap<String, String> = BTreeMap::new();
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_BRANCH.into(),
+            build::BRANCH.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_CARGO_VERSION.into(),
+            build::CARGO_VERSION.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_COMMIT_HASH.into(),
+            build::COMMIT_HASH.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_OS.into(),
+            build::BUILD_OS.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_PKG_VERSION.into(),
+            build::PKG_VERSION.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_RUST_CHANNEL.into(),
+            build::RUST_CHANNEL.into(),
+        );
+        build_information.insert(
+            aptos_telemetry::build_information::BUILD_RUST_VERSION.into(),
+            build::RUST_VERSION.into(),
+        );
+        Ok(build_information)
+    }
+}
+
+pub fn build_commit_hash() -> String {
+    build::COMMIT_HASH.to_string()
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -122,7 +122,7 @@ name = \"{}\"
 version = \"0.0.0\"
 
 [dependencies]
-AptosFramework = {{ git = \"https://github.com/aptos-labs/aptos-core.git\", subdir = \"aptos-move/framework/aptos-framework/\", rev = \"main\" }}
+AptosFramework = {{ git = \"https://github.com/aptos-labs/aptos-core.git\", subdir = \"aptos-move/framework/aptos-framework/\", rev = \"devnet\" }}
 
 [addresses]
 {}


### PR DESCRIPTION
### Description
This should help us debug stuff and complete some features with the CLI.  I wanted to fix the fact that the move download is slow and that it doesn't always match, but I wasn't able to get that working quite yet.  Waiting on updates to package referencing.

### Test Plan
```
$ aptos info 
{
  "Result": {
    "build_branch": "main",
    "build_cargo_version": "cargo 1.61.0 (a028ae42f 2022-04-29)",
    "build_commit_hash": "1e7ab8569be65cefd78b2f44724831010ee8dbdc",
    "build_os": "macos-aarch64",
    "build_pkg_version": "0.2.0",
    "build_rust_channel": "1.61.0-aarch64-apple-darwin",
    "build_rust_version": "rustc 1.61.0 (fe5b13d68 2022-05-18)"
  }
}

$ aptos config show-global-config
{
  "Result": {
    "config_type": "Global"
  }
}

$ aptos move init --name test --package-dir tester
"tester/Move.toml" already exists, are you sure you want to overwrite it? [yes/no] >
yes
{
  "Result": "Success"
}
$ cat ./tester/Move.toml 
[package]
name = "test"
version = "0.0.0"

[dependencies]
AptosFramework = { git = "https://github.com/aptos-labs/aptos-core.git", subdir = "aptos-move/framework/aptos-framework/", rev = "devnet" }

[addresses]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2104)
<!-- Reviewable:end -->
