### PR TITLE
[consensus] rename some network methods and failpoints to make them more consistent

### DIFF
--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -188,7 +188,7 @@ impl BlockStore {
         if highest_commit_cert.ledger_info().ledger_info().ends_epoch() {
             retriever
                 .network
-                .notify_epoch_change(EpochChangeProof::new(
+                .send_epoch_change(EpochChangeProof::new(
                     vec![highest_ordered_cert.ledger_info().clone()],
                     /* more = */ false,
                 ))
@@ -333,7 +333,7 @@ impl BlockStore {
             && self.block_exists(ledger_info.commit_info().id())
             && self.ordered_root().round() >= ledger_info.commit_info().round()
         {
-            network.notify_commit_proof(ledger_info.clone()).await
+            network.send_commit_proof(ledger_info.clone()).await
         }
     }
 

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -249,7 +249,7 @@ impl BufferManager {
                 let aggregated_item = item.unwrap_aggregated();
                 if aggregated_item.commit_proof.ledger_info().ends_epoch() {
                     self.commit_msg_tx
-                        .notify_epoch_change(EpochChangeProof::new(
+                        .send_epoch_change(EpochChangeProof::new(
                             vec![aggregated_item.commit_proof.clone()],
                             false,
                         ))

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -92,7 +92,7 @@ impl NetworkSender {
         from: Author,
         timeout: Duration,
     ) -> anyhow::Result<BlockRetrievalResponse> {
-        fail_point!("consensus::request_block", |_| {
+        fail_point!("consensus::send::block_retrieval", |_| {
             Err(anyhow::anyhow!("Injected error in request_block"))
         });
 
@@ -169,31 +169,31 @@ impl NetworkSender {
     }
 
     pub async fn broadcast_proposal(&mut self, proposal_msg: ProposalMsg) {
-        fail_point!("consensus::broadcast_proposal", |_| ());
+        fail_point!("consensus::send::broadcast_proposal", |_| ());
         let msg = ConsensusMsg::ProposalMsg(Box::new(proposal_msg));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_sync_info(&mut self, sync_info_msg: SyncInfo) {
-        fail_point!("consensus::broadcast_sync_info", |_| ());
+        fail_point!("consensus::send::broadcast_sync_info", |_| ());
         let msg = ConsensusMsg::SyncInfo(Box::new(sync_info_msg));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_timeout_vote(&mut self, timeout_vote_msg: VoteMsg) {
-        fail_point!("consensus::broadcast_timeout_vote", |_| ());
+        fail_point!("consensus::send::broadcast_timeout_vote", |_| ());
         let msg = ConsensusMsg::VoteMsg(Box::new(timeout_vote_msg));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_epoch_change(&mut self, epoch_chnage_proof: EpochChangeProof) {
-        fail_point!("consensus::broadcast_epoch_change", |_| ());
+        fail_point!("consensus::send::broadcast_epoch_change", |_| ());
         let msg = ConsensusMsg::EpochChangeProof(Box::new(epoch_chnage_proof));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_commit_vote(&mut self, commit_vote: CommitVote) {
-        fail_point!("consensus::broadcast_commit_vote", |_| ());
+        fail_point!("consensus::send::broadcast_commit_vote", |_| ());
         let msg = ConsensusMsg::CommitVoteMsg(Box::new(commit_vote));
         self.broadcast(msg).await
     }
@@ -207,26 +207,26 @@ impl NetworkSender {
     /// out. It does not give indication about when the message is delivered to the recipients,
     /// as well as there is no indication about the network failures.
     pub async fn send_vote(&self, vote_msg: VoteMsg, recipients: Vec<Author>) {
-        fail_point!("consensus::send_vote", |_| ());
+        fail_point!("consensus::send::vote", |_| ());
         let msg = ConsensusMsg::VoteMsg(Box::new(vote_msg));
         self.send(msg, recipients).await
     }
 
     pub async fn send_proposal(&self, proposal_msg: ProposalMsg, recipients: Vec<Author>) {
-        fail_point!("consensus::send_proposal", |_| ());
+        fail_point!("consensus::send::proposal", |_| ());
         let msg = ConsensusMsg::ProposalMsg(Box::new(proposal_msg));
         self.send(msg, recipients).await
     }
 
     pub async fn send_epoch_change(&mut self, proof: EpochChangeProof) {
-        fail_point!("consensus::send_epoch_change", |_| ());
+        fail_point!("consensus::send::epoch_change", |_| ());
         let msg = ConsensusMsg::EpochChangeProof(Box::new(proof));
         self.send(msg, vec![self.author]).await
     }
 
     /// Sends the ledger info to self buffer manager
     pub async fn send_commit_proof(&self, ledger_info: LedgerInfoWithSignatures) {
-        fail_point!("consensus::send_commit_proof", |_| ());
+        fail_point!("consensus::send::commit_proof", |_| ());
 
         // this requires re-verification of the ledger info we can probably optimize it later
         let msg = ConsensusMsg::CommitDecisionMsg(Box::new(CommitDecision::new(ledger_info)));

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -92,7 +92,7 @@ impl NetworkSender {
         from: Author,
         timeout: Duration,
     ) -> anyhow::Result<BlockRetrievalResponse> {
-        fail_point!("consensus::send_block_retrieval", |_| {
+        fail_point!("consensus::request_block", |_| {
             Err(anyhow::anyhow!("Injected error in request_block"))
         });
 
@@ -169,31 +169,31 @@ impl NetworkSender {
     }
 
     pub async fn broadcast_proposal(&mut self, proposal_msg: ProposalMsg) {
-        fail_point!("consensus::send_proposal", |_| ());
+        fail_point!("consensus::broadcast_proposal", |_| ());
         let msg = ConsensusMsg::ProposalMsg(Box::new(proposal_msg));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_sync_info(&mut self, sync_info_msg: SyncInfo) {
-        fail_point!("consensus::send_sync_info", |_| ());
+        fail_point!("consensus::broadcast_sync_info", |_| ());
         let msg = ConsensusMsg::SyncInfo(Box::new(sync_info_msg));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_timeout_vote(&mut self, timeout_vote_msg: VoteMsg) {
-        fail_point!("consensus::send_vote", |_| ());
+        fail_point!("consensus::broadcast_timeout_vote", |_| ());
         let msg = ConsensusMsg::VoteMsg(Box::new(timeout_vote_msg));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_epoch_change(&mut self, epoch_chnage_proof: EpochChangeProof) {
-        fail_point!("consensus::send_epoch_change", |_| ());
+        fail_point!("consensus::broadcast_epoch_change", |_| ());
         let msg = ConsensusMsg::EpochChangeProof(Box::new(epoch_chnage_proof));
         self.broadcast(msg).await
     }
 
     pub async fn broadcast_commit_vote(&mut self, commit_vote: CommitVote) {
-        fail_point!("consensus::send_commit_vote", |_| ());
+        fail_point!("consensus::broadcast_commit_vote", |_| ());
         let msg = ConsensusMsg::CommitVoteMsg(Box::new(commit_vote));
         self.broadcast(msg).await
     }
@@ -218,14 +218,14 @@ impl NetworkSender {
         self.send(msg, recipients).await
     }
 
-    pub async fn notify_epoch_change(&mut self, proof: EpochChangeProof) {
+    pub async fn send_epoch_change(&mut self, proof: EpochChangeProof) {
         fail_point!("consensus::send_epoch_change", |_| ());
         let msg = ConsensusMsg::EpochChangeProof(Box::new(proof));
         self.send(msg, vec![self.author]).await
     }
 
     /// Sends the ledger info to self buffer manager
-    pub async fn notify_commit_proof(&self, ledger_info: LedgerInfoWithSignatures) {
+    pub async fn send_commit_proof(&self, ledger_info: LedgerInfoWithSignatures) {
         fail_point!("consensus::send_commit_proof", |_| ());
 
         // this requires re-verification of the ledger info we can probably optimize it later


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2130)
<!-- Reviewable:end -->
