### PR TITLE
[Consensus] Add compression to consensus messages.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5531,6 +5531,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-bitvec",
+ "aptos-compression",
  "aptos-config",
  "aptos-crypto",
  "aptos-crypto-derive",

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -87,9 +87,14 @@ pub struct ConsensusNetworkSender {
 }
 
 /// Supported protocols in preferred order (from highest priority to lowest).
-pub const RPC: &[ProtocolId] = &[ProtocolId::ConsensusRpcBcs, ProtocolId::ConsensusRpcJson];
+pub const RPC: &[ProtocolId] = &[
+    ProtocolId::ConsensusRpcCompressed,
+    ProtocolId::ConsensusRpcBcs,
+    ProtocolId::ConsensusRpcJson,
+];
 /// Supported protocols in preferred order (from highest priority to lowest).
 pub const DIRECT_SEND: &[ProtocolId] = &[
+    ProtocolId::ConsensusDirectSendCompressed,
     ProtocolId::ConsensusDirectSendBcs,
     ProtocolId::ConsensusDirectSendJson,
 ];
@@ -107,8 +112,6 @@ pub fn network_endpoint_config() -> AppConfig {
 }
 
 impl NewNetworkSender for ConsensusNetworkSender {
-    /// Returns a Sender that only sends for the `CONSENSUS_DIRECT_SEND_PROTOCOL` and
-    /// `CONSENSUS_RPC_PROTOCOL` ProtocolId.
     fn new(
         peer_mgr_reqs_tx: PeerManagerRequestSender,
         connection_reqs_tx: ConnectionRequestSender,
@@ -157,13 +160,13 @@ impl ConsensusNetworkSender {
 
 #[async_trait]
 impl ApplicationNetworkSender<ConsensusMsg> for ConsensusNetworkSender {
-    /// Send a single message to the destination peer using available ProtocolId.
+    /// Send a single message to the destination peer using the available ProtocolId.
     fn send_to(&self, recipient: PeerId, message: ConsensusMsg) -> Result<(), NetworkError> {
         let protocol = self.preferred_protocol_for_peer(recipient, DIRECT_SEND)?;
         self.network_sender.send_to(recipient, protocol, message)
     }
 
-    /// Send a single message to the destination peers using available ProtocolId.
+    /// Send a single message to the destination peers using the available ProtocolId.
     fn send_to_many(
         &self,
         recipients: impl Iterator<Item = PeerId>,
@@ -191,7 +194,7 @@ impl ApplicationNetworkSender<ConsensusMsg> for ConsensusNetworkSender {
         Ok(())
     }
 
-    /// Send a RPC to the destination peer using the `CONSENSUS_RPC_PROTOCOL` ProtocolId.
+    /// Send a RPC to the destination peer using the available ProtocolId.
     async fn send_rpc(
         &self,
         recipient: PeerId,

--- a/crates/aptos-compression/src/tests.rs
+++ b/crates/aptos-compression/src/tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::CompressionClient;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_crypto::hash::HashValue;
 use aptos_crypto::{PrivateKey, SigningKey, Uniform};
@@ -38,8 +39,10 @@ fn test_basic_compression() {
 /// when BCS encoded.
 fn test_compress_and_decompress<T: Debug + DeserializeOwned + PartialEq + Serialize>(object: T) {
     let bcs_encoded_bytes = bcs::to_bytes(&object).unwrap();
-    let compressed_bytes = crate::compress(bcs_encoded_bytes).unwrap();
-    let decompressed_bytes = crate::decompress(&compressed_bytes).unwrap();
+    let compressed_bytes =
+        crate::compress(bcs_encoded_bytes, CompressionClient::StateSync).unwrap();
+    let decompressed_bytes =
+        crate::decompress(&compressed_bytes, CompressionClient::StateSync).unwrap();
     let decoded_object = bcs::from_bytes::<T>(&decompressed_bytes).unwrap();
 
     assert_eq!(object, decoded_object);

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.18.2", features = ["full"] }
 tokio-retry = "0.3.0"
 tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
 
+aptos-compression = { path = "../crates/aptos-compression" }
 aptos-config = { path = "../config" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -25,7 +25,7 @@ use futures::{
     task::{Context, Poll},
 };
 use pin_project::pin_project;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use short_hex_str::AsShortHexStr;
 use std::{cmp::min, iter::FromIterator, marker::PhantomData, pin::Pin, time::Duration};
 
@@ -382,7 +382,7 @@ pub trait SerializedRequest {
 
     /// Converts the `SerializedMessage` into its deserialized version of `TMessage` based on the
     /// `ProtocolId`.  See: [`ProtocolId::from_bytes`]
-    fn to_message<'a, TMessage: Deserialize<'a>>(&'a self) -> anyhow::Result<TMessage> {
+    fn to_message<TMessage: DeserializeOwned>(&self) -> anyhow::Result<TMessage> {
         self.protocol_id().from_bytes(self.data())
     }
 }

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -24,8 +24,10 @@ use std::{
 };
 use thiserror::Error;
 
+use aptos_compression::metrics::CompressionClient;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
+use serde::de::DeserializeOwned;
 
 #[cfg(test)]
 mod test;
@@ -52,11 +54,14 @@ pub enum ProtocolId {
     StorageServiceRpc = 8,
     MempoolRpc = 9,
     PeerMonitoringServiceRpc = 10,
+    ConsensusRpcCompressed = 11,
+    ConsensusDirectSendCompressed = 12,
 }
 
 /// The encoding types for Protocols
 enum Encoding {
     Bcs,
+    CompressedBcs,
     Json,
 }
 
@@ -75,6 +80,8 @@ impl ProtocolId {
             StorageServiceRpc => "StorageServiceRpc",
             MempoolRpc => "MempoolRpc",
             PeerMonitoringServiceRpc => "PeerMonitoringServiceRpc",
+            ConsensusRpcCompressed => "ConsensusRpcCompressed",
+            ConsensusDirectSendCompressed => "ConsensusDirectSendCompressed",
         }
     }
 
@@ -91,6 +98,8 @@ impl ProtocolId {
             ProtocolId::StorageServiceRpc,
             ProtocolId::MempoolRpc,
             ProtocolId::PeerMonitoringServiceRpc,
+            ProtocolId::ConsensusRpcCompressed,
+            ProtocolId::ConsensusDirectSendCompressed,
         ]
     }
 
@@ -98,6 +107,9 @@ impl ProtocolId {
     fn encoding(self) -> Encoding {
         match self {
             ProtocolId::ConsensusDirectSendJson | ProtocolId::ConsensusRpcJson => Encoding::Json,
+            ProtocolId::ConsensusDirectSendCompressed | ProtocolId::ConsensusRpcCompressed => {
+                Encoding::CompressedBcs
+            }
             _ => Encoding::Bcs,
         }
     }
@@ -109,16 +121,35 @@ impl ProtocolId {
 
     pub fn to_bytes<T: Serialize>(&self, value: &T) -> anyhow::Result<Vec<u8>> {
         match self.encoding() {
+            Encoding::Bcs => self.bcs_encode(value),
+            Encoding::CompressedBcs => {
+                let bcs_bytes = self.bcs_encode(value)?;
+                aptos_compression::compress(bcs_bytes, CompressionClient::Consensus)
+                    .map_err(|e| anyhow!("{:?}", e))
+            }
             Encoding::Json => serde_json::to_vec(value).map_err(|e| anyhow!("{:?}", e)),
-            Encoding::Bcs => bcs::to_bytes(value).map_err(|e| anyhow! {"{:?}", e}),
         }
     }
 
-    pub fn from_bytes<'a, T: Deserialize<'a>>(&self, bytes: &'a [u8]) -> anyhow::Result<T> {
+    pub fn from_bytes<T: DeserializeOwned>(&self, bytes: &[u8]) -> anyhow::Result<T> {
         match self.encoding() {
+            Encoding::Bcs => self.bcs_decode(bytes),
+            Encoding::CompressedBcs => {
+                let raw_bytes =
+                    aptos_compression::decompress(&bytes.to_vec(), CompressionClient::Consensus)
+                        .map_err(|e| anyhow! {"{:?}", e})?;
+                self.bcs_decode(&raw_bytes)
+            }
             Encoding::Json => serde_json::from_slice(bytes).map_err(|e| anyhow!("{:?}", e)),
-            Encoding::Bcs => bcs::from_bytes(bytes).map_err(|e| anyhow! {"{:?}", e}),
         }
+    }
+
+    fn bcs_encode<T: Serialize>(&self, value: &T) -> anyhow::Result<Vec<u8>> {
+        bcs::to_bytes(value).map_err(|e| anyhow!("{:?}", e))
+    }
+
+    fn bcs_decode<T: DeserializeOwned>(&self, bytes: &[u8]) -> anyhow::Result<T> {
+        bcs::from_bytes(bytes).map_err(|e| anyhow!("{:?}", e))
     }
 }
 

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -145,6 +145,10 @@ ProtocolId:
       MempoolRpc: UNIT
     10:
       PeerMonitoringServiceRpc: UNIT
+    11:
+      ConsensusRpcCompressed: UNIT
+    12:
+      ConsensusDirectSendCompressed: UNIT
 ProtocolIdSet:
   NEWTYPESTRUCT: BYTES
 PublicKey:


### PR DESCRIPTION
### Description

This PR adds data compression to consensus messages using the compression crate at the network layer. Specifically:
1. Compression can now be configured via the consensus config.
2. We add additional metrics labels to the compression crate to better track the compression ratios and latencies between clients (i.e., consensus and state sync).
3. In order to get this to work, I've added the node config to the network sender trait and all relevant code. This isn't great, but there doesn't appear to be an easy work around without heavy refactoring (and I'd like to minimize the amount of network changes I make 😄).

### Test Plan
Existing tests should cover this. I've also inspected the metrics on a forge run. Here's the compression ratio being reported by consensus for the last run:

<img width="1308" alt="Screen Shot 2022-08-03 at 10 15 28 AM" src="https://user-images.githubusercontent.com/4578587/182630727-6f105a3c-1a57-446b-9a2b-fa2a9258457c.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2459)
<!-- Reviewable:end -->
