### PR TITLE
[forge] Better error message when unauthorized

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3170,6 +3170,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 name = "forge"
 version = "0.0.0"
 dependencies = [
+ "again",
  "anyhow",
  "aptos-config",
  "aptos-genesis",
@@ -3198,6 +3199,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "termcolor",
+ "thiserror",
  "tokio",
  "transaction-emitter-lib",
  "url",

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+again = "0.1.2"
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 async-trait = "0.1.53"
 either = "1.6.1"
@@ -28,6 +29,7 @@ serde_json = "1.0.81"
 structopt = "0.3.21"
 tempfile = "3.3.0"
 termcolor = "1.1.2"
+thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["full"] }
 url = "2.2.2"
 

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -6,9 +6,11 @@ use crate::{
     nodes_healthcheck, K8sNode, Result, DEFAULT_ROOT_KEY, FULLNODE_HAPROXY_SERVICE_SUFFIX,
     FULLNODE_SERVICE_SUFFIX, VALIDATOR_HAPROXY_SERVICE_SUFFIX, VALIDATOR_SERVICE_SUFFIX,
 };
+use again::RetryPolicy;
 use anyhow::{bail, format_err};
 use aptos_logger::info;
 use aptos_sdk::types::PeerId;
+use async_trait::async_trait;
 use k8s_openapi::api::{
     apps::v1::{Deployment, StatefulSet},
     batch::v1::Job,
@@ -30,9 +32,12 @@ use std::{
     path::Path,
     process::{Command, Stdio},
     str,
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tempfile::TempDir;
+use thiserror::Error;
+use tokio::time::Duration;
 
 // binaries expected to be present on test runner
 const HELM_BIN: &str = "helm";
@@ -613,49 +618,97 @@ fn dump_helm_values_to_file(helm_release_name: &str, tmp_dir: &TempDir) -> Resul
     dump_string_to_file(file_name, content, tmp_dir)
 }
 
+struct K8sNamespacesApi {
+    api: Api<Namespace>,
+}
+
+#[async_trait]
+trait CreateNamespace: Send + Sync {
+    async fn create(&self, pp: &PostParams, namespace: &Namespace) -> Result<Namespace, KubeError>;
+}
+
+#[async_trait]
+impl CreateNamespace for Api<Namespace> {
+    async fn create(&self, pp: &PostParams, namespace: &Namespace) -> Result<Namespace, KubeError> {
+        self.create(pp, namespace).await
+    }
+}
+
+impl K8sNamespacesApi {
+    fn from_client(kube_client: K8sClient) -> Self {
+        K8sNamespacesApi {
+            api: Api::all(kube_client),
+        }
+    }
+}
+
+#[async_trait]
+impl CreateNamespace for K8sNamespacesApi {
+    async fn create(&self, pp: &PostParams, namespace: &Namespace) -> Result<Namespace, KubeError> {
+        self.api.create(pp, namespace).await
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("{0}")]
+enum ApiError {
+    RetryableError(String),
+    FinalError(String),
+}
+
+async fn create_namespace(
+    namespace_creator: Arc<dyn CreateNamespace>,
+    kube_namespace: String,
+) -> Result<(), ApiError> {
+    let kube_namespace_name = kube_namespace.clone();
+    let namespace = Namespace {
+        metadata: ObjectMeta {
+            name: Some(kube_namespace_name.clone()),
+            ..ObjectMeta::default()
+        },
+        spec: None,
+        status: None,
+    };
+    if let Err(KubeError::Api(api_err)) = namespace_creator
+        .create(&PostParams::default(), &namespace)
+        .await
+    {
+        if api_err.code == 409 {
+            return Err(ApiError::RetryableError(format!(
+                "Namespace {} already exists, continuing with it",
+                &kube_namespace_name
+            )));
+        } else if api_err.code == 401 {
+            return Err(ApiError::FinalError(
+                "Unauthorized, did you authorize with kubernetes? \
+                    Try running `kubectl get current-context`"
+                    .to_string(),
+            ));
+        } else {
+            return Err(ApiError::RetryableError(format!(
+                "Failed to use existing namespace {}: {:?}",
+                &kube_namespace_name, api_err
+            )));
+        }
+    }
+    Ok(())
+}
+
 pub async fn create_management_configmap(kube_namespace: String, keep: bool) -> Result<()> {
     let kube_client = create_k8s_client().await;
+    let namespaces_api = Arc::new(K8sNamespacesApi::from_client(kube_client.clone()));
+    let other_kube_namespace = kube_namespace.clone();
 
     // try to create a new namespace
     // * if it errors with 409, the namespace exists already and we should use it
     // * if it errors with 403, the namespace is likely in the process of being terminated, so try again
-    aptos_retrier::retry_async(k8s_wait_genesis_strategy(), || {
-        let namespaces_api: Api<Namespace> = Api::all(kube_client.clone());
-        let kube_namespace_name = kube_namespace.clone();
-        let namespace = Namespace {
-            metadata: ObjectMeta {
-                name: Some(kube_namespace_name.clone()),
-                ..ObjectMeta::default()
-            },
-            spec: None,
-            status: None,
-        };
-        Box::pin(async move {
-            if let Err(KubeError::Api(api_err)) = namespaces_api
-                .create(&PostParams::default(), &namespace)
-                .await
-            {
-                if api_err.code == 409 {
-                    info!(
-                        "Namespace {} already exists, continuing with it",
-                        &kube_namespace_name
-                    );
-                } else {
-                    info!(
-                        "Failed to use existing namespace {}: {:?}",
-                        &kube_namespace_name, api_err
-                    );
-                    bail!(
-                        "Failed to use existing namespace {}: {:?}",
-                        &kube_namespace_name,
-                        api_err
-                    );
-                }
-            };
-            Ok(())
-        })
-    })
-    .await?;
+    RetryPolicy::exponential(Duration::from_millis(1000))
+        .with_max_delay(Duration::from_millis(10 * 60 * 1000))
+        .retry_if(
+            move || create_namespace(namespaces_api.clone(), other_kube_namespace.clone()),
+            |e: &ApiError| matches!(e, ApiError::RetryableError(_)),
+        )
+        .await?;
 
     let configmap: Api<ConfigMap> = Api::namespaced(kube_client.clone(), &kube_namespace);
 
@@ -771,4 +824,58 @@ pub async fn cleanup_cluster_with_management() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyper::http::StatusCode;
+    use kube::error::ErrorResponse;
+
+    struct FailedNamespacesApi {
+        status_code: u16,
+    }
+
+    impl FailedNamespacesApi {
+        fn from_status_code(status_code: u16) -> Self {
+            FailedNamespacesApi { status_code }
+        }
+    }
+
+    #[async_trait]
+    impl CreateNamespace for FailedNamespacesApi {
+        async fn create(
+            &self,
+            _pp: &PostParams,
+            _namespace: &Namespace,
+        ) -> Result<Namespace, KubeError> {
+            let status = StatusCode::from_u16(self.status_code).unwrap();
+            Err(KubeError::Api(ErrorResponse {
+                status: status.to_string(),
+                code: status.as_u16(),
+                message: "Failed to create namespace".to_string(),
+                reason: "Failed to parse error data".into(),
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_namespace_final_error() {
+        let namespace_creator = Arc::new(FailedNamespacesApi::from_status_code(401));
+        let result = create_namespace(namespace_creator, "banana".to_string()).await;
+        match result {
+            Err(ApiError::FinalError(_)) => {}
+            _ => panic!("Expected final error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_namespace_retryable_error() {
+        let namespace_creator = Arc::new(FailedNamespacesApi::from_status_code(403));
+        let result = create_namespace(namespace_creator, "banana".to_string()).await;
+        match result {
+            Err(ApiError::RetryableError(_)) => {}
+            _ => panic!("Expected retryable error"),
+        }
+    }
 }


### PR DESCRIPTION
Print a better error message when you're not authorized. Additionally remove some overly complex logic for performing retries in favor of the more standard again crate.

I also added unittests and split up the function a bit to make it somewhat testable.

Test Plan:

Running unauthorized fails

```
$ cargo run -p forge-cli -- test k8s-swarm --namespace forge-banana --port-forward

2022-07-21T22:27:35.976025Z [main] INFO testsuite/forge/src/backend/k8s/mod.rs:53 Using forge namespace: forge-banana

running 1 tests
Starting Swarm with supported versions: ["devnet", "devnet"]
Failed to run tests:
Unauthorized, did you authorize with kubernetes? Try running `kubectl get current-context`
Error: Unauthorized, did you authorize with kubernetes? Try running `kubectl get current-context`
```

Then running authorized still works

```
$ cargo run -p forge-cli -- test k8s-swarm --namespace forge-banana --port-forward

====json-report-end===
2022-07-21T22:24:59.222911Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:279 Deleting namespace forge-banana: Some(NamespaceStatus { phase: Some("Terminating") })
2022-07-21T22:24:59.223309Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:390 aptos-node resources for Forge removed in namespace: forge-banana

test result: ok. 1 passed; 0 failed; 0 filtered out

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2137)
<!-- Reviewable:end -->
