### PR TITLE
[helm] separate prometheus k8s service

### DIFF
--- a/terraform/helm/monitoring/templates/monitoring.yaml
+++ b/terraform/helm/monitoring/templates/monitoring.yaml
@@ -150,6 +150,23 @@ spec:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aptos-monitoring.fullname" . }}-prometheus
+  labels:
+    {{- include "aptos-monitoring.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "aptos-monitoring.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: monitoring
+  ports:
+  - name: prometheus-http
+    port: 9090
+  type: ClusterIP
+
+---
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -22,6 +22,8 @@ spec:
     env:
     - name: FORGE_TRIGGERED_BY
       value: {FORGE_TRIGGERED_BY}
+    - name: PROMETHEUS_URL
+      value: http://aptos-node-mon-aptos-monitoring-prometheus.default.svc:9090
     # - name: RUST_LOG
     #   value: debug
   affinity:


### PR DESCRIPTION
### Description

Add a separate `ClusterIP` prometheus service to the `monitoring` helm chart.

This makes it such that pods within the cluster can access prometheus, such as Forge, which will use prometheus to define and validate complex success criteria a la https://github.com/aptos-labs/aptos-core/pull/2270

### Test Plan

Terraform apply, and see that the service comes up and we're able to access it

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2425)
<!-- Reviewable:end -->
