### PR TITLE
[consensus] increase timeout for leader and make sleep async

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -370,7 +370,7 @@ impl BlockStore {
                     executed_block.block()
                 );
             }
-            self.time_service.wait_until(block_time);
+            self.time_service.wait_until(block_time).await;
         }
         self.storage
             .save_tree(vec![executed_block.block().clone()], vec![])

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -212,6 +212,7 @@ impl NetworkSender {
         self.send(msg, recipients).await
     }
 
+    #[cfg(feature = "failpoints")]
     pub async fn send_proposal(&self, proposal_msg: ProposalMsg, recipients: Vec<Author>) {
         fail_point!("consensus::send::proposal", |_| ());
         let msg = ConsensusMsg::ProposalMsg(Box::new(proposal_msg));

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -227,6 +227,7 @@ impl RoundManager {
             .proposer_election
             .is_valid_proposer(self.proposal_generator.author(), new_round_event.round)
         {
+            self.round_state.setup_leader_timeout();
             let proposal_msg = self.generate_proposal(new_round_event).await?;
             let mut network = self.network.clone();
             #[cfg(feature = "failpoints")]

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -136,7 +136,7 @@ fn create_node_for_fuzzing() -> RoundManager {
 
     // TODO: remove
     let time_service = Arc::new(SimulatedTimeService::new());
-    time_service.sleep(Duration::from_millis(1));
+    block_on(time_service.sleep(Duration::from_millis(1)));
 
     // TODO: remove
     let proposal_generator = ProposalGenerator::new(

--- a/consensus/src/util/mock_time_service.rs
+++ b/consensus/src/util/mock_time_service.rs
@@ -4,6 +4,7 @@
 use crate::util::time_service::{ScheduledTask, TimeService};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
+use async_trait::async_trait;
 use futures::future::AbortHandle;
 use std::{sync::Arc, time::Duration};
 
@@ -27,6 +28,7 @@ struct SimulatedTimeServiceInner {
     max: Duration,
 }
 
+#[async_trait]
 impl TimeService for SimulatedTimeService {
     fn run_after(&self, timeout: Duration, mut t: Box<dyn ScheduledTask>) -> AbortHandle {
         let mut inner = self.inner.lock();
@@ -61,7 +63,7 @@ impl TimeService for SimulatedTimeService {
         self.inner.lock().now
     }
 
-    fn sleep(&self, t: Duration) {
+    async fn sleep(&self, t: Duration) {
         let inner = self.inner.clone();
         let mut inner = inner.lock();
         inner.now += t;

--- a/consensus/src/util/time_service.rs
+++ b/consensus/src/util/time_service.rs
@@ -1,14 +1,14 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::counters;
 use aptos_logger::prelude::*;
+use async_trait::async_trait;
 use futures::{
     future::{AbortHandle, Abortable},
     Future, FutureExt, SinkExt,
 };
-use std::{pin::Pin, thread, time::Duration};
-
-use crate::counters;
+use std::{pin::Pin, time::Duration};
 use tokio::{runtime::Handle, time::sleep};
 
 /// Time service is an abstraction for operations that depend on time
@@ -18,6 +18,7 @@ use tokio::{runtime::Handle, time::sleep};
 /// Time service also supports opportunities for future optimizations
 /// For example instead of scheduling O(N) tasks in TaskExecutor we could have more optimal code
 /// that only keeps single task in TaskExecutor
+#[async_trait]
 pub trait TimeService: Send + Sync {
     /// Sends message to given sender after timeout, returns a handle that could use to cancel the task.
     fn run_after(&self, timeout: Duration, task: Box<dyn ScheduledTask>) -> AbortHandle;
@@ -32,14 +33,14 @@ pub trait TimeService: Send + Sync {
     /// time_service::sleep(Y).await;
     /// Z = time_service::get_current_timestamp();
     /// assert(Z >= X + Y)
-    fn sleep(&self, t: Duration);
+    async fn sleep(&self, t: Duration);
 
     /// Wait until the Duration t since UNIX_EPOCH pass at least 1ms.
-    fn wait_until(&self, t: Duration) {
+    async fn wait_until(&self, t: Duration) {
         while let Some(mut wait_duration) = t.checked_sub(self.get_current_timestamp()) {
             wait_duration += Duration::from_millis(1);
             counters::WAIT_DURATION_S.observe_duration(wait_duration);
-            self.sleep(wait_duration);
+            self.sleep(wait_duration).await;
         }
     }
 }
@@ -102,6 +103,7 @@ impl ClockTimeService {
     }
 }
 
+#[async_trait]
 impl TimeService for ClockTimeService {
     fn run_after(&self, timeout: Duration, mut t: Box<dyn ScheduledTask>) -> AbortHandle {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
@@ -120,8 +122,8 @@ impl TimeService for ClockTimeService {
         aptos_infallible::duration_since_epoch()
     }
 
-    fn sleep(&self, t: Duration) {
-        thread::sleep(t)
+    async fn sleep(&self, t: Duration) {
+        sleep(t).await
     }
 }
 


### PR DESCRIPTION
Leader enters the round earlier than others, the difference is the whole broadcast period, increase the timeout period to compensate it.### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2178)
<!-- Reviewable:end -->
