### PR TITLE
Add type info equality function, tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9071,6 +9071,7 @@ dependencies = [
  "fail 0.5.0",
  "move-deps",
  "rand 0.7.3",
+ "scratchpad",
  "storage-interface",
  "vm-genesis",
 ]

--- a/aptos-move/framework/aptos-framework/sources/type_info.move
+++ b/aptos-move/framework/aptos-framework/sources/type_info.move
@@ -19,9 +19,9 @@ module aptos_framework::type_info {
 
     public native fun type_of<T>(): TypeInfo;
 
-    /// Return `true` if `type_info_1` and `type_info_2` are the same,
-    /// else `false`
-    public fun are_same_type_info(
+    /// Return `true` if `type_info_1` and `type_info_2` are equal, else
+    /// `false`
+    public fun are_equal(
         type_info_1: &TypeInfo,
         type_info_2: &TypeInfo
     ): bool {
@@ -39,24 +39,24 @@ module aptos_framework::type_info {
     }
 
     #[test]
-    fun test_are_same_type_info() {
+    fun test_are_equal() {
         let type_info = type_of<TypeInfo>();
-        // Verify same type infos assesed as such
-        assert!(are_same_type_info(&type_info, &type_info), 0);
+        // Verify same type infos assessed as such
+        assert!(are_equal(&type_info, &type_info), 0);
         let type_info_2 = copy type_info; // Copy reference type info
         // Assign a different struct name to copy
         type_info_2.struct_name = b"DifferentType";
         // Verify different type infos from same module assessed as such
-        assert!(!are_same_type_info(&type_info, &type_info_2), 1);
+        assert!(!are_equal(&type_info, &type_info_2), 1);
         let type_info_3 = copy type_info; // Copy reference type info
         // Assign a different module name to copy
         type_info_3.module_name = b"different_module";
         // Verify false return when only module name different
-        assert!(!are_same_type_info(&type_info, &type_info_3), 2);
+        assert!(!are_equal(&type_info, &type_info_3), 2);
         let type_info_4 = copy type_info; // Copy reference type info
         // Assign a different account address to copy
         type_info_4.account_address = @core_resources;
         // Verify false return when only account address different
-        assert!(!are_same_type_info(&type_info, &type_info_4), 3);
+        assert!(!are_equal(&type_info, &type_info_4), 3);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/type_info.move
+++ b/aptos-move/framework/aptos-framework/sources/type_info.move
@@ -19,11 +19,44 @@ module aptos_framework::type_info {
 
     public native fun type_of<T>(): TypeInfo;
 
+    /// Return `true` if `type_info_1` and `type_info_2` are the same,
+    /// else `false`
+    public fun are_same_type_info(
+        type_info_1: &TypeInfo,
+        type_info_2: &TypeInfo
+    ): bool {
+        type_info_1.account_address == type_info_2.account_address &&
+        type_info_1.module_name == type_info_2.module_name &&
+        type_info_1.struct_name == type_info_2.struct_name
+    }
+
     #[test]
     fun test() {
         let type_info = type_of<TypeInfo>();
         assert!(account_address(&type_info) == @aptos_framework, 0);
         assert!(module_name(&type_info) == b"type_info", 1);
         assert!(struct_name(&type_info) == b"TypeInfo", 2);
+    }
+
+    #[test]
+    fun test_are_same_type_info() {
+        let type_info = type_of<TypeInfo>();
+        // Verify same type infos assesed as such
+        assert!(are_same_type_info(&type_info, &type_info), 0);
+        let type_info_2 = copy type_info; // Copy reference type info
+        // Assign a different struct name to copy
+        type_info_2.struct_name = b"DifferentType";
+        // Verify different type infos from same module assessed as such
+        assert!(!are_same_type_info(&type_info, &type_info_2), 1);
+        let type_info_3 = copy type_info; // Copy reference type info
+        // Assign a different module name to copy
+        type_info_3.module_name = b"different_module";
+        // Verify false return when only module name different
+        assert!(!are_same_type_info(&type_info, &type_info_3), 2);
+        let type_info_4 = copy type_info; // Copy reference type info
+        // Assign a different account address to copy
+        type_info_4.account_address = @core_resources;
+        // Verify false return when only account address different
+        assert!(!are_same_type_info(&type_info, &type_info_4), 3);
     }
 }

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -353,10 +353,7 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
     )?;
 
     // Create the chunk executor
-    let chunk_executor = Arc::new(
-        ChunkExecutor::<AptosVM>::new(db_rw.clone())
-            .map_err(|err| anyhow!("Failed to create chunk executor {}", err))?,
-    );
+    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
 
     // Create the state sync multiplexer
     let state_sync_multiplexer = StateSyncMultiplexer::new(

--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+### 1.2.1 (2022-07-23)
+
+
+### Features
+
+* deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
+* memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
+* **mutiagent:** support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
+* support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
+
+
+### Bug Fixes
+
+* get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
+* **ts-sdk:** fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
+
 ## 1.2.0 (2022-06-28)
 
 ### Features

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -58,5 +58,5 @@
     "typescript-memoize": "^1.1.0",
     "yarn": "^1.22.18"
   },
-  "version": "1.2.0"
+  "version": "1.2.1"
 }

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -76,6 +76,9 @@ pub trait ChunkExecutorTrait: Send + Sync {
 
     /// Resets the chunk executor by synchronizing state with storage.
     fn reset(&self) -> Result<()>;
+
+    /// Finishes the chunk executor by releasing memory held by inner data structures(SMT).
+    fn finish(&self);
 }
 
 pub struct StateSnapshotDelta {
@@ -89,7 +92,7 @@ pub trait BlockExecutorTrait: Send + Sync {
     fn committed_block_id(&self) -> HashValue;
 
     /// Reset the internal state including cache with newly fetched latest committed block from storage.
-    fn reset(&self) -> Result<(), Error>;
+    fn reset(&self);
 
     /// Executes a block.
     fn execute_block(
@@ -125,6 +128,9 @@ pub trait BlockExecutorTrait: Send + Sync {
             true, /* save_state_snapshots */
         )
     }
+
+    /// Finishes the block executor by releasing memory held by inner data structures(SMT).
+    fn finish(&self);
 }
 
 pub trait TransactionReplayer: Send {

--- a/execution/executor/src/block_executor.rs
+++ b/execution/executor/src/block_executor.rs
@@ -6,6 +6,7 @@
 use crate::logging::{LogEntry, LogSchema};
 use anyhow::Result;
 use aptos_crypto::HashValue;
+use aptos_infallible::RwLock;
 use aptos_logger::prelude::*;
 use aptos_state_view::StateViewId;
 use aptos_types::{
@@ -31,11 +32,90 @@ use storage_interface::{jmt_updates, DbReaderWriter};
 
 pub struct BlockExecutor<V> {
     pub db: DbReaderWriter,
+    inner: RwLock<Option<BlockExecutorInner<V>>>,
+}
+
+impl<V> BlockExecutor<V>
+where
+    V: VMExecutor,
+{
+    pub fn new(db: DbReaderWriter) -> Self {
+        Self {
+            db,
+            inner: RwLock::new(None),
+        }
+    }
+
+    pub fn root_smt(&self) -> SparseMerkleTree<StateValue> {
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .root_smt()
+    }
+
+    fn maybe_initialize(&self) {
+        if self.inner.read().is_none() {
+            self.reset();
+        }
+    }
+}
+
+impl<V> BlockExecutorTrait for BlockExecutor<V>
+where
+    V: VMExecutor,
+{
+    fn committed_block_id(&self) -> HashValue {
+        self.maybe_initialize();
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .committed_block_id()
+    }
+
+    fn reset(&self) {
+        *self.inner.write() = Some(BlockExecutorInner::new(self.db.clone()));
+    }
+
+    fn execute_block(
+        &self,
+        block: (HashValue, Vec<Transaction>),
+        parent_block_id: HashValue,
+    ) -> Result<StateComputeResult, Error> {
+        self.maybe_initialize();
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .execute_block(block, parent_block_id)
+    }
+
+    fn commit_blocks_ext(
+        &self,
+        block_ids: Vec<HashValue>,
+        ledger_info_with_sigs: LedgerInfoWithSignatures,
+        save_state_snapshots: bool,
+    ) -> Result<Option<StateSnapshotDelta>, Error> {
+        self.inner
+            .read()
+            .as_ref()
+            .expect("BlockExecutor is not reset")
+            .commit_blocks_ext(block_ids, ledger_info_with_sigs, save_state_snapshots)
+    }
+
+    fn finish(&self) {
+        *self.inner.write() = None;
+    }
+}
+
+struct BlockExecutorInner<V> {
+    db: DbReaderWriter,
     block_tree: BlockTree,
     phantom: PhantomData<V>,
 }
 
-impl<V> BlockExecutor<V>
+impl<V> BlockExecutorInner<V>
 where
     V: VMExecutor,
 {
@@ -48,7 +128,7 @@ where
         }
     }
 
-    pub fn root_smt(&self) -> SparseMerkleTree<StateValue> {
+    fn root_smt(&self) -> SparseMerkleTree<StateValue> {
         self.block_tree
             .root_block()
             .output
@@ -59,16 +139,12 @@ where
     }
 }
 
-impl<V> BlockExecutorTrait for BlockExecutor<V>
+impl<V> BlockExecutorInner<V>
 where
     V: VMExecutor,
 {
     fn committed_block_id(&self) -> HashValue {
         self.block_tree.root_block().id
-    }
-
-    fn reset(&self) -> Result<(), Error> {
-        Ok(self.block_tree.reset(&self.db.reader)?)
     }
 
     fn execute_block(

--- a/execution/executor/src/components/chunk_commit_queue.rs
+++ b/execution/executor/src/components/chunk_commit_queue.rs
@@ -16,10 +16,7 @@ pub struct ChunkCommitQueue {
 
 impl ChunkCommitQueue {
     pub fn new_from_db(db: &Arc<dyn DbReader>) -> Result<Self> {
-        let persisted_view = db
-            .get_startup_info()?
-            .ok_or_else(|| anyhow!("DB not bootstrapped."))?
-            .into_latest_executed_trees();
+        let persisted_view = db.get_latest_executed_trees()?;
         Ok(Self::new(persisted_view))
     }
 

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -28,7 +28,7 @@ pub fn fuzz_execute_and_commit_chunk(
     verified_target_li: LedgerInfoWithSignatures,
 ) {
     let db = DbReaderWriter::new(FakeDb {});
-    let executor = ChunkExecutor::<FakeVM>::new(db).unwrap();
+    let executor = ChunkExecutor::<FakeVM>::new(db);
 
     let _events = executor.execute_and_commit_chunk(txn_list_with_proof, &verified_target_li, None);
 }

--- a/execution/executor/src/tests/chunk_executor_tests.rs
+++ b/execution/executor/src/tests/chunk_executor_tests.rs
@@ -35,7 +35,7 @@ impl TestExecutor {
         let genesis = vm_genesis::test_genesis_transaction();
         let waypoint = generate_waypoint::<MockVM>(&db, &genesis).unwrap();
         maybe_bootstrap::<MockVM>(&db, &genesis, waypoint).unwrap();
-        let executor = ChunkExecutor::new(db.clone()).unwrap();
+        let executor = ChunkExecutor::new(db.clone());
 
         TestExecutor {
             _path: path,
@@ -216,7 +216,7 @@ fn test_executor_execute_and_commit_chunk_restart() {
 
     // Then we restart executor and resume to the next chunk.
     {
-        let executor = ChunkExecutor::<MockVM>::new(db.clone()).unwrap();
+        let executor = ChunkExecutor::<MockVM>::new(db.clone());
 
         executor
             .execute_and_commit_chunk(chunks[1].clone(), &ledger_info, None)
@@ -264,7 +264,9 @@ fn test_executor_execute_and_commit_chunk_local_result_mismatch() {
     }
 
     // Fork starts. Should fail.
+    chunk_manager.finish();
     chunk_manager.reset().unwrap();
+
     assert!(chunk_manager
         .execute_and_commit_chunk(chunks[0].clone(), &ledger_info, None)
         .is_err());

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -722,14 +722,14 @@ proptest! {
 
         // Commit the first chunk without committing the ledger info.
         let TestExecutor { _path, db, executor } = TestExecutor::new();
-        ChunkExecutor::<MockVM>::new(db).unwrap()
+        ChunkExecutor::<MockVM>::new(db)
             .execute_and_commit_chunk(txn_list_with_proof_to_commit, &ledger_info, None).unwrap();
 
         first_block_txns.extend(overlap_txn_list_with_proof.transactions);
         let second_block_txns = ((chunk_size + overlap_size + 1..=chunk_size + overlap_size + num_new_txns)
                              .map(|i| encode_mint_transaction(gen_address(i), 100))).collect::<Vec<_>>();
 
-        executor.reset().unwrap();
+        executor.reset();
         let parent_block_id = executor.committed_block_id();
         let first_block_id = gen_block_id(1);
         let _output1 = executor.execute_block(

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -365,7 +365,7 @@ mod tests {
             .unwrap();
 
         // Create an executor proxy
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw));
         let mut executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Publish a subscribed event
@@ -567,7 +567,7 @@ mod tests {
             .unwrap();
 
         // Create an executor
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
         let mut executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Verify that the initial configs returned to the subscriber don't contain the unknown on-chain config
@@ -650,7 +650,7 @@ mod tests {
 
         // Create the executors
         let block_executor = Box::new(BlockExecutor::<AptosVM>::new(db_rw.clone()));
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw));
         let executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         (

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -175,7 +175,7 @@ pub(crate) mod test_utils {
             .unwrap();
 
         // Create executor proxy
-        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw));
         let executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Get initial state

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -371,6 +371,8 @@ impl<
                     )));
                 }
             }
+            self.reset_active_stream();
+            self.storage_synchronizer.finish_chunk_executor(); // The bootstrapper is now complete
         }
 
         Ok(())

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -470,6 +470,7 @@ impl<
         // so that in the event another sync request occurs, we have a fresh state.
         if !self.active_sync_request() {
             self.continuous_syncer.reset_active_stream();
+            self.storage_synchronizer.finish_chunk_executor(); // Consensus is now in control
         }
         Ok(())
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -92,7 +92,11 @@ pub trait StorageSynchronizerInterface {
 
     /// Resets the chunk executor. This is required to support continuous
     /// interaction between consensus and state sync.
-    fn reset_chunk_executor(&mut self) -> Result<(), Error>;
+    fn reset_chunk_executor(&self) -> Result<(), Error>;
+
+    /// Finish the chunk executor at this round of state sync by releasing
+    /// any in-memory resources to prevent memory leak.
+    fn finish_chunk_executor(&self);
 }
 
 /// The implementation of the `StorageSynchronizerInterface` used by state sync
@@ -311,13 +315,17 @@ impl<ChunkExecutor: ChunkExecutorTrait + 'static> StorageSynchronizerInterface
         }
     }
 
-    fn reset_chunk_executor(&mut self) -> Result<(), Error> {
+    fn reset_chunk_executor(&self) -> Result<(), Error> {
         self.chunk_executor.reset().map_err(|error| {
             Error::UnexpectedError(format!(
                 "Failed to reset the chunk executor! Error: {:?}",
                 error
             ))
         })
+    }
+
+    fn finish_chunk_executor(&self) {
+        self.chunk_executor.finish()
     }
 }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -265,7 +265,7 @@ async fn create_driver_for_tests(
         mempool_notifications::new_mempool_notifier_listener_pair();
 
     // Create the chunk executor
-    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()).unwrap());
+    let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
 
     // Create a streaming service client
     let (streaming_service_client, _) = new_streaming_service_client_listener_pair();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -108,6 +108,9 @@ pub fn create_ready_storage_synchronizer(expect_reset_executor: bool) -> MockSto
         .return_const(false);
     if expect_reset_executor {
         mock_storage_synchronizer
+            .expect_finish_chunk_executor()
+            .return_const(());
+        mock_storage_synchronizer
             .expect_reset_chunk_executor()
             .return_const(Ok(()));
     }
@@ -150,6 +153,8 @@ mock! {
         fn commit_chunk(&self) -> Result<ChunkCommitNotification>;
 
         fn reset(&self) -> Result<()>;
+
+        fn finish(&self);
     }
 }
 
@@ -422,7 +427,9 @@ mock! {
             state_value_chunk_with_proof: StateValueChunkWithProof,
         ) -> Result<(), crate::error::Error>;
 
-        fn reset_chunk_executor(&mut self) -> Result<(), crate::error::Error>;
+        fn reset_chunk_executor(&self) -> Result<(), crate::error::Error>;
+
+        fn finish_chunk_executor(&self);
     }
     impl Clone for StorageSynchronizer {
         fn clone(&self) -> Self;

--- a/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
@@ -245,7 +245,7 @@ mod tests {
             mempool_notifier,
             consensus_listener,
             db_rw.clone(),
-            Arc::new(ChunkExecutor::<AptosVM>::new(db_rw).unwrap()),
+            Arc::new(ChunkExecutor::<AptosVM>::new(db_rw)),
             &node_config,
             Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::random())),
             event_subscription_service,

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -40,7 +40,7 @@ use futures::{
 };
 use itertools::zip_eq;
 use std::{cmp::min, pin::Pin, sync::Arc, time::Instant};
-use storage_interface::{DbReader, DbReaderWriter};
+use storage_interface::DbReaderWriter;
 use structopt::StructOpt;
 use tokio::io::BufReader;
 
@@ -409,12 +409,7 @@ impl TransactionRestoreBatchController {
         restore_handler.maybe_reset_state_store(expected_latest_version);
         let replay_start = Instant::now();
         let db = DbReaderWriter::from_arc(Arc::clone(&restore_handler.aptosdb));
-        let persisted_view = restore_handler.aptosdb.get_latest_executed_trees()?;
-        assert_eq!(
-            persisted_view.state().current_version,
-            first_version.checked_sub(1)
-        );
-        let chunk_replayer = Arc::new(ChunkExecutor::<AptosVM>::new_with_view(db, persisted_view));
+        let chunk_replayer = Arc::new(ChunkExecutor::<AptosVM>::new(db));
 
         let db_commit_stream = txns_to_execute_stream
             .try_chunks(BATCH_SIZE)

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -13,7 +13,7 @@
 pwd | grep -qE 'aptos-core$' || (echo "Please run from aptos-core root directory" && exit 1)
 
 # for calculating regression
-TPS_THRESHOLD=5000
+TPS_THRESHOLD=3500
 P99_LATENCY_MS_THRESHOLD=6000
 
 FORGE_OUTPUT=${FORGE_OUTPUT:-forge_output.txt}

--- a/vm-validator/Cargo.toml
+++ b/vm-validator/Cargo.toml
@@ -19,6 +19,7 @@ aptos-vm = { path = "../aptos-move/aptos-vm" }
 
 executor = { path = "../execution/executor" }
 executor-types = { path = "../execution/executor-types" }
+scratchpad = { path = "../storage/scratchpad" }
 storage-interface = { path = "../storage/storage-interface" }
 
 [dev-dependencies]


### PR DESCRIPTION
@movekevin @davidiw @wrwg

The proposed changes add an `aptos_framework::type_info::are_same_type_info` function that returns `true` when both arguments refer to identical `TypeInfo` fields. Tests included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2268)
<!-- Reviewable:end -->
