### PR TITLE
Revert "infra: consistency - put all built binaries into thes same path in docker image and make them available in $PATH"

### DIFF
--- a/docker/compose/aptos-node/docker-compose-fullnode.yaml
+++ b/docker/compose/aptos-node/docker-compose-fullnode.yaml
@@ -23,7 +23,7 @@ services:
       - type: bind
         source: ./validator-full-node-identity.yaml
         target: /opt/aptos/genesis/validator-full-node-identity.yaml
-    command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
+    command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
     restart: unless-stopped
     ports:
       - "6182:6182"

--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       - type: bind
         source: ./validator-identity.yaml
         target: /opt/aptos/genesis/validator-identity.yaml
-    command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/validator.yaml"]
+    command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/validator.yaml"]
     restart: unless-stopped
     ports:
       - "6180:6180"

--- a/docker/compose/public_full_node/docker-compose.yaml
+++ b/docker/compose/public_full_node/docker-compose.yaml
@@ -48,7 +48,7 @@ services:
         source: ./waypoint.txt
         target: /opt/aptos/etc/waypoint.txt
         read_only: true
-    command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/node.yaml"]
+    command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/node.yaml"]
     ports:
       - "8080:8080"
       - "9101:9101"

--- a/docker/compose/validator-testnet/docker-compose.yaml
+++ b/docker/compose/validator-testnet/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       - type: bind
         source: ./validator_node_template.yaml
         target: /opt/aptos/var/validator_node_template.yaml
-    command: ["/usr/local/bin/aptos-node", "--test", "--test-dir", "/opt/aptos/var/", "--config", "/opt/aptos/var/"]
+    command: ["/opt/aptos/bin/aptos-node", "--test", "--test-dir", "/opt/aptos/var/", "--config", "/opt/aptos/var/"]
     ports:
       - "8080:8080"
     expose:
@@ -62,7 +62,7 @@ services:
             sleep 1
           else
             sleep 1
-            /usr/local/bin/aptos-faucet \\
+            /opt/aptos/bin/aptos-faucet \\
               --address 0.0.0.0 \\
               --port 8000 \\
               --chain-id TESTING \\

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -34,11 +34,11 @@ RUN ln -sf /usr/bin/perf_* /usr/bin/perf
 
 RUN addgroup --system --gid 6180 aptos && adduser --system --ingroup aptos --no-create-home --uid 6180 aptos
 
-RUN mkdir -p /opt/aptos/etc
-COPY --link --from=builder /aptos/dist/aptos-node /usr/local/bin/
-COPY --link --from=builder /aptos/dist/db-backup /usr/local/bin/
-COPY --link --from=builder /aptos/dist/db-bootstrapper /usr/local/bin/
-COPY --link --from=builder /aptos/dist/db-restore /usr/local/bin/
+RUN mkdir -p /opt/aptos/bin /opt/aptos/etc
+COPY --link --from=builder /aptos/dist/aptos-node /opt/aptos/bin/
+COPY --link --from=builder /aptos/dist/db-backup /opt/aptos/bin/
+COPY --link --from=builder /aptos/dist/db-bootstrapper /opt/aptos/bin/
+COPY --link --from=builder /aptos/dist/db-restore /opt/aptos/bin/
 
 # Admission control
 EXPOSE 8000
@@ -61,6 +61,7 @@ FROM debian-base AS indexer
 RUN apt-get update && apt-get install -y libssl1.1 ca-certificates net-tools tcpdump iproute2 netcat libpq-dev \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
+RUN mkdir -p /opt/aptos/bin
 COPY --link --from=builder /aptos/dist/aptos-indexer /usr/local/bin/aptos-indexer
 
 ENV RUST_LOG_FORMAT=json
@@ -72,6 +73,7 @@ FROM debian-base AS node-checker
 RUN apt-get update && apt-get install -y libssl1.1 ca-certificates net-tools tcpdump iproute2 netcat libpq-dev \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
+RUN mkdir -p /opt/aptos/bin
 COPY --link --from=builder /aptos/dist/aptos-node-checker /usr/local/bin/aptos-node-checker
 
 ENV RUST_LOG_FORMAT=json
@@ -117,9 +119,9 @@ FROM debian-base AS faucet
 RUN apt-get update && apt-get install -y libssl1.1 ca-certificates nano net-tools tcpdump iproute2 netcat \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
-RUN mkdir -p /aptos/client/data/wallet/
+RUN mkdir -p /opt/aptos/bin  /aptos/client/data/wallet/
 
-COPY --link --from=builder /aptos/dist/aptos-faucet /usr/local/bin/aptos-faucet
+COPY --link --from=builder /aptos/dist/aptos-faucet /opt/aptos/bin/aptos-faucet
 
 #install needed tools
 RUN apt-get update && apt-get install -y procps

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -69,7 +69,7 @@ spec:
       - name: fullnode
         image: {{ $.Values.validator.image.repo }}:{{ $.Values.validator.image.tag | default $.Values.imageTag }}
         imagePullPolicy: {{ $.Values.validator.image.pullPolicy }}
-        command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
+        command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
       {{- with $.Values.fullnode }}
         resources:
           {{- toYaml .resources | nindent 10 }}

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -74,7 +74,7 @@ spec:
         image: {{ $.Values.validator.image.repo }}:{{ $.Values.validator.image.tag | default $.Values.imageTag }}
       {{- with $.Values.validator }}
         imagePullPolicy: {{ .image.pullPolicy }}
-        command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/validator.yaml"]
+        command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/validator.yaml"]
         resources:
           {{- toYaml .resources | nindent 10 }}
         env:

--- a/terraform/helm/fullnode/templates/fullnode.yaml
+++ b/terraform/helm/fullnode/templates/fullnode.yaml
@@ -26,7 +26,7 @@ spec:
       - name: fullnode
         image: {{ .Values.image.repo }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command: ["/usr/local/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
+        command: ["/opt/aptos/bin/aptos-node", "-f", "/opt/aptos/etc/fullnode.yaml"]
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#2394

this is breaking the instructions to run a fullnode since the docs copy a fullnode config from main instead of devnet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2401)
<!-- Reviewable:end -->
