### PR TITLE
Bump maxkb pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,8 @@ repos:
       - id: end-of-file-fixer
         files: \.(rs|move)$
       - id: check-added-large-files
+        args:
+          - --maxkb=2000
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
     hooks:


### PR DESCRIPTION
We have files larger than the 500kb default (package.json in the SDK), and I need to generate a file that is similar to that existing file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2293)
<!-- Reviewable:end -->
