### PR TITLE
[consensus] fix the retry request in buffer manager

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -333,3 +333,12 @@ pub static BLOCK_RETRIEVAL_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Count of the buffer manager retry requests since last restart.
+pub static BUFFER_MANAGER_RETRY_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_buffer_manager_retry_count",
+        "Count of the buffer manager retry requests since last restart"
+    )
+    .unwrap()
+});


### PR DESCRIPTION
the check for if the request is retry has a bug when the cursor is None, it'll spawn the request as retry and delay for 100ms.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2331)
<!-- Reviewable:end -->
