### PR TITLE
[API] Rework response and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ dependencies = [
  "mime",
  "move-deps",
  "once_cell",
+ "paste",
  "percent-encoding",
  "poem",
  "poem-openapi",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -19,6 +19,7 @@ hex = "0.4.3"
 hyper = "0.14.18"
 mime = "0.3.16"
 once_cell = "1.10.0"
+paste = "1.0.7"
 percent-encoding = "2.1.0"
 poem = { version = "1.3.35", features = ["anyhow", "rustls"] }
 poem-openapi = { version = "2.0.5", features = ["swagger-ui", "url"] }

--- a/api/src/failpoint.rs
+++ b/api/src/failpoint.rs
@@ -6,7 +6,7 @@
 use anyhow::{format_err, Result};
 use aptos_api_types::Error;
 
-use crate::poem_backend::{AptosError, AptosErrorResponse};
+use crate::poem_backend::{AptosError, InternalError};
 use poem_openapi::payload::Json;
 
 #[allow(unused_variables)]
@@ -19,10 +19,11 @@ pub fn fail_point(name: &str) -> Result<(), Error> {
 
 #[allow(unused_variables)]
 #[inline]
-pub fn fail_point_poem(name: &str) -> Result<(), AptosErrorResponse> {
+pub fn fail_point_poem<E: InternalError>(name: &str) -> Result<(), E> {
     Ok(fail::fail_point!(format!("api::{}", name).as_str(), |_| {
-        Err(AptosErrorResponse::InternalServerError(Json(
-            AptosError::new(format!("unexpected internal error for {}", name)),
+        Err(E::internal_str(&format!(
+            "unexpected internal error for {}",
+            name
         )))
     }))
 }

--- a/api/src/poem_backend/accept_type.rs
+++ b/api/src/poem_backend/accept_type.rs
@@ -1,12 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::TryFrom;
-
 use poem::web::Accept;
-use poem_openapi::payload::Json;
 
-use super::{AptosError, AptosErrorCode, AptosErrorResponse};
+use super::{AptosErrorCode, BadRequestError};
 
 #[derive(PartialEq)]
 pub enum AcceptType {
@@ -14,25 +11,24 @@ pub enum AcceptType {
     Bcs,
 }
 
-impl TryFrom<&Accept> for AcceptType {
-    type Error = AptosErrorResponse;
-
-    fn try_from(accept: &Accept) -> Result<Self, Self::Error> {
-        for mime in &accept.0 {
-            match mime.as_ref() {
-                "application/json" => return Ok(AcceptType::Json),
-                "application/x-bcs" => return Ok(AcceptType::Bcs),
-                "*/*" => {}
-                wildcard => {
-                    return Err(AptosErrorResponse::BadRequest(Json(
-                        AptosError::new(format!("Invalid Accept type: {:?}", wildcard))
-                            .error_code(AptosErrorCode::UnsupportedAcceptType),
-                    )));
-                }
+// I can't use TryFrom here right now:
+// https://stackoverflow.com/questions/73072492/apply-trait-bounds-to-associated-type
+pub fn parse_accept<E: BadRequestError>(accept: &Accept) -> Result<AcceptType, E> {
+    for mime in &accept.0 {
+        match mime.as_ref() {
+            "application/json" => return Ok(AcceptType::Json),
+            "application/x-bcs" => return Ok(AcceptType::Bcs),
+            "*/*" => {}
+            wildcard => {
+                return Err(E::bad_request_str(&format!(
+                    "Unsupported Accept type: {:?}",
+                    wildcard
+                ))
+                .error_code(AptosErrorCode::UnsupportedAcceptType));
             }
         }
-
-        // Default to returning content as JSON.
-        Ok(AcceptType::Json)
     }
+
+    // Default to returning content as JSON.
+    Ok(AcceptType::Json)
 }

--- a/api/src/poem_backend/mod.rs
+++ b/api/src/poem_backend/mod.rs
@@ -22,16 +22,14 @@ pub enum ApiTags {
     General,
 }
 
+pub use accept_type::AcceptType;
 pub use accounts::AccountsApi;
 pub use basic::BasicApi;
 pub use events::EventsApi;
 pub use index::IndexApi;
 pub use log::middleware_log;
 pub use post::AptosPost;
-pub use response::{
-    AptosError, AptosErrorCode, AptosErrorResponse, AptosInternalResult, AptosResponse,
-    AptosResponseContent,
-};
+pub use response::*;
 pub use runtime::attach_poem_to_runtime;
 pub use transactions::TransactionsApi;
 

--- a/api/src/poem_backend/transactions.rs
+++ b/api/src/poem_backend/transactions.rs
@@ -4,25 +4,22 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::convert::TryFrom;
 use std::sync::Arc;
 
-use super::accept_type::AcceptType;
+use super::accept_type::{parse_accept, AcceptType};
 use super::page::Page;
-use super::{response::AptosResponseResult, ApiTags, AptosResponse};
-use super::{AptosError, AptosErrorCode, AptosErrorResponse};
+use super::AptosErrorCode;
+use super::{
+    ApiTags, AptosErrorResponse, BasicErrorWith404, BasicResponse, BasicResponseStatus,
+    BasicResultWith404, InternalError,
+};
 use crate::context::Context;
 use crate::failpoint::fail_point_poem;
-use anyhow::format_err;
-use aptos_api_types::AsConverter;
-use aptos_api_types::{LedgerInfo, Transaction, TransactionOnChainData};
+use anyhow::Context as AnyhowContext;
+use aptos_api_types::{AsConverter, LedgerInfo, Transaction, TransactionOnChainData};
 use poem::web::Accept;
 use poem_openapi::param::Query;
-use poem_openapi::payload::Json;
 use poem_openapi::OpenApi;
-
-// TODO: Make a helper that builds an AptosResponse from just an anyhow error,
-// that assumes that it's an internal error. We can use .context() add more info.
 
 pub struct TransactionsApi {
     pub context: Arc<Context>,
@@ -44,16 +41,16 @@ impl TransactionsApi {
         accept: Accept,
         start: Query<Option<u64>>,
         limit: Query<Option<u16>>,
-    ) -> AptosResponseResult<Vec<Transaction>> {
-        fail_point_poem("endpoint_get_transactions")?;
-        let accept_type = AcceptType::try_from(&accept)?;
+    ) -> BasicResultWith404<Vec<Transaction>> {
+        fail_point_poem("endppoint_get_transactions")?;
+        let accept_type = parse_accept(&accept)?;
         let page = Page::new(start.0, limit.0);
         self.list(&accept_type, page)
     }
 }
 
 impl TransactionsApi {
-    fn list(&self, accept_type: &AcceptType, page: Page) -> AptosResponseResult<Vec<Transaction>> {
+    fn list(&self, accept_type: &AcceptType, page: Page) -> BasicResultWith404<Vec<Transaction>> {
         let latest_ledger_info = self.context.get_latest_ledger_info_poem()?;
         let ledger_version = latest_ledger_info.version();
         let limit = page.limit()?;
@@ -67,15 +64,9 @@ impl TransactionsApi {
         let data = self
             .context
             .get_transactions(start_version, limit, ledger_version)
-            .map_err(|e| {
-                AptosErrorResponse::InternalServerError(Json(
-                    AptosError::new(
-                        format_err!("Failed to read raw transactions from storage: {}", e)
-                            .to_string(),
-                    )
-                    .error_code(AptosErrorCode::InvalidBcsInStorageError),
-                ))
-            })?;
+            .context("Failed to read raw transactions from storage")
+            .map_err(BasicErrorWith404::internal)
+            .map_err(|e| e.error_code(AptosErrorCode::InvalidBcsInStorageError))?;
 
         self.render_transactions(data, accept_type, &latest_ledger_info)
     }
@@ -85,9 +76,15 @@ impl TransactionsApi {
         data: Vec<TransactionOnChainData>,
         accept_type: &AcceptType,
         latest_ledger_info: &LedgerInfo,
-    ) -> AptosResponseResult<Vec<Transaction>> {
+    ) -> BasicResultWith404<Vec<Transaction>> {
         if data.is_empty() {
-            return AptosResponse::try_from_rust_value(vec![], latest_ledger_info, accept_type);
+            let data: Vec<Transaction> = vec![];
+            return BasicResponse::try_from_rust_value((
+                data,
+                latest_ledger_info,
+                BasicResponseStatus::Ok,
+                accept_type,
+            ));
         }
 
         let resolver = self.context.move_resolver_poem()?;
@@ -101,16 +98,14 @@ impl TransactionsApi {
                 Ok(txn)
             })
             .collect::<Result<_, anyhow::Error>>()
-            .map_err(|e| {
-                AptosErrorResponse::InternalServerError(Json(
-                    AptosError::new(
-                        format_err!("Failed to convert transaction data from storage: {}", e)
-                            .to_string(),
-                    )
-                    .error_code(AptosErrorCode::InvalidBcsInStorageError),
-                ))
-            })?;
+            .context("Failed to convert transaction data from storage")
+            .map_err(BasicErrorWith404::internal)?;
 
-        AptosResponse::try_from_rust_value(txns, latest_ledger_info, accept_type)
+        BasicResponse::try_from_rust_value((
+            txns,
+            latest_ledger_info,
+            BasicResponseStatus::Ok,
+            accept_type,
+        ))
     }
 }

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -31,6 +31,7 @@ use std::{
 };
 
 // TODO: Add read_only / write_only (and their all variants) where appropriate.
+// TODO: Explore whether we should use discriminator_name, see https://github.com/poem-web/poem/issues/329.
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum TransactionData {
@@ -130,7 +131,7 @@ impl
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Transaction {
     PendingTransaction(PendingTransaction),
@@ -395,14 +396,14 @@ impl From<(&ContractEvent, serde_json::Value)> for Event {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum GenesisPayload {
     WriteSetPayload(WriteSetPayload),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TransactionPayload {
     ScriptFunctionPayload(ScriptFunctionPayload),
@@ -454,7 +455,7 @@ pub struct WriteSetPayload {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WriteSet {
     ScriptWriteSet(ScriptWriteSet),
@@ -474,7 +475,7 @@ pub struct DirectWriteSet {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WriteSetChange {
     DeleteModule(DeleteModule),
@@ -542,7 +543,7 @@ impl WriteSetChange {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TransactionSignature {
     Ed25519Signature(Ed25519Signature),
@@ -666,7 +667,7 @@ impl TryFrom<MultiEd25519Signature> for AccountAuthenticator {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AccountSignature {
     Ed25519Signature(Ed25519Signature),
@@ -817,7 +818,7 @@ impl From<TransactionAuthenticator> for TransactionSignature {
 /// 1. Transaction hash: hex-encoded string, e.g. "0x374eda71dce727c6cd2dd4a4fd47bfb85c16be2e3e95ab0df4948f39e1af9981"
 /// 2. Transaction version: u64 number string (as we encode u64 into string in JSON), e.g. "122"
 #[derive(Clone, Debug, Union)]
-#[oai(discriminator_name = "type")]
+#[oai(one_of)]
 pub enum TransactionId {
     Hash(HashValue),
     Version(u64),


### PR DESCRIPTION
## Description
This PR reworks the response and error handling.

The good:
- Previously, every endpoint returned the same response struct. This meant the spec would say every endpoint could return (for example), 200, 202 on the success path and 400, 404, 413, 500 on the failure path. This is misleading because not all endpoints return the same set of status codes (as evidenced by the existing spec). With this change, we have the ability to generate types at a more granular level for each endpoint.
- Returning errors from endpoint handler functions is much less verbose now.
- "Internal functions", as in those below the endpoint handlers (but still in the API code) can now return errors specific to the endpoints, with the status code data baked in. This is all guaranteed at compile time, we don't do any runtime checks to the effect of "can this endpoint handler handle the status code returned by this function).
- It removes a great deal of repetition that was already getting out of hand in our response types.

The bad:
- In some cases, we cannot use existing traits like TryFrom because it doesn't work with the pattern we're using for this internal function error returning model. [See this SO question](https://stackoverflow.com/questions/73072492/apply-trait-bounds-to-associated-type#73072713). This just means we have to write our own bare functions, not a big deal.

The ugly:
- To make this all happen, I wrote a few macros. These macros are responsible for creating the error type traits that we use for all this status code based type checking, error response types that leverage them, and success response types. To mitigate the fact that macros are often hard to understand, I've added a gratuitous amount of comments explaining in what is happening.
- ~Many endpoint handlers cannot imply the error type used in their results, meaning there are a lot of turbofish (`::<>`) uses. Down the line we can investigate how to hint to rustc what is happening, since I feel it should be possible for it to figure out what's going on~. Figured it out, much nicer.

The macros are pretty much a way to concentrate complexity that was previously all over the API codebase into just one place. At any rate I don't think there are many other good ways to make such strong checks happen at compile-time.

## Test Plan
Same as for #1906. The main test is to run the server see what spec it generates:
```
curl localhost:8080/v1/spec.yaml | gist -f spec.yaml 
```
Output: https://gist.github.com/banool/c9bc0659d4b155d7dd9584480378b8fc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2139)
<!-- Reviewable:end -->
