### PR TITLE
Update your-first-nft.md

### DIFF
--- a/developer-docs-site/docs/tutorials/your-first-nft.md
+++ b/developer-docs-site/docs/tutorials/your-first-nft.md
@@ -146,7 +146,7 @@ The Aptos Token enables creators to create finite or unlimited collections. Many
 
 Finite, that is no more than a `maximum` number of tokens can ever be minted:
 ```rust
-public(script) fun create_finite_collection_script(
+public(script) fun create_limited_collection_script (
     account: signer,
     description: vector<u8>,
     name: vector<u8>,


### PR DESCRIPTION
function create_finite_collection_script  is posted incorrectly , replace it with create_limited_collection_script

### Description
when i test the create_limited_collection_script, it can't sign and submit the transaction successfully.And I can hardly find a definition of this function in aptos-lab.But create_finite_collection_script replaced with create_finite_collection_script and then it signs and submit transaction normally.I think create_finite_collection_script is posted wrong.
https://github.com/aptos-labs/aptos-core/blob/bfd6dba22795240d726008777723e57020b8c71c/aptos-move/framework/aptos-framework/sources/token.move#L162

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
it is definited as
```
 public entry fun create_limited_collection_script(
        creator: &signer,
        name: vector<u8>,
        description: vector<u8>,
        uri: vector<u8>,
        maximum: u64,
    ) acquires Collections {
        create_collection(
            creator,
            string::utf8(name),
            string::utf8(description),
            string::utf8(uri),
            option::some(maximum),
        );
    }

```
In https://github.com/aptos-labs/aptos-core/blob/bfd6dba22795240d726008777723e57020b8c71c/aptos-move/framework/aptos-framework/sources/token.move#L162 

but in your-first-nft.md , it was incorrectly written as
```
public(script) fun create_finite_collection_script(
    account: signer,
    description: vector<u8>,
    name: vector<u8>,
    uri: vector<u8>,
    maximum: u64,
)
```
so i replace the function create_finite_collection_script with create_limited_collection_script

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2385)
<!-- Reviewable:end -->
