### PR TITLE
[gha] keep one forge run comment per attempt

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -28,7 +28,7 @@ env:
   FORGE_CLUSTER_NAME: ${{ secrets.FORGE_CLUSTER_NAME }}
   FORGE_OUTPUT: forge_output.txt
   FORGE_REPORT: forge_report.json
-  FORGE_COMMENT_FILE: forge_comment.txt
+  FORGE_COMMENT: forge_comment.txt
   FORGE_PRE_COMMENT: forge_pre_comment.txt
   FORGE_RUNNER_MODE: k8s
   FORGE_NAMESPACE: ${{ inputs.FORGE_NAMESPACE }}
@@ -60,11 +60,18 @@ jobs:
           # export env vars for next step
           echo "FORGE_PRE_COMMENT=$FORGE_PRE_COMMENT" >> $GITHUB_ENV
 
+          # append some GHA-specific content to the comment
+          cat << EOF >> $FORGE_PRE_COMMENT
+          * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          * Pending test run ${{ github.run_attempt }} ${{ env.FORGE_BLOCKING == 'true' && 'is land-blocking' || 'is not land-blocking' }}
+          EOF
+
       - name: Post pre-Forge comment
         if: env.FORGE_ENABLED == 'true' && github.event.number != null
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true
+          header: forge-comment-${{ github.run_attempt }}
           path: ${{ env.FORGE_PRE_COMMENT }}
 
       - name: Run Forge
@@ -81,13 +88,13 @@ jobs:
           source testsuite/run_forge.sh
 
           # append some GHA-specific content to the comment
-          cat << EOF >> $FORGE_COMMENT_FILE
-          ${{ env.FORGE_BLOCKING == 'true' && 'Forge is land-blocking' || 'Forge is not land-blocking' }}
+          cat << EOF >> $FORGE_COMMENT
           * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          * Test run ${{ github.run_attempt }} ${{ env.FORGE_BLOCKING == 'true' && 'is land-blocking' || 'is not land-blocking' }}
           EOF
 
           # add github step summary as described here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
-          cat $FORGE_COMMENT_FILE >> $GITHUB_STEP_SUMMARY
+          cat $FORGE_COMMENT >> $GITHUB_STEP_SUMMARY
 
           if [ "$FORGE_BLOCKING" = "true" ]; then
             exit $FORGE_EXIT_CODE
@@ -98,4 +105,5 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true
-          path: ${{ env.FORGE_COMMENT_FILE }}
+          path: ${{ env.FORGE_COMMENT }}
+          header: forge-comment-${{ github.run_attempt }}

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -49,7 +49,6 @@ FORGE_TEST_SUITE=${FORGE_TEST_SUITE:-land_blocking}
 [ "$FORGE_NAMESPACE_KEEP" = "true" ] && KEEP_ARGS="--keep"
 [ "$FORGE_ENABLE_HAPROXY" = "true" ] && ENABLE_HAPROXY_ARGS="--enable-haproxy"
 
-
 # Set variables for o11y resource locations depending on the type of cluster that is running Forge
 set_o11y_resources() {
     if echo $FORGE_CLUSTER_NAME | grep "forge"; then
@@ -95,12 +94,12 @@ set_image_tag() {
 get_validator_logs_link() {
     # build the logs link in a readable way...
     # filter by:
-    #   * chain_name: name of the Forge cluster "chain"
+    #   * chain_name: name of the Forge cluster/chain
     #   * namespace: kubernetes namespace the Forge test was executed in
     #   * hostname: name of a kubernetes pod e.g. validator name
     if [ -n "$ENABLE_LOG_AUTO_REFRESH" ]; then
         ES_TIME_FILTER="refreshInterval:(pause:!f,value:10000),time:(from:now-15m,to:now)"
-    else 
+    else
         ES_TIME_FILTER="refreshInterval:(pause:!t,value:0),time:(from:'${ES_START_TIME}',to:'${ES_END_TIME}')"
     fi
     VAL0_HOSTNAME="aptos-node-0-validator-0"
@@ -122,7 +121,7 @@ get_dashboard_link() {
     fi
     if [ -n "$ENABLE_DASHBOARD_AUTO_REFRESH" ]; then
         GRAFANA_TIME_FILTER="&refresh=10s&from=now-15m&to=now"
-    else 
+    else
         GRAFANA_TIME_FILTER="&from=${FORGE_START_TIME_MS}&to=${FORGE_END_TIME_MS}"
     fi
     FORGE_DASHBOARD_LINK="${GRAFANA_BASE_URL}&var-namespace=${FORGE_NAMESPACE}&var-chain_name=${FORGE_CHAIN_NAME}${GRAFANA_TIME_FILTER}"


### PR DESCRIPTION
### Description

Add the test runner output for both the pre-forge and forge results comment. Also add an indicator for the GHA run attempt, which makes it easier to parse spammy GH comments in the case where Forge is triggered many times in a row.

Also fixes a bug that was introduced in https://github.com/aptos-labs/aptos-core/commit/6e88ffbea18d4147497e83bbf54638b72c8bb27a which did a bit of variable name cleanup, resulting in bad GH comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2262)
<!-- Reviewable:end -->
