### PR TITLE
[api] Add round to State in the API header

### DIFF
--- a/api/types/src/ledger_info.rs
+++ b/api/types/src/ledger_info.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct LedgerInfo {
     pub chain_id: u8,
     pub epoch: u64,
+    pub round: u64,
     pub ledger_version: U64,
     pub oldest_ledger_version: U64,
     pub ledger_timestamp: U64,
@@ -26,6 +27,7 @@ impl LedgerInfo {
         Self {
             chain_id: chain_id.id(),
             epoch: ledger_info.epoch(),
+            round: ledger_info.round(),
             ledger_version: ledger_info.version().into(),
             oldest_ledger_version: oldest_ledger_version.into(),
             ledger_timestamp: ledger_info.timestamp_usecs().into(),

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -33,7 +33,7 @@ pub use move_types::{
     U128, U64,
 };
 pub use response::{
-    Response, X_APTOS_CHAIN_ID, X_APTOS_EPOCH, X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
+    Response, X_APTOS_CHAIN_ID, X_APTOS_EPOCH, X_APTOS_ROUND, X_APTOS_LEDGER_TIMESTAMP, X_APTOS_LEDGER_VERSION,
 };
 pub use table::TableItemRequest;
 pub use transaction::{

--- a/api/types/src/response.rs
+++ b/api/types/src/response.rs
@@ -14,6 +14,7 @@ use warp::{
 
 pub const X_APTOS_CHAIN_ID: &str = "X-Aptos-Chain-Id";
 pub const X_APTOS_EPOCH: &str = "X-Aptos-Epoch";
+pub const X_APTOS_ROUND: &str = "X-Aptos-Round";
 pub const X_APTOS_LEDGER_VERSION: &str = "X-Aptos-Ledger-Version";
 pub const X_APTOS_LEDGER_OLDEST_VERSION: &str = "X-Aptos-Ledger-Oldest-Version";
 pub const X_APTOS_LEDGER_TIMESTAMP: &str = "X-Aptos-Ledger-TimestampUsec";
@@ -71,6 +72,7 @@ impl warp::Reply for Response {
             self.ledger_info.ledger_timestamp.into(),
         );
         headers.insert(X_APTOS_EPOCH, self.ledger_info.epoch.into());
+        headers.insert(X_APTOS_ROUND, self.ledger_info.round.into());
 
         res
     }

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -23,7 +23,7 @@ pub mod faucet;
 pub use faucet::FaucetClient;
 pub mod response;
 pub use response::Response;
-mod state;
+pub mod state;
 pub mod types;
 use crate::aptos::{AptosVersion, Balance};
 pub use types::{Account, Resource, RestError};
@@ -81,6 +81,7 @@ impl Client {
         struct Response {
             chain_id: u8,
             epoch: u64,
+            round: u64,
             #[serde(deserialize_with = "types::deserialize_from_string")]
             ledger_version: u64,
             #[serde(deserialize_with = "types::deserialize_from_string")]
@@ -95,6 +96,7 @@ impl Client {
             .map(|r| State {
                 chain_id: r.chain_id,
                 epoch: r.epoch,
+                round: r.round,
                 version: r.ledger_version,
                 timestamp_usecs: r.ledger_timestamp,
                 oldest_ledger_version: Some(r.oldest_ledger_version),


### PR DESCRIPTION
### Description

I found it useful to understand progress/state of the node with both (epoch, round) and version information, so adding round to the API.

### Test Plan

Used in the unit tests in the PRs on top of this one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2131)
<!-- Reviewable:end -->
