### PR TITLE
[forge] Run e2e tests when #e2e in pull request message

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -64,7 +64,8 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'CICD:build-images') ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
       contains(github.event.pull_request.labels.*.name, 'CICD:deploy-community-platform-to-staging') ||
-      github.event.pull_request.auto_merge != null
+      github.event.pull_request.auto_merge != null ||
+      contains(github.event.pull_request.body, '#e2e')
     runs-on: ubuntu-latest
     steps:
       - name: Check repository permission for user which triggered workflow
@@ -119,7 +120,8 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null)
+      github.event.pull_request.auto_merge != null) ||
+      contains(github.event.pull_request.body, '#e2e')
     uses: ./.github/workflows/sdk-integration-test.yaml
     secrets: inherit
     with:
@@ -129,10 +131,12 @@ jobs:
     needs: rust-images
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-      github.event.pull_request.auto_merge != null)
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null ||
+        contains(github.event.pull_request.body, '#e2e')
+      )
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
    [forge] Run e2e tests when #e2e in pull request message

    This change adds the ability to trigger forge on your commit by simply adding #e2e anywhere in your PR message body!

    Test Plan:

    I changed pull_request_target -> pull_request in build-images.yaml github action, then it will run from this workflow instead of from main workflow

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2208)
<!-- Reviewable:end -->
