### PR TITLE
docker: add tini as init process to docker images to ensure SIGTERM is propagated

### DIFF
--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -2,6 +2,11 @@
 
 FROM debian:buster-20220228@sha256:fd510d85d7e0691ca551fe08e8a2516a86c7f24601a940a299b5fe5cdd22c03a AS debian-base
 
+# Add Tini to make sure the binaries receive proper SIGTERM signals when Docker is shut down
+ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 FROM rust:1.61-buster AS rust-base
 WORKDIR /aptos
 RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev
@@ -151,4 +156,4 @@ WORKDIR /aptos
 COPY --link --from=builder /aptos/dist/forge /usr/local/bin/forge
 ENV RUST_LOG_FORMAT=json
 
-ENTRYPOINT ["forge"]
+ENTRYPOINT ["/tini", "--", "forge"]


### PR DESCRIPTION
### Description

This add tini as entrypoint to our docker images (https://github.com/krallin/tini).
This is quite important as otherwise the processes we run inside the container don't receive SIGTERM as signal properly. For example I noticed that while trying to run aptos-node via docker locally it never terminated when doing CTRL+C but rather I hard to hard SIGKILL it via docker stop in another terminal. This very likely also negatively affected our node's shutdown behaviour in kubernetes since essentially in our current setup the container would always get SIGKILLED after a while.
This might be also the root cause behind aptos-logger not logging certain exit conditions properly.

Also solves #1994 

### Test Plan
Build image on a codespace and compared CTRL+C behaviour before and after the change. Before change, nothing happens, after change it properly terminates gracefully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2402)
<!-- Reviewable:end -->
