### PR TITLE
[Forge] Increase the latency threshold and decrease load

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -248,7 +248,7 @@ impl<'t> TxnEmitter<'t> {
         let workers_per_endpoint = match req.workers_per_endpoint {
             Some(x) => x,
             None => {
-                let target_threads = 1200;
+                let target_threads = 800;
                 // Trying to create somewhere between target_threads/2..target_threads threads
                 // We want to have equal numbers of threads for each endpoint, so that they are equally loaded
                 // Otherwise things like flamegrap/perf going to show different numbers depending on which endpoint is chosen

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -53,7 +53,7 @@ pub struct SuccessCriteriaArgs {
     // general options
     #[structopt(long, default_value = "3500")]
     avg_tps: usize,
-    #[structopt(long, default_value = "8000")]
+    #[structopt(long, default_value = "10000")]
     max_latency_ms: usize,
 }
 


### PR DESCRIPTION
### Description

There is a regression in forge TPS and latency after https://github.com/aptos-labs/aptos-core/pull/2241. Updating the threshold for now until we land a bunch of improvements on storage side to speed it up.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2269)
<!-- Reviewable:end -->
