### PR TITLE
[deps] align on a single version of serde-reflection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ dependencies = [
  "move-deps",
  "regex",
  "serde-generate",
- "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba)",
+ "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb)",
  "serde_yaml",
  "structopt 0.3.26",
  "tempfile",
@@ -3532,7 +3532,7 @@ dependencies = [
  "network",
  "rand 0.7.3",
  "serde 1.0.137",
- "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection)",
+ "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb)",
  "serde_yaml",
  "structopt 0.3.26",
 ]
@@ -4797,7 +4797,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
- "serde-reflection 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba)",
 ]
 
 [[package]]
@@ -7478,7 +7478,7 @@ dependencies = [
 [[package]]
 name = "serde-generate"
 version = "0.20.6"
-source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
+source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "bcs",
  "bincode",
@@ -7486,7 +7486,7 @@ dependencies = [
  "include_dir 0.6.2",
  "maplit",
  "serde 1.0.137",
- "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba)",
+ "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb)",
  "serde_bytes",
  "serde_yaml",
  "structopt 0.3.26",
@@ -7518,8 +7518,7 @@ dependencies = [
 [[package]]
 name = "serde-reflection"
 version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167450ba550f903a2b35a81ba3ca387585189e2430e3df6b94b95f3bec2f26bd"
+source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "once_cell",
  "serde 1.0.137",
@@ -7530,16 +7529,6 @@ dependencies = [
 name = "serde-reflection"
 version = "0.3.5"
 source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
-dependencies = [
- "once_cell",
- "serde 1.0.137",
- "thiserror",
-]
-
-[[package]]
-name = "serde-reflection"
-version = "0.3.5"
-source = "git+https://github.com/aptos-labs/serde-reflection#262fe0545367563e056eef99d6108cacbb102192"
 dependencies = [
  "once_cell",
  "serde 1.0.137",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,3 +162,6 @@ codegen-units = 1
 
 [profile.bench]
 debug = true
+
+[patch.crates-io]
+serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }

--- a/aptos-move/aptos-sdk-builder/Cargo.toml
+++ b/aptos-move/aptos-sdk-builder/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 heck = "0.3.2"
 regex = "1.5.5"
-serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
-serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
+serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccb" }
+serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccb" }
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 textwrap = "0.15.0"

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 bcs = "0.1.3"
 rand = "0.7.3"
 serde = { version = "1.0.137", features = ["derive"] }
-serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection" }
+serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccb" }
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 


### PR DESCRIPTION
Using multiple versions of serde-reflection breaks tools like Nix or
cargo-vendor which expect only one version of a crate per
dependency.

#1779 cleaning up this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2389)
<!-- Reviewable:end -->
