### PR TITLE
[aptos-faucet] Print out the endpoint running the faucet on stdout

### DIFF
--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -134,6 +134,8 @@ impl FaucetArgs {
                 .await
         };
 
+        println!("Faucet is running.  Faucet endpoint: {}", address);
+
         info!(
             "[faucet]: running on: {}. Minting from {}",
             address,


### PR DESCRIPTION
### Description
Print out the faucet address and port so we can tell in local testnet mode of the CLI

### Test Plan
```
$ target/debug/aptos node run-local-testnet --with-faucet --assume-yes --force-restart
Completed generating configuration:
        Log file: "/Users/greg/.aptos/testnet/validator.log"
        Test dir: "/Users/greg/.aptos/testnet"
        Aptos root key path: "/Users/greg/.aptos/testnet/mint.key"
        Waypoint: 0:d302c6b10e0fa68bfec9cdb383f24ef1189d8850d50b832365eea21ae52d8101
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit

Faucet started on 0.0.0.0:8081
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2123)
<!-- Reviewable:end -->
