### PR TITLE
[Indexer] Create ledger_info table and add test

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -14,7 +14,7 @@ use aptos_types::{
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
-use state::State;
+pub use state::State;
 use std::time::Duration;
 use url::Url;
 

--- a/ecosystem/indexer/migrations/2022-07-28-181243_ledger_info/down.sql
+++ b/ecosystem/indexer/migrations/2022-07-28-181243_ledger_info/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE ledger_infos;

--- a/ecosystem/indexer/migrations/2022-07-28-181243_ledger_info/up.sql
+++ b/ecosystem/indexer/migrations/2022-07-28-181243_ledger_info/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+CREATE TABLE ledger_infos
+(
+    chain_id BIGINT NOT NULL,
+    PRIMARY KEY (chain_id)
+);

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -861,15 +861,7 @@ mod test {
             .process_transaction(Arc::new(message_txn.clone()))
             .await
             .unwrap();
-    }
 
-    #[tokio::test]
-    async fn test_chain_id_check() {
-        // This is needed to avoid db errors. I think that db needs some time to reset.
-        std::thread::sleep(std::time::Duration::from_millis(1000));
-        if crate::should_skip_pg_tests() {
-            return;
-        }
         let (_conn_pool, tailer) = setup_indexer().unwrap();
         tailer.set_fetcher_version(4).await;
         assert!(tailer.check_or_update_chain_id().await.is_ok());

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -1,14 +1,20 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 use crate::{
-    database::PgDbPool,
+    database::{execute_with_better_error, PgDbPool},
     indexer::{
-        errors::TransactionProcessingError, fetcher::TransactionFetcher,
-        processing_result::ProcessingResult, transaction_processor::TransactionProcessor,
+        errors::TransactionProcessingError,
+        fetcher::{TransactionFetcher, TransactionFetcherTrait},
+        processing_result::ProcessingResult,
+        transaction_processor::TransactionProcessor,
     },
+    models::ledger_info::LedgerInfo,
+    schema::ledger_infos::{self, dsl},
 };
+use anyhow::{ensure, Result};
 use aptos_logger::info;
 use aptos_rest_client::Transaction;
+use diesel::{prelude::*, RunQueryDsl};
 use serde_json::Value;
 use std::{fmt::Debug, sync::Arc};
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -51,7 +57,7 @@ pub fn remove_null_bytes_from_txn(txn: Arc<Transaction>) -> Arc<Transaction> {
 
 #[derive(Clone)]
 pub struct Tailer {
-    transaction_fetcher: Arc<Mutex<TransactionFetcher>>,
+    transaction_fetcher: Arc<Mutex<dyn TransactionFetcherTrait>>,
     processors: Vec<Arc<dyn TransactionProcessor>>,
     connection_pool: PgDbPool,
 }
@@ -78,6 +84,48 @@ impl Tailer {
         )
         .expect("migrations failed!");
         info!("Migrations complete!");
+    }
+
+    /// If chain id doesn't exist, save it. Otherwise make sure that we're indexing the same chain
+    pub async fn check_or_update_chain_id(&self) -> anyhow::Result<bool> {
+        info!("Checking if chain id is correct");
+        let conn = self
+            .connection_pool
+            .get()
+            .expect("DB connection should be available at this stage");
+
+        let query_chain = dsl::ledger_infos
+            .select(dsl::chain_id)
+            .load::<i64>(&conn)
+            .expect("Error loading chain id from db");
+        let maybe_existing_chain_id = query_chain.first();
+
+        let new_chain_id = self
+            .transaction_fetcher
+            .lock()
+            .await
+            .fetch_ledger_info()
+            .await
+            .chain_id as i64;
+
+        match maybe_existing_chain_id {
+            Some(chain_id) => {
+                ensure!(*chain_id == new_chain_id, "Wrong chain detected! Trying to index chain {} now but existing data is for chain {}", new_chain_id, chain_id);
+                info!("Chain id matches! Continuing to index chain {}", chain_id);
+                Ok(true)
+            }
+            None => {
+                info!("Adding chain id {} to db, continue indexing", new_chain_id);
+                execute_with_better_error(
+                    &conn,
+                    diesel::insert_into(ledger_infos::table).values(LedgerInfo {
+                        chain_id: new_chain_id,
+                    }),
+                )
+                .expect("Error updating chain_id!");
+                Ok(true)
+            }
+        }
     }
 
     pub fn add_processor(&mut self, processor: Arc<dyn TransactionProcessor>) {
@@ -238,8 +286,50 @@ mod test {
         models::transactions::TransactionModel,
         token_processor::TokenTransactionProcessor,
     };
+    use aptos_rest_client::State;
     use diesel::Connection;
     use serde_json::json;
+
+    struct FakeFetcher {
+        version: u64,
+        chain_id: u8,
+    }
+
+    impl FakeFetcher {
+        fn new(_node_url: Url, _starting_version: Option<u64>) -> Self {
+            Self {
+                version: 0,
+                chain_id: 0,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TransactionFetcherTrait for FakeFetcher {
+        fn set_version(&mut self, version: u64) {
+            self.version = version;
+            // Super hacky way of mocking chain_id
+            self.chain_id = version as u8;
+        }
+
+        async fn fetch_ledger_info(&mut self) -> State {
+            State {
+                chain_id: self.chain_id,
+                epoch: 0,
+                version: 0,
+                timestamp_usecs: 0,
+                oldest_ledger_version: None,
+            }
+        }
+
+        async fn fetch_next(&mut self) -> Transaction {
+            unimplemented!();
+        }
+
+        async fn fetch_version(&self, _version: u64) -> Transaction {
+            unimplemented!();
+        }
+    }
 
     pub fn wipe_database(conn: &PgPoolConnection) {
         for table in [
@@ -254,6 +344,7 @@ mod test {
             "block_metadata_transactions",
             "transactions",
             "processor_statuses",
+            "ledger_infos",
             "__diesel_schema_migrations",
         ] {
             conn.execute(&format!("DROP TABLE IF EXISTS {}", table))
@@ -268,6 +359,10 @@ mod test {
         wipe_database(&conn_pool.get()?);
 
         let mut tailer = Tailer::new("http://fake-url.aptos.dev", conn_pool.clone())?;
+        tailer.transaction_fetcher = Arc::new(Mutex::new(FakeFetcher::new(
+            Url::parse("http://fake-url.aptos.dev")?,
+            None,
+        )));
         tailer.run_migrations();
 
         let pg_transaction_processor = DefaultTransactionProcessor::new(conn_pool.clone());
@@ -767,5 +862,24 @@ mod test {
             .process_transaction(Arc::new(message_txn.clone()))
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_chain_id_check() {
+        // This is needed to avoid db errors. I think that db needs some time to reset. 
+        std::thread::sleep(std::time::Duration::from_millis(300));
+        if crate::should_skip_pg_tests() {
+            return;
+        }
+        let (_conn_pool, tailer) = setup_indexer().unwrap();
+        tailer.set_fetcher_version(4).await;
+        assert!(tailer.check_or_update_chain_id().await.is_ok());
+        assert!(tailer.check_or_update_chain_id().await.is_ok());
+
+        tailer.set_fetcher_version(10).await;
+        assert!(tailer.check_or_update_chain_id().await.is_err());
+
+        tailer.set_fetcher_version(4).await;
+        assert!(tailer.check_or_update_chain_id().await.is_ok());
     }
 }

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -866,7 +866,7 @@ mod test {
     #[tokio::test]
     async fn test_chain_id_check() {
         // This is needed to avoid db errors. I think that db needs some time to reset.
-        std::thread::sleep(std::time::Duration::from_millis(300));
+        std::thread::sleep(std::time::Duration::from_millis(1000));
         if crate::should_skip_pg_tests() {
             return;
         }

--- a/ecosystem/indexer/src/main.rs
+++ b/ecosystem/indexer/src/main.rs
@@ -76,6 +76,7 @@ async fn main() -> std::io::Result<()> {
         tailer.run_migrations();
     }
 
+    tailer.check_or_update_chain_id().await.unwrap();
     let pg_transaction_processor = DefaultTransactionProcessor::new(conn_pool.clone());
     tailer.add_processor(Arc::new(pg_transaction_processor));
     if args.index_token_data {

--- a/ecosystem/indexer/src/models/ledger_info.rs
+++ b/ecosystem/indexer/src/models/ledger_info.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::schema::ledger_infos;
+
+#[derive(Debug, Identifiable, Insertable, Queryable)]
+#[diesel(table_name = "ledger_infos")]
+#[primary_key(chain_id)]
+pub struct LedgerInfo {
+    pub chain_id: i64,
+}

--- a/ecosystem/indexer/src/models/ledger_info.rs
+++ b/ecosystem/indexer/src/models/ledger_info.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-
+#![allow(clippy::extra_unused_lifetimes)]
 use crate::schema::ledger_infos;
 
 #[derive(Debug, Identifiable, Insertable, Queryable)]

--- a/ecosystem/indexer/src/models/mod.rs
+++ b/ecosystem/indexer/src/models/mod.rs
@@ -9,3 +9,4 @@ pub mod processor_statuses;
 pub mod token;
 pub mod transactions;
 pub mod write_set_changes;
+pub mod ledger_info;

--- a/ecosystem/indexer/src/models/mod.rs
+++ b/ecosystem/indexer/src/models/mod.rs
@@ -3,10 +3,10 @@
 
 pub mod collection;
 pub mod events;
+pub mod ledger_info;
 pub mod metadata;
 pub mod ownership;
 pub mod processor_statuses;
 pub mod token;
 pub mod transactions;
 pub mod write_set_changes;
-pub mod ledger_info;

--- a/ecosystem/indexer/src/schema.rs
+++ b/ecosystem/indexer/src/schema.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
 table! {
     block_metadata_transactions (hash) {
         hash -> Varchar,

--- a/ecosystem/indexer/src/schema.rs
+++ b/ecosystem/indexer/src/schema.rs
@@ -1,6 +1,3 @@
-// Copyright (c) Aptos
-// SPDX-License-Identifier: Apache-2.0
-
 table! {
     block_metadata_transactions (hash) {
         hash -> Varchar,
@@ -38,6 +35,12 @@ table! {
         type_ -> Text,
         data -> Jsonb,
         inserted_at -> Timestamp,
+    }
+}
+
+table! {
+    ledger_infos (chain_id) {
+        chain_id -> Int8,
     }
 }
 
@@ -158,6 +161,7 @@ allow_tables_to_appear_in_same_query!(
     block_metadata_transactions,
     collections,
     events,
+    ledger_infos,
     metadatas,
     ownerships,
     processor_statuses,


### PR DESCRIPTION
### Description
Saves chain_id when the indexer starts. If we somehow try to index a different chain, exit program. 

I also had to create a trait for TransactionFetcher in order to mock the data for the test. 

### Test Plan
```
Cargo test

running 1 test
test indexer::tailer::test::test_chain_id_check ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
```

Also tested by running
`cargo run -- --pg-uri "postgresql://localhost/postgres" --node-url "http://0.0.0.0:8080" --emit-every 25 --batch-size 100` and making sure that if we tail a different full node (e.g. devnode) the process crashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2334)
<!-- Reviewable:end -->
