### PR TITLE
[tf/aws][aptos-node] install ebs csi driver and gp3

### DIFF
--- a/terraform/aptos-node/aws/cluster.tf
+++ b/terraform/aptos-node/aws/cluster.tf
@@ -125,3 +125,49 @@ resource "aws_iam_openid_connect_provider" "cluster" {
 locals {
   oidc_provider = replace(aws_iam_openid_connect_provider.cluster.url, "https://", "")
 }
+
+# EBS CSI ADDON
+
+data "aws_iam_policy_document" "aws-ebs-csi-driver-trust-policy" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.oidc_provider}"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:sub"
+      values   = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "aws-ebs-csi-driver" {
+  name                 = "aptos-${local.workspace_name}-ebs-csi-controller"
+  path                 = var.iam_path
+  permissions_boundary = var.permissions_boundary_policy
+  assume_role_policy   = data.aws_iam_policy_document.aws-ebs-csi-driver-trust-policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "caws-ebs-csi-driver" {
+  role = aws_iam_role.aws-ebs-csi-driver.name
+  # From this reference: https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+resource "aws_eks_addon" "aws-ebs-csi-driver" {
+  cluster_name             = aws_eks_cluster.aptos.name
+  addon_name               = "aws-ebs-csi-driver"
+  service_account_role_arn = aws_iam_role.aws-ebs-csi-driver.arn
+}

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -44,6 +44,22 @@ resource "kubernetes_storage_class" "gp2" {
   depends_on = [null_resource.delete-gp2]
 }
 
+resource "kubernetes_storage_class" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = false
+    }
+  }
+  storage_provisioner = "ebs.csi.aws.com"
+  volume_binding_mode = "WaitForFirstConsumer"
+  parameters = {
+    type = "gp3"
+  }
+
+  depends_on = [null_resource.delete-gp2, aws_eks_addon.aws-ebs-csi-driver]
+}
+
 resource "kubernetes_role_binding" "psp-kube-system" {
   metadata {
     name      = "eks:podsecuritypolicy:privileged"


### PR DESCRIPTION
### Description

Install the EBS CSI Driver EKS Addon
* https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
* https://docs.aws.amazon.com/eks/latest/userguide/managing-ebs-csi.html

Also install `gp3` storage class. Leave the default as `gp2` for now, but we should consider migration to gp3 for cost and perf improvements. (https://aws.amazon.com/blogs/containers/migrating-amazon-eks-clusters-from-gp2-to-gp3-ebs-volumes/) (also re-visit our provisioned iops)

### Test Plan

* TF apply and successfully create the addons
* (pending) Test gp3 volume creation

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2371)
<!-- Reviewable:end -->
