### PR TITLE
[storage][pruner] Separate state pruners and ledger pruners into two …

### DIFF
--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -69,3 +69,11 @@ pub trait DBPruner {
         self.target_version() > self.min_readable_version()
     }
 }
+
+pub enum Command {
+    Quit,
+    Prune {
+        /// The target DB version for the pruner.
+        target_db_version: Option<Version>,
+    },
+}

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -77,10 +77,7 @@ fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
     // start pruning events batches of size 2 and verify transactions have been pruned from DB
     for i in (0..=num_versions).step_by(2) {
         pruner
-            .wake_and_wait(
-                i as u64, /* latest_version */
-                PrunerIndex::LedgerPrunerIndex as usize,
-            )
+            .wake_and_wait_ledger_pruner(i as u64 /* latest_version */)
             .unwrap();
         // ensure that all events up to i * 2 has been pruned
         for j in 0..i {
@@ -125,7 +122,7 @@ fn verify_event_store_pruner_disabled(events: Vec<Vec<ContractEvent>>) {
     // Verify no pruning has happened.
     for _i in (0..=num_versions).step_by(2) {
         pruner
-            .ensure_disabled(PrunerIndex::LedgerPrunerIndex as usize)
+            .ensure_disabled(PrunerIndex::LedgerPrunerIndex)
             .unwrap();
         // ensure that all events up to i * 2 are valid in DB
         for version in 0..num_versions {

--- a/storage/aptosdb/src/pruner/ledger_pruner_worker.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_worker.rs
@@ -3,55 +3,45 @@
 use aptos_types::transaction::Version;
 use schemadb::DB;
 
-use crate::pruner::{db_pruner::DBPruner, utils};
-use crate::PrunerIndex;
+use crate::pruner::{db_pruner, db_pruner::DBPruner, utils};
 use aptos_config::config::StoragePrunerConfig;
 use aptos_infallible::Mutex;
 use std::sync::{mpsc::Receiver, Arc};
 
-/// Maintains all the DBPruners and periodically calls the db_pruner's prune method to prune the DB.
+/// Maintains the ledger pruner and periodically calls the db_pruner's prune method to prune the DB.
 /// This also exposes API to report the progress to the parent thread.
-pub struct Worker {
-    command_receiver: Receiver<Command>,
-    /// State store pruner. If a pruner is not enabled, its value will be None.
-    state_pruner: Option<Mutex<Arc<dyn DBPruner + Send + Sync>>>,
+pub struct LedgerPrunerWorker {
+    command_receiver: Receiver<db_pruner::Command>,
     /// Ledger pruner. If a pruner is not enabled, its value will be None.
     ledger_pruner: Option<Mutex<Arc<dyn DBPruner + Send + Sync>>>,
     /// Keeps a record of the pruning progress. If this equals to version `V`, we know versions
     /// smaller than `V` are no longer readable.
     /// This being an atomic value is to communicate the info with the Pruner thread (for tests).
     /// If the pruner is disabled, its value will be None.
-    min_readable_versions: Arc<Mutex<Vec<Option<Version>>>>,
+    min_readable_version: Arc<Mutex<Option<Version>>>,
     /// Indicates if there's NOT any pending work to do currently, to hint
     /// `Self::receive_commands()` to `recv()` blocking-ly.
     blocking_recv: bool,
     /// Max items to prune per batch. For the ledger pruner, this means the max versions to prune
     /// and for the state pruner, this means the max stale nodes to prune.
     ledger_store_max_versions_to_prune_per_batch: u64,
-    state_store_max_nodes_to_prune_per_batch: u64,
 }
 
-impl Worker {
+impl LedgerPrunerWorker {
     pub(crate) fn new(
         ledger_db: Arc<DB>,
-        state_merkle_db: Arc<DB>,
-        command_receiver: Receiver<Command>,
-        min_readable_versions: Arc<Mutex<Vec<Option<Version>>>>,
+        command_receiver: Receiver<db_pruner::Command>,
+        min_readable_version: Arc<Mutex<Option<Version>>>,
         storage_pruner_config: StoragePrunerConfig,
     ) -> Self {
-        let state_pruner = utils::create_state_pruner(state_merkle_db, storage_pruner_config);
         let ledger_pruner = utils::create_ledger_pruner(ledger_db, storage_pruner_config);
         Self {
-            state_pruner,
             ledger_pruner,
             command_receiver,
-            min_readable_versions,
+            min_readable_version,
             blocking_recv: true,
             ledger_store_max_versions_to_prune_per_batch: storage_pruner_config
                 .ledger_pruning_batch_size
-                as u64,
-            state_store_max_nodes_to_prune_per_batch: storage_pruner_config
-                .state_store_pruning_batch_size
                 as u64,
         }
     }
@@ -62,18 +52,6 @@ impl Worker {
             // in case `Command::Quit` is received (that's when we should quit.)
             let mut error_in_pruning = false;
             let mut pruning_pending = false;
-
-            if let Some(state_pruner) = &self.state_pruner {
-                let state_store_pruner = state_pruner.lock();
-                state_store_pruner
-                    .prune(self.state_store_max_nodes_to_prune_per_batch as usize)
-                    .map_err(|_| error_in_pruning = true)
-                    .ok();
-
-                if state_store_pruner.is_pruning_pending() {
-                    pruning_pending = true;
-                }
-            }
 
             if let Some(ledger_pruner) = &self.ledger_pruner {
                 let ledger_pruner = ledger_pruner.lock();
@@ -97,16 +75,10 @@ impl Worker {
     }
 
     fn record_progress(&mut self) {
-        let updated_min_readable_versions: Vec<Option<Version>> = vec![
-            self.state_pruner
-                .as_ref()
-                .map(|state_pruner| state_pruner.lock().min_readable_version()),
-            self.ledger_pruner
-                .as_ref()
-                .map(|ledger_pruner| ledger_pruner.lock().min_readable_version()),
-        ];
-
-        *self.min_readable_versions.lock() = updated_min_readable_versions;
+        *self.min_readable_version.lock() = self
+            .ledger_pruner
+            .as_ref()
+            .map(|ledger_pruner| ledger_pruner.lock().min_readable_version());
     }
 
     /// Tries to receive all pending commands, blocking waits for the next command if no work needs
@@ -118,12 +90,12 @@ impl Worker {
     fn receive_commands(&mut self) -> bool {
         loop {
             let command = if self.blocking_recv {
-                // Worker has nothing to do, blocking wait for the next command.
+                // LedgerPrunerWorker has nothing to do, blocking wait for the next command.
                 self.command_receiver
                     .recv()
                     .expect("Sender should not destruct prematurely.")
             } else {
-                // Worker has pending work to do, non-blocking recv.
+                // LedgerPrunerWorker has pending work to do, non-blocking recv.
                 match self.command_receiver.try_recv() {
                     Ok(command) => command,
                     // Channel has drained, yield control to the outer loop.
@@ -133,26 +105,9 @@ impl Worker {
 
             match command {
                 // On `Command::Quit` inform the outer loop to quit by returning `false`.
-                Command::Quit => return false,
-                Command::Prune { target_db_versions } => {
-                    if let Some(state_pruner_target_version) =
-                        target_db_versions[PrunerIndex::StateStorePrunerIndex as usize]
-                    {
-                        if let Some(state_pruner) = &self.state_pruner {
-                            if state_pruner_target_version > state_pruner.lock().target_version() {
-                                // Switch to non-blocking to allow some work to be done after the
-                                // channel has drained.
-                                self.blocking_recv = false;
-                            }
-                            state_pruner
-                                .lock()
-                                .set_target_version(state_pruner_target_version);
-                        }
-                    }
-
-                    if let Some(ledger_pruner_target_version) =
-                        target_db_versions[PrunerIndex::LedgerPrunerIndex as usize]
-                    {
+                db_pruner::Command::Quit => return false,
+                db_pruner::Command::Prune { target_db_version } => {
+                    if let Some(ledger_pruner_target_version) = target_db_version {
                         if let Some(ledger_pruner) = &self.ledger_pruner {
                             if ledger_pruner_target_version > ledger_pruner.lock().target_version()
                             {
@@ -169,14 +124,4 @@ impl Worker {
             }
         }
     }
-}
-
-pub enum Command {
-    Quit,
-    Prune {
-        /// The first element represents the target DB version for state store pruner while the
-        /// second element is for ledger pruner. If a pruner is not enabled, the corresponding
-        /// value is None.
-        target_db_versions: Vec<Option<Version>>,
-    },
 }

--- a/storage/aptosdb/src/pruner/state_pruner_worker.rs
+++ b/storage/aptosdb/src/pruner/state_pruner_worker.rs
@@ -1,0 +1,125 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+use aptos_types::transaction::Version;
+use schemadb::DB;
+
+use crate::pruner::{db_pruner, db_pruner::DBPruner, utils};
+use aptos_config::config::StoragePrunerConfig;
+use aptos_infallible::Mutex;
+use std::sync::{mpsc::Receiver, Arc};
+
+/// Maintains the state store pruner and periodically calls the db_pruner's prune method to prune
+/// the DB. This also exposes API to report the progress to the parent thread.
+pub struct StatePrunerWorker {
+    command_receiver: Receiver<db_pruner::Command>,
+    /// State store pruner. If a pruner is not enabled, its value will be None.
+    state_pruner: Option<Mutex<Arc<dyn DBPruner + Send + Sync>>>,
+    /// Keeps a record of the pruning progress. If this equals to version `V`, we know versions
+    /// smaller than `V` are no longer readable.
+    /// This being an atomic value is to communicate the info with the Pruner thread (for tests).
+    /// If the pruner is disabled, its value will be None.
+    min_readable_version: Arc<Mutex<Option<Version>>>,
+    /// Indicates if there's NOT any pending work to do currently, to hint
+    /// `Self::receive_commands()` to `recv()` blocking-ly.
+    blocking_recv: bool,
+    /// Max items to prune per batch (i.e. the max stale nodes to prune.)
+    state_store_max_nodes_to_prune_per_batch: u64,
+}
+
+impl StatePrunerWorker {
+    pub(crate) fn new(
+        state_merkle_db: Arc<DB>,
+        command_receiver: Receiver<db_pruner::Command>,
+        min_readable_version: Arc<Mutex<Option<Version>>>,
+        storage_pruner_config: StoragePrunerConfig,
+    ) -> Self {
+        let state_pruner = utils::create_state_pruner(state_merkle_db, storage_pruner_config);
+        Self {
+            state_pruner,
+            command_receiver,
+            min_readable_version,
+            blocking_recv: true,
+            state_store_max_nodes_to_prune_per_batch: storage_pruner_config
+                .state_store_pruning_batch_size
+                as u64,
+        }
+    }
+
+    pub(crate) fn work(mut self) {
+        while self.receive_commands() {
+            // Process a reasonably small batch of work before trying to receive commands again,
+            // in case `Command::Quit` is received (that's when we should quit.)
+            let mut error_in_pruning = false;
+            let mut pruning_pending = false;
+
+            if let Some(state_pruner) = &self.state_pruner {
+                let state_store_pruner = state_pruner.lock();
+                state_store_pruner
+                    .prune(self.state_store_max_nodes_to_prune_per_batch as usize)
+                    .map_err(|_| error_in_pruning = true)
+                    .ok();
+
+                if state_store_pruner.is_pruning_pending() {
+                    pruning_pending = true;
+                }
+            }
+
+            if !pruning_pending || error_in_pruning {
+                self.blocking_recv = true;
+            } else {
+                self.blocking_recv = false;
+            }
+            self.record_progress();
+        }
+    }
+
+    fn record_progress(&mut self) {
+        *self.min_readable_version.lock() = self
+            .state_pruner
+            .as_ref()
+            .map(|state_pruner| state_pruner.lock().min_readable_version());
+    }
+
+    /// Tries to receive all pending commands, blocking waits for the next command if no work needs
+    /// to be done, otherwise quits with `true` to allow the outer loop to do some work before
+    /// getting back here.
+    ///
+    /// Returns `false` if `Command::Quit` is received, to break the outer loop and let
+    /// `work_loop()` return.
+    fn receive_commands(&mut self) -> bool {
+        loop {
+            let command = if self.blocking_recv {
+                // Worker has nothing to do, blocking wait for the next command.
+                self.command_receiver
+                    .recv()
+                    .expect("Sender should not destruct prematurely.")
+            } else {
+                // Worker has pending work to do, non-blocking recv.
+                match self.command_receiver.try_recv() {
+                    Ok(command) => command,
+                    // Channel has drained, yield control to the outer loop.
+                    Err(_) => return true,
+                }
+            };
+
+            match command {
+                // On `Command::Quit` inform the outer loop to quit by returning `false`.
+                db_pruner::Command::Quit => return false,
+                db_pruner::Command::Prune { target_db_version } => {
+                    if let Some(state_pruner_target_version) = target_db_version {
+                        if let Some(state_pruner) = &self.state_pruner {
+                            if state_pruner_target_version > state_pruner.lock().target_version() {
+                                // Switch to non-blocking to allow some work to be done after the
+                                // channel has drained.
+                                self.blocking_recv = false;
+                            }
+                            state_pruner
+                                .lock()
+                                .set_target_version(state_pruner_target_version);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -94,10 +94,7 @@ fn test_state_store_pruner() {
     // Prune till version=0. This should basically be a no-op
     {
         pruner
-            .wake_and_wait(
-                0, /* latest_version */
-                PrunerIndex::StateStorePrunerIndex as usize,
-            )
+            .wake_and_wait_state_pruner(0 /* latest_version */)
             .unwrap();
         for i in 0..num_versions {
             verify_state_in_store(
@@ -109,23 +106,11 @@ fn test_state_store_pruner() {
         }
     }
 
-    // Test for batched pruning, since we use a batch size of 10, updating the latest version to
-    // less than 10 should not perform any actual pruning.
-    assert!(pruner
-        .wake_and_wait(
-            5, /* latest_version */
-            PrunerIndex::StateStorePrunerIndex as usize,
-        )
-        .is_err());
-
     // Notify the pruner to update the version to be 10 - since we use a batch size of 10,
     // we expect versions 0 to 9 to be pruned.
     {
         pruner
-            .wake_and_wait(
-                prune_batch_size as u64, /* latest_version */
-                PrunerIndex::StateStorePrunerIndex as usize,
-            )
+            .wake_and_wait_state_pruner(prune_batch_size as u64 /* latest_version */)
             .unwrap();
         for i in 0..prune_batch_size {
             assert!(state_store
@@ -214,10 +199,7 @@ fn test_state_store_pruner_partial_version() {
     // Prune till version=0. This should basically be a no-op
     {
         pruner
-            .wake_and_wait(
-                0, /* latest_version */
-                PrunerIndex::StateStorePrunerIndex as usize,
-            )
+            .wake_and_wait_state_pruner(0 /* latest_version */)
             .unwrap();
         verify_state_in_store(state_store, key1.clone(), Some(&value1), 1);
         verify_state_in_store(state_store, key2.clone(), Some(&value2_update), 1);
@@ -228,10 +210,7 @@ fn test_state_store_pruner_partial_version() {
     // should prune 1 stale node with the version 0.
     {
         assert!(pruner
-            .wake_and_wait(
-                1, /* latest_version */
-                PrunerIndex::StateStorePrunerIndex as usize,
-            )
+            .wake_and_wait_state_pruner(1 /* latest_version */,)
             .is_ok());
         assert!(state_store
             .get_state_value_with_proof_by_version(&key1, 0_u64)
@@ -244,23 +223,14 @@ fn test_state_store_pruner_partial_version() {
     // Prune 3 more times. All version 0 and 1 stale nodes should be gone.
     {
         assert!(pruner
-            .wake_and_wait(
-                2, /* latest_version */
-                PrunerIndex::StateStorePrunerIndex as usize,
-            )
+            .wake_and_wait_state_pruner(2 /* latest_version */,)
             .is_ok());
         assert!(pruner
-            .wake_and_wait(
-                2, /* latest_version */
-                PrunerIndex::StateStorePrunerIndex as usize,
-            )
+            .wake_and_wait_state_pruner(2 /* latest_version */,)
             .is_ok());
 
         assert!(pruner
-            .wake_and_wait(
-                2, /* latest_version */
-                PrunerIndex::StateStorePrunerIndex as usize,
-            )
+            .wake_and_wait_state_pruner(2 /* latest_version */,)
             .is_ok());
         assert!(state_store
             .get_state_value_with_proof_by_version(&key1, 0_u64)
@@ -325,7 +295,7 @@ fn test_state_store_pruner_disabled() {
     // Prune till version=0. This should basically be a no-op
     {
         pruner
-            .ensure_disabled(PrunerIndex::StateStorePrunerIndex as usize)
+            .ensure_disabled(PrunerIndex::StateStorePrunerIndex)
             .unwrap();
         for i in 0..num_versions {
             verify_state_in_store(
@@ -341,7 +311,7 @@ fn test_state_store_pruner_disabled() {
     // we expect versions 0 to 9 to be pruned.
     {
         pruner
-            .ensure_disabled(PrunerIndex::StateStorePrunerIndex as usize)
+            .ensure_disabled(PrunerIndex::StateStorePrunerIndex)
             .unwrap();
         for i in 0..prune_batch_size {
             assert!(state_store
@@ -397,11 +367,10 @@ fn test_worker_quit_eagerly() {
 
     {
         let (command_sender, command_receiver) = channel();
-        let worker = Worker::new(
-            Arc::clone(&db),
+        let worker = StatePrunerWorker::new(
             Arc::clone(&aptos_db.state_merkle_db),
             command_receiver,
-            Arc::new(Mutex::new(vec![Some(0), Some(0)])), /* progress */
+            Arc::new(Mutex::new(Some(0))), /* progress */
             StoragePrunerConfig {
                 state_store_prune_window: Some(1),
                 ledger_prune_window: Some(1),
@@ -410,16 +379,16 @@ fn test_worker_quit_eagerly() {
             },
         );
         command_sender
-            .send(Command::Prune {
-                target_db_versions: vec![Some(1), Some(0)],
+            .send(db_pruner::Command::Prune {
+                target_db_version: Some(1),
             })
             .unwrap();
         command_sender
-            .send(Command::Prune {
-                target_db_versions: vec![Some(2), Some(0)],
+            .send(db_pruner::Command::Prune {
+                target_db_version: Some(2),
             })
             .unwrap();
-        command_sender.send(Command::Quit).unwrap();
+        command_sender.send(db_pruner::Command::Quit).unwrap();
         // Worker quits immediately although `Command::Quit` is not the first command sent.
         worker.work();
         verify_state_in_store(state_store, key.clone(), Some(&value0), 0);

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -69,10 +69,7 @@ fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {
     // start pruning write sets in batches of size 2 and verify transactions have been pruned from DB
     for i in (0..=num_write_sets).step_by(2) {
         pruner
-            .wake_and_wait(
-                i as u64, /* latest_version */
-                PrunerIndex::LedgerPrunerIndex as usize,
-            )
+            .wake_and_wait_ledger_pruner(i as u64 /* latest_version */)
             .unwrap();
         // ensure that all transaction up to i * 2 has been pruned
         for j in 0..i {
@@ -120,14 +117,11 @@ fn verify_txn_store_pruner(
     // start pruning transactions batches of size step_size and verify transactions have been pruned from DB
     for i in (0..=num_transaction).step_by(step_size) {
         pruner
-            .wake_and_wait(
-                i as u64, /* latest_version */
-                PrunerIndex::LedgerPrunerIndex as usize,
-            )
+            .wake_and_wait_ledger_pruner(i as u64 /* latest_version */)
             .unwrap();
         // ensure that all transaction up to i * 2 has been pruned
         assert_eq!(
-            *pruner.last_version_sent_to_pruners.as_ref().lock(),
+            *pruner.last_version_sent_to_state_pruner.as_ref().lock(),
             i as u64
         );
         for j in 0..i {


### PR DESCRIPTION
### Description
- Separate `worker.rs` into `state_pruner_worker.rs` and `ledger_pruner_worker.rs` and create two separate threads and their corresponding variables in `pruner/mod.rs`.
- State pruner will be triggered every round while the ledger pruner will only be triggered if there are X pending number of versions to prune.
- Each pruner still uses a channel to receive pruning commands. A single thread is used to both receive commands and process prunings.
- The next step is to get rid of the channels and use one thread to set the target versions and two separate threads to prune, one for state pruner and one for ledger pruner.

### Test Plan
Existing UTs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2288)
<!-- Reviewable:end -->
