### PR TITLE
cicd: improve forge failure UX

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -86,21 +86,19 @@ jobs:
           * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           EOF
 
+          # add github step summary as described here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
+          echo "$FORGE_COMMENT" >> $GITHUB_STEP_SUMMARY
+
           # export env vars for next step
-          echo "FORGE_EXIT_CODE=$FORGE_EXIT_CODE" >> $GITHUB_ENV
           echo "FORGE_COMMENT=$FORGE_COMMENT" >> $GITHUB_ENV
 
+          if [ "$FORGE_BLOCKING" = "true" ]; then
+            exit $FORGE_EXIT_CODE
+          fi
+
       - name: Post forge result comment
-        if: env.FORGE_ENABLED == 'true' && github.event.number != null
+        if: env.FORGE_ENABLED == 'true' && github.event.number != null && !cancelled()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true
           path: ${{ env.FORGE_COMMENT }}
-
-      - name: Check Forge status
-        if: env.FORGE_ENABLED == 'true'
-        shell: bash
-        run: |
-          if [ "$FORGE_BLOCKING" = "true" ]; then
-            exit $FORGE_EXIT_CODE
-          fi

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -26,14 +26,15 @@ impl SuccessCriteria {
         let p99_latency = stats.latency_buckets.percentile(99, 100);
         if avg_tps < self.avg_tps as u64 {
             bail!(
-                "TPS requirement failed. Average TPS {}, minimum TPS requirement {}",
+                // ::error:: is github specific syntax to set an error on the job that is highlighted as described here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+                "::error::TPS requirement failed. Average TPS {}, minimum TPS requirement {}",
                 avg_tps,
                 self.avg_tps
             )
         }
         if p99_latency > self.max_latency_ms as u64 {
             bail!(
-                "Latency requirement failed. P99 latency {}, maximum latency requirement {}",
+                "::error::Latency requirement failed. P99 latency {}, maximum latency requirement {}",
                 p99_latency,
                 self.max_latency_ms
             )


### PR DESCRIPTION
### Description

This improves the UX when a forge job fails.
Previously the github actions job failure would occur in a separate step that was meant to check for whether forge is land blocking or not and didn't give any context whatsoever:
<img width="1329" alt="image" src="https://user-images.githubusercontent.com/1221897/181171032-279fb0c4-e812-4f1d-b4fd-db4b6048d267.png">

With this change:
- the actual step that runs forge will fail
- when latency requirements etc. fail, it will print a nice error message by leveraging the `::error::` syntax
- the job summary will be posted as github actions job summary.

Overall this should make it more obvious what and why things failed.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2250)
<!-- Reviewable:end -->
