### PR TITLE
[Configs] Increase default configs for state sync.

### DIFF
--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -39,8 +39,7 @@ pub const PING_FAILURES_TOLERATED: u64 = 5;
 pub const CONNECTIVITY_CHECK_INTERVAL_MS: u64 = 5000;
 pub const MAX_CONCURRENT_NETWORK_REQS: usize = 100;
 pub const MAX_CONNECTION_DELAY_MS: u64 = 60_000; /* 1 minute */
-// Max default fullnode outbound connections is now 2 to decrease load on network
-pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 2;
+pub const MAX_FULLNODE_OUTBOUND_CONNECTIONS: usize = 5;
 pub const MAX_INBOUND_CONNECTIONS: usize = 100;
 pub const MAX_FRAME_SIZE: usize = 16 * 1024 * 1024; /* 16 MiB */
 pub const CONNECTION_BACKOFF_BASE: u64 = 2;

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -186,7 +186,7 @@ impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
             global_summary_refresh_interval_ms: 50,
-            max_concurrent_requests: 1,
+            max_concurrent_requests: 3,
             max_data_stream_channel_sizes: 1000,
             max_request_retry: 3,
             max_notification_id_mappings: 2000,


### PR DESCRIPTION
### Description

This PR makes two small improvements to the default config values for state sync and networking:
1. Turn on the data pre-fetcher for performance.
2. Increase the default number of outbound connections from 2 to 5. With more validators and more decentralization, we're seeing that 2 outbound connections is not great (there's a reasonably high chance of connecting to bad/slow peers on PFNs).

### Test Plan
None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2136)
<!-- Reviewable:end -->
