### PR TITLE
Vanderwaal/fix docs links

### DIFF
--- a/developer-docs-site/docs/guides/move-guides/move-on-aptos.md
+++ b/developer-docs-site/docs/guides/move-guides/move-on-aptos.md
@@ -35,13 +35,13 @@ The Aptos Move adapter features include:
 * Parallelism via [Block-STM](https://medium.com/aptoslabs/block-stm-how-we-execute-over-160k-transactions-per-second-on-the-aptos-blockchain-3b003657e4ba) that enables concurrent execution of transactions without any input from the user
 
 The Aptos framework ships with many useful libraries:
-* A [Token standard](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/Token.move) that makes it possible to create NFTs and other rich tokens without publishing a smart contract
-* A [Coin standard](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/Coin.move) that makes it possible to create type-safe Coins by publishing a trivial module
-* An [iterable Table](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/IterableTable.move) that allows for traversing all the entries within a table
+* A [Token standard](https://github.com/aptos-labs/aptos-core/blob/devnet/aptos-move/framework/aptos-framework/sources/token.move) that makes it possible to create NFTs and other rich tokens without publishing a smart contract
+* A [Coin standard](https://github.com/aptos-labs/aptos-core/blob/devnet/aptos-move/framework/aptos-framework/sources/coin.move) that makes it possible to create type-safe Coins by publishing a trivial module
+* An [iterable Table](https://github.com/aptos-labs/aptos-core/blob/devnet/aptos-move/framework/aptos-framework/sources/iterable_table.move) that allows for traversing all the entries within a table
 * A staking and delegation framework
-* A [`type_of`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/TypeInfo.move) service to identify at run-time the address, module, and struct name of a given type
+* A [`type_of`](https://github.com/aptos-labs/aptos-core/blob/devnet/aptos-move/framework/aptos-framework/sources/type_info.move) service to identify at run-time the address, module, and struct name of a given type
 * Multi-signer framework that allows multiple `signer` entities
-* A [timestamp service](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/Timestamp.move) that provides a monotonically increasing clock that maps to the actual current unixtime
+* A [timestamp service](https://github.com/aptos-labs/aptos-core/blob/devnet/aptos-move/framework/aptos-framework/sources/timestamp.move) that provides a monotonically increasing clock that maps to the actual current unixtime
 
 With much more coming soon...
 
@@ -93,9 +93,9 @@ Assets can be programmed to be entirely constrained within a module by making it
 Contrast the following two functions of implementing a coins transfer using deposit and withdraw:
 
 ```rust
-public fun transfer<T>(sender: &signer, reciepient: address, amount: u64) {
+public fun transfer<T>(sender: &signer, recipient: address, amount: u64) {
     let coin = withdraw(&signer, amount);
-    deposit(reciepient, coin);
+    deposit(recipient, coin);
 }
 ```
 

--- a/developer-docs-site/docs/guides/move-guides/move-on-aptos.md
+++ b/developer-docs-site/docs/guides/move-guides/move-on-aptos.md
@@ -31,7 +31,7 @@ Each deployment of the MoveVM has the ability to extend the core MoveVM with add
 
 The Aptos Move adapter features include:
 * Fine grained storage that decouples the amount of data stored in an account affecting the gas fees for transactions associated with the account
-* [Tables](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/Table.move) for storing key, value data within an account at scale
+* [Tables](https://github.com/aptos-labs/aptos-core/blob/devnet/aptos-move/framework/aptos-framework/sources/table.move) for storing key, value data within an account at scale
 * Parallelism via [Block-STM](https://medium.com/aptoslabs/block-stm-how-we-execute-over-160k-transactions-per-second-on-the-aptos-blockchain-3b003657e4ba) that enables concurrent execution of transactions without any input from the user
 
 The Aptos framework ships with many useful libraries:

--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+### 1.2.1 (2022-07-23)
+
+
+### Features
+
+* deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
+* memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
+* **mutiagent:** support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
+* support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
+
+
+### Bug Fixes
+
+* get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
+* **ts-sdk:** fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
+
 ## 1.2.0 (2022-06-28)
 
 ### Features

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -58,5 +58,5 @@
     "typescript-memoize": "^1.1.0",
     "yarn": "^1.22.18"
   },
-  "version": "1.2.0"
+  "version": "1.2.1"
 }


### PR DESCRIPTION
### Description
Links on the `Move on Aptos` page are broken because they link to the mainnet branch and also use capitalized filenames instead of lowercase. This fixes the links by linking to the `devnet` branch and lowercasing/snake-casing the filenames.

I could not figure out what link the GUID one was supposed to point to so that one still 404's. 

I also fixed a simple spelling error.

### Test Plan
Run `yarn start` in developer-docs-site and check that the docs behave as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2190)
<!-- Reviewable:end -->
