### PR TITLE
[forge] tune direction and delay of latency test

### DIFF
--- a/testsuite/forge/src/backend/k8s/chaos/network_delay.yaml
+++ b/testsuite/forge/src/backend/k8s/chaos/network_delay.yaml
@@ -15,7 +15,12 @@ spec:
     latency: "{latency_ms}ms"
     correlation: "{correlation_percentage}"
     jitter: "{jitter_ms}ms"
-  direction: both
+  # Indicates the direction of target packets. Available vaules include:
+  # from (the packets from target)
+  # to (the packets to target)
+  # both (the packets from or to target)
+  # This parameter makes Chaos only take effect for a specific direction of packets.
+  direction: from
   target:
     selector:
       namespaces:

--- a/testsuite/testcases/src/network_latency_test.rs
+++ b/testsuite/testcases/src/network_latency_test.rs
@@ -7,8 +7,8 @@ use forge::{NetworkContext, NetworkTest, Result, SwarmChaos, SwarmNetworkDelay, 
 pub struct NetworkLatencyTest;
 
 // Delay
-pub const LATENCY_MS: u64 = 80;
-pub const JITTER_MS: u64 = 20;
+pub const LATENCY_MS: u64 = 200;
+pub const JITTER_MS: u64 = 100;
 pub const CORRELATION_PERCENTAGE: u64 = 10;
 
 impl Test for NetworkLatencyTest {


### PR DESCRIPTION
### Description

Same as https://github.com/aptos-labs/aptos-core/pull/2455 but opposite direction

### Test Plan

Run forge


<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2464)
<!-- Reviewable:end -->
