### PR TITLE
[vm-validator] hot fix for vm-validator memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8743,6 +8743,7 @@ dependencies = [
  "fail 0.5.0",
  "move-deps",
  "rand 0.7.3",
+ "scratchpad",
  "storage-interface",
  "vm-genesis",
 ]

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -19,6 +19,7 @@ aptos-vm = { path = "../aptos-move/aptos-vm" }
 
 executor = { path = "../execution/executor" }
 executor-types = { path = "../execution/executor-types" }
+scratchpad = { path = "../storage/scratchpad" }
 storage-interface = { path = "../storage/storage-interface" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Description

https://github.com/aptos-labs/aptos-core/blob/67691be4d2d4232dd5227b058d0843116b1c1fa0/vm-validator/src/vm_validator.rs#L100

This line never release the oldest ancestor of the in-memory smt chain. So the smt size keep growing... forever.

### Test Plan
ut.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2193)
<!-- Reviewable:end -->
