### PR TITLE
[CLI][AF] Fix max staking time

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -259,7 +259,7 @@ where
             .with_randomize_first_validator_ports(random_ports)
             .with_initial_lockup_timestamp(now_secs + EPOCH_LENGTH_SECS)
             .with_min_lockup_duration_secs(0)
-            .with_max_lockup_duration_secs(86400);
+            .with_max_lockup_duration_secs(86400 * 14);
 
         let (root_key, _genesis, genesis_waypoint, validators) = builder.build(rng)?;
 


### PR DESCRIPTION
### Description
1. The staking module was renamed from `Stake` to `Stake`
2. The minimum lockup for a proposal was 7 days, whereas the maximum proposal allowed when running a test node locally was 24 hours. Updated maximum stake to be 14 days

### Test Plan
Tested Manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2247)
<!-- Reviewable:end -->
