### PR TITLE
[fix] wrap BlockExecutor and ChunkExecutor as an Option of Inner

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -353,10 +353,7 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
     )?;
 
     // Create the chunk executor
-    let chunk_executor = Arc::new(
-        ChunkExecutor::<AptosVM>::new(db_rw.clone())
-            .map_err(|err| anyhow!("Failed to create chunk executor {}", err))?,
-    );
+    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
 
     // Create the state sync multiplexer
     let state_sync_multiplexer = StateSyncMultiplexer::new(

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -207,11 +207,12 @@ impl StateComputer for ExecutionProxy {
 
     /// Synchronize to a commit that not present locally.
     async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+        let _guard = self.write_mutex.lock().await;
+
         // Before the state synchronization, we have to call finish() to free the in-memory SMT
         // held by BlockExecutor to prevent memory leak.
-        self.executor.finish()?;
+        self.executor.finish();
 
-        let _guard = self.write_mutex.lock().await;
         fail_point!("consensus::sync_to", |_| {
             Err(anyhow::anyhow!("Injected error in sync_to").into())
         });

--- a/consensus/src/state_computer.rs
+++ b/consensus/src/state_computer.rs
@@ -207,6 +207,10 @@ impl StateComputer for ExecutionProxy {
 
     /// Synchronize to a commit that not present locally.
     async fn sync_to(&self, target: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
+        // Before the state synchronization, we have to call finish() to free the in-memory SMT
+        // held by BlockExecutor to prevent memory leak.
+        self.executor.finish()?;
+
         let _guard = self.write_mutex.lock().await;
         fail_point!("consensus::sync_to", |_| {
             Err(anyhow::anyhow!("Injected error in sync_to").into())
@@ -220,9 +224,10 @@ impl StateComputer for ExecutionProxy {
             "sync_to",
             self.state_sync_notifier.sync_to_target(target).await
         );
+
         // Similarly, after the state synchronization, we have to reset the cache
         // of BlockExecutor to guarantee the latest committed state is up to date.
-        self.executor.reset()?;
+        self.executor.reset();
 
         res.map_err(|error| {
             let anyhow_error: anyhow::Error = error.into();

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -76,6 +76,9 @@ pub trait ChunkExecutorTrait: Send + Sync {
 
     /// Resets the chunk executor by synchronizing state with storage.
     fn reset(&self) -> Result<()>;
+
+    /// Finishes the chunk executor by releasing memory held by inner data structures(SMT).
+    fn finish(&self) -> Result<()>;
 }
 
 pub struct StateSnapshotDelta {
@@ -89,7 +92,7 @@ pub trait BlockExecutorTrait: Send + Sync {
     fn committed_block_id(&self) -> HashValue;
 
     /// Reset the internal state including cache with newly fetched latest committed block from storage.
-    fn reset(&self) -> Result<(), Error>;
+    fn reset(&self);
 
     /// Executes a block.
     fn execute_block(
@@ -125,6 +128,9 @@ pub trait BlockExecutorTrait: Send + Sync {
             true, /* save_state_snapshots */
         )
     }
+
+    /// Finishes the block executor by releasing memory held by inner data structures(SMT).
+    fn finish(&self) -> Result<()>;
 }
 
 pub trait TransactionReplayer: Send {

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -78,7 +78,7 @@ pub trait ChunkExecutorTrait: Send + Sync {
     fn reset(&self) -> Result<()>;
 
     /// Finishes the chunk executor by releasing memory held by inner data structures(SMT).
-    fn finish(&self) -> Result<()>;
+    fn finish(&self);
 }
 
 pub struct StateSnapshotDelta {
@@ -130,7 +130,7 @@ pub trait BlockExecutorTrait: Send + Sync {
     }
 
     /// Finishes the block executor by releasing memory held by inner data structures(SMT).
-    fn finish(&self) -> Result<()>;
+    fn finish(&self);
 }
 
 pub trait TransactionReplayer: Send {

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -4,8 +4,9 @@
 #![forbid(unsafe_code)]
 
 use crate::logging::{LogEntry, LogSchema};
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use aptos_crypto::HashValue;
+use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
 use aptos_state_view::StateViewId;
 use aptos_types::{
@@ -31,11 +32,92 @@ use storage_interface::{jmt_updates, DbReaderWriter};
 
 pub struct BlockExecutor<V> {
     pub db: DbReaderWriter,
+    inner: RwLock<Option<BlockExecutorInner<V>>>,
+}
+
+impl<V> BlockExecutor<V>
+where
+    V: VMExecutor,
+{
+    pub fn new(db: DbReaderWriter) -> Self {
+        Self {
+            db,
+            inner: RwLock::new(None),
+        }
+    }
+
+    pub fn root_smt(&self) -> SparseMerkleTree<StateValue> {
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .root_smt()
+    }
+
+    fn maybe_reset(&self) {
+        if self.inner.read().is_none() {
+            self.reset();
+        }
+    }
+}
+
+impl<V> BlockExecutorTrait for BlockExecutor<V>
+where
+    V: VMExecutor,
+{
+    fn committed_block_id(&self) -> HashValue {
+        self.maybe_reset();
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .committed_block_id()
+    }
+
+    fn reset(&self) {
+        *self.inner.write() = Some(BlockExecutorInner::new(self.db.clone()));
+    }
+
+    fn execute_block(
+        &self,
+        block: (HashValue, Vec<Transaction>),
+        parent_block_id: HashValue,
+    ) -> Result<StateComputeResult, Error> {
+        self.maybe_reset();
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .execute_block(block, parent_block_id)
+    }
+
+    fn commit_blocks_ext(
+        &self,
+        block_ids: Vec<HashValue>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        save_state_snapshots: bool,
+    ) -> Result<Option<StateSnapshotDelta>, Error> {
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .commit_blocks_ext(block_ids, ledger_info_with_sigs, save_state_snapshots)
+    }
+
+    fn finish(&self) -> Result<()> {
+        let mut inner = self.inner.write();
+        ensure!(inner.is_some());
+        *inner = None;
+        Ok(())
+    }
+}
+struct BlockExecutorInner<V> {
+    db: DbReaderWriter,
     block_tree: BlockTree,
     phantom: PhantomData<V>,
 }
 
-impl<V> BlockExecutor<V>
+impl<V> BlockExecutorInner<V>
 where
     V: VMExecutor,
 {
@@ -48,7 +130,7 @@ where
         }
     }
 
-    pub fn root_smt(&self) -> SparseMerkleTree<StateValue> {
+    fn root_smt(&self) -> SparseMerkleTree<StateValue> {
         self.block_tree
             .root_block()
             .output
@@ -59,16 +141,12 @@ where
     }
 }
 
-impl<V> BlockExecutorTrait for BlockExecutor<V>
+impl<V> BlockExecutorInner<V>
 where
     V: VMExecutor,
 {
     fn committed_block_id(&self) -> HashValue {
         self.block_tree.root_block().id
-    }
-
-    fn reset(&self) -> Result<(), Error> {
-        Ok(self.block_tree.reset(&self.db.reader)?)
     }
 
     fn execute_block(

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -15,8 +15,8 @@ use crate::{
         APTOS_EXECUTOR_EXECUTE_CHUNK_SECONDS, APTOS_EXECUTOR_VM_EXECUTE_CHUNK_SECONDS,
     },
 };
-use anyhow::Result;
-use aptos_infallible::Mutex;
+use anyhow::{ensure, Result};
+use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::prelude::*;
 use aptos_state_view::StateViewId;
 use aptos_types::{
@@ -36,11 +36,115 @@ use storage_interface::{cached_state_view::CachedStateView, DbReaderWriter, Exec
 
 pub struct ChunkExecutor<V> {
     db: DbReaderWriter,
+    inner: RwLock<Option<ChunkExecutorInner<V>>>,
+}
+
+impl<V: VMExecutor> ChunkExecutor<V> {
+    pub fn new(db: DbReaderWriter) -> Self {
+        Self {
+            db,
+            inner: RwLock::new(None),
+        }
+    }
+
+    fn maybe_reset(&self) -> Result<()> {
+        if self.inner.read().is_none() {
+            self.reset()?;
+        }
+        Ok(())
+    }
+}
+
+impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
+    fn execute_chunk(
+        &self,
+        txn_list_with_proof: TransactionListWithProof,
+        verified_target_li: &LedgerInfoWithSignatures,
+        epoch_change_li: Option<&LedgerInfoWithSignatures>,
+    ) -> Result<()> {
+        self.maybe_reset()?;
+        self.inner
+            .read()
+            .as_ref()
+            .expect("not reset")
+            .execute_chunk(txn_list_with_proof, verified_target_li, epoch_change_li)
+    }
+
+    fn apply_chunk(
+        &self,
+        txn_output_list_with_proof: TransactionOutputListWithProof,
+        verified_target_li: &LedgerInfoWithSignatures,
+        epoch_change_li: Option<&LedgerInfoWithSignatures>,
+    ) -> Result<()> {
+        self.inner.read().as_ref().expect("not reset").apply_chunk(
+            txn_output_list_with_proof,
+            verified_target_li,
+            epoch_change_li,
+        )
+    }
+
+    fn commit_chunk(&self) -> Result<ChunkCommitNotification> {
+        self.inner
+            .read()
+            .as_ref()
+            .expect("not reset")
+            .commit_chunk()
+    }
+
+    fn execute_and_commit_chunk(
+        &self,
+        txn_list_with_proof: TransactionListWithProof,
+        verified_target_li: &LedgerInfoWithSignatures,
+        epoch_change_li: Option<&LedgerInfoWithSignatures>,
+    ) -> Result<ChunkCommitNotification> {
+        // Re-sync with DB, make sure the queue is empty.
+        self.reset()?;
+        self.inner
+            .read()
+            .as_ref()
+            .expect("not reset")
+            .execute_and_commit_chunk(txn_list_with_proof, verified_target_li, epoch_change_li)
+    }
+
+    fn apply_and_commit_chunk(
+        &self,
+        txn_output_list_with_proof: TransactionOutputListWithProof,
+        verified_target_li: &LedgerInfoWithSignatures,
+        epoch_change_li: Option<&LedgerInfoWithSignatures>,
+    ) -> Result<ChunkCommitNotification> {
+        // Re-sync with DB, make sure the queue is empty.
+        self.reset()?;
+        self.inner
+            .read()
+            .as_ref()
+            .expect("not reset")
+            .apply_and_commit_chunk(
+                txn_output_list_with_proof,
+                verified_target_li,
+                epoch_change_li,
+            )
+    }
+
+    fn reset(&self) -> Result<()> {
+        *self.inner.write() = Some(ChunkExecutorInner::new(self.db.clone())?);
+        Ok(())
+    }
+
+    fn finish(&self) -> Result<()> {
+        let mut inner = self.inner.write();
+        ensure!(inner.is_some());
+        *inner = None;
+        Ok(())
+    }
+}
+
+struct ChunkExecutorInner<V> {
+    db: DbReaderWriter,
     commit_queue: Mutex<ChunkCommitQueue>,
     _phantom: PhantomData<V>,
 }
 
-impl<V> ChunkExecutor<V> {
+impl<V: VMExecutor> ChunkExecutorInner<V> {
     pub fn new(db: DbReaderWriter) -> Result<Self> {
         let commit_queue = Mutex::new(ChunkCommitQueue::new_from_db(&db.reader)?);
         Ok(Self {
@@ -48,15 +152,6 @@ impl<V> ChunkExecutor<V> {
             commit_queue,
             _phantom: PhantomData,
         })
-    }
-
-    pub fn new_with_view(db: DbReaderWriter, persisted_view: ExecutedTrees) -> Self {
-        let commit_queue = Mutex::new(ChunkCommitQueue::new(persisted_view));
-        Self {
-            db,
-            commit_queue,
-            _phantom: PhantomData,
-        }
     }
 
     fn state_view(&self, latest_view: &ExecutedTrees) -> Result<CachedStateView<SyncProofFetcher>> {
@@ -106,9 +201,8 @@ impl<V> ChunkExecutor<V> {
         self.commit_queue.lock().dequeue()?;
         Ok(to_commit)
     }
-}
 
-impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
+    // ************************* Block Executor Implementation *************************
     fn execute_chunk(
         &self,
         txn_list_with_proof: TransactionListWithProof,
@@ -233,9 +327,6 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> Result<ChunkCommitNotification> {
-        // Re-sync with DB, make sure the queue is empty.
-        self.reset()?;
-
         self.execute_chunk(txn_list_with_proof, verified_target_li, epoch_change_li)?;
         self.commit_chunk()
     }
@@ -246,9 +337,6 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> Result<ChunkCommitNotification> {
-        // Re-sync with DB, make sure the queue is empty.
-        self.reset()?;
-
         self.apply_chunk(
             txn_output_list_with_proof,
             verified_target_li,
@@ -256,16 +344,28 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         )?;
         self.commit_chunk()
     }
+}
 
-    fn reset(&self) -> Result<()> {
-        *self.commit_queue.lock() = ChunkCommitQueue::new_from_db(&self.db.reader)?;
-        Ok(())
+impl<V: VMExecutor> TransactionReplayer for ChunkExecutor<V> {
+    fn replay(
+        &self,
+        transactions: Vec<Transaction>,
+        transaction_infos: Vec<TransactionInfo>,
+    ) -> Result<()> {
+        self.maybe_reset()?;
+        self.inner
+            .read()
+            .as_ref()
+            .expect("not reset")
+            .replay(transactions, transaction_infos)
+    }
+
+    fn commit(&self) -> Result<Arc<ExecutedChunk>> {
+        self.inner.read().as_ref().expect("not reset").commit()
     }
 }
 
-impl<V: VMExecutor> ChunkExecutor<V> {}
-
-impl<V: VMExecutor> TransactionReplayer for ChunkExecutor<V> {
+impl<V: VMExecutor> TransactionReplayer for ChunkExecutorInner<V> {
     fn replay(
         &self,
         transactions: Vec<Transaction>,

--- a/execution/executor/src/components/chunk_commit_queue.rs
+++ b/execution/executor/src/components/chunk_commit_queue.rs
@@ -16,11 +16,7 @@ pub struct ChunkCommitQueue {
 
 impl ChunkCommitQueue {
     pub fn new_from_db(db: &Arc<dyn DbReader>) -> Result<Self> {
-        let persisted_view = match db.get_startup_info()? {
-            Some(info) => info.into_latest_executed_trees(),
-            // This is a hack for backup-types tests.
-            None => db.get_latest_executed_trees()?,
-        };
+        let persisted_view = db.get_latest_executed_trees()?;
         Ok(Self::new(persisted_view))
     }
 

--- a/execution/executor/src/components/chunk_commit_queue.rs
+++ b/execution/executor/src/components/chunk_commit_queue.rs
@@ -16,10 +16,11 @@ pub struct ChunkCommitQueue {
 
 impl ChunkCommitQueue {
     pub fn new_from_db(db: &Arc<dyn DbReader>) -> Result<Self> {
-        let persisted_view = db
-            .get_startup_info()?
-            .ok_or_else(|| anyhow!("DB not bootstrapped."))?
-            .into_latest_executed_trees();
+        let persisted_view = match db.get_startup_info()? {
+            Some(info) => info.into_latest_executed_trees(),
+            // This is a hack for backup-types tests.
+            None => db.get_latest_executed_trees()?,
+        };
         Ok(Self::new(persisted_view))
     }
 

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -28,7 +28,7 @@ pub fn fuzz_execute_and_commit_chunk(
     verified_target_li: LedgerInfoWithSignatures,
 ) {
     let db = DbReaderWriter::new(FakeDb {});
-    let executor = ChunkExecutor::<FakeVM>::new(db).unwrap();
+    let executor = ChunkExecutor::<FakeVM>::new(db);
 
     let _events = executor.execute_and_commit_chunk(txn_list_with_proof, &verified_target_li, None);
 }

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -264,7 +264,7 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
     }
 
     // Fork starts. Should fail.
-    chunk_manager.finish().unwrap();
+    chunk_manager.finish();
     chunk_manager.reset().unwrap();
 
     assert!(chunk_manager

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -35,7 +35,7 @@ impl TestExecutor {
         let genesis = vm_genesis::test_genesis_transaction();
         let waypoint = generate_waypoint::<MockVM>(&db, &genesis).unwrap();
         maybe_bootstrap::<MockVM>(&db, &genesis, waypoint).unwrap();
-        let executor = ChunkExecutor::new(db.clone()).unwrap();
+        let executor = ChunkExecutor::new(db.clone());
 
         TestExecutor {
             _path: path,
@@ -216,7 +216,7 @@ fn test_executor_execute_and_commit_chunk_restart() {
 
     // Then we restart executor and resume to the next chunk.
     {
-        let executor = ChunkExecutor::<MockVM>::new(db.clone()).unwrap();
+        let executor = ChunkExecutor::<MockVM>::new(db.clone());
 
         executor
             .execute_and_commit_chunk(chunks[1].clone(), &ledger_info, None)
@@ -264,7 +264,9 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
     }
 
     // Fork starts. Should fail.
+    chunk_manager.finish().unwrap();
     chunk_manager.reset().unwrap();
+
     assert!(chunk_manager
         .execute_and_commit_chunk(chunks[0].clone(), &ledger_info, None)
         .is_err());

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -729,7 +729,6 @@ proptest! {
         let second_block_txns = ((chunk_size + overlap_size + 1..=chunk_size + overlap_size + num_new_txns)
                              .map(|i| encode_mint_transaction(gen_address(i), 100))).collect::<Vec<_>>();
 
-        executor.finish().unwrap();
         executor.reset();
         let parent_block_id = executor.committed_block_id();
         let first_block_id = gen_block_id(1);

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -722,14 +722,15 @@ proptest! {
 
         // Commit the first chunk without committing the ledger info.
         let TestExecutor { _path, db, executor } = TestExecutor::new();
-        ChunkExecutor::<MockVM>::new(db).unwrap()
+        ChunkExecutor::<MockVM>::new(db)
             .execute_and_commit_chunk(txn_list_with_proof_to_commit, &ledger_info, None).unwrap();
 
         first_block_txns.extend(overlap_txn_list_with_proof.transactions);
         let second_block_txns = ((chunk_size + overlap_size + 1..=chunk_size + overlap_size + num_new_txns)
                              .map(|i| encode_mint_transaction(gen_address(i), 100))).collect::<Vec<_>>();
 
-        executor.reset().unwrap();
+        executor.finish().unwrap();
+        executor.reset();
         let parent_block_id = executor.committed_block_id();
         let first_block_id = gen_block_id(1);
         let _output1 = executor.execute_block(

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -365,7 +365,7 @@ mod tests {
             .unwrap();
 
         // Create an executor proxy
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw));
         let mut executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Publish a subscribed event
@@ -567,7 +567,7 @@ mod tests {
             .unwrap();
 
         // Create an executor
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
         let mut executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Verify that the initial configs returned to the subscriber don't contain the unknown on-chain config
@@ -650,7 +650,7 @@ mod tests {
 
         // Create the executors
         let block_executor = Box::new(BlockExecutor::<AptosVM>::new(db_rw.clone()));
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw));
         let executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         (

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -175,7 +175,7 @@ pub(crate) mod test_utils {
             .unwrap();
 
         // Create executor proxy
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw));
         let executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Get initial state

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -372,7 +372,7 @@ impl<
                 }
             }
             self.reset_active_stream();
-            self.storage_synchronizer.finish_chunk_executor()?; // The bootstrapper is now complete
+            self.storage_synchronizer.finish_chunk_executor(); // The bootstrapper is now complete
         }
 
         Ok(())

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -371,6 +371,8 @@ impl<
                     )));
                 }
             }
+            self.reset_active_stream();
+            self.storage_synchronizer.finish_chunk_executor()?; // The bootstrapper is now complete
         }
 
         Ok(())

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -470,6 +470,7 @@ impl<
         // so that in the event another sync request occurs, we have a fresh state.
         if !self.active_sync_request() {
             self.continuous_syncer.reset_active_stream();
+            self.storage_synchronizer.finish_chunk_executor()?; // Consensus is now in control
         }
         Ok(())
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -470,7 +470,7 @@ impl<
         // so that in the event another sync request occurs, we have a fresh state.
         if !self.active_sync_request() {
             self.continuous_syncer.reset_active_stream();
-            self.storage_synchronizer.finish_chunk_executor()?; // Consensus is now in control
+            self.storage_synchronizer.finish_chunk_executor(); // Consensus is now in control
         }
         Ok(())
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -96,7 +96,7 @@ pub trait StorageSynchronizerInterface {
 
     /// Finish the chunk executor at this round of state sync by releasing
     /// any in-memory resources to prevent memory leak.
-    fn finish_chunk_executor(&self) -> Result<(), Error>;
+    fn finish_chunk_executor(&self);
 }
 
 /// The implementation of the `StorageSynchronizerInterface` used by state sync
@@ -324,13 +324,8 @@ impl<ChunkExecutor: ChunkExecutorTrait + 'static> StorageSynchronizerInterface
         })
     }
 
-    fn finish_chunk_executor(&self) -> Result<(), Error> {
-        self.chunk_executor.finish().map_err(|error| {
-            Error::UnexpectedError(format!(
-                "Failed to reset the chunk executor! Error: {:?}",
-                error
-            ))
-        })
+    fn finish_chunk_executor(&self) {
+        self.chunk_executor.finish()
     }
 }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -92,7 +92,11 @@ pub trait StorageSynchronizerInterface {
 
     /// Resets the chunk executor. This is required to support continuous
     /// interaction between consensus and state sync.
-    fn reset_chunk_executor(&mut self) -> Result<(), Error>;
+    fn reset_chunk_executor(&self) -> Result<(), Error>;
+
+    /// Finish the chunk executor at this round of state sync by releasing
+    /// any in-memory resources to prevent memory leak.
+    fn finish_chunk_executor(&self) -> Result<(), Error>;
 }
 
 /// The implementation of the `StorageSynchronizerInterface` used by state sync
@@ -311,8 +315,17 @@ impl<ChunkExecutor: ChunkExecutorTrait + 'static> StorageSynchronizerInterface
         }
     }
 
-    fn reset_chunk_executor(&mut self) -> Result<(), Error> {
+    fn reset_chunk_executor(&self) -> Result<(), Error> {
         self.chunk_executor.reset().map_err(|error| {
+            Error::UnexpectedError(format!(
+                "Failed to reset the chunk executor! Error: {:?}",
+                error
+            ))
+        })
+    }
+
+    fn finish_chunk_executor(&self) -> Result<(), Error> {
+        self.chunk_executor.finish().map_err(|error| {
             Error::UnexpectedError(format!(
                 "Failed to reset the chunk executor! Error: {:?}",
                 error

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -265,7 +265,7 @@ async fn create_driver_for_tests(
         mempool_notifications::new_mempool_notifier_listener_pair();
 
     // Create the chunk executor
-    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()).unwrap());
+    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
 
     // Create a streaming service client
     let (streaming_service_client, _) = new_streaming_service_client_listener_pair();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -108,6 +108,9 @@ pub fn create_ready_storage_synchronizer(expect_reset_executor: bool) -> MockSto
         .return_const(false);
     if expect_reset_executor {
         mock_storage_synchronizer
+            .expect_finish_chunk_executor()
+            .return_const(Ok(()));
+        mock_storage_synchronizer
             .expect_reset_chunk_executor()
             .return_const(Ok(()));
     }
@@ -150,6 +153,8 @@ mock! {
         fn commit_chunk(&self) -> Result<ChunkCommitNotification>;
 
         fn reset(&self) -> Result<()>;
+
+        fn finish(&self) -> Result<()>;
     }
 }
 
@@ -422,7 +427,9 @@ mock! {
             state_value_chunk_with_proof: StateValueChunkWithProof,
         ) -> Result<(), crate::error::Error>;
 
-        fn reset_chunk_executor(&mut self) -> Result<(), crate::error::Error>;
+        fn reset_chunk_executor(&self) -> Result<(), crate::error::Error>;
+
+        fn finish_chunk_executor(&self) -> Result<(), crate::error::Error>;
     }
     impl Clone for StorageSynchronizer {
         fn clone(&self) -> Self;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -109,7 +109,7 @@ pub fn create_ready_storage_synchronizer(expect_reset_executor: bool) -> MockSto
     if expect_reset_executor {
         mock_storage_synchronizer
             .expect_finish_chunk_executor()
-            .return_const(Ok(()));
+            .return_const(());
         mock_storage_synchronizer
             .expect_reset_chunk_executor()
             .return_const(Ok(()));
@@ -154,7 +154,7 @@ mock! {
 
         fn reset(&self) -> Result<()>;
 
-        fn finish(&self) -> Result<()>;
+        fn finish(&self);
     }
 }
 
@@ -429,7 +429,7 @@ mock! {
 
         fn reset_chunk_executor(&self) -> Result<(), crate::error::Error>;
 
-        fn finish_chunk_executor(&self) -> Result<(), crate::error::Error>;
+        fn finish_chunk_executor(&self);
     }
     impl Clone for StorageSynchronizer {
         fn clone(&self) -> Self;

--- a/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
@@ -245,7 +245,7 @@ mod tests {
             mempool_notifier,
             consensus_listener,
             db_rw.clone(),
-            Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap()),
+            Arc::new(ChunkExecutor::<AptosVM>::new(db_rw)),
             &node_config,
             Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::random())),
             event_subscription_service,

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -40,7 +40,7 @@ use futures::{
 };
 use itertools::zip_eq;
 use std::{cmp::min, pin::Pin, sync::Arc, time::Instant};
-use storage_interface::{DbReader, DbReaderWriter};
+use storage_interface::DbReaderWriter;
 use structopt::StructOpt;
 use tokio::io::BufReader;
 
@@ -409,12 +409,7 @@ impl TransactionRestoreBatchController {
         restore_handler.maybe_reset_state_store(expected_latest_version);
         let replay_start = Instant::now();
         let db = DbReaderWriter::from_arc(Arc::clone(&restore_handler.aptosdb));
-        let persisted_view = restore_handler.aptosdb.get_latest_executed_trees()?;
-        assert_eq!(
-            persisted_view.state().current_version,
-            first_version.checked_sub(1)
-        );
-        let chunk_replayer = Arc::new(ChunkExecutor::<AptosVM>::new_with_view(db, persisted_view));
+        let chunk_replayer = Arc::new(ChunkExecutor::<AptosVM>::new(db));
 
         let db_commit_stream = txns_to_execute_stream
             .try_chunks(BATCH_SIZE)

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -51,7 +51,7 @@ struct Args {
 #[structopt(about = "Forge success criteria that includes a bunch of performance metrics")]
 pub struct SuccessCriteriaArgs {
     // general options
-    #[structopt(long, default_value = "5000")]
+    #[structopt(long, default_value = "3500")]
     avg_tps: usize,
     #[structopt(long, default_value = "8000")]
     max_latency_ms: usize,


### PR DESCRIPTION
### Description

This PR wraps both `BlockExecutor` and `ChunkExecutor` with a wrapper that can drop the inner executors to release the `ExecutedTrees` they hold. Specifically, we want the `StateDelta` that includes 2 SMTs to be dropped. Otherwise, the SMT descendants from these trees would increase the memory usage into infinity, causing memory leak. 
This is a hot fix. The best solution should merge these two executors together into one and shared by StateSync and Consensus. 

### Test Plan
ut should all be okay. Will deploy to clusters to see the counter will change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2210)
<!-- Reviewable:end -->
