### PR TITLE
ts-gen: init commit

### DIFF
--- a/ecosystem/typescript/ts-gen/.eslintignore
+++ b/ecosystem/typescript/ts-gen/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+packages/**/node_modules/
+dist/**
+**/*.test.ts

--- a/ecosystem/typescript/ts-gen/.eslintrc.js
+++ b/ecosystem/typescript/ts-gen/.eslintrc.js
@@ -1,0 +1,35 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  ignorePatterns: ["*.js", "examples/*"],
+  extends: ["airbnb-base", "airbnb-typescript/base", "prettier"],
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: ["tsconfig.json"],
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  plugins: ["@typescript-eslint"],
+  rules: {
+    quotes: ["error", "double"],
+    "max-len": ["error", 120],
+    "import/extensions": ["error", "never"],
+    "max-classes-per-file": ["error", 10],
+    "import/prefer-default-export": "off",
+    "object-curly-newline": "off",
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": ["error", { functions: false, classes: false }],
+    "no-console": "off",
+  },
+  settings: {
+    "import/resolver": {
+      node: {
+        extensions: [".js", ".jsx", ".ts", ".tsx"],
+      },
+    },
+  },
+};

--- a/ecosystem/typescript/ts-gen/.gitignore
+++ b/ecosystem/typescript/ts-gen/.gitignore
@@ -1,0 +1,17 @@
+.DS_Store
+*/**/.DS_Store
+npm-debug.log
+.npm/
+/coverage
+/tmp
+node_modules
+.idea/
+.history/
+.vscode/
+dist/
+.nyc_output/
+build/
+yarn.lock
+
+# Doc generation output
+docs/

--- a/ecosystem/typescript/ts-gen/.npmignore
+++ b/ecosystem/typescript/ts-gen/.npmignore
@@ -1,0 +1,2 @@
+coverage
+node_modules

--- a/ecosystem/typescript/ts-gen/jest.config.js
+++ b/ecosystem/typescript/ts-gen/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import("ts-jest/dist/types").InitialOptionsTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  coveragePathIgnorePatterns: [],
+  testPathIgnorePatterns: ["dist/*"],
+  collectCoverage: true,
+  coverageThreshold: {
+    global: {
+      branches: 80, // 90,
+      functions: 60, // 95,
+      lines: 60, // 95,
+      statements: 60, // 95,
+    },
+  },
+};

--- a/ecosystem/typescript/ts-gen/package.json
+++ b/ecosystem/typescript/ts-gen/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "mousse",
+  "description": "Aptos SDK",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=11.0.0"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist && tsc -p .",
+    "lint": "eslint \"**/*.ts\"",
+    "push": "yarn publish --non-interactive --new-version",
+    "test": "jest",
+    "_fmt": "prettier 'src/**/*.ts' '.eslintrc.js'",
+    "fmt": "yarn _fmt --write",
+    "fmt:check": "yarn _fmt --check"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aptos-labs/aptos-core.git"
+  },
+  "homepage": "https://github.com/aptos-labs/aptos-core",
+  "bugs": {
+    "url": "https://github.com/aptos-labs/aptos-core/issues"
+  },
+  "author": "aptoslabs.com",
+  "keywords": [
+    "Aptos",
+    "Aptos Labs",
+    "Move"
+  ],
+  "devDependencies": {
+    "@types/docopt": "^0.6.33",
+    "@types/jest": "^28.1.6",
+    "@types/node": "^18.6.2",
+    "@typescript-eslint/eslint-plugin": "^5.31.0",
+    "@typescript-eslint/parser": "^5.31.0",
+    "eslint": "^8.20.0",
+    "eslint-config-airbnb-base": "^15.0.0",
+    "eslint-config-airbnb-typescript": "^17.0.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-import": "^2.26.0",
+    "jest": "^28.1.3",
+    "prettier": "^2.7.1",
+    "ts-jest": "^28.0.7",
+    "ts-node": "^10.9.1",
+    "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "aptos": "/Users/jleng/Workspace/aptos-core/ecosystem/typescript/sdk/aptos-v1.2.2.tgz",
+    "change-case": "^4.1.2",
+    "docopt": "^0.6.2",
+    "globby": "^11.0.4",
+    "tiny-invariant": "^1.2.0"
+  },
+  "version": "0.0.1"
+}

--- a/ecosystem/typescript/ts-gen/src/index.ts
+++ b/ecosystem/typescript/ts-gen/src/index.ts
@@ -1,0 +1,2 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0

--- a/ecosystem/typescript/ts-gen/src/typescript/code-gen.ts
+++ b/ecosystem/typescript/ts-gen/src/typescript/code-gen.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+import { docopt } from "docopt";
+import globby from "globby";
+import fs from "fs";
+import { BCS, HexString } from "aptos";
+import { pascalCase } from "change-case";
+import { ScriptFunctionABI, ScriptABI } from "aptos/dist/transaction_builder/aptos_types";
+import { MoveModule, EntryFunction } from "./ir";
+
+const doc = `
+Usage:
+  code-gen <abi_path>
+  code-gen -h | --help | --version
+`;
+
+async function genTSCode(abiPath: string, moduleMap: Map<string, MoveModule>) {
+  const buf = await fs.promises.readFile(abiPath);
+  const deserializer = new BCS.Deserializer(Uint8Array.from(buf));
+  const scriptABI = ScriptABI.deserialize(deserializer);
+  if (scriptABI instanceof ScriptFunctionABI) {
+    const entryFunc = new EntryFunction(scriptABI);
+
+    const moduleAddress = HexString.fromUint8Array(scriptABI.module_name.address.address);
+    const moduleName = scriptABI.module_name.name.value;
+
+    const fullModuleName = `${moduleAddress}::${moduleName}`;
+
+    if (!moduleMap.has(fullModuleName)) {
+      moduleMap.set(fullModuleName, new MoveModule(moduleAddress, moduleName));
+    }
+
+    moduleMap.get(fullModuleName).addEntryFunction(entryFunc);
+  }
+}
+
+async function run() {
+  const args = docopt(doc);
+
+  const moduleMap = new Map<string, MoveModule>();
+
+  const paths = await globby(`${args["<abi_path>"]}/**/*.abi`);
+
+  await Promise.all(paths.map((path) => genTSCode(path, moduleMap)));
+
+  // TODO: remove hardcoded path
+  const dir = "./artifacts";
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  moduleMap.forEach((m, k) => {
+    const moduleName = k.split("::")[1];
+    fs.writeFileSync(`${dir}/${pascalCase(moduleName)}.ts`, m.gen().join("\n"));
+  });
+}
+
+run();

--- a/ecosystem/typescript/ts-gen/src/typescript/ir.ts
+++ b/ecosystem/typescript/ts-gen/src/typescript/ir.ts
@@ -1,0 +1,406 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable quotes */
+/* eslint-disable max-len */
+
+import { HexString } from "aptos";
+import {
+  ArgumentABI,
+  ScriptFunctionABI,
+  TypeTag,
+  TypeTagAddress,
+  TypeTagBool,
+  TypeTagU128,
+  TypeTagU64,
+  TypeTagU8,
+  TypeTagVector,
+} from "aptos/dist/transaction_builder/aptos_types";
+import { camelCase, pascalCase } from "change-case";
+import invariant from "tiny-invariant";
+import { MapWithDefault } from "../utils";
+
+// A simple IR for code generation
+
+export abstract class IRObject {
+  protected lines: string[] = [];
+
+  protected currentIndent: string = "";
+
+  abstract gen(): string[];
+
+  // Emit a block of code
+  protected emitBlock(block: string) {
+    let lines = block.split("\n");
+    // We want to trim all the lines by the same number of leading spaces.
+    // Count the leading spaces of the non-empty lines.
+    const leadingSpaces = lines
+      .filter((l) => l.trim().length > 0)
+      .reduce((min, ln) => {
+        let spaces = 0;
+        for (; spaces < ln.length; spaces += 1) {
+          if (ln[spaces] !== " ") {
+            break;
+          }
+        }
+
+        return Math.min(min, spaces);
+      }, block.length);
+
+    // Trim the lines
+    lines = lines.map((l) => l.substring(leadingSpaces));
+
+    lines.forEach((l) => this.emitln(l));
+  }
+
+  protected emitln(line: string) {
+    this.lines.push(this.currentIndent + line);
+  }
+
+  protected getLines(): string[] {
+    return this.lines;
+  }
+
+  protected indent() {
+    this.currentIndent = `${this.currentIndent}  `;
+  }
+
+  protected unindent() {
+    this.currentIndent = this.currentIndent.length < 2 ? "" : this.currentIndent.substring(2);
+  }
+}
+
+export enum ImportType {
+  BCS,
+  TRANSACTION_BUILDER_TYPES,
+  APTOS_ACCOUNT,
+  APTOS_CLIENT,
+  MAYBE_HEX_STRING,
+  HEX_STRING,
+  TYPE_TAG_PARSER,
+}
+
+export class MoveModule extends IRObject {
+  private imports: Imports;
+
+  private entryFunctions: EntryFunction[] = [];
+
+  constructor(private readonly address: HexString, private readonly module: string) {
+    super();
+    this.imports = new Imports(new Set());
+    this.imports.addImport(ImportType.APTOS_ACCOUNT);
+    this.imports.addImport(ImportType.APTOS_CLIENT);
+    this.imports.addImport(ImportType.BCS);
+    this.imports.addImport(ImportType.TRANSACTION_BUILDER_TYPES);
+  }
+
+  moduleFullName(): string {
+    return `${this.address.hex()}::${this.module}`;
+  }
+
+  addEntryFunction(f: EntryFunction) {
+    this.entryFunctions.push(f);
+  }
+
+  gen(): string[] {
+    // eslint-disable-next-line prefer-destructuring
+    const imports = this.imports;
+
+    const entryFuncLines = this.entryFunctions.map((ef) => ef.gen());
+
+    this.entryFunctions.forEach((ef) => {
+      imports.mergeImports(ef.imports);
+    });
+
+    // Generate imports
+    imports.gen().forEach((l) => this.emitln(l));
+
+    // Generate type aliases
+    const typeArgNames = new Set();
+    this.entryFunctions.forEach((ef) => {
+      ef.typeTags.forEach((typeTag) => typeArgNames.add(typeTag));
+    });
+    typeArgNames.forEach((typeTag) => {
+      this.emitln(`type ${typeTag} = string;`);
+    });
+    this.emitln("type TransactionHash = string;");
+    this.emitln("");
+
+    // Generate module class name
+    this.emitln(`export class ${pascalCase(this.module)}`);
+    this.emitln("{");
+    this.indent();
+
+    // Module fields
+    this.emitln("private readonly moduleName: TxnBuilderTypes.ModuleId");
+
+    // Contructor
+    this.emitBlock(`
+      constructor(
+        private client: AptosClient,
+        private sender: AptosAccount,
+        private gasUnitPrice: BCS.Uint64 = 1n,
+        private maxGasAmount: BCS.Uint64 = 1000n,
+        private expSecFromNow: number = 10,
+      ) {
+        this.moduleName = new TxnBuilderTypes.ModuleId(
+          TxnBuilderTypes.AccountAddress.fromHex("${this.address}"),
+          new TxnBuilderTypes.Identifier("${this.module}"))
+      }
+    `);
+
+    // Setters
+    this.emitBlock(`
+      setSender(sender: AptosAccount): ${pascalCase(this.module)} {
+        this.sender = sender;
+        return this;
+      }
+
+      setGasUnitPrice(gasUnitPrice: BCS.Uint64): ${pascalCase(this.module)} {
+        this.gasUnitPrice = gasUnitPrice;
+        return this;
+      }
+
+      setMaxGasAmount(maxGasAmount: BCS.Uint64): ${pascalCase(this.module)} {
+        this.maxGasAmount = maxGasAmount;
+        return this;
+      }
+
+      setExpSecFromNow(expSecFromNow: number): ${pascalCase(this.module)} {
+        this.expSecFromNow = expSecFromNow;
+        return this;
+      }
+    `);
+
+    entryFuncLines.forEach((func) => {
+      func.forEach((l) => this.emitln(l));
+      this.emitln("");
+    });
+    this.unindent();
+    this.emitln("}");
+
+    return this.getLines();
+  }
+}
+
+// <name, module>
+type ImportTuple = [string, string];
+
+class Imports extends IRObject {
+  static IMPORT_MAP: Record<ImportType, ImportTuple> = {
+    [ImportType.BCS]: ["BCS", "aptos"],
+    [ImportType.TRANSACTION_BUILDER_TYPES]: ["TxnBuilderTypes", "aptos"],
+    [ImportType.APTOS_ACCOUNT]: ["AptosAccount", "aptos"],
+    [ImportType.APTOS_CLIENT]: ["AptosClient", "aptos"],
+    [ImportType.MAYBE_HEX_STRING]: ["MaybeHexString", "aptos"],
+    [ImportType.HEX_STRING]: ["HexString", "aptos"],
+    [ImportType.TYPE_TAG_PARSER]: ["TypeTagParser", "aptos/dist/transaction_builder/builder_utils"],
+  };
+
+  constructor(private readonly imports: Set<ImportType>) {
+    super();
+  }
+
+  addImport(importType: ImportType) {
+    this.imports.add(importType);
+  }
+
+  mergeImports(impts: Imports) {
+    impts.imports.forEach((impt) => {
+      this.imports.add(impt);
+    });
+  }
+
+  gen(): string[] {
+    const compactedImportMap = new MapWithDefault<string, string[]>(() => []);
+    this.imports.forEach((im) => {
+      const [name, module] = Imports.IMPORT_MAP[im];
+      compactedImportMap.get(module).push(name);
+    });
+
+    compactedImportMap.forEach((names, module) => {
+      this.emitln(`import { ${names.sort().join(", ")} } from "${module}";`);
+    });
+
+    this.emitln("");
+
+    return this.getLines();
+  }
+}
+
+export class EntryFunction extends IRObject {
+  // Dependencies of the function
+  readonly imports: Imports;
+
+  readonly typeTags: string[];
+
+  constructor(private readonly abi: ScriptFunctionABI) {
+    super();
+    this.imports = new Imports(new Set());
+    this.typeTags = abi.ty_args.map((ta) => pascalCase(ta.name));
+    if (this.typeTags.length > 0) {
+      this.imports.addImport(ImportType.TYPE_TAG_PARSER);
+    }
+
+    // Function always requires transaction builder types to build raw transactions.
+    this.imports.addImport(ImportType.TRANSACTION_BUILDER_TYPES);
+
+    // Function always requires AptosClient to submit txns.
+    this.imports.addImport(ImportType.APTOS_CLIENT);
+  }
+
+  // eslint-disable-next-line consistent-return
+  private typeTagToString(typeTag: TypeTag): string {
+    if (typeTag instanceof TypeTagBool) {
+      return "boolean";
+    }
+
+    if (typeTag instanceof TypeTagU8) {
+      this.imports.addImport(ImportType.BCS);
+      return "BCS.Uint8";
+    }
+
+    if (typeTag instanceof TypeTagU64) {
+      this.imports.addImport(ImportType.BCS);
+      return "BCS.Uint64";
+    }
+
+    if (typeTag instanceof TypeTagU128) {
+      this.imports.addImport(ImportType.BCS);
+      return "BCS.Uint128";
+    }
+
+    if (typeTag instanceof TypeTagAddress) {
+      this.imports.addImport(ImportType.TRANSACTION_BUILDER_TYPES);
+      return "TxnBuilderTypes.AccountAddress";
+    }
+
+    if (typeTag instanceof TypeTagVector) {
+      this.imports.addImport(ImportType.BCS);
+      const vecTag = typeTag as TypeTagVector;
+      return `BCS.Seq<${this.typeTagToString(vecTag.value)}>`;
+    }
+
+    // Shouldn't be here
+    invariant(false, "Unsupported type tag");
+  }
+
+  private genArgInSignature(arg: ArgumentABI): string {
+    return `${camelCase(arg.name)}: ${this.typeTagToString(arg.type_tag)}`;
+  }
+
+  private genArgBCS(serializerName: string, argName: string, argType: TypeTag, level: number) {
+    if (argType instanceof TypeTagBool) {
+      this.emitln(`${serializerName}.serializeBool(${argName});`);
+      this.emitln("");
+    } else if (argType instanceof TypeTagU8) {
+      this.emitln(`${serializerName}.serializeU8(${argName});`);
+      this.emitln("");
+    } else if (argType instanceof TypeTagU64) {
+      this.emitln(`${serializerName}.serializeU64(${argName});`);
+      this.emitln("");
+    } else if (argType instanceof TypeTagU128) {
+      this.emitln(`${serializerName}.serializeU128(${argName});`);
+      this.emitln("");
+    } else if (argType instanceof TypeTagAddress) {
+      this.emitln(`${argName}.serialize(${serializerName});`);
+      this.emitln("");
+    } else if (argType instanceof TypeTagVector) {
+      this.emitln(`${serializerName}.serializeU32AsUleb128(${argName}.length);`);
+      this.emitln(`for (const ${argName}${level} of ${argName})`);
+      this.emitln("{");
+      this.indent();
+      this.genArgBCS(serializerName, `${argName}${level}`, (argType as TypeTagVector).value, level + 1);
+      this.unindent();
+      this.emitln("}");
+    } else {
+      // Shouldn't be here
+      invariant(false, "Unsupported arg type");
+    }
+  }
+
+  gen(): string[] {
+    // Because of the limitation of TypeScript generics, we have to ask users to pass in
+    // the typeArgs as normal function args.
+    let typeArgAsNormalArgs = "";
+
+    if (this.typeTags.length > 0) {
+      // typeArgs is defined as a tuple
+      typeArgAsNormalArgs = `typeArgs: [${this.typeTags.join(", ")}], `;
+    }
+
+    // e.g. async transfer(to: TxnBuilderTypes.AccountAddress, amount: BCS.Uint64): string
+    // Transaction hash string is returned
+    const signature = `async ${camelCase(this.abi.name)}(${typeArgAsNormalArgs}${this.abi.args
+      .map((arg) => this.genArgInSignature(arg))
+      .join(", ")}): Promise<TransactionHash>`;
+
+    this.emitln(signature);
+    this.emitln("{");
+    this.indent();
+
+    // Serializes the args
+    this.abi.args.forEach((arg) => {
+      const serializerName = `${camelCase(arg.name)}Serializer`;
+      this.emitln(`const ${serializerName} = new BCS.Serializer();`);
+      this.genArgBCS(serializerName, camelCase(arg.name), arg.type_tag, 0);
+    });
+
+    // Prepares the type tags
+    this.emitln("const parsedTypeTags: TxnBuilderTypes.TypeTag[] = [];");
+
+    if (this.typeTags.length > 0) {
+      this.emitBlock(`
+        if (typeArgs.length !== ${this.typeTags.length}) {
+          throw new Error("typeArgs length should be ${this.typeTags.length}");
+        }
+      `);
+    }
+
+    for (let i = 0; i < this.typeTags.length; i += 1) {
+      this.emitBlock(`
+        const tyTagParser${i} = new TypeTagParser(typeArgs[${i}]);
+        parsedTypeTags.push(tyTagParser${i}.parseTypeTag());
+      `);
+    }
+
+    this.emitBlock(`
+      const payload = new TxnBuilderTypes.TransactionPayloadScriptFunction(
+        new TxnBuilderTypes.ScriptFunction(
+          this.moduleName,
+          new TxnBuilderTypes.Identifier("${this.abi.name}"),
+          parsedTypeTags,
+          [${this.abi.args.map((arg) => `${camelCase(arg.name)}Serializer.getBytes()`).join(", ")}]
+        )
+      );
+
+      if (!this.sender) {
+        throw new Error("Transaction sender is not found.");
+      }
+
+      const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
+        this.client.getAccount(this.sender.address()),
+        this.client.getChainId(),
+      ]);
+
+      const rawTxn = new TxnBuilderTypes.RawTransaction(
+        TxnBuilderTypes.AccountAddress.fromHex(this.sender.address()),
+        BigInt(sequenceNumber),
+        payload,
+        BigInt(this.maxGasAmount),
+        BigInt(this.gasUnitPrice),
+        BigInt(Math.floor(Date.now() / 1000) + this.expSecFromNow),
+        new TxnBuilderTypes.ChainId(chainId),
+      );
+
+      const bcsTxn = AptosClient.generateBCSTransaction(this.sender, rawTxn);
+      const { hash } = await this.client.submitSignedBCSTransaction(bcsTxn);
+      return hash;
+    `);
+
+    this.unindent();
+    this.emitln("}");
+
+    return this.getLines();
+  }
+}

--- a/ecosystem/typescript/ts-gen/src/utils.ts
+++ b/ecosystem/typescript/ts-gen/src/utils.ts
@@ -1,0 +1,15 @@
+export class MapWithDefault<K, V> extends Map<K, V> {
+  private readonly default: () => V;
+
+  get(key: K) {
+    if (!this.has(key)) {
+      this.set(key, this.default());
+    }
+    return super.get(key);
+  }
+
+  constructor(defaultFunction: () => V) {
+    super();
+    this.default = defaultFunction;
+  }
+}

--- a/ecosystem/typescript/ts-gen/tsconfig.json
+++ b/ecosystem/typescript/ts-gen/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "outDir": "./dist",
+    "allowJs": true,
+    "target": "es2020",
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "module": "commonjs",
+    "pretty": true,
+    "noImplicitAny": true,
+    "allowSyntheticDefaultImports": true,
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
### Description
One problem with BCS txn submissions is that users have to write a lot of boilerplate code. This code generation tool generates classes and function calls based on ABI with one command.

### Test Plan
`npx ts-node src/typescript/code-gen.ts /Users/jleng/Workspace/aptos-core/aptos-move/framework/aptos-framework/build/AptosFramework`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2414)
<!-- Reviewable:end -->
