### PR TITLE
[forge] label test runner pods with image tag

### DIFF
--- a/terraform/helm/aptos-node/templates/_helpers.tpl
+++ b/terraform/helm/aptos-node/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "aptos-validator.labels" -}}
+{{ toYaml .Values.labels }}
 helm.sh/chart: {{ include "aptos-validator.chart" . }}
 {{ include "aptos-validator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -47,6 +48,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "aptos-validator.selectorLabels" -}}
+{{ toYaml .Values.labels }}
 app.kubernetes.io/part-of: {{ include "aptos-validator.name" . }}
 app.kubernetes.io/managed-by: helm
 {{- end -}}

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -120,3 +120,6 @@ podSecurityPolicy: true
 
 # Load test-data for starting a test network
 loadTestGenesis: false
+
+# Additional labels
+labels:

--- a/terraform/helm/genesis/templates/_helpers.tpl
+++ b/terraform/helm/genesis/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "aptos-genesis.labels" -}}
+{{ toYaml .Values.labels }}
 helm.sh/chart: {{ include "aptos-genesis.chart" . }}
 {{ include "aptos-genesis.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -47,6 +48,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "aptos-genesis.selectorLabels" -}}
+{{ toYaml .Values.labels }}
 app.kubernetes.io/part-of: {{ include "aptos-genesis.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -47,3 +47,6 @@ serviceAccount:
 
 # LEGACY: create PodSecurityPolicy, which exists at the cluster-level
 podSecurityPolicy: true
+
+# Additional labels
+labels:

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {FORGE_POD_NAME}
   labels:
     app.kubernetes.io/name: forge
+    forge-namespace: {FORGE_NAMESPACE}
+    forge-image-tag: {IMAGE_TAG}
 spec:
   restartPolicy: Never
   serviceAccountName: forge
@@ -20,6 +22,8 @@ spec:
     env:
     - name: FORGE_TRIGGERED_BY
       value: {FORGE_TRIGGERED_BY}
+    # - name: RUST_LOG
+    #   value: debug
   affinity:
     # avoid scheduling with other forge or validator/fullnode pods
     podAntiAffinity:

--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-values.yaml
@@ -28,3 +28,7 @@ service:
       type: "ClusterIP"
     enableRestApi: true
     enableMetricsPort: true
+
+labels:
+  forge-namespace: {namespace}
+  forge-image-tag: {image_tag}

--- a/testsuite/forge/src/backend/k8s/helm-values/genesis-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/genesis-values.yaml
@@ -15,3 +15,7 @@ genesis:
   fullnode:
     # use non-HAProxy service for fullnode AptosNet in genesis
     internal_host_suffix: {fullnode_internal_host_suffix}
+
+labels:
+  forge-namespace: {namespace}
+  forge-image-tag: {image_tag}


### PR DESCRIPTION
### Description

Make forge test runner pod names more descriptive and non-overlapping. Include in the pod name the Forge namespace, timestamp, and image_tag/git_ref. 

Also label all resources managed by Forge (the test runner, all resources in the included helm releases) with labels `forge-namespace` and `forge-image-tag`. We could consider labeling with the Github actions run ID too, but we'd need to propagate that into the rust code.

Also fix a big that was re-introduced where the test runner acquires a namespace by pre-empting another test runner, but fails on the k8s API 409 error code instead of continuing.

### Test Plan

Run forge with k8s test runner. Then run another one in the same namespace and let them pre-empt each other.

Run it the first time with a known namespace. Test runner pod starts with the name `forge-rustie-test-1659115106-e9dcb772a90b6941d73053bbc473257c768`

```
$ IMAGE_TAG=$(git rev-parse HEAD) FORGE_NAMESPACE=forge-rustie-test ./testsuite/run_forge.sh
```

Run it a second time and preempt. Test runner pod starts with the name `forge-rustie-test-1659115193-e9dcb772a90b6941d73053bbc473257c768`
```
$ IMAGE_TAG=$(git rev-parse HEAD) FORGE_NAMESPACE=forge-rustie-test ./testsuite/run_forge.sh
...
{"level":"INFO","source":{"package":"forge","file":"testsuite/forge/src/backend/k8s/cluster_helper.rs:701"},"thread_name":"main","hostname":"forge-rustie-test-1659115193-e9dcb772a90b6941d73053bbc473257c76","timestamp":"2022-07-29T17:19:57.033416Z","message":"Namespace forge-rustie-test already exists, continuing with it"}

test continues as it should...
```

The first instance exits with a good exit code, but knows that it has been preempted. This will help keep the `main` branch green when many PRs land in succession and their Forge runs are pre-empted, eliminating some of the noise we've seen on `main` with preempted Forge runs reporting "failed"
```
Forge test preempted on `e9dcb772a90b6941d73053bbc473257c768cffe7`: command not found
...
Forge exit with: 0
```

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2276)
<!-- Reviewable:end -->
