### PR TITLE
[gha] run multiple forge tests on nightly

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -141,7 +141,6 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      merge_or_canary: ${{ github.event.pull_request.auto_merge != null && 'merge' || 'canary' }}
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.

--- a/.github/workflows/pre-release-continuous-test.yaml
+++ b/.github/workflows/pre-release-continuous-test.yaml
@@ -10,14 +10,21 @@ on:
     branches:
       - pre-release-continuous-test
   schedule:
-    # Run hourly
-    - cron: "0 * * * *"
+    # Run every 3 hours
+    - cron: "0 */3 * * *"
 
 jobs:
-  run-forge:
+  # run two concurrent forge test jobs on the same cluster
+  # they must use different namespaces, or they will preempt each other
+  run-forge-0:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      GIT_SHA: ${{ github.sha }}
-      merge_or_canary: canary
-      FORGE_NAMESPACE: continuous
+      FORGE_NAMESPACE: forge-continuous-0
+      FORGE_CLUSTER_NAME: aptos-forge-1
+  run-forge-1:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-continuous-1
+      FORGE_CLUSTER_NAME: aptos-forge-1

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -5,17 +5,18 @@ on:
   workflow_call:
     inputs:
       GIT_SHA:
-        required: true
+        required: false
         type: string
         description:
-      merge_or_canary:
-        required: true
-        type: string
-        description: "indicate whether this is a forge run for an auto-merge or a canary, must be `merge` or `canary`"
       FORGE_NAMESPACE:
         required: true
         type: string
         description: The Forge k8s namespace to be used for test. This value should manage Forge test concurrency. It may be truncated.
+      FORGE_CLUSTER_NAME:
+        required: true
+        type: string
+        default: aptos-forge-0
+        description: The Forge k8s cluster to be used for test
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
@@ -25,7 +26,7 @@ env:
   IMAGE_TAG: ${{ inputs.GIT_SHA }}
   FORGE_ENABLED: ${{ secrets.FORGE_ENABLED }}
   FORGE_BLOCKING: ${{ secrets.FORGE_BLOCKING }}
-  FORGE_CLUSTER_NAME: ${{ secrets.FORGE_CLUSTER_NAME }}
+  FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}
   FORGE_OUTPUT: forge_output.txt
   FORGE_REPORT: forge_report.json
   FORGE_COMMENT: forge_comment.txt
@@ -44,6 +45,8 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         with:
           ref: ${{ inputs.GIT_SHA }}
+          # get the last 10 commits if IMAGE_TAG is not specified
+          fetch-depth: env.IMAGE_TAG != null && 0 || 10
       - name: Set kubectl context
         if: env.FORGE_ENABLED == 'true'
         run: aws eks update-kubeconfig --name $FORGE_CLUSTER_NAME


### PR DESCRIPTION
### Description

Since nightly forge tests will run on a separate cluster, try running a few concurrently. We should have enough capacity since land-blocking Forge tests are run in a separate cluster. For now, two namespaces/jobs spin up: 
* `forge-continuous-0`
* `forge-continuous-1`

Also explicitly specify which Forge cluster each job is using in GHA in the job spec yaml itself, rather than injecting it via Github secrets. The secrets were are hard to read (can't read them once you set them), and not exactly secret either.

Also include some logic in `run_forge.sh` that will crawl the last few commits behind `HEAD` to find the last built docker image. This ensures that we're testing a valid image tag now that we're not running Forge after the `build-images` job.

### Test Plan

Add GHA trigger to run the nightly tests on push to this branch (`rustielin/forge-multi-nightly`). Will remove the condition before landing. 

The cluster `aptos-forge-1` is using the recommended `c5.xlarge` so the perf is not as high as land-blocking, so the success criteria will need to be changed: 

https://github.com/aptos-labs/aptos-core/actions/runs/2763964950

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2361)
<!-- Reviewable:end -->
