### PR TITLE
[forge] prometheus integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ dependencies = [
  "inspection-service",
  "k8s-openapi",
  "kube",
+ "prometheus-http-query",
  "rand 0.7.3",
  "rayon",
  "regex",
@@ -6350,6 +6351,19 @@ dependencies = [
  "memchr",
  "parking_lot 0.11.2",
  "thiserror",
+]
+
+[[package]]
+name = "prometheus-http-query"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae2f6a3f14ff35c16b51ac796d1dc73c15ad6472c48836c6c467f6d52266648"
+dependencies = [
+ "reqwest",
+ "serde 1.0.137",
+ "serde_json",
+ "time 0.3.9",
+ "url",
 ]
 
 [[package]]

--- a/terraform/helm/k8s-metrics/values.yaml
+++ b/terraform/helm/k8s-metrics/values.yaml
@@ -11,11 +11,8 @@ autoscaler:
     repo: k8s.gcr.io/autoscaling/cluster-autoscaler
     tag: v1.21.0
   resources:
-    limits:
-      cpu: 100m
-      memory: 600Mi
     requests:
-      cpu: 100m
-      memory: 600Mi
+      cpu: 1
+      memory: 1Gi
   serviceAccount:
     annotations:

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -20,6 +20,7 @@ hyper = { version = "0.14.18", features = ["full"] }
 hyper-tls = "0.5.0"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_15"] }
 kube = "0.51.0"
+prometheus-http-query = "0.5.2"
 rand = "0.7.3"
 rayon = "1.5.2"
 regex = "1.5.5"

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -10,6 +10,7 @@ use std::{convert::TryInto, num::NonZeroUsize};
 pub mod chaos;
 mod cluster_helper;
 pub mod node;
+pub mod prometheus;
 mod swarm;
 
 pub use cluster_helper::*;

--- a/testsuite/forge/src/backend/k8s/prometheus.rs
+++ b/testsuite/forge/src/backend/k8s/prometheus.rs
@@ -1,0 +1,124 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Result;
+
+use anyhow::bail;
+use aptos_logger::info;
+use prometheus_http_query::{response::PromqlResult, Client as PrometheusClient};
+use std::{collections::BTreeMap, convert::TryFrom};
+
+pub fn get_prometheus_client() -> Result<PrometheusClient> {
+    let prom_url =
+        std::env::var("PROMETHEUS_URL").unwrap_or_else(|_| "http://127.0.0.1:9090".to_string());
+    info!("Attempting to create prometheus client with: {} ", prom_url);
+    match PrometheusClient::try_from(prom_url) {
+        Ok(c) => Ok(c),
+        Err(e) => bail!("Failed to create client {}", e),
+    }
+}
+
+fn construct_query_with_extra_labels(query: &str, labels_map: BTreeMap<String, String>) -> String {
+    // edit the query string to insert swarm metadata
+    let mut new_query = query.to_string();
+    let mut label_start_idx = query.find('{').unwrap_or(query.len());
+    if label_start_idx == query.len() {
+        // add a new curly and insert after it
+        new_query.insert_str(query.len(), "{}");
+        label_start_idx += 1;
+    } else {
+        // add a comma prefix to the existing labels and insert before it
+        label_start_idx += 1;
+        new_query.insert(label_start_idx, ',');
+    }
+
+    let mut labels_strs = vec![];
+    for (k, v) in labels_map {
+        labels_strs.push(format!(r#"{}="{}""#, k, v));
+    }
+
+    let labels = labels_strs.join(",");
+
+    // assume no collisions in Forge namespace
+    new_query.insert_str(label_start_idx, &labels);
+    new_query
+}
+
+pub async fn query_with_metadata(
+    prom_client: &PrometheusClient,
+    query: &str,
+    time: Option<i64>,
+    timeout: Option<i64>,
+    labels_map: BTreeMap<String, String>,
+) -> Result<PromqlResult> {
+    let new_query = construct_query_with_extra_labels(query, labels_map);
+    match prom_client.query(&new_query, time, timeout).await {
+        Ok(r) => Ok(r),
+        Err(e) => bail!(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prometheus_http_query::Error as PrometheusError;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_query_prometheus() {
+        let client = get_prometheus_client().unwrap();
+
+        // try a simple instant query
+        // if it fails to connect to a prometheus instance, skip the test
+        let query = r#"rate(container_cpu_usage_seconds_total{pod=~".*validator.*", container="validator"}[1m])"#;
+        let response = client.query(query, None, None).await;
+        match response {
+            Ok(pres) => println!("{:?}", pres),
+            Err(PrometheusError::Client(e)) => {
+                println!("Skipping test. Failed to create prometheus client: {}", e);
+                return;
+            }
+            Err(e) => panic!("Expected PromqlResult: {}", e),
+        }
+
+        // try a range query
+        let start = SystemTime::now();
+        let since_the_epoch = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
+        let start_timestamp: i64 = (since_the_epoch - 60) as i64;
+        let end_timestamp: i64 = since_the_epoch as i64;
+        let step = 15.0;
+
+        let response = client
+            .query_range(query, start_timestamp, end_timestamp, step, None)
+            .await;
+        match response {
+            Ok(pres) => println!("{:?}", pres),
+            _ => panic!("Expected PromqlResult"),
+        }
+    }
+
+    #[test]
+    fn test_create_query() {
+        // test when no existing labels
+        let original_query = "aptos_connections";
+        let mut labels_map = BTreeMap::new();
+        labels_map.insert("a".to_string(), "a".to_string());
+        labels_map.insert("some_label".to_string(), "blabla".to_string());
+        let expected_query = r#"aptos_connections{a="a",some_label="blabla"}"#;
+        let new_query = construct_query_with_extra_labels(original_query, labels_map);
+        assert_eq!(expected_query, new_query);
+
+        // test when existing labels
+        let original_query = r#"aptos_connections{abc="123",def="456"}"#;
+        let mut labels_map = BTreeMap::new();
+        labels_map.insert("a".to_string(), "a".to_string());
+        labels_map.insert("some_label".to_string(), "blabla".to_string());
+        let expected_query = r#"aptos_connections{a="a",some_label="blabla",abc="123",def="456"}"#;
+        let new_query = construct_query_with_extra_labels(original_query, labels_map);
+        assert_eq!(expected_query, new_query);
+    }
+}

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -15,6 +15,7 @@ use aptos_sdk::{
         PeerId,
     },
 };
+use prometheus_http_query::response::PromqlResult;
 use std::{
     collections::HashMap,
     fs, mem,
@@ -530,6 +531,15 @@ impl Swarm for LocalSwarm {
     }
 
     fn remove_chaos(&mut self, _chaos: SwarmChaos) -> Result<()> {
+        todo!()
+    }
+
+    async fn query_metrics(
+        &self,
+        _query: &str,
+        _time: Option<i64>,
+        _timeout: Option<i64>,
+    ) -> Result<PromqlResult> {
         todo!()
     }
 }

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -7,6 +7,7 @@ use aptos_config::config::NodeConfig;
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::types::PeerId;
 use futures::future::try_join_all;
+use prometheus_http_query::response::PromqlResult;
 use std::time::{Duration, Instant};
 use tokio::runtime::Runtime;
 
@@ -67,6 +68,14 @@ pub trait Swarm: Sync {
     /// Injects all types of chaos
     fn inject_chaos(&mut self, chaos: SwarmChaos) -> Result<()>;
     fn remove_chaos(&mut self, chaos: SwarmChaos) -> Result<()>;
+
+    // Get prometheus metrics from the swarm
+    async fn query_metrics(
+        &self,
+        query: &str,
+        time: Option<i64>,
+        timeout: Option<i64>,
+    ) -> Result<PromqlResult>;
 }
 
 impl<T: ?Sized> SwarmExt for T where T: Swarm {}


### PR DESCRIPTION
### Description

Implement `Swarm::query_metrics`, which uses the [`prometheus_http_query` crate](https://docs.rs/prometheus-http-query/latest/prometheus_http_query/index.html) to connect to a prometheus instance. This will allow us to define specific SuccessCriteria that are backed by metrics.

### Test Plan

New unit tests written and can be run with `cargo test -p forge`. 

```
running 4 tests
test backend::k8s::prometheus::tests::test_create_query ... ok
test backend::k8s::cluster_helper::tests::test_create_namespace_final_error ... ok
test backend::k8s::cluster_helper::tests::test_create_namespace_retryable_error ... ok
test backend::k8s::prometheus::tests::test_query_prometheus ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s
```

One of the tests attempts to connect to a remote prometheus instance, and is skipped when a connection cannot be established. Running that one specifically:

```
$ cargo test --package forge --lib -- backend::k8s::prometheus::tests::test_query_prometheus --exact --nocapture 

running 1 test
Vector([InstantVector { metric: {"pod": "aptos-node-0-validator-0", "job": "kubernetes-cadvisor", "name": "k8s_validator_aptos-node-0-validator-0_default_538b025c-9c7a-4c82-a7b3-e619328caba2_0", "instance": "ip-192-168-148-34.us-west-2.compute.internal", "cpu": "total", "container": "validator", "id": "/kubepods/pod538b025c-9c7a-4c82-a7b3-e619328caba2/34fd0e2ed64c8e0a4ed7696d3e9f0ab832adeeda115c71d0324c680c24485da4", "image": "sha256:8be5a56b0c4bd0999fe5ceb9b8e1621e93f4a564671fc72689192b82af78b550", "namespace": "default"}, sample: Sample { timestamp: 1658951241.966, value: 2.207069435013394 } }, InstantVector { metric: {"image": "sha256:8be5a56b0c4bd0999fe5ceb9b8e1621e93f4a564671fc72689192b82af78b550", "id": "/kubepods/podbdffdbc5-6988-4252-9671-12c54a759066/403d916d2015cbe0fa439e6947ac5d5ddbeb49ae5dfa1a2a2a21385847427c96", "instance": "ip-192-168-138-74.us-west-2.compute.internal", "namespace": "default", "cpu": "total", "job": "kubernetes-cadvisor", "pod": "aptos-node-1-validator-0", "container": "validator", "name": "k8s_validator_aptos-node-1-validator-0_default_bdffdbc5-6988-4252-9671-12c54a759066_0"}, sample: Sample { timestamp: 1658951241.966, value: 1.866661638971126 } }, InstantVector { metric: {"namespace": "default", "container": "validator", "image": "sha256:8be5a56b0c4bd0999fe5ceb9b8e1621e93f4a564671fc72689192b82af78b550", "job": "kubernetes-cadvisor", "pod": "aptos-node-2-validator-0", "id": "/kubepods/podca959c8e-0d0e-4059-8dd0-559aa28dd359/809839ea954972dd51da23a2c5c34e68eebbc0a88fbd6ba4d94f11fe403d1095", "name": "k8s_validator_aptos-node-2-validator-0_default_ca959c8e-0d0e-4059-8dd0-559aa28dd359_0", "cpu": "total", "instance": "ip-192-168-138-60.us-west-2.compute.internal"}, sample: Sample { timestamp: 1658951241.966, value: 2.2009283806412157 } }])
Matrix([RangeVector { metric: {"job": "kubernetes-cadvisor", "container": "validator", "namespace": "default", "pod": "aptos-node-0-validator-0", "image": "sha256:8be5a56b0c4bd0999fe5ceb9b8e1621e93f4a564671fc72689192b82af78b550", "name": "k8s_validator_aptos-node-0-validator-0_default_538b025c-9c7a-4c82-a7b3-e619328caba2_0", "cpu": "total", "id": "/kubepods/pod538b025c-9c7a-4c82-a7b3-e619328caba2/34fd0e2ed64c8e0a4ed7696d3e9f0ab832adeeda115c71d0324c680c24485da4", "instance": "ip-192-168-148-34.us-west-2.compute.internal"}, samples: [Sample { timestamp: 1658951181.0, value: 2.1873577830803064 }, Sample { timestamp: 1658951196.0, value: 2.2068716645669695 }, Sample { timestamp: 1658951211.0, value: 1.5770287892189236 }, Sample { timestamp: 1658951226.0, value: 2.2131553999557387 }, Sample { timestamp: 1658951241.0, value: 2.207069435013394 }] }, RangeVector { metric: {"image": "sha256:8be5a56b0c4bd0999fe5ceb9b8e1621e93f4a564671fc72689192b82af78b550", "container": "validator", "job": "kubernetes-cadvisor", "id": "/kubepods/podbdffdbc5-6988-4252-9671-12c54a759066/403d916d2015cbe0fa439e6947ac5d5ddbeb49ae5dfa1a2a2a21385847427c96", "pod": "aptos-node-1-validator-0", "instance": "ip-192-168-138-74.us-west-2.compute.internal", "cpu": "total", "name": "k8s_validator_aptos-node-1-validator-0_default_bdffdbc5-6988-4252-9671-12c54a759066_0", "namespace": "default"}, samples: [Sample { timestamp: 1658951181.0, value: 2.2290832905366207 }, Sample { timestamp: 1658951196.0, value: 2.2326568012248313 }, Sample { timestamp: 1658951211.0, value: 2.2294168275305792 }, Sample { timestamp: 1658951226.0, value: 2.243018561151044 }, Sample { timestamp: 1658951241.0, value: 2.248718996471661 }] }, RangeVector { metric: {"image": "sha256:8be5a56b0c4bd0999fe5ceb9b8e1621e93f4a564671fc72689192b82af78b550", "name": "k8s_validator_aptos-node-2-validator-0_default_ca959c8e-0d0e-4059-8dd0-559aa28dd359_0", "job": "kubernetes-cadvisor", "container": "validator", "pod": "aptos-node-2-validator-0", "cpu": "total", "namespace": "default", "id": "/kubepods/podca959c8e-0d0e-4059-8dd0-559aa28dd359/809839ea954972dd51da23a2c5c34e68eebbc0a88fbd6ba4d94f11fe403d1095", "instance": "ip-192-168-138-60.us-west-2.compute.internal"}, samples: [Sample { timestamp: 1658951181.0, value: 2.1698954600128935 }, Sample { timestamp: 1658951196.0, value: 2.193123890413416 }, Sample { timestamp: 1658951211.0, value: 2.203820358819186 }, Sample { timestamp: 1658951226.0, value: 2.20703870266103 }, Sample { timestamp: 1658951241.0, value: 2.2009283806412157 }] }])
test backend::k8s::prometheus::tests::test_query_prometheus ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.11s
```


<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2270)
<!-- Reviewable:end -->
