### PR TITLE
[forge] reuse existing management configmap

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -93,6 +93,11 @@ struct K8sSwarm {
     port_forward: bool,
     #[structopt(
         long,
+        help = "If set, reuse the forge testnet active in the specified namespace"
+    )]
+    reuse: bool,
+    #[structopt(
+        long,
         help = "If set, keeps the forge testnet active in the specified namespace"
     )]
     keep: bool,
@@ -196,6 +201,7 @@ fn main() -> Result<()> {
                         k8s.image_tag,
                         k8s.base_image_tag,
                         k8s.port_forward,
+                        k8s.reuse,
                         k8s.keep,
                         k8s.enable_haproxy,
                     )

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -16,7 +16,7 @@ spec:
     - -c
     - |
       ulimit -n 1048576
-      forge test k8s-swarm --image-tag {IMAGE_TAG} --namespace {FORGE_NAMESPACE} {KEEP_ARGS} {ENABLE_HAPROXY_ARGS}
+      forge --suite {FORGE_TEST_SUITE} test k8s-swarm --image-tag {IMAGE_TAG} --namespace {FORGE_NAMESPACE} {REUSE_ARGS} {KEEP_ARGS} {ENABLE_HAPROXY_ARGS}
   affinity:
     # avoid scheduling with other forge or validator/fullnode pods
     podAntiAffinity:

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -302,7 +302,6 @@ pub(crate) async fn get_validators(
 pub(crate) async fn get_fullnodes(
     client: K8sClient,
     image_tag: &str,
-    era: &str,
     kube_namespace: &str,
     use_port_forward: bool,
     enable_haproxy: bool,
@@ -328,8 +327,9 @@ pub(crate) async fn get_fullnodes(
                 ip = LOCALHOST.to_string();
             }
             let node_id = parse_node_id(&s.name).expect("error to parse node id");
-            // the base fullnode name is the same as that of the StatefulSet, and includes era
-            let fullnode_name = format!("{}-e{}", &s.name, era);
+            // the base fullnode name is the same as that of the StatefulSet
+            // TODO: get the era and fullnode group, for now ignore it
+            let fullnode_name = format!("aptos-node-{}-fullnode", node_id);
             let node = K8sNode {
                 name: fullnode_name.clone(),
                 sts_name: fullnode_name,


### PR DESCRIPTION
### Description

Ability to reuse existing forge-management configmaps. This lets you re-run a Forge test in the same namespace as one that did not clean up properly (e.g. crashed or was `--keep`). We see this crash Forge every now and then due to high test volume and high test pre-emption due to GHA triggering logic.

Also introduce `forge test k8s --reuse` option, which reuses the running network (e.g. it was `--keep` before) instead of wiping the network (re-run genesis and re-install validators)

### Test Plan

Run on forge

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2132)
<!-- Reviewable:end -->
