### PR TITLE
[aptos-cli] Split out some dependencies to aptos-cli-base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 name = "aptos"
 version = "0.2.1"
 dependencies = [
- "anyhow",
+ "aptos-cli-base",
  "aptos-config",
  "aptos-crypto",
  "aptos-faucet",
@@ -158,35 +158,23 @@ dependencies = [
  "aptos-transaction-builder",
  "aptos-types",
  "aptos-vm",
- "aptosdb",
  "async-trait",
  "base64 0.13.0",
  "bcs",
  "cached-framework-packages",
  "clap 3.2.11",
  "clap_complete",
- "dirs",
- "executor",
- "framework",
  "hex",
- "itertools",
  "move-deps",
  "parse_duration",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_yaml",
  "shadow-rs",
- "short-hex-str",
- "storage-interface",
- "tempfile",
- "thiserror",
  "tokio",
- "tokio-util 0.7.2",
  "toml",
- "uuid",
- "vm-genesis",
 ]
 
 [[package]]
@@ -232,7 +220,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "storage-interface",
  "tokio",
@@ -261,7 +249,7 @@ dependencies = [
  "move-deps",
  "poem",
  "poem-openapi",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "warp",
 ]
@@ -273,8 +261,25 @@ dependencies = [
  "bcs",
  "proptest",
  "proptest-derive",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_bytes",
+]
+
+[[package]]
+name = "aptos-cli-base"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-crypto",
+ "aptos-types",
+ "bcs",
+ "clap 3.2.11",
+ "dirs",
+ "itertools",
+ "serde 1.0.140",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
 ]
 
 [[package]]
@@ -288,7 +293,7 @@ dependencies = [
  "bcs",
  "lz4",
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -309,7 +314,7 @@ dependencies = [
  "mirai-annotations",
  "poem-openapi",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_yaml",
  "short-hex-str",
  "thiserror",
@@ -339,7 +344,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde-name",
  "serde_bytes",
  "serde_json",
@@ -384,7 +389,7 @@ dependencies = [
  "netcore",
  "network",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "short-hex-str",
  "storage-service-client",
  "storage-service-server",
@@ -412,7 +417,7 @@ dependencies = [
  "hex",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "tempfile",
  "tokio",
@@ -440,7 +445,7 @@ dependencies = [
  "hex",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_yaml",
  "tempfile",
@@ -517,7 +522,7 @@ dependencies = [
  "consensus-types",
  "executor",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_yaml",
  "storage-interface",
  "structopt",
@@ -531,7 +536,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "proxy",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "thiserror",
  "ureq",
@@ -563,7 +568,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "tokio",
  "url",
@@ -595,7 +600,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "thiserror",
 ]
@@ -632,7 +637,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "prometheus",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "strum",
  "strum_macros",
@@ -655,7 +660,7 @@ dependencies = [
  "aptos-types",
  "bcs",
  "hex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_yaml",
  "structopt",
  "thiserror",
@@ -692,7 +697,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "short-hex-str",
  "storage-interface",
@@ -789,7 +794,7 @@ dependencies = [
  "poem-openapi",
  "prometheus-parse",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_yaml",
  "thiserror",
@@ -806,7 +811,7 @@ dependencies = [
  "mime",
  "poem",
  "poem-openapi",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
 ]
 
@@ -834,7 +839,7 @@ dependencies = [
  "netcore",
  "network",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_yaml",
  "structopt",
@@ -908,7 +913,7 @@ dependencies = [
  "hex",
  "move-deps",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "tokio",
  "url",
@@ -947,7 +952,7 @@ dependencies = [
  "move-deps",
  "percent-encoding",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "shadow-rs",
  "thiserror",
@@ -969,7 +974,7 @@ dependencies = [
  "aptos-types",
  "clap 3.2.11",
  "hex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "tokio",
  "url",
@@ -985,7 +990,7 @@ dependencies = [
  "bcs",
  "move-deps",
  "rand_core 0.5.1",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -1016,7 +1021,7 @@ dependencies = [
  "aptos-logger",
  "aptos-secure-push-metrics",
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -1046,7 +1051,7 @@ dependencies = [
  "chrono",
  "enum_dispatch",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "thiserror",
 ]
@@ -1060,7 +1065,7 @@ dependencies = [
  "aptos-types",
  "bcs",
  "move-deps",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_bytes",
  "serde_json",
 ]
@@ -1084,7 +1089,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "shadow-rs",
  "state-sync-driver",
@@ -1184,7 +1189,7 @@ dependencies = [
  "language-e2e-tests",
  "move-deps",
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "vm-genesis",
 ]
@@ -1210,7 +1215,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_bytes",
  "serde_json",
  "serde_yaml",
@@ -1243,7 +1248,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "proptest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "thiserror",
  "ureq",
@@ -1273,7 +1278,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "rayon",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "smallvec",
  "tracing",
@@ -1293,7 +1298,7 @@ dependencies = [
  "framework",
  "handlebars",
  "move-deps",
- "serde 1.0.137",
+ "serde 1.0.140",
  "tempfile",
 ]
 
@@ -1329,7 +1334,7 @@ dependencies = [
  "rayon",
  "schemadb",
  "scratchpad",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "thiserror",
 ]
@@ -1438,7 +1443,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -1474,7 +1479,7 @@ dependencies = [
  "regex",
  "reqwest",
  "scratchpad",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "storage-interface",
  "structopt",
@@ -1502,7 +1507,7 @@ dependencies = [
  "hyper",
  "once_cell",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "tokio",
  "warp",
@@ -1532,7 +1537,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510fd83e3eaf7263b06182f3550b4c0af2af42cb36ab8024969ff5ea7fcb2833"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -1573,7 +1578,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -1713,7 +1718,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "memchr",
  "regex-automata",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -1768,7 +1773,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -1857,7 +1862,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits 0.2.15",
- "serde 1.0.137",
+ "serde 1.0.140",
  "time 0.1.44",
  "winapi 0.3.9",
 ]
@@ -1998,7 +2003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -2007,7 +2012,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
  "termcolor",
  "unicode-width",
 ]
@@ -2032,7 +2037,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -2080,7 +2085,7 @@ dependencies = [
  "rand 0.7.3",
  "safety-rules",
  "schemadb",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "short-hex-str",
  "storage-interface",
@@ -2101,7 +2106,7 @@ dependencies = [
  "claim",
  "futures",
  "move-deps",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
  "tokio",
 ]
@@ -2121,7 +2126,7 @@ dependencies = [
  "itertools",
  "mirai-annotations",
  "proptest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "short-hex-str",
 ]
@@ -2212,7 +2217,7 @@ dependencies = [
  "idna",
  "log",
  "publicsuffix",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "time 0.2.27",
  "url",
@@ -2249,7 +2254,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-logger",
  "backtrace",
- "serde 1.0.137",
+ "serde 1.0.140",
  "toml",
 ]
 
@@ -2271,7 +2276,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -2464,7 +2469,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.8",
  "ryu",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -2588,7 +2593,7 @@ dependencies = [
  "network",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "short-hex-str",
  "storage-service-types",
  "thiserror",
@@ -2799,7 +2804,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
  "signature",
 ]
 
@@ -2812,7 +2817,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -2827,7 +2832,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand 0.8.5",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -2898,7 +2903,7 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad132dd8d0d0b546348d7d86cb3191aad14b34e5f979781fc005c80d4ac67ffd"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -2926,7 +2931,7 @@ dependencies = [
  "executor-test-helpers",
  "futures",
  "move-deps",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "thiserror",
  "vm-genesis",
@@ -2962,7 +2967,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "scratchpad",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "vm-genesis",
 ]
@@ -2997,7 +3002,7 @@ dependencies = [
  "rayon",
  "schemadb",
  "scratchpad",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "structopt",
  "toml",
@@ -3039,7 +3044,7 @@ dependencies = [
  "itertools",
  "once_cell",
  "scratchpad",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "thiserror",
 ]
@@ -3164,7 +3169,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "structopt",
  "tempfile",
@@ -3353,7 +3358,7 @@ dependencies = [
  "move-deps",
  "network",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection)",
  "serde_yaml",
  "structopt",
@@ -3538,7 +3543,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "thiserror",
 ]
@@ -4030,7 +4035,7 @@ dependencies = [
  "array_tool",
  "env_logger 0.7.1",
  "log",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
 ]
 
@@ -4043,7 +4048,7 @@ dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
  "chrono",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde-value",
  "serde_json",
 ]
@@ -4077,7 +4082,7 @@ dependencies = [
  "openssl",
  "pem",
  "pin-project",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_yaml",
  "static_assertions",
@@ -4113,7 +4118,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "vm-genesis",
 ]
 
@@ -4136,7 +4141,7 @@ dependencies = [
  "language-e2e-tests",
  "move-deps",
  "proptest",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4234,7 +4239,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.137",
+ "serde 1.0.140",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -4311,7 +4316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4385,7 +4390,7 @@ dependencies = [
  "async-trait",
  "claim",
  "futures",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
  "tokio",
 ]
@@ -4532,7 +4537,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4546,7 +4551,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "ref-cast",
- "serde 1.0.137",
+ "serde 1.0.140",
  "variant_count",
 ]
 
@@ -4567,7 +4572,7 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4646,7 +4651,7 @@ dependencies = [
  "once_cell",
  "read-write-set",
  "read-write-set-dynamic",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_yaml",
  "tempfile",
  "walkdir",
@@ -4662,7 +4667,7 @@ dependencies = [
  "hex",
  "move-core-types",
  "num-bigint 0.4.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -4709,7 +4714,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_bytes",
 ]
 
@@ -4730,7 +4735,7 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4798,7 +4803,7 @@ dependencies = [
  "num 0.4.0",
  "once_cell",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4812,7 +4817,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4888,7 +4893,7 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4914,7 +4919,7 @@ dependencies = [
  "num 0.4.0",
  "once_cell",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -4942,7 +4947,7 @@ dependencies = [
  "petgraph 0.5.1",
  "ptree",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_yaml",
  "sha2 0.9.9",
  "tempfile",
@@ -4980,7 +4985,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "simplelog",
  "tokio",
@@ -5009,7 +5014,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "tera",
  "tokio",
@@ -5023,7 +5028,7 @@ dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -5038,7 +5043,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -5065,7 +5070,7 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -5083,7 +5088,7 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num 0.4.0",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -5114,7 +5119,7 @@ version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=a34266fc6c51bfc669d44f4c0faa337058e7833f#a34266fc6c51bfc669d44f4c0faa337058e7833f"
 dependencies = [
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -5233,7 +5238,7 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "proptest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "smallvec",
 ]
 
@@ -5327,7 +5332,7 @@ dependencies = [
  "memsocket",
  "pin-project",
  "proxy",
- "serde 1.0.137",
+ "serde 1.0.140",
  "tokio",
  "tokio-util 0.7.2",
  "url",
@@ -5368,7 +5373,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_bytes",
  "serde_json",
  "short-hex-str",
@@ -5398,7 +5403,7 @@ dependencies = [
  "network",
  "network-discovery",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "tokio",
 ]
 
@@ -5907,7 +5912,7 @@ dependencies = [
  "network",
  "once_cell",
  "peer-monitoring-service-types",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
  "tokio",
 ]
@@ -5918,7 +5923,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-config",
  "network",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -6131,7 +6136,7 @@ dependencies = [
  "regex",
  "rfc7239",
  "rustls-pemfile",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
@@ -6173,7 +6178,7 @@ dependencies = [
  "poem",
  "poem-openapi-derive",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_urlencoded",
  "serde_yaml",
@@ -6418,7 +6423,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.0",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde-value",
  "tint",
 ]
@@ -6756,7 +6761,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "proc-macro-hack",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -6780,7 +6785,7 @@ dependencies = [
  "futures",
  "http",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "task-local-extensions",
  "thiserror",
 ]
@@ -6973,7 +6978,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "rusty-fork",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -7144,9 +7149,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 dependencies = [
  "serde_derive",
 ]
@@ -7161,7 +7166,7 @@ dependencies = [
  "heck 0.3.3",
  "include_dir 0.6.2",
  "maplit",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba)",
  "serde_bytes",
  "serde_yaml",
@@ -7187,7 +7192,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -7198,7 +7203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "167450ba550f903a2b35a81ba3ca387585189e2430e3df6b94b95f3bec2f26bd"
 dependencies = [
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -7208,7 +7213,7 @@ version = "0.3.5"
 source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -7218,7 +7223,7 @@ version = "0.3.5"
 source = "git+https://github.com/aptos-labs/serde-reflection#262fe0545367563e056eef99d6108cacbb102192"
 dependencies = [
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -7229,7 +7234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -7238,7 +7243,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212e73464ebcde48d723aa02eb270ba62eff38a9b732df31f33f1b4e145f3a54"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -7248,14 +7253,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2 1.0.39",
  "quote 1.0.18",
@@ -7264,14 +7269,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "indexmap",
  "itoa 1.0.2",
  "ryu",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -7283,18 +7288,18 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.2",
  "ryu",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
- "serde 1.0.137",
+ "serde 1.0.140",
  "yaml-rust",
 ]
 
@@ -7419,7 +7424,7 @@ dependencies = [
  "hex",
  "mirai-annotations",
  "proptest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "static_assertions",
  "thiserror",
 ]
@@ -7633,7 +7638,7 @@ dependencies = [
  "network",
  "once_cell",
  "scratchpad",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "storage-service-client",
  "storage-service-types",
@@ -7713,7 +7718,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "rand 0.7.3",
- "serde 1.0.137",
+ "serde 1.0.140",
  "short-hex-str",
  "storage-interface",
  "thiserror",
@@ -7756,7 +7761,7 @@ checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
 dependencies = [
  "proc-macro2 1.0.39",
  "quote 1.0.18",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_derive",
  "syn 1.0.95",
 ]
@@ -7770,7 +7775,7 @@ dependencies = [
  "base-x",
  "proc-macro2 1.0.39",
  "quote 1.0.18",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_derive",
  "serde_json",
  "sha1",
@@ -7801,7 +7806,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "rayon",
  "scratchpad",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -7841,7 +7846,7 @@ dependencies = [
  "move-deps",
  "network",
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "storage-interface",
  "storage-service-types",
  "thiserror",
@@ -7858,7 +7863,7 @@ dependencies = [
  "claim",
  "num-traits 0.2.15",
  "proptest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "thiserror",
 ]
 
@@ -8017,7 +8022,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "slug",
  "unic-segment",
@@ -8233,7 +8238,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
 ]
 
@@ -8408,7 +8413,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -8536,7 +8541,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.137",
+ "serde 1.0.140",
  "termion",
  "tokio",
  "url",
@@ -8556,7 +8561,7 @@ checksum = "7fc92f558afb6d1d7c6f175eb8d615b8ef49c227543e68e19c123d4ee43d8a7d"
 dependencies = [
  "glob",
  "once_cell",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_derive",
  "serde_json",
  "termcolor",
@@ -8785,7 +8790,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "qstring",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "url",
 ]
@@ -8800,7 +8805,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -8816,7 +8821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
 dependencies = [
  "getrandom 0.2.6",
- "serde 1.0.137",
+ "serde 1.0.140",
 ]
 
 [[package]]
@@ -8946,7 +8951,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "scoped-tls",
- "serde 1.0.137",
+ "serde 1.0.140",
  "serde_json",
  "serde_urlencoded",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "consensus/safety-rules",
     "crates/aptos",
     "crates/aptos-bitvec",
+    "crates/aptos-cli-base",
     "crates/aptos-compression",
     "crates/aptos-crypto",
     "crates/aptos-crypto-derive",

--- a/crates/aptos-cli-base/Cargo.toml
+++ b/crates/aptos-cli-base/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "aptos-cli-base"
+version = "0.1.0"
+authors = ["Aptos Labs <opensource@aptoslabs.com>"]
+description = "CLI common constructs to remove dependencies"
+repository = "https://github.com/aptos-labs/aptos-core"
+homepage = "https://aptoslabs.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.58"
+bcs = "0.1.3"
+clap = "3.2.11"
+dirs = "4.0.0"
+itertools = "0.10.3"
+serde = "1.0.140"
+serde_json = "1.0.82"
+serde_yaml = "0.8.26"
+thiserror = "1.0.31"
+
+aptos-crypto = { path = "../aptos-crypto" }
+aptos-types = { path = "../../types" }

--- a/crates/aptos-cli-base/src/config.rs
+++ b/crates/aptos-cli-base/src/config.rs
@@ -1,0 +1,246 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::file::{
+    create_dir_if_not_exist, current_dir, home_dir, read_from_file, write_to_user_only_file,
+};
+use crate::parse::{from_yaml, to_yaml};
+use crate::types::{CliError, CliTypedResult};
+use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
+use aptos_types::account_address::AccountAddress;
+use clap::ArgEnum;
+use clap::Parser;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fmt::Formatter;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+pub const DEFAULT_REST_URL: &str = "https://fullnode.devnet.aptoslabs.com";
+pub const CONFIG_FOLDER: &str = ".aptos";
+const CONFIG_FILE: &str = "config.yaml";
+const LEGACY_CONFIG_FILE: &str = "config.yml";
+const GLOBAL_CONFIG_FILE: &str = "global_config.yaml";
+const GLOBAL: &str = "global";
+const WORKSPACE: &str = "workspace";
+
+/// A global configuration for global settings related to a user
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct GlobalConfig {
+    /// Whether to be using Global or Workspace mode
+    pub config_type: ConfigType,
+}
+
+impl GlobalConfig {
+    pub fn load() -> CliTypedResult<Self> {
+        let path = global_folder()?.join(GLOBAL_CONFIG_FILE);
+        if path.exists() {
+            from_yaml(&String::from_utf8(read_from_file(path.as_path())?)?)
+        } else {
+            // If we don't have a config, let's load the default
+            Ok(GlobalConfig::default())
+        }
+    }
+
+    /// Get the config location based on the type
+    pub fn get_config_location(&self) -> CliTypedResult<PathBuf> {
+        match self.config_type {
+            ConfigType::Global => global_folder(),
+            ConfigType::Workspace => Ok(current_dir()?.join(CONFIG_FOLDER)),
+        }
+    }
+
+    pub fn save(&self) -> CliTypedResult<()> {
+        let global_folder = global_folder()?;
+        create_dir_if_not_exist(global_folder.as_path())?;
+
+        write_to_user_only_file(
+            global_folder.join(GLOBAL_CONFIG_FILE).as_path(),
+            "Global Config",
+            &to_yaml(&self)?.into_bytes(),
+        )
+    }
+}
+
+fn global_folder() -> CliTypedResult<PathBuf> {
+    Ok(home_dir()?.join(CONFIG_FOLDER))
+}
+
+/// A configuration for where to place and use the config
+///
+/// Workspace allows for multiple configs based on location, where
+/// Global allows for one config for every part of the code
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, ArgEnum)]
+pub enum ConfigType {
+    /// Per system user configuration put in `<HOME>/.aptos`
+    Global,
+    /// Per directory configuration put in `<CURRENT_DIR>/.aptos`
+    Workspace,
+}
+
+impl Default for ConfigType {
+    fn default() -> Self {
+        // TODO: When we version up, we can change this to global
+        Self::Workspace
+    }
+}
+
+impl std::fmt::Display for ConfigType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ConfigType::Global => GLOBAL,
+            ConfigType::Workspace => WORKSPACE,
+        })
+    }
+}
+
+impl FromStr for ConfigType {
+    type Err = CliError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().trim() {
+            GLOBAL => Ok(Self::Global),
+            WORKSPACE => Ok(Self::Workspace),
+            _ => Err(CliError::CommandArgumentError(
+                "Invalid config type, must be one of [global, workspace]".to_string(),
+            )),
+        }
+    }
+}
+
+/// An individual profile
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ProfileConfig {
+    /// Private key for commands.
+    pub private_key: Option<Ed25519PrivateKey>,
+    /// Public key for commands
+    pub public_key: Option<Ed25519PublicKey>,
+    /// Account for commands
+    pub account: Option<AccountAddress>,
+    /// URL for the Aptos rest endpoint
+    pub rest_url: Option<String>,
+    /// URL for the Faucet endpoint (if applicable)
+    pub faucet_url: Option<String>,
+}
+
+/// Config saved to `.aptos/config.yaml`
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CliConfig {
+    /// Map of profile configs
+    pub profiles: Option<HashMap<String, ProfileConfig>>,
+}
+
+impl Default for CliConfig {
+    fn default() -> Self {
+        CliConfig {
+            profiles: Some(HashMap::new()),
+        }
+    }
+}
+
+impl CliConfig {
+    /// Checks if the config exists in the current working directory
+    pub fn config_exists() -> bool {
+        if let Ok(folder) = Self::aptos_folder() {
+            let config_file = folder.join(CONFIG_FILE);
+            let old_config_file = folder.join(LEGACY_CONFIG_FILE);
+            config_file.exists() || old_config_file.exists()
+        } else {
+            false
+        }
+    }
+
+    /// Loads the config from the current working directory
+    pub fn load() -> CliTypedResult<Self> {
+        let folder = Self::aptos_folder()?;
+
+        let config_file = folder.join(CONFIG_FILE);
+        let old_config_file = folder.join(LEGACY_CONFIG_FILE);
+        if config_file.exists() {
+            from_yaml(
+                &String::from_utf8(read_from_file(config_file.as_path())?)
+                    .map_err(CliError::from)?,
+            )
+        } else if old_config_file.exists() {
+            from_yaml(
+                &String::from_utf8(read_from_file(old_config_file.as_path())?)
+                    .map_err(CliError::from)?,
+            )
+        } else {
+            Err(CliError::ConfigNotFoundError(format!(
+                "{}",
+                config_file.display()
+            )))
+        }
+    }
+
+    pub fn load_profile(profile: &str) -> CliTypedResult<Option<ProfileConfig>> {
+        let mut config = Self::load()?;
+        Ok(config.remove_profile(profile))
+    }
+
+    pub fn remove_profile(&mut self, profile: &str) -> Option<ProfileConfig> {
+        if let Some(ref mut profiles) = self.profiles {
+            profiles.remove(&profile.to_string())
+        } else {
+            None
+        }
+    }
+
+    /// Saves the config to ./.aptos/config.yaml
+    pub fn save(&self) -> CliTypedResult<()> {
+        let aptos_folder = Self::aptos_folder()?;
+
+        // Create if it doesn't exist
+        create_dir_if_not_exist(aptos_folder.as_path())?;
+
+        // Save over previous config file
+        let config_file = aptos_folder.join(CONFIG_FILE);
+        let config_bytes = serde_yaml::to_string(&self).map_err(|err| {
+            CliError::UnexpectedError(format!("Failed to serialize config {}", err))
+        })?;
+        write_to_user_only_file(&config_file, CONFIG_FILE, config_bytes.as_bytes())?;
+
+        // As a cleanup, delete the old if it exists
+        let legacy_config_file = aptos_folder.join(LEGACY_CONFIG_FILE);
+        if legacy_config_file.exists() {
+            eprintln!("Removing legacy config file {}", LEGACY_CONFIG_FILE);
+            let _ = std::fs::remove_file(legacy_config_file);
+        }
+        Ok(())
+    }
+
+    /// Finds the current directory's .aptos folder
+    fn aptos_folder() -> CliTypedResult<PathBuf> {
+        let global_config = GlobalConfig::load()?;
+        global_config.get_config_location()
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct ProfileOptions {
+    /// Profile to use from config
+    #[clap(long, default_value = "default")]
+    pub profile: String,
+}
+
+impl ProfileOptions {
+    pub fn account_address(&self) -> CliTypedResult<AccountAddress> {
+        if let Some(profile) = CliConfig::load_profile(&self.profile)? {
+            if let Some(account) = profile.account {
+                return Ok(account);
+            }
+        }
+
+        Err(CliError::ConfigNotFoundError(self.profile.clone()))
+    }
+}
+
+impl Default for ProfileOptions {
+    fn default() -> Self {
+        Self {
+            profile: "default".to_string(),
+        }
+    }
+}

--- a/crates/aptos-cli-base/src/file.rs
+++ b/crates/aptos-cli-base/src/file.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::prompts::{check_if_file_exists, PromptOptions};
+use crate::types::{CliError, CliTypedResult};
+use clap::Parser;
+use std::fs::OpenOptions;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+
+/// Platform agnostic pull current directory
+pub fn current_dir() -> CliTypedResult<PathBuf> {
+    std::env::current_dir().map_err(|err| {
+        CliError::UnexpectedError(format!("Failed to get current directory {}", err))
+    })
+}
+
+/// Platform agnostic pull home directory
+pub fn home_dir() -> CliTypedResult<PathBuf> {
+    dirs::home_dir().ok_or(CliError::UnexpectedError(
+        "Failed to get home directory".to_string(),
+    ))
+}
+
+/// Pull directory argument, but default to current dir
+pub fn dir_default_to_current(maybe_dir: Option<PathBuf>) -> CliTypedResult<PathBuf> {
+    if let Some(dir) = maybe_dir {
+        Ok(dir)
+    } else {
+        current_dir()
+    }
+}
+
+/// Create a directory structure if it doesn't exist
+pub fn create_dir_if_not_exist(dir: &Path) -> CliTypedResult<()> {
+    // Check if the directory exists, if it's not a dir, it will also fail here
+    if !dir.exists() || !dir.is_dir() {
+        std::fs::create_dir_all(dir).map_err(|e| CliError::IO(dir.display().to_string(), e))?;
+    }
+    Ok(())
+}
+
+/// Read from a file
+pub fn read_from_file(path: &Path) -> CliTypedResult<Vec<u8>> {
+    std::fs::read(path)
+        .map_err(|e| CliError::UnableToReadFile(format!("{}", path.display()), e.to_string()))
+}
+
+/// Write a `&[u8]` to a file
+pub fn write_to_file(path: &Path, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
+    write_to_file_with_opts(path, name, bytes, &mut OpenOptions::new())
+}
+
+/// Write a User only read / write file
+pub fn write_to_user_only_file(path: &Path, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
+    let mut opts = OpenOptions::new();
+    #[cfg(unix)]
+    opts.mode(0o600);
+    write_to_file_with_opts(path, name, bytes, &mut opts)
+}
+
+/// Write a `&[u8]` to a file with the given options
+pub fn write_to_file_with_opts(
+    path: &Path,
+    name: &str,
+    bytes: &[u8],
+    opts: &mut OpenOptions,
+) -> CliTypedResult<()> {
+    let mut file = opts
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .map_err(|e| CliError::IO(name.to_string(), e))?;
+    file.write_all(bytes)
+        .map_err(|e| CliError::IO(name.to_string(), e))
+}
+
+/// Appends a file extension to a `Path` without overwriting the original extension.
+pub fn append_file_extension(
+    file: &Path,
+    appended_extension: &'static str,
+) -> CliTypedResult<PathBuf> {
+    let extension = file
+        .extension()
+        .map(|extension| extension.to_str().unwrap_or_default());
+    if let Some(extension) = extension {
+        Ok(file.with_extension(extension.to_owned() + "." + appended_extension))
+    } else {
+        Ok(file.with_extension(appended_extension))
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct SaveFile {
+    /// Output file name
+    #[clap(long, parse(from_os_str))]
+    pub output_file: PathBuf,
+
+    #[clap(flatten)]
+    pub prompt_options: PromptOptions,
+}
+
+impl SaveFile {
+    /// Check if the key file exists already
+    pub fn check_file(&self) -> CliTypedResult<()> {
+        check_if_file_exists(self.output_file.as_path(), self.prompt_options)
+    }
+
+    /// Save to the `output_file`
+    pub fn save_to_file(&self, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
+        write_to_file(self.output_file.as_path(), name, bytes)
+    }
+
+    /// Save to the `output_file` with restricted permissions (mode 0600)
+    pub fn save_to_file_confidential(&self, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
+        let mut opts = OpenOptions::new();
+        #[cfg(unix)]
+        opts.mode(0o600);
+        write_to_file_with_opts(self.output_file.as_path(), name, bytes, &mut opts)
+    }
+}

--- a/crates/aptos-cli-base/src/lib.rs
+++ b/crates/aptos-cli-base/src/lib.rs
@@ -1,0 +1,9 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod config;
+pub mod file;
+pub mod parse;
+pub mod prompts;
+pub mod types;
+pub mod utils;

--- a/crates/aptos-cli-base/src/parse.rs
+++ b/crates/aptos-cli-base/src/parse.rs
@@ -1,0 +1,55 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::{CliError, CliTypedResult};
+use itertools::Itertools;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::str::FromStr;
+
+/// Error message for parsing a map
+const PARSE_MAP_SYNTAX_MSG: &str = "Invalid syntax for map. Example: Name=Value,Name2=Value";
+
+/// Parses an inline map of values
+///
+/// Example: Name=Value,Name2=Value
+pub fn parse_map<K: FromStr + Ord, V: FromStr>(str: &str) -> CliTypedResult<BTreeMap<K, V>>
+where
+    K::Err: 'static + std::error::Error + Send + Sync,
+    V::Err: 'static + std::error::Error + Send + Sync,
+{
+    let mut map = BTreeMap::new();
+
+    // Split pairs by commas
+    for pair in str.split_terminator(',') {
+        // Split pairs by = then trim off any spacing
+        let (first, second): (&str, &str) = pair
+            .split_terminator('=')
+            .collect_tuple()
+            .ok_or_else(|| CliError::CommandArgumentError(PARSE_MAP_SYNTAX_MSG.to_string()))?;
+        let first = first.trim();
+        let second = second.trim();
+        if first.is_empty() || second.is_empty() {
+            return Err(CliError::CommandArgumentError(
+                PARSE_MAP_SYNTAX_MSG.to_string(),
+            ));
+        }
+
+        // At this point, we just give error messages appropriate to parsing
+        let key: K =
+            K::from_str(first).map_err(|err| CliError::CommandArgumentError(err.to_string()))?;
+        let value: V =
+            V::from_str(second).map_err(|err| CliError::CommandArgumentError(err.to_string()))?;
+        map.insert(key, value);
+    }
+    Ok(map)
+}
+
+pub fn to_yaml<T: Serialize + ?Sized>(input: &T) -> CliTypedResult<String> {
+    Ok(serde_yaml::to_string(input)?)
+}
+
+pub fn from_yaml<T: DeserializeOwned>(input: &str) -> CliTypedResult<T> {
+    Ok(serde_yaml::from_str(input)?)
+}

--- a/crates/aptos-cli-base/src/prompts.rs
+++ b/crates/aptos-cli-base/src/prompts.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::{CliError, CliTypedResult};
+use clap::Parser;
+use std::path::Path;
+
+/// Reads a line from input
+pub fn read_line(input_name: &'static str) -> CliTypedResult<String> {
+    let mut input_buf = String::new();
+    let _ = std::io::stdin()
+        .read_line(&mut input_buf)
+        .map_err(|err| CliError::IO(input_name.to_string(), err))?;
+
+    Ok(input_buf)
+}
+
+/// Prompts for confirmation until a yes or no is given explicitly
+pub fn prompt_yes(prompt: &str) -> bool {
+    let mut result: Result<bool, ()> = Err(());
+
+    // Read input until a yes or a no is given
+    while result.is_err() {
+        println!("{} [yes/no] >", prompt);
+        let mut input = String::new();
+        if std::io::stdin().read_line(&mut input).is_err() {
+            continue;
+        }
+        result = match input.trim().to_lowercase().as_str() {
+            "yes" | "y" => Ok(true),
+            "no" | "n" => Ok(false),
+            _ => Err(()),
+        };
+    }
+    result.unwrap()
+}
+
+/// Prompt yes but override with a command line option
+pub fn prompt_yes_with_override(prompt: &str, prompt_options: PromptOptions) -> CliTypedResult<()> {
+    if prompt_options.assume_no || (!prompt_options.assume_yes && !prompt_yes(prompt)) {
+        Err(CliError::AbortedError)
+    } else {
+        Ok(())
+    }
+}
+
+/// Checks if a file exists, being overridden by `PromptOptions`
+pub fn check_if_file_exists(file: &Path, prompt_options: PromptOptions) -> CliTypedResult<()> {
+    if file.exists() {
+        prompt_yes_with_override(
+            &format!(
+                "{:?} already exists, are you sure you want to overwrite it?",
+                file.as_os_str(),
+            ),
+            prompt_options,
+        )?
+    }
+
+    Ok(())
+}
+
+/// An insertable option for use with prompts.
+#[derive(Clone, Copy, Debug, Parser)]
+pub struct PromptOptions {
+    /// Assume yes for all yes/no prompts
+    #[clap(long, group = "prompt_options")]
+    pub assume_yes: bool,
+    /// Assume no for all yes/no prompts
+    #[clap(long, group = "prompt_options")]
+    pub assume_no: bool,
+}
+
+impl PromptOptions {
+    pub fn yes() -> Self {
+        Self {
+            assume_yes: true,
+            assume_no: false,
+        }
+    }
+}

--- a/crates/aptos-cli-base/src/types.rs
+++ b/crates/aptos-cli-base/src/types.rs
@@ -1,0 +1,119 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Serialize;
+use thiserror::Error;
+
+/// A common result to be returned to users
+pub type CliResult = Result<String, String>;
+
+/// A common result to remove need for typing `Result<T, CliError>`
+pub type CliTypedResult<T> = Result<T, CliError>;
+
+/// CLI Errors for reporting through telemetry and outputs
+#[derive(Debug, Error)]
+pub enum CliError {
+    #[error("Aborted command")]
+    AbortedError,
+    #[error("API error: {0}")]
+    ApiError(String),
+    #[error("Error (de)serializing '{0}': {1}")]
+    BCS(&'static str, #[source] bcs::Error),
+    #[error("Invalid arguments: {0}")]
+    CommandArgumentError(String),
+    #[error("Unable to load config: {0} {1}")]
+    ConfigLoadError(String, String),
+    #[error("Unable to find config {0}, have you run `aptos init`?")]
+    ConfigNotFoundError(String),
+    #[error("Error accessing '{0}': {1}")]
+    IO(String, #[source] std::io::Error),
+    #[error("Move compilation failed: {0}")]
+    MoveCompilationError(String),
+    #[error("Move unit tests failed")]
+    MoveTestError,
+    #[error("Move Prover failed")]
+    MoveProverError,
+    #[error("Unable to parse '{0}': error: {1}")]
+    UnableToParse(&'static str, String),
+    #[error("Unable to read file '{0}', error: {1}")]
+    UnableToReadFile(String, String),
+    #[error("Unexpected error: {0}")]
+    UnexpectedError(String),
+}
+
+impl CliError {
+    pub fn unexpected<Err: std::fmt::Display>(err: Err) -> CliError {
+        CliError::UnexpectedError(err.to_string())
+    }
+
+    pub fn to_str(&self) -> &'static str {
+        match self {
+            CliError::AbortedError => "AbortedError",
+            CliError::ApiError(_) => "ApiError",
+            CliError::BCS(_, _) => "BCS",
+            CliError::CommandArgumentError(_) => "CommandArgumentError",
+            CliError::ConfigLoadError(_, _) => "ConfigLoadError",
+            CliError::ConfigNotFoundError(_) => "ConfigNotFoundError",
+            CliError::IO(_, _) => "IO",
+            CliError::MoveCompilationError(_) => "MoveCompilationError",
+            CliError::MoveTestError => "MoveTestError",
+            CliError::MoveProverError => "MoveProverError",
+            CliError::UnableToParse(_, _) => "UnableToParse",
+            CliError::UnableToReadFile(_, _) => "UnableToReadFile",
+            CliError::UnexpectedError(_) => "UnexpectedError",
+        }
+    }
+}
+
+impl From<anyhow::Error> for CliError {
+    fn from(err: anyhow::Error) -> Self {
+        CliError::unexpected(err)
+    }
+}
+
+impl From<serde_yaml::Error> for CliError {
+    fn from(err: serde_yaml::Error) -> Self {
+        CliError::unexpected(err)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for CliError {
+    fn from(err: std::string::FromUtf8Error) -> Self {
+        CliError::unexpected(err)
+    }
+}
+
+impl From<bcs::Error> for CliError {
+    fn from(err: bcs::Error) -> Self {
+        CliError::unexpected(err)
+    }
+}
+
+/// A result wrapper for displaying either a correct execution result or an error.
+///
+/// The purpose of this is to have a pretty easy to recognize JSON output format e.g.
+///
+/// {
+///   "Result":{
+///     "encoded":{ ... }
+///   }
+/// }
+///
+/// {
+///   "Error":"Failed to run command"
+/// }
+///
+#[derive(Debug, Serialize)]
+pub enum ResultWrapper<T> {
+    Result(T),
+    Error(String),
+}
+
+impl<T> From<CliTypedResult<T>> for ResultWrapper<T> {
+    fn from(result: CliTypedResult<T>) -> Self {
+        match result {
+            Ok(inner) => ResultWrapper::Result(inner),
+            Err(inner) => ResultWrapper::Error(inner.to_string()),
+        }
+    }
+}

--- a/crates/aptos-cli-base/src/utils.rs
+++ b/crates/aptos-cli-base/src/utils.rs
@@ -1,0 +1,15 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::CliResult;
+use std::process::exit;
+
+pub fn print_cli_result(result: CliResult) {
+    match result {
+        Ok(inner) => println!("{}", inner),
+        Err(inner) => {
+            println!("{}", inner);
+            exit(1);
+        }
+    }
+}

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -11,15 +11,12 @@ edition = "2018"
 build = "build.rs"
 
 [dependencies]
-anyhow = "1.0.57"
 async-trait = "0.1.53"
 base64 = "0.13.0"
 bcs = "0.1.3"
 clap = "3.2.11"
 clap_complete = "3.2.3"
-dirs = "4.0.0"
 hex = "0.4.3"
-itertools = "0.10.3"
 parse_duration = "2.1.1"
 rand = "0.7.3"
 reqwest = { version = "0.11.10", features = ["blocking", "json"] }
@@ -27,13 +24,10 @@ serde = "1.0.137"
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
 shadow-rs = "0.11.0"
-tempfile = "3.3.0"
-thiserror = "1.0.31"
-tokio = { version = "1.18.2", features = ["full"] }
-tokio-util = { version = "0.7.2", features = ["compat"] }
+tokio =  "1.18.2"
 toml = "0.5.9"
-uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
+aptos-cli-base = { path = "../aptos-cli-base" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto", features = [] }
 aptos-faucet = { path = "../aptos-faucet" }
@@ -52,14 +46,8 @@ aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 
-aptosdb = { path = "../../storage/aptosdb" }
 cached-framework-packages =  { path = "../../aptos-move/framework/cached-packages" }
-executor = { path = "../../execution/executor" }
-framework = { path = '../../aptos-move/framework' }
 move-deps = { path = "../../aptos-move/move-deps", features = ["address32", "testing", "table-extension"] }
-short-hex-str = { path = "../short-hex-str" }
-storage-interface = { path = "../../storage/storage-interface" }
-vm-genesis = { path = "../../aptos-move/vm-genesis" }
 
 [build-dependencies]
 shadow-rs = "0.11.0"

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{
-    types::{CliCommand, CliTypedResult, FaucetOptions, TransactionOptions},
+    types::{CliCommand, FaucetOptions, TransactionOptions},
     utils::fund_account,
 };
+use aptos_cli_base::types::CliTypedResult;
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;

--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions};
+use crate::common::types::{CliCommand, TransactionOptions};
+use aptos_cli_base::types::CliTypedResult;
 use aptos_rest_client::{
     aptos_api_types::{WriteResource, WriteSetChange},
     Transaction,

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -4,10 +4,12 @@
 use crate::{
     account::create::DEFAULT_FUNDED_COINS,
     common::{
-        types::{CliCommand, CliTypedResult, FaucetOptions, ProfileOptions},
+        types::{CliCommand, FaucetOptions},
         utils::fund_account,
     },
 };
+use aptos_cli_base::config::ProfileOptions;
+use aptos_cli_base::types::CliTypedResult;
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
 use clap::Parser;

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{
-    CliCommand, CliConfig, CliError, CliTypedResult, ProfileOptions, RestOptions,
-};
+use crate::common::types::{CliCommand, RestOptions};
+use aptos_cli_base::config::{CliConfig, ProfileOptions};
+use aptos_cli_base::types::{CliError, CliTypedResult};
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
 use clap::{ArgEnum, Parser};
@@ -85,7 +85,6 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
         };
 
         let client = self.rest_options.client(&self.profile_options.profile)?;
-        let map_err_func = |err: anyhow::Error| CliError::ApiError(err.to_string());
         let response = match self.query {
             ListQuery::Balance => vec![
                 client
@@ -94,7 +93,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
                         "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
                     )
                     .await
-                    .map_err(map_err_func)?
+                    .map_err(|err| CliError::ApiError(err.to_string()))?
                     .into_inner()
                     .unwrap()
                     .data,
@@ -102,7 +101,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
             ListQuery::Modules => client
                 .get_account_modules(account)
                 .await
-                .map_err(map_err_func)?
+                .map_err(|err| CliError::ApiError(err.to_string()))?
                 .into_inner()
                 .iter()
                 .cloned()
@@ -112,7 +111,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
             ListQuery::Resources => client
                 .get_account_resources(account)
                 .await
-                .map_err(map_err_func)?
+                .map_err(|err| CliError::ApiError(err.to_string()))?
                 .into_inner()
                 .iter()
                 .map(|json| json.data.clone())

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliResult};
+use crate::common::types::CliCommand;
+use aptos_cli_base::types::CliResult;
 use clap::Subcommand;
 
 pub mod create;

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions};
+use crate::common::types::{CliCommand, TransactionOptions};
+use aptos_cli_base::types::CliTypedResult;
 use aptos_rest_client::{
     aptos_api_types::{WriteResource, WriteSetChange},
     Transaction,

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -3,12 +3,14 @@
 
 use crate::common::{
     types::{
-        account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
-        EncodingOptions, PrivateKeyInputOptions, ProfileConfig, ProfileOptions, PromptOptions,
+        account_address_from_public_key, CliCommand, EncodingOptions, PrivateKeyInputOptions,
         RngArgs,
     },
-    utils::{fund_account, prompt_yes_with_override, read_line},
+    utils::fund_account,
 };
+use aptos_cli_base::config::{CliConfig, ProfileConfig, ProfileOptions};
+use aptos_cli_base::prompts::{prompt_yes_with_override, read_line, PromptOptions};
+use aptos_cli_base::types::{CliError, CliTypedResult};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, ValidCryptoMaterialStringExt};
 use async_trait::async_trait;
 use clap::Parser;

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1,19 +1,14 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::utils::{create_dir_if_not_exist, dir_default_to_current, start_logger};
-use crate::config::GlobalConfig;
-use crate::{
-    common::{
-        init::{DEFAULT_FAUCET_URL, DEFAULT_REST_URL},
-        utils::{
-            chain_id, check_if_file_exists, get_sequence_number, read_from_file, to_common_result,
-            to_common_success_result, write_to_file, write_to_file_with_opts,
-            write_to_user_only_file,
-        },
-    },
-    genesis::git::from_yaml,
+use crate::common::utils::start_logger;
+use crate::common::{
+    init::{DEFAULT_FAUCET_URL, DEFAULT_REST_URL},
+    utils::{chain_id, get_sequence_number, to_common_result, to_common_success_result},
 };
+use aptos_cli_base::config::{CliConfig, ProfileOptions};
+use aptos_cli_base::file::{dir_default_to_current, read_from_file};
+use aptos_cli_base::types::{CliError, CliResult, CliTypedResult};
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     x25519, PrivateKey, ValidCryptoMaterial, ValidCryptoMaterialStringExt,
@@ -36,244 +31,15 @@ use aptos_types::transaction::{
 };
 use async_trait::async_trait;
 use clap::{ArgEnum, Parser};
-use hex::FromHexError;
 use move_deps::move_core_types::account_address::AccountAddress;
-use serde::{Deserialize, Serialize};
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt;
+use serde::Serialize;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     fmt::{Debug, Display, Formatter},
-    fs::OpenOptions,
     path::{Path, PathBuf},
     str::FromStr,
     time::Instant,
 };
-use thiserror::Error;
-
-/// A common result to be returned to users
-pub type CliResult = Result<String, String>;
-
-/// A common result to remove need for typing `Result<T, CliError>`
-pub type CliTypedResult<T> = Result<T, CliError>;
-
-/// CLI Errors for reporting through telemetry and outputs
-#[derive(Debug, Error)]
-pub enum CliError {
-    #[error("Aborted command")]
-    AbortedError,
-    #[error("API error: {0}")]
-    ApiError(String),
-    #[error("Error (de)serializing '{0}': {1}")]
-    BCS(&'static str, #[source] bcs::Error),
-    #[error("Invalid arguments: {0}")]
-    CommandArgumentError(String),
-    #[error("Unable to load config: {0} {1}")]
-    ConfigLoadError(String, String),
-    #[error("Unable to find config {0}, have you run `aptos init`?")]
-    ConfigNotFoundError(String),
-    #[error("Error accessing '{0}': {1}")]
-    IO(String, #[source] std::io::Error),
-    #[error("Move compilation failed: {0}")]
-    MoveCompilationError(String),
-    #[error("Move unit tests failed")]
-    MoveTestError,
-    #[error("Move Prover failed")]
-    MoveProverError,
-    #[error("Unable to parse '{0}': error: {1}")]
-    UnableToParse(&'static str, String),
-    #[error("Unable to read file '{0}', error: {1}")]
-    UnableToReadFile(String, String),
-    #[error("Unexpected error: {0}")]
-    UnexpectedError(String),
-}
-
-impl CliError {
-    pub fn to_str(&self) -> &'static str {
-        match self {
-            CliError::AbortedError => "AbortedError",
-            CliError::ApiError(_) => "ApiError",
-            CliError::BCS(_, _) => "BCS",
-            CliError::CommandArgumentError(_) => "CommandArgumentError",
-            CliError::ConfigLoadError(_, _) => "ConfigLoadError",
-            CliError::ConfigNotFoundError(_) => "ConfigNotFoundError",
-            CliError::IO(_, _) => "IO",
-            CliError::MoveCompilationError(_) => "MoveCompilationError",
-            CliError::MoveTestError => "MoveTestError",
-            CliError::MoveProverError => "MoveProverError",
-            CliError::UnableToParse(_, _) => "UnableToParse",
-            CliError::UnableToReadFile(_, _) => "UnableToReadFile",
-            CliError::UnexpectedError(_) => "UnexpectedError",
-        }
-    }
-}
-
-impl From<aptos_config::config::Error> for CliError {
-    fn from(e: aptos_config::config::Error) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<aptos_github_client::Error> for CliError {
-    fn from(e: aptos_github_client::Error) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<serde_yaml::Error> for CliError {
-    fn from(e: serde_yaml::Error) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<base64::DecodeError> for CliError {
-    fn from(e: base64::DecodeError) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<std::string::FromUtf8Error> for CliError {
-    fn from(e: std::string::FromUtf8Error) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<aptos_crypto::CryptoMaterialError> for CliError {
-    fn from(e: aptos_crypto::CryptoMaterialError) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<hex::FromHexError> for CliError {
-    fn from(e: FromHexError) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<anyhow::Error> for CliError {
-    fn from(e: anyhow::Error) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-impl From<bcs::Error> for CliError {
-    fn from(e: bcs::Error) -> Self {
-        CliError::UnexpectedError(e.to_string())
-    }
-}
-
-/// Config saved to `.aptos/config.yaml`
-#[derive(Debug, Serialize, Deserialize)]
-pub struct CliConfig {
-    /// Map of profile configs
-    pub profiles: Option<HashMap<String, ProfileConfig>>,
-}
-
-const CONFIG_FILE: &str = "config.yaml";
-const LEGACY_CONFIG_FILE: &str = "config.yml";
-pub const CONFIG_FOLDER: &str = ".aptos";
-
-/// An individual profile
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct ProfileConfig {
-    /// Private key for commands.
-    pub private_key: Option<Ed25519PrivateKey>,
-    /// Public key for commands
-    pub public_key: Option<Ed25519PublicKey>,
-    /// Account for commands
-    pub account: Option<AccountAddress>,
-    /// URL for the Aptos rest endpoint
-    pub rest_url: Option<String>,
-    /// URL for the Faucet endpoint (if applicable)
-    pub faucet_url: Option<String>,
-}
-
-impl Default for CliConfig {
-    fn default() -> Self {
-        CliConfig {
-            profiles: Some(HashMap::new()),
-        }
-    }
-}
-
-impl CliConfig {
-    /// Checks if the config exists in the current working directory
-    pub fn config_exists() -> bool {
-        if let Ok(folder) = Self::aptos_folder() {
-            let config_file = folder.join(CONFIG_FILE);
-            let old_config_file = folder.join(LEGACY_CONFIG_FILE);
-            config_file.exists() || old_config_file.exists()
-        } else {
-            false
-        }
-    }
-
-    /// Loads the config from the current working directory
-    pub fn load() -> CliTypedResult<Self> {
-        let folder = Self::aptos_folder()?;
-
-        let config_file = folder.join(CONFIG_FILE);
-        let old_config_file = folder.join(LEGACY_CONFIG_FILE);
-        if config_file.exists() {
-            from_yaml(
-                &String::from_utf8(read_from_file(config_file.as_path())?)
-                    .map_err(CliError::from)?,
-            )
-        } else if old_config_file.exists() {
-            from_yaml(
-                &String::from_utf8(read_from_file(old_config_file.as_path())?)
-                    .map_err(CliError::from)?,
-            )
-        } else {
-            Err(CliError::ConfigNotFoundError(format!(
-                "{}",
-                config_file.display()
-            )))
-        }
-    }
-
-    pub fn load_profile(profile: &str) -> CliTypedResult<Option<ProfileConfig>> {
-        let mut config = Self::load()?;
-        Ok(config.remove_profile(profile))
-    }
-
-    pub fn remove_profile(&mut self, profile: &str) -> Option<ProfileConfig> {
-        if let Some(ref mut profiles) = self.profiles {
-            profiles.remove(&profile.to_string())
-        } else {
-            None
-        }
-    }
-
-    /// Saves the config to ./.aptos/config.yaml
-    pub fn save(&self) -> CliTypedResult<()> {
-        let aptos_folder = Self::aptos_folder()?;
-
-        // Create if it doesn't exist
-        create_dir_if_not_exist(aptos_folder.as_path())?;
-
-        // Save over previous config file
-        let config_file = aptos_folder.join(CONFIG_FILE);
-        let config_bytes = serde_yaml::to_string(&self).map_err(|err| {
-            CliError::UnexpectedError(format!("Failed to serialize config {}", err))
-        })?;
-        write_to_user_only_file(&config_file, CONFIG_FILE, config_bytes.as_bytes())?;
-
-        // As a cleanup, delete the old if it exists
-        let legacy_config_file = aptos_folder.join(LEGACY_CONFIG_FILE);
-        if legacy_config_file.exists() {
-            eprintln!("Removing legacy config file {}", LEGACY_CONFIG_FILE);
-            let _ = std::fs::remove_file(legacy_config_file);
-        }
-        Ok(())
-    }
-
-    /// Finds the current directory's .aptos folder
-    fn aptos_folder() -> CliTypedResult<PathBuf> {
-        let global_config = GlobalConfig::load()?;
-        global_config.get_config_location()
-    }
-}
 
 /// Types of Keys used by the blockchain
 #[derive(ArgEnum, Clone, Copy, Debug)]
@@ -302,33 +68,6 @@ impl FromStr for KeyType {
             "ed25519" => Ok(KeyType::Ed25519),
             "x25519" => Ok(KeyType::X25519),
             _ => Err("Invalid key type"),
-        }
-    }
-}
-
-#[derive(Debug, Parser)]
-pub struct ProfileOptions {
-    /// Profile to use from config
-    #[clap(long, default_value = "default")]
-    pub profile: String,
-}
-
-impl ProfileOptions {
-    pub fn account_address(&self) -> CliTypedResult<AccountAddress> {
-        if let Some(profile) = CliConfig::load_profile(&self.profile)? {
-            if let Some(account) = profile.account {
-                return Ok(account);
-            }
-        }
-
-        Err(CliError::ConfigNotFoundError(self.profile.clone()))
-    }
-}
-
-impl Default for ProfileOptions {
-    fn default() -> Self {
-        Self {
-            profile: "default".to_string(),
         }
     }
 }
@@ -415,7 +154,11 @@ impl RngArgs {
             let seed = seed.strip_prefix("0x").unwrap_or(seed);
             let mut seed_slice = [0u8; 32];
 
-            hex::decode_to_slice(seed, &mut seed_slice)?;
+            hex::decode_to_slice(seed, &mut seed_slice).map_err(|_| {
+                CliError::CommandArgumentError(
+                    "Invalid --random-seed, must be 32 hex bytes".to_string(),
+                )
+            })?;
             Ok(KeyGen::from_seed(seed_slice))
         } else {
             Ok(KeyGen::from_os_rng())
@@ -449,26 +192,6 @@ impl FromStr for EncodingType {
             "bcs" => Ok(EncodingType::BCS),
             "base64" => Ok(EncodingType::Base64),
             _ => Err("Invalid encoding type"),
-        }
-    }
-}
-
-/// An insertable option for use with prompts.
-#[derive(Clone, Copy, Debug, Parser)]
-pub struct PromptOptions {
-    /// Assume yes for all yes/no prompts
-    #[clap(long, group = "prompt_options")]
-    pub assume_yes: bool,
-    /// Assume no for all yes/no prompts
-    #[clap(long, group = "prompt_options")]
-    pub assume_no: bool,
-}
-
-impl PromptOptions {
-    pub fn yes() -> Self {
-        Self {
-            assume_yes: true,
-            assume_no: false,
         }
     }
 }
@@ -604,36 +327,6 @@ pub fn account_address_from_public_key(public_key: &Ed25519PublicKey) -> Account
     AccountAddress::new(*auth_key.derived_address())
 }
 
-#[derive(Debug, Parser)]
-pub struct SaveFile {
-    /// Output file name
-    #[clap(long, parse(from_os_str))]
-    pub output_file: PathBuf,
-
-    #[clap(flatten)]
-    pub prompt_options: PromptOptions,
-}
-
-impl SaveFile {
-    /// Check if the key file exists already
-    pub fn check_file(&self) -> CliTypedResult<()> {
-        check_if_file_exists(self.output_file.as_path(), self.prompt_options)
-    }
-
-    /// Save to the `output_file`
-    pub fn save_to_file(&self, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
-        write_to_file(self.output_file.as_path(), name, bytes)
-    }
-
-    /// Save to the `output_file` with restricted permissions (mode 0600)
-    pub fn save_to_file_confidential(&self, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
-        let mut opts = OpenOptions::new();
-        #[cfg(unix)]
-        opts.mode(0o600);
-        write_to_file_with_opts(self.output_file.as_path(), name, bytes, &mut opts)
-    }
-}
-
 /// Options specific to using the Rest endpoint
 #[derive(Debug, Default, Parser)]
 pub struct RestOptions {
@@ -684,7 +377,7 @@ pub struct MovePackageDir {
     /// Example: alice=0x1234, bob=0x5678
     ///
     /// Note: This will fail if there are duplicates in the Move.toml file remove those first.
-    #[clap(long, parse(try_from_str = crate::common::utils::parse_map), default_value = "")]
+    #[clap(long, parse(try_from_str = aptos_cli_base::parse::parse_map), default_value = "")]
     named_addresses: BTreeMap<String, AccountAddressWrapper>,
 }
 

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -1,48 +1,18 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    common::types::{CliError, CliTypedResult, PromptOptions},
-    CliResult,
-};
-use aptos_logger::{debug, Level};
+use aptos_cli_base::types::{CliError, CliResult, CliTypedResult, ResultWrapper};
+use aptos_logger::Level;
 use aptos_rest_client::Client;
 use aptos_telemetry::collect_build_information;
 use aptos_types::chain_id::ChainId;
-use itertools::Itertools;
 use move_deps::move_core_types::account_address::AccountAddress;
 use reqwest::Url;
 use serde::Serialize;
 use std::{
     collections::BTreeMap,
-    env,
-    fs::OpenOptions,
-    io::Write,
-    os::unix::fs::OpenOptionsExt,
-    path::{Path, PathBuf},
-    str::FromStr,
     time::{Duration, Instant},
 };
-
-/// Prompts for confirmation until a yes or no is given explicitly
-pub fn prompt_yes(prompt: &str) -> bool {
-    let mut result: Result<bool, ()> = Err(());
-
-    // Read input until a yes or a no is given
-    while result.is_err() {
-        println!("{} [yes/no] >", prompt);
-        let mut input = String::new();
-        if std::io::stdin().read_line(&mut input).is_err() {
-            continue;
-        }
-        result = match input.trim().to_lowercase().as_str() {
-            "yes" | "y" => Ok(true),
-            "no" | "n" => Ok(false),
-            _ => Err(()),
-        };
-    }
-    result.unwrap()
-}
 
 /// Convert any successful response to Success
 pub async fn to_common_success_result<T>(
@@ -97,108 +67,6 @@ async fn send_telemetry_event(
     .await;
 }
 
-/// A result wrapper for displaying either a correct execution result or an error.
-///
-/// The purpose of this is to have a pretty easy to recognize JSON output format e.g.
-///
-/// {
-///   "Result":{
-///     "encoded":{ ... }
-///   }
-/// }
-///
-/// {
-///   "Error":"Failed to run command"
-/// }
-///
-#[derive(Debug, Serialize)]
-enum ResultWrapper<T> {
-    Result(T),
-    Error(String),
-}
-
-impl<T> From<CliTypedResult<T>> for ResultWrapper<T> {
-    fn from(result: CliTypedResult<T>) -> Self {
-        match result {
-            Ok(inner) => ResultWrapper::Result(inner),
-            Err(inner) => ResultWrapper::Error(inner.to_string()),
-        }
-    }
-}
-
-/// Checks if a file exists, being overridden by `PromptOptions`
-pub fn check_if_file_exists(file: &Path, prompt_options: PromptOptions) -> CliTypedResult<()> {
-    if file.exists() {
-        prompt_yes_with_override(
-            &format!(
-                "{:?} already exists, are you sure you want to overwrite it?",
-                file.as_os_str(),
-            ),
-            prompt_options,
-        )?
-    }
-
-    Ok(())
-}
-
-pub fn prompt_yes_with_override(prompt: &str, prompt_options: PromptOptions) -> CliTypedResult<()> {
-    if prompt_options.assume_no || (!prompt_options.assume_yes && !prompt_yes(prompt)) {
-        Err(CliError::AbortedError)
-    } else {
-        Ok(())
-    }
-}
-
-pub fn read_from_file(path: &Path) -> CliTypedResult<Vec<u8>> {
-    std::fs::read(path)
-        .map_err(|e| CliError::UnableToReadFile(format!("{}", path.display()), e.to_string()))
-}
-
-/// Write a `&[u8]` to a file
-pub fn write_to_file(path: &Path, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
-    write_to_file_with_opts(path, name, bytes, &mut OpenOptions::new())
-}
-
-/// Write a User only read / write file
-pub fn write_to_user_only_file(path: &Path, name: &str, bytes: &[u8]) -> CliTypedResult<()> {
-    let mut opts = OpenOptions::new();
-    #[cfg(unix)]
-    opts.mode(0o600);
-    write_to_file_with_opts(path, name, bytes, &mut opts)
-}
-
-/// Write a `&[u8]` to a file with the given options
-pub fn write_to_file_with_opts(
-    path: &Path,
-    name: &str,
-    bytes: &[u8],
-    opts: &mut OpenOptions,
-) -> CliTypedResult<()> {
-    let mut file = opts
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path)
-        .map_err(|e| CliError::IO(name.to_string(), e))?;
-    file.write_all(bytes)
-        .map_err(|e| CliError::IO(name.to_string(), e))
-}
-
-/// Appends a file extension to a `Path` without overwriting the original extension.
-pub fn append_file_extension(
-    file: &Path,
-    appended_extension: &'static str,
-) -> CliTypedResult<PathBuf> {
-    let extension = file
-        .extension()
-        .map(|extension| extension.to_str().unwrap_or_default());
-    if let Some(extension) = extension {
-        Ok(file.with_extension(extension.to_owned() + "." + appended_extension))
-    } else {
-        Ok(file.with_extension(appended_extension))
-    }
-}
-
 /// Retrieves sequence number from the rest client
 pub async fn get_sequence_number(
     client: &aptos_rest_client::Client,
@@ -220,74 +88,6 @@ pub async fn chain_id(rest_client: &Client) -> CliTypedResult<ChainId> {
         .map_err(|err| CliError::ApiError(err.to_string()))?
         .into_inner();
     Ok(ChainId::new(state.chain_id))
-}
-/// Error message for parsing a map
-const PARSE_MAP_SYNTAX_MSG: &str = "Invalid syntax for map. Example: Name=Value,Name2=Value";
-
-/// Parses an inline map of values
-///
-/// Example: Name=Value,Name2=Value
-pub fn parse_map<K: FromStr + Ord, V: FromStr>(str: &str) -> anyhow::Result<BTreeMap<K, V>>
-where
-    K::Err: 'static + std::error::Error + Send + Sync,
-    V::Err: 'static + std::error::Error + Send + Sync,
-{
-    let mut map = BTreeMap::new();
-
-    // Split pairs by commas
-    for pair in str.split_terminator(',') {
-        // Split pairs by = then trim off any spacing
-        let (first, second): (&str, &str) = pair
-            .split_terminator('=')
-            .collect_tuple()
-            .ok_or_else(|| anyhow::Error::msg(PARSE_MAP_SYNTAX_MSG))?;
-        let first = first.trim();
-        let second = second.trim();
-        if first.is_empty() || second.is_empty() {
-            return Err(anyhow::Error::msg(PARSE_MAP_SYNTAX_MSG));
-        }
-
-        // At this point, we just give error messages appropriate to parsing
-        let key: K = K::from_str(first)?;
-        let value: V = V::from_str(second)?;
-        map.insert(key, value);
-    }
-    Ok(map)
-}
-
-pub fn current_dir() -> CliTypedResult<PathBuf> {
-    env::current_dir().map_err(|err| {
-        CliError::UnexpectedError(format!("Failed to get current directory {}", err))
-    })
-}
-
-pub fn dir_default_to_current(maybe_dir: Option<PathBuf>) -> CliTypedResult<PathBuf> {
-    if let Some(dir) = maybe_dir {
-        Ok(dir)
-    } else {
-        current_dir()
-    }
-}
-
-pub fn create_dir_if_not_exist(dir: &Path) -> CliTypedResult<()> {
-    // Check if the directory exists, if it's not a dir, it will also fail here
-    if !dir.exists() || !dir.is_dir() {
-        std::fs::create_dir_all(dir).map_err(|e| CliError::IO(dir.display().to_string(), e))?;
-        debug!("Created {} folder", dir.display());
-    } else {
-        debug!("{} folder already exists", dir.display());
-    }
-    Ok(())
-}
-
-/// Reads a line from input
-pub fn read_line(input_name: &'static str) -> CliTypedResult<String> {
-    let mut input_buf = String::new();
-    let _ = std::io::stdin()
-        .read_line(&mut input_buf)
-        .map_err(|err| CliError::IO(input_name.to_string(), err))?;
-
-    Ok(input_buf)
 }
 
 /// Fund account (and possibly create it) from a faucet

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -1,22 +1,15 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliError, CliResult, CliTypedResult, CONFIG_FOLDER};
-use crate::common::utils::{
-    create_dir_if_not_exist, current_dir, read_from_file, write_to_user_only_file,
-};
-use crate::genesis::git::{from_yaml, to_yaml};
+use crate::common::types::CliCommand;
 use crate::Tool;
+use aptos_cli_base::config::{ConfigType, GlobalConfig};
+use aptos_cli_base::types::{CliError, CliResult, CliTypedResult};
 use async_trait::async_trait;
-use clap::ArgEnum;
 use clap::CommandFactory;
 use clap::Parser;
 use clap_complete::{generate, Shell};
-use serde::Deserialize;
-use serde::Serialize;
-use std::fmt::Formatter;
 use std::path::PathBuf;
-use std::str::FromStr;
 
 /// Tool for configuration of the CLI tool
 ///
@@ -113,100 +106,5 @@ impl CliCommand<GlobalConfig> for ShowGlobalConfig {
     async fn execute(self) -> CliTypedResult<GlobalConfig> {
         // Load the global config
         GlobalConfig::load()
-    }
-}
-
-const GLOBAL_CONFIG_FILE: &str = "global_config.yaml";
-
-/// A global configuration for global settings related to a user
-#[derive(Serialize, Deserialize, Debug, Default)]
-pub struct GlobalConfig {
-    /// Whether to be using Global or Workspace mode
-    pub config_type: ConfigType,
-}
-
-impl GlobalConfig {
-    pub fn load() -> CliTypedResult<Self> {
-        let path = global_folder()?.join(GLOBAL_CONFIG_FILE);
-        if path.exists() {
-            from_yaml(&String::from_utf8(read_from_file(path.as_path())?)?)
-        } else {
-            // If we don't have a config, let's load the default
-            Ok(GlobalConfig::default())
-        }
-    }
-
-    /// Get the config location based on the type
-    pub fn get_config_location(&self) -> CliTypedResult<PathBuf> {
-        match self.config_type {
-            ConfigType::Global => global_folder(),
-            ConfigType::Workspace => Ok(current_dir()?.join(CONFIG_FOLDER)),
-        }
-    }
-
-    fn save(&self) -> CliTypedResult<()> {
-        let global_folder = global_folder()?;
-        create_dir_if_not_exist(global_folder.as_path())?;
-
-        write_to_user_only_file(
-            global_folder.join(GLOBAL_CONFIG_FILE).as_path(),
-            "Global Config",
-            &to_yaml(&self)?.into_bytes(),
-        )
-    }
-}
-
-fn global_folder() -> CliTypedResult<PathBuf> {
-    if let Some(dir) = dirs::home_dir() {
-        Ok(dir.join(CONFIG_FOLDER))
-    } else {
-        Err(CliError::UnexpectedError(
-            "Unable to retrieve home directory".to_string(),
-        ))
-    }
-}
-
-const GLOBAL: &str = "global";
-const WORKSPACE: &str = "workspace";
-
-/// A configuration for where to place and use the config
-///
-/// Workspace allows for multiple configs based on location, where
-/// Global allows for one config for every part of the code
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, ArgEnum)]
-pub enum ConfigType {
-    /// Per system user configuration put in `<HOME>/.aptos`
-    Global,
-    /// Per directory configuration put in `<CURRENT_DIR>/.aptos`
-    Workspace,
-}
-
-impl Default for ConfigType {
-    fn default() -> Self {
-        // TODO: When we version up, we can change this to global
-        Self::Workspace
-    }
-}
-
-impl std::fmt::Display for ConfigType {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            ConfigType::Global => GLOBAL,
-            ConfigType::Workspace => WORKSPACE,
-        })
-    }
-}
-
-impl FromStr for ConfigType {
-    type Err = CliError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().trim() {
-            GLOBAL => Ok(Self::Global),
-            WORKSPACE => Ok(Self::Workspace),
-            _ => Err(CliError::CommandArgumentError(
-                "Invalid config type, must be one of [global, workspace]".to_string(),
-            )),
-        }
     }
 }

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -1,15 +1,13 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::utils::{create_dir_if_not_exist, dir_default_to_current};
-use crate::{
-    common::{
-        types::{CliError, CliTypedResult, PromptOptions, RngArgs},
-        utils::{check_if_file_exists, read_from_file, write_to_user_only_file},
-    },
-    genesis::git::{from_yaml, to_yaml, GitOptions},
-    CliCommand,
+use crate::{common::types::RngArgs, genesis::git::GitOptions, CliCommand};
+use aptos_cli_base::file::{
+    create_dir_if_not_exist, dir_default_to_current, read_from_file, write_to_user_only_file,
 };
+use aptos_cli_base::parse::{from_yaml, to_yaml};
+use aptos_cli_base::prompts::{check_if_file_exists, PromptOptions};
+use aptos_cli_base::types::{CliError, CliTypedResult};
 use aptos_crypto::{bls12381, PrivateKey};
 use aptos_genesis::{
     config::{HostAndPort, ValidatorConfiguration},

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -6,15 +6,13 @@ pub mod keys;
 #[cfg(test)]
 mod tests;
 
-use crate::common::utils::dir_default_to_current;
 use crate::{
-    common::{
-        types::{CliError, CliTypedResult, PromptOptions},
-        utils::{check_if_file_exists, write_to_file},
-    },
     genesis::git::{Client, GitOptions, LAYOUT_NAME},
-    CliCommand, CliResult,
+    CliCommand,
 };
+use aptos_cli_base::file::{dir_default_to_current, write_to_file};
+use aptos_cli_base::prompts::{check_if_file_exists, PromptOptions};
+use aptos_cli_base::types::{CliError, CliResult, CliTypedResult};
 use aptos_crypto::{bls12381, ed25519::Ed25519PublicKey, x25519, ValidCryptoMaterialStringExt};
 use aptos_genesis::{
     config::{HostAndPort, Layout, ValidatorConfiguration},

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::{
-        types::{PromptOptions, RngArgs},
-        utils::write_to_file,
-    },
+    common::types::RngArgs,
     genesis::{
         git::{GitOptions, SetupGit},
         keys::{GenerateKeys, SetValidatorConfiguration},
@@ -13,6 +10,8 @@ use crate::{
     },
     CliCommand,
 };
+use aptos_cli_base::file::write_to_file;
+use aptos_cli_base::prompts::PromptOptions;
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     PrivateKey,

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -12,7 +12,8 @@ pub mod node;
 pub mod op;
 pub mod test;
 
-use crate::common::types::{CliCommand, CliResult, CliTypedResult};
+use crate::common::types::CliCommand;
+use aptos_cli_base::types::{CliResult, CliTypedResult};
 use async_trait::async_trait;
 use clap::Parser;
 use std::collections::BTreeMap;
@@ -70,7 +71,7 @@ impl CliCommand<BTreeMap<String, String>> for InfoTool {
     }
 
     async fn execute(self) -> CliTypedResult<BTreeMap<String, String>> {
-        let mut build_information: std::collections::BTreeMap<String, String> = BTreeMap::new();
+        let mut build_information: BTreeMap<String, String> = BTreeMap::new();
         build_information.insert(
             aptos_telemetry::build_information::BUILD_BRANCH.into(),
             build::BRANCH.into(),

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -6,8 +6,8 @@
 #![forbid(unsafe_code)]
 
 use aptos::Tool;
+use aptos_cli_base::utils::print_cli_result;
 use clap::Parser;
-use std::process::exit;
 
 #[tokio::main]
 async fn main() {
@@ -15,11 +15,5 @@ async fn main() {
     let result = Tool::parse().execute().await;
 
     // At this point, we'll want to print and determine whether to exit for an error code
-    match result {
-        Ok(inner) => println!("{}", inner),
-        Err(inner) => {
-            println!("{}", inner);
-            exit(1);
-        }
-    }
+    print_cli_result(result);
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -3,17 +3,13 @@
 
 mod aptos_debug_natives;
 
-use crate::common::utils::{create_dir_if_not_exist, dir_default_to_current};
-use crate::{
-    common::{
-        types::{
-            load_account_arg, AccountAddressWrapper, CliError, CliTypedResult, MovePackageDir,
-            PromptOptions, TransactionOptions, TransactionSummary,
-        },
-        utils::check_if_file_exists,
-    },
-    CliCommand, CliResult,
+use crate::common::types::{
+    AccountAddressWrapper, MovePackageDir, TransactionOptions, TransactionSummary,
 };
+use crate::{common::types::load_account_arg, CliCommand};
+use aptos_cli_base::file::{create_dir_if_not_exist, dir_default_to_current};
+use aptos_cli_base::prompts::{check_if_file_exists, PromptOptions};
+use aptos_cli_base::types::{CliError, CliResult, CliTypedResult};
 use aptos_module_verifier::module_init::verify_module_init_function;
 use aptos_rest_client::aptos_api_types::MoveType;
 use aptos_types::transaction::{ModuleBundle, ScriptFunction, TransactionPayload};
@@ -82,7 +78,7 @@ pub struct InitPackage {
     /// Example: alice=0x1234, bob=0x5678
     ///
     /// Note: This will fail if there are duplicates in the Move.toml file remove those first.
-    #[clap(long, parse(try_from_str = crate::common::utils::parse_map), default_value = "")]
+    #[clap(long, parse(try_from_str = aptos_cli_base::parse::parse_map), default_value = "")]
     named_addresses: BTreeMap<String, AccountAddressWrapper>,
     #[clap(flatten)]
     prompt_options: PromptOptions,

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1,19 +1,13 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::PromptOptions;
-use crate::common::utils::prompt_yes_with_override;
-use crate::config::GlobalConfig;
-use crate::{
-    common::{
-        types::{
-            CliCommand, CliError, CliResult, CliTypedResult, ProfileOptions, RestOptions,
-            TransactionOptions,
-        },
-        utils::read_from_file,
-    },
-    genesis::git::from_yaml,
-};
+use crate::common::types::{RestOptions, TransactionOptions};
+use crate::CliCommand;
+use aptos_cli_base::config::{GlobalConfig, ProfileOptions};
+use aptos_cli_base::file::read_from_file;
+use aptos_cli_base::parse::from_yaml;
+use aptos_cli_base::prompts::{prompt_yes_with_override, PromptOptions};
+use aptos_cli_base::types::{CliError, CliResult, CliTypedResult};
 use aptos_config::config::NodeConfig;
 use aptos_crypto::{bls12381, x25519, ValidCryptoMaterialStringExt};
 use aptos_faucet::FaucetArgs;

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::{
-        types::{
-            CliError, CliTypedResult, EncodingOptions, EncodingType, ExtractPublicKey, KeyType,
-            PrivateKeyInputOptions, ProfileOptions, RngArgs, SaveFile,
-        },
-        utils::{append_file_extension, check_if_file_exists, write_to_file},
+    common::types::{
+        EncodingOptions, EncodingType, ExtractPublicKey, KeyType, PrivateKeyInputOptions, RngArgs,
     },
-    CliCommand, CliResult,
+    CliCommand,
 };
+use aptos_cli_base::config::ProfileOptions;
+use aptos_cli_base::file::{append_file_extension, write_to_file, SaveFile};
+use aptos_cli_base::prompts::check_if_file_exists;
+use aptos_cli_base::types::{CliError, CliResult, CliTypedResult};
 use aptos_config::config::{Peer, PeerRole};
 use aptos_crypto::{ed25519, x25519, PrivateKey, ValidCryptoMaterial};
 use aptos_types::account_address::{from_identity_public_key, AccountAddress};

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -15,12 +15,14 @@ use crate::{
     common::{
         init::InitTool,
         types::{
-            CliConfig, CliTypedResult, EncodingOptions, PrivateKeyInputOptions, ProfileOptions,
-            PromptOptions, RestOptions, RngArgs, TransactionOptions,
+            EncodingOptions, PrivateKeyInputOptions, RestOptions, RngArgs, TransactionOptions,
         },
     },
     CliCommand,
 };
+use aptos_cli_base::config::{CliConfig, ProfileOptions};
+use aptos_cli_base::prompts::PromptOptions;
+use aptos_cli_base::types::CliTypedResult;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_crypto::{bls12381, x25519};
 use aptos_genesis::config::HostAndPort;


### PR DESCRIPTION
### Description
This allows others to build on top of parsers for the config
as well as allows us to reuse code across multiple CLIs.

Additionally, I've cut down the number of dependencies, so
it hopefully can build faster if we split the tool into
multiple pieces.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2267)
<!-- Reviewable:end -->
