### PR TITLE
devtools: measure and report test coverage to codecov.io

### DIFF
--- a/.github/actions/upload-test-results/action.yaml
+++ b/.github/actions/upload-test-results/action.yaml
@@ -1,0 +1,34 @@
+name: Upload test results
+
+inputs:
+  BUILDPULSE_ACCESS_KEY_ID:
+    required: true
+  BUILDPULSE_SECRET_ACCESS_KEY:
+    required: true
+  DD_API_KEY:
+    required: true
+  SUITE:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Upload test results to BuildPulse for flaky test detection
+      # Only run this step for branches where where we have access to secrets.
+      # Run this step even when the tests fail. Skip if the workflow is cancelled.
+      if: inputs.BUILDPULSE_SECRET_ACCESS_KEY != '' == 'true' && !cancelled()
+      uses: Workshop64/buildpulse-action@main
+      with:
+        account: 99841612
+        repository: 462597790
+        path: target/nextest/ci/junit.xml
+        key: ${{ inputs.BUILDPULSE_ACCESS_KEY_ID }}
+        secret: ${{ inputs.BUILDPULSE_SECRET_ACCESS_KEY }}
+
+    - uses: datadog/junit-upload-github-action@v1
+      if: inputs.DD_API_KEY != '' && !cancelled()
+      with:
+        api-key: ${{ inputs.DD_API_KEY }}
+        datadog-site: us5.datadoghq.com
+        service: ${{ inputs.SUITE }}
+        files: target/nextest/ci/junit.xml

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,79 @@
+name: Test Coverage
+on:
+  workflow_dispatch:
+  workflow_call:
+  schedule:
+    # every day at 9am PST
+    - cron: "0 16 * * *"
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+
+# cancel redundant builds
+concurrency:
+  # cancel redundant builds on PRs (only on PR, not on branches)
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  rust-unit:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage') 
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+      - uses: ./.github/actions/rust-setup
+      - run: rustup component add llvm-tools-preview
+      - uses: taiki-e/install-action@v1.5.6
+        with:
+          tool: nextest,cargo-llvm-cov
+      - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
+      - run: cargo llvm-cov nextest --workspace --lcov --output-path lcov.info --exclude smoke-test --exclude testcases --no-fail-fast  -- --profile ci
+        env:
+          INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+
+      - uses: ./.github/actions/upload-test-results
+        with:
+          BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          SUITE: rust-unit-coverage
+
+  rust-smoke:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage')
+    runs-on: high-perf-docker
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
+      - uses: ./.github/actions/rust-setup
+      - run: rustup component add llvm-tools-preview
+      - uses: taiki-e/install-action@v1.5.6
+        with:
+          tool: nextest,cargo-llvm-cov
+      - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
+      # --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
+      - run: cargo llvm-cov nextest --lcov --output-path lcov.info --package smoke-test --no-fail-fast -- --profile ci --test-threads 6 --retries 3
+        env:
+          INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          fail_ci_if_error: true
+
+      - uses: ./.github/actions/upload-test-results
+        with:
+          BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          SUITE: rust-smoke-coverage

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -151,25 +151,12 @@ jobs:
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 
-      - name: Upload test results to BuildPulse for flaky test detection
-        # Only run this step for branches where where we have access to secrets.
-        # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled()
-        uses: Workshop64/buildpulse-action@main
+      - uses: ./.github/actions/upload-test-results
         with:
-          account: 99841612
-          repository: 462597790
-          path: target/nextest/ci/junit.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-      - uses: datadog/junit-upload-github-action@v1
-        if: env.HAS_DATADOG_SECRETS == 'true' && !cancelled()
-        with:
-          api-key: ${{ secrets.DD_API_KEY }}
-          datadog-site: us5.datadoghq.com
-          service: rust-unit-nextest
-          files: target/nextest/ci/junit.xml
+          BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          SUITE: rust-unit
 
   rust-smoke-test:
     runs-on: high-perf-docker
@@ -185,25 +172,12 @@ jobs:
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 
-      - name: Upload test results to BuildPulse for flaky test detection
-        # Only run this step for branches where where we have access to secrets.
-        # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        if: env.HAS_BUILDPULSE_SECRETS == 'true' && !cancelled()
-        uses: Workshop64/buildpulse-action@main
+      - uses: ./.github/actions/upload-test-results
         with:
-          account: 99841612
-          repository: 462597790
-          path: target/nextest/ci/junit.xml
-          key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-          secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-
-      - uses: datadog/junit-upload-github-action@v1
-        if: env.HAS_DATADOG_SECRETS == 'true' && !cancelled()
-        with:
-          api-key: ${{ secrets.DD_API_KEY }}
-          datadog-site: us5.datadoghq.com
-          service: rust-e2e-test
-          files: target/nextest/ci/junit.xml
+          BUILDPULSE_ACCESS_KEY_ID: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+          BUILDPULSE_SECRET_ACCESS_KEY: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          SUITE: rust-smoke
 
       - name: Upload smoke test logs for failures
         uses: actions/upload-artifact@v3
@@ -215,3 +189,4 @@ jobs:
             /tmp/.tmp*
             !/tmp/.tmp*/**/db/
           retention-days: 1
+

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -17,10 +17,6 @@ on:
         type: string
         description: The Forge k8s namespace to be used for test. This value should manage Forge test concurrency. It may be truncated.
 
-# temporarily limit amount of concurrent forge runs until we have autoscaling forge
-concurrency:
-  group: ${{ inputs.merge_or_canary }}
-
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,18 +1,17 @@
 ---
-codecov:
-  require_ci_to_pass: true
-
 ignore:
   - testsuite/*
-  - x/*
 
 coverage:
   # range for color spectrum display, red=50%, green=80%
   range: "50...80"
-  round: down
   precision: 1
 
   status:
-    project: true
-    patch: true
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
     changes: false


### PR DESCRIPTION
This introduces code coverage measurement for our rust code via codecov.io.
Coverage runs either when:
- triggered through `CICD:run-coverage` label on PRs.
- every morning 9am via cronjob
- manually triggered via Actions tab "Run Workflow".

It's measuring coverage from all the unit and smoke tests which run through nextest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2120)
<!-- Reviewable:end -->
