### PR TITLE
[vm] Delta writes in sequential execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
  "aptos-crypto-derive",
  "bcs",
  "chrono",
+ "claim",
  "hex",
  "itertools",
  "mirai-annotations",

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -261,7 +261,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
                 }),
             },
             // Deltas never use access paths.
-            WriteOp::Delta(..) => unreachable!("unexpected conversion"),
+            WriteOp::Delta(_) => unreachable!("unexpected conversion"),
         };
         Ok(ret)
     }
@@ -288,7 +288,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
                 value: value.into(),
             }),
             // Deltas are materialized into WriteOP::Value(..) in executor.
-            WriteOp::Delta(..) => unreachable!("unexpected conversion"),
+            WriteOp::Delta(_) => unreachable!("unexpected conversion"),
         };
         Ok(ret)
     }

--- a/aptos-move/aptos-vm/src/parallel_executor/storage_wrapper.rs
+++ b/aptos-move/aptos-vm/src/parallel_executor/storage_wrapper.rs
@@ -35,7 +35,7 @@ impl<'a, S: StateView> StateView for VersionedView<'a, S> {
             Some(v) => Ok(match v.as_ref() {
                 WriteOp::Value(w) => Some(w.clone()),
                 WriteOp::Deletion => None,
-                WriteOp::Delta(..) => {
+                WriteOp::Delta(_) => {
                     unimplemented!("parallel execution is not supported for deltas")
                 }
             }),

--- a/aptos-move/e2e-tests/src/data_store.rs
+++ b/aptos-move/e2e-tests/src/data_store.rs
@@ -50,7 +50,7 @@ impl FakeDataStore {
                 WriteOp::Deletion => {
                     self.remove(state_key);
                 }
-                WriteOp::Delta(..) => unreachable!("deltas are only used in executor"),
+                WriteOp::Delta(_) => unreachable!("deltas are only used in executor"),
             }
         }
     }

--- a/aptos-move/genesis-viewer/src/main.rs
+++ b/aptos-move/genesis-viewer/src/main.rs
@@ -188,7 +188,7 @@ fn print_modules(ws: &WriteSet) {
             AccessPath::try_from(k.clone()).expect("State key can't be converted to access path");
         match v {
             WriteOp::Deletion => panic!("found WriteOp::Deletion in WriteSet"),
-            WriteOp::Delta(..) => panic!("found WriteOp::Delta in WriteSet"),
+            WriteOp::Delta(_) => panic!("found WriteOp::Delta in WriteSet"),
             WriteOp::Value(blob) => {
                 let tag = ap.path.get(0).expect("empty blob in WriteSet");
                 if *tag == 0 {
@@ -214,7 +214,7 @@ fn print_resources(storage: &impl MoveResolverExt, ws: &WriteSet) {
             AccessPath::try_from(k.clone()).expect("State key can't be converted to access path");
         match v {
             WriteOp::Deletion => panic!("found WriteOp::Deletion in WriteSet"),
-            WriteOp::Delta(..) => panic!("found WriteOp::Delta in WriteSet"),
+            WriteOp::Delta(_) => panic!("found WriteOp::Delta in WriteSet"),
             WriteOp::Value(blob) => {
                 let tag = ap.path.get(0).expect("empty blob in WriteSet");
                 if *tag == 1 {
@@ -245,7 +245,7 @@ fn print_account_states(storage: &impl MoveResolverExt, ws: &WriteSet) {
             AccessPath::try_from(k.clone()).expect("State key can't be converted to access path");
         match v {
             WriteOp::Deletion => panic!("found WriteOp::Deletion in WriteSet"),
-            WriteOp::Delta(..) => panic!("found WriteOp::Delta in WriteSet"),
+            WriteOp::Delta(_) => panic!("found WriteOp::Delta in WriteSet"),
             WriteOp::Value(blob) => {
                 let tag = ap.path.get(0).expect("empty blob in WriteSet");
                 if *tag == 1 {

--- a/aptos-move/transaction-replay/src/lib.rs
+++ b/aptos-move/transaction-replay/src/lib.rs
@@ -177,12 +177,12 @@ impl AptosDebugger {
                 access_path::Path::Resource(tag) => match op {
                     WriteOp::Deletion => state_view.delete_resource(addr, tag)?,
                     WriteOp::Value(bytes) => state_view.save_resource(addr, tag, bytes)?,
-                    WriteOp::Delta(..) => unreachable!("deltas are only used in executor"),
+                    WriteOp::Delta(_) => unreachable!("deltas are only used in executor"),
                 },
                 access_path::Path::Code(module_id) => match op {
                     WriteOp::Deletion => state_view.delete_module(&module_id)?,
                     WriteOp::Value(bytes) => state_view.save_module(&module_id, bytes)?,
-                    WriteOp::Delta(..) => unreachable!("deltas are only used in executor"),
+                    WriteOp::Delta(_) => unreachable!("deltas are only used in executor"),
                 },
             }
         }

--- a/execution/executor-types/src/in_memory_state_calculator.rs
+++ b/execution/executor-types/src/in_memory_state_calculator.rs
@@ -244,7 +244,7 @@ fn process_state_key_write_op(
     let state_value = match write_op {
         WriteOp::Value(new_value) => StateValue::from(new_value),
         WriteOp::Deletion => StateValue::empty(),
-        WriteOp::Delta(..) => unreachable!("deltas are only used in executor"),
+        WriteOp::Delta(_) => unreachable!("deltas are only used in executor"),
     };
     match state_cache.entry(state_key.clone()) {
         hash_map::Entry::Occupied(mut entry) => {

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -36,6 +36,7 @@ aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
 move-deps = { path = "../aptos-move/move-deps", features = ["address32"] }
 
 [dev-dependencies]
+claim = "0.5.0"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 regex = "1.5.5"

--- a/types/src/delta_set.rs
+++ b/types/src/delta_set.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+//! Parallel data aggregation uses a `Delta` op (note: this is a temporary
+//! solution and ideally we should modify `ChangeSet` and `TransactionOutput`
+//! to keep deltas internal to executor). Every delta is parametrized by an
+//! operation: a partial function with a postcondition.
+
+/// Specifies different delta partial function specifications.
+#[derive(Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
+pub enum DeltaOperation {
+    // Addition of `value` which overflows on `limit`.
+    Addition { value: u128, limit: u128 },
+    // Subtraction of `value` which cannot go below zero.
+    Subtraction { value: u128 },
+}
+
+impl DeltaOperation {
+    /// Returns optional result of delta application to `base` (None if
+    /// postocndition not satisfied).
+    pub fn apply_to(&self, base: u128) -> Option<u128> {
+        match self {
+            DeltaOperation::Addition { value, limit } => addition(base, *value, *limit),
+            DeltaOperation::Subtraction { value } => subtraction(base, *value),
+        }
+    }
+}
+
+/// Implements application of `Addition` to `base`.
+fn addition(base: u128, value: u128, limit: u128) -> Option<u128> {
+    if value > (limit - base) {
+        None
+    } else {
+        Some(base + value)
+    }
+}
+
+/// Implements application of `Subtraction` to `base`.
+fn subtraction(base: u128, value: u128) -> Option<u128> {
+    if value > base {
+        None
+    } else {
+        Some(base - value)
+    }
+}
+
+impl std::fmt::Debug for DeltaOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DeltaOperation::Addition { value, limit } => {
+                write!(f, "+{} ensures result <= {}", value, limit)
+            }
+            DeltaOperation::Subtraction { value } => {
+                write!(f, "-{} ensures 0 <= result", value)
+            }
+        }
+    }
+}
+
+/// Serializes value after delta application.
+pub fn serialize(value: &u128) -> Vec<u8> {
+    bcs::to_bytes(value).expect("unexpected serialization error")
+}
+
+/// Deserializes value for delta application.
+pub fn deserialize(value_bytes: &Vec<u8>) -> u128 {
+    bcs::from_bytes(value_bytes).expect("unexpected deserialization error")
+}

--- a/types/src/delta_set.rs
+++ b/types/src/delta_set.rs
@@ -66,3 +66,37 @@ pub fn serialize(value: &u128) -> Vec<u8> {
 pub fn deserialize(value_bytes: &Vec<u8>) -> u128 {
     bcs::from_bytes(value_bytes).expect("unexpected deserialization error")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use claim::{assert_matches, assert_some_eq};
+
+    fn addition(value: u128, limit: u128) -> DeltaOperation {
+        DeltaOperation::Addition { value, limit }
+    }
+
+    fn subtraction(value: u128) -> DeltaOperation {
+        DeltaOperation::Subtraction { value }
+    }
+
+    #[test]
+    fn test_delta_addition() {
+        let add5 = addition(5, 100);
+        assert_some_eq!(add5.apply_to(0), 5);
+        assert_some_eq!(add5.apply_to(5), 10);
+        assert_some_eq!(add5.apply_to(95), 100);
+
+        assert_matches!(add5.apply_to(96), None);
+    }
+
+    #[test]
+    fn test_delta_subtraction() {
+        let sub5 = subtraction(5);
+        assert_matches!(sub5.apply_to(0), None);
+        assert_matches!(sub5.apply_to(1), None);
+
+        assert_some_eq!(sub5.apply_to(5), 0);
+        assert_some_eq!(sub5.apply_to(100), 95);
+    }
+}

--- a/types/src/delta_set.rs
+++ b/types/src/delta_set.rs
@@ -63,7 +63,7 @@ pub fn serialize(value: &u128) -> Vec<u8> {
 }
 
 /// Deserializes value for delta application.
-pub fn deserialize(value_bytes: &Vec<u8>) -> u128 {
+pub fn deserialize(value_bytes: &[u8]) -> u128 {
     bcs::from_bytes(value_bytes).expect("unexpected deserialization error")
 }
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -11,6 +11,7 @@ pub mod block_info;
 pub mod block_metadata;
 pub mod chain_id;
 pub mod contract_event;
+pub mod delta_set;
 pub mod epoch_change;
 pub mod epoch_state;
 pub mod event;

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -2,46 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! For each transaction the VM executes, the VM will output a `WriteSet` that contains each access
-//! path it updates. For each access path, the VM can either give its new value or delete it. For
-//! aggregator, delta updates are used (note: this is a temporary solution and ideally we should
-//! modify `ChangeSet` and `TransactionOutput` to keep deltas internal to executor).
+//! path it updates. For each access path, the VM can either give its new value or delete it.
 
-use crate::state_store::state_key::StateKey;
+use crate::{delta_set::DeltaOperation, state_store::state_key::StateKey};
 use anyhow::Result;
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use serde::{Deserialize, Serialize};
-
-/// Specifies partial function such as +X or -X to use with `WriteOp::Delta`.
-#[derive(Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
-pub enum DeltaOperation {
-    Addition(u128),
-    Subtraction(u128),
-}
-
-impl std::fmt::Debug for DeltaOperation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            DeltaOperation::Addition(value) => write!(f, "+{}", value),
-            DeltaOperation::Subtraction(value) => write!(f, "-{}", value),
-        }
-    }
-}
-
-#[derive(Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
-pub struct DeltaLimit(pub u128);
-
-impl std::fmt::Debug for DeltaLimit {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "result <= {}", self.0)
-    }
-}
 
 #[derive(Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum WriteOp {
     Deletion,
     Value(#[serde(with = "serde_bytes")] Vec<u8>),
     #[serde(skip)]
-    Delta(DeltaOperation, DeltaLimit),
+    Delta(DeltaOperation),
 }
 
 impl WriteOp {
@@ -49,7 +22,7 @@ impl WriteOp {
     pub fn is_deletion(&self) -> bool {
         match self {
             WriteOp::Deletion => true,
-            WriteOp::Delta(..) => false,
+            WriteOp::Delta(_) => false,
             WriteOp::Value(_) => false,
         }
     }
@@ -66,9 +39,7 @@ impl std::fmt::Debug for WriteOp {
                     .map(|byte| format!("{:02x}", byte))
                     .collect::<String>()
             ),
-            WriteOp::Delta(op, limit) => {
-                write!(f, "Delta({:?} ensures {:?})", op, limit)
-            }
+            WriteOp::Delta(op) => write!(f, "Delta({:?})", op),
             WriteOp::Deletion => write!(f, "Deletion"),
         }
     }
@@ -76,7 +47,8 @@ impl std::fmt::Debug for WriteOp {
 
 /// `WriteSet` contains all access paths that one transaction modifies. Each of them is a `WriteOp`
 /// where `Value(val)` means that serialized representation should be updated to `val`, and
-/// `Deletion` means that we are going to delete this access path.
+/// `Deletion` means that we are going to delete this access path. `Delta(op)` means `op` should
+/// be applied to a deserialized value at the corresponding access path.
 #[derive(
     BCSCryptoHash, Clone, CryptoHasher, Debug, Default, Eq, Hash, PartialEq, Serialize, Deserialize,
 )]


### PR DESCRIPTION
### Description

Slightly refactored delta operations so that `Aggregator` 1) can reuse `apply_to` functionality based on operation 2) can reuse unique serialization/deserialization for delta op values (This way it should also be easier to extract these deltas to `ChangeSet`, etc.). Added tests.

Implemented delta application for sequential execution. @gelash @zekun000 I am looking for a place to put tests in the form of a) generate writeset with deltas b) apply with fake executor / fake data store c) check result of application and/or VM status. I suppose `e2e-tests/src/executor.rs` might be the best place for that? Or a separate file?

### Test Plan

- [x] Unit tests
- [ ] Fake executor tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2135)
<!-- Reviewable:end -->
