### PR TITLE
[forge] Add required permissions for forge workflow

### DIFF
--- a/.github/workflows/pre-release-continuous-test.yaml
+++ b/.github/workflows/pre-release-continuous-test.yaml
@@ -1,4 +1,9 @@
 name: Run continuous pre release testing
+
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Add permissions that forge needs to function

Test Plan:

commit and try to run the workflow from the ui

https://github.com/aptos-labs/aptos-core/actions/runs/2754772940

Sounds clowny but this is the best I've got for now
