### PR TITLE
[gha] sticky forge comment

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -36,12 +36,8 @@ env:
   AWS_ECR_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   # In case of pull_request events by default github actions merges main into the PR branch and then runs the tests etc
   # on the prospective merge result instead of only on the tip of the PR.
-  # We want to avoid this in case of docker image builds on PRs since want more predictable images then correspond to the code state a developer pushed from local.
-  # Therefore we build the images with the head of the PR branch instead of the prospective merge result.
-  # Safety-wise the merge queue (bors/kodiak or whatever we use) will retest the PR branch merged with the base branch anyways.
-  # In case of push events, this hack is a noop as we default to `github.sha`.
   # For more info also see https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
-  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  GIT_SHA: ${{ github.sha }}
 
   # TARGET_CACHE_ID is used as part of the docker tag / cache key inside our bake.hcl docker bake files.
   # The goal here is to have a branch or PR-local cache such that consecutive pushes to a shared branch or a specific PR can
@@ -127,7 +123,7 @@ jobs:
     uses: ./.github/workflows/sdk-integration-test.yaml
     secrets: inherit
     with:
-      GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      GIT_SHA: ${{ github.sha }}
 
   forge-e2e-test:
     needs: rust-images
@@ -140,7 +136,7 @@ jobs:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      GIT_SHA: ${{ github.sha }}
       merge_or_canary: ${{ github.event.pull_request.auto_merge != null && 'merge' || 'canary' }}
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -32,6 +32,8 @@ env:
   FORGE_CLUSTER_NAME: ${{ secrets.FORGE_CLUSTER_NAME }}
   FORGE_OUTPUT: forge_output.txt
   FORGE_REPORT: forge_report.json
+  FORGE_COMMENT: forge_comment.txt
+  FORGE_PRE_COMMENT: forge_pre_comment.txt
   FORGE_RUNNER_MODE: k8s
   FORGE_NAMESPACE: ${{ inputs.FORGE_NAMESPACE }}
 
@@ -49,6 +51,26 @@ jobs:
       - name: Set kubectl context
         if: env.FORGE_ENABLED == 'true'
         run: aws eks update-kubeconfig --name $FORGE_CLUSTER_NAME
+      - name: Run pre-Forge checks
+        if: env.FORGE_ENABLED == 'true'
+        shell: bash
+        env:
+          FORGE_RUNNER_MODE: pre-forge
+        run: |
+          set +e
+
+          source testsuite/run_forge.sh
+
+          # export env vars for next step
+          echo "FORGE_PRE_COMMENT=$FORGE_PRE_COMMENT" >> $GITHUB_ENV
+
+      - name: Post pre-Forge comment
+        if: env.FORGE_ENABLED == 'true' && github.event.number != null
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          recreate: true
+          path: ${{ env.FORGE_PRE_COMMENT }}
+
       - name: Run Forge
         if: env.FORGE_ENABLED == 'true'
         shell: bash
@@ -56,43 +78,28 @@ jobs:
           PUSH_GATEWAY: ${{ secrets.PUSH_GATEWAY }}
           PUSH_GATEWAY_USER: ${{ secrets.PUSH_GATEWAY_USER }}
           PUSH_GATEWAY_PASSWORD: ${{ secrets.PUSH_GATEWAY_PASSWORD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set +e
 
           # source this script to run and get environment variables
           source testsuite/run_forge.sh
 
-          # attempt to get the PR number
-          # If this workflow was not triggered by PR, then the result is null and will not comment on PR
-          PR_NUMBER="${{ github.event.number }}"
-
           # export env vars for next step
-          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
           echo "FORGE_EXIT_CODE=$FORGE_EXIT_CODE" >> $GITHUB_ENV
+          echo "FORGE_COMMENT=$FORGE_COMMENT" >> $GITHUB_ENV
 
-          # env vars to form the comment
-          echo "FORGE_COMMENT_HEADER=$FORGE_COMMENT_HEADER" >> $GITHUB_ENV
-          echo "FORGE_DASHBOARD_LINK=$FORGE_DASHBOARD_LINK" >> $GITHUB_ENV
-          echo "FORGE_REPORT_TXT=$FORGE_REPORT_TXT" >> $GITHUB_ENV
-          echo "FORGE_DASHBOARD_LINK=$FORGE_DASHBOARD_LINK" >> $GITHUB_ENV
-          echo "VALIDATOR_LOGS_LINK=$VALIDATOR_LOGS_LINK" >> $GITHUB_ENV
+          # append some GHA-specific content to the comment
+          cat << EOF >> $FORGE_COMMENT
+          ${{ env.FORGE_BLOCKING == 'true' && 'Forge is land-blocking' || 'Forge is not land-blocking' }}
+          * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          EOF
 
-      - name: Post result as PR comment
-        if: env.FORGE_ENABLED == 'true' && env.PR_NUMBER != null
-        uses: thollander/actions-comment-pull-request@v1
+      - name: Post forge result comment
+        if: env.FORGE_ENABLED == 'true' && github.event.number != null
+        uses: marocchino/sticky-pull-request-comment@v2
         with:
-          message: |
-            ${{ env.FORGE_COMMENT_HEADER }}
-            ${{ env.FORGE_BLOCKING == 'true' && 'Forge is land-blocking' || 'Forge is not land-blocking' }}
-            * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            * [Grafana dashboard](${{ env.FORGE_DASHBOARD_LINK }})
-            * [Validator 0 logs](${{ env.VALIDATOR_LOGS_LINK }})
-            ```
-            ${{ env.FORGE_REPORT_TXT }}
-            ```
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pr_number: ${{ env.PR_NUMBER }}
+          recreate: true
+          path: ${{ env.FORGE_COMMENT }}
 
       - name: Check Forge status
         if: env.FORGE_ENABLED == 'true'

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -91,7 +91,7 @@ spec:
         - sh
         - -c
         - |-
-          set -ex
+          set -e
           . /tmp/genesis.sh
         resources:
           {{- toYaml .Values.genesis.resources | nindent 10 }}

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -16,8 +16,17 @@ pwd | grep -qE 'aptos-core$' || (echo "Please run from aptos-core root directory
 TPS_THRESHOLD=5000
 P99_LATENCY_MS_THRESHOLD=8000
 
-FORGE_OUTPUT=${FORGE_OUTPUT:-forge_output.txt}
-FORGE_REPORT=${FORGE_REPORT:-forge_report.json}
+# output files
+FORGE_OUTPUT=${FORGE_OUTPUT:-$(mktemp)}
+FORGE_REPORT=${FORGE_REPORT:-$(mktemp)}
+FORGE_PRE_COMMENT=${FORGE_PRE_COMMENT:-$(mktemp)}
+FORGE_COMMENT=${FORGE_COMMENT:-$(mktemp)}
+echo "FORGE_OUTPUT: ${FORGE_OUTPUT}"
+echo "FORGE_REPORT: ${FORGE_REPORT}"
+echo "FORGE_PRE_COMMENT: ${FORGE_PRE_COMMENT}"
+echo "FORGE_COMMENT: ${FORGE_COMMENT}"
+
+# cluster auth
 AWS_ACCOUNT_NUM=${AWS_ACCOUNT_NUM:-$(aws sts get-caller-identity | jq -r .Account)}
 AWS_REGION=${AWS_REGION:-us-west-2}
 
@@ -36,51 +45,116 @@ FORGE_NAMESPACE_REUSE=${FORGE_NAMESPACE_REUSE:-false}
 FORGE_ENABLE_HAPROXY=${FORGE_ENABLE_HAPROXY:-false}
 FORGE_TEST_SUITE=${FORGE_TEST_SUITE:-land_blocking}
 
-# if this script is not triggered in GHA, use a default value
-[ -z "$GITHUB_RUN_ID" ] && GITHUB_RUN_ID=0
-
-if [ -z "$FORGE_NAMESPACE" ]; then
-    namespace="forge-${USER}-$(date '+%s')"
-    echo "FORGE_NAMESPACE not set, using auto-generated namespace: ${namespace}"
-fi
-FORGE_NAMESPACE=${FORGE_NAMESPACE:-$namespace}
-# clean up namespace name
-# replace non alphanumeric chars with dash
-FORGE_NAMESPACE="${FORGE_NAMESPACE//[^[:alnum:]]/-}"
-# use the first 64 chars only for namespace, as it is the maximum for k8s resources
-FORGE_NAMESPACE=${FORGE_NAMESPACE:0:64}
-
 [ "$FORGE_NAMESPACE_REUSE" = "true" ] && REUSE_ARGS="--reuse"
 [ "$FORGE_NAMESPACE_KEEP" = "true" ] && KEEP_ARGS="--keep"
 [ "$FORGE_ENABLE_HAPROXY" = "true" ] && ENABLE_HAPROXY_ARGS="--enable-haproxy"
 
-if [ -z "$IMAGE_TAG" ]; then
-    IMAGE_TAG_DEFAULT=$(git rev-parse HEAD)
-    echo "IMAGE_TAG not set, defaulting to current HEAD commit as tag: ${IMAGE_TAG_DEFAULT}"
-    IMAGE_TAG=${IMAGE_TAG_DEFAULT}
-fi
 
-echo "Ensure image exists"
-img=$(aws ecr describe-images --repository-name="aptos/validator" --image-ids=imageTag=$IMAGE_TAG)
-if [ $? != 0 ]; then
-    echo "IMAGE_TAG does not exist in ECR: ${IMAGE_TAG}. Make sure your commit has been pushed to GitHub previously."
-    echo "If you're trying to run the code from your PR, apply the label 'CICD:build-images' and wait for the builds to finish."
-    exit 1
-fi
+# Set variables for o11y resource locations depending on the type of cluster that is running Forge
+set_o11y_resources() {
+    if echo $FORGE_CLUSTER_NAME | grep "forge"; then
+        ES_DEFAULT_INDEX=$DEVINFRA_ES_DEFAULT_INDEX
+        ES_BASE_URL=$DEVINFRA_ES_BASE_URL
+        GRAFANA_BASE_URL=$DEVINFRA_GRAFANA_BASE_URL
+    else
+        ES_DEFAULT_INDEX=$INTERN_ES_DEFAULT_INDEX
+        ES_BASE_URL=$INTERN_ES_BASE_URL
+        GRAFANA_BASE_URL=$INTERN_GRAFANA_BASE_URL
+    fi
+}
+
+# Set the k8s namespace in which to execute Forge tests
+set_forge_namespace() {
+    if [ -z "$FORGE_NAMESPACE" ]; then
+        namespace="forge-${USER}-$(date '+%s')"
+        echo "FORGE_NAMESPACE not set, using auto-generated namespace: ${namespace}"
+    fi
+    FORGE_NAMESPACE=${FORGE_NAMESPACE:-$namespace}
+    # it must be under 64 chars alphanumeric
+    FORGE_NAMESPACE="${FORGE_NAMESPACE//[^[:alnum:]]/-}"
+    FORGE_NAMESPACE=${FORGE_NAMESPACE:0:64}
+}
+
+# Set an image tag to use
+set_image_tag() {
+    if [ -z "$IMAGE_TAG" ]; then
+        IMAGE_TAG_DEFAULT=$(git rev-parse HEAD)
+        echo "IMAGE_TAG not set, defaulting to current HEAD commit as tag: ${IMAGE_TAG_DEFAULT}"
+        IMAGE_TAG=${IMAGE_TAG_DEFAULT}
+    fi
+    echo "Ensure image exists"
+    img=$(aws ecr describe-images --repository-name="aptos/validator" --image-ids=imageTag=$IMAGE_TAG)
+    if [ $? != 0 ]; then
+        echo "IMAGE_TAG does not exist in ECR: ${IMAGE_TAG}. Make sure your commit has been pushed to GitHub previously."
+        echo "If you're trying to run the code from your PR, apply the label 'CICD:build-images' and wait for the builds to finish."
+        exit 1
+    fi
+}
+
+# Once o11y resource locations setup, build a link to the validator logs
+get_validator_logs_link() {
+    # build the logs link in a readable way...
+    # filter by:
+    #   * chain_name: name of the Forge cluster "chain"
+    #   * namespace: kubernetes namespace the Forge test was executed in
+    #   * hostname: name of a kubernetes pod e.g. validator name
+    if [ -n "$ENABLE_LOG_AUTO_REFRESH" ]; then
+        ES_TIME_FILTER="refreshInterval:(pause:!f,value:10000),time:(from:now-15m,to:now)"
+    else 
+        ES_TIME_FILTER="refreshInterval:(pause:!t,value:0),time:(from:'${ES_START_TIME}',to:'${ES_END_TIME}')"
+    fi
+    VAL0_HOSTNAME="aptos-node-0-validator-0"
+    VALIDATOR_LOGS_LINK="${ES_BASE_URL}/_dashboards/app/discover#/?
+        _g=(filters:!(),${ES_TIME_FILTER})
+        &_a=(columns:!(_source),filters:!(
+            ('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'${ES_DEFAULT_INDEX}',key:chain_name,negate:!f,params:(query:${FORGE_CHAIN_NAME}),type:phrase),query:(match_phrase:(chain_name:${FORGE_CHAIN_NAME}))),
+            ('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'${ES_DEFAULT_INDEX}',key:namespace,negate:!f,params:(query:${FORGE_NAMESPACE}),type:phrase),query:(match_phrase:(namespace:${FORGE_NAMESPACE}))),
+            ('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'${ES_DEFAULT_INDEX}',key:hostname,negate:!f,params:(query:${VAL0_HOSTNAME}),type:phrase),query:(match_phrase:(hostname:${VAL0_HOSTNAME})))
+        ),index:'${ES_DEFAULT_INDEX}',interval:auto,query:(language:kuery,query:''),sort:!())"
+
+    # trim all the whitespace in logs link
+    VALIDATOR_LOGS_LINK=$(echo $VALIDATOR_LOGS_LINK | tr -d '[:space:]')
+}
+
+get_dashboard_link() {
+    if echo $FORGE_CLUSTER_NAME | grep -qv "forge"; then
+        FORGE_CHAIN_NAME="${FORGE_CHAIN_NAME}net"
+    fi
+    if [ -n "$ENABLE_DASHBOARD_AUTO_REFRESH" ]; then
+        GRAFANA_TIME_FILTER="&refresh=10s&from=now-15m&to=now"
+    else 
+        GRAFANA_TIME_FILTER="&from=${FORGE_START_TIME_MS}&to=${FORGE_END_TIME_MS}"
+    fi
+    FORGE_DASHBOARD_LINK="${GRAFANA_BASE_URL}&var-namespace=${FORGE_NAMESPACE}&var-chain_name=${FORGE_CHAIN_NAME}${GRAFANA_TIME_FILTER}"
+}
 
 # determine cluster name from kubectl context and set o11y resources
 FORGE_CLUSTER_NAME=$(kubectl config current-context | grep -oE 'aptos.*')
-if echo $FORGE_CLUSTER_NAME | grep "forge"; then
-    ES_DEFAULT_INDEX=$DEVINFRA_ES_DEFAULT_INDEX
-    ES_BASE_URL=$DEVINFRA_ES_BASE_URL
-    GRAFANA_BASE_URL=$DEVINFRA_GRAFANA_BASE_URL
-else
-    ES_DEFAULT_INDEX=$INTERN_ES_DEFAULT_INDEX
-    ES_BASE_URL=$INTERN_ES_BASE_URL
-    GRAFANA_BASE_URL=$INTERN_GRAFANA_BASE_URL
-fi
-
 echo "Using cluster ${FORGE_CLUSTER_NAME} from current kubectl context"
+# remove the "aptos-" prefix and add "net" suffix to get the chain name
+# as used by the deployment setup and as reported to o11y systems
+FORGE_CHAIN_NAME=${FORGE_CLUSTER_NAME#"aptos-"}
+
+# set the namespace in FORGE_NAMESPACE
+set_forge_namespace
+
+# set the image tag in IMAGE_TAG
+set_image_tag
+
+# set the o11y resource locations in
+# ES_DEFAULT_INDEX, ES_BASE_URL, GRAFANA_BASE_URL
+set_o11y_resources
+ENABLE_LOG_AUTO_REFRESH=true get_validator_logs_link
+ENABLE_DASHBOARD_AUTO_REFRESH=true get_dashboard_link
+# construct a pre-comment
+cat <<EOF >$FORGE_PRE_COMMENT
+### Forge is running with \`${IMAGE_TAG}\`
+* [Grafana dashboard (auto-refresh)]($FORGE_DASHBOARD_LINK)
+* [Validator 0 logs (auto-refresh)]($VALIDATOR_LOGS_LINK)
+EOF
+echo "=====START PRE_FORGE COMMENT====="
+cat $FORGE_PRE_COMMENT
+echo "=====END PRE_FORGE COMMENT====="
 
 FORGE_START_TIME_MS="$(date '+%s')000"
 ES_START_TIME=$(TZ=UTC date +"%Y-%m-%dT%H:%M:%S.000Z")
@@ -91,8 +165,7 @@ if [ "$FORGE_RUNNER_MODE" = "local" ]; then
     # more file descriptors for heavy txn generation
     ulimit -n 1048576
 
-    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 \
-	test k8s-swarm 
+    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 test k8s-swarm \
         --image-tag $IMAGE_TAG \
         --namespace $FORGE_NAMESPACE \
         --port-forward $REUSE_ARGS $KEEP_ARGS $ENABLE_HAPROXY_ARGS | tee $FORGE_OUTPUT
@@ -101,7 +174,7 @@ if [ "$FORGE_RUNNER_MODE" = "local" ]; then
 
     # try to kill orphaned port-forwards
     if [ -z "$KEEP_ARGS" ]; then
-        ps -A | grep  "kubectl port-forward -n $FORGE_NAMESPACE" | awk '{ print $1 }' | xargs -I{} kill -9 {}
+        ps -A | grep "kubectl port-forward -n $FORGE_NAMESPACE" | awk '{ print $1 }' | xargs -I{} kill -9 {}
     fi
 
 elif [ "$FORGE_RUNNER_MODE" = "k8s" ]; then
@@ -122,11 +195,11 @@ elif [ "$FORGE_RUNNER_MODE" = "k8s" ]; then
         -e "s/{AWS_ACCOUNT_NUM}/${AWS_ACCOUNT_NUM}/g" \
         -e "s/{AWS_REGION}/${AWS_REGION}/g" \
         -e "s/{FORGE_NAMESPACE}/${FORGE_NAMESPACE}/g" \
-         -e "s/{REUSE_ARGS}/${REUSE_ARGS}/g" \
+        -e "s/{REUSE_ARGS}/${REUSE_ARGS}/g" \
         -e "s/{KEEP_ARGS}/${KEEP_ARGS}/g" \
         -e "s/{ENABLE_HAPROXY_ARGS}/${ENABLE_HAPROXY_ARGS}/g" \
-        testsuite/forge-test-runner-template.yaml > ${specfile}
-    
+        testsuite/forge-test-runner-template.yaml >${specfile}
+
     kubectl apply -n default -f $specfile
 
     # wait for enough time for the pod to start and potentially new nodes to come online
@@ -146,6 +219,9 @@ elif [ "$FORGE_RUNNER_MODE" = "k8s" ]; then
 elif [ "$FORGE_RUNNER_MODE" = "dry-run" ]; then
     # assume you already have the local report and output files
     FORGE_EXIT_CODE=0
+elif [ "$FORGE_RUNNER_MODE" = "pre-forge" ]; then
+    # perform the pre-forge checks first and exit cleanly
+    exit 0
 else
     echo "Invalid FORGE_RUNNER_MODE: ${FORGE_RUNNER_MODE}"
     exit 1
@@ -155,17 +231,26 @@ FORGE_END_TIME_MS="$(date '+%s')000"
 ES_END_TIME=$(TZ=UTC date +"%Y-%m-%dT%H:%M:%S.000Z")
 
 # parse the JSON report
+# also handle test report failure cases
 cat $FORGE_OUTPUT | awk '/====json-report-begin===/{f=1;next} /====json-report-end===/{f=0} f' >"${FORGE_REPORT}"
 # If no report was generated, fill with default report
 if [ ! -s "${FORGE_REPORT}" ]; then
     echo '{"text": "Forge test runner terminated"}' >"${FORGE_REPORT}"
+    FORGE_EXIT_CODE=1
+fi
+# If no report text was generated, fill with default text
+FORGE_REPORT_TXT=$(cat $FORGE_REPORT | jq -r .text)
+if [ -z "$FORGE_REPORT_TXT" ]; then
+    FORGE_REPORT_TXT="Forge report text empty. See test runner output."
+    FORGE_EXIT_CODE=1
 fi
 
 # print the Forge report
 cat $FORGE_REPORT
 
-# detect regressions
-# TODO(rustielin): do not block on perf regressions for now until Forge network performance stabilizes
+# detect regressions. TODO: do this in the Forge test runner itself since it's complex
+# if this script is not triggered in GHA, use a default value
+[ -z "$GITHUB_RUN_ID" ] && GITHUB_RUN_ID=0
 AVG_TPS=$(cat $FORGE_REPORT | grep -oE '[0-9]+ TPS' | awk '{print $1}')
 P99_LATENCY=$(cat $FORGE_REPORT | grep -oE '[0-9]+ ms p99 latency' | awk '{print $1}')
 if [ -n "$AVG_TPS" ]; then
@@ -173,8 +258,8 @@ if [ -n "$AVG_TPS" ]; then
     echo "forge_job_avg_tps {FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\",GITHUB_RUN_ID=\"$GITHUB_RUN_ID\"} $AVG_TPS" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
     if [[ "$AVG_TPS" -lt "$TPS_THRESHOLD" ]]; then
         echo "(\!) AVG_TPS: ${avg_tps} < ${TPS_THRESHOLD} tps"
-	if [ "$FORGE_RUNNER_MODE" != "local" ]; then
-           FORGE_EXIT_CODE=1
+        if [ "$FORGE_RUNNER_MODE" != "local" ]; then
+            FORGE_EXIT_CODE=2
         fi
     fi
 fi
@@ -183,57 +268,35 @@ if [ -n "$P99_LATENCY" ]; then
     echo "forge_job_p99_latency {FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\",GITHUB_RUN_ID=\"$GITHUB_RUN_ID\"} $P99_LATENCY" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
     if [[ "$P99_LATENCY" -gt "$P99_LATENCY_MS_THRESHOLD" ]]; then
         echo "(\!) P99_LATENCY: ${P99_LATENCY} > ${P99_LATENCY_MS_THRESHOLD} ms"
-	if [ "$FORGE_RUNNER_MODE" != "local" ]; then
-            FORGE_EXIT_CODE=1
+        if [ "$FORGE_RUNNER_MODE" != "local" ]; then
+            FORGE_EXIT_CODE=2
         fi
     fi
 fi
 
-# If no report text was generated, fill with default text
-FORGE_REPORT_TXT=$(cat $FORGE_REPORT | jq -r .text)
-if [ -z "$FORGE_REPORT_TXT" ]; then
-    FORGE_REPORT_TXT="Forge report text empty. See test runner output."
-    FORGE_EXIT_CODE=1
-fi
+# Get the final o11y links that are not auto-refresh
+get_dashboard_link
+get_validator_logs_link
 
+# construct forge comment output
 if [ "$FORGE_EXIT_CODE" = "0" ]; then
-    FORGE_COMMENT_HEADER='### :white_check_mark: Forge test success'
+    FORGE_COMMENT_HEADER="### :white_check_mark: Forge test success on \`${IMAGE_TAG}\`"
+else if [ "$FORGE_EXIT_CODE" = "2" ]
+    FORGE_COMMENT_HEADER"### :x: Forge test perf regression on \`${IMAGE_TAG}\`"
 else
-    FORGE_COMMENT_HEADER='### :x: Forge test failure'
+    FORGE_COMMENT_HEADER="### :x: Forge test failure on \`${IMAGE_TAG}\`"
 fi
-
-# remove the "aptos-" prefix and add "net" suffix to get the chain name
-# as used by the deployment setup and as reported to o11y systems
-FORGE_CHAIN_NAME=${FORGE_CLUSTER_NAME#"aptos-"}
-if echo $FORGE_CLUSTER_NAME | grep -qv "forge"; then
-    FORGE_CHAIN_NAME="${FORGE_CHAIN_NAME}net"
-fi
-FORGE_DASHBOARD_LINK="${GRAFANA_BASE_URL}&var-namespace=${FORGE_NAMESPACE}&var-chain_name=${FORGE_CHAIN_NAME}&from=${FORGE_START_TIME_MS}&to=${FORGE_END_TIME_MS}"
-
-# build the logs link in a readable way...
-# filter by:
-#   * chain_name: name of the Forge cluster "chain"
-#   * namespace: kubernetes namespace the Forge test was executed in
-#   * hostname: name of a kubernetes pod e.g. validator name
-VAL0_HOSTNAME="aptos-node-0-validator-0"
-VALIDATOR_LOGS_LINK="${ES_BASE_URL}/_dashboards/app/discover#/?
-    _g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'${ES_START_TIME}',to:'${ES_END_TIME}'))
-    &_a=(columns:!(_source),filters:!(
-        ('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'${ES_DEFAULT_INDEX}',key:chain_name,negate:!f,params:(query:${FORGE_CHAIN_NAME}),type:phrase),query:(match_phrase:(chain_name:${FORGE_CHAIN_NAME}))),
-        ('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'${ES_DEFAULT_INDEX}',key:namespace,negate:!f,params:(query:${FORGE_NAMESPACE}),type:phrase),query:(match_phrase:(namespace:${FORGE_NAMESPACE}))),
-        ('\$state':(store:appState),meta:(alias:!n,disabled:!f,index:'${ES_DEFAULT_INDEX}',key:hostname,negate:!f,params:(query:${VAL0_HOSTNAME}),type:phrase),query:(match_phrase:(hostname:${VAL0_HOSTNAME})))
-    ),index:'${ES_DEFAULT_INDEX}',interval:auto,query:(language:kuery,query:''),sort:!())"
-
-# trim all the whitespace in logs link
-VALIDATOR_LOGS_LINK=$(echo $VALIDATOR_LOGS_LINK | tr -d '[:space:]')
+cat <<EOF >$FORGE_COMMENT
+$FORGE_COMMENT_HEADER
+\`\`\`
+$FORGE_REPORT_TXT
+\`\`\`
+* [Grafana dashboard]($FORGE_DASHBOARD_LINK)
+* [Validator 0 logs]($VALIDATOR_LOGS_LINK)
+EOF
 
 echo "=====START FORGE COMMENT====="
-echo "$FORGE_COMMENT_HEADER"
-echo "Dashboard: ${FORGE_DASHBOARD_LINK}"
-echo "Logs: ${VALIDATOR_LOGS_LINK}"
-echo '```'
-echo "$FORGE_REPORT_TXT"
-echo '```'
+cat $FORGE_COMMENT
 echo "=====END FORGE COMMENT====="
 
 echo "Forge exit with: $FORGE_EXIT_CODE"


### PR DESCRIPTION
### Description

A few improvements to the Forge UX:
* Move the GHA comment creation to `run_forge.sh` script, since it serves for a pretty good command output as well. The comment contents can be redirected using env var `FORGE_COMMENT`. 
* Generate some useful pre-Forge output such as auto-refreshing dashboards and logs. Use it to generate a comment that gets posted right before tests run in `FORGE_PRE_COMMENT`
* Use https://github.com/marocchino/sticky-pull-request-comment to post and update a single Forge output comment on PRs, rather than spamming the PR each time. Use the action in `recreate` mode, which ensures that the Forge comment will always append to the bottom, and since it's deleted and re-created, will trigger a GH notification. This makes it easier to see what is exactly running and when (and what stage it's in), rather than needing to click into the Github checks UI and look through the running actions.
* Also write some better comments and reorganize some stuff in `run_forge.sh` since it's getting quite complicated. We should ideally move some of the o11y resource generation and regression checking / failure cases into the Forge test runner itself.
* Fail Forge with a different comment if perf regression detected

As a bonus: stop doing `set -x` for genesis. Especially since we tail the logs in Forge, the output can get quite verbose.

### Test Plan

Run the script locally to get the comment output. `FORGE_RUNNER_MODE=local ./testsuite/run_forge.sh`. Check all generated o11y links are good



<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2166)
<!-- Reviewable:end -->
