### PR TITLE
[tf] upgrade k8s minimum version to 1.22

### DIFF
--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -3,6 +3,11 @@ variable "region" {
   type        = string
 }
 
+variable "kubernetes_version" {
+  description = "Version of Kubernetes to use for EKS cluster"
+  default     = "1.22"
+}
+
 variable "k8s_api_sources" {
   description = "List of CIDR subnets which can access the Kubernetes API endpoint"
   default     = ["0.0.0.0/0"]

--- a/terraform/modules/eks/cluster.tf
+++ b/terraform/modules/eks/cluster.tf
@@ -7,7 +7,7 @@ resource "aws_cloudwatch_log_group" "eks" {
 resource "aws_eks_cluster" "aptos" {
   name                      = var.eks_cluster_name
   role_arn                  = aws_iam_role.cluster.arn
-  version                   = "1.21"
+  version                   = var.kubernetes_version
   enabled_cluster_log_types = ["api", "audit", "authenticator", "controllerManager", "scheduler"]
   tags                      = local.default_tags
 
@@ -16,6 +16,13 @@ resource "aws_eks_cluster" "aptos" {
     public_access_cidrs     = var.k8s_api_sources
     endpoint_private_access = true
     security_group_ids      = [aws_security_group.cluster.id]
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # ignore autoupgrade version
+      version,
+    ]
   }
 
   depends_on = [

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -3,6 +3,11 @@ variable "region" {
   type        = string
 }
 
+variable "kubernetes_version" {
+  description = "Version of Kubernetes to use for EKS cluster"
+  default     = "1.22"
+}
+
 variable "eks_cluster_name" {
   description = "Name of the eks cluster"
   type        = string


### PR DESCRIPTION
### Description

Upgrade minimum version of k8s to 1.22 across all supported clouds. Only EKS needed to be updated. Also include an lifecycle `ignore_changes` block so we don't force the upgrade, which might take a while. This makes it such that only new clusters are spun up directly at the new version. Existing clusters need to upgrade manually outside of TF, which is much safer -- e.g. through cloud consoles or other CLI.

### Test Plan

Apply to a test Forge cluster and see that things still work.

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2165)
<!-- Reviewable:end -->
