### PR TITLE
[docker] Fix command for validator

### DIFF
--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       - type: bind
         source: ./validator_node_template.yaml
         target: /opt/aptos/var/validator_node_template.yaml
-    command: ["/opt/aptos/bin/aptos-node", "--test", "--config", "/opt/aptos/var/"]
+    command: ["/opt/aptos/bin/aptos-node", "--test", "--test-dir", "/opt/aptos/var/", "--config", "/opt/aptos/var/"]
     ports:
       - "8080:8080"
     expose:


### PR DESCRIPTION
You should specify the test directory explicitly, because otherwise faucet will not be able to use the mint.key

### Description

In the new version `aptos-node` without the `--test-dir` flag the mint.key will not be created in `/opt/aptos/var/`. This will cause faucet not to start.

Without flag:
```
Entering test mode, this should never be used in production!
Completed generating configuration:
	Log file: "/tmp/27eaa46b5aa5363e2bdac1279e1386be/validator.log"
	Test dir: "/tmp/27eaa46b5aa5363e2bdac1279e1386be"
	-> Aptos root key path: "/tmp/27eaa46b5aa5363e2bdac1279e1386be/mint.key" <- Before
	Waypoint: 0:f0f52e7410713832f22ce3da2c1eaf0c7c81fc3b0c3bd2a2cf2e50441e9b71f0
	ChainId: TESTING
	REST API endpoint: 0.0.0.0:8080
	FullNode network: /ip4/0.0.0.0/tcp/6181
```
With `--test-dir /opt/aptos/var`:
```
Entering test mode, this should never be used in production!
Completed generating configuration:
	Log file: "/opt/aptos/var/validator.log"
	Test dir: "/opt/aptos/var"
	-> Aptos root key path: "/opt/aptos/var/mint.key" <- After
	Waypoint: 0:1f2a925fd8b049282585d87395ba86351b012d134c53e3598005eb50010d0652
	ChainId: TESTING
	REST API endpoint: 0.0.0.0:8080
	FullNode network: /ip4/0.0.0.0/tcp/6181
```
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
docker-compose up

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2327)
<!-- Reviewable:end -->
