### PR TITLE
[move] Disable package publishing for devnet release.

### DIFF
--- a/aptos-move/aptos-vm/src/move_vm_ext/code_context.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/code_context.rs
@@ -101,6 +101,8 @@ const EALREADY_REQUESTED: u64 = 0x03_0000;
 /// Abort code when from_bytes fails (0x03 == INVALID_ARGUMENT)
 const EFROM_BYTES: u64 = 0x01_0001;
 
+const ENOT_SUPPORTED: u64 = 0x03_0002;
+
 const CHECK_COMPAT_POLICY: u8 = 1;
 
 /// The native code context.
@@ -143,6 +145,11 @@ fn native_request_publish(
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert_eq!(args.len(), 4);
+
+    if !cfg!(any(test, feature = "fuzzing")) {
+        // This feature is currently disabled outside of test builds
+        return Err(PartialVMError::new(StatusCode::ABORTED).with_sub_status(ENOT_SUPPORTED));
+    }
     let policy = pop_arg!(args, u8);
     let mut code = vec![];
     for module in pop_arg!(args, Vec<Value>) {

--- a/aptos-move/e2e-testsuite/Cargo.toml
+++ b/aptos-move/e2e-testsuite/Cargo.toml
@@ -22,7 +22,7 @@ aptos-parallel-executor = { path = "../parallel-executor" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types", features = ["fuzzing"] }
-aptos-vm = { path = "../aptos-vm" }
+aptos-vm = { path = "../aptos-vm", features = ["fuzzing"] }
 
 aptos-writeset-generator = { path = "../writeset-transaction-generator" }
 cached-framework-packages =  { path = "../framework/cached-packages" }


### PR DESCRIPTION
### Description

As there are still some vulnerabilities about code caching which may be hit on devnet if someone figures out how to construct the `code::publish_package_txn`, this PR guards this features temporarily. The transaction for now aborts if not compiled in fuzzing or test mode.


### Test Plan

Existing tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2265)
<!-- Reviewable:end -->
