### PR TITLE
[aptos-cli] Remove some unwraps for error handling

### DIFF
--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -83,15 +83,14 @@ impl CliCommand<CreateResourceAccountSummary> for CreateResourceAccount {
     }
 
     async fn execute(self) -> CliTypedResult<CreateResourceAccountSummary> {
-        let seed: Vec<u8> = bcs::to_bytes(&self.seed).unwrap();
         let authentication_key: Vec<u8> = if let Some(key) = self.authentication_key {
-            bcs::to_bytes(&key).unwrap()
+            bcs::to_bytes(&key)?
         } else {
             vec![]
         };
         self.txn_options
             .submit_transaction(resource_account_create_resource_account(
-                seed,
+                bcs::to_bytes(&self.seed)?,
                 authentication_key,
             ))
             .await

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -376,12 +376,12 @@ impl EncodingType {
         match self {
             EncodingType::BCS => bcs::from_bytes(&data).map_err(|err| CliError::BCS(name, err)),
             EncodingType::Hex => {
-                let hex_string = String::from_utf8(data).unwrap();
+                let hex_string = String::from_utf8(data)?;
                 Key::from_encoded_string(hex_string.trim())
                     .map_err(|err| CliError::UnableToParse(name, err.to_string()))
             }
             EncodingType::Base64 => {
-                let string = String::from_utf8(data).unwrap();
+                let string = String::from_utf8(data)?;
                 let bytes = base64::decode(string.trim())
                     .map_err(|err| CliError::UnableToParse(name, err.to_string()))?;
                 Key::try_from(bytes.as_slice()).map_err(|err| {

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -132,7 +132,7 @@ AptosFramework = {{ git = \"https://github.com/aptos-labs/aptos-core.git\", subd
 {}
 ",
             self.name,
-            toml::to_string(&addresses).unwrap()
+            toml::to_string(&addresses).map_err(|err| CliError::UnexpectedError(err.to_string()))?
         )
         .map_err(|err| {
             CliError::UnexpectedError(format!(

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -145,7 +145,7 @@ impl GenerateKey {
         let args = format!(
             "generate --key-type {key_type:?} --output-file {key_file} --encoding {encoding:?} --assume-yes",
             key_type = KeyType::X25519,
-            key_file = key_file.to_str().unwrap(),
+            key_file = key_file.display(),
             encoding = encoding,
         );
         let command = GenerateKey::parse_from(args.split_whitespace());
@@ -167,7 +167,7 @@ impl GenerateKey {
         let args = format!(
             "generate --key-type {key_type:?} --output-file {key_file} --encoding {encoding:?} --assume-yes",
             key_type = KeyType::Ed25519,
-            key_file = key_file.to_str().unwrap(),
+            key_file = key_file.display(),
             encoding = encoding,
         );
         let command = GenerateKey::parse_from(args.split_whitespace());


### PR DESCRIPTION
### Description
Remove some general unwraps so that errors are handled more gracefully in the CLI

### Test Plan
E2E tests / Clippy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2251)
<!-- Reviewable:end -->
