### PR TITLE
[community] Add :body_class slot for classes on <body>.

### DIFF
--- a/ecosystem/platform/server/app/views/layouts/_application.html.erb
+++ b/ecosystem/platform/server/app/views/layouts/_application.html.erb
@@ -14,7 +14,7 @@
     <%= render 'layouts/google_analytics' %>
   </head>
 
-  <body class="flex flex-col h-screen justify-between bg-neutral-900 antialiased">
+  <body class="flex flex-col h-screen justify-between antialiased bg-neutral-900 <%= content_for(:body_class) %>">
     <div class="flex flex-col flex-1">
       <%= render HeaderComponent.new(user: current_user) %>
 


### PR DESCRIPTION
### Description

Allows setting additional classes on `<body>` via `content_for(:body_class, "additional classes here")`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2318)
<!-- Reviewable:end -->
