### PR TITLE
[api] discard diem for aptos

### DIFF
--- a/api/types/src/error.rs
+++ b/api/types/src/error.rs
@@ -14,7 +14,7 @@ use crate::U64;
 pub struct Error {
     pub code: u16,
     pub message: String,
-    /// Diem blockchain latest onchain ledger version.
+    /// Aptos blockchain latest onchain ledger version.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aptos_ledger_version: Option<U64>,
 }


### PR DESCRIPTION
### Description
In the Error struct type comment, renamed Diem to Aptos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2177)
<!-- Reviewable:end -->
