### PR TITLE
[cli][smoke-test] Fix node CLI for stake handling, and add register_validator_candidate unit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7470,6 +7470,7 @@ dependencies = [
  "aptos-global-constants",
  "aptos-indexer",
  "aptos-infallible",
+ "aptos-keygen",
  "aptos-logger",
  "aptos-management",
  "aptos-operational-tool",

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -25,6 +25,7 @@ aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-faucet = { path = "../../crates/aptos-faucet" }
 aptos-indexer = { path = "../../ecosystem/indexer" }
+aptos-keygen = { path = "../../crates/aptos-keygen" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-rosetta = { path = "../../crates/aptos-rosetta" }
 aptos-sdk = { path = "../../sdk" }

--- a/testsuite/smoke-test/src/aptos_cli.rs
+++ b/testsuite/smoke-test/src/aptos_cli.rs
@@ -5,13 +5,22 @@ use crate::smoke_test_environment::new_local_swarm_with_aptos;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_config::{keys::ConfigKey, utils::get_available_port};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
+use aptos_crypto::{bls12381, ValidCryptoMaterialStringExt};
 use aptos_faucet::FaucetArgs;
-use aptos_types::{account_config::aptos_root_address, chain_id::ChainId};
+use aptos_genesis::config::HostAndPort;
+use aptos_keygen::KeyGen;
+use aptos_types::{
+    account_config::aptos_root_address, chain_id::ChainId, network_address::DnsName,
+};
 use forge::{LocalSwarm, Node};
+use std::convert::TryFrom;
 use std::path::PathBuf;
 use tokio::task::JoinHandle;
 
-pub async fn setup_cli_test(num_nodes: usize) -> (LocalSwarm, CliTestFramework, JoinHandle<()>) {
+pub async fn setup_cli_test(
+    num_nodes: usize,
+    num_cli_accounts: usize,
+) -> (LocalSwarm, CliTestFramework, JoinHandle<()>) {
     let swarm = new_local_swarm_with_aptos(num_nodes).await;
     let chain_id = swarm.chain_id();
     let validator = swarm.validators().next().unwrap();
@@ -26,7 +35,12 @@ pub async fn setup_cli_test(num_nodes: usize) -> (LocalSwarm, CliTestFramework, 
     let faucet_endpoint: reqwest::Url =
         format!("http://localhost:{}", faucet_port).parse().unwrap();
     // Connect the operator tool to the node's JSON RPC API
-    let tool = CliTestFramework::new(validator.rest_api_endpoint(), faucet_endpoint, 2).await;
+    let tool = CliTestFramework::new(
+        validator.rest_api_endpoint(),
+        faucet_endpoint,
+        num_cli_accounts,
+    )
+    .await;
 
     (swarm, tool, faucet)
 }
@@ -53,7 +67,7 @@ pub fn launch_faucet(
 
 #[tokio::test]
 async fn test_account_flow() {
-    let (_swarm, cli, _faucet) = setup_cli_test(1).await;
+    let (_swarm, cli, _faucet) = setup_cli_test(1, 2).await;
 
     assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(0).await.unwrap());
     assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(1).await.unwrap());
@@ -86,5 +100,56 @@ async fn test_account_flow() {
         cli.wait_for_balance(0, expected_sender_amount)
             .await
             .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn test_register_and_update_validator() {
+    let (_swarm, cli, _faucet) = setup_cli_test(1, 0).await;
+    let mut keygen = KeyGen::from_os_rng();
+    let private_key = keygen.generate_ed25519_private_key();
+    let network_private_key = keygen.generate_x25519_private_key().unwrap();
+    let consensus_private_key = keygen.generate_bls12381_private_key();
+    let consensus_public_key = bls12381::PublicKey::from(&consensus_private_key);
+    let validator_cli_index = 0;
+    cli.init(validator_cli_index, &private_key).await.unwrap();
+    assert_eq!(
+        DEFAULT_FUNDED_COINS,
+        cli.account_balance(validator_cli_index).await.unwrap()
+    );
+
+    let validator_config = cli.show_validator_config(validator_cli_index).await;
+    assert!(validator_config.is_err()); // validator not registered
+
+    let port = 1234;
+    cli.register_validator_candidate(
+        validator_cli_index,
+        bls12381::PublicKey::from(&consensus_private_key),
+        bls12381::ProofOfPossession::create(&consensus_private_key),
+        HostAndPort {
+            host: DnsName::try_from("0.0.0.0".to_string()).unwrap(),
+            port,
+        },
+        network_private_key.public_key(),
+    )
+    .await
+    .unwrap();
+
+    let validator_config = cli
+        .show_validator_config(validator_cli_index)
+        .await
+        .unwrap();
+    assert_eq!(
+        bls12381::PublicKey::from_encoded_string(
+            validator_config
+                .as_object()
+                .unwrap()
+                .get("consensus_pubkey")
+                .unwrap()
+                .as_str()
+                .unwrap()
+        )
+        .unwrap(),
+        consensus_public_key
     );
 }

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -29,7 +29,7 @@ pub async fn setup_test(
     num_nodes: usize,
     num_accounts: usize,
 ) -> (LocalSwarm, CliTestFramework, JoinHandle<()>, RosettaClient) {
-    let (swarm, cli, faucet) = setup_cli_test(num_nodes).await;
+    let (swarm, cli, faucet) = setup_cli_test(num_nodes, num_accounts).await;
     let validator = swarm.validators().next().unwrap();
 
     // And the client


### PR DESCRIPTION
### Description

node CLI for stake handling was broken:
- module names are case sensitive : Stake => stake
- when we moved to bls, CLI wasn't updated to receive proof of possesion

Extracted ValidatorConfigArgs for being able to use same args for future new commands

### Test Plan

Adding unit test to catch issues like that in the future

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2234)
<!-- Reviewable:end -->
