### PR TITLE
Stating epoch in seconds, correctly.

### DIFF
--- a/developer-docs-site/docs/nodes/staking.md
+++ b/developer-docs-site/docs/nodes/staking.md
@@ -88,7 +88,7 @@ The above minimum and maximums for staked amount and the lockup period are decid
 An epoch in the Aptos blockchain is defined as a duration of time, in seconds, during which a number of blocks are voted on by the validators, the validator set is updated, and the rewards are distributed to the validators. 
 
 :::tip
-Currently an epoch on the Aptos blockchain is defined as sixty seconds (one hour).
+Currently an epoch on the Aptos blockchain is defined as 3600 seconds (one hour).
 :::
 
 ### Triggers at the epoch start


### PR DESCRIPTION
Blatant error. Fixing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2226)
<!-- Reviewable:end -->
