### PR TITLE
continuous testing

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -141,11 +141,12 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      merge_or_canary: ${{ github.event.pull_request.auto_merge != null && 'merge' || 'canary' }}
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
       FORGE_NAMESPACE: forge-${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
+      FORGE_CLUSTER_NAME: ${{ secrets.FORGE_CLUSTER_NAME }}
+      FORGE_TEST_SUITE: land_blocking
 
   community-platform:
     needs: [permission-check]

--- a/.github/workflows/pre-release-continuous-test.yaml
+++ b/.github/workflows/pre-release-continuous-test.yaml
@@ -1,0 +1,19 @@
+name: Run continuous pre release testing
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - nightly
+  schedule:
+    # Run hourly
+    - cron: "0 * * * *"
+
+jobs:
+  run-forge:
+    uses: ./.github/workflows/run-forge.yaml
+    with:
+      GIT_SHA: ${{ github.sha }}
+      FORGE_NAMESPACE: continuous
+      FORGE_TEST_SUITE: pre_release
+      FORGE_CLUSTER_NAME: ${{ secrets.FORGE_CLUSTER_NAME_CONTINUOUS }}
+    secrets: inherit

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -8,14 +8,19 @@ on:
         required: true
         type: string
         description:
-      merge_or_canary:
-        required: true
-        type: string
-        description: "indicate whether this is a forge run for an auto-merge or a canary, must be `merge` or `canary`"
       FORGE_NAMESPACE:
         required: true
         type: string
         description: The Forge k8s namespace to be used for test. This value should manage Forge test concurrency. It may be truncated.
+      FORGE_TEST_SUITE:
+        required: true
+        type: string
+        description: The Forge test suite to exercise
+      FORGE_CLUSTER_NAME:
+        required: true
+        type: string
+        description: The Forge cluster to test on
+
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
@@ -25,13 +30,14 @@ env:
   IMAGE_TAG: ${{ inputs.GIT_SHA }}
   FORGE_ENABLED: ${{ secrets.FORGE_ENABLED }}
   FORGE_BLOCKING: ${{ secrets.FORGE_BLOCKING }}
-  FORGE_CLUSTER_NAME: ${{ secrets.FORGE_CLUSTER_NAME }}
+  FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}
   FORGE_OUTPUT: forge_output.txt
   FORGE_REPORT: forge_report.json
   FORGE_COMMENT: forge_comment.txt
   FORGE_PRE_COMMENT: forge_pre_comment.txt
   FORGE_RUNNER_MODE: k8s
   FORGE_NAMESPACE: ${{ inputs.FORGE_NAMESPACE }}
+  FORGE_TEST_SUITE: ${{ inputs.FORGE_TEST_SUITE }}
 
 jobs:
   forge:


### PR DESCRIPTION
    Forge is currently running on PR as a "quick" e2e / perf test however there are many behaviors that we find post release that cannot be easily captured in a couple minutes. Therefore we'd like to run forge on a longer, continuous basis with more realistic setting to replicate realistic released network characteristics.
    
    Test Plan:
    
    Put up pr, with pull_request instead of pull_request_target in build-images.yaml
    
    Run #e2e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2235)
<!-- Reviewable:end -->
