### PR TITLE
fix panic error with indexer when enabling --index-token-data

### DIFF
--- a/ecosystem/indexer/src/models/token.rs
+++ b/ecosystem/indexer/src/models/token.rs
@@ -110,6 +110,7 @@ pub struct DepositEventType {
 pub struct CreationEventType {
     pub id: TokenId,
     pub token_data: TokenData,
+    #[serde(deserialize_with = "types::deserialize_from_string")]
     pub initial_balance: i64,
 }
 


### PR DESCRIPTION

### Description
the indexer will panic when enabling `--index-token-data`, since type conversion is lost for `initial_balance`

### Test Plan
add `--index-token-data` option to start indexer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2405)
<!-- Reviewable:end -->
