### PR TITLE
[gha] fix nightly forge tests and cluster selection

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -141,7 +141,6 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-      merge_or_canary: ${{ github.event.pull_request.auto_merge != null && 'merge' || 'canary' }}
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.

--- a/.github/workflows/pre-release-continuous-test.yaml
+++ b/.github/workflows/pre-release-continuous-test.yaml
@@ -10,14 +10,21 @@ on:
     branches:
       - pre-release-continuous-test
   schedule:
-    # Run hourly
-    - cron: "0 * * * *"
+    # Run every 3 hours
+    - cron: "0 */3 * * *"
 
 jobs:
-  run-forge:
+  # run two concurrent forge test jobs on the same cluster
+  # they must use different namespaces, or they will preempt each other
+  run-forge-0:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      GIT_SHA: ${{ github.sha }}
-      merge_or_canary: canary
-      FORGE_NAMESPACE: continuous
+      FORGE_NAMESPACE: forge-continuous-0
+      FORGE_CLUSTER_NAME: aptos-forge-1
+  run-forge-1:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-continuous-1
+      FORGE_CLUSTER_NAME: aptos-forge-1

--- a/.github/workflows/pre-release-continuous-test.yaml
+++ b/.github/workflows/pre-release-continuous-test.yaml
@@ -10,8 +10,8 @@ on:
     branches:
       - pre-release-continuous-test
   schedule:
-    # Run every 3 hours
-    - cron: "0 */3 * * *"
+    # Run every 6 hours
+    - cron: "0 */6 * * *"
 
 jobs:
   # run two concurrent forge test jobs on the same cluster

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -5,17 +5,18 @@ on:
   workflow_call:
     inputs:
       GIT_SHA:
-        required: true
+        required: false
         type: string
         description:
-      merge_or_canary:
-        required: true
-        type: string
-        description: "indicate whether this is a forge run for an auto-merge or a canary, must be `merge` or `canary`"
       FORGE_NAMESPACE:
         required: true
         type: string
         description: The Forge k8s namespace to be used for test. This value should manage Forge test concurrency. It may be truncated.
+      FORGE_CLUSTER_NAME:
+        required: true
+        type: string
+        default: aptos-forge-0
+        description: The Forge k8s cluster to be used for test
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
@@ -25,7 +26,7 @@ env:
   IMAGE_TAG: ${{ inputs.GIT_SHA }}
   FORGE_ENABLED: ${{ secrets.FORGE_ENABLED }}
   FORGE_BLOCKING: ${{ secrets.FORGE_BLOCKING }}
-  FORGE_CLUSTER_NAME: ${{ secrets.FORGE_CLUSTER_NAME }}
+  FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}
   FORGE_OUTPUT: forge_output.txt
   FORGE_REPORT: forge_report.json
   FORGE_COMMENT: forge_comment.txt
@@ -44,6 +45,8 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         with:
           ref: ${{ inputs.GIT_SHA }}
+          # get the last 10 commits if IMAGE_TAG is not specified
+          fetch-depth: env.IMAGE_TAG != null && 0 || 10
       - name: Set kubectl context
         if: env.FORGE_ENABLED == 'true'
         run: aws eks update-kubeconfig --name $FORGE_CLUSTER_NAME

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -7,13 +7,13 @@ on:
       GIT_SHA:
         required: false
         type: string
-        description:
+        description: The git SHA1 to test. If not specified, Forge will check the latest commits on the current branch
       FORGE_NAMESPACE:
         required: true
         type: string
         description: The Forge k8s namespace to be used for test. This value should manage Forge test concurrency. It may be truncated.
       FORGE_CLUSTER_NAME:
-        required: true
+        required: false
         type: string
         default: aptos-forge-0
         description: The Forge k8s cluster to be used for test


### PR DESCRIPTION
### Description

Re-introduce #2361 

Also fix the GHA workflow triggering logic that was missed in above PR. Namely: making the `run-forge.yaml` inputs `required: false` and specifying a default when appropriate.
* `FORGE_CLUSTER_NAME` defaults to `aptos-forge-0` for all land-blocking Forge invocations. Otherwise explicitly use `aptos-forge-1` for nightly continuous testing
* `GIT_SHA` has no default and is not required. If specified, Forge will try to use images that are tagged with that git SHA. Otherwise if not specified, Forge will check out the current branch and check the last few commit hashes (e.g. nightly test will check latest commits in `main`, but the last commit may not necessarily have finished building)

### Test Plan

The nighty workflow itself was tested in https://github.com/aptos-labs/aptos-core/pull/2361 e.g. this GHA run: https://github.com/aptos-labs/aptos-core/actions/runs/2763964950 which is successfully triggered and runs Forge. As per the previous PR, we need to follow up and improve the success criteria since `aptos-forge-1` cluster has smaller machines as to emulate AIT environments.

The actual new change in this PR (the last commit) simply fixes GHA syntax

I've also kicked off a canary that executes the workflows in question on push to `rustielin/forge-multi-nightly-canary` branch: https://github.com/aptos-labs/aptos-core/pull/2410. Workflows trigger as intended
* nightly forge run on push: https://github.com/aptos-labs/aptos-core/actions/runs/2776832077
* forge run on push: https://github.com/aptos-labs/aptos-core/actions/runs/2776832075

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2409)
<!-- Reviewable:end -->
