### PR TITLE
[storage][pruner] separate ledger and state pruners

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1627,18 +1627,23 @@ impl DbWriter for AptosDB {
     fn delete_genesis(&self) -> Result<()> {
         gauged_api("delete_genesis", || {
             // Create all the db pruners
-            let db_pruners = utils::create_db_pruners(
-                Arc::clone(&self.ledger_db),
-                Arc::clone(&self.state_merkle_db),
-                self.pruner_config,
-            );
+            let state_pruner_option =
+                utils::create_state_pruner(Arc::clone(&self.state_merkle_db), self.pruner_config);
+            let ledger_pruner_option =
+                utils::create_ledger_pruner(Arc::clone(&self.ledger_db), self.pruner_config);
 
             // Execute each pruner to clean up the genesis state
             let target_version = 1; // The genesis version is 0. Delete [0,1) (exclusive).
             let max_version = 1; // We should only really be pruning at a single version.
-            for db_pruner in db_pruners.into_iter().flatten() {
-                db_pruner.lock().set_target_version(target_version);
-                db_pruner.lock().prune(max_version)?;
+
+            if let Some(state_pruner) = state_pruner_option {
+                state_pruner.lock().set_target_version(target_version);
+                state_pruner.lock().prune(max_version)?;
+            }
+
+            if let Some(ledger_pruner) = ledger_pruner_option {
+                ledger_pruner.lock().set_target_version(target_version);
+                ledger_pruner.lock().prune(max_version)?;
             }
             Ok(())
         })

--- a/storage/aptosdb/src/pruner/utils.rs
+++ b/storage/aptosdb/src/pruner/utils.rs
@@ -15,29 +15,32 @@ use aptos_infallible::Mutex;
 use schemadb::DB;
 use std::sync::Arc;
 
-/// A useful utility function to instantiate all db pruners.
-pub fn create_db_pruners(
-    ledger_db: Arc<DB>,
+/// Utility functions to instantiate pruners.
+pub fn create_state_pruner(
     state_merkle_db: Arc<DB>,
     storage_pruner_config: StoragePrunerConfig,
-) -> Vec<Option<Mutex<Arc<dyn DBPruner + Send + Sync>>>> {
-    vec![
-        if storage_pruner_config.state_store_prune_window.is_some() {
-            Some(Mutex::new(Arc::new(StateStorePruner::new(Arc::clone(
-                &state_merkle_db,
-            )))))
-        } else {
-            None
-        },
-        if storage_pruner_config.ledger_prune_window.is_some() {
-            Some(Mutex::new(Arc::new(LedgerPruner::new(
-                Arc::clone(&ledger_db),
-                Arc::new(TransactionStore::new(Arc::clone(&ledger_db))),
-                Arc::new(EventStore::new(Arc::clone(&ledger_db))),
-                Arc::new(LedgerStore::new(Arc::clone(&ledger_db))),
-            ))))
-        } else {
-            None
-        },
-    ]
+) -> Option<Mutex<Arc<dyn DBPruner + Send + Sync>>> {
+    if storage_pruner_config.state_store_prune_window.is_some() {
+        Some(Mutex::new(Arc::new(StateStorePruner::new(Arc::clone(
+            &state_merkle_db,
+        )))))
+    } else {
+        None
+    }
+}
+
+pub fn create_ledger_pruner(
+    ledger_db: Arc<DB>,
+    storage_pruner_config: StoragePrunerConfig,
+) -> Option<Mutex<Arc<dyn DBPruner + Send + Sync>>> {
+    if storage_pruner_config.ledger_prune_window.is_some() {
+        Some(Mutex::new(Arc::new(LedgerPruner::new(
+            Arc::clone(&ledger_db),
+            Arc::new(TransactionStore::new(Arc::clone(&ledger_db))),
+            Arc::new(EventStore::new(Arc::clone(&ledger_db))),
+            Arc::new(LedgerStore::new(Arc::clone(&ledger_db))),
+        ))))
+    } else {
+        None
+    }
 }


### PR DESCRIPTION
### Description
As a first step to separate ledger and state pruners, replace the vector of pruners with objects ledger pruner and state pruner. The next step is to wake them up separately and probably running in different threads.
### Test Plan
Existing UTs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2213)
<!-- Reviewable:end -->
