### PR TITLE
observability: implement json-logging to stdout for aptos-logger

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,10 @@ repos:
       - id: end-of-file-fixer
         files: \.(rs|move)$
       - id: check-added-large-files
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    -   id: fmt
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.3.0
     hooks:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -614,9 +614,12 @@ dependencies = [
  "erased-serde",
  "hostname",
  "once_cell",
+ "pretty_assertions",
  "prometheus",
  "serde 1.0.137",
  "serde_json",
+ "strum",
+ "strum_macros",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2432,6 +2435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
+dependencies = [
+ "quote 1.0.18",
+ "syn 1.0.95",
+]
+
+[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2641,12 @@ dependencies = [
  "migrations_internals",
  "migrations_macros",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "difference"
@@ -5664,6 +5683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6156,6 +6184,18 @@ checksum = "ad9940b913ee56ddd94aec2d3cd179dd47068236f42a1a6415ccf9d880ce2a61"
 dependencies = [
  "arrayvec",
  "typed-arena",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
+dependencies = [
+ "ansi_term",
+ "ctor",
+ "diff",
+ "output_vt100",
 ]
 
 [[package]]
@@ -6797,6 +6837,12 @@ checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
  "base64 0.13.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
 
 [[package]]
 name = "rusty-fork"
@@ -7765,6 +7811,25 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.39",
  "quote 1.0.18",
+ "syn 1.0.95",
+]
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro2 1.0.39",
+ "quote 1.0.18",
+ "rustversion",
  "syn 1.0.95",
 ]
 

--- a/consensus/src/experimental/linkedlist.rs
+++ b/consensus/src/experimental/linkedlist.rs
@@ -4,11 +4,11 @@
 // modified from https://rust-unofficial.github.io/too-many-lists/fourth-final.html (MIT License)
 
 // maybe later we can move this to /common
+use aptos_infallible::{Mutex, MutexGuard};
 use std::{
     cell::{Ref, RefCell, RefMut},
     rc::Rc,
 };
-use aptos_infallible::{Mutex, MutexGuard};
 
 pub struct List<T> {
     pub head: Link<T>,

--- a/crates/aptos-crypto/src/unit_tests/compilation/cross_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/compilation/cross_test.rs
@@ -7,7 +7,7 @@ use aptos_crypto::{
     test_utils::KeyPair,
     traits::*,
 };
-use aptos_crypto_derive::{CryptoHasher, BCSCryptoHash};
+use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use rand::{prelude::ThreadRng, thread_rng};
 use serde::{Deserialize, Serialize};
 

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -20,8 +20,13 @@ once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
+strum = "0.24.1"
+strum_macros = "0.24.2"
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
 
 aptos-infallible = { path = "../aptos-infallible" }
 aptos-log-derive = { path = "../aptos-log-derive" }
+
+[dev-dependencies]
+pretty_assertions = "1.2.1"

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -17,44 +17,81 @@ use aptos_infallible::RwLock;
 use backtrace::Backtrace;
 use chrono::{SecondsFormat, Utc};
 use once_cell::sync::Lazy;
-use serde::Serialize;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
 use std::{
     collections::BTreeMap,
     env, fmt,
     io::Write,
+    str::FromStr,
     sync::{
         mpsc::{self, Receiver, SyncSender},
         Arc,
     },
     thread,
 };
+use strum_macros::EnumString;
 
 const RUST_LOG: &str = "RUST_LOG";
 const RUST_LOG_REMOTE: &str = "RUST_LOG_REMOTE";
+const RUST_LOG_FORMAT: &str = "RUST_LOG_FORMAT";
 /// Default size of log write channel, if the channel is full, logs will be dropped
 pub const CHANNEL_SIZE: usize = 10000;
 const NUM_SEND_RETRIES: u8 = 1;
 
+#[derive(EnumString)]
+#[strum(serialize_all = "lowercase")]
+enum LogFormat {
+    Json,
+    Text,
+}
+
 /// A single log entry emitted by a logging macro with associated metadata
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct LogEntry {
-    #[serde(flatten)]
     metadata: Metadata,
-    #[serde(skip_serializing_if = "Option::is_none")]
     thread_name: Option<String>,
     /// The program backtrace taken when the event occurred. Backtraces
     /// are only supported for errors and must be configured.
-    #[serde(skip_serializing_if = "Option::is_none")]
     backtrace: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     hostname: Option<&'static str>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     namespace: Option<&'static str>,
     timestamp: String,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     data: BTreeMap<Key, serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     message: Option<String>,
+}
+
+// implement custom serializer for LogEntry since we want to promote the `metadata.level` field into a top-level `level` field
+// and prefix the remaining metadata attributes as `source.<metadata_field>` which can't be expressed with serde macros alone.
+impl Serialize for LogEntry {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("LogEntry", 9)?;
+        state.serialize_field("level", &self.metadata.level())?;
+        state.serialize_field("source", &self.metadata)?;
+        if let Some(thread_name) = &self.thread_name {
+            state.serialize_field("thread_name", thread_name)?;
+        }
+        if let Some(hostname) = &self.hostname {
+            state.serialize_field("hostname", hostname)?;
+        }
+        if let Some(namespace) = &self.namespace {
+            state.serialize_field("namespace", namespace)?;
+        }
+        state.serialize_field("timestamp", &self.timestamp)?;
+        if let Some(message) = &self.message {
+            state.serialize_field("message", message)?;
+        }
+        if !&self.data.is_empty() {
+            state.serialize_field("data", &self.data)?;
+        }
+        if let Some(backtrace) = &self.backtrace {
+            state.serialize_field("backtrace", backtrace)?;
+        }
+        state.end()
+    }
 }
 
 impl LogEntry {
@@ -180,7 +217,7 @@ impl AptosDataBuilder {
             level: Level::Info,
             remote_level: Level::Info,
             address: None,
-            printer: Some(Box::new(StderrWriter)),
+            printer: Some(Box::new(StdoutWriter)),
             is_async: false,
             custom_format: None,
         }
@@ -277,6 +314,14 @@ impl AptosDataBuilder {
             }
         };
 
+        if let Ok(log_format) = env::var(RUST_LOG_FORMAT) {
+            let log_format = LogFormat::from_str(&log_format).unwrap();
+            self.custom_format = match log_format {
+                LogFormat::Json => Some(json_format),
+                LogFormat::Text => Some(text_format),
+            }
+        }
+
         let logger = if self.is_async {
             let (sender, receiver) = mpsc::sync_channel(self.channel_size);
             let logger = Arc::new(AptosData {
@@ -284,7 +329,7 @@ impl AptosDataBuilder {
                 sender: Some(sender),
                 printer: None,
                 filter: RwLock::new(filter),
-                formatter: self.custom_format.take().unwrap_or(default_format),
+                formatter: self.custom_format.take().unwrap_or(text_format),
             });
             let service = LoggerService {
                 receiver,
@@ -301,7 +346,7 @@ impl AptosDataBuilder {
                 sender: None,
                 printer: self.printer.take(),
                 filter: RwLock::new(filter),
-                formatter: self.custom_format.take().unwrap_or(default_format),
+                formatter: self.custom_format.take().unwrap_or(text_format),
             })
         };
 
@@ -350,7 +395,7 @@ impl AptosData {
         Self::builder()
             .is_async(false)
             .enable_backtrace()
-            .printer(Box::new(StderrWriter))
+            .printer(Box::new(StdoutWriter))
             .build();
     }
 
@@ -463,20 +508,12 @@ impl LoggerService {
     }
 
     /// Writes a log line into json_lines logstash format, which has a newline at the end
-    fn write_to_logstash(stream: &mut TcpWriter, mut entry: LogEntry) {
-        // XXX Temporary hack to ensure that log lines don't show up empty in kibana when the
-        // "message" field isn't set.
-        if entry.message.is_none() {
-            entry.message = Some(serde_json::to_string(&entry.data).unwrap());
-        }
-
-        let message = if let Ok(json) = serde_json::to_string(&entry) {
+    fn write_to_logstash(stream: &mut TcpWriter, entry: LogEntry) {
+        let message = if let Ok(json) = json_format(&entry) {
             json
         } else {
-            STRUCT_LOG_PARSE_ERROR_COUNT.inc();
             return;
         };
-
         let message = message + "\n";
         let bytes = message.as_bytes();
         let message_length = bytes.len();
@@ -512,13 +549,13 @@ pub trait Writer: Send + Sync {
     fn write(&self, log: String);
 }
 
-/// A struct for writing logs to stderr
-struct StderrWriter;
+/// A struct for writing logs to stdout
+struct StdoutWriter;
 
-impl Writer for StderrWriter {
-    /// Write log to stderr
+impl Writer for StdoutWriter {
+    /// Write log to stdout
     fn write(&self, log: String) {
-        eprintln!("{}", log);
+        println!("{}", log);
     }
 }
 
@@ -553,7 +590,7 @@ impl Writer for FileWriter {
 /// UNIX_TIMESTAMP LOG_LEVEL [thread_name] FILE:LINE MESSAGE JSON_DATA
 /// Example:
 /// 2020-03-07 05:03:03 INFO [thread_name] common/aptos-logger/src/lib.rs:261 Hello { "world": true }
-fn default_format(entry: &LogEntry) -> Result<String, fmt::Error> {
+fn text_format(entry: &LogEntry) -> Result<String, fmt::Error> {
     use std::fmt::Write;
 
     let mut w = String::new();
@@ -567,7 +604,7 @@ fn default_format(entry: &LogEntry) -> Result<String, fmt::Error> {
         w,
         " {} {}",
         entry.metadata.level(),
-        entry.metadata.location()
+        entry.metadata.source_path()
     )?;
 
     if let Some(message) = &entry.message {
@@ -581,14 +618,28 @@ fn default_format(entry: &LogEntry) -> Result<String, fmt::Error> {
     Ok(w)
 }
 
+// converts a record into json format
+fn json_format(entry: &LogEntry) -> Result<String, fmt::Error> {
+    match serde_json::to_string(&entry) {
+        Ok(s) => Ok(s),
+        Err(_) => {
+            // TODO: Improve the error handling here. Currently we're just increasing some misleadingly-named metric and dropping any context on why this could not be deserialized.
+            STRUCT_LOG_PARSE_ERROR_COUNT.inc();
+            Err(fmt::Error)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::LogEntry;
     use crate::{
-        debug, error, info, logger::Logger, trace, warn, Event, Key, KeyValue, Level, Metadata,
-        Schema, Value, Visitor,
+        aptos_logger::json_format, debug, error, info, logger::Logger, trace, warn, Event, Key,
+        KeyValue, Level, Metadata, Schema, Value, Visitor,
     };
     use chrono::{DateTime, Utc};
+    #[cfg(test)]
+    use pretty_assertions::assert_eq;
     use serde_json::Value as JsonValue;
     use std::{
         sync::{
@@ -676,7 +727,7 @@ mod tests {
         );
         let after = Utc::now();
 
-        let entry = receiver.recv().unwrap();
+        let mut entry = receiver.recv().unwrap();
 
         // Ensure standard fields are filled
         assert_eq!(entry.metadata.level(), Level::Info);
@@ -684,10 +735,17 @@ mod tests {
             entry.metadata.target(),
             module_path!().split("::").next().unwrap()
         );
-        assert_eq!(entry.metadata.module_path(), module_path!());
-        assert_eq!(entry.metadata.file(), file!());
         assert_eq!(entry.message.as_deref(), Some("This is a log"));
         assert!(entry.backtrace.is_none());
+
+        // Ensure json formatter works
+        // hardcoding a timestamp and hostname to make the tests deterministic and not depend on environment
+        let original_timestamp = entry.timestamp;
+        entry.timestamp = String::from("2022-07-24T23:42:29.540278Z");
+        entry.hostname = Some("test-host");
+        let expected = r#"{"level":"INFO","source":{"package":"aptos_logger","file":"crates/aptos-logger/src/aptos_logger.rs:718"},"thread_name":"aptos_logger::tests::basic","hostname":"test-host","timestamp":"2022-07-24T23:42:29.540278Z","message":"This is a log","data":{"bar":"foo_bar","category":"name","display":"12345","foo":5,"test":true}}"#;
+        assert_eq!(json_format(&entry).unwrap(), expected);
+        entry.timestamp = original_timestamp;
 
         // Log time should be the time the structured log entry was created
         let timestamp = DateTime::parse_from_rfc3339(&entry.timestamp).unwrap();

--- a/crates/aptos-logger/src/filter.rs
+++ b/crates/aptos-logger/src/filter.rs
@@ -188,7 +188,7 @@ mod tests {
     use super::{Builder, Level, LevelFilter, Metadata};
 
     fn make_metadata(level: Level, target: &'static str) -> Metadata {
-        Metadata::new(level, target, target, "", 0, "")
+        Metadata::new(level, target, target, "")
     }
 
     #[test]

--- a/crates/aptos-logger/src/macros.rs
+++ b/crates/aptos-logger/src/macros.rs
@@ -12,8 +12,6 @@ macro_rules! log {
             $level,
             env!("CARGO_CRATE_NAME"),
             module_path!(),
-            file!(),
-            line!(),
             concat!(file!(), ':', line!()),
         );
 

--- a/crates/aptos-logger/src/metadata.rs
+++ b/crates/aptos-logger/src/metadata.rs
@@ -8,22 +8,19 @@ use std::{fmt, str::FromStr};
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct Metadata {
     /// The level of verbosity of the event
+    #[serde(skip_serializing)]
     level: Level,
 
     /// The part of the system where the event occurred
-    target: &'static str,
+    package: &'static str,
 
     /// The name of the Rust module where the event occurred
+    // do not emit this field into the json logs since source.location is already more useful
+    #[serde(skip)]
     module_path: &'static str,
 
-    /// The name of the source code file where the event occurred
+    /// The source code file path and line number together as 'file_path:line'
     file: &'static str,
-
-    /// The line number in the source code file where the event occurred
-    line: u32,
-
-    /// The file name and line number together 'file:line'
-    location: &'static str,
 }
 
 impl Metadata {
@@ -31,17 +28,13 @@ impl Metadata {
         level: Level,
         target: &'static str,
         module_path: &'static str,
-        file: &'static str,
-        line: u32,
-        location: &'static str,
+        source_path: &'static str,
     ) -> Self {
         Self {
             level,
-            target,
+            package: target,
             module_path,
-            file,
-            line,
-            location,
+            file: source_path,
         }
     }
 
@@ -54,23 +47,15 @@ impl Metadata {
     }
 
     pub fn target(&self) -> &'static str {
-        self.target
+        self.package
     }
 
     pub fn module_path(&self) -> &'static str {
         self.module_path
     }
 
-    pub fn file(&self) -> &'static str {
+    pub fn source_path(&self) -> &'static str {
         self.file
-    }
-
-    pub fn line(&self) -> u32 {
-        self.line
-    }
-
-    pub fn location(&self) -> &'static str {
-        self.location
     }
 }
 

--- a/crates/aptos-logger/src/tracing_adapter.rs
+++ b/crates/aptos-logger/src/tracing_adapter.rs
@@ -83,8 +83,6 @@ fn translate_metadata(metadata: &Metadata<'static>) -> Option<dl::Metadata> {
         level,
         metadata.target(),
         metadata.module_path().unwrap_or(""),
-        metadata.file().unwrap_or(""),
-        metadata.line().unwrap_or(0),
         "",
     ))
 }

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -41,7 +41,7 @@ EXPOSE 6186
 
 # Capture backtrace on error
 ENV RUST_BACKTRACE 1
-
+ENV RUST_LOG_FORMAT=json
 
 
 ### Indexer Image ###
@@ -54,6 +54,8 @@ RUN apt-get update && apt-get install -y libssl1.1 ca-certificates net-tools tcp
 RUN mkdir -p /opt/aptos/bin
 COPY --link --from=builder /aptos/dist/aptos-indexer /usr/local/bin/aptos-indexer
 
+ENV RUST_LOG_FORMAT=json
+
 ### Node Checker Image ###
 
 FROM debian-base AS node-checker
@@ -64,6 +66,7 @@ RUN apt-get update && apt-get install -y libssl1.1 ca-certificates net-tools tcp
 RUN mkdir -p /opt/aptos/bin
 COPY --link --from=builder /aptos/dist/aptos-node-checker /usr/local/bin/aptos-node-checker
 
+ENV RUST_LOG_FORMAT=json
 
 ### Tools Image ###
 FROM debian-base AS tools
@@ -113,6 +116,7 @@ RUN apt-get update && apt-get install -y procps
 
 # Mint proxy listening address
 EXPOSE 8000
+ENV RUST_LOG_FORMAT=json
 
 
 
@@ -133,6 +137,6 @@ ENV PATH "$PATH:/root/bin"
 
 WORKDIR /aptos
 COPY --link --from=builder /aptos/dist/forge /usr/local/bin/forge
-
+ENV RUST_LOG_FORMAT=json
 
 ENTRYPOINT ["forge"]


### PR DESCRIPTION
This introduces support for printing json-formatted logs to stdout by setting the environment variable `RUST_LOG_FORMAT=json`. This is part of the observability improvements.

furthermore this does some general enhancements to the aptos-logger json logging:
- removes redundant `file` and `line` attribute from logger metadata
- renames `location` to `file`
- rename `target` to `package`
- wrap `package` and `file` into a `source` object. E.g. `source: {package: "foo", file: "src/stuff.rs:44"`
- skips `module_path` from json output (package and file are already useful enough imo)

This should produce less noisy / more human-readable json logs that look like this:

```json
{"level":"INFO","source":{"package":"aptos_logger","file":"crates/aptos-logger/src/aptos_logger.rs:735"},"thread_name":"aptos_logger::tests::basic","hostname":"MacBook-Pro-6.attlocal.net","timestamp":"2022-07-24T23:42:29.540278Z","message":"This is a log","data":{"bar":"foo_bar","category":"name","display":"12345","foo":5,"test":true}}
```

### Test Plan
Unit test and run forge to observe the log output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2182)
<!-- Reviewable:end -->
