### PR TITLE
Add codeowners for `/api`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,5 @@
 /crates/aptos-crypto/ @alinush
 # Owners for the `/crates/aptos-crypto-derive` directory and all its subdirectories.
 /crates/aptos-crypto-derive/ @alinush
+# Owners for the `/api` directory and all its subdirectories.
+/api/ @banool @gregnazario


### PR DESCRIPTION
I want this for now while we have two APIs, to make sure changes don't introduce any kind of incompatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2352)
<!-- Reviewable:end -->
