### PR TITLE
[Execution] Use AsyncProofFetcher.

### DIFF
--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -12,7 +12,6 @@ use aptos_vm::VMExecutor;
 use executor_types::ExecutedChunk;
 use fail::fail_point;
 use std::collections::HashSet;
-use storage_interface::sync_proof_fetcher::SyncProofFetcher;
 use storage_interface::{
     cached_state_view::{CachedStateView, StateCache},
     ExecutedTrees,
@@ -32,7 +31,7 @@ pub struct ChunkOutput {
 impl ChunkOutput {
     pub fn by_transaction_execution<V: VMExecutor>(
         transactions: Vec<Transaction>,
-        state_view: CachedStateView<SyncProofFetcher>,
+        state_view: CachedStateView,
     ) -> Result<Self> {
         let transaction_outputs = V::execute_block(transactions.clone(), &state_view)?;
 
@@ -45,7 +44,7 @@ impl ChunkOutput {
 
     pub fn by_transaction_output(
         transactions_and_outputs: Vec<(Transaction, TransactionOutput)>,
-        state_view: CachedStateView<SyncProofFetcher>,
+        state_view: CachedStateView,
     ) -> Result<Self> {
         let (transactions, transaction_outputs): (Vec<_>, Vec<_>) =
             transactions_and_outputs.into_iter().unzip();

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -58,11 +58,11 @@ use aptos_config::config::{RocksdbConfigs, StoragePrunerConfig, NO_OP_STORAGE_PR
 use aptos_crypto::hash::HashValue;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
-use aptos_types::epoch_state::EpochState;
 use aptos_types::{
     account_address::AccountAddress,
     contract_event::EventWithVersion,
     epoch_change::EpochChangeProof,
+    epoch_state::EpochState,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     nibble::nibble_path::NibblePath,
@@ -287,11 +287,11 @@ impl AptosDB {
             state_merkle_db: Arc::clone(&arc_state_merkle_rocksdb),
             event_store: Arc::new(EventStore::new(Arc::clone(&arc_ledger_rocksdb))),
             ledger_store: Arc::new(LedgerStore::new(Arc::clone(&arc_ledger_rocksdb))),
-            state_store: Arc::new(StateStore::new(
+            state_store: StateStore::new(
                 Arc::clone(&arc_ledger_rocksdb),
                 Arc::clone(&arc_state_merkle_rocksdb),
                 hack_for_tests,
-            )),
+            ),
             system_store: Arc::new(SystemStore::new(Arc::clone(&arc_ledger_rocksdb))),
             transaction_store: Arc::new(TransactionStore::new(Arc::clone(&arc_ledger_rocksdb))),
             pruner_config,

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -13,11 +13,14 @@ use aptos_types::{
 };
 use parking_lot::RwLock;
 use scratchpad::{FrozenSparseMerkleTree, SparseMerkleTree, StateStoreStatus};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 /// `CachedStateView` is like a snapshot of the global state comprised of state view at two
 /// levels, persistent storage and memory.
-pub struct CachedStateView<T> {
+pub struct CachedStateView {
     /// For logging and debugging purpose, identifies what this view is for.
     id: StateViewId,
 
@@ -69,22 +72,19 @@ pub struct CachedStateView<T> {
     /// the corresponding key has been deleted. This is a temporary hack until we support deletion
     /// in JMT node.
     state_cache: RwLock<HashMap<StateKey, StateValue>>,
-    proof_fetcher: T,
+    proof_fetcher: Arc<dyn ProofFetcher>,
 }
 
-impl<T> CachedStateView<T>
-where
-    T: ProofFetcher,
-{
+impl CachedStateView {
     /// Constructs a [`CachedStateView`] with persistent state view in the DB and the in-memory
     /// speculative state represented by `speculative_state`. The persistent state view is the
     /// latest one preceding `next_version`
     pub fn new(
         id: StateViewId,
-        reader: &dyn DbReader,
+        reader: Arc<dyn DbReader>,
         next_version: Version,
         speculative_state: SparseMerkleTree<StateValue>,
-        proof_fetcher: T,
+        proof_fetcher: Arc<dyn ProofFetcher>,
     ) -> Result<Self> {
         // n.b. Freeze the state before getting the state snapshot, otherwise it's possible that
         // after we got the snapshot, in-mem trees newer than it gets dropped before being frozen,
@@ -163,10 +163,7 @@ pub struct StateCache {
     pub proofs: HashMap<HashValue, SparseMerkleProof>,
 }
 
-impl<T> StateView for CachedStateView<T>
-where
-    T: ProofFetcher,
-{
+impl StateView for CachedStateView {
     fn id(&self) -> StateViewId {
         self.id
     }

--- a/storage/storage-interface/src/executed_trees.rs
+++ b/storage/storage-interface/src/executed_trees.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cached_state_view::CachedStateView, no_proof_fetcher::NoProofFetcher, state_delta::StateDelta,
-    sync_proof_fetcher::SyncProofFetcher, DbReader,
+    cached_state_view::CachedStateView, no_proof_fetcher::NoProofFetcher,
+    proof_fetcher::ProofFetcher, state_delta::StateDelta, DbReader,
 };
 use anyhow::Result;
 use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
 use aptos_state_view::StateViewId;
 use aptos_types::{proof::accumulator::InMemoryAccumulator, transaction::Version};
-use std::ops::Deref;
 use std::sync::Arc;
 
 /// A wrapper of the in-memory state sparse merkle tree and the transaction accumulator that
@@ -88,31 +87,32 @@ impl ExecutedTrees {
             && self.transaction_accumulator.root_hash() == rhs.transaction_accumulator.root_hash()
     }
 
-    pub fn verified_state_view<'a>(
+    pub fn verified_state_view(
         &self,
         id: StateViewId,
-        reader: &'a dyn DbReader,
-    ) -> Result<CachedStateView<SyncProofFetcher<'a>>> {
+        reader: Arc<dyn DbReader>,
+        proof_fetcher: Arc<dyn ProofFetcher>,
+    ) -> Result<CachedStateView> {
         CachedStateView::new(
             id,
             reader,
             self.transaction_accumulator.num_leaves(),
             self.state.current.clone(),
-            SyncProofFetcher::new(reader),
+            proof_fetcher,
         )
     }
 
     pub fn state_view(
         &self,
         id: StateViewId,
-        reader: &Arc<dyn DbReader>,
-    ) -> Result<CachedStateView<NoProofFetcher>> {
+        reader: Arc<dyn DbReader>,
+    ) -> Result<CachedStateView> {
         CachedStateView::new(
             id,
-            reader.deref(),
+            Arc::clone(&reader),
             self.transaction_accumulator.num_leaves(),
             self.state.current.clone(),
-            NoProofFetcher::new(reader.clone()),
+            Arc::new(NoProofFetcher::new(reader.clone())),
         )
     }
 }

--- a/storage/storage-interface/src/sync_proof_fetcher.rs
+++ b/storage/storage-interface/src/sync_proof_fetcher.rs
@@ -9,17 +9,17 @@ use aptos_types::{
     transaction::Version,
 };
 use parking_lot::RwLock;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 /// An implementation of proof fetcher, which synchronously fetches proofs from the underlying persistent
 /// storage.
-pub struct SyncProofFetcher<'a> {
-    reader: &'a dyn DbReader,
+pub struct SyncProofFetcher {
+    reader: Arc<dyn DbReader>,
     state_proof_cache: RwLock<HashMap<HashValue, SparseMerkleProof>>,
 }
 
-impl<'a> SyncProofFetcher<'a> {
-    pub fn new(reader: &'a dyn DbReader) -> Self {
+impl SyncProofFetcher {
+    pub fn new(reader: Arc<dyn DbReader>) -> Self {
         Self {
             reader,
             state_proof_cache: RwLock::new(HashMap::new()),
@@ -27,7 +27,7 @@ impl<'a> SyncProofFetcher<'a> {
     }
 }
 
-impl<'a> ProofFetcher for SyncProofFetcher<'a> {
+impl ProofFetcher for SyncProofFetcher {
     fn fetch_state_value_and_proof(
         &self,
         state_key: &StateKey,


### PR DESCRIPTION
### Description
Switch to AsyncProofFetcher in block executor.

On a 250M accounts DB, observed tps increases from 3.25K to 5.8K for p2p txns on a 32vCPU, 128G RAM machine.

### Test Plan
Tested on large DB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2240)
<!-- Reviewable:end -->
