### PR TITLE
[helm][monitoring] prom scrape pods with annotation

### DIFF
--- a/terraform/helm/monitoring/files/prometheus.yml
+++ b/terraform/helm/monitoring/files/prometheus.yml
@@ -95,6 +95,31 @@ scrape_configs:
   - targets: ['kube-state-metrics.default.svc.cluster.local:8080']
 {{ end }}
 
+- job_name: "prom-pod-annotation"
+
+  kubernetes_sd_configs:
+  - role: pod
+
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+    action: keep
+    regex: true
+  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+  - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+    action: replace
+    regex: ([^:]+)(?::\d+)?;(\d+)
+    replacement: ${1}:${2}
+    target_label: __address__
+  - source_labels: [__meta_kubernetes_namespace]
+    action: replace
+    target_label: namespace
+  - source_labels: [__meta_kubernetes_pod_name]
+    action: replace
+    target_label: kubernetes_pod_name
+
 - job_name: "aptos-procs"
 
   kubernetes_sd_configs:


### PR DESCRIPTION
### Description

Scrape all prometheus pods with annotation `prometheus.io/scrape: "true"`, such as the cluster-autoscaler.

### Test Plan

Apply in a cluster and query metrics from Prometheus. Run Forge and watch the autoscaler spin up nodes and query unschedulable pods to understand the autoscaler's performance

<img width="1699" alt="image" src="https://user-images.githubusercontent.com/12578616/181072861-6d169f06-29f2-4ba0-bd43-0e6d785aa8b3.png">

The scrape target gets cluster-autoscaler since it is annotated

<img width="1385" alt="image" src="https://user-images.githubusercontent.com/12578616/181072580-905bd93d-3752-4817-b1e3-d993aabbcdaa.png">



<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2224)
<!-- Reviewable:end -->
