### PR TITLE
[community] Fix bad hover/focus interaction.

### DIFF
--- a/ecosystem/platform/server/app/components/header_component.html.erb
+++ b/ecosystem/platform/server/app/components/header_component.html.erb
@@ -7,7 +7,7 @@
   <nav class="hidden md:flex md:h-full items-center text-base flex-row flex-wrap md:justify-end mr-32 font-mono text-sm open:flex open:fixed open:top-16 open:left-0 open:right-0 open:gap-2 open:p-10 open:bg-black/95 open:m-0" data-header-target="nav">
     <ul class="flex flex-col md:flex-row gap-8 w-full md:h-full">
     <% nav_groups.each do |group| %>
-      <li class="group relative md:flex items-center">
+      <li class="group relative md:flex items-center" data-action="mouseover->header#navGroupHover">
         <%= content_tag :a, group.item.name, href: group.item.url, title: group.item.title, class: 'py-2 text-lg md:text-base text-neutral-100 hover:text-teal-400 md:hover:text-white', target: group.item.url.starts_with?('http') ? '_blank' : '' %>
         <% if group.children.length > 0 %>
         <div class="absolute hidden md:group-focus-within:flex md:group-hover:flex h-[3px] bottom-0 left-0 right-0 rounded bg-teal-400"></div>

--- a/ecosystem/platform/server/app/javascript/controllers/header_controller.ts
+++ b/ecosystem/platform/server/app/javascript/controllers/header_controller.ts
@@ -19,4 +19,16 @@ export default class extends Controller {
     const open = this.userTarget.toggleAttribute('open');
     if (open) this.navTarget.removeAttribute('open');
   }
+
+  navGroupHover(event: MouseEvent) {
+    // If another nav group has focus (and thus its dropdown is visible),
+    // remove focus so that only one dropdown is visible at a time.
+    if (!(event.target instanceof HTMLElement)) return;
+    if (!(document.activeElement instanceof HTMLElement)) return;
+    const hoverGroup = event.target.closest('li.group');
+    const focusGroup = document.activeElement.closest('li.group');
+    if (focusGroup && focusGroup != hoverGroup) {
+      document.activeElement.blur();
+    }
+  }
 }


### PR DESCRIPTION
### Description

On hover, if another nav group has focus (and thus its dropdown is visible), remove focus so that only one dropdown is visible at a time.

### Test Plan
Manual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2220)
<!-- Reviewable:end -->
