### PR TITLE
[State Sync] Add data compression to state sync.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,3 +22,10 @@ xclippy = [
 
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+# This is a temporary workaround to avoid multiple library
+# definitions for LZ4 (caused by rocksdb).
+# This will be removed once rocksdb provides a fix, see:
+# https://github.com/rust-rocksdb/rust-rocksdb/issues/666
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,--allow-multiple-definition"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8075,9 +8075,11 @@ dependencies = [
 name = "storage-service-types"
 version = "0.1.0"
 dependencies = [
+ "aptos-compression",
  "aptos-config",
  "aptos-crypto",
  "aptos-types",
+ "bcs",
  "claim",
  "num-traits 0.2.15",
  "proptest",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -202,6 +202,7 @@ pub struct AptosDataClientConfig {
     pub max_num_in_flight_regular_polls: u64,  // Max num of in-flight polls for regular peers
     pub response_timeout_ms: u64, // Timeout (in milliseconds) when waiting for a response
     pub summary_poll_interval_ms: u64, // Interval (in milliseconds) between data summary polls
+    pub use_compression: bool,    // Whether or not to request compression for incoming data
 }
 
 impl Default for AptosDataClientConfig {
@@ -211,6 +212,7 @@ impl Default for AptosDataClientConfig {
             max_num_in_flight_regular_polls: 10,
             response_timeout_ms: 5000,
             summary_poll_interval_ms: 200,
+            use_compression: true,
         }
     }
 }

--- a/state-sync/aptos-data-client/src/aptosnet/mod.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/mod.rs
@@ -37,7 +37,7 @@ use rand::seq::SliceRandom;
 use std::{convert::TryFrom, fmt, sync::Arc, time::Duration};
 use storage_service_client::StorageServiceClient;
 use storage_service_types::requests::{
-    EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
+    DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
     NewTransactionsWithProofRequest, StateValuesWithProofRequest, StorageServiceRequest,
     TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
 };
@@ -121,6 +121,11 @@ impl AptosNetDataClient {
             time_service,
         );
         (client, poller)
+    }
+
+    /// Returns true iff compression should be requested
+    fn use_compression(&self) -> bool {
+        self.data_client_config.use_compression
     }
 
     /// Generates a new response id
@@ -312,7 +317,7 @@ impl AptosNetDataClient {
             );
             error
         })?;
-        let _timer = start_request_timer(&metrics::REQUEST_LATENCIES, request.get_label(), peer);
+        let _timer = start_request_timer(&metrics::REQUEST_LATENCIES, &request.get_label(), peer);
         self.send_request_to_peer_and_decode(peer, request).await
     }
 
@@ -326,12 +331,25 @@ impl AptosNetDataClient {
         T: TryFrom<StorageServiceResponse, Error = E>,
         E: Into<Error>,
     {
-        let response = self.send_request_to_peer(peer, request).await?;
+        let response = self.send_request_to_peer(peer, request.clone()).await?;
 
-        let (context, payload) = response.into_parts();
+        let (context, storage_response) = response.into_parts();
+
+        // Ensure the response obeys the compression requirements
+        if request.use_compression && !storage_response.is_compressed() {
+            return Err(Error::InvalidResponse(format!(
+                "Requested compressed data, but the response was uncompressed! Response: {:?}",
+                storage_response.get_label()
+            )));
+        } else if !request.use_compression && storage_response.is_compressed() {
+            return Err(Error::InvalidResponse(format!(
+                "Requested uncompressed data, but the response was compressed! Response: {:?}",
+                storage_response.get_label()
+            )));
+        }
 
         // try to convert the storage service enum into the exact variant we're expecting.
-        match T::try_from(payload) {
+        match T::try_from(storage_response) {
             Ok(new_payload) => Ok(Response::new(context, new_payload)),
             // if the variant doesn't match what we're expecting, report the issue.
             Err(err) => {
@@ -354,13 +372,13 @@ impl AptosNetDataClient {
         debug!(
             (LogSchema::new(LogEntry::StorageServiceRequest)
                 .event(LogEvent::SendRequest)
-                .request_type(request.get_label())
+                .request_type(&request.get_label())
                 .request_id(id)
                 .peer(&peer)
                 .request_data(&request))
         );
 
-        increment_request_counter(&metrics::SENT_REQUESTS, request.get_label(), peer);
+        increment_request_counter(&metrics::SENT_REQUESTS, &request.get_label(), peer);
 
         let result = self
             .network_client
@@ -376,12 +394,12 @@ impl AptosNetDataClient {
                 debug!(
                     (LogSchema::new(LogEntry::StorageServiceResponse)
                         .event(LogEvent::ResponseSuccess)
-                        .request_type(request.get_label())
+                        .request_type(&request.get_label())
                         .request_id(id)
                         .peer(&peer))
                 );
 
-                increment_request_counter(&metrics::SUCCESS_RESPONSES, request.get_label(), peer);
+                increment_request_counter(&metrics::SUCCESS_RESPONSES, &request.get_label(), peer);
 
                 // For now, record all responses that at least pass the data
                 // client layer successfully. An alternative might also have the
@@ -423,7 +441,7 @@ impl AptosNetDataClient {
                 error!(
                     (LogSchema::new(LogEntry::StorageServiceResponse)
                         .event(LogEvent::ResponseError)
-                        .request_type(request.get_label())
+                        .request_type(&request.get_label())
                         .request_id(id)
                         .peer(&peer)
                         .error(&client_error))
@@ -466,12 +484,13 @@ impl AptosDataClient for AptosNetDataClient {
         start_epoch: Epoch,
         expected_end_epoch: Epoch,
     ) -> Result<Response<Vec<LedgerInfoWithSignatures>>> {
-        let request =
-            StorageServiceRequest::GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest {
-                start_epoch,
-                expected_end_epoch,
-            });
-        let response: Response<EpochChangeProof> = self.send_request_and_decode(request).await?;
+        let data_request = DataRequest::GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest {
+            start_epoch,
+            expected_end_epoch,
+        });
+        let storage_request = StorageServiceRequest::new(data_request, self.use_compression());
+        let response: Response<EpochChangeProof> =
+            self.send_request_and_decode(storage_request).await?;
         Ok(response.map(|epoch_change| epoch_change.ledger_info_with_sigs))
     }
 
@@ -480,13 +499,13 @@ impl AptosDataClient for AptosNetDataClient {
         known_version: Version,
         known_epoch: Epoch,
     ) -> Result<Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>> {
-        let request = StorageServiceRequest::GetNewTransactionOutputsWithProof(
-            NewTransactionOutputsWithProofRequest {
+        let data_request =
+            DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
                 known_version,
                 known_epoch,
-            },
-        );
-        self.send_request_and_decode(request).await
+            });
+        let storage_request = StorageServiceRequest::new(data_request, self.use_compression());
+        self.send_request_and_decode(storage_request).await
     }
 
     async fn get_new_transactions_with_proof(
@@ -495,18 +514,20 @@ impl AptosDataClient for AptosNetDataClient {
         known_epoch: Epoch,
         include_events: bool,
     ) -> Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>> {
-        let request =
-            StorageServiceRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+        let data_request =
+            DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
                 known_version,
                 known_epoch,
                 include_events,
             });
-        self.send_request_and_decode(request).await
+        let storage_request = StorageServiceRequest::new(data_request, self.use_compression());
+        self.send_request_and_decode(storage_request).await
     }
 
     async fn get_number_of_states(&self, version: Version) -> Result<Response<u64>> {
-        let request = StorageServiceRequest::GetNumberOfStatesAtVersion(version);
-        self.send_request_and_decode(request).await
+        let data_request = DataRequest::GetNumberOfStatesAtVersion(version);
+        let storage_request = StorageServiceRequest::new(data_request, self.use_compression());
+        self.send_request_and_decode(storage_request).await
     }
 
     async fn get_state_values_with_proof(
@@ -515,12 +536,13 @@ impl AptosDataClient for AptosNetDataClient {
         start_index: u64,
         end_index: u64,
     ) -> Result<Response<StateValueChunkWithProof>> {
-        let request = StorageServiceRequest::GetStateValuesWithProof(StateValuesWithProofRequest {
+        let data_request = DataRequest::GetStateValuesWithProof(StateValuesWithProofRequest {
             version,
             start_index,
             end_index,
         });
-        self.send_request_and_decode(request).await
+        let storage_request = StorageServiceRequest::new(data_request, self.use_compression());
+        self.send_request_and_decode(storage_request).await
     }
 
     async fn get_transaction_outputs_with_proof(
@@ -529,14 +551,14 @@ impl AptosDataClient for AptosNetDataClient {
         start_version: Version,
         end_version: Version,
     ) -> Result<Response<TransactionOutputListWithProof>> {
-        let request = StorageServiceRequest::GetTransactionOutputsWithProof(
-            TransactionOutputsWithProofRequest {
+        let data_request =
+            DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
                 proof_version,
                 start_version,
                 end_version,
-            },
-        );
-        self.send_request_and_decode(request).await
+            });
+        let storage_request = StorageServiceRequest::new(data_request, self.use_compression());
+        self.send_request_and_decode(storage_request).await
     }
 
     async fn get_transactions_with_proof(
@@ -546,14 +568,14 @@ impl AptosDataClient for AptosNetDataClient {
         end_version: Version,
         include_events: bool,
     ) -> Result<Response<TransactionListWithProof>> {
-        let request =
-            StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
-                proof_version,
-                start_version,
-                end_version,
-                include_events,
-            });
-        self.send_request_and_decode(request).await
+        let data_request = DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+            proof_version,
+            start_version,
+            end_version,
+            include_events,
+        });
+        let storage_request = StorageServiceRequest::new(data_request, self.use_compression());
+        self.send_request_and_decode(storage_request).await
     }
 }
 
@@ -719,16 +741,21 @@ pub(crate) fn poll_peer(
 
     // Create the poller for the peer
     let poller = async move {
+        // Construct the request for polling
+        let data_request = DataRequest::GetStorageServerSummary;
+        let storage_request =
+            StorageServiceRequest::new(data_request, data_client.use_compression());
+
         // Start the peer polling timer
         let timer = start_request_timer(
             &metrics::REQUEST_LATENCIES,
-            StorageServiceRequest::GetStorageServerSummary.get_label(),
+            &storage_request.get_label(),
             peer,
         );
 
         // Fetch the storage summary for the peer and stop the timer
         let result: Result<StorageServerSummary> = data_client
-            .send_request_to_peer_and_decode(peer, StorageServiceRequest::GetStorageServerSummary)
+            .send_request_to_peer_and_decode(peer, storage_request)
             .await
             .map(Response::into_payload);
         drop(timer);

--- a/state-sync/aptos-data-client/src/aptosnet/state.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/state.rs
@@ -18,7 +18,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use storage_service_types::requests::StorageServiceRequest;
+use storage_service_types::requests::{DataRequest, StorageServiceRequest};
 use storage_service_types::responses::StorageServerSummary;
 
 /// Scores for peer rankings based on preferences and behavior.
@@ -143,9 +143,9 @@ impl PeerStates {
         // requests to new peers (who don't have a peer state yet).
         // Likewise, we can always send subscription requests to any peers and
         // all peers should support versioning.
-        if request.is_get_storage_server_summary()
-            || request.is_data_subscription_request()
-            || matches!(request, StorageServiceRequest::GetServerProtocolVersion)
+        if request.data_request.is_get_storage_server_summary()
+            || request.data_request.is_data_subscription_request()
+            || matches!(request.data_request, DataRequest::GetServerProtocolVersion)
         {
             return true;
         }

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -34,11 +34,12 @@ use std::{
 use storage_service_client::{StorageServiceClient, StorageServiceNetworkSender};
 use storage_service_server::network::{NetworkRequest, ResponseSender};
 use storage_service_types::requests::{
-    NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest, StorageServiceRequest,
-    TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
+    DataRequest, NewTransactionOutputsWithProofRequest, NewTransactionsWithProofRequest,
+    StorageServiceRequest, TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
 };
 use storage_service_types::responses::{
-    CompleteDataRange, DataSummary, ProtocolMetadata, StorageServerSummary, StorageServiceResponse,
+    CompleteDataRange, DataResponse, DataSummary, ProtocolMetadata, StorageServerSummary,
+    StorageServiceResponse,
 };
 use storage_service_types::{StorageServiceError, StorageServiceMessage};
 
@@ -233,10 +234,12 @@ async fn request_works_only_when_data_available() {
     let (peer, protocol, request, response_sender) = mock_network.next_request().await.unwrap();
     assert_eq!(peer, expected_peer.peer_id());
     assert_eq!(protocol, ProtocolId::StorageServiceRpc);
-    assert_matches!(request, StorageServiceRequest::GetStorageServerSummary);
+    assert!(request.use_compression);
+    assert_matches!(request.data_request, DataRequest::GetStorageServerSummary);
 
     let summary = mock_storage_summary(200);
-    response_sender.send(Ok(StorageServiceResponse::StorageServerSummary(summary)));
+    let data_response = DataResponse::StorageServerSummary(summary);
+    response_sender.send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
 
     // Let the poller finish processing the response
     tokio::task::yield_now().await;
@@ -247,9 +250,10 @@ async fn request_works_only_when_data_available() {
 
         assert_eq!(peer, expected_peer.peer_id());
         assert_eq!(protocol, ProtocolId::StorageServiceRpc);
+        assert!(request.use_compression);
         assert_matches!(
-            request,
-            StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+            request.data_request,
+            DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
                 start_version: 50,
                 end_version: 100,
                 proof_version: 100,
@@ -257,9 +261,9 @@ async fn request_works_only_when_data_available() {
             })
         );
 
-        response_sender.send(Ok(StorageServiceResponse::TransactionsWithProof(
-            TransactionListWithProof::new_empty(),
-        )));
+        let data_response =
+            DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
+        response_sender.send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
     });
 
     // The client's request should succeed since a peer finally has advertised
@@ -652,24 +656,25 @@ async fn prioritized_peer_request_selection() {
     let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
 
     // Ensure the properties hold for storage summary and data subscription requests
-    let storage_summary_request = StorageServiceRequest::GetStorageServerSummary;
+    let storage_summary_request = DataRequest::GetStorageServerSummary;
     let new_transactions_request =
-        StorageServiceRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+        DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
             known_version: 1023,
             known_epoch: 23,
             include_events: false,
         });
-    let new_outputs_request = StorageServiceRequest::GetNewTransactionOutputsWithProof(
-        NewTransactionOutputsWithProofRequest {
+    let new_outputs_request =
+        DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
             known_version: 4504,
             known_epoch: 3,
-        },
-    );
-    for storage_request in [
+        });
+    for data_request in [
         storage_summary_request,
         new_transactions_request,
         new_outputs_request,
     ] {
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
         // Ensure no peers can service the request (we have no connections)
         assert_matches!(
             client.choose_peer_for_request(&storage_request),
@@ -722,7 +727,8 @@ async fn all_peer_request_selection() {
     let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
 
     // Ensure no peers can service the given request (we have no connections)
-    let server_version_request = StorageServiceRequest::GetServerProtocolVersion;
+    let server_version_request =
+        StorageServiceRequest::new(DataRequest::GetServerProtocolVersion, true);
     assert_matches!(
         client.choose_peer_for_request(&server_version_request),
         Err(Error::DataIsUnavailable(_))
@@ -741,28 +747,27 @@ async fn all_peer_request_selection() {
 
     // Request data that is not being advertised and verify we get an error
     let output_data_request =
-        StorageServiceRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+        DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
             proof_version: 100,
             start_version: 0,
             end_version: 100,
         });
+    let storage_request = StorageServiceRequest::new(output_data_request, false);
     assert_matches!(
-        client.choose_peer_for_request(&output_data_request),
+        client.choose_peer_for_request(&storage_request),
         Err(Error::DataIsUnavailable(_))
     );
 
     // Advertise the data for the regular peer and verify it is now selected
     client.update_summary(regular_peer_1, mock_storage_summary(100));
     assert_eq!(
-        client.choose_peer_for_request(&output_data_request),
+        client.choose_peer_for_request(&storage_request),
         Ok(regular_peer_1)
     );
 
     // Advertise the data for the priority peer and verify the priority peer is selected
     client.update_summary(priority_peer_2, mock_storage_summary(100));
-    let peer_for_request = client
-        .choose_peer_for_request(&output_data_request)
-        .unwrap();
+    let peer_for_request = client.choose_peer_for_request(&storage_request).unwrap();
     assert_eq!(peer_for_request, priority_peer_2);
 
     // Reconnect priority peer 1 and remove the advertised data for priority peer 2
@@ -771,22 +776,18 @@ async fn all_peer_request_selection() {
 
     // Request the data again and verify the regular peer is chosen
     assert_eq!(
-        client.choose_peer_for_request(&output_data_request),
+        client.choose_peer_for_request(&storage_request),
         Ok(regular_peer_1)
     );
 
     // Advertise the data for priority peer 1 and verify the priority peer is selected
     client.update_summary(priority_peer_1, mock_storage_summary(100));
-    let peer_for_request = client
-        .choose_peer_for_request(&output_data_request)
-        .unwrap();
+    let peer_for_request = client.choose_peer_for_request(&storage_request).unwrap();
     assert_eq!(peer_for_request, priority_peer_1);
 
     // Advertise the data for priority peer 2 and verify either priority peer is selected
     client.update_summary(priority_peer_2, mock_storage_summary(100));
-    let peer_for_request = client
-        .choose_peer_for_request(&output_data_request)
-        .unwrap();
+    let peer_for_request = client.choose_peer_for_request(&storage_request).unwrap();
     assert!(peer_for_request == priority_peer_1 || peer_for_request == priority_peer_2);
 }
 
@@ -896,9 +897,9 @@ async fn bad_peer_is_eventually_banned_internal() {
         while let Some((peer, _, _, response_sender)) = mock_network.next_request().await {
             if peer == good_peer.peer_id() {
                 // Good peer responds with good response.
-                response_sender.send(Ok(StorageServiceResponse::TransactionsWithProof(
-                    TransactionListWithProof::new_empty(),
-                )));
+                let data_response =
+                    DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
+                response_sender.send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
             } else if peer == bad_peer.peer_id() {
                 // Bad peer responds with error.
                 response_sender.send(Err(StorageServiceError::InternalError("".to_string())));
@@ -962,9 +963,9 @@ async fn bad_peer_is_eventually_banned_callback() {
     // Spawn a handler for both peers.
     tokio::spawn(async move {
         while let Some((_, _, _, response_sender)) = mock_network.next_request().await {
-            response_sender.send(Ok(StorageServiceResponse::TransactionsWithProof(
-                TransactionListWithProof::new_empty(),
-            )));
+            let data_response =
+                DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
+            response_sender.send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
         }
     });
 
@@ -1011,6 +1012,175 @@ async fn bad_peer_is_eventually_banned_callback() {
 }
 
 #[tokio::test]
+async fn compression_mismatch_disabled() {
+    ::aptos_logger::Logger::init_for_testing();
+
+    // Disable compression
+    let data_client_config = AptosDataClientConfig {
+        use_compression: false,
+        ..Default::default()
+    };
+    let (mut mock_network, mock_time, client, poller) =
+        MockNetwork::new(None, Some(data_client_config), None);
+
+    tokio::spawn(poller.start_poller());
+
+    // Add a connected peer
+    let _ = mock_network.add_peer(true);
+
+    // Advance time so the poller sends a data summary request
+    tokio::task::yield_now().await;
+    mock_time.advance_async(Duration::from_millis(1_000)).await;
+
+    // Receive their request and respond
+    let (_, _, _, response_sender) = mock_network.next_request().await.unwrap();
+    let data_response = DataResponse::StorageServerSummary(mock_storage_summary(200));
+    response_sender.send(Ok(
+        StorageServiceResponse::new(data_response, false).unwrap()
+    ));
+
+    // Let the poller finish processing the response
+    tokio::task::yield_now().await;
+
+    // Handle the client's transactions request using compression
+    tokio::spawn(async move {
+        let (_, _, request, response_sender) = mock_network.next_request().await.unwrap();
+        assert!(!request.use_compression);
+
+        // Compress the response
+        let data_response =
+            DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
+        let storage_response = StorageServiceResponse::new(data_response, true).unwrap();
+        response_sender.send(Ok(storage_response));
+    });
+
+    // The client should receive a compressed response and return an error
+    let response = client
+        .get_transactions_with_proof(100, 50, 100, false)
+        .await
+        .unwrap_err();
+    assert_matches!(response, Error::InvalidResponse(_));
+}
+
+#[tokio::test]
+async fn compression_mismatch_enabled() {
+    ::aptos_logger::Logger::init_for_testing();
+
+    // Enable compression
+    let data_client_config = AptosDataClientConfig {
+        use_compression: true,
+        ..Default::default()
+    };
+    let (mut mock_network, mock_time, client, poller) =
+        MockNetwork::new(None, Some(data_client_config), None);
+
+    tokio::spawn(poller.start_poller());
+
+    // Add a connected peer
+    let _ = mock_network.add_peer(true);
+
+    // Advance time so the poller sends a data summary request
+    tokio::task::yield_now().await;
+    mock_time.advance_async(Duration::from_millis(1_000)).await;
+
+    // Receive their request and respond
+    let (_, _, _, response_sender) = mock_network.next_request().await.unwrap();
+    let data_response = DataResponse::StorageServerSummary(mock_storage_summary(200));
+    response_sender.send(Ok(StorageServiceResponse::new(data_response, true).unwrap()));
+
+    // Let the poller finish processing the response
+    tokio::task::yield_now().await;
+
+    // Handle the client's transactions request without compression
+    tokio::spawn(async move {
+        let (_, _, request, response_sender) = mock_network.next_request().await.unwrap();
+        assert!(request.use_compression);
+
+        // Compress the response
+        let data_response =
+            DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
+        let storage_response = StorageServiceResponse::new(data_response, false).unwrap();
+        response_sender.send(Ok(storage_response));
+    });
+
+    // The client should receive a compressed response and return an error
+    let response = client
+        .get_transactions_with_proof(100, 50, 100, false)
+        .await
+        .unwrap_err();
+    assert_matches!(response, Error::InvalidResponse(_));
+}
+
+#[tokio::test]
+async fn disable_compression() {
+    ::aptos_logger::Logger::init_for_testing();
+
+    // Disable compression
+    let data_client_config = AptosDataClientConfig {
+        use_compression: false,
+        ..Default::default()
+    };
+    let (mut mock_network, mock_time, client, poller) =
+        MockNetwork::new(None, Some(data_client_config), None);
+
+    tokio::spawn(poller.start_poller());
+
+    // Add a connected peer
+    let expected_peer = mock_network.add_peer(true);
+
+    // Advance time so the poller sends a data summary request
+    tokio::task::yield_now().await;
+    mock_time.advance_async(Duration::from_millis(1_000)).await;
+
+    // Receive their request
+    let (peer, protocol, request, response_sender) = mock_network.next_request().await.unwrap();
+    assert_eq!(peer, expected_peer.peer_id());
+    assert_eq!(protocol, ProtocolId::StorageServiceRpc);
+    assert!(!request.use_compression);
+    assert_matches!(request.data_request, DataRequest::GetStorageServerSummary);
+
+    // Fulfill their request
+    let data_response = DataResponse::StorageServerSummary(mock_storage_summary(200));
+    response_sender.send(Ok(
+        StorageServiceResponse::new(data_response, false).unwrap()
+    ));
+
+    // Let the poller finish processing the response
+    tokio::task::yield_now().await;
+
+    // Handle the client's transactions request
+    tokio::spawn(async move {
+        let (peer, protocol, request, response_sender) = mock_network.next_request().await.unwrap();
+
+        assert_eq!(peer, expected_peer.peer_id());
+        assert_eq!(protocol, ProtocolId::StorageServiceRpc);
+        assert!(!request.use_compression);
+        assert_matches!(
+            request.data_request,
+            DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+                start_version: 50,
+                end_version: 100,
+                proof_version: 100,
+                include_events: false,
+            })
+        );
+
+        let data_response =
+            DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
+        let storage_response = StorageServiceResponse::new(data_response, false).unwrap();
+        response_sender.send(Ok(storage_response));
+    });
+
+    // The client's request should succeed since a peer finally has advertised
+    // data for this range.
+    let response = client
+        .get_transactions_with_proof(100, 50, 100, false)
+        .await
+        .unwrap();
+    assert_eq!(response.payload, TransactionListWithProof::new_empty());
+}
+
+#[tokio::test]
 async fn bad_peer_is_eventually_added_back() {
     ::aptos_logger::Logger::init_for_testing();
     let (mut mock_network, mock_time, client, poller) = MockNetwork::new(None, None, None);
@@ -1021,15 +1191,25 @@ async fn bad_peer_is_eventually_added_back() {
     tokio::spawn(poller.start_poller());
     tokio::spawn(async move {
         while let Some((_, _, request, response_sender)) = mock_network.next_request().await {
-            match request {
-                StorageServiceRequest::GetTransactionsWithProof(_) => {
-                    response_sender.send(Ok(StorageServiceResponse::TransactionsWithProof(
-                        TransactionListWithProof::new_empty(),
-                    )))
+            match request.data_request {
+                DataRequest::GetTransactionsWithProof(_) => {
+                    let data_response =
+                        DataResponse::TransactionsWithProof(TransactionListWithProof::new_empty());
+                    response_sender.send(Ok(StorageServiceResponse::new(
+                        data_response,
+                        request.use_compression,
+                    )
+                    .unwrap()));
                 }
-                StorageServiceRequest::GetStorageServerSummary => response_sender.send(Ok(
-                    StorageServiceResponse::StorageServerSummary(mock_storage_summary(200)),
-                )),
+                DataRequest::GetStorageServerSummary => {
+                    let data_response =
+                        DataResponse::StorageServerSummary(mock_storage_summary(200));
+                    response_sender.send(Ok(StorageServiceResponse::new(
+                        data_response,
+                        request.use_compression,
+                    )
+                    .unwrap()));
+                }
                 _ => panic!("unexpected: {:?}", request),
             }
         }

--- a/state-sync/storage-service/types/Cargo.toml
+++ b/state-sync/storage-service/types/Cargo.toml
@@ -10,10 +10,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
+bcs = "0.1.3"
 num-traits = { version = "0.2.15", default-features = false }
 serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 
+aptos-compression = { path = "../../../crates/aptos-compression"}
 aptos-config = { path = "../../../config" }
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-types = { path = "../../../types" }

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -14,9 +14,14 @@ pub mod responses;
 #[cfg(test)]
 mod tests;
 
+/// The suffix to append to data request and responses labels
+/// (if the request/response requires compression).
+const COMPRESSION_SUFFIX_LABEL: &str = "_compressed";
+
 /// A type alias for different epochs.
 pub type Epoch = u64;
 
+/// Shorthand error typing
 pub type Result<T, E = StorageServiceError> = ::std::result::Result<T, E>;
 
 /// A storage service error that can be returned to the client on a failure
@@ -31,7 +36,6 @@ pub enum StorageServiceError {
 
 /// A single storage service message sent or received over AptosNet.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-// TODO(philiphayes): do something about this without making it ugly :(
 #[allow(clippy::large_enum_variant)]
 pub enum StorageServiceMessage {
     /// A request to the storage service.

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -1,12 +1,38 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::COMPRESSION_SUFFIX_LABEL;
 use aptos_types::transaction::Version;
 use serde::{Deserialize, Serialize};
 
 /// A storage service request.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub enum StorageServiceRequest {
+pub struct StorageServiceRequest {
+    pub data_request: DataRequest, // The data to fetch from the storage service
+    pub use_compression: bool,     // Whether or not the client wishes data to be compressed
+}
+
+impl StorageServiceRequest {
+    pub fn new(data_request: DataRequest, use_compression: bool) -> Self {
+        Self {
+            data_request,
+            use_compression,
+        }
+    }
+
+    /// Returns a summary label for the request
+    pub fn get_label(&self) -> String {
+        let mut label = self.data_request.get_label().to_string();
+        if self.use_compression {
+            label += COMPRESSION_SUFFIX_LABEL;
+        }
+        label
+    }
+}
+
+/// A single data request.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum DataRequest {
     GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest), // Fetches a list of epoch ending ledger infos
     GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest), // Subscribes to new transaction outputs
     GetNewTransactionsWithProof(NewTransactionsWithProofRequest), // Subscribes to new transactions with a proof
@@ -18,7 +44,7 @@ pub enum StorageServiceRequest {
     GetTransactionsWithProof(TransactionsWithProofRequest), // Fetches a list of transactions with a proof
 }
 
-impl StorageServiceRequest {
+impl DataRequest {
     /// Returns a summary label for the request
     pub fn get_label(&self) -> &'static str {
         match self {
@@ -47,8 +73,8 @@ impl StorageServiceRequest {
 /// A storage service request for fetching a list of epoch ending ledger infos.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct EpochEndingLedgerInfoRequest {
-    pub start_epoch: u64,
-    pub expected_end_epoch: u64,
+    pub start_epoch: u64,        // The epoch to start at
+    pub expected_end_epoch: u64, // The epoch to finish at
 }
 
 /// A storage service request for fetching a new transaction output list


### PR DESCRIPTION
### Description

This PR adds data compression to state sync (i.e., it utilizes the recently added `aptos-compression` crate: https://github.com/aptos-labs/aptos-core/pull/2232). At a high-level:
1. Storage service clients will specify (in the `StorageServiceRequest`) whether or not the response should be compressed. Compression can be configured via the `AptosDataClientConfig`. The default is true.
2. If the client requests compression, the server will compress the response (see `StorageServiceResponse`).
3. Compression happens at the application layer (instead of at the network layer). There's obviously trade-offs with this approach, but the benefits are: (i) clients can enable/disable compression easily; (ii) the storage service can use cached responses to serve directly to clients, without needing to re-compress data for every request; and (iii) we can selectively compress data, e.g., there's no need to compress all messages, because some are tiny and might actually become larger (like the actual client requests themselves).

A couple notes:
- Most of this PR is just updating the tests and adding new ones. At the core, we're essentially just making the existing `StorageServiceRequest` and `StorageServiceResponse` messages enums (to support compression).
- This relates to: https://github.com/aptos-labs/aptos-core/issues/541

### Test Plan
New tests have been added, including:
1. Two smoke tests (for validators and fullnodes, testing no compression). All other smoke tests use compression by default.
5. Several unit tests (e.g., to check that the config values work as expected and that client-server interaction is valid).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2263)
<!-- Reviewable:end -->
