### PR TITLE
Redirect community.aptoslabs.com -> aptoslabs.com.

### DIFF
--- a/ecosystem/platform/server/config/environments/production.rb
+++ b/ecosystem/platform/server/config/environments/production.rb
@@ -73,7 +73,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "cp_production"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'community.aptoslabs.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: 'aptoslabs.com', protocol: 'https' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/ecosystem/platform/server/config/routes.rb
+++ b/ecosystem/platform/server/config/routes.rb
@@ -19,6 +19,12 @@ Rails.application.routes.draw do
     root to: redirect('/it2') # creates user_root_path, where users go after confirming email
   end
 
+  # Redirect community.aptoslabs.com to aptoslabs.com
+  constraints host: /community.aptoslabs.com/ do
+    match '/*path' => redirect { |params, _req| "https://aptoslabs.com/#{params[:path]}" }, via: %i[get post]
+    match '/' => redirect { |_params, _req| 'https://aptoslabs.com/community' }, via: %i[get post]
+  end
+
   # CMS
   resources :articles, param: :slug, only: %i[index show]
 


### PR DESCRIPTION
### Description

Redirects community.aptoslabs.com to aptoslabs.com/community and everything else to aptoslabs.com/{path}.

To be merged after #1640 is deployed and DNS for both domains is pointing to it.

### Test Plan
Tested manually with curl and Host header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2200)
<!-- Reviewable:end -->
