### PR TITLE
[framework] Adds tests that generated Rust SDKs are up-to-date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,12 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
+
+[[package]]
+name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -165,7 +171,7 @@ dependencies = [
  "cached-framework-packages",
  "clap 3.2.11",
  "clap_complete",
- "dirs",
+ "dirs 4.0.0",
  "executor",
  "framework",
  "hex",
@@ -498,7 +504,7 @@ dependencies = [
  "state-sync-v1",
  "stats_alloc",
  "storage-interface",
- "structopt",
+ "structopt 0.3.26",
 ]
 
 [[package]]
@@ -525,7 +531,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_yaml",
  "storage-interface",
- "structopt",
+ "structopt 0.3.26",
  "toml",
  "vm-genesis",
 ]
@@ -664,7 +670,7 @@ dependencies = [
  "hex",
  "serde 1.0.137",
  "serde_yaml",
- "structopt",
+ "structopt 0.3.26",
  "thiserror",
 ]
 
@@ -844,7 +850,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_json",
  "serde_yaml",
- "structopt",
+ "structopt 0.3.26",
  "thiserror",
  "tokio",
  "tokio-util 0.7.2",
@@ -1009,7 +1015,7 @@ dependencies = [
  "serde-generate",
  "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba)",
  "serde_yaml",
- "structopt",
+ "structopt 0.3.26",
  "tempfile",
  "textwrap 0.15.0",
  "which",
@@ -1167,7 +1173,7 @@ dependencies = [
  "framework",
  "hex",
  "move-deps",
- "structopt",
+ "structopt 0.3.26",
  "vm-genesis",
 ]
 
@@ -1563,7 +1569,7 @@ dependencies = [
  "serde 1.0.137",
  "serde_json",
  "storage-interface",
- "structopt",
+ "structopt 0.3.26",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
@@ -1724,6 +1730,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1875,6 +1892,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive",
+ "tempfile",
 ]
 
 [[package]]
@@ -2011,7 +2029,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.12.1",
  "atty",
  "bitflags",
  "strsim 0.8.0",
@@ -2288,6 +2306,12 @@ dependencies = [
  "quote 1.0.18",
  "unicode-xid 0.2.3",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -2734,7 +2758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0ff02642cff6f40d39f61c8d51cb394fd313e1aa2057833b91ad788c4e9331f"
 dependencies = [
  "regex",
- "structopt",
+ "structopt 0.3.26",
  "termcolor",
  "walkdir",
 ]
@@ -2753,7 +2777,7 @@ dependencies = [
  "bcs",
  "executor",
  "storage-interface",
- "structopt",
+ "structopt 0.3.26",
 ]
 
 [[package]]
@@ -2873,6 +2897,17 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users 0.3.5",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
@@ -2897,7 +2932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.3",
  "winapi 0.3.9",
 ]
 
@@ -2908,7 +2943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.3",
  "winapi 0.3.9",
 ]
 
@@ -3130,7 +3165,7 @@ dependencies = [
  "scratchpad",
  "serde 1.0.137",
  "storage-interface",
- "structopt",
+ "structopt 0.3.26",
  "toml",
 ]
 
@@ -3308,7 +3343,7 @@ dependencies = [
  "reqwest",
  "serde 1.0.137",
  "serde_json",
- "structopt",
+ "structopt 0.3.26",
  "tempfile",
  "termcolor",
  "thiserror",
@@ -3327,7 +3362,7 @@ dependencies = [
  "async-trait",
  "cached-framework-packages",
  "forge",
- "structopt",
+ "structopt 0.3.26",
  "testcases",
  "tokio",
  "url",
@@ -3370,7 +3405,7 @@ dependencies = [
  "sha2 0.9.9",
  "siphasher",
  "smallvec",
- "structopt",
+ "structopt 0.3.26",
  "tempfile",
 ]
 
@@ -3498,7 +3533,7 @@ dependencies = [
  "serde 1.0.137",
  "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection)",
  "serde_yaml",
- "structopt",
+ "structopt 0.3.26",
 ]
 
 [[package]]
@@ -3529,7 +3564,7 @@ dependencies = [
  "aptos-vm",
  "cached-framework-packages",
  "move-deps",
- "structopt",
+ "structopt 0.3.26",
  "vm-genesis",
 ]
 
@@ -4933,6 +4968,7 @@ dependencies = [
  "move-model",
  "move-package",
  "move-prover",
+ "move-prover-test-utils",
  "move-resource-viewer",
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
@@ -5195,6 +5231,17 @@ dependencies = [
  "serde_json",
  "tera",
  "tokio",
+]
+
+[[package]]
+name = "move-prover-test-utils"
+version = "0.1.0"
+source = "git+https://github.com/move-language/move?rev=a34266fc6c51bfc669d44f4c0faa337058e7833f#a34266fc6c51bfc669d44f4c0faa337058e7833f"
+dependencies = [
+ "anyhow",
+ "move-command-line-common",
+ "prettydiff",
+ "regex",
 ]
 
 [[package]]
@@ -6292,7 +6339,7 @@ dependencies = [
 [[package]]
 name = "poem"
 version = "1.3.36"
-source = "git+https://github.com/poem-web/poem#6c786c3d6e5ef46f3d45659f6c7ddf3e2407eace"
+source = "git+https://github.com/poem-web/poem#3f10656f7b78f00e5b16dcd232746eba0c73e3d3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6330,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "poem-derive"
 version = "1.3.36"
-source = "git+https://github.com/poem-web/poem#6c786c3d6e5ef46f3d45659f6c7ddf3e2407eace"
+source = "git+https://github.com/poem-web/poem#3f10656f7b78f00e5b16dcd232746eba0c73e3d3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.39",
@@ -6341,7 +6388,7 @@ dependencies = [
 [[package]]
 name = "poem-openapi"
 version = "2.0.6"
-source = "git+https://github.com/poem-web/poem#6c786c3d6e5ef46f3d45659f6c7ddf3e2407eace"
+source = "git+https://github.com/poem-web/poem#3f10656f7b78f00e5b16dcd232746eba0c73e3d3"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.1.0",
@@ -6364,7 +6411,7 @@ dependencies = [
 [[package]]
 name = "poem-openapi-derive"
 version = "2.0.6"
-source = "git+https://github.com/poem-web/poem#6c786c3d6e5ef46f3d45659f6c7ddf3e2407eace"
+source = "git+https://github.com/poem-web/poem#3f10656f7b78f00e5b16dcd232746eba0c73e3d3"
 dependencies = [
  "Inflector",
  "darling",
@@ -6452,10 +6499,35 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89f989ac94207d048d92db058e4f6ec7342b0971fc58d1271ca148b799b3563"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.12.1",
  "ctor",
  "diff",
  "output_vt100",
+]
+
+[[package]]
+name = "prettydiff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bc9e8bdfe446d34975ff774fbb4a2b944d17054f6b5845ec132d4fb9ff8f559"
+dependencies = [
+ "ansi_term 0.9.0",
+ "prettytable-rs",
+ "structopt 0.2.18",
+]
+
+[[package]]
+name = "prettytable-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+dependencies = [
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static 1.4.0",
+ "term",
+ "unicode-width",
 ]
 
 [[package]]
@@ -6637,7 +6709,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0de80796b316aec75344095a6d2ef68ec9b8f573b9e7adc821149ba3598e270"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.12.1",
  "atty",
  "config",
  "directories",
@@ -6891,6 +6963,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
@@ -7075,6 +7158,18 @@ checksum = "7a62eca5cacf2c8261128631bed9f045598d40bfbe4b29f5163f0f802f8f44a7"
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64 0.13.0",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -7337,7 +7432,7 @@ dependencies = [
  "hex",
  "rand 0.7.3",
  "serde_yaml",
- "structopt",
+ "structopt 0.3.26",
  "thiserror",
  "tokio",
  "url",
@@ -7393,7 +7488,7 @@ dependencies = [
  "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba)",
  "serde_bytes",
  "serde_yaml",
- "structopt",
+ "structopt 0.3.26",
  "textwrap 0.13.4",
 ]
 
@@ -8114,13 +8209,35 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c2cdbf9cc375f15d1b4141bc48aeef444806655cd0e904207edc8d68d86ed7"
+dependencies = [
+ "clap 2.34.0",
+ "structopt-derive 0.2.18",
+]
+
+[[package]]
+name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap 2.34.0",
  "lazy_static 1.4.0",
- "structopt-derive",
+ "structopt-derive 0.4.18",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010261a84b37689f9ed7d395165029f9cc7abb9f56bbfe86bee2597ed25107"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
 ]
 
 [[package]]
@@ -8265,6 +8382,17 @@ dependencies = [
  "serde_json",
  "slug",
  "unic-segment",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+dependencies = [
+ "byteorder",
+ "dirs 1.0.5",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -8800,7 +8928,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.12.1",
  "lazy_static 1.4.0",
  "matchers",
  "regex",

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -18,6 +18,7 @@ move-deps = { path = "../../move-deps", features = ["address32"] }
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
+tempfile = "3.3.0"
 
 [build-dependencies]
 framework = { path = ".." }

--- a/aptos-move/framework/cached-packages/src/lib.rs
+++ b/aptos-move/framework/cached-packages/src/lib.rs
@@ -12,6 +12,9 @@ pub mod aptos_framework_sdk_builder;
 pub mod aptos_stdlib;
 pub mod aptos_token_sdk_builder;
 
+// ================================================================================
+// Artifacts
+
 static PACKAGE: Dir<'static> = include_dir!("$OUT_DIR/framework");
 
 static MODULE_BLOBS: Lazy<Vec<Vec<u8>>> = Lazy::new(|| load_modules("build"));
@@ -92,24 +95,63 @@ pub fn module_blobs() -> &'static [Vec<u8>] {
 fn verify_load_framework() {
     module_blobs();
     error_map();
-    /*
-    std::fs::read(concat!(
-        env!("OUT_DIR"),
-        "/framework/transaction_script_builder.rs"
-    ))
-    .unwrap();
-     */
 }
 
 #[test]
 fn verify_load_token() {
     module_blobs();
     error_map();
-    /*
-    std::fs::read(concat!(
-        env!("OUT_DIR"),
-        "/token/transaction_script_builder.rs"
-    ))
-    .unwrap();
-     */
+}
+
+// ================================================================================
+// SDK builders
+
+#[cfg(test)]
+mod tests {
+    use move_deps::move_prover_test_utils::baseline_test::verify_or_update_baseline;
+    use std::path::PathBuf;
+
+    fn sdk_is_up_to_date(package_name: &str, built_file: &str, target_file: &str) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let release = framework::release::ReleaseOptions {
+            no_check_layout_compatibility: false,
+            no_build_docs: true,
+            with_diagram: false,
+            no_script_builder: false,
+            no_script_abis: false,
+            no_errmap: true,
+            package: PathBuf::from(package_name),
+            output: tempdir.path().to_path_buf(),
+        };
+        release.create_release();
+        let current_content = std::fs::read_to_string(tempdir.path().join(built_file)).unwrap();
+        let target_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join(target_file);
+        if verify_or_update_baseline(&target_path, &current_content).is_err() {
+            // Don't use original output of baseline test but specific one for this scenario
+            panic!(
+                "`{}` out of date. Please run `UPBL=1 cargo test -p cached-framework-packages`",
+                target_file
+            )
+        }
+    }
+
+    #[test]
+    fn aptos_sdk_up_to_date() {
+        sdk_is_up_to_date(
+            "aptos-framework",
+            "aptos_sdk_builder.rs",
+            "aptos_framework_sdk_builder.rs",
+        )
+    }
+
+    #[test]
+    fn token_sdk_up_to_date() {
+        sdk_is_up_to_date(
+            "aptos-token",
+            "aptos_sdk_builder.rs",
+            "aptos_token_sdk_builder.rs",
+        )
+    }
 }

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -23,6 +23,7 @@ move-ir-compiler = { git = "https://github.com/move-language/move", rev = "a3426
 move-model = { git = "https://github.com/move-language/move", rev = "a34266fc6c51bfc669d44f4c0faa337058e7833f" }
 move-package = { git = "https://github.com/move-language/move", rev = "a34266fc6c51bfc669d44f4c0faa337058e7833f" }
 move-prover = { git = "https://github.com/move-language/move", rev = "a34266fc6c51bfc669d44f4c0faa337058e7833f" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "a34266fc6c51bfc669d44f4c0faa337058e7833f" }
 move-resource-viewer = { git = "https://github.com/move-language/move", rev = "a34266fc6c51bfc669d44f4c0faa337058e7833f" }
 move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "a34266fc6c51bfc669d44f4c0faa337058e7833f" }
 move-stdlib = { git = "https://github.com/move-language/move", rev = "a34266fc6c51bfc669d44f4c0faa337058e7833f" }

--- a/aptos-move/move-deps/src/lib.rs
+++ b/aptos-move/move-deps/src/lib.rs
@@ -15,6 +15,7 @@ pub use move_ir_compiler;
 pub use move_model;
 pub use move_package;
 pub use move_prover;
+pub use move_prover_test_utils;
 pub use move_resource_viewer;
 pub use move_stackless_bytecode_interpreter;
 pub use move_stdlib;


### PR DESCRIPTION
### Description

I also would have wished to remove the entire custom `build.rs` but there are various dependencies from abis, bytecode, etc. which are referenced through our code. Better wait with refactoring this until there is more clarity about our release process beyond running genesis every time again.

Closes #2348

### Test Plan

New tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2354)
<!-- Reviewable:end -->
