### PR TITLE
defaulting concurrency level to 8

### DIFF
--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -34,7 +34,7 @@ validator:
   config:
     provide_genesis: true
     sync_only: false
-    concurrency_level: 4
+    concurrency_level: 8
     enable_state_sync_v2: true
     round_initial_timeout_ms:
     quorum_store_poll_count: 1


### PR DESCRIPTION
### Description

4 seems to conservative especially considering the target hardware spec in everyone's mind.

(forge goes up to > 5k with 8, and a bit more with 16)

### Test Plan
forge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2243)
<!-- Reviewable:end -->
