### PR TITLE
[Mempool] Increase the maximum concurrent task for bounded executor

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -29,7 +29,7 @@ impl Default for MempoolConfig {
             shared_mempool_backoff_interval_ms: 30_000,
             shared_mempool_batch_size: 100,
             shared_mempool_ack_timeout_ms: 2_000,
-            shared_mempool_max_concurrent_inbound_syncs: 2,
+            shared_mempool_max_concurrent_inbound_syncs: 4,
             max_broadcasts_per_peer: 1,
             mempool_snapshot_interval_secs: 180,
             capacity: 1_000_000,


### PR DESCRIPTION
### Description

While running transaction emitter in AIT2, one thing we observed is that the REST APIs become the major bottleneck in transaction submission. Per REST endpoint, we are not able to submit more than ~250 transaction per second. Digging into it, figured that the reason for this is we limit the maximum outstanding transaction processing task to be 2 and given each transaction validation takes ~8 ms, we can only process ~250 TPS. Bumping up the max concurrent transaction processing backlog for mempool to 24. This change will hopefully help us achieve a higher TPS for upcoming AIT3.  This along with other changes I have in flight for the transaction emitter can help bump up the TPS for forge as well to 6.5K (https://github.com/aptos-labs/aptos-core/pull/2375).

### Test Plan

Ran forge with this change and can bump up the TPS to 6.5k (https://github.com/aptos-labs/aptos-core/pull/2375).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2390)
<!-- Reviewable:end -->
