### PR TITLE
[Storage] Serialize JMT updates in multiple threads.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1285,6 +1285,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
+ "rayon",
  "schemadb",
  "scratchpad",
  "serde 1.0.137",
@@ -6930,6 +6931,7 @@ name = "schemadb"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",
  "aptos-temppath",

--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -83,14 +83,14 @@ impl ConsensusDB {
     }
 
     pub fn save_highest_2chain_timeout_certificate(&self, tc: Vec<u8>) -> Result<(), DbError> {
-        let mut batch = SchemaBatch::new();
+        let batch = SchemaBatch::new();
         batch.put::<SingleEntrySchema>(&SingleEntryKey::Highest2ChainTimeoutCert, &tc)?;
         self.commit(batch)?;
         Ok(())
     }
 
     pub fn save_vote(&self, last_vote: Vec<u8>) -> Result<(), DbError> {
-        let mut batch = SchemaBatch::new();
+        let batch = SchemaBatch::new();
         batch.put::<SingleEntrySchema>(&SingleEntryKey::LastVote, &last_vote)?;
         self.commit(batch)
     }
@@ -103,7 +103,7 @@ impl ConsensusDB {
         if block_data.is_empty() && qc_data.is_empty() {
             return Err(anyhow::anyhow!("Consensus block and qc data is empty!").into());
         }
-        let mut batch = SchemaBatch::new();
+        let batch = SchemaBatch::new();
         block_data
             .iter()
             .try_for_each(|block| batch.put::<BlockSchema>(&block.id(), block))?;
@@ -120,7 +120,7 @@ impl ConsensusDB {
         if block_ids.is_empty() {
             return Err(anyhow::anyhow!("Consensus block ids is empty!").into());
         }
-        let mut batch = SchemaBatch::new();
+        let batch = SchemaBatch::new();
         block_ids.iter().try_for_each(|hash| {
             batch.delete::<BlockSchema>(hash)?;
             batch.delete::<QCSchema>(hash)
@@ -143,7 +143,7 @@ impl ConsensusDB {
     }
 
     pub fn delete_highest_2chain_timeout_certificate(&self) -> Result<(), DbError> {
-        let mut batch = SchemaBatch::new();
+        let batch = SchemaBatch::new();
         batch.delete::<SingleEntrySchema>(&SingleEntryKey::Highest2ChainTimeoutCert)?;
         self.commit(batch)
     }
@@ -155,7 +155,7 @@ impl ConsensusDB {
     }
 
     pub fn delete_last_vote_msg(&self) -> Result<(), DbError> {
-        let mut batch = SchemaBatch::new();
+        let batch = SchemaBatch::new();
         batch.delete::<SingleEntrySchema>(&SingleEntryKey::LastVote)?;
         self.commit(batch)?;
         Ok(())

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = "0.2.15"
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
+rayon = "1.5.2"
 serde = "1.0.137"
 thiserror = "1.0.31"
 

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -50,7 +50,7 @@ pub fn confirm_or_save_frozen_subtrees(
     num_leaves: LeafCount,
     frozen_subtrees: &[HashValue],
 ) -> Result<()> {
-    let mut cs = ChangeSet::new();
+    let cs = ChangeSet::new();
     let positions: Vec<_> = FrozenSubTreeIterator::new(num_leaves).collect();
 
     ensure!(

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -10,8 +10,10 @@ use aptos_jellyfish_merkle::StaleNodeIndex;
 use aptos_logger::error;
 use aptos_types::transaction::{AtomicVersion, Version};
 use schemadb::{ReadOptions, SchemaBatch, DB};
-use std::sync::atomic::AtomicBool;
-use std::sync::{atomic::Ordering, Arc};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 #[cfg(test)]
 mod test;
@@ -126,7 +128,7 @@ impl StateStorePruner {
                 .start_timer();
             let new_min_readable_version =
                 indices.last().expect("Should exist.").stale_since_version;
-            let mut batch = SchemaBatch::new();
+            let batch = SchemaBatch::new();
             // Delete stale nodes.
             indices.into_iter().try_for_each(|index| {
                 batch.delete::<JellyfishMerkleNodeSchema>(&index.node_key)?;

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.57"
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 
+aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
 

--- a/storage/schemadb/tests/db.rs
+++ b/storage/schemadb/tests/db.rs
@@ -175,7 +175,7 @@ fn test_schema_put_get() {
 
 fn test_schemabatch_delete_range_util(begin: u32, end: u32, is_inclusive: bool) {
     let db = TestDB::new();
-    let mut db_batch = SchemaBatch::new();
+    let db_batch = SchemaBatch::new();
     for i in 0..100u32 {
         db_batch
             .put::<TestSchema1>(&TestField(i), &TestField(i))
@@ -275,7 +275,7 @@ fn gen_expected_values(values: &[(u32, u32)]) -> Vec<(TestField, TestField)> {
 fn test_single_schema_batch() {
     let db = TestDB::new();
 
-    let mut db_batch = SchemaBatch::new();
+    let db_batch = SchemaBatch::new();
     db_batch
         .put::<TestSchema1>(&TestField(0), &TestField(0))
         .unwrap();
@@ -313,7 +313,7 @@ fn test_single_schema_batch() {
 fn test_two_schema_batches() {
     let db = TestDB::new();
 
-    let mut db_batch1 = SchemaBatch::new();
+    let db_batch1 = SchemaBatch::new();
     db_batch1
         .put::<TestSchema1>(&TestField(0), &TestField(0))
         .unwrap();
@@ -331,7 +331,7 @@ fn test_two_schema_batches() {
         gen_expected_values(&[(0, 0), (1, 1)]),
     );
 
-    let mut db_batch2 = SchemaBatch::new();
+    let db_batch2 = SchemaBatch::new();
     db_batch2.delete::<TestSchema2>(&TestField(3)).unwrap();
     db_batch2
         .put::<TestSchema2>(&TestField(3), &TestField(3))
@@ -411,7 +411,7 @@ fn test_report_size() {
     let db = TestDB::new();
 
     for i in 0..1000 {
-        let mut db_batch = SchemaBatch::new();
+        let db_batch = SchemaBatch::new();
         db_batch
             .put::<TestSchema1>(&TestField(i), &TestField(i))
             .unwrap();


### PR DESCRIPTION
### Description
It is cpu heavy so we should do it in parallel.

This reduces the JMT update time to ~30% on a 250M accounts DB.

### Test Plan
Manually tested on large DBs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2115)
<!-- Reviewable:end -->
