### PR TITLE
Add aptos-openapi-spec-generator to CI

### DIFF
--- a/docker/build-rust-all.sh
+++ b/docker/build-rust-all.sh
@@ -6,36 +6,38 @@ set -e
 # Build all the rust release binaries
 RUSTFLAGS="--cfg tokio_unstable" cargo build --release \
         -p aptos \
-        -p aptos-node \
-        -p aptos-indexer \
         -p aptos-faucet \
+        -p aptos-indexer \
+        -p aptos-node \
         -p aptos-node-checker \
+        -p aptos-openapi-spec-generator \
         -p backup-cli \
         -p db-bootstrapper \
-        -p transaction-emitter \
         -p forge-cli \
+        -p transaction-emitter \
         "$@"
 
-# after building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
+# After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
 BINS=(
     aptos
+    aptos-faucet
+    aptos-indexer
     aptos-node
     aptos-node-checker
-    aptos-indexer
-    aptos-faucet
+    aptos-openapi-spec-generator
     db-backup
     db-backup-verify
-    db-restore
     db-bootstrapper
-    transaction-emitter
+    db-restore
     forge
+    transaction-emitter
 )
 
 mkdir dist
 
 for BIN in "${BINS[@]}"
 do
-        cp target/release/$BIN dist/$BIN
+    cp target/release/$BIN dist/$BIN
 done
 
 # Build the Aptos Move framework

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -114,6 +114,7 @@ COPY --link --from=builder /aptos/dist/db-backup /usr/local/bin/db-backup
 COPY --link --from=builder /aptos/dist/db-backup-verify /usr/local/bin/db-backup-verify
 COPY --link --from=builder /aptos/dist/db-restore /usr/local/bin/db-restore
 COPY --link --from=builder /aptos/dist/aptos /usr/local/bin/aptos
+COPY --link --from=builder /aptos/dist/aptos-openapi-spec-generator /usr/local/bin/aptos-openapi-spec-generator
 COPY --link --from=builder /aptos/dist/transaction-emitter /usr/local/bin/transaction-emitter
 
 ### Get Aptos Move modules bytecodes for genesis ceremony


### PR DESCRIPTION
## Description
I want to use this in CI. Having it in the tools image enables me to use this from docker, potentially benefiting from caching to speed up the CI.

I sort some stuff while I'm at it.

## Test Plan
Build the tools image:
```
docker context create builders
docker context use builders
docker buildx create --driver docker-container --use --builder builders --name builder-dda7b2c6-4289-4ae5-9b50-38624dae0f9f --buildkitd-flags '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'
docker buildx inspect --bootstrap --builder builder-dda7b2c6-4289-4ae5-9b50-38624dae0f9f
export LAST_GREEN_COMMIT=25e4d7320a0a4dac20b4c07e353350636a8c3d01
docker/docker-bake-rust-all.sh tools
```
See that the new binary is in there:
```
todo, waiting for long ass build
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2432)
<!-- Reviewable:end -->
