### PR TITLE
[testsuite] Re-enable rosetta block test

### DIFF
--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -201,7 +201,6 @@ async fn get_balance(
     try_until_ok_default(|| rosetta_client.account_balance(&request)).await
 }
 
-#[ignore]
 #[tokio::test]
 async fn test_block() {
     let (swarm, _cli, _faucet, rosetta_client) = setup_test(1, 0).await;


### PR DESCRIPTION
### Description
This test was failing, and I didn't know why, until we found out that
the block height had been increased by one.  So, this test should now
do it's proper job.

### Test Plan
It's a test, so the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2340)
<!-- Reviewable:end -->
