### PR TITLE
[Aptos Framework] Validate against empty execution hash in voting::resolve()

### DIFF
--- a/aptos-move/aptos-vm/src/move_vm_ext/transaction_context.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/transaction_context.rs
@@ -78,5 +78,6 @@ fn test_native_get_script_hash(
     _args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     let cost = native_gas(context.cost_table(), NativeCostIndex::SHA3_256, 0);
-    Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(vec![])]))
+    // TODO: Allow tests to configure the script hash value.
+    Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(vec![1])]))
 }

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -306,7 +306,7 @@ module aptos_framework::aptos_governance {
         create_proposal(
             &proposer,
             signer::address_of(&proposer),
-            b"",
+            b"123",
             b"",
             b"",
         );


### PR DESCRIPTION
### Description

Empty execution hash technically is not exploitable as transaction_context::script_hash() only returns empty if voting::resolve() is called from a script function and not script. This is not a serious issue as the transaction can only call voting::resolve() but cannot do anything else (script function is a single call per transaction). However, we might as well add a validation against empty execution hash for peace of mind.

### Test Plan
Unit Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2154)
<!-- Reviewable:end -->
