### PR TITLE
[telemetry] pass git revision info via env variables

### DIFF
--- a/crates/aptos-telemetry/src/build_information.rs
+++ b/crates/aptos-telemetry/src/build_information.rs
@@ -34,7 +34,7 @@ macro_rules! collect_build_information {
 
         // Get Git metadata from environment variables set during build-time.
         // This is applicable for docker based builds.
-        const GIT_COMMIT_HASH: Option<&str> = option_env!("GIT_COMMIT_HASH");
+        const GIT_SHA: Option<&str> = option_env!("GIT_SHA");
         const GIT_BRANCH: Option<&str> = option_env!("GIT_BRANCH");
         const GIT_TAG: Option<&str> = option_env!("GIT_TAG");
 
@@ -54,7 +54,7 @@ macro_rules! collect_build_information {
         );
         build_information.insert(
             aptos_telemetry::build_information::BUILD_COMMIT_HASH.into(),
-            GIT_COMMIT_HASH.unwrap_or(build::COMMIT_HASH).into(),
+            GIT_SHA.unwrap_or(build::COMMIT_HASH).into(),
         );
         build_information.insert(
             aptos_telemetry::build_information::BUILD_OS.into(),

--- a/crates/aptos-telemetry/src/build_information.rs
+++ b/crates/aptos-telemetry/src/build_information.rs
@@ -32,11 +32,17 @@ macro_rules! collect_build_information {
         // Get access to shadow BUILD information
         shadow_rs::shadow!(build);
 
+        // Get Git metadata from environment variables set during build-time.
+        // This is applicable for docker based builds.
+        const GIT_COMMIT_HASH: Option<&str> = option_env!("GIT_COMMIT_HASH");
+        const GIT_BRANCH: Option<&str> = option_env!("GIT_BRANCH");
+        const GIT_TAG: Option<&str> = option_env!("GIT_TAG");
+
         // Collect and return the build information
         let mut build_information: std::collections::BTreeMap<String, String> = BTreeMap::new();
         build_information.insert(
             aptos_telemetry::build_information::BUILD_BRANCH.into(),
-            build::BRANCH.into(),
+            GIT_BRANCH.unwrap_or(build::BRANCH).into(),
         );
         build_information.insert(
             aptos_telemetry::build_information::BUILD_CARGO_VERSION.into(),
@@ -48,7 +54,7 @@ macro_rules! collect_build_information {
         );
         build_information.insert(
             aptos_telemetry::build_information::BUILD_COMMIT_HASH.into(),
-            build::COMMIT_HASH.into(),
+            GIT_COMMIT_HASH.unwrap_or(build::COMMIT_HASH).into(),
         );
         build_information.insert(
             aptos_telemetry::build_information::BUILD_OS.into(),
@@ -72,7 +78,7 @@ macro_rules! collect_build_information {
         );
         build_information.insert(
             aptos_telemetry::build_information::BUILD_TAG.into(),
-            build::TAG.into(),
+            GIT_TAG.unwrap_or(build::TAG).into(),
         );
         build_information.insert(
             aptos_telemetry::build_information::BUILD_TARGET.into(),

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -47,7 +47,7 @@ target "builder" {
   cache-to   = generate_cache_to("builder")
   tags       = generate_tags("builder")
   args       = {
-    GIT_COMMIT_HASH = "${GIT_SHA}"
+    GIT_SHA = "${GIT_SHA}"
     GIT_BRANCH      = "${GIT_BRANCH}"
     GIT_TAG         = "${GIT_TAG}"
   }

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -16,6 +16,10 @@ variable "BUILD_DATE" {}
 // this is the full GIT_SHA - let's use that as primary identifier going forward
 variable "GIT_SHA" {}
 
+variable "GIT_BRANCH" {}
+
+variable "GIT_TAG" {}
+
 variable "LAST_GREEN_COMMIT" {}
 
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
@@ -42,6 +46,11 @@ target "builder" {
   cache-from = generate_cache_from("builder")
   cache-to   = generate_cache_to("builder")
   tags       = generate_tags("builder")
+  args       = {
+    GIT_COMMIT_HASH = "${GIT_SHA}"
+    GIT_BRANCH      = "${GIT_BRANCH}"
+    GIT_TAG         = "${GIT_TAG}"
+  }
 }
 
 group "all" {

--- a/docker/docker-bake-rust-all.sh
+++ b/docker/docker-bake-rust-all.sh
@@ -12,6 +12,8 @@
 set -ex
 
 export GIT_SHA=$(git rev-parse HEAD)
+export GIT_BRANCH=$(git symbolic-ref --short HEAD)
+export GIT_TAG=$(git tag -l --contains HEAD)
 export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
 if [ "$CI" == "true" ]; then

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-
 FROM rust-base as builder
 COPY --link . /aptos/
 
-ARG GIT_COMMIT_HASH
-ENV GIT_COMMIT_HASH ${GIT_COMMIT_HASH}
+ARG GIT_SHA
+ENV GIT_SHA ${GIT_SHA}
 
 ARG GIT_BRANCH
 ENV GIT_BRANCH ${GIT_BRANCH}

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -9,6 +9,16 @@ RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-
 ### Build Rust code ###
 FROM rust-base as builder
 COPY --link . /aptos/
+
+ARG GIT_COMMIT_HASH
+ENV GIT_COMMIT_HASH ${GIT_COMMIT_HASH}
+
+ARG GIT_BRANCH
+ENV GIT_BRANCH ${GIT_BRANCH}
+
+ARG GIT_TAG
+ENV GIT_TAG ${GIT_TAG}
+
 RUN --mount=type=cache,target=/aptos/target --mount=type=cache,target=$CARGO_HOME/registry docker/build-rust-all.sh && rm -rf $CARGO_HOME/registry/index
 
 ### Validator Image ###


### PR DESCRIPTION
### Description

Fixes #2109 

**Issue:** The docker image build flow ignores the .git/ repository from docker build context which `shadow_rs` uses to extract git revision info including commit hash consumed and emitted by the telemetry-service's metrics.

**Fix:** Set Git metadata as environment variable in `Dockerfile` and consume it within the telemetry-service.

- Adds three arguments ARGs  and environment variables ENVs to Dockerfile: `GIT_COMMIT_HASH`, `GIT_BRANCH`, and `GIT_TAG`.
- Modifies the `docker-bake-rust-all.sh` to define these arguments and pass then to the buildx bake definition `docker-bake-rust-all.hcl`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
- Add a `println!` to print [`build_information`](https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-telemetry/src/build_information.rs#L113)
- Build a container by `./docker/docker-bake-rust-all.sh builder`
- Run the container locally: `docker run -it aptos-core/builder:from-local /aptos/dist/aptos-node --test`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2110)
<!-- Reviewable:end -->
