### PR TITLE
Enabling Tokio-Console

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,3 +19,6 @@ xclippy = [
   "-Aclippy::enum-variant-names",
   "-Aclippy::self-named-constructors",
 ]
+
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "aptos-log-derive",
  "backtrace",
  "chrono",
+ "console-subscriber",
  "erased-serde",
  "hostname",
  "once_cell",
@@ -636,6 +637,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1461,6 +1463,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "axum"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2504b827a8bef941ba3dd64bdffe9cf56ca182908a147edd6189c95fbcae7d"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes 1.1.0",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa 1.0.2",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde 1.0.137",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da31c0ed7b4690e2c78fe4b880d21cd7db04a346ebc658b4270251b695437f17"
+dependencies = [
+ "async-trait",
+ "bytes 1.1.0",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2222,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06c5fd425783d81668ed68ec98408a80498fb4ae2fd607797539e1a9dfa3618f"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31432bc31ff8883bf6a693a79371862f73087822470c82d6a1ec778781ee3978"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime 2.1.0",
+ "prost-types",
+ "serde 1.0.137",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2367,15 @@ dependencies = [
  "backtrace",
  "serde 1.0.137",
  "toml",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3142,6 +3232,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,6 +3698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31672b7011be2c4f7456c4ddbcb40e7e9a4a9fad8efe49a6ebaf5f307d0109c0"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "flate2",
+ "nom 7.1.1",
+ "num-traits 0.2.15",
+]
+
+[[package]]
 name = "headers"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,6 +3856,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -4392,10 +4511,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
 name = "memchr"
@@ -6444,6 +6578,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71adf41db68aa0daaefc69bb30bcd68ded9b9abaad5d1fbb6304c4fb390e083e"
+dependencies = [
+ "bytes 1.1.0",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b670f45da57fb8542ebdbb6105a925fe571b67f9e7ed9f47a06a84e72b4e7cc"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.39",
+ "quote 1.0.18",
+ "syn 1.0.95",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d0a014229361011dc8e69c8a1ec6c2e8d0f2af7c91e3ea3f5b2170298461e68"
+dependencies = [
+ "bytes 1.1.0",
+ "prost",
+]
+
+[[package]]
 name = "proxy"
 version = "0.1.0"
 dependencies = [
@@ -6761,6 +6928,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -7996,6 +8166,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8319,6 +8495,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "winapi 0.3.9",
 ]
 
@@ -8462,6 +8639,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be9d60db39854b30b835107500cf0aca0b0d14d6e1c3de124217c23a29c2ddb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.0",
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util 0.7.2",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8469,13 +8678,35 @@ checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
  "tokio",
  "tokio-util 0.7.2",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d342c6d58709c0a6d48d48dabbb62d4ef955cf5f0f3bbfd845838e7ae88dbae"
+dependencies = [
+ "bitflags",
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -8525,6 +8756,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8542,9 +8783,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static 1.4.0",
+ "matchers",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -166,6 +166,7 @@ pub fn start(config: NodeConfig, log_file: Option<PathBuf>) -> anyhow::Result<()
         .channel_size(config.logger.chan_size)
         .is_async(config.logger.is_async)
         .level(config.logger.level)
+        .console_port(config.logger.console_port)
         .read_env();
     if config.logger.enable_backtrace {
         logger.enable_backtrace();

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::utils;
 use aptos_logger::{Level, CHANNEL_SIZE};
 use serde::{Deserialize, Serialize};
 
@@ -15,6 +16,8 @@ pub struct LoggerConfig {
     pub is_async: bool,
     // The default logging level for slog.
     pub level: Level,
+    // tokio-console port
+    pub console_port: Option<u16>,
 }
 
 impl Default for LoggerConfig {
@@ -24,6 +27,19 @@ impl Default for LoggerConfig {
             enable_backtrace: false,
             is_async: true,
             level: Level::Info,
+            console_port: Some(6669),
         }
+    }
+}
+
+impl LoggerConfig {
+    pub fn disable_console(&mut self) {
+        self.console_port = None;
+    }
+}
+
+impl LoggerConfig {
+    pub fn randomize_ports(&mut self) {
+        self.console_port = Some(utils::get_available_port());
     }
 }

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -320,6 +320,7 @@ impl NodeConfig {
         self.api.randomize_ports();
         self.inspection_service.randomize_ports();
         self.storage.randomize_ports();
+        self.logger.disable_console();
 
         if let Some(network) = self.validator_network.as_mut() {
             network.listen_address = crate::utils::get_available_port_in_multiaddr(true);

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2018"
 [dependencies]
 backtrace = { version = "0.3.58", features = ["serde"] }
 chrono = "0.4.19"
+console-subscriber = { version = "0.1.6", optional = true }
 erased-serde = "0.3.13"
 hostname = "0.3.1"
 once_cell = "1.10.0"
@@ -22,6 +23,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 strum = "0.24.1"
 strum_macros = "0.24.2"
+tokio = { version = "1.18.2", features = ["full"] }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
 
@@ -30,3 +32,7 @@ aptos-log-derive = { path = "../aptos-log-derive" }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
+
+[features]
+default = []
+aptos-console = ["tokio/tracing", "console-subscriber"]

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -199,6 +199,7 @@ impl LogEntry {
 /// A builder for a `AptosData`, configures what, where, and how to write logs.
 pub struct AptosDataBuilder {
     channel_size: usize,
+    console_port: Option<u16>,
     enable_backtrace: bool,
     level: Level,
     remote_level: Level,
@@ -213,6 +214,7 @@ impl AptosDataBuilder {
     pub fn new() -> Self {
         Self {
             channel_size: CHANNEL_SIZE,
+            console_port: Some(6669),
             enable_backtrace: false,
             level: Level::Info,
             remote_level: Level::Info,
@@ -260,6 +262,10 @@ impl AptosDataBuilder {
         self
     }
 
+    pub fn console_port(&mut self, console_port: Option<u16>) -> &mut Self {
+        self.console_port = console_port;
+        self
+    }
     pub fn is_async(&mut self, is_async: bool) -> &mut Self {
         self.is_async = is_async;
         self
@@ -350,7 +356,13 @@ impl AptosDataBuilder {
             })
         };
 
-        crate::logger::set_global_logger(logger.clone());
+        let console_port = if cfg!(feature = "aptos-console") {
+            self.console_port
+        } else {
+            None
+        };
+
+        crate::logger::set_global_logger(logger.clone(), console_port);
         logger
     }
 }
@@ -703,7 +715,7 @@ mod tests {
     fn set_test_logger() -> Receiver<LogEntry> {
         let (logger, receiver) = LogStream::new(true);
         let logger = Arc::new(logger);
-        crate::logger::set_global_logger(logger);
+        crate::logger::set_global_logger(logger, None);
         receiver
     }
 
@@ -715,6 +727,7 @@ mod tests {
 
         // Send an info log
         let before = Utc::now();
+        let mut line_num = line!();
         info!(
             TestSchema {
                 foo: 5,
@@ -725,6 +738,7 @@ mod tests {
             KeyValue::new("display", Value::from_display(&number)),
             "This is a log"
         );
+
         let after = Utc::now();
 
         let mut entry = receiver.recv().unwrap();
@@ -743,9 +757,10 @@ mod tests {
         let original_timestamp = entry.timestamp;
         entry.timestamp = String::from("2022-07-24T23:42:29.540278Z");
         entry.hostname = Some("test-host");
+        line_num += 1;
         let thread_name = thread::current().name().map(|s| s.to_string()).unwrap();
 
-        let expected = format!("{{\"level\":\"INFO\",\"source\":{{\"package\":\"aptos_logger\",\"file\":\"crates/aptos-logger/src/aptos_logger.rs:718\"}},\"thread_name\":\"{thread_name}\",\"hostname\":\"test-host\",\"timestamp\":\"2022-07-24T23:42:29.540278Z\",\"message\":\"This is a log\",\"data\":{{\"bar\":\"foo_bar\",\"category\":\"name\",\"display\":\"12345\",\"foo\":5,\"test\":true}}}}");
+        let expected = format!("{{\"level\":\"INFO\",\"source\":{{\"package\":\"aptos_logger\",\"file\":\"crates/aptos-logger/src/aptos_logger.rs:{line_num}\"}},\"thread_name\":\"{thread_name}\",\"hostname\":\"test-host\",\"timestamp\":\"2022-07-24T23:42:29.540278Z\",\"message\":\"This is a log\",\"data\":{{\"bar\":\"foo_bar\",\"category\":\"name\",\"display\":\"12345\",\"foo\":5,\"test\":true}}}}");
 
         assert_eq!(json_format(&entry).unwrap(), expected);
 

--- a/crates/aptos-logger/src/logger.rs
+++ b/crates/aptos-logger/src/logger.rs
@@ -3,11 +3,11 @@
 
 //! Global logger definition and functions
 
-use crate::{counters::STRUCT_LOG_COUNT, Event, Metadata};
+use crate::{counters::STRUCT_LOG_COUNT, error, Event, Metadata};
 
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
-use tracing_subscriber::Layer;
+use tracing_subscriber::prelude::*;
 
 /// The global `Logger`
 static LOGGER: OnceCell<Arc<dyn Logger>> = OnceCell::new();
@@ -41,14 +41,37 @@ pub(crate) fn enabled(metadata: &Metadata) -> bool {
 }
 
 /// Sets the global `Logger` exactly once
-pub fn set_global_logger(logger: Arc<dyn Logger>) {
+pub fn set_global_logger(logger: Arc<dyn Logger>, console_port: Option<u16>) {
     if LOGGER.set(logger).is_err() {
         eprintln!("Global logger has already been set");
+        error!("Global logger has already been set");
+        return;
     }
-    let _ = tracing::subscriber::set_global_default(
-        crate::tracing_adapter::TracingToAptosDataLayer
-            .with_subscriber(tracing_subscriber::Registry::default()),
-    );
+
+    /*
+     * if console_port is set all tracing::log are captured by the tokio-tracing infrastructure.
+     * else aptos-logger intercepts all tracing::log events
+     * In both scenarios *ALL* aptos-logger::log events are captured by aptos-logger as usual.
+     */
+    #[cfg(feature = "aptos-console")]
+    {
+        if let Some(p) = console_port {
+            let console_layer = console_subscriber::ConsoleLayer::builder()
+                .server_addr(([0, 0, 0, 0], p))
+                .spawn();
+
+            tracing_subscriber::registry().with(console_layer).init();
+            return;
+        }
+    }
+    if None == console_port {
+        let _ = tracing::subscriber::set_global_default(
+            crate::tracing_adapter::TracingToAptosDataLayer
+                .with_subscriber(tracing_subscriber::Registry::default()),
+        );
+    } else {
+        error!("console_port was set but has no effect, build with --cfg aptos-console");
+    }
 }
 
 /// Flush the global `Logger`

--- a/crates/aptos-logger/tests/tracing_translation_tests.rs
+++ b/crates/aptos-logger/tests/tracing_translation_tests.rs
@@ -37,6 +37,7 @@ fn verify_tracing_kvs() {
     let logs = writer.logs.clone();
     AptosData::builder()
         .is_async(false)
+        .console_port(None)
         .printer(Box::new(writer.write_to_stderr(false)))
         .build();
 

--- a/docker/build-rust-all.sh
+++ b/docker/build-rust-all.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Build all the rust release binaries
-cargo build --release \
+RUSTFLAGS="--cfg tokio_unstable" cargo build --release \
         -p aptos \
         -p aptos-node \
         -p aptos-indexer \


### PR DESCRIPTION
### Description

Hey Folks, I'm enabling tokio-console for all our builds. 
It can be disabled with --cfg disable_tokio_console

+ 

Adding Cargo.lock to .gitignore
### Test Plan

<!-- Please provide us with clear details for verifying that your changes work. -->
cargo install --locked tokio-console // Once

1. kubectl port-forward pods/<pod-name> 6669:6669
2. tokio-console

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2203)
<!-- Reviewable:end -->
