### PR TITLE
[smoke-tests] Add a smoke test for txn broadcasting

### DIFF
--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -201,6 +201,15 @@ impl Swarm for K8sSwarm {
         todo!()
     }
 
+    fn add_validator_full_node(
+        &mut self,
+        _version: &Version,
+        _template: NodeConfig,
+        _id: PeerId,
+    ) -> Result<PeerId> {
+        todo!()
+    }
+
     fn add_full_node(&mut self, _version: &Version, _template: NodeConfig) -> Result<PeerId> {
         todo!()
     }

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ChainInfo, FullNode, HealthCheckError, LocalNode, LocalVersion, Node, NodeExt, Swarm,
-    SwarmChaos, SwarmExt, Validator, Version,
+    ChainInfo, FullNode, HealthCheckError, LocalNode, LocalVersion, Node, Swarm, SwarmChaos,
+    SwarmExt, Validator, Version,
 };
 use anyhow::{anyhow, bail, Result};
+use aptos_config::config::NetworkConfig;
+use aptos_config::network_id::NetworkId;
 use aptos_config::{config::NodeConfig, keys::ConfigKey};
 use aptos_genesis::builder::{FullnodeNodeConfig, InitConfigFn, InitGenesisConfigFn};
 use aptos_sdk::{
@@ -81,6 +83,7 @@ pub struct LocalSwarm {
     versions: Arc<HashMap<Version, LocalVersion>>,
     validators: HashMap<PeerId, LocalNode>,
     fullnodes: HashMap<PeerId, LocalNode>,
+    public_networks: HashMap<PeerId, NetworkConfig>,
     dir: SwarmDirectory,
     root_account: LocalAccount,
     chain_id: ChainId,
@@ -150,11 +153,38 @@ impl LocalSwarm {
         });
         let version = versions.get(&initial_version_actual).unwrap();
 
-        let validators = validators
+        let mut validators = validators
             .into_iter()
             .map(|v| {
                 let node = LocalNode::new(version.to_owned(), v.name, v.dir)?;
                 Ok((node.peer_id(), node))
+            })
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        // After genesis, remove public network from validator and add to public_networks
+        let public_networks = validators
+            .values_mut()
+            .map(|validator| {
+                let mut validator_config = validator.config().clone();
+
+                // Grab the public network config from the validator and insert it into the VFN's config
+                // The validator's public network identity is the same as the VFN's public network identity
+                // We remove it from the validator so the VFN can hold it
+                let public_network = {
+                    let (i, _) = validator_config
+                        .full_node_networks
+                        .iter()
+                        .enumerate()
+                        .find(|(_i, config)| config.network_id == NetworkId::Public)
+                        .expect("Validator should have a public network");
+                    validator_config.full_node_networks.remove(i)
+                };
+
+                // Since the validator's config has changed we need to save it
+                validator_config.save(validator.config_path())?;
+                *validator.config_mut() = validator_config;
+
+                Ok((validator.peer_id(), public_network))
             })
             .collect::<Result<HashMap<_, _>>>()?;
         let root_key = ConfigKey::new(root_key);
@@ -171,6 +201,7 @@ impl LocalSwarm {
             versions,
             validators,
             fullnodes: HashMap::new(),
+            public_networks,
             dir: dir_actual,
             root_account,
             chain_id: ChainId::test(),
@@ -257,29 +288,29 @@ impl LocalSwarm {
     ) -> Result<PeerId> {
         let validator = self
             .validators
-            .get_mut(&validator_peer_id)
+            .get(&validator_peer_id)
             .ok_or_else(|| anyhow!("no validator with peer_id: {}", validator_peer_id))?;
+
+        let public_network = self
+            .public_networks
+            .get(&validator_peer_id)
+            .ok_or_else(|| anyhow!("no public network with peer_id: {}", validator_peer_id))?;
 
         if self.fullnodes.contains_key(&validator_peer_id) {
             bail!("VFN for validator {} already configured", validator_peer_id);
         }
 
-        let mut validator_config = validator.config().clone();
         let name = self.node_name_counter.to_string();
         self.node_name_counter += 1;
         let fullnode_config = FullnodeNodeConfig::validator_fullnode(
             name,
             self.dir.as_ref(),
             template,
-            &mut validator_config,
+            validator.config(),
             &self.genesis_waypoint,
             &self.genesis,
+            public_network,
         )?;
-
-        // Since the validator's config has changed we need to save it
-        validator_config.save(validator.config_path())?;
-        *validator.config_mut() = validator_config;
-        validator.restart().await?;
 
         let version = self.versions.get(version).unwrap();
         let mut fullnode = LocalNode::new(

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -280,7 +280,7 @@ impl LocalSwarm {
         Err(anyhow!("Launching Swarm timed out"))
     }
 
-    pub async fn add_validator_fullnode(
+    pub fn add_validator_fullnode(
         &mut self,
         version: &Version,
         template: NodeConfig,
@@ -467,6 +467,15 @@ impl Swarm for LocalSwarm {
 
     fn remove_validator(&mut self, _id: PeerId) -> Result<()> {
         todo!()
+    }
+
+    fn add_validator_full_node(
+        &mut self,
+        version: &Version,
+        template: NodeConfig,
+        id: PeerId,
+    ) -> Result<PeerId> {
+        self.add_validator_fullnode(version, template, id)
     }
 
     fn add_full_node(&mut self, version: &Version, template: NodeConfig) -> Result<PeerId> {

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -45,13 +45,20 @@ pub trait Swarm: Sync {
     /// Returns a mutable reference to the FullNode with the provided PeerId
     fn full_node_mut(&mut self, id: PeerId) -> Option<&mut dyn FullNode>;
 
-    /// Adds a Validator to the swarm with the provided PeerId
+    /// Adds a Validator to the swarm and returns the PeerId
     fn add_validator(&mut self, version: &Version, template: NodeConfig) -> Result<PeerId>;
 
     /// Removes the Validator with the provided PeerId
     fn remove_validator(&mut self, id: PeerId) -> Result<()>;
 
-    /// Adds a FullNode to the swarm with the provided PeerId
+    fn add_validator_full_node(
+        &mut self,
+        version: &Version,
+        template: NodeConfig,
+        id: PeerId,
+    ) -> Result<PeerId>;
+
+    /// Adds a FullNode to the swarm and returns the PeerId
     fn add_full_node(&mut self, version: &Version, template: NodeConfig) -> Result<PeerId>;
 
     /// Removes the FullNode with the provided PeerId

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -29,7 +29,6 @@ async fn test_full_node_basic_flow() {
             NodeConfig::default_for_validator_full_node(),
             validator_peer_id,
         )
-        .await
         .unwrap();
     let pfn_peer_id = swarm
         .add_full_node(&version, NodeConfig::default_for_public_full_node())
@@ -133,7 +132,6 @@ async fn test_vfn_failover() {
                 NodeConfig::default_for_validator_full_node(),
                 validator_peer_id,
             )
-            .await
             .unwrap();
         vfns.push(vfn);
     }
@@ -202,6 +200,15 @@ async fn test_private_full_node() {
     let transaction_factory = swarm.chain_info().transaction_factory();
     let version = swarm.versions().max().unwrap();
 
+    // Add a single vfn to connect to
+    let validator_peer_id = swarm.validators().next().unwrap().peer_id();
+    let vfn_peer_id = swarm
+        .add_validator_fullnode(
+            &version,
+            NodeConfig::default_for_validator_full_node(),
+            validator_peer_id,
+        )
+        .unwrap();
     // Here we want to add two swarms, a private full node, followed by a user full node connected to it
     let mut private_config = NodeConfig::default_for_public_full_node();
     let private_network = private_config.full_node_networks.first_mut().unwrap();
@@ -227,7 +234,7 @@ async fn test_private_full_node() {
     // Now we need to connect the VFNs to the private swarm
     add_node_to_seeds(
         &mut private_config,
-        swarm.validators().next().unwrap().config(),
+        swarm.fullnode(vfn_peer_id).unwrap().config(),
         NetworkId::Public,
         PeerRole::PreferredUpstream,
     );

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -33,12 +33,6 @@ async fn test_full_node_basic_flow() {
     let pfn_peer_id = swarm
         .add_full_node(&version, NodeConfig::default_for_public_full_node())
         .unwrap();
-    swarm
-        .validator_mut(validator_peer_id)
-        .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
-        .await
-        .unwrap();
     for fullnode in swarm.full_nodes_mut() {
         fullnode
             .wait_until_healthy(Instant::now() + Duration::from_secs(10))
@@ -134,12 +128,6 @@ async fn test_vfn_failover() {
             )
             .unwrap();
         vfns.push(vfn);
-    }
-    for validator in swarm.validators_mut() {
-        validator
-            .wait_until_healthy(Instant::now() + Duration::from_secs(10))
-            .await
-            .unwrap();
     }
     for fullnode in swarm.full_nodes_mut() {
         fullnode

--- a/testsuite/smoke-test/src/fullnode.rs
+++ b/testsuite/smoke-test/src/fullnode.rs
@@ -34,6 +34,12 @@ impl LaunchFullnode {
         let fullnode_peer_id = ctx
             .swarm()
             .add_full_node(&version, NodeConfig::default_for_public_full_node())?;
+        let validator_peer_id = ctx.swarm().validators().next().unwrap().peer_id();
+        let _vfn_peer_id = ctx.swarm().add_validator_full_node(
+            &version,
+            NodeConfig::default_for_validator_full_node(),
+            validator_peer_id,
+        )?;
 
         let fullnode = ctx.swarm().full_node_mut(fullnode_peer_id).unwrap();
         fullnode

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -28,6 +28,8 @@ mod state_sync;
 mod state_sync_v2;
 #[cfg(test)]
 mod storage;
+#[cfg(test)]
+mod txn_broadcast;
 
 #[cfg(test)]
 mod smoke_test_environment;

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -49,12 +49,6 @@ async fn test_connection_limiting() {
 
     // Wait till nodes are healthy
     swarm
-        .validator_mut(validator_peer_id)
-        .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
-        .await
-        .unwrap();
-    swarm
         .fullnode_mut(vfn_peer_id)
         .unwrap()
         .wait_until_healthy(Instant::now() + Duration::from_secs(10))

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -45,7 +45,6 @@ async fn test_connection_limiting() {
 
     let vfn_peer_id = swarm
         .add_validator_fullnode(&version, full_node_config, validator_peer_id)
-        .await
         .unwrap();
 
     // Wait till nodes are healthy

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -168,7 +168,6 @@ async fn create_full_node(full_node_config: NodeConfig, swarm: &mut LocalSwarm) 
             full_node_config,
             validator_peer_id,
         )
-        .await
         .unwrap();
     for fullnode in swarm.full_nodes_mut() {
         fullnode

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -32,12 +32,6 @@ async fn test_txn_broadcast() {
         )
         .unwrap();
 
-    for validator in swarm.validators_mut() {
-        validator
-            .wait_until_healthy(Instant::now() + Duration::from_secs(10))
-            .await
-            .unwrap();
-    }
     for fullnode in swarm.full_nodes_mut() {
         fullnode
             .wait_until_healthy(Instant::now() + Duration::from_secs(10))

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -8,6 +8,8 @@ use forge::{NodeExt, Swarm, SwarmExt};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+/// Checks txn goes through consensus even if the local validator is not creating proposals.
+/// This behavior should be true with both mempool and quorum store.
 #[tokio::test]
 async fn test_txn_broadcast() {
     let mut swarm = SwarmBuilder::new_local(4)

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -28,7 +28,6 @@ async fn test_txn_broadcast() {
             NodeConfig::default_for_validator_full_node(),
             validator,
         )
-        .await
         .unwrap();
 
     for validator in swarm.validators_mut() {

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::smoke_test_environment::SwarmBuilder;
+use crate::test_utils::{assert_balance, create_and_fund_account, transfer_coins};
+use aptos_config::config::NodeConfig;
+use forge::{NodeExt, Swarm, SwarmExt};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[tokio::test]
+async fn test_txn_broadcast() {
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, conf, _| {
+            conf.api.failpoints_enabled = true;
+        }))
+        .build()
+        .await;
+    let transaction_factory = swarm.chain_info().transaction_factory();
+    let version = swarm.versions().max().unwrap();
+    let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+
+    let validator = validator_peer_ids[1];
+    let vfn = swarm
+        .add_validator_fullnode(
+            &version,
+            NodeConfig::default_for_validator_full_node(),
+            validator,
+        )
+        .await
+        .unwrap();
+
+    for validator in swarm.validators_mut() {
+        validator
+            .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+            .await
+            .unwrap();
+    }
+    for fullnode in swarm.full_nodes_mut() {
+        fullnode
+            .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+            .await
+            .unwrap();
+        fullnode
+            .wait_for_connectivity(Instant::now() + Duration::from_secs(60))
+            .await
+            .unwrap();
+    }
+
+    // Setup accounts
+    let mut account_0 = create_and_fund_account(&mut swarm, 10).await;
+    let account_1 = create_and_fund_account(&mut swarm, 10).await;
+
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    // set up vfn_client
+    let vfn_client = swarm.full_node(vfn).unwrap().rest_client();
+
+    // set up validator_client. proposals not sent from this validator. txn should still go through.
+    let validator_client = swarm.validator(validator).unwrap().rest_client();
+    validator_client
+        .set_failpoint("consensus::send_proposal".to_string(), "return".to_string())
+        .await
+        .unwrap();
+
+    // send to validator_client
+    let txn = transfer_coins(
+        &validator_client,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        1,
+    )
+    .await;
+
+    assert_balance(&validator_client, &account_0, 9).await;
+    assert_balance(&validator_client, &account_1, 11).await;
+    vfn_client.wait_for_signed_transaction(&txn).await.unwrap();
+    assert_balance(&vfn_client, &account_0, 9).await;
+    assert_balance(&vfn_client, &account_1, 11).await;
+
+    transfer_coins(
+        &vfn_client,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        1,
+    )
+    .await;
+
+    assert_balance(&validator_client, &account_0, 8).await;
+    assert_balance(&validator_client, &account_1, 12).await;
+    assert_balance(&vfn_client, &account_0, 8).await;
+    assert_balance(&vfn_client, &account_1, 12).await;
+}

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -83,6 +83,7 @@ async fn test_txn_broadcast() {
     assert_balance(&vfn_client, &account_0, 9).await;
     assert_balance(&vfn_client, &account_1, 11).await;
 
+    // send to vfn_client
     transfer_coins(
         &vfn_client,
         &transaction_factory,


### PR DESCRIPTION
### Description

Add smoke test that checks txn goes through consensus even if the local validator is not creating proposals. This behavior should be true with both mempool and quorum store.

Also improve bringing up vfn in a local swarm to:
* Avoid having a public network at validators on launch
* Avoid restart of validators on vfn startup

### Test Plan

Locally reverted #1954 and confirmed the test will fail with that bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2249)
<!-- Reviewable:end -->
