### PR TITLE
[forge] Add back most simple version for continuous testing

### DIFF
--- a/.github/workflows/pre-release-continuous-test.yaml
+++ b/.github/workflows/pre-release-continuous-test.yaml
@@ -1,0 +1,17 @@
+name: Run continuous pre release testing
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - pre-release-continuous-test
+  schedule:
+    # Run hourly
+    - cron: "0 * * * *"
+
+jobs:
+  run-forge:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ github.sha }}
+      FORGE_NAMESPACE: continuous


### PR DESCRIPTION
The last attempt at this tried to do too much, turns out github actions are really difficult to test (oh the irony).

Instead this embodies KISS by doing as little as possible to get something, anything running first

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2313)
<!-- Reviewable:end -->
