### PR TITLE
[Indexer Server] Add ownership query by owner and fix errors / tests

### DIFF
--- a/ecosystem/indexer-server/doc/openapi.yaml
+++ b/ecosystem/indexer-server/doc/openapi.yaml
@@ -232,17 +232,41 @@ paths:
           $ref: "#/components/responses/400"
         '500':
           $ref: "#/components/responses/500"
-  /ownerships/{ownershipId}:
+  /ownerships/byId:
     get:
       description: "Returns ownership by ownershipId"
       operationId: getOwnershipById
       parameters:
         - name: "ownershipId"
-          in: path
+          in: query
           required: true
           description: Ownership Id has the format of "${tokenID}::${ownerAddress}"
           schema:
             $ref: "#/components/schemas/OwnershipId"
+      responses:
+        "200":
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Ownership"
+        '404':
+          $ref: "#/components/responses/404"
+        '400':
+          $ref: "#/components/responses/400"
+        '500':
+          $ref: "#/components/responses/500"
+  /ownerships/byOwner:
+    get:
+      description: "Returns ownership by owner address"
+      operationId: getOwnershipsByOwner
+      parameters:
+        - name: "ownerAddress"
+          in: query
+          required: true
+          description: Address of owner in string format
+          schema:
+            $ref: "#/components/schemas/Address"
       responses:
         "200":
           description: "OK"

--- a/ecosystem/indexer-server/typescript/prisma/schema.prisma
+++ b/ecosystem/indexer-server/typescript/prisma/schema.prisma
@@ -101,25 +101,23 @@ model write_set_changes {
 }
 
 model collections {
-  creator     String   @db.VarChar
-  name        String   @db.VarChar
-  description String   @db.VarChar
-  max_amount  BigInt?
-  uri         String   @db.VarChar
-  created_at  DateTime @db.Timestamp(6)
-  inserted_at DateTime @default(now()) @db.Timestamp(6)
-
-  @@id([creator, name])
+  collection_id String   @id @db.VarChar
+  creator       String   @db.VarChar
+  name          String   @db.VarChar
+  description   String   @db.VarChar
+  max_amount    BigInt?
+  uri           String   @db.VarChar
+  created_at    DateTime @db.Timestamp(6)
+  inserted_at   DateTime @default(now()) @db.Timestamp(6)
 }
 
 model ownerships {
-  token_id    String   @db.VarChar
-  owner       String   @db.VarChar
-  amount      BigInt
-  updated_at  DateTime @db.Timestamp(6)
-  inserted_at DateTime @default(now()) @db.Timestamp(6)
-
-  @@id([token_id, owner])
+  ownership_id String   @id @db.VarChar
+  token_id     String?  @db.VarChar
+  owner        String?  @db.VarChar
+  amount       BigInt
+  updated_at   DateTime @db.Timestamp(6)
+  inserted_at  DateTime @default(now()) @db.Timestamp(6)
 }
 
 model token_activities {

--- a/ecosystem/indexer-server/typescript/src/api/v1/openapi.yaml
+++ b/ecosystem/indexer-server/typescript/src/api/v1/openapi.yaml
@@ -452,19 +452,76 @@ paths:
           description: |
             Server internal error, caused by unexpected issues.
       x-eov-operation-handler: controllers/DefaultController
-  /ownerships/{ownershipId}:
+  /ownerships/byId:
     get:
       description: Returns ownership by ownershipId
       operationId: getOwnershipById
       parameters:
       - description: Ownership Id has the format of "${tokenID}::${ownerAddress}"
-        explode: false
-        in: path
+        explode: true
+        in: query
         name: ownershipId
         required: true
         schema:
           $ref: '#/components/schemas/OwnershipId'
-        style: simple
+        style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Ownership'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/AptosError'
+                example:
+                  code: 404
+                  message: resource not found
+                  aptos_ledger_version: "37829327"
+          description: |
+            Resource or data not found.
+            Client may retry the request if it is waiting for transaction execution or ledger synchronization.
+        "400":
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/AptosError'
+                example:
+                  code: 400
+                  message: invalid parameter
+          description: |
+            Bad request due to a client error: invalid request headers, parameters or body.
+            Client should not retry the request without modification.
+        "500":
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/AptosError'
+                example:
+                  code: 500
+                  message: unexpected internal error
+          description: |
+            Server internal error, caused by unexpected issues.
+      x-eov-operation-handler: controllers/DefaultController
+  /ownerships/byOwner:
+    get:
+      description: Returns ownership by owner address
+      operationId: getOwnershipsByOwner
+      parameters:
+      - description: Address of owner in string format
+        explode: true
+        in: query
+        name: ownerAddress
+        required: true
+        schema:
+          $ref: '#/components/schemas/Address'
+        style: form
       responses:
         "200":
           content:

--- a/ecosystem/indexer-server/typescript/src/controllers/DefaultController.ts
+++ b/ecosystem/indexer-server/typescript/src/controllers/DefaultController.ts
@@ -33,6 +33,10 @@ export const getOwnershipsByIds = async (request: any, response: any) => {
   await Controller.handleRequest(request, response, service.getOwnershipsByIds);
 };
 
+export const getOwnershipsByOwner = async (request: any, response: any) => {
+  await Controller.handleRequest(request, response, service.getOwnershipsByOwner);
+};
+
 export const getOwnershipsByToken = async (request: any, response: any) => {
   await Controller.handleRequest(request, response, service.getOwnershipsByToken);
 };
@@ -64,6 +68,7 @@ export const DefaultController = {
   getCollectionById,
   getOwnershipById,
   getOwnershipsByIds,
+  getOwnershipsByOwner,
   getOwnershipsByToken,
   getTokenById,
   getTokenByIds,
@@ -81,6 +86,7 @@ export default {
   getCollectionById,
   getOwnershipById,
   getOwnershipsByIds,
+  getOwnershipsByOwner,
   getOwnershipsByToken,
   getTokenById,
   getTokenByIds,

--- a/ecosystem/indexer-server/typescript/src/openapi-schema.ts
+++ b/ecosystem/indexer-server/typescript/src/openapi-schema.ts
@@ -41,9 +41,13 @@ export interface paths {
     /** Returns all ownerships */
     get: operations["getAllOwnerships"];
   };
-  "/ownerships/{ownershipId}": {
+  "/ownerships/byId": {
     /** Returns ownership by ownershipId */
     get: operations["getOwnershipById"];
+  };
+  "/ownerships/byOwner": {
+    /** Returns ownership by owner address */
+    get: operations["getOwnershipsByOwner"];
   };
   "/ownerships/byToken": {
     /** Returns ownerships by token */
@@ -1207,9 +1211,29 @@ export interface operations {
   /** Returns ownership by ownershipId */
   getOwnershipById: {
     parameters: {
-      path: {
+      query: {
         /** Ownership Id has the format of "${tokenID}::${ownerAddress}" */
         ownershipId: components["schemas"]["OwnershipId"];
+      };
+    };
+    responses: {
+      /** OK */
+      200: {
+        content: {
+          "application/json": components["schemas"]["Ownership"];
+        };
+      };
+      400: components["responses"]["400"];
+      404: components["responses"]["404"];
+      500: components["responses"]["500"];
+    };
+  };
+  /** Returns ownership by owner address */
+  getOwnershipsByOwner: {
+    parameters: {
+      query: {
+        /** Address of owner in string format */
+        ownerAddress: components["schemas"]["Address"];
       };
     };
     responses: {

--- a/ecosystem/indexer-server/typescript/src/services/DefaultService.ts
+++ b/ecosystem/indexer-server/typescript/src/services/DefaultService.ts
@@ -117,12 +117,10 @@ const getCollectionById = ({
   async (resolve, reject) => {
     try {
       const [creator, name] = collectionId.split('::');
-      const data = await prisma.collections.findUnique({
+      const data = await prisma.collections.findFirst({
         where: {
-          creator_name: {
-            creator,
-            name,
-          },
+          creator,
+          name,
         },
       });
       resolve(Service.successResponse(data));
@@ -152,12 +150,10 @@ const getOwnershipById = ({
     try {
       const [creator, collectionName, tokenName, ownerAddress] = ownershipId.split('::');
       const token_id = `${creator}::${collectionName}::${tokenName}`;
-      const data = await prisma.ownerships.findUnique({
+      const data = await prisma.ownerships.findFirst({
         where: {
-          token_id_owner: {
-            owner: ownerAddress,
-            token_id,
-          },
+          owner: ownerAddress,
+          token_id,
         },
       });
       resolve(Service.successResponse(data));
@@ -175,14 +171,14 @@ interface GetOwnershipsByIdsParams {
 }
 
 /**
-* Returns Ownerships by Ids
-*
-* @param ownershipIds OwnershipIds
-* @returns Ownership
-* */
+ * Returns Ownerships by Ids
+ *
+ * @param ownershipIds OwnershipIds
+ * @returns Ownership
+ * */
 const getOwnershipsByIds = ({
   ownershipIds,
-}: GetOwnershipsByIdsParams) => new Promise<SuccessResponseType<PrismaOwnerships []>>(
+}: GetOwnershipsByIdsParams) => new Promise<SuccessResponseType<PrismaOwnerships[]>>(
   async (resolve, reject) => {
     try {
       const owners: string[] = [];
@@ -200,6 +196,39 @@ const getOwnershipsByIds = ({
           token_id: {
             in: tokenIds,
           },
+        },
+      });
+      resolve(Service.successResponse(data));
+    } catch (e: any) {
+      reject(Service.rejectResponse(
+        e.message || 'Invalid input',
+        e.status || 405,
+      ));
+    }
+  },
+);
+
+interface GetOwnershipByOwnerParams {
+  ownerAddress: string;
+}
+
+/**
+* Returns ownership by owner address
+*
+* @param ownerAddress ownerAddress
+* @returns Ownership
+* */
+const getOwnershipsByOwner = ({
+  ownerAddress,
+}: GetOwnershipByOwnerParams) => new Promise<SuccessResponseType<PrismaOwnerships | null>>(
+  async (resolve, reject) => {
+    try {
+      const data = await prisma.ownerships.findMany({
+        where: {
+          amount: {
+            gt: 0,
+          },
+          owner: ownerAddress,
         },
       });
       resolve(Service.successResponse(data));
@@ -230,7 +259,7 @@ const getOwnershipsByToken = ({
   offset,
   size,
   tokenId,
-}: GetOwnershipsByTokenParams) => new Promise<SuccessResponseType<PrismaOwnerships []>>(
+}: GetOwnershipsByTokenParams) => new Promise<SuccessResponseType<PrismaOwnerships[]>>(
   async (resolve, reject) => {
     try {
       const data = await prisma.ownerships.findMany({
@@ -351,7 +380,7 @@ type GetTokenMetaDataByIdsParams = GetTokenByIdsParams;
 * */
 const getTokenMetaDataByIds = ({
   tokenIds,
-}: GetTokenMetaDataByIdsParams) => new Promise<SuccessResponseType<PrismaMetadatas []>>(
+}: GetTokenMetaDataByIdsParams) => new Promise<SuccessResponseType<PrismaMetadatas[]>>(
   async (resolve, reject) => {
     try {
       const data = await prisma.metadatas.findMany({
@@ -402,6 +431,7 @@ export const DefaultServiceFunctions = {
   getCollectionById,
   getOwnershipById,
   getOwnershipsByIds,
+  getOwnershipsByOwner,
   getOwnershipsByToken,
   getTokenById,
   getTokenByIds,
@@ -417,6 +447,7 @@ export default {
   getCollectionById,
   getOwnershipById,
   getOwnershipsByIds,
+  getOwnershipsByOwner,
   getOwnershipsByToken,
   getTokenById,
   getTokenByIds,

--- a/ecosystem/indexer-server/typescript/src/services/service_v1.test.ts
+++ b/ecosystem/indexer-server/typescript/src/services/service_v1.test.ts
@@ -69,12 +69,32 @@ const cleanupMetadata = async (tokenId: string) => {
 
 const createRandomOwnership = async () => {
   const token_name = `Ape${Math.random() * 10000000}`;
+  const token_id = `${creator_address}::${collection_name}::${token_name}`;
+  const ownership_id = `${token_id}::${creator_address}`;
   const ownership = await prisma.ownerships.create({
     data: {
       amount: 1,
       inserted_at: new Date(),
       owner: creator_address,
-      token_id: `${creator_address}::${collection_name}::${token_name}`,
+      ownership_id,
+      token_id,
+      updated_at: new Date(),
+    },
+  });
+  return ownership;
+};
+
+const createRandomEmptyOwnership = async () => {
+  const token_name = `Ape${Math.random() * 10000000}`;
+  const token_id = `${creator_address}::${collection_name}::${token_name}`;
+  const ownership_id = `${token_id}::${creator_address}`;
+  const ownership = await prisma.ownerships.create({
+    data: {
+      amount: 0,
+      inserted_at: new Date(),
+      owner: creator_address,
+      ownership_id,
+      token_id,
       updated_at: new Date(),
     },
   });
@@ -82,24 +102,25 @@ const createRandomOwnership = async () => {
 };
 
 const cleanupOwnership = async (owner: string, token_id: string) => {
-  await prisma.ownerships.delete({
+  await prisma.ownerships.deleteMany({
     where: {
-      token_id_owner: {
-        owner,
-        token_id,
-      },
+      owner,
+      token_id,
     },
   });
 };
 
 const createRandomCollection = async () => {
+  const name = collection_name + (Math.random() * 10000000);
+  const collection_id = `${creator_address}::${name}`;
   const collection = await prisma.collections.create({
     data: {
+      collection_id,
       created_at: new Date(),
       creator: creator_address,
       description,
       inserted_at: new Date(),
-      name: collection_name + (Math.random() * 10000000),
+      name,
       uri,
     },
   });
@@ -110,12 +131,10 @@ const cleanupCollection = async (
   creatorAddress: string,
   collectionName: string,
 ) => {
-  await prisma.collections.delete({
+  await prisma.collections.deleteMany({
     where: {
-      creator_name: {
-        creator: creatorAddress,
-        name: collectionName,
-      },
+      creator: creatorAddress,
+      name: collectionName,
     },
   });
 };
@@ -205,19 +224,53 @@ test('/ownerships/all', async () => {
   } = ownership2;
   const fetchedOwnerships = await axios.get<ownerships[]>(`http://localhost:${URL_PORT}/${version}/ownerships/all`);
   expect(fetchedOwnerships.data.length).toBeGreaterThan(1);
-  await cleanupOwnership(owner1, token_id1);
-  await cleanupOwnership(owner2, token_id2);
+  await cleanupOwnership(owner1!, token_id1!);
+  await cleanupOwnership(owner2!, token_id2!);
 });
 
-test('/ownerships/{ownershipId}', async () => {
+test('/ownerships/byId', async () => {
   const ownership = await createRandomOwnership();
   const {
     owner,
     token_id,
   } = ownership;
-  const fetchedOwnership = await axios.get<ownerships>(`http://localhost:${URL_PORT}/${version}/ownerships/${token_id}::${owner}`);
+  const ownership_id = `${token_id}::${owner}`;
+  const fetchedOwnership = await axios.get<ownerships>(`http://localhost:${URL_PORT}/${version}/ownerships/byId`, {
+    params: {
+      ownershipId: ownership_id,
+    },
+  });
   expect(fetchedOwnership.data.owner).toBe(owner);
-  await cleanupOwnership(owner, token_id);
+  await cleanupOwnership(owner!, token_id!);
+});
+
+test('/ownerships/byOwner', async () => {
+  const ownership = await createRandomOwnership();
+  const ownership1 = await createRandomOwnership();
+  const ownership2 = await createRandomEmptyOwnership();
+  const {
+    owner,
+    token_id,
+  } = ownership;
+  const {
+    owner: owner1,
+    token_id: token_id1,
+  } = ownership1;
+  const {
+    owner: owner2,
+    token_id: token_id2,
+  } = ownership2;
+  const fetchedOwnerships = await axios.get<ownerships[]>(`http://localhost:${URL_PORT}/${version}/ownerships/byOwner`, {
+    params: {
+      ownerAddress: owner,
+    },
+  });
+  const token_ids = fetchedOwnerships.data.map((value) => value.token_id);
+  expect(token_ids).toEqual(expect.arrayContaining([token_id, token_id1]));
+  expect(token_ids).not.toContain(token_id2);
+  await cleanupOwnership(owner!, token_id!);
+  await cleanupOwnership(owner1!, token_id1!);
+  await cleanupOwnership(owner2!, token_id2!);
 });
 
 test('/ownerships/byIds', async () => {
@@ -239,8 +292,8 @@ test('/ownerships/byIds', async () => {
   });
   const fetchedOwnershipsData = fetchedOwnerships.data.map((value) => `${value.token_id}::${value.owner}`);
   expect(fetchedOwnershipsData).toEqual(ownershipIds);
-  await cleanupOwnership(owner1, token_id1);
-  await cleanupOwnership(owner2, token_id2);
+  await cleanupOwnership(owner1!, token_id1!);
+  await cleanupOwnership(owner2!, token_id2!);
 });
 
 test('/collections/{collectionId}', async () => {


### PR DESCRIPTION
### Description
* Fix bugs for /ownerships/byToken
* Changed ownerships/{ownership_id} to ownerships/byId and pass ownership_id as query param (otherwise subsequent paths never get reached).
* Added ownerships/byOwner (note, this is only returning items where amount > 0). 

### Test Plan
Fixed service_v1.test.ts and ran `yarn run test`. Tests pass. Then I added a test case for ownerships/byOwner and ensured test pass. 

Also tested in open API. 
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/11738325/180093294-d4bbb0d6-b971-4e9f-9600-998a583e820c.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2112)
<!-- Reviewable:end -->
