### PR TITLE
[forge] swarm network chaos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,4 +18,4 @@
 !ecosystem/indexer/migrations/**/*.sql
 !terraform/helm/aptos-node/
 !terraform/helm/genesis/
-!testsuite/forge/src/backend/k8s/helm-values
+!testsuite/forge/src/backend/k8s/

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -96,7 +96,6 @@ impl<'t> AccountMinter<'t> {
             "Minting additional {} accounts with {} coins each",
             num_accounts, coins_per_account
         );
-        // tokio::time::sleep(Duration::from_secs(10)).await;
 
         let seed_rngs = gen_rng_for_reusable_account(actual_num_seed_accounts);
         // For each seed account, create a future and transfer coins from that seed account to new accounts

--- a/testsuite/forge/src/backend/k8s/chaos.rs
+++ b/testsuite/forge/src/backend/k8s/chaos.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use crate::{
+    dump_string_to_file, Result, SwarmChaos, SwarmNetworkBandwidth, SwarmNetworkDelay,
+    SwarmNetworkPartition, KUBECTL_BIN,
+};
+
+macro_rules! DELAY_NETWORK_CHAOS_TEMPLATE {
+    () => {
+        "chaos/network_delay.yaml"
+    };
+}
+macro_rules! PARTITION_NETWORK_CHAOS_TEMPLATE {
+    () => {
+        "chaos/network_partition.yaml"
+    };
+}
+macro_rules! BANDWIDTH_NETWORK_CHAOS_TEMPLATE {
+    () => {
+        "chaos/network_bandwidth.yaml"
+    };
+}
+
+/// Injects the SwarmChaos into the specified namespace
+pub fn inject_swarm_chaos(kube_namespace: &str, chaos: &SwarmChaos) -> Result<()> {
+    let template = create_chaos_template(kube_namespace, chaos)?;
+    inject_chaos_template(kube_namespace, template)
+}
+
+/// Removes the SwarmChaos from the specified namespace, if it exists
+pub fn remove_swarm_chaos(kube_namespace: &str, chaos: &SwarmChaos) -> Result<()> {
+    let template = create_chaos_template(kube_namespace, chaos)?;
+    remove_chaos_template(kube_namespace, template)
+}
+
+fn create_network_delay_template(
+    kube_namespace: &str,
+    swarm_network_delay: &SwarmNetworkDelay,
+) -> String {
+    format!(
+        include_str!(DELAY_NETWORK_CHAOS_TEMPLATE!()),
+        namespace = kube_namespace,
+        latency_ms = swarm_network_delay.latency_ms,
+        jitter_ms = swarm_network_delay.jitter_ms,
+        correlation_percentage = swarm_network_delay.correlation_percentage,
+    )
+}
+
+fn create_network_partition_template(
+    kube_namespace: &str,
+    swarm_network_partition: &SwarmNetworkPartition,
+) -> String {
+    format!(
+        include_str!(PARTITION_NETWORK_CHAOS_TEMPLATE!()),
+        namespace = kube_namespace,
+        partition_percentage = swarm_network_partition.partition_percentage
+    )
+}
+
+fn create_network_bandwidth_template(
+    kube_namespace: &str,
+    swarm_network_bandwidth: &SwarmNetworkBandwidth,
+) -> String {
+    format!(
+        include_str!(BANDWIDTH_NETWORK_CHAOS_TEMPLATE!()),
+        namespace = kube_namespace,
+        rate = swarm_network_bandwidth.rate,
+        limit = swarm_network_bandwidth.limit,
+        buffer = swarm_network_bandwidth.buffer
+    )
+}
+
+fn create_chaos_template(kube_namespace: &str, chaos: &SwarmChaos) -> Result<String> {
+    let template = match chaos {
+        SwarmChaos::Delay(c) => create_network_delay_template(kube_namespace, c),
+        SwarmChaos::Partition(c) => create_network_partition_template(kube_namespace, c),
+        SwarmChaos::Bandwidth(c) => create_network_bandwidth_template(kube_namespace, c),
+    };
+    Ok(template)
+}
+
+/// Creates and applies the NetworkChaos CRD
+fn inject_chaos_template(kube_namespace: &str, chaos_template: String) -> Result<()> {
+    let tmp_dir = TempDir::new().expect("Could not create temp dir");
+    let latency_network_chaos_file_path = dump_string_to_file(
+        format!("{}-chaos.yaml", kube_namespace),
+        chaos_template,
+        &tmp_dir,
+    )?;
+    Command::new(KUBECTL_BIN)
+        .args([
+            "-n",
+            kube_namespace,
+            "apply",
+            "-f",
+            &latency_network_chaos_file_path,
+        ])
+        .status()
+        .expect("Failed to submit chaos template");
+
+    Ok(())
+}
+
+/// Removes the NetworkChaos CRD
+fn remove_chaos_template(kube_namespace: &str, chaos_template: String) -> Result<()> {
+    let tmp_dir = TempDir::new().expect("Could not create temp dir");
+    let latency_network_chaos_file_path = dump_string_to_file(
+        format!("{}-chaos.yaml", kube_namespace),
+        chaos_template,
+        &tmp_dir,
+    )?;
+    Command::new(KUBECTL_BIN)
+        .args([
+            "-n",
+            kube_namespace,
+            "delete",
+            "-f",
+            &latency_network_chaos_file_path,
+        ])
+        .status()
+        .expect("Failed to delete chaos by template");
+
+    Ok(())
+}

--- a/testsuite/forge/src/backend/k8s/chaos/network_bandwidth.yaml
+++ b/testsuite/forge/src/backend/k8s/chaos/network_bandwidth.yaml
@@ -1,0 +1,17 @@
+kind: NetworkChaos
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  namespace: {namespace}
+  name: forge-namespace-{rate}mbps-bandwidth
+spec:
+  action: bandwidth
+  mode: all
+  selector:
+    namespaces:
+      - {namespace}
+    labelSelectors:
+      app.kubernetes.io/name: validator
+  bandwidth:
+    rate: "{rate}mbps"
+    limit: {limit}
+    buffer: {buffer}

--- a/testsuite/forge/src/backend/k8s/chaos/network_delay.yaml
+++ b/testsuite/forge/src/backend/k8s/chaos/network_delay.yaml
@@ -1,0 +1,25 @@
+kind: NetworkChaos
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  namespace: {namespace}
+  name: forge-namespace-{latency_ms}ms-latency
+spec:
+  selector:
+    namespaces:
+      - {namespace}
+    labelSelectors:
+      app.kubernetes.io/name: validator
+  mode: all
+  action: delay
+  delay:
+    latency: "{latency_ms}ms"
+    correlation: "{correlation_percentage}"
+    jitter: "{jitter_ms}ms"
+  direction: both
+  target:
+    selector:
+      namespaces:
+        - {namespace}
+      labelSelectors:
+        app.kubernetes.io/name: validator
+    mode: all

--- a/testsuite/forge/src/backend/k8s/chaos/network_partition.yaml
+++ b/testsuite/forge/src/backend/k8s/chaos/network_partition.yaml
@@ -1,0 +1,22 @@
+kind: NetworkChaos
+apiVersion: chaos-mesh.org/v1alpha1
+metadata:
+  namespace: {namespace}
+  name: forge-namespace-{partition_percentage}-percent-partition
+spec:
+  selector:
+    namespaces:
+      - {namespace}
+    labelSelectors:
+      app.kubernetes.io/name: validator
+  mode: all
+  action: partition
+  direction: both
+  target:
+    selector:
+      namespaces:
+        - {namespace}
+      labelSelectors:
+        app.kubernetes.io/name: validator
+    mode: fixed-percent
+    value: "{partition_percentage}"

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -7,8 +7,9 @@ use aptos_logger::info;
 use rand::rngs::StdRng;
 use std::{convert::TryInto, num::NonZeroUsize};
 
+pub mod chaos;
 mod cluster_helper;
-mod node;
+pub mod node;
 mod swarm;
 
 pub use cluster_helper::*;

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ChainInfo, FullNode, HealthCheckError, LocalNode, LocalVersion, Node, NodeExt, Swarm, SwarmExt,
-    Validator, Version,
+    ChainInfo, FullNode, HealthCheckError, LocalNode, LocalVersion, Node, NodeExt, Swarm,
+    SwarmChaos, SwarmExt, Validator, Version,
 };
 use anyhow::{anyhow, bail, Result};
 use aptos_config::{config::NodeConfig, keys::ConfigKey};
@@ -523,5 +523,13 @@ impl Swarm for LocalSwarm {
     fn logs_location(&mut self) -> String {
         self.dir.persist();
         self.dir.display().to_string()
+    }
+
+    fn inject_chaos(&mut self, _chaos: SwarmChaos) -> Result<()> {
+        todo!()
+    }
+
+    fn remove_chaos(&mut self, _chaos: SwarmChaos) -> Result<()> {
+        todo!()
     }
 }

--- a/testsuite/forge/src/interface/chaos.rs
+++ b/testsuite/forge/src/interface/chaos.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub enum SwarmChaos {
+    Delay(SwarmNetworkDelay),
+    Partition(SwarmNetworkPartition),
+    Bandwidth(SwarmNetworkBandwidth),
+}
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub enum NodeChaos {
+    NodeNetworkDelayChaos(NodeNetworkDelay),
+}
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct SwarmNetworkDelay {
+    pub latency_ms: u64,
+    pub jitter_ms: u64,
+    pub correlation_percentage: u64,
+}
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct SwarmNetworkPartition {
+    pub partition_percentage: u64,
+}
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct SwarmNetworkBandwidth {
+    pub rate: u64,
+    pub limit: u64,
+    pub buffer: u64,
+}
+
+#[derive(Eq, Hash, PartialEq, Debug, Clone)]
+pub struct NodeNetworkDelay {
+    pub latency_ms: u64,
+}

--- a/testsuite/forge/src/interface/mod.rs
+++ b/testsuite/forge/src/interface/mod.rs
@@ -13,6 +13,8 @@ mod factory;
 pub use factory::*;
 mod swarm;
 pub use swarm::*;
+mod chaos;
+pub use chaos::*;
 mod node;
 pub use node::*;
 mod chain_info;

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ChainInfo, FullNode, NodeExt, Result, Validator, Version};
+use crate::{ChainInfo, FullNode, NodeExt, Result, SwarmChaos, Validator, Version};
 use anyhow::{anyhow, bail};
 use aptos_config::config::NodeConfig;
 use aptos_rest_client::Client as RestClient;
@@ -63,6 +63,10 @@ pub trait Swarm: Sync {
     fn chain_info(&mut self) -> ChainInfo<'_>;
 
     fn logs_location(&mut self) -> String;
+
+    /// Injects all types of chaos
+    fn inject_chaos(&mut self, chaos: SwarmChaos) -> Result<()>;
+    fn remove_chaos(&mut self, chaos: SwarmChaos) -> Result<()>;
 }
 
 impl<T: ?Sized> SwarmExt for T where T: Swarm {}

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -91,8 +91,7 @@ if [ "$FORGE_RUNNER_MODE" = "local" ]; then
     # more file descriptors for heavy txn generation
     ulimit -n 1048576
 
-    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 \
-	test k8s-swarm 
+    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 test k8s-swarm \
         --image-tag $IMAGE_TAG \
         --namespace $FORGE_NAMESPACE \
         --port-forward $REUSE_ARGS $KEEP_ARGS $ENABLE_HAPROXY_ARGS | tee $FORGE_OUTPUT

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod compatibility_test;
 pub mod fixed_tps_test;
 pub mod gas_price_test;
+pub mod network_chaos_test;
 pub mod partial_nodes_down_test;
 pub mod performance_test;
 pub mod reconfiguration_test;

--- a/testsuite/testcases/src/network_chaos_test.rs
+++ b/testsuite/testcases/src/network_chaos_test.rs
@@ -1,0 +1,102 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use crate::generate_traffic;
+use forge::{
+    NetworkContext, NetworkTest, Result, SwarmChaos, SwarmNetworkBandwidth, SwarmNetworkDelay,
+    SwarmNetworkPartition, Test,
+};
+
+pub struct NetworkChaosTest;
+
+// Delay
+pub const LATENCY_MS: u64 = 80;
+pub const JITTER_MS: u64 = 20;
+pub const CORRELATION_PERCENTAGE: u64 = 10;
+
+// Bandwidth
+// Indicates the rate of bandwidth limit
+pub const RATE_MBPS: u64 = 100;
+// Indicates the number of bytes waiting in queue
+pub const LIMIT_BYTES: u64 = 20971520;
+// Indicates the maximum number of bytes that can be sent instantaneously
+pub const BUFFER_BYTES: u64 = 10000;
+
+// Partition
+pub const PARTITION_PERCENTAGE: u64 = 30;
+
+impl Test for NetworkChaosTest {
+    fn name(&self) -> &'static str {
+        "network::inject-chaos"
+    }
+}
+
+impl NetworkTest for NetworkChaosTest {
+    fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        // test each phase with 30s txn emission
+        let duration = Duration::from_secs(30);
+        let delay = SwarmChaos::Delay(SwarmNetworkDelay {
+            latency_ms: LATENCY_MS,
+            jitter_ms: JITTER_MS,
+            correlation_percentage: CORRELATION_PERCENTAGE,
+        });
+        let bandwidth = SwarmChaos::Bandwidth(SwarmNetworkBandwidth {
+            rate: RATE_MBPS,
+            limit: LIMIT_BYTES,
+            buffer: BUFFER_BYTES,
+        });
+        let partition = SwarmChaos::Partition(SwarmNetworkPartition {
+            partition_percentage: PARTITION_PERCENTAGE,
+        });
+
+        // emit to all validator
+        let all_validators = ctx
+            .swarm()
+            .validators()
+            .map(|v| v.peer_id())
+            .collect::<Vec<_>>();
+
+        // INJECT DELAY AND EMIT TXNS
+        ctx.swarm().inject_chaos(delay.clone())?;
+        let msg = format!(
+            "Injected {}ms +- {}ms with {}% correlation latency to namespace",
+            LATENCY_MS, JITTER_MS, CORRELATION_PERCENTAGE
+        );
+        println!("{}", msg);
+        ctx.report.report_text(msg);
+        let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
+        ctx.report
+            .report_txn_stats(format!("{}:delay", self.name()), txn_stat, duration);
+        ctx.swarm().remove_chaos(delay)?;
+
+        // INJECT BANDWIDTH LIMIT AND EMIT TXNS
+        ctx.swarm().inject_chaos(bandwidth.clone())?;
+        let msg = format!(
+            "Limited bandwidth to {}mbps with limit {} and buffer {} to namespace",
+            RATE_MBPS, LIMIT_BYTES, BUFFER_BYTES
+        );
+        println!("{}", msg);
+        ctx.report.report_text(msg);
+        let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
+        ctx.report
+            .report_txn_stats(format!("{}:bandwidth", self.name()), txn_stat, duration);
+        ctx.swarm().remove_chaos(bandwidth)?;
+
+        // INJECT PARTITION AND EMIT TXNS
+        ctx.swarm().inject_chaos(partition.clone())?;
+        let msg = format!(
+            "Partitioned {}% validators in namespace",
+            PARTITION_PERCENTAGE
+        );
+        println!("{}", msg);
+        ctx.report.report_text(msg);
+        let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
+        ctx.report
+            .report_txn_stats(format!("{}:partition", self.name()), txn_stat, duration);
+        ctx.swarm().remove_chaos(partition)?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Description

Introduce network chaos at the swarm level. New test suite `land_blocking_real` attempts to run tests against three types of network chaos, in a new experiment called `NetworkChaosTest`. In three independent steps, the experiment injects latency, limits bandwidth, and partitions the network, all while using txn-emitter to validate the network is still healthy.

Abstractly, we're introducing `SwarmChaos` with options `Delay`, `Bandwidth`, and `Partition`. Then we can do `Swarm::inject_chaos(SwarmChaos)` and `Swarm::remove_chaos(SwarmChaos)`. It's unimplemented for `LocalSwarm`, but for `K8sSwarm`, it creates/manages/deletes the NetworkChaos CRDs from Chaos Mesh: https://chaos-mesh.org/docs/simulate-network-chaos-on-kubernetes/

Also included is some boilerplate for `NodeChaos`, which is applied on individual nodes rather than the entire Swarm. One can imagine this is useful in specifying more detailed network topologies -- such as for simulating N-regions.

Caveats:
* Chaos CRDs seem to need to be applied to already running pods (otherwise are stuck in `Injecting` state infinitely / have a long backoff). This necessitates per-namespace chaos being injected at runtime, after network setup. 
* Txn-emitter needs to be tuned to account for higher latency and potentially stuck nodes (e.g. when they're split from the >2/3 supermajority)
* Chaos CRDs are applied via string template. There may be a way to specify them via https://docs.rs/kube/0.42.0/kube/derive.CustomResource.html instead

### Test Plan

Run the new test suite in Forge on the `forge-1` cluster. It's configured with 4vCPU, 8GB machines. Test fails in the final stage after 30% partition, even though the network continues to be live, because of txn-emitter workload

```
$ FORGE_RUNNER_MODE=local FORGE_TEST_SUITE=land_blocking_real ./testsuite/run_forge.sh
...
Tests Failed

failures:
    network::inject-chaos

test result: FAILED. 0 passed; 1 failed; 0 filtered out

Error: Tests Failed
{
  "metrics": [
    {
      "test_name": "network::inject-chaos:delay",
      "metric": "submitted_txn",
      "value": 17145.0
    },
    {
      "test_name": "network::inject-chaos:delay",
      "metric": "expired_txn",
      "value": 45.0
    },
    {
      "test_name": "network::inject-chaos:delay",
      "metric": "avg_tps",
      "value": 570.0
    },
    {
      "test_name": "network::inject-chaos:delay",
      "metric": "avg_latency",
      "value": 6917.0
    },
    {
      "test_name": "network::inject-chaos:delay",
      "metric": "p99_latency",
      "value": 11800.0
    },
    {
      "test_name": "network::inject-chaos:bandwidth",
      "metric": "submitted_txn",
      "value": 13365.0
    },
    {
      "test_name": "network::inject-chaos:bandwidth",
      "metric": "expired_txn",
      "value": 30.0
    },
    {
      "test_name": "network::inject-chaos:bandwidth",
      "metric": "avg_tps",
      "value": 444.0
    },
    {
      "test_name": "network::inject-chaos:bandwidth",
      "metric": "avg_latency",
      "value": 14104.0
    },
    {
      "test_name": "network::inject-chaos:bandwidth",
      "metric": "p99_latency",
      "value": 26600.0
    }
  ],
...
Injected 80ms +- 20ms with 10% correlation latency to namespace
network::inject-chaos:delay : 570 TPS, 6917 ms latency, 11800 ms p99 latency,(!) expired 45 out of 17145 txns
Limited bandwidth to 100mbps with limit 20971520 and buffer 10000 to namespace
network::inject-chaos:bandwidth : 444 TPS, 14104 ms latency, 26600 ms p99 latency,(!) expired 30 out of 13365 txns
Partitioned 30% validators in namespace
```

and see that the NetworkChaos resources are created

```
$ kubectl get networkchaos                   
NAME                                   ACTION      DURATION
forge-namespace-100mbps-bandwidth      bandwidth   
forge-namespace-30-percent-partition   partition   
forge-namespace-80ms-latency           delay       
```

Can also get to the chaos dashboard and view the network chaos 

```
# get the dashboard
$ kubectl port-forward -n chaos-mesh svc/chaos-dashboard 8333:2333
```


<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2111)
<!-- Reviewable:end -->
