### PR TITLE
Fix Wallet build with JS optional operator

### DIFF
--- a/ecosystem/web-wallet/src/core/queries/account.ts
+++ b/ecosystem/web-wallet/src/core/queries/account.ts
@@ -54,7 +54,7 @@ export const getAptosCoinTokenBalanceFromAccountResources = ({
     accountResources,
     resource: '0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>',
   });
-  return aptosCoinResource ? (aptosCoinResource.data as { coin: { value: string } }).coin.value : undefined;
+  return (aptosCoinResource?.data as { coin: { value: string } })?.coin?.value;
 };
 
 export const getAccountExists = async ({


### PR DESCRIPTION
### Description
The wallet extension wasn't building properly due to this eslint error.

``` 
./aptos-core/ecosystem/web-wallet/src/core/queries/account.ts
57:1  error  This line has a length of 108. Maximum allowed is 100  max-len
```

This PR uses the optional chaining operator to fix the error and eliminate the ternary.

### Test Plan
Build the wallet extension
Install in chrome, Brave, Firefox and any other supported browsers
Make sure coin amount queries work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2458)
<!-- Reviewable:end -->
