### PR TITLE
[cli][smoke-test] Make genesis and stake configurable in swarm and test e2e validator runbook

### DIFF
--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -107,10 +107,13 @@ pub fn new_test_context(test_name: String, api_version: &str) -> TestContext {
         cached_framework_packages::module_blobs().to_vec(),
     )
     .unwrap()
-    .with_min_price_per_gas_unit(0)
-    .with_min_lockup_duration_secs(0)
-    .with_max_lockup_duration_secs(86400)
-    .with_initial_lockup_timestamp(0)
+    .with_init_genesis_config(Some(Arc::new(|genesis_config| {
+        genesis_config.min_price_per_gas_unit = 0;
+        genesis_config.min_lockup_duration_secs = 0;
+        genesis_config.max_lockup_duration_secs = 86400;
+        // changed from lockup_timestamp being 0
+        genesis_config.initial_lockup_duration_secs = 0;
+    })))
     .with_randomize_first_validator_ports(false);
 
     let (root_key, genesis, genesis_waypoint, validators) = builder.build(&mut rng).unwrap();

--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -14,10 +14,6 @@ pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
         cached_framework_packages::module_blobs().to_vec(),
     )
     .unwrap()
-    .with_template(NodeConfig::default_for_validator())
-    .with_min_lockup_duration_secs(0)
-    .with_max_lockup_duration_secs(86400)
-    .with_initial_lockup_timestamp(0)
     .build(StdRng::from_seed([0; 32]))
     .unwrap();
     let (

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -141,6 +141,9 @@ impl CliCommand<Transaction> for UnlockStake {
 pub struct WithdrawStake {
     #[clap(flatten)]
     pub(crate) node_op_options: TransactionOptions,
+    /// Amount of coins to withdraw
+    #[clap(long)]
+    pub amount: u64,
 }
 
 #[async_trait]
@@ -151,7 +154,13 @@ impl CliCommand<Transaction> for WithdrawStake {
 
     async fn execute(mut self) -> CliTypedResult<Transaction> {
         self.node_op_options
-            .submit_script_function(AccountAddress::ONE, "stake", "withdraw", vec![], vec![])
+            .submit_script_function(
+                AccountAddress::ONE,
+                "stake",
+                "withdraw",
+                vec![],
+                vec![bcs::to_bytes(&self.amount)?],
+            )
             .await
     }
 }

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::{Factory, GenesisConfig, Result, Swarm, Version};
 use anyhow::{bail, Context};
-use aptos_genesis::builder::InitConfigFn;
+use aptos_genesis::builder::{InitConfigFn, InitGenesisConfigFn};
 use rand::rngs::StdRng;
 use std::{
     collections::HashMap,
@@ -16,7 +16,7 @@ mod cargo;
 mod node;
 mod swarm;
 pub use node::LocalNode;
-pub use swarm::{LocalSwarm, LocalSwarmBuilder, SwarmDirectory};
+pub use swarm::{LocalSwarm, SwarmDirectory};
 
 #[derive(Clone, Debug)]
 pub struct LocalVersion {
@@ -113,7 +113,7 @@ impl LocalFactory {
         R: ::rand::RngCore + ::rand::CryptoRng,
     {
         let version = self.versions.keys().max().unwrap();
-        self.new_swarm_with_version(rng, number_of_validators, version, None, 1, None)
+        self.new_swarm_with_version(rng, number_of_validators, version, None, None, None)
             .await
     }
 
@@ -123,23 +123,24 @@ impl LocalFactory {
         number_of_validators: NonZeroUsize,
         version: &Version,
         genesis_modules: Option<Vec<Vec<u8>>>,
-        min_price_per_gas_unit: u64,
         init_config: Option<InitConfigFn>,
+        init_genesis_config: Option<InitGenesisConfigFn>,
     ) -> Result<LocalSwarm>
     where
         R: ::rand::RngCore + ::rand::CryptoRng,
     {
         println!("Preparing a new swarm");
-        let mut builder = LocalSwarm::builder(self.versions.clone())
-            .number_of_validators(number_of_validators)
-            .initial_version(version.clone())
-            .min_price_per_gas_unit(min_price_per_gas_unit)
-            .with_init_config(init_config);
-        if let Some(genesis_modules) = genesis_modules {
-            builder = builder.genesis_modules(genesis_modules);
-        }
+        let mut swarm = LocalSwarm::build(
+            rng,
+            number_of_validators,
+            self.versions.clone(),
+            Some(version.clone()),
+            init_config,
+            init_genesis_config,
+            None,
+            genesis_modules,
+        )?;
 
-        let mut swarm = builder.build(rng)?;
         swarm
             .launch()
             .await
@@ -173,7 +174,7 @@ impl Factory for LocalFactory {
             None => None,
         };
         let swarm = self
-            .new_swarm_with_version(rng, node_num, version, genesis_modules, 1, None)
+            .new_swarm_with_version(rng, node_num, version, genesis_modules, None, None)
             .await?;
 
         Ok(Box::new(swarm))

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::aptos_cli::setup_cli_test;
+use crate::smoke_test_environment::SwarmBuilder;
 use anyhow::anyhow;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_config::{config::ApiConfig, utils::get_available_port};
@@ -29,7 +29,10 @@ pub async fn setup_test(
     num_nodes: usize,
     num_accounts: usize,
 ) -> (LocalSwarm, CliTestFramework, JoinHandle<()>, RosettaClient) {
-    let (swarm, cli, faucet) = setup_cli_test(num_nodes, num_accounts).await;
+    let (swarm, cli, faucet) = SwarmBuilder::new_local(num_nodes)
+        .with_aptos()
+        .build_with_cli(num_accounts)
+        .await;
     let validator = swarm.validators().next().unwrap();
 
     // And the client
@@ -161,6 +164,7 @@ async fn test_account_balance() {
     .await
     .unwrap();
 
+    // TODO: Receive money by faucet
     // TODO: Make a bad transaction, which will cause gas to be spent but no transfer
 }
 

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    smoke_test_environment::{new_local_swarm_with_aptos, new_local_swarm_with_aptos_and_config},
+    smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
     test_utils::{assert_balance, create_and_fund_account, transfer_coins},
 };
 use forge::{NodeExt, Swarm, SwarmExt};
@@ -21,13 +21,13 @@ async fn test_basic_state_synchronization() {
     // - Verify that the restarted node has synced up with the submitted transactions.
 
     // we set a smaller chunk limit (=5) here to properly test multi-chunk state sync
-    let mut swarm = new_local_swarm_with_aptos_and_config(
-        4,
-        Arc::new(|_, config| {
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.chunk_limit = 5;
-        }),
-    )
-    .await;
+        }))
+        .build()
+        .await;
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
 
     let client_1 = swarm

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    smoke_test_environment::{new_local_swarm_with_aptos, new_local_swarm_with_aptos_and_config},
+    smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
     test_utils::{create_and_fund_account, transfer_and_reconfig, transfer_coins},
 };
 use aptos_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
@@ -196,17 +196,17 @@ async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_c
 #[tokio::test]
 async fn test_validator_bootstrap_outputs() {
     // Create a swarm of 4 validators with state sync v2 enabled (output syncing)
-    let swarm = new_local_swarm_with_aptos_and_config(
-        4,
-        Arc::new(|_, config| {
+    let swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ApplyTransactionOutputsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
                 ContinuousSyncingMode::ApplyTransactionOutputs;
-        }),
-    )
-    .await;
+        }))
+        .build()
+        .await;
 
     // Test the ability of the validators to sync
     test_validator_sync(swarm).await;
@@ -215,17 +215,17 @@ async fn test_validator_bootstrap_outputs() {
 #[tokio::test]
 async fn test_validator_bootstrap_transactions() {
     // Create a swarm of 4 validators with state sync v2 enabled (transaction syncing)
-    let swarm = new_local_swarm_with_aptos_and_config(
-        4,
-        Arc::new(|_, config| {
+    let swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
                 ContinuousSyncingMode::ExecuteTransactions;
-        }),
-    )
-    .await;
+        }))
+        .build()
+        .await;
 
     // Test the ability of the validators to sync
     test_validator_sync(swarm).await;
@@ -283,17 +283,17 @@ async fn test_validator_sync(mut swarm: LocalSwarm) {
 async fn test_validator_failure_bootstrap_outputs() {
     // Create a swarm of 4 validators with state sync v2 enabled (account
     // bootstrapping and transaction output application).
-    let swarm = new_local_swarm_with_aptos_and_config(
-        4,
-        Arc::new(|_, config| {
+    let swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
                 ContinuousSyncingMode::ApplyTransactionOutputs;
-        }),
-    )
-    .await;
+        }))
+        .build()
+        .await;
 
     // Test the ability of the validators to sync
     test_all_validator_failures(swarm).await;
@@ -303,17 +303,17 @@ async fn test_validator_failure_bootstrap_outputs() {
 async fn test_validator_failure_bootstrap_execution() {
     // Create a swarm of 4 validators with state sync v2 enabled (account
     // bootstrapping and transaction execution).
-    let swarm = new_local_swarm_with_aptos_and_config(
-        4,
-        Arc::new(|_, config| {
+    let swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
             config.state_sync.state_sync_driver.continuous_syncing_mode =
                 ContinuousSyncingMode::ExecuteTransactions;
-        }),
-    )
-    .await;
+        }))
+        .build()
+        .await;
 
     // Test the ability of the validators to sync
     test_all_validator_failures(swarm).await;
@@ -379,13 +379,13 @@ async fn test_all_validator_failures(mut swarm: LocalSwarm) {
 #[ignore]
 async fn test_single_validator_failure() {
     // Create a swarm of 1 validator
-    let mut swarm = new_local_swarm_with_aptos_and_config(
-        1,
-        Arc::new(|_, mut config| {
+    let mut swarm = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, mut config, _| {
             config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
-        }),
-    )
-    .await;
+        }))
+        .build()
+        .await;
 
     // Execute multiple transactions
     let validator = swarm.validators_mut().next().unwrap();


### PR DESCRIPTION
### Description

- Made genesis and stake configurable from local swarm tests
- In order to do that nicely, without every test needing to set everything, add SwarmBuilder. 
- removed LocalSwarmBuilder that was used always with same configuration

### Test Plan

Unit test added follows the full validator e2e runbook  from AIT2 :
https://aptos.dev/nodes/ait/connect-to-testnet#joining-validator-set
https://aptos.dev/nodes/ait/connect-to-testnet/#leaving-validator-set

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2273)
<!-- Reviewable:end -->
