### PR TITLE
[Aptos Framework][Prover] Made the Aptos Framework compatible with Prover

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -81,6 +81,14 @@ module aptos_framework::account {
     native fun create_address(bytes: vector<u8>): address;
     native fun create_signer(addr: address): signer;
 
+    spec create_address { // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec create_signer { // TODO: temporary mockup.
+        pragma opaque;
+    }
+
     public fun initialize(account: &signer,
         module_addr: address,
         module_name: vector<u8>,

--- a/aptos-move/framework/aptos-framework/sources/bucket_table.move
+++ b/aptos-move/framework/aptos-framework/sources/bucket_table.move
@@ -86,11 +86,19 @@ module aptos_framework::bucket_table {
         }
     }
 
+    fun xor(a: u64, b: u64): u64 {
+        a ^ b
+    }
+    spec xor { // TODO: temporary mockup until Prover supports the operator `^`.
+        pragma opaque;
+        pragma verify = false;
+    }
+
     /// Split the next bucket into two and re-insert existing items.
     fun split_one_bucket<K, V>(map: &mut BucketTable<K, V>) {
         let new_bucket_index = map.num_buckets;
         // the next bucket to split is num_bucket without the most significant bit.
-        let to_split = new_bucket_index ^ (1 << map.level);
+        let to_split = xor(new_bucket_index, (1 << map.level));
         let new_bucket = vector::empty();
         map.num_buckets = new_bucket_index + 1;
         // if the whole level is splitted once, bump the level.
@@ -278,7 +286,7 @@ module aptos_framework::bucket_table {
         while (i < 256) {
             let j = i & 15; // i % 16
             if (j >= map.num_buckets) {
-                j = j ^ 8; // i % 8
+                j = xor(j, 8); // i % 8
             };
             let index = bucket_index(map.level, map.num_buckets, i);
             assert!(index == j, 0);

--- a/aptos-move/framework/aptos-framework/sources/timestamp.move
+++ b/aptos-move/framework/aptos-framework/sources/timestamp.move
@@ -11,7 +11,6 @@
 /// which reflect that the system has been successfully initialized.
 module aptos_framework::timestamp {
     use aptos_framework::system_addresses;
-    use std::signer;
     use std::error;
 
     friend aptos_framework::genesis;
@@ -46,16 +45,13 @@ module aptos_framework::timestamp {
         /// and need to hold.
         pragma delegate_invariants_to_caller;
         include AbortsIfNotGenesis;
-        include system_addresses::AbortsIfNotaptos_framework{account: signer::address_of(account)};
+        include system_addresses::AbortsIfNotAptosFramework{account};
         ensures is_operating();
     }
 
     #[test_only]
     public fun set_time_has_started_for_testing(account: &signer) {
         set_time_has_started(account);
-    }
-    spec set_time_has_started_for_testing {
-        pragma verify = false;
     }
 
     /// Updates the wall clock time by consensus. Requires VM privilege and will be invoked during block prologue.

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.move
@@ -1,4 +1,8 @@
 module aptos_framework::transaction_context {
     /// Return the script hash of the current script function.
     public native fun get_script_hash(): vector<u8>;
+
+    spec get_script_hash { // TODO: temporary mockup.
+        pragma opaque;
+    }
 }

--- a/aptos-move/framework/aptos-stdlib/Move.toml
+++ b/aptos-move/framework/aptos-stdlib/Move.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 [addresses]
 std = "0x1"
 aptos_std = "0x1"
+Extensions = "0x1" # TODO: Needed for Prover to instantiate `{{Ext}}` in prelude.
 
 [dependencies]
 MoveStdlib = { local = "../move-stdlib" }

--- a/aptos-move/framework/aptos-stdlib/sources/signature.move
+++ b/aptos-move/framework/aptos-stdlib/sources/signature.move
@@ -14,6 +14,9 @@ module aptos_std::signature {
     /// Return `false` otherwise.
     /// Does not abort.
     native public fun bls12381_validate_pubkey(public_key: vector<u8>, proof_of_possesion: vector<u8>): bool;
+    spec bls12381_validate_pubkey { // TODO: temporary mockup.
+        pragma opaque;
+    }
 
     /// Return true if the Ed25519 `signature` on `message` verifies against the Ed25519 public key
     /// `public_key`.

--- a/aptos-move/framework/aptos-stdlib/sources/table.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table.spec.move
@@ -1,0 +1,54 @@
+/// Specifications of the `Table` module.
+spec aptos_std::table {
+
+    // Make most of the public API intrinsic. Those functions have custom specifications in the prover.
+
+    spec Table {
+        pragma intrinsic;
+    }
+
+    spec new {
+        pragma intrinsic;
+    }
+
+    spec destroy_empty {
+        pragma intrinsic;
+    }
+
+    spec add {
+        pragma intrinsic;
+    }
+
+    spec borrow {
+        pragma intrinsic;
+    }
+
+    spec borrow_mut {
+        pragma intrinsic;
+    }
+
+    spec length {
+        pragma intrinsic;
+    }
+
+    spec empty {
+        pragma intrinsic;
+    }
+
+    spec remove {
+        pragma intrinsic;
+    }
+
+    spec contains {
+        pragma intrinsic;
+    }
+
+    // Specification functions for tables
+
+    spec native fun spec_table<K, V>(): Table<K, V>;
+    spec native fun spec_len<K, V>(t: Table<K, V>): num;
+    spec native fun spec_contains<K, V>(t: Table<K, V>, k: K): bool;
+    spec native fun spec_add<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;
+    spec native fun spec_remove<K, V>(t: Table<K, V>, k: K): Table<K, V>;
+    spec native fun spec_get<K, V>(t: Table<K, V>, k: K): V;
+}

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -22,6 +22,10 @@ module aptos_std::type_info {
     public native fun type_of<T>(): TypeInfo;
     public native fun type_name<T>(): string::String;
 
+    spec type_of { // TODO: temporary mockup.
+        pragma opaque;
+    }
+
     #[test]
     fun test() {
         let type_info = type_of<TypeInfo>();

--- a/aptos-move/framework/move-stdlib/sources/error.move
+++ b/aptos-move/framework/move-stdlib/sources/error.move
@@ -64,6 +64,14 @@ module std::error {
   public fun canonical(category: u64, reason: u64): u64 {
     (category << 16) + reason
   }
+  spec canonical {
+    pragma opaque = true;
+    // TODO: `<<` has different meanings in code and spec in case of overvlow.
+    let shl_res = (category * 65536) % 18446744073709551616; // (category << 16)
+    ensures [concrete] result == shl_res + reason;
+    aborts_if [abstract] false;
+    ensures [abstract] result == category;
+  }
 
   /// Functions to construct a canonical error code of the given category.
   public fun invalid_argument(r: u64): u64 {  canonical(INVALID_ARGUMENT, r) }

--- a/aptos-move/framework/move-stdlib/sources/hash.move
+++ b/aptos-move/framework/move-stdlib/sources/hash.move
@@ -7,4 +7,8 @@ module std::hash {
     native public fun sip_hash<MoveValue>(v: &MoveValue): u64;
     native public fun sha2_256(data: vector<u8>): vector<u8>;
     native public fun sha3_256(data: vector<u8>): vector<u8>;
+
+    spec sip_hash { // TODO: temporary mockup.
+        pragma opaque;
+    }
 }


### PR DESCRIPTION
This commit makes the Aptos Framework compatible with Prover.
  - fixed the existing spec that has been broken
  - mocked up the native functions and the xor operation so that Prover does not crash.

`aptos move prove` works without any error/crash for all of the following Move packages:
  - `aptos-framework`
  - `aptos-token`
  - `aptos-stdlib`
  - `move-stdlib`

TODO:
- add a new spec to the Stake module
- add the boogie implementation for the native functions which are temporarily mocked up in this PR.

### Description

### Test Plan
Run `aptos move prove` in any of the Aptos Move packages above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2162)
<!-- Reviewable:end -->
