### PR TITLE
Check if collections exists

### DIFF
--- a/aptos-move/framework/aptos-token/sources/token_v1.move
+++ b/aptos-move/framework/aptos-token/sources/token_v1.move
@@ -607,6 +607,16 @@ module aptos_token::token_v1 {
         );
     }
 
+    public fun check_collection_exists(creator: address, name: String): bool acquires Collections {
+        assert!(
+            exists<Collections>(creator),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
+
+        let collections = &borrow_global<Collections>(creator).collections;
+        table::contains(collections, name)
+    }
+
     public fun create_tokendata(
         account: &signer,
         collection: String,


### PR DESCRIPTION
### Description
It is essential for a NFT marketplace to check if a creator has a collection in their collections resource to avoid a case when someone, who would like to list a collection in the marketplace, adds a not existing collection, hence creating potential huge amount of redundant and junky data.

### Test Plan
It is extracted and little modified code from _create_collection_ function, therefore I don't expect it needs to be tested. Moreover, it doesn't write or modify any of the existing data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2307)
<!-- Reviewable:end -->
