### PR TITLE
[State Sync] Drop the chunk executor before handing over to consensus.

### DIFF
--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -76,6 +76,12 @@ pub trait ChunkExecutorTrait: Send + Sync {
 
     /// Resets the chunk executor by synchronizing state with storage.
     fn reset(&self) -> Result<()>;
+
+    /// Drops the executor to ensure garbage collection occurs.
+    fn drop_executor(&self) -> Result<()> {
+        // TODO(Aaron): implement me!
+        Ok(())
+    }
 }
 
 pub struct StateSnapshotDelta {

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -370,6 +370,8 @@ impl<
                         error
                     )));
                 }
+                self.reset_active_stream();
+                self.storage_synchronizer.drop_chunk_executor()?; // The bootstrapper is now complete
             }
         }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -470,6 +470,7 @@ impl<
         // so that in the event another sync request occurs, we have a fresh state.
         if !self.active_sync_request() {
             self.continuous_syncer.reset_active_stream();
+            self.storage_synchronizer.drop_chunk_executor()?; // Consensus is now in control
         }
         Ok(())
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -90,6 +90,10 @@ pub trait StorageSynchronizerInterface {
         state_value_chunk_with_proof: StateValueChunkWithProof,
     ) -> Result<(), Error>;
 
+    /// Drops the chunk executor. This is required so that the executor
+    /// is not actively held by state sync when consensus is running.
+    fn drop_chunk_executor(&mut self) -> Result<(), Error>;
+
     /// Resets the chunk executor. This is required to support continuous
     /// interaction between consensus and state sync.
     fn reset_chunk_executor(&mut self) -> Result<(), Error>;
@@ -315,6 +319,15 @@ impl<ChunkExecutor: ChunkExecutorTrait + 'static> StorageSynchronizerInterface
         self.chunk_executor.reset().map_err(|error| {
             Error::UnexpectedError(format!(
                 "Failed to reset the chunk executor! Error: {:?}",
+                error
+            ))
+        })
+    }
+
+    fn drop_chunk_executor(&mut self) -> Result<(), Error> {
+        self.chunk_executor.drop_executor().map_err(|error| {
+            Error::UnexpectedError(format!(
+                "Failed to drop the chunk executor! Error: {:?}",
                 error
             ))
         })

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -110,6 +110,9 @@ pub fn create_ready_storage_synchronizer(expect_reset_executor: bool) -> MockSto
         mock_storage_synchronizer
             .expect_reset_chunk_executor()
             .return_const(Ok(()));
+        mock_storage_synchronizer
+            .expect_drop_chunk_executor()
+            .return_const(Ok(()));
     }
 
     mock_storage_synchronizer
@@ -421,6 +424,8 @@ mock! {
             notification_id: NotificationId,
             state_value_chunk_with_proof: StateValueChunkWithProof,
         ) -> Result<(), crate::error::Error>;
+
+        fn drop_chunk_executor(&mut self) -> Result<(), crate::error::Error>;
 
         fn reset_chunk_executor(&mut self) -> Result<(), crate::error::Error>;
     }


### PR DESCRIPTION
### Description

This PR updates state sync to drop the chunk executor before handing over to consensus. This helps avoid any memory leaks when data is referenced by the executor across consensus and state sync. Note:
- @lightmark will need to actually implement the method.
- `reset()` will be called on the executor when consensus hands control back to state sync (or when state sync moves between bootstrapping and continuous syncing).

### Test Plan
Unit tests and manual verification once the real fix is implemented. 'cc @lightmark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2206)
<!-- Reviewable:end -->
