### PR TITLE
[Aptos Framework] Replace GovernanceProposal with AptosFramework signer in stake and block's update functions

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -277,7 +277,7 @@ module aptos_framework::aptos_governance {
     }
 
     /// Return a signer for making changes to 0x1 as part of on-chain governance proposal process.
-    public fun get_framework_signer(_proposal: &GovernanceProposal): signer acquires GovernanceResponsbility {
+    public fun get_framework_signer(_proposal: GovernanceProposal): signer acquires GovernanceResponsbility {
         let governance_responsibility = borrow_global<GovernanceResponsbility>(@aptos_framework);
         create_signer_with_capability(&governance_responsibility.signer_cap)
     }

--- a/aptos-move/framework/aptos-framework/sources/block.move
+++ b/aptos-move/framework/aptos-framework/sources/block.move
@@ -3,7 +3,6 @@ module aptos_framework::block {
     use std::error;
     use aptos_std::event;
 
-    use aptos_framework::governance_proposal::GovernanceProposal;
     use aptos_framework::timestamp;
     use aptos_framework::system_addresses;
     use aptos_framework::reconfiguration;
@@ -52,9 +51,10 @@ module aptos_framework::block {
     /// Update the epoch interval.
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_epoch_interval(
-        _gov_proposal: &GovernanceProposal,
+        aptos_framework: &signer,
         new_epoch_interval: u64,
     ) acquires BlockMetadata {
+        system_addresses::assert_aptos_framework(aptos_framework);
         let block_metadata = borrow_global_mut<BlockMetadata>(@aptos_framework);
         block_metadata.epoch_internal = new_epoch_interval;
     }
@@ -118,11 +118,19 @@ module aptos_framework::block {
 
     #[test(aptos_framework = @aptos_framework)]
     public entry fun test_update_epoch_interval(aptos_framework: signer) acquires BlockMetadata {
-        use aptos_framework::governance_proposal;
-
         initialize_block_metadata(&aptos_framework, 1);
         assert!(borrow_global<BlockMetadata>(@aptos_framework).epoch_internal == 1, 0);
-        update_epoch_interval(&governance_proposal::create_test_proposal(), 2);
+        update_epoch_interval(&aptos_framework, 2);
         assert!(borrow_global<BlockMetadata>(@aptos_framework).epoch_internal == 2, 1);
+    }
+
+    #[test(aptos_framework = @aptos_framework, account = @0x123)]
+    #[expected_failure(abort_code = 0x50002)]
+    public entry fun test_update_epoch_interval_unauthorized_should_fail(
+        aptos_framework: signer,
+        account: signer,
+    ) acquires BlockMetadata {
+        initialize_block_metadata(&aptos_framework, 1);
+        update_epoch_interval(&account, 2);
     }
 }


### PR DESCRIPTION
### Description

It makes more sense to require the signer of 0x1 to make upgrades to framework modules that are governed by the on-chain AptosGovernance as only a passed proposal (via voting) can be resolved to obtain the signer.

### Test Plan
Unit tests, integration tests (WIP), and manual tests in local testnet and AITs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2157)
<!-- Reviewable:end -->
