### PR TITLE
[CLI] Bound the number of instructions that can be executed by any one test.

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -236,6 +236,15 @@ pub struct TestPackage {
 
     #[clap(flatten)]
     pub(crate) move_options: MovePackageDir,
+
+    /// Bound the number of instructions that can be executed by any one test.
+    #[clap(
+        name = "instructions",
+        default_value = "100000",
+        short = 'i',
+        long = "instructions"
+    )]
+    pub instruction_execution_bound: u64,
 }
 
 #[async_trait]
@@ -256,7 +265,8 @@ impl CliCommand<&'static str> for TestPackage {
             config,
             UnitTestingConfig {
                 filter: self.filter,
-                ..UnitTestingConfig::default_with_bound(Some(100_000))
+                instruction_execution_bound: Some(self.instruction_execution_bound),
+                ..UnitTestingConfig::default_with_bound(None)
             },
             // TODO(Gas): we may want to switch to non-zero costs in the future
             aptos_debug_natives::aptos_debug_natives(

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -658,6 +658,7 @@ impl CliTestFramework {
         filter: Option<&str>,
     ) -> CliTypedResult<&'static str> {
         TestPackage {
+            instruction_execution_bound: 100_000,
             move_options: self.move_options(account_strs),
             filter: filter.map(|str| str.to_string()),
         }


### PR DESCRIPTION
### Description
Added a option from move-cli: `--instructions`, `-i`
Bound the number of instructions that can be executed by any one test.
see: https://github.com/diem/move/blob/main/language/tools/move-cli/src/package/cli.rs#L135

```bash
aptos move test --instructions <NUMBER>
```
or

```bash
aptos move test -i <NUMBER>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2444)
<!-- Reviewable:end -->
