### PR TITLE
[helm] template label helper as range

### DIFF
--- a/terraform/helm/aptos-node/templates/_helpers.tpl
+++ b/terraform/helm/aptos-node/templates/_helpers.tpl
@@ -35,7 +35,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "aptos-validator.labels" -}}
-{{ toYaml .Values.labels }}
+{{- range $k, $v := .Values.labels }}
+{{ $k }}: {{ $v }}
+{{- end }}
 helm.sh/chart: {{ include "aptos-validator.chart" . }}
 {{ include "aptos-validator.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -48,7 +50,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "aptos-validator.selectorLabels" -}}
-{{ toYaml .Values.labels }}
+{{- range $k, $v := .Values.labels }}
+{{ $k }}: {{ $v }}
+{{- end }}
 app.kubernetes.io/part-of: {{ include "aptos-validator.name" . }}
 app.kubernetes.io/managed-by: helm
 {{- end -}}

--- a/terraform/helm/genesis/templates/_helpers.tpl
+++ b/terraform/helm/genesis/templates/_helpers.tpl
@@ -35,7 +35,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "aptos-genesis.labels" -}}
-{{ toYaml .Values.labels }}
+{{- range $k, $v := .Values.labels }}
+{{ $k }}: {{ $v }}
+{{- end }}
 helm.sh/chart: {{ include "aptos-genesis.chart" . }}
 {{ include "aptos-genesis.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
@@ -48,7 +50,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "aptos-genesis.selectorLabels" -}}
-{{ toYaml .Values.labels }}
+{{- range $k, $v := .Values.labels }}
+{{ $k }}: {{ $v }}
+{{- end }}
 app.kubernetes.io/part-of: {{ include "aptos-genesis.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}


### PR DESCRIPTION
### Description

Template `.Values.labels` into the helpers using a range and specifying each key/value, rather than trying to use `toYaml`

Previous way results in cryptic helm error in the case that additional labels are not supplied... 

```
Error: YAML parse error on aptos-node/templates/configmap.yaml: error converting YAML to JSON: yaml: line 9: mapping values are not allowed in this context
```

Warning was not heeded in https://github.com/aptos-labs/aptos-core/pull/2276#issuecomment-1200034519 😅 

### Test Plan

TF apply in a testnet both when labels are specified and not

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2370)
<!-- Reviewable:end -->
