### PR TITLE
devex: remove #Description heading from PR template since its redundant

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-### Description
+
 
 ### Test Plan
 <!-- Please provide us with clear details for verifying that your changes work. -->


### PR DESCRIPTION
Removing the description heading since it's redundant and implied that this field must contain a description.
Allows one to start typing right away without placing the cursor in a specific position of the PR field.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2403)
<!-- Reviewable:end -->
