### PR TITLE
[Forge] Add TPS/latency validation to forge test runner

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -88,6 +88,7 @@ pub struct EmitJobRequest {
     thread_params: EmitThreadParams,
     gas_price: u64,
     invalid_transaction_ratio: usize,
+    pub duration: Duration,
     vasp: bool,
     transaction_type: TransactionType,
 }
@@ -101,6 +102,7 @@ impl Default for EmitJobRequest {
             thread_params: EmitThreadParams::default(),
             gas_price: 0,
             invalid_transaction_ratio: 0,
+            duration: Duration::from_secs(300),
             vasp: false,
             transaction_type: TransactionType::P2P,
         }
@@ -164,6 +166,11 @@ impl EmitJobRequest {
 
     pub fn vasp(mut self) -> Self {
         self.vasp = true;
+        self
+    }
+
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
         self
     }
 }
@@ -355,11 +362,8 @@ impl<'t> TxnEmitter<'t> {
         }
     }
 
-    pub async fn emit_txn_for(
-        &mut self,
-        duration: Duration,
-        emit_job_request: EmitJobRequest,
-    ) -> Result<TxnStats> {
+    pub async fn emit_txn_for(&mut self, emit_job_request: EmitJobRequest) -> Result<TxnStats> {
+        let duration = emit_job_request.duration;
         let job = self.start_job(emit_job_request).await?;
         info!("Starting emitting txns for {} secs", duration.as_secs());
         time::sleep(duration).await;
@@ -371,10 +375,10 @@ impl<'t> TxnEmitter<'t> {
 
     pub async fn emit_txn_for_with_stats(
         &mut self,
-        duration: Duration,
         emit_job_request: EmitJobRequest,
         interval_secs: u64,
     ) -> Result<TxnStats> {
+        let duration = emit_job_request.duration;
         info!("Starting emitting txns for {} secs", duration.as_secs());
         let job = self.start_job(emit_job_request).await?;
         self.periodic_stat(&job, duration, interval_secs).await;

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -54,6 +54,7 @@ pub async fn emit_transactions_with_cluster(
             .thread_params(thread_params)
             .invalid_transaction_ratio(args.invalid_tx)
             .transaction_type(args.transaction_type)
+            .duration(duration)
             .gas_price(1);
     if let Some(workers_per_endpoint) = args.workers_per_ac {
         emit_job_request = emit_job_request.workers_per_endpoint(workers_per_endpoint);
@@ -62,11 +63,7 @@ pub async fn emit_transactions_with_cluster(
         emit_job_request = emit_job_request.vasp();
     }
     let stats = emitter
-        .emit_txn_for_with_stats(
-            duration,
-            emit_job_request,
-            min(10, max(args.duration / 5, 1)),
-        )
+        .emit_txn_for_with_stats(emit_job_request, min(10, max(args.duration / 5, 1)))
         .await?;
     Ok(stats)
 }

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Test;
+use crate::success_criteria::SuccessCriteria;
 use crate::{CoreContext, Result, Swarm, TestReport};
 use transaction_emitter_lib::EmitJobRequest;
 
@@ -18,6 +19,7 @@ pub struct NetworkContext<'t> {
     swarm: &'t mut dyn Swarm,
     pub report: &'t mut TestReport,
     pub global_job: EmitJobRequest,
+    success_criteria: SuccessCriteria,
 }
 
 impl<'t> NetworkContext<'t> {
@@ -26,12 +28,14 @@ impl<'t> NetworkContext<'t> {
         swarm: &'t mut dyn Swarm,
         report: &'t mut TestReport,
         global_job: EmitJobRequest,
+        success_criteria: SuccessCriteria,
     ) -> Self {
         Self {
             core,
             swarm,
             report,
             global_job,
+            success_criteria,
         }
     }
 
@@ -41,5 +45,8 @@ impl<'t> NetworkContext<'t> {
 
     pub fn core(&mut self) -> &mut CoreContext {
         &mut self.core
+    }
+    pub fn success_criteria(&self) -> &SuccessCriteria {
+        &self.success_criteria
     }
 }

--- a/testsuite/forge/src/lib.rs
+++ b/testsuite/forge/src/lib.rs
@@ -23,4 +23,6 @@ mod github;
 pub use github::*;
 
 mod slack;
+pub mod success_criteria;
+
 pub use slack::*;

--- a/testsuite/forge/src/report.rs
+++ b/testsuite/forge/src/report.rs
@@ -38,7 +38,7 @@ impl TestReport {
         self.text.push_str(&text);
     }
 
-    pub fn report_txn_stats(&mut self, test_name: String, stats: TxnStats, window: Duration) {
+    pub fn report_txn_stats(&mut self, test_name: String, stats: &TxnStats, window: Duration) {
         let submitted_txn = stats.submitted;
         let expired_txn = stats.expired;
         let avg_tps = stats.committed / window.as_secs();

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::bail;
+use serde::Serialize;
+use std::time::Duration;
+use transaction_emitter_lib::emitter::stats::TxnStats;
+
+#[derive(Default, Clone, Debug, Serialize)]
+pub struct SuccessCriteria {
+    avg_tps: usize,
+    max_latency_ms: usize,
+}
+
+impl SuccessCriteria {
+    pub fn new(tps: usize, max_latency_ms: usize) -> Self {
+        Self {
+            avg_tps: tps,
+            max_latency_ms,
+        }
+    }
+
+    pub fn check_for_success(&self, stats: &TxnStats, window: &Duration) -> anyhow::Result<()> {
+        // TODO: Add more success criteria like expired transactions, CPU, memory usage etc
+        let avg_tps = stats.committed / window.as_secs();
+        let p99_latency = stats.latency_buckets.percentile(99, 100);
+        if avg_tps < self.avg_tps as u64 {
+            bail!(
+                "TPS requirement failed. Average TPS {}, minimum TPS requirement {}",
+                avg_tps,
+                self.avg_tps
+            )
+        }
+        if p99_latency > self.max_latency_ms as u64 {
+            bail!(
+                "Latency requirement failed. P99 latency {}, maximum latency requirement {}",
+                p99_latency,
+                self.max_latency_ms
+            )
+        }
+        Ok(())
+    }
+}

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -12,9 +12,9 @@
 # ensure the script is run from project root
 pwd | grep -qE 'aptos-core$' || (echo "Please run from aptos-core root directory" && exit 1)
 
-# for calculating regression
-TPS_THRESHOLD=5000
-P99_LATENCY_MS_THRESHOLD=8000
+# for calculating regression in local mode
+LOCAL_TPS_THRESHOLD=400
+LOCAL_P99_LATENCY_MS_THRESHOLD=60000
 
 # output files
 FORGE_OUTPUT=${FORGE_OUTPUT:-$(mktemp)}
@@ -168,7 +168,9 @@ if [ "$FORGE_RUNNER_MODE" = "local" ]; then
     # more file descriptors for heavy txn generation
     ulimit -n 1048576
 
-    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 --avg-tps 300 --max-latency-ms 60000 test k8s-swarm \
+    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 --avg-tps $LOCAL_TPS_THRESHOLD \
+        --max-latency-ms $LOCAL_P99_LATENCY_MS_THRESHOLD \
+        test k8s-swarm \
         --image-tag $IMAGE_TAG \
         --namespace $FORGE_NAMESPACE \
         --port-forward $REUSE_ARGS $KEEP_ARGS $ENABLE_HAPROXY_ARGS | tee $FORGE_OUTPUT

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -168,7 +168,7 @@ if [ "$FORGE_RUNNER_MODE" = "local" ]; then
     # more file descriptors for heavy txn generation
     ulimit -n 1048576
 
-    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 test k8s-swarm \
+    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --workers-per-ac 10 --avg-tps 300 --max-latency-ms 60000 test k8s-swarm \
         --image-tag $IMAGE_TAG \
         --namespace $FORGE_NAMESPACE \
         --port-forward $REUSE_ARGS $KEEP_ARGS $ENABLE_HAPROXY_ARGS | tee $FORGE_OUTPUT
@@ -251,30 +251,16 @@ fi
 # print the Forge report
 cat $FORGE_REPORT
 
-# detect regressions. TODO: do this in the Forge test runner itself since it's complex
-# if this script is not triggered in GHA, use a default value
 [ -z "$GITHUB_RUN_ID" ] && GITHUB_RUN_ID=0
 AVG_TPS=$(cat $FORGE_REPORT | grep -oE '[0-9]+ TPS' | awk '{print $1}')
 P99_LATENCY=$(cat $FORGE_REPORT | grep -oE '[0-9]+ ms p99 latency' | awk '{print $1}')
 if [ -n "$AVG_TPS" ]; then
     echo "AVG_TPS: ${AVG_TPS}"
     echo "forge_job_avg_tps {FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\",GITHUB_RUN_ID=\"$GITHUB_RUN_ID\"} $AVG_TPS" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
-    if [[ "$AVG_TPS" -lt "$TPS_THRESHOLD" ]]; then
-        echo "(\!) AVG_TPS: ${avg_tps} < ${TPS_THRESHOLD} tps"
-        if [ "$FORGE_RUNNER_MODE" != "local" ]; then
-            FORGE_EXIT_CODE=2
-        fi
-    fi
 fi
 if [ -n "$P99_LATENCY" ]; then
     echo "P99_LATENCY: ${P99_LATENCY}"
     echo "forge_job_p99_latency {FORGE_CLUSTER_NAME=\"$FORGE_CLUSTER_NAME\",FORGE_NAMESPACE=\"$FORGE_NAMESPACE\",GITHUB_RUN_ID=\"$GITHUB_RUN_ID\"} $P99_LATENCY" | curl -u "$PUSH_GATEWAY_USER:$PUSH_GATEWAY_PASSWORD" --data-binary @- ${PUSH_GATEWAY}/metrics/job/forge
-    if [[ "$P99_LATENCY" -gt "$P99_LATENCY_MS_THRESHOLD" ]]; then
-        echo "(\!) P99_LATENCY: ${P99_LATENCY} > ${P99_LATENCY_MS_THRESHOLD} ms"
-        if [ "$FORGE_RUNNER_MODE" != "local" ]; then
-            FORGE_EXIT_CODE=2
-        fi
-    fi
 fi
 
 # Get the final o11y links that are not auto-refresh

--- a/testsuite/testcases/src/fixed_tps_test.rs
+++ b/testsuite/testcases/src/fixed_tps_test.rs
@@ -25,7 +25,7 @@ impl NetworkTest for FixedTpsTest {
         // Generate some traffic with fixed tps 10
         let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, Some(10))?;
         ctx.report
-            .report_txn_stats(self.name().to_string(), txn_stat, duration);
+            .report_txn_stats(self.name().to_string(), &txn_stat, duration);
 
         Ok(())
     }

--- a/testsuite/testcases/src/gas_price_test.rs
+++ b/testsuite/testcases/src/gas_price_test.rs
@@ -25,7 +25,7 @@ impl NetworkTest for NonZeroGasPrice {
         // Generate some traffic
         let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
         ctx.report
-            .report_txn_stats(self.name().to_string(), txn_stat, duration);
+            .report_txn_stats(self.name().to_string(), &txn_stat, duration);
 
         Ok(())
     }

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -70,11 +70,12 @@ pub fn generate_traffic<'t>(
 
     emit_job_request = emit_job_request
         .rest_clients(validator_clients)
-        .gas_price(gas_price);
+        .gas_price(gas_price)
+        .duration(duration);
     if let Some(target_tps) = fixed_tps {
         emit_job_request = emit_job_request.fixed_tps(target_tps.try_into().unwrap());
     }
-    let stats = rt.block_on(emitter.emit_txn_for(duration, emit_job_request))?;
+    let stats = rt.block_on(emitter.emit_txn_for(emit_job_request))?;
 
     Ok(stats)
 }

--- a/testsuite/testcases/src/network_chaos_test.rs
+++ b/testsuite/testcases/src/network_chaos_test.rs
@@ -68,7 +68,7 @@ impl NetworkTest for NetworkChaosTest {
         ctx.report.report_text(msg);
         let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
         ctx.report
-            .report_txn_stats(format!("{}:delay", self.name()), txn_stat, duration);
+            .report_txn_stats(format!("{}:delay", self.name()), &txn_stat, duration);
         ctx.swarm().remove_chaos(delay)?;
 
         // INJECT BANDWIDTH LIMIT AND EMIT TXNS
@@ -81,7 +81,7 @@ impl NetworkTest for NetworkChaosTest {
         ctx.report.report_text(msg);
         let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
         ctx.report
-            .report_txn_stats(format!("{}:bandwidth", self.name()), txn_stat, duration);
+            .report_txn_stats(format!("{}:bandwidth", self.name()), &txn_stat, duration);
         ctx.swarm().remove_chaos(bandwidth)?;
 
         // INJECT PARTITION AND EMIT TXNS
@@ -94,7 +94,7 @@ impl NetworkTest for NetworkChaosTest {
         ctx.report.report_text(msg);
         let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
         ctx.report
-            .report_txn_stats(format!("{}:partition", self.name()), txn_stat, duration);
+            .report_txn_stats(format!("{}:partition", self.name()), &txn_stat, duration);
         ctx.swarm().remove_chaos(partition)?;
 
         Ok(())

--- a/testsuite/testcases/src/partial_nodes_down_test.rs
+++ b/testsuite/testcases/src/partial_nodes_down_test.rs
@@ -34,7 +34,7 @@ impl NetworkTest for PartialNodesDown {
         // Generate some traffic
         let txn_stat = generate_traffic(ctx, &up_nodes, duration, 1, None)?;
         ctx.report
-            .report_txn_stats(self.name().to_string(), txn_stat, duration);
+            .report_txn_stats(self.name().to_string(), &txn_stat, duration);
         let runtime = Runtime::new()?;
         for n in &down_nodes {
             let node = ctx.swarm().validator_mut(*n).unwrap();

--- a/testsuite/testcases/src/performance_test.rs
+++ b/testsuite/testcases/src/performance_test.rs
@@ -3,7 +3,6 @@
 
 use crate::generate_traffic;
 use forge::{NetworkContext, NetworkTest, Result, Test};
-use tokio::time::Duration;
 
 pub struct PerformanceBenchmark;
 
@@ -15,7 +14,7 @@ impl Test for PerformanceBenchmark {
 
 impl NetworkTest for PerformanceBenchmark {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = Duration::from_secs(300);
+        let duration = ctx.global_job.duration;
         let all_validators = ctx
             .swarm()
             .validators()
@@ -25,7 +24,10 @@ impl NetworkTest for PerformanceBenchmark {
         // Generate some traffic
         let txn_stat = generate_traffic(ctx, &all_validators, duration, 1, None)?;
         ctx.report
-            .report_txn_stats(self.name().to_string(), txn_stat, duration);
+            .report_txn_stats(self.name().to_string(), &txn_stat, duration);
+        // ensure we meet the success criteria
+        ctx.success_criteria()
+            .check_for_success(&txn_stat, &duration)?;
 
         Ok(())
     }


### PR DESCRIPTION
### Description

Moving the success criteria validation to test runner, which can evolve over time and also simplifies the run script. Also, make the duration configurable, which can be used in nightly run for forge to run for a longer time period. 

### Test Plan

Running locally

```
FORGE_RUNNER_MODE=local ./testsuite/run_forge.sh
```

Output

```
=====START FORGE COMMENT=====
### :white_check_mark: Forge test success on `0e3493265c1c45ac925e127e87ed70a1318a7d61`
```
all up : 653 TPS, 4513 ms latency, 8900 ms p99 latency,no expired txns
```
* [Grafana dashboard](https://o11y.aptosdev.com/grafana/d/overview/overview?orgId=1&refresh=10s&var-Datasource=Remote%20Prometheus%20Devinfra&var-namespace=forge-sitalkedia-1658864771&var-chain_name=forge-0&from=1658864772000&to=1658865474000)
* [Validator 0 logs](https://es.devinfra.aptosdev.com/_dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2022-07-26T19:46:12.000Z',to:'2022-07-26T19:57:54.000Z'))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'d0bc5e20-badc-11ec-9a50-89b84ac337af',key:chain_name,negate:!f,params:(query:forge-0),type:phrase),query:(match_phrase:(chain_name:forge-0))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'d0bc5e20-badc-11ec-9a50-89b84ac337af',key:namespace,negate:!f,params:(query:forge-sitalkedia-1658864771),type:phrase),query:(match_phrase:(namespace:forge-sitalkedia-1658864771))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'d0bc5e20-badc-11ec-9a50-89b84ac337af',key:hostname,negate:!f,params:(query:aptos-node-0-validator-0),type:phrase),query:(match_phrase:(hostname:aptos-node-0-validator-0)))),index:'d0bc5e20-badc-11ec-9a50-89b84ac337af',interval:auto,query:(language:kuery,query:''),sort:!()))
* [Humio Logs](https://cloud.us.humio.com/k8s/search?query=%24forgeLogs%28validator_instance%3Dvalidator-0%29%20%7C%20forge-sitalkedia-1658864771%20&live=true&start=24h&widgetType=list-view&columns=%5B%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22%40timestamp%22%2C%22format%22%3A%22timestamp%22%2C%22width%22%3A180%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22level%22%2C%22format%22%3A%22text%22%2C%22width%22%3A54%7D%2C%7B%22type%22%3A%22link%22%2C%22openInNewBrowserTab%22%3Atrue%2C%22style%22%3A%22button%22%2C%22hrefTemplate%22%3A%22https%3A%2F%2Fgithub.com%2Faptos-labs%2Faptos-core%2Fpull%2F%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22textTemplate%22%3A%22%7B%7Bfields%5B%5C%22github_pr%5C%22%5D%7D%7D%22%2C%22header%22%3A%22Forge%20PR%22%2C%22width%22%3A79%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.namespace%22%2C%22format%22%3A%22text%22%2C%22width%22%3A104%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.pod_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A126%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22k8s.container_name%22%2C%22format%22%3A%22text%22%2C%22width%22%3A85%7D%2C%7B%22type%22%3A%22field%22%2C%22fieldName%22%3A%22message%22%2C%22format%22%3A%22text%22%7D%5D&newestAtBottom=true&showOnlyFirstLine=false)
=====END FORGE COMMENT=====

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2214)
<!-- Reviewable:end -->
