### PR TITLE
feat: expose more BCS helpers

### DIFF
--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.test.ts
@@ -1,6 +1,19 @@
 import { AccountAddress } from "../aptos_types";
 import { Deserializer } from "./deserializer";
-import { bcsToBytes, deserializeVector, serializeVector } from "./helper";
+import {
+  bcsSerializeBool,
+  bcsSerializeBytes,
+  bcsSerializeFixedBytes,
+  bcsSerializeStr,
+  bcsSerializeU128,
+  bcsSerializeU16,
+  bcsSerializeU32,
+  bcsSerializeU8,
+  bcsSerializeUint64,
+  bcsToBytes,
+  deserializeVector,
+  serializeVector,
+} from "./helper";
 import { Serializer } from "./serializer";
 
 test("serializes and deserializes a vector of serializables", () => {
@@ -22,5 +35,54 @@ test("bcsToBytes", () => {
 
   expect(bcsToBytes(address)).toEqual(
     new Uint8Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]),
+  );
+});
+
+test("bcsSerializeU8", () => {
+  expect(bcsSerializeU8(255)).toEqual(new Uint8Array([0xff]));
+});
+
+test("bcsSerializeU16", () => {
+  expect(bcsSerializeU16(65535)).toEqual(new Uint8Array([0xff, 0xff]));
+});
+
+test("bcsSerializeU32", () => {
+  expect(bcsSerializeU32(4294967295)).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff]));
+});
+
+test("bcsSerializeU64", () => {
+  expect(bcsSerializeUint64(18446744073709551615n)).toEqual(
+    new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+  );
+});
+
+test("bcsSerializeU128", () => {
+  expect(bcsSerializeU128(340282366920938463463374607431768211455n)).toEqual(
+    new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
+  );
+});
+
+test("bcsSerializeBool", () => {
+  expect(bcsSerializeBool(true)).toEqual(new Uint8Array([0x01]));
+});
+
+test("bcsSerializeStr", () => {
+  expect(bcsSerializeStr("çå∞≠¢õß∂ƒ∫")).toEqual(
+    new Uint8Array([
+      24, 0xc3, 0xa7, 0xc3, 0xa5, 0xe2, 0x88, 0x9e, 0xe2, 0x89, 0xa0, 0xc2, 0xa2, 0xc3, 0xb5, 0xc3, 0x9f, 0xe2, 0x88,
+      0x82, 0xc6, 0x92, 0xe2, 0x88, 0xab,
+    ]),
+  );
+});
+
+test("bcsSerializeBytes", () => {
+  expect(bcsSerializeBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]))).toEqual(
+    new Uint8Array([5, 0x41, 0x70, 0x74, 0x6f, 0x73]),
+  );
+});
+
+test("bcsSerializeFixedBytes", () => {
+  expect(bcsSerializeFixedBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]))).toEqual(
+    new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]),
   );
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
@@ -1,6 +1,6 @@
 import { Deserializer } from "./deserializer";
 import { Serializer } from "./serializer";
-import { AnyNumber, Bytes, Seq } from "./types";
+import { AnyNumber, Bytes, Seq, Uint16, Uint32, Uint8 } from "./types";
 
 interface Serializable {
   serialize(serializer: Serializer): void;
@@ -40,8 +40,50 @@ export function bcsSerializeUint64(value: AnyNumber): Bytes {
   return serializer.getBytes();
 }
 
+export function bcsSerializeU8(value: Uint8): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeU8(value);
+  return serializer.getBytes();
+}
+
+export function bcsSerializeU16(value: Uint16): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeU16(value);
+  return serializer.getBytes();
+}
+
+export function bcsSerializeU32(value: Uint32): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeU32(value);
+  return serializer.getBytes();
+}
+
+export function bcsSerializeU128(value: AnyNumber): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeU128(value);
+  return serializer.getBytes();
+}
+
+export function bcsSerializeBool(value: boolean): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeBool(value);
+  return serializer.getBytes();
+}
+
 export function bcsSerializeStr(value: string): Bytes {
   const serializer = new Serializer();
   serializer.serializeStr(value);
+  return serializer.getBytes();
+}
+
+export function bcsSerializeBytes(value: Bytes): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeBytes(value);
+  return serializer.getBytes();
+}
+
+export function bcsSerializeFixedBytes(value: Bytes): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeFixedBytes(value);
   return serializer.getBytes();
 }


### PR DESCRIPTION
### Description
Add more BCS helpers and expose them. This would simplify the usage of BCS. e.g.

```
  const serializer = new Serializer();
  serializer.serializeU32(123);
  const bytes = serializer.getBytes();
```
 can be reduced to
`const bytes =  bcsSerializeU32(123);`

### Test Plan
Added unit tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2369)
<!-- Reviewable:end -->
