### PR TITLE
[Aptos Framework] Update proposal fields for AptosGovernance to allow more generic metadata

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -72,6 +72,8 @@ module aptos_framework::aptos_governance {
         stake_pool: address,
         proposal_id: u64,
         execution_hash: vector<u8>,
+        metadata_location: vector<u8>,
+        metadata_hash: vector<u8>,
     }
 
     /// Event emitted when there's a vote on a proposa;
@@ -157,9 +159,8 @@ module aptos_framework::aptos_governance {
         proposer: &signer,
         stake_pool: address,
         execution_hash: vector<u8>,
-        code_location: vector<u8>,
-        title: vector<u8>,
-        description: vector<u8>,
+        metadata_location: vector<u8>,
+        metadata_hash: vector<u8>,
     ) acquires GovernanceConfig, GovernanceEvents {
         let proposer_address = signer::address_of(proposer);
         assert!(stake::get_delegated_voter(stake_pool) == proposer_address, error::invalid_argument(ENOT_DELEGATED_VOTER));
@@ -196,9 +197,8 @@ module aptos_framework::aptos_governance {
             proposer_address,
             @aptos_framework,
             governance_proposal::create_proposal(
-                utf8(code_location),
-                utf8(title),
-                utf8(description),
+                utf8(metadata_location),
+                utf8(metadata_hash),
             ),
             execution_hash,
             governance_config.min_voting_threshold,
@@ -214,6 +214,8 @@ module aptos_framework::aptos_governance {
                 proposer: proposer_address,
                 stake_pool,
                 execution_hash,
+                metadata_location,
+                metadata_hash,
             },
         );
     }
@@ -307,7 +309,6 @@ module aptos_framework::aptos_governance {
             b"",
             b"",
             b"",
-            b"",
         );
         vote(&yes_voter, signer::address_of(&yes_voter), 0, true);
         vote(&no_voter, signer::address_of(&no_voter), 0, false);
@@ -342,7 +343,6 @@ module aptos_framework::aptos_governance {
             b"",
             b"",
             b"",
-            b"",
         );
 
         // Double voting should throw an error.
@@ -370,7 +370,6 @@ module aptos_framework::aptos_governance {
         create_proposal(
             &proposer,
             signer::address_of(&proposer),
-            b"",
             b"",
             b"",
             b"",

--- a/aptos-move/framework/aptos-framework/sources/governance_proposal.move
+++ b/aptos-move/framework/aptos-framework/sources/governance_proposal.move
@@ -7,42 +7,33 @@ module aptos_framework::governance_proposal {
     use std::string::{String, length, utf8};
     use std::error;
 
-    const ECODE_LOCATION_TOO_LONG: u64 = 1;
-    const ETITLE_TOO_LONG: u64 = 2;
-    const EDESCRIPTION_TOO_LONG: u64 = 3;
+    const ETOO_LONG: u64 = 1;
 
     struct GovernanceProposal has store, drop {
-        /// The location (e.g. url) where the proposal resolution script's code can be accessed.
-        /// Maximum length allowed is 256 chars.
-        code_location: String,
-        /// Title of the proposal.
-        /// Maximum length allowed is 256 chars.
-        title: String,
-        /// Description of the proposal.
-        /// Maximum length allowed is 256 chars.
-        description: String,
+        // Location where metadata such as the proposal's execution script content, description, etc. are hosted.
+        metadata_location: String,
+        // The hash of the metadata to allow easy verification when a user votes that the metadata hosted at a url is
+        // correct.
+        metadata_hash: String,
     }
 
     /// Create and return a GovernanceProposal resource. Can only be called by AptosGovernance
     public(friend) fun create_proposal(
-        code_location: String,
-        title: String,
-        description: String,
+        metadata_location: String,
+        metadata_hash: String,
     ): GovernanceProposal {
-        assert!(length(&code_location) <= 256, error::invalid_argument(ECODE_LOCATION_TOO_LONG));
-        assert!(length(&title) <= 256, error::invalid_argument(ETITLE_TOO_LONG));
-        assert!(length(&description) <= 256, error::invalid_argument(EDESCRIPTION_TOO_LONG));
+        assert!(length(&metadata_location) <= 256, error::invalid_argument(ETOO_LONG));
+        assert!(length(&metadata_hash) <= 256, error::invalid_argument(ETOO_LONG));
 
         GovernanceProposal {
-            code_location,
-            title,
-            description
+            metadata_location,
+            metadata_hash,
         }
     }
 
     /// Useful for AptosGovernance to create an empty proposal as proof.
     public(friend) fun create_empty_proposal(): GovernanceProposal {
-        create_proposal(utf8(b""), utf8(b""), utf8(b""))
+        create_proposal(utf8(b""), utf8(b""))
     }
 
     #[test_only]
@@ -52,29 +43,17 @@ module aptos_framework::governance_proposal {
 
     #[test]
     #[expected_failure(abort_code = 65537)]
-    public fun test_code_location_too_long(): GovernanceProposal {
+    public fun test_metadata_url_too_long(): GovernanceProposal {
         create_proposal(
-            utf8(b"123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789"),
-            utf8(b""),
-            utf8(b""),
-        )
-    }
-
-    #[test]
-    #[expected_failure(abort_code = 65538)]
-    public fun test_title_too_long(): GovernanceProposal {
-        create_proposal(
-            utf8(b""),
             utf8(b"123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789"),
             utf8(b""),
         )
     }
 
     #[test]
-    #[expected_failure(abort_code = 65539)]
-    public fun test_description_too_long(): GovernanceProposal {
+    #[expected_failure(abort_code = 65537)]
+    public fun test_metadata_hash_too_long(): GovernanceProposal {
         create_proposal(
-            utf8(b""),
             utf8(b""),
             utf8(b"123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789"),
         )


### PR DESCRIPTION
### Description

Currently a proposal has code location, title and description. This is not very flexible. This PR changes the fields to be more generic, allowing the metadata to be constructed in dynamically off-chain.

### Test Plan
Unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2121)
<!-- Reviewable:end -->
