### PR TITLE
[smoke-tests] Fix vfn failover test to send transactions across public network to vfn instead of validator

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -303,6 +303,7 @@ impl FullnodeNodeConfig {
             .expect("VFN should have a public network");
         fullnode_public_network.identity = public_network.identity;
         fullnode_public_network.listen_address = public_network.listen_address;
+        fullnode_public_network.max_outbound_connections = 0;
 
         // Grab the validator's vfn network information and configure it as a seed for the VFN's
         // vfn network

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -303,7 +303,6 @@ impl FullnodeNodeConfig {
             .expect("VFN should have a public network");
         fullnode_public_network.identity = public_network.identity;
         fullnode_public_network.listen_address = public_network.listen_address;
-        fullnode_public_network.max_outbound_connections = 0;
 
         // Grab the validator's vfn network information and configure it as a seed for the VFN's
         // vfn network

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -102,9 +102,16 @@ pub trait FullNode: Node + Sync {
         const DIRECTION: Option<&str> = Some("outbound");
         const EXPECTED_PEERS: usize = 1;
 
-        self.get_connected_peers(NetworkId::Public, DIRECTION)
-            .await
-            .map(|maybe_n| maybe_n.map(|n| n >= EXPECTED_PEERS as i64).unwrap_or(false))
+        for &network_id in &[NetworkId::Public, NetworkId::Vfn] {
+            let r = self
+                .get_connected_peers(network_id, DIRECTION)
+                .await
+                .map(|maybe_n| maybe_n.map(|n| n >= EXPECTED_PEERS as i64).unwrap_or(false));
+            if let Ok(true) = r {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     async fn wait_for_connectivity(&self, deadline: Instant) -> Result<()> {

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -3,9 +3,7 @@
 
 use crate::{
     smoke_test_environment::new_local_swarm_with_aptos,
-    test_utils::{
-        assert_balance, create_and_fund_account, transfer_coins, transfer_coins_non_blocking,
-    },
+    test_utils::{assert_balance, create_and_fund_account, transfer_coins},
 };
 use aptos_config::{
     config::{DiscoveryMethod, NodeConfig, Peer, PeerRole, HANDSHAKE_VERSION},


### PR DESCRIPTION
### Description

* VFN was sending transactions to all validators using the public network.
* The test_vfn_failover smoke-test was nonsensical. It should actually fail to run the transactions if the VFN's validator is down. But managed to do so because the transactions were reaching other validators through the public network.

### Test Plan
Existing and modified smoke tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2248)
<!-- Reviewable:end -->
