### PR TITLE
[Forge] Send higher load to increase the TPS

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -248,12 +248,12 @@ impl<'t> TxnEmitter<'t> {
         let workers_per_endpoint = match req.workers_per_endpoint {
             Some(x) => x,
             None => {
-                let target_threads = 800;
+                let target_threads = 1200;
                 // Trying to create somewhere between target_threads/2..target_threads threads
                 // We want to have equal numbers of threads for each endpoint, so that they are equally loaded
-                // Otherwise things like flamegrap/perf going to show different numbers depending on which endpoint is chosen
+                // Otherwise things like flamegraph/perf going to show different numbers depending on which endpoint is chosen
                 // Also limiting number of threads as max 10 per endpoint for use cases with very small number of nodes or use --peers
-                min(60, max(1, target_threads / req.rest_clients.len()))
+                min(100, max(1, target_threads / req.rest_clients.len()))
             }
         };
         let num_clients = req.rest_clients.len() * workers_per_endpoint;

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -417,7 +417,7 @@ async fn wait_for_single_account_sequence(
 ) -> Result<()> {
     let deadline = Instant::now() + wait_timeout;
     while Instant::now() <= deadline {
-        time::sleep(Duration::from_millis(500)).await;
+        time::sleep(Duration::from_millis(150)).await;
         match query_sequence_numbers(client, &[account.address()]).await {
             Ok(sequence_numbers) => {
                 if sequence_numbers[0] >= account.sequence_number() {
@@ -492,7 +492,7 @@ async fn wait_for_accounts_sequence(
                 );
             }
         }
-        time::sleep(Duration::from_millis(500)).await;
+        time::sleep(Duration::from_millis(150)).await;
     }
 
     Err(uncommitted)


### PR DESCRIPTION
### Description

We dialed down the load because of regression from y'day but now we increased the number of threads to gain some of the TPS back.  We are doing 4k TPS currently and this is pushing it to 4.5k.

### Test Plan
Run forge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2168)
<!-- Reviewable:end -->
