### PR TITLE
[cli][consensus] Add analyze-validator-performance to node cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ name = "aptos"
 version = "0.2.4"
 dependencies = [
  "anyhow",
+ "aptos-bitvec",
  "aptos-config",
  "aptos-crypto",
  "aptos-faucet",

--- a/consensus/src/liveness/leader_reputation_test.rs
+++ b/consensus/src/liveness/leader_reputation_test.rs
@@ -456,6 +456,10 @@ impl MockDbReader {
     pub fn add_event(&self, epoch: u64, round: Round) {
         let mut idx = self.idx.lock();
         *idx += 1;
+
+        let mut votes = BitVec::with_num_bits(1);
+        votes.set(0);
+
         self.events.lock().push(EventWithVersion::new(
             *idx,
             ContractEvent::new(
@@ -466,7 +470,7 @@ impl MockDbReader {
                     epoch,
                     round,
                     round,
-                    vec![],
+                    votes.into(),
                     self.random_address,
                     vec![],
                     *self.last_timestamp.lock(),

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -1,13 +1,26 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Result};
+pub mod aptos;
+pub mod error;
+pub mod faucet;
+pub use faucet::FaucetClient;
+pub mod response;
+pub use response::Response;
+pub mod state;
+pub mod types;
+
 pub use aptos_api_types::{
     self, IndexResponse, MoveModuleBytecode, PendingTransaction, Transaction,
 };
+pub use state::State;
+pub use types::{Account, Resource};
+
+use crate::aptos::{AptosVersion, Balance};
+use anyhow::{anyhow, Result};
 use aptos_api_types::{
-    mime_types::BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE, AptosError, Block, BlockInfo, Event,
-    HexEncodedBytes,
+    mime_types::BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE, AptosError, Block, BlockInfo,
+    HexEncodedBytes, VersionedEvent,
 };
 use aptos_crypto::HashValue;
 use aptos_types::{
@@ -18,21 +31,9 @@ use aptos_types::{
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
-pub use state::State;
 use std::time::Duration;
-use url::Url;
-
-pub mod error;
-pub mod faucet;
-pub use faucet::FaucetClient;
-pub mod response;
-pub use response::Response;
-pub mod state;
-pub mod types;
-use crate::aptos::{AptosVersion, Balance};
-pub use types::{Account, Resource};
-pub mod aptos;
 use types::{deserialize_from_prefixed_hex_string, deserialize_from_string};
+use url::Url;
 
 pub const USER_AGENT: &str = concat!("aptos-client-sdk-rust / ", env!("CARGO_PKG_VERSION"));
 pub const DEFAULT_VERSION_PATH_BASE: &str = "v1/";
@@ -369,8 +370,8 @@ impl Client {
         struct_tag: &str,
         field_name: &str,
         start: Option<u64>,
-        limit: Option<u64>,
-    ) -> Result<Response<Vec<Event>>> {
+        limit: Option<u16>,
+    ) -> Result<Response<Vec<VersionedEvent>>> {
         let url = self.build_path(&format!(
             "accounts/{}/events/{}/{}",
             address.to_hex_literal(),
@@ -393,8 +394,8 @@ impl Client {
     pub async fn get_new_block_events(
         &self,
         start: Option<u64>,
-        limit: Option<u64>,
-    ) -> Result<Response<Vec<NewBlockEvent>>> {
+        limit: Option<u16>,
+    ) -> Result<Response<Vec<VersionedNewBlockEvent>>> {
         #[derive(Clone, Debug, Serialize, Deserialize)]
         pub struct NewBlockEventResponse {
             #[serde(deserialize_with = "deserialize_from_string")]
@@ -425,22 +426,28 @@ impl Client {
             let new_events: Result<Vec<_>> = events
                 .into_iter()
                 .map(|event| {
+                    let version = event.version.into();
+                    let sequence_number = event.sequence_number.into();
                     serde_json::from_value::<NewBlockEventResponse>(event.data)
                         .map_err(|e| anyhow!(e))
                         .and_then(|e| {
-                            Ok(NewBlockEvent::new(
-                                e.epoch,
-                                e.round,
-                                e.height,
-                                e.previous_block_votes_bitvec.0,
-                                AccountAddress::from_hex_literal(&e.proposer)
-                                    .map_err(|e| anyhow!(e))?,
-                                e.failed_proposer_indices
-                                    .iter()
-                                    .map(|v| v.parse())
-                                    .collect::<Result<Vec<_>, _>>()?,
-                                e.time_microseconds,
-                            ))
+                            Ok(VersionedNewBlockEvent {
+                                event: NewBlockEvent::new(
+                                    e.epoch,
+                                    e.round,
+                                    e.height,
+                                    e.previous_block_votes_bitvec.0,
+                                    AccountAddress::from_hex_literal(&e.proposer)
+                                        .map_err(|e| anyhow!(e))?,
+                                    e.failed_proposer_indices
+                                        .iter()
+                                        .map(|v| v.parse())
+                                        .collect::<Result<Vec<_>, _>>()?,
+                                    e.time_microseconds,
+                                ),
+                                version,
+                                sequence_number,
+                            })
                         })
                 })
                 .collect();
@@ -543,4 +550,14 @@ impl From<(ReqwestClient, Url)> for Client {
             version_path_base: DEFAULT_VERSION_PATH_BASE.to_string(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct VersionedNewBlockEvent {
+    /// event
+    pub event: NewBlockEvent,
+    /// version
+    pub version: u64,
+    /// sequence number
+    pub sequence_number: u64,
 }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -36,6 +36,7 @@ toml = "0.5.9"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 walkdir = "2.3.2"
 
+aptos-bitvec = { path = "../../crates/aptos-bitvec" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto", features = [] }
 aptos-faucet = { path = "../aptos-faucet" }

--- a/crates/aptos/src/node/analyze/analyze_validators.rs
+++ b/crates/aptos/src/node/analyze/analyze_validators.rs
@@ -1,0 +1,483 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use aptos_bitvec::BitVec;
+use aptos_rest_client::VersionedNewBlockEvent;
+use aptos_types::account_address::AccountAddress;
+use aptos_types::account_config::{new_block_event_key, NewBlockEvent};
+use itertools::Itertools;
+use std::cmp::Ordering;
+use std::convert::TryFrom;
+use std::ops::Add;
+use storage_interface::{DbReader, Order};
+
+/// Single validator stats
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct ValidatorStats {
+    /// Number of successful proposals
+    pub proposal_successes: u32,
+    /// Number of failed proposals
+    pub proposal_failures: u32,
+    /// Number of votes proposals
+    pub votes: u32,
+    /// Number of transactions in a block
+    pub transactions: u32,
+}
+
+impl ValidatorStats {
+    /// Proposal failure rate
+    pub fn failure_rate(&self) -> f32 {
+        (self.proposal_failures as f32) / (self.proposal_failures + self.proposal_successes) as f32
+    }
+
+    /// Whether node is proposing well enough
+    pub fn is_reliable(&self) -> bool {
+        (self.proposal_successes > 0) && (self.failure_rate() < 0.1)
+    }
+
+    // Whether node is voting well enough
+    pub fn is_voting_enough(&self, rounds: u32) -> bool {
+        self.votes as f32 > rounds as f32 * 0.3
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum NodeState {
+    // Proposal failure < 10%, >30% votes
+    Reliable,
+    // Proposal failure < 10%, <30% votes
+    ReliableLowVotes,
+    // Has successful proposals, but proposal failure > 10%
+    AliveUnreliable,
+    // No successful proposals, but voting
+    OnlyVoting,
+    // Not participating in consensus
+    NotParticipatingInConsensus,
+    // Not in ValidatorSet
+    Absent,
+}
+
+impl NodeState {
+    pub fn to_char(&self) -> &str {
+        match self {
+            Self::Reliable => "+",
+            Self::ReliableLowVotes => "P",
+            Self::AliveUnreliable => "~",
+            Self::OnlyVoting => "V",
+            Self::NotParticipatingInConsensus => "X",
+            Self::Absent => " ",
+        }
+    }
+
+    // Large the value, the worse the node is performing.
+    pub fn to_order_weight(&self) -> usize {
+        match self {
+            Self::Reliable => 0,
+            Self::ReliableLowVotes => 100,
+            Self::AliveUnreliable => 10000,
+            Self::OnlyVoting => 1000000,
+            Self::NotParticipatingInConsensus => 100000000,
+            Self::Absent => 1,
+        }
+    }
+}
+
+impl Add for ValidatorStats {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            proposal_successes: self.proposal_successes + other.proposal_successes,
+            proposal_failures: self.proposal_failures + other.proposal_failures,
+            votes: self.votes + other.votes,
+            transactions: self.transactions + other.transactions,
+        }
+    }
+}
+
+/// Statistics for all validators
+#[derive(Clone)]
+pub struct EpochStats {
+    /// Statistics for each of the validators
+    pub validator_stats: HashMap<AccountAddress, ValidatorStats>,
+    /// Total rounds in an epoch
+    pub total_rounds: u32,
+    /// Total transactions in an epoch
+    pub total_transactions: u32,
+    /// Successful rounds in an epoch
+    pub round_successes: u32,
+    /// Failed rounds in an epoch
+    pub round_failures: u32,
+    /// Nil blocks in an epoch
+    pub nil_blocks: u32,
+}
+
+impl EpochStats {
+    pub fn to_state(&self, validator: &AccountAddress) -> NodeState {
+        self.validator_stats
+            .get(validator)
+            .map(|b| {
+                if b.is_reliable() {
+                    if b.is_voting_enough(self.total_rounds) {
+                        NodeState::Reliable
+                    } else {
+                        NodeState::ReliableLowVotes
+                    }
+                } else if b.proposal_successes > 0 {
+                    NodeState::AliveUnreliable
+                } else if b.votes > 0 {
+                    NodeState::OnlyVoting
+                } else {
+                    NodeState::NotParticipatingInConsensus
+                }
+            })
+            .unwrap_or(NodeState::Absent)
+    }
+}
+
+impl Add for EpochStats {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        let mut validator_stats = self.validator_stats.clone();
+        for (key, other_validator_stats) in other.validator_stats.into_iter() {
+            validator_stats.insert(
+                key,
+                other_validator_stats
+                    + *validator_stats.get(&key).unwrap_or(&ValidatorStats {
+                        proposal_failures: 0,
+                        proposal_successes: 0,
+                        votes: 0,
+                        transactions: 0,
+                    }),
+            );
+        }
+        Self {
+            validator_stats,
+            total_rounds: self.total_rounds + other.total_rounds,
+            round_successes: self.round_successes + other.round_successes,
+            round_failures: self.round_failures + other.round_failures,
+            nil_blocks: self.nil_blocks + other.nil_blocks,
+            total_transactions: self.total_transactions + other.total_transactions,
+        }
+    }
+}
+
+/// Analyze validator performance
+pub struct AnalyzeValidators {}
+
+impl AnalyzeValidators {
+    /// Fetch all events from a single epoch from DB.
+    pub fn fetch_epoch(epoch: u64, aptos_db: &dyn DbReader) -> Result<Vec<VersionedNewBlockEvent>> {
+        let batch = 1000;
+
+        let mut cursor = u64::max_value();
+        let mut result: Vec<VersionedNewBlockEvent> = vec![];
+        let ledger_version = aptos_db.get_latest_ledger_info()?.ledger_info().version();
+
+        loop {
+            let raw_events = aptos_db.get_events(
+                &new_block_event_key(),
+                cursor,
+                Order::Descending,
+                batch as u64,
+                ledger_version,
+            )?;
+            let end = raw_events.len() < batch;
+            for raw_event in raw_events {
+                if cursor <= raw_event.event.sequence_number() {
+                    println!(
+                        "Duplicate event found for {} : {:?}",
+                        cursor,
+                        raw_event.event.sequence_number()
+                    );
+                } else {
+                    cursor = raw_event.event.sequence_number();
+                    let event = bcs::from_bytes::<NewBlockEvent>(raw_event.event.event_data())?;
+
+                    match epoch.cmp(&event.epoch()) {
+                        Ordering::Equal => {
+                            result.push(VersionedNewBlockEvent {
+                                event,
+                                version: raw_event.transaction_version,
+                                sequence_number: raw_event.event.sequence_number(),
+                            });
+                        }
+                        Ordering::Greater => {
+                            return Ok(result);
+                        }
+                        Ordering::Less => {}
+                    };
+                }
+            }
+
+            if end {
+                return Ok(result);
+            }
+        }
+    }
+
+    /// Analyze single epoch
+    pub fn analyze(
+        mut blocks: Vec<VersionedNewBlockEvent>,
+        validators: &[AccountAddress],
+    ) -> EpochStats {
+        assert!(
+            validators.iter().as_slice().windows(2).all(|w| {
+                w[0].partial_cmp(&w[1])
+                    .map(|o| o != Ordering::Greater)
+                    .unwrap_or(false)
+            }),
+            "Validators need to be sorted"
+        );
+        blocks.sort_by_key(|e| e.event.round());
+
+        let mut successes = HashMap::<AccountAddress, u32>::new();
+        let mut failures = HashMap::<AccountAddress, u32>::new();
+        let mut votes = HashMap::<AccountAddress, u32>::new();
+        let mut transactions = HashMap::<AccountAddress, u32>::new();
+
+        let mut nil_blocks = 0;
+        let mut previous_round = 0;
+        for (pos, block) in blocks.iter().enumerate() {
+            let event = &block.event;
+            let is_nil = event.proposer() == AccountAddress::ZERO;
+            if is_nil {
+                nil_blocks += 1;
+            }
+            if event.round() + (if is_nil { 1 } else { 0 })
+                != previous_round + 1 + event.failed_proposer_indices().len() as u64
+            {
+                println!(
+                    "Missing failed AccountAddresss : {} {:?}",
+                    previous_round, &event
+                );
+            }
+            previous_round = event.round();
+
+            if !is_nil {
+                *successes.entry(event.proposer()).or_insert(0) += 1;
+            }
+
+            for failed_proposer_index in event.failed_proposer_indices() {
+                *failures
+                    .entry(validators[*failed_proposer_index as usize])
+                    .or_insert(0) += 1;
+            }
+
+            let previous_block_votes_bitvec: BitVec =
+                event.previous_block_votes_bitvec().clone().into();
+            assert_eq!(
+                BitVec::required_buckets(validators.len() as u16),
+                previous_block_votes_bitvec.num_buckets()
+            );
+            for (i, validator) in validators.iter().enumerate() {
+                if previous_block_votes_bitvec.is_set(i as u16) {
+                    *votes.entry(*validator).or_insert(0) += 1;
+                }
+            }
+
+            let cur_transactions_option = blocks
+                .get(pos + 1)
+                .map(|next| u32::try_from(next.version - block.version - 2).unwrap());
+            if let Some(cur_transactions) = cur_transactions_option {
+                if is_nil {
+                    assert_eq!(
+                        cur_transactions,
+                        0,
+                        "{} {:?}",
+                        block.version,
+                        blocks.get(pos + 1)
+                    );
+                }
+                *transactions.entry(event.proposer()).or_insert(0) += cur_transactions;
+            }
+        }
+        let total_successes: u32 = successes.values().sum();
+        let total_failures: u32 = failures.values().sum();
+        let total_transactions: u32 = transactions.values().sum();
+        let total_rounds = total_successes + total_failures;
+        assert_eq!(
+            total_rounds, previous_round as u32,
+            "{} {}",
+            total_rounds, previous_round
+        );
+
+        return EpochStats {
+            validator_stats: validators
+                .iter()
+                .map(|validator| {
+                    (
+                        *validator,
+                        ValidatorStats {
+                            proposal_successes: *successes.get(validator).unwrap_or(&0),
+                            proposal_failures: *failures.get(validator).unwrap_or(&0),
+                            votes: *votes.get(validator).unwrap_or(&0),
+                            transactions: *transactions.get(validator).unwrap_or(&0),
+                        },
+                    )
+                })
+                .collect(),
+            total_rounds,
+            total_transactions,
+            round_successes: total_successes,
+            round_failures: total_failures,
+            nil_blocks,
+        };
+    }
+
+    /// Print validator stats in a table
+    pub fn print_detailed_epoch_table(
+        epoch_stats: &EpochStats,
+        extra: Option<&HashMap<AccountAddress, &str>>,
+        sort_by_health: bool,
+    ) {
+        println!(
+            "Rounds: {} successes, {} failures, {} NIL blocks, failure rate: {}%, nil block rate: {}%",
+            epoch_stats.round_successes, epoch_stats.round_failures, epoch_stats.nil_blocks,
+            100.0 * epoch_stats.round_failures as f32 / epoch_stats.total_rounds as f32,
+            100.0 * epoch_stats.nil_blocks as f32 / epoch_stats.total_rounds as f32,
+        );
+        println!(
+            "{: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | ",
+            "elected", "% rounds", "% failed", "succeded", "failed", "voted", "transact"
+        );
+
+        let mut validator_order: Vec<&AccountAddress> =
+            epoch_stats.validator_stats.keys().collect();
+        if sort_by_health {
+            validator_order.sort_by_cached_key(|v| {
+                epoch_stats
+                    .validator_stats
+                    .get(v)
+                    .map(|s| {
+                        (
+                            if s.proposal_successes > 0 {
+                                (s.failure_rate() * 100000.0) as u32
+                            } else {
+                                200000
+                            },
+                            -((s.proposal_failures + s.proposal_successes) as i32),
+                            *v,
+                        )
+                    })
+                    .unwrap()
+            });
+        } else {
+            validator_order.sort();
+        }
+
+        for validator in validator_order {
+            let cur_stats = epoch_stats.validator_stats.get(validator).unwrap();
+            println!(
+                "{: <10} | {:5.2}%     | {:7.3}%   | {: <10} | {: <10} | {: <10} | {: <10} | {}",
+                cur_stats.proposal_failures + cur_stats.proposal_successes,
+                100.0 * (cur_stats.proposal_failures + cur_stats.proposal_successes) as f32
+                    / (epoch_stats.total_rounds as f32),
+                100.0 * cur_stats.failure_rate(),
+                cur_stats.proposal_successes,
+                cur_stats.proposal_failures,
+                cur_stats.votes,
+                cur_stats.transactions,
+                if let Some(extra_map) = extra {
+                    format!(
+                        "{: <30} | {}",
+                        extra_map.get(validator).unwrap_or(&""),
+                        validator
+                    )
+                } else {
+                    format!("{}", validator)
+                }
+            );
+        }
+    }
+
+    pub fn print_validator_health_over_time(
+        stats: &HashMap<u64, EpochStats>,
+        validators: &[AccountAddress],
+        extra: Option<&HashMap<AccountAddress, &str>>,
+    ) {
+        let epochs: Vec<_> = stats.keys().sorted().collect();
+
+        let mut sorted_validators = validators.to_vec();
+        sorted_validators.sort_by_cached_key(|validator| {
+            (
+                epochs
+                    .iter()
+                    .map(|cur_epoch| {
+                        stats
+                            .get(cur_epoch)
+                            .unwrap()
+                            .to_state(validator)
+                            .to_order_weight()
+                    })
+                    .sum::<usize>(),
+                *validator,
+            )
+        });
+
+        for validator in sorted_validators {
+            print!(
+                "{}:  ",
+                if let Some(extra_map) = extra {
+                    format!(
+                        "{: <30} | {}",
+                        extra_map.get(&validator).unwrap_or(&""),
+                        validator
+                    )
+                } else {
+                    format!("{}", validator)
+                }
+            );
+            for cur_epoch in epochs.iter() {
+                print!(
+                    "{}",
+                    stats.get(cur_epoch).unwrap().to_state(&validator).to_char()
+                );
+            }
+            println!();
+        }
+    }
+
+    pub fn print_network_health_over_time(
+        stats: &HashMap<u64, EpochStats>,
+        validators: &[AccountAddress],
+    ) {
+        let epochs = stats.keys().sorted();
+
+        println!(
+            "{: <8} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <8} | {: <8}",
+            "epoch",
+            "reliable",
+            "r low vote",
+            "unreliable",
+            "only vote",
+            "down(cons)",
+            "rounds",
+            "failure rate"
+        );
+        for cur_epoch in epochs {
+            let counts = validators
+                .iter()
+                .map(|v| stats.get(cur_epoch).unwrap().to_state(v))
+                .counts();
+            let epoch_stats = stats.get(cur_epoch).unwrap();
+            println!(
+                "{: <8} | {: <10} | {: <10} | {: <10} | {: <10} | {: <10} | {: <8} | {: <8}",
+                cur_epoch,
+                counts.get(&NodeState::Reliable).unwrap_or(&0),
+                counts.get(&NodeState::ReliableLowVotes).unwrap_or(&0),
+                counts.get(&NodeState::AliveUnreliable).unwrap_or(&0),
+                counts.get(&NodeState::OnlyVoting).unwrap_or(&0),
+                counts
+                    .get(&NodeState::NotParticipatingInConsensus)
+                    .unwrap_or(&0),
+                epoch_stats.total_rounds,
+                100.0 * epoch_stats.round_failures as f32 / epoch_stats.total_rounds as f32,
+            );
+        }
+    }
+}

--- a/crates/aptos/src/node/analyze/fetch_metadata.rs
+++ b/crates/aptos/src/node/analyze/fetch_metadata.rs
@@ -1,0 +1,236 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use aptos_rest_client::{
+    aptos_api_types::{IdentifierWrapper, MoveResource, WriteSetChange},
+    Client as RestClient, Transaction, VersionedNewBlockEvent,
+};
+use aptos_types::account_address::AccountAddress;
+use std::convert::TryFrom;
+use std::str::FromStr;
+
+pub struct EpochInfo {
+    pub epoch: u64,
+    pub blocks: Vec<VersionedNewBlockEvent>,
+    pub validators: Vec<AccountAddress>,
+}
+
+pub struct FetchMetadata {}
+
+impl FetchMetadata {
+    fn get_validator_addresses(
+        data: &MoveResource,
+        field_name: &str,
+    ) -> Result<Vec<AccountAddress>> {
+        fn extract_validator_address(validator: &serde_json::Value) -> Result<AccountAddress> {
+            if let serde_json::Value::Object(value) = validator {
+                if let Some(serde_json::Value::String(address)) = &value.get("addr") {
+                    AccountAddress::from_hex_literal(address)
+                        .map_err(|e| anyhow!("Cannot parse address {:?}", e))
+                } else {
+                    Err(anyhow!("Addr not present or of correct type"))
+                }
+            } else {
+                Err(anyhow!("Validator config not a json object"))
+            }
+        }
+
+        let validators_json = data
+            .data
+            .0
+            .get(&IdentifierWrapper::from_str(field_name).unwrap())
+            .unwrap();
+        if let serde_json::Value::Array(validators_array) = validators_json {
+            let mut validators: Vec<AccountAddress> = vec![];
+            for validator in validators_array {
+                validators.push(extract_validator_address(validator)?);
+            }
+            Ok(validators)
+        } else {
+            Err(anyhow!("{} validators not in json", field_name))
+        }
+    }
+
+    fn get_validators_from_transaction(transaction: &Transaction) -> Result<Vec<AccountAddress>> {
+        if let Ok(info) = transaction.transaction_info() {
+            for change in &info.changes {
+                if let WriteSetChange::WriteResource(resource) = change {
+                    if resource.data.typ.name.0.clone().into_string() == "ValidatorSet" {
+                        // No pending at epoch change
+                        assert_eq!(
+                            Vec::<AccountAddress>::new(),
+                            FetchMetadata::get_validator_addresses(
+                                &resource.data,
+                                "pending_inactive"
+                            )?
+                        );
+                        assert_eq!(
+                            Vec::<AccountAddress>::new(),
+                            FetchMetadata::get_validator_addresses(
+                                &resource.data,
+                                "pending_active"
+                            )?
+                        );
+                        return FetchMetadata::get_validator_addresses(
+                            &resource.data,
+                            "active_validators",
+                        );
+                    }
+                }
+            }
+        }
+        Err(anyhow!("Couldn't find ValidatorSet in the transaction"))
+    }
+
+    pub async fn fetch_new_block_events(
+        client: &RestClient,
+        start_epoch: Option<u64>,
+        end_epoch: Option<u64>,
+    ) -> Result<Vec<EpochInfo>> {
+        let mut start_seq_num = 0;
+        let last_seq_num = client
+            .get_new_block_events(None, Some(1))
+            .await?
+            .into_inner()
+            .first()
+            .unwrap()
+            .sequence_number;
+
+        if let Some(start_epoch) = start_epoch {
+            if start_epoch > 1 {
+                let mut search_end = last_seq_num;
+
+                // Stop when search is close enough, and we can then linearly
+                // proceed from there.
+                // Since we are ignoring results we are fetching during binary search
+                // we want to stop when we are close.
+                while start_seq_num + 20 < search_end {
+                    let mid = (start_seq_num + search_end) / 2;
+
+                    let mid_epoch = client
+                        .get_new_block_events(Some(mid), Some(1))
+                        .await?
+                        .into_inner()
+                        .first()
+                        .unwrap()
+                        .event
+                        .epoch();
+
+                    if mid_epoch < start_epoch {
+                        start_seq_num = mid;
+                    } else {
+                        search_end = mid;
+                    }
+                }
+            }
+        }
+
+        let batch: u16 = 1000;
+        let mut batch_index = 0;
+
+        println!(
+            "Fetching {} to {} sequence number",
+            start_seq_num, last_seq_num
+        );
+
+        let mut validators: Vec<AccountAddress> = vec![];
+        let mut epoch = 0;
+
+        let mut current: Vec<VersionedNewBlockEvent> = vec![];
+        let mut result: Vec<EpochInfo> = vec![];
+
+        let mut cursor = start_seq_num;
+        let start_epoch = start_epoch.unwrap_or(2);
+        loop {
+            let events = client.get_new_block_events(Some(cursor), Some(batch)).await;
+
+            if events.is_err() {
+                println!(
+                    "Failed to read new_block_events beyond {}, stopping. {:?}",
+                    cursor,
+                    events.unwrap_err()
+                );
+                assert!(!validators.is_empty());
+                result.push(EpochInfo {
+                    epoch,
+                    blocks: current,
+                    validators: validators.clone(),
+                });
+                return Ok(result);
+            }
+
+            for event in events.unwrap().into_inner() {
+                if event.event.epoch() > epoch {
+                    if epoch == 0 {
+                        epoch = event.event.epoch();
+                        current = vec![];
+                    } else {
+                        let last = current.last().cloned();
+                        if let Some(last) = last {
+                            let transactions = client
+                                .get_transactions(
+                                    Some(last.version),
+                                    Some(u16::try_from(event.version - last.version).unwrap()),
+                                )
+                                .await?
+                                .into_inner();
+                            assert_eq!(
+                                transactions.first().unwrap().version().unwrap(),
+                                last.version
+                            );
+                            for transaction in transactions {
+                                if let Ok(new_validators) =
+                                    FetchMetadata::get_validators_from_transaction(&transaction)
+                                {
+                                    if epoch >= start_epoch {
+                                        assert!(!validators.is_empty());
+                                        result.push(EpochInfo {
+                                            epoch,
+                                            blocks: current,
+                                            validators: validators.clone(),
+                                        });
+                                    }
+                                    current = vec![];
+
+                                    validators = new_validators;
+                                    validators.sort();
+                                    assert_eq!(epoch + 1, event.event.epoch());
+                                    epoch = event.event.epoch();
+                                    if end_epoch.is_some() && epoch >= end_epoch.unwrap() {
+                                        return Ok(result);
+                                    }
+                                    break;
+                                }
+                            }
+                            assert!(
+                                current.is_empty(),
+                                "Couldn't find ValidatorSet change for transactions start={}, limit={} for epoch {}",
+                                last.version,
+                                event.version - last.version,
+                                event.event.epoch(),
+                            );
+                        }
+                    }
+                }
+                current.push(event);
+            }
+
+            cursor += u64::from(batch);
+            batch_index += 1;
+            if batch_index % 100 == 0 {
+                println!(
+                    "Fetched {} epochs (in epoch {} with {} blocks) from {} transactions",
+                    result.len(),
+                    epoch,
+                    current.len(),
+                    cursor
+                );
+            }
+
+            if cursor > last_seq_num {
+                return Ok(result);
+            }
+        }
+    }
+}

--- a/crates/aptos/src/node/analyze/mod.rs
+++ b/crates/aptos/src/node/analyze/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod analyze_validators;
+pub mod fetch_metadata;

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1,9 +1,13 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod analyze;
+
 use crate::common::types::{ConfigSearchMode, PromptOptions};
 use crate::common::utils::prompt_yes_with_override;
 use crate::config::GlobalConfig;
+use crate::node::analyze::analyze_validators::AnalyzeValidators;
+use crate::node::analyze::fetch_metadata::FetchMetadata;
 use crate::{
     common::{
         types::{
@@ -28,6 +32,7 @@ use hex::FromHex;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use reqwest::Url;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::{path::PathBuf, thread, time::Duration};
@@ -49,6 +54,7 @@ pub enum NodeTool {
     ShowValidatorStake(ShowValidatorStake),
     RunLocalTestnet(RunLocalTestnet),
     UpdateValidatorNetworkAddresses(UpdateValidatorNetworkAddresses),
+    AnalyzeValidatorPerformance(AnalyzeValidatorPerformance),
 }
 
 impl NodeTool {
@@ -67,6 +73,7 @@ impl NodeTool {
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
             RunLocalTestnet(tool) => tool.execute_serialized_without_logger().await,
             UpdateValidatorNetworkAddresses(tool) => tool.execute_serialized().await,
+            AnalyzeValidatorPerformance(tool) => tool.execute_serialized().await,
         }
     }
 }
@@ -705,5 +712,102 @@ impl CliCommand<Transaction> for UpdateValidatorNetworkAddresses {
                 bcs::to_bytes(&full_node_network_addresses)?,
             ))
             .await
+    }
+}
+
+#[derive(Parser)]
+pub struct AnalyzeValidatorPerformance {
+    #[clap(long)]
+    pub start_epoch: Option<u64>,
+    #[clap(long)]
+    pub end_epoch: Option<u64>,
+    #[clap(flatten)]
+    pub(crate) rest_options: RestOptions,
+    #[clap(flatten)]
+    pub(crate) profile_options: ProfileOptions,
+    #[clap(arg_enum, long)]
+    pub(crate) analyze_mode: AnalyzeMode,
+}
+
+#[derive(PartialEq, clap::ArgEnum, Clone)]
+pub enum AnalyzeMode {
+    /// Print all other modes simultaneously
+    All,
+    /// For each epoch, print a detailed table containing performance
+    /// of each of the validators.
+    DetailedEpochTable,
+    /// For each validator, summarize it's performance in an epoch into
+    /// one of the predefined reliability buckets,
+    /// and prints it's performance across epochs.
+    ValidatorHealthOverTime,
+    /// For each epoch summarize how many validators were in
+    /// each of the reliability buckets.
+    NetworkHealthOverTime,
+}
+
+#[async_trait]
+impl CliCommand<()> for AnalyzeValidatorPerformance {
+    fn command_name(&self) -> &'static str {
+        "AnalyzeValidatorPerformance"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<()> {
+        let client = self.rest_options.client(&self.profile_options.profile)?;
+
+        let epochs =
+            FetchMetadata::fetch_new_block_events(&client, self.start_epoch, self.end_epoch)
+                .await?;
+        let mut stats = HashMap::new();
+
+        let print_detailed = self.analyze_mode == AnalyzeMode::DetailedEpochTable
+            || self.analyze_mode == AnalyzeMode::All;
+        for epoch_info in epochs {
+            let epoch_stats = AnalyzeValidators::analyze(epoch_info.blocks, &epoch_info.validators);
+            if print_detailed {
+                println!("Detailed table for epoch {}:", epoch_info.epoch);
+                AnalyzeValidators::print_detailed_epoch_table(&epoch_stats, None, true);
+            }
+            stats.insert(epoch_info.epoch, epoch_stats);
+        }
+
+        if stats.is_empty() {
+            println!("No data found for given input");
+            return Ok(());
+        }
+        let total_stats = stats
+            .iter()
+            .map(|(_k, v)| v.clone())
+            .reduce(|a, b| a + b)
+            .unwrap();
+        if print_detailed {
+            println!(
+                "Detailed table for all epochs [{}, {}]:",
+                stats.keys().min().unwrap(),
+                stats.keys().max().unwrap()
+            );
+            AnalyzeValidators::print_detailed_epoch_table(&total_stats, None, true);
+        }
+        let all_validators: Vec<_> = total_stats.validator_stats.keys().cloned().collect();
+        if self.analyze_mode == AnalyzeMode::ValidatorHealthOverTime
+            || self.analyze_mode == AnalyzeMode::All
+        {
+            println!(
+                "Validator health over epochs [{}, {}]:",
+                stats.keys().min().unwrap(),
+                stats.keys().max().unwrap()
+            );
+            AnalyzeValidators::print_validator_health_over_time(&stats, &all_validators, None);
+        }
+        if self.analyze_mode == AnalyzeMode::NetworkHealthOverTime
+            || self.analyze_mode == AnalyzeMode::All
+        {
+            println!(
+                "Network health over epochs [{}, {}]:",
+                stats.keys().min().unwrap(),
+                stats.keys().max().unwrap()
+            );
+            AnalyzeValidators::print_network_health_over_time(&stats, &all_validators);
+        }
+        Ok(())
     }
 }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -1,34 +1,30 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    account::{
-        create::{CreateAccount, DEFAULT_FUNDED_COINS},
-        fund::FundAccount,
-        list::{ListAccount, ListQuery},
-        transfer::{TransferCoins, TransferSummary},
-    },
-    common::{
-        init::InitTool,
-        types::{
-            account_address_from_public_key, AccountAddressWrapper, CliError, CliTypedResult,
-            EncodingOptions, FaucetOptions, GasOptions, MoveManifestAccountWrapper, MovePackageDir,
-            PrivateKeyInputOptions, PromptOptions, RestOptions, RngArgs, TransactionOptions,
-            TransactionSummary,
-        },
-        utils::write_to_file,
-    },
-    move_tool::{
-        ArgWithType, CompilePackage, InitPackage, MemberId, PublishPackage, RunFunction,
-        TestPackage,
-    },
-    node::{
-        AddStake, IncreaseLockup, JoinValidatorSet, LeaveValidatorSet, OperatorArgs,
-        RegisterValidatorCandidate, ShowValidatorConfig, ShowValidatorSet, ShowValidatorStake,
-        UnlockStake, UpdateValidatorNetworkAddresses, ValidatorConfigArgs, WithdrawStake,
-    },
-    CliCommand,
+use crate::account::{
+    create::{CreateAccount, DEFAULT_FUNDED_COINS},
+    fund::FundAccount,
+    list::{ListAccount, ListQuery},
+    transfer::{TransferCoins, TransferSummary},
 };
+use crate::common::init::InitTool;
+use crate::common::types::{
+    account_address_from_public_key, AccountAddressWrapper, CliError, CliTypedResult,
+    EncodingOptions, FaucetOptions, GasOptions, MoveManifestAccountWrapper, MovePackageDir,
+    PrivateKeyInputOptions, PromptOptions, RestOptions, RngArgs, TransactionOptions,
+    TransactionSummary,
+};
+use crate::common::utils::write_to_file;
+use crate::move_tool::{
+    ArgWithType, CompilePackage, InitPackage, MemberId, PublishPackage, RunFunction, TestPackage,
+};
+use crate::node::{
+    AddStake, AnalyzeMode, AnalyzeValidatorPerformance, IncreaseLockup, JoinValidatorSet,
+    LeaveValidatorSet, OperatorArgs, RegisterValidatorCandidate, ShowValidatorConfig,
+    ShowValidatorSet, ShowValidatorStake, UnlockStake, UpdateValidatorNetworkAddresses,
+    ValidatorConfigArgs, WithdrawStake,
+};
+use crate::CliCommand;
 use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519, PrivateKey};
 use aptos_genesis::config::HostAndPort;
 use aptos_keygen::KeyGen;
@@ -349,6 +345,22 @@ impl CliTestFramework {
                 full_node_host: None,
                 full_node_network_public_key: None,
             },
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn analyze_validator_performance(
+        &self,
+        start_epoch: Option<u64>,
+        end_epoch: Option<u64>,
+    ) -> CliTypedResult<()> {
+        AnalyzeValidatorPerformance {
+            start_epoch,
+            end_epoch,
+            rest_options: self.rest_options(),
+            profile_options: Default::default(),
+            analyze_mode: AnalyzeMode::All,
         }
         .execute()
         .await

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -16,6 +16,39 @@ use std::sync::Arc;
 use std::time::Duration;
 
 #[tokio::test]
+async fn test_analyze_validators() {
+    let (mut swarm, cli, _faucet) = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_i, _conf, genesis_stake_amount| {
+            *genesis_stake_amount = 100000;
+        }))
+        .build_with_cli(0)
+        .await;
+    let transaction_factory = swarm.chain_info().transaction_factory();
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    reconfig(
+        &rest_client,
+        &transaction_factory,
+        swarm.chain_info().root_account(),
+    )
+    .await;
+
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    reconfig(
+        &rest_client,
+        &transaction_factory,
+        swarm.chain_info().root_account(),
+    )
+    .await;
+
+    cli.analyze_validator_performance(None, None).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_show_validator_set() {
     let (swarm, cli, _faucet) = SwarmBuilder::new_local(1)
         .with_aptos()

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -134,8 +134,8 @@ async fn test_latest_events_and_transactions() {
         .unwrap()
         .into_parts();
 
-    assert!(start_events[0].round() < cur_events[0].round());
-    assert!(cur_events[0].round() < cur_events[1].round());
+    assert!(start_events[0].event.round() < cur_events[0].event.round());
+    assert!(cur_events[0].event.round() < cur_events[1].event.round());
     assert_eq!(cur_events.len(), 2);
 
     assert!(start_transations[0].version() < cur_transations[0].version());


### PR DESCRIPTION
Adding utilities to analyze validator performance, based on accessing live on-chain data 

Fastest to run a full node locally, and connecting cli to it.


Currently fetching from all transactions. We can fetch create API for just metadata transactions and/or fetch from BigQuery, if this is too slow for people. When we run loadtest, and BlockMetadata transactions are not the majority, it does slow down. 

Test Plan:
cargo run -p aptos -- node analyze-validator-performance --analyze-mode=all

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2364)
<!-- Reviewable:end -->
