### PR TITLE
[SDK] Add helpers for working with `MoveStructTag`s

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
+## 1.3.3 (2022-08-05)
+### Added
+- New helpers for working with the `MoveStructTag` type, `toMoveStructTagParam` and `fromMoveStructTagParam`.
+
 ## 1.3.2 (2022-08-04)
 This special entry does not conform to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) as there are noteworthy breaking changes with necessary rationale. Future entries will follow this format.
 

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -62,5 +62,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
-  "version": "1.3.2"
+  "version": "1.3.3"
 }

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -1,6 +1,6 @@
 import { MemoizeExpiring } from "typescript-memoize";
 import { HexString, MaybeHexString } from "./hex_string";
-import { moveStructTagToParam, sleep } from "./util";
+import { toMoveStructTagParam, sleep } from "./util";
 import { AptosAccount } from "./aptos_account";
 import * as Gen from "./generated/index";
 import { TxnBuilderTypes, TransactionBuilderEd25519 } from "./transaction_builder";
@@ -141,7 +141,7 @@ export class AptosClient {
   ): Promise<Gen.MoveResource> {
     return this.client.accounts.getAccountResource(
       HexString.ensure(accountAddress).hex(),
-      moveStructTagToParam(resourceType),
+      toMoveStructTagParam(resourceType),
       query?.ledgerVersion?.toString(),
     );
   }
@@ -278,7 +278,7 @@ export class AptosClient {
   ): Promise<Gen.Event[]> {
     return this.client.events.getEventsByEventHandle(
       HexString.ensure(address).hex(),
-      moveStructTagToParam(eventHandleStruct),
+      toMoveStructTagParam(eventHandleStruct),
       fieldName,
       query?.start?.toString(),
       query?.limit,

--- a/ecosystem/typescript/sdk/src/util.test.ts
+++ b/ecosystem/typescript/sdk/src/util.test.ts
@@ -1,3 +1,5 @@
+import { fromMoveStructTagParam, toMoveStructTagParam } from "./util";
+
 export const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com/v1";
 export const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
 
@@ -6,4 +8,44 @@ test("noop", () => {
   // Adding this empty test allows us to:
   // 1. Guarantee that this test library won't get compiled
   // 2. Prevent jest from exploding when it finds a file with no tests in it
+});
+
+test("toMoveStructTagParam", () => {
+  const moveStructTag1 = {
+    address: "0x1",
+    module: "coin",
+    name: "CoinStore",
+    generic_type_params: ["0x1::aptos_coin::AptosCoin", "0x3::token::Whatever"],
+  };
+  let actual1 = toMoveStructTagParam(moveStructTag1);
+  expect(actual1).toBe("0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin,0x3::token::Whatever>");
+
+  const moveStructTag2 = {
+    address: "0x1",
+    module: "coin",
+    name: "CoinStore",
+    generic_type_params: [] as string[],
+  };
+  let actual2 = toMoveStructTagParam(moveStructTag2);
+  expect(actual2).toBe("0x1::coin::CoinStore");
+});
+
+test("fromMoveStructTagParam", () => {
+  const moveStructTagParam1 = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin,0x3::token::Whatever>";
+  let actual1 = fromMoveStructTagParam(moveStructTagParam1);
+  expect(actual1).toStrictEqual({
+    address: "0x1",
+    module: "coin",
+    name: "CoinStore",
+    generic_type_params: ["0x1::aptos_coin::AptosCoin", "0x3::token::Whatever"],
+  });
+
+  const moveStructTagParam2 = "0x1::coin::CoinStore";
+  let actual2 = fromMoveStructTagParam(moveStructTagParam2);
+  expect(actual2).toStrictEqual({
+    address: "0x1",
+    module: "coin",
+    name: "CoinStore",
+    generic_type_params: [],
+  });
 });

--- a/ecosystem/typescript/sdk/src/util.ts
+++ b/ecosystem/typescript/sdk/src/util.ts
@@ -10,10 +10,23 @@ export async function sleep(timeMs: number): Promise<null> {
   });
 }
 
-export function moveStructTagToParam(moveStructTag: Gen.MoveStructTag): Gen.MoveStructTagParam {
+export function toMoveStructTagParam(moveStructTag: Gen.MoveStructTag): Gen.MoveStructTagParam {
   let genericTypeParamsString = "";
   if (moveStructTag.generic_type_params.length > 0) {
     genericTypeParamsString = `<${moveStructTag.generic_type_params.join(",")}>`;
   }
   return `${moveStructTag.address}::${moveStructTag.module}::${moveStructTag.name}${genericTypeParamsString}`;
+}
+
+// Note: This is not tested against generic type params that themselves have generic type params.
+const moveStructTagParamRegex = /^(0x[0-9a-zA-Z_]+)::([0-9a-zA-Z_]+)::([0-9a-zA-Z_]+)(?:<([0-9a-zA-Z:_<>,]+)>){0,1}$/;
+
+export function fromMoveStructTagParam(moveStructTagParam: Gen.MoveStructTagParam): Gen.MoveStructTag {
+  const test = moveStructTagParamRegex.exec(moveStructTagParam);
+  return {
+    address: test[1],
+    module: test[2],
+    name: test[3],
+    generic_type_params: test[4]?.split(",") ?? [],
+  };
 }


### PR DESCRIPTION
## Description
This PR adds some helpers for working with MoveStructTags. This is necessary because we need these as strings for path params but otherwise we use them as the actual objects.

Open to feedback / improvements on these functions.

## Test Plan
```
yarn test
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2456)
<!-- Reviewable:end -->
