### PR TITLE
[storage][pruner] Always initialize pruners

### DIFF
--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     test_helper,
     test_helper::{arb_blocks_to_commit, put_as_state_root, put_transaction_info},
-    AptosDB, PrunerManager, ROCKSDB_PROPERTIES,
+    AptosDB, ROCKSDB_PROPERTIES,
 };
 use aptos_config::config::StoragePrunerConfig;
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -85,7 +85,7 @@ fn test_too_many_requested() {
 fn test_error_if_version_is_pruned() {
     let tmp_dir = TempPath::new();
     let aptos_db = AptosDB::new_for_test(&tmp_dir);
-    let mut state_pruner = StatePrunerManager::new(
+    let state_pruner = StatePrunerManager::new(
         Arc::clone(&aptos_db.state_merkle_db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
@@ -95,7 +95,7 @@ fn test_error_if_version_is_pruned() {
         },
     );
 
-    let mut ledger_pruner = LedgerPrunerManager::new(
+    let ledger_pruner = LedgerPrunerManager::new(
         Arc::clone(&aptos_db.ledger_db),
         StoragePrunerConfig {
             state_store_prune_window: Some(0),
@@ -104,8 +104,8 @@ fn test_error_if_version_is_pruned() {
             state_store_pruning_batch_size: 1,
         },
     );
-    state_pruner.testonly_update_min_version(Some(5));
-    ledger_pruner.testonly_update_min_version(Some(10));
+    state_pruner.testonly_update_min_version(5);
+    ledger_pruner.testonly_update_min_version(10);
     assert_eq!(
         error_if_version_is_pruned(&state_pruner, "State", 4)
             .unwrap_err()

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -49,6 +49,7 @@ use crate::{
         API_LATENCY_SECONDS, COMMITTED_TXNS, LATEST_TXN_VERSION, LEDGER_VERSION, NEXT_BLOCK_EPOCH,
         OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES, STATE_ITEM_COUNT,
     },
+    pruner::db_pruner::DBPruner,
     pruner::pruner_manager::PrunerManager,
     pruner::utils,
     schema::*,
@@ -107,7 +108,9 @@ use std::{
 };
 
 use crate::pruner::ledger_pruner_manager::LedgerPrunerManager;
+use crate::pruner::ledger_store::ledger_store_pruner::LedgerPruner;
 use crate::pruner::state_pruner_manager::StatePrunerManager;
+use crate::pruner::state_store::StateStorePruner;
 use storage_interface::state_view::DbStateView;
 use storage_interface::{
     state_delta::StateDelta, DbReader, DbWriter, ExecutedTrees, Order, StartupInfo,
@@ -175,15 +178,14 @@ fn error_if_version_is_pruned(
     data_type: &str,
     version: Version,
 ) -> Result<()> {
-    if let Some(min_readable_version) = pruner.get_min_readable_version() {
-        ensure!(
-            version >= min_readable_version,
-            "{} version {} is pruned, min available version is {}.",
-            data_type,
-            version,
-            min_readable_version
-        );
-    }
+    let min_readable_version = pruner.get_min_readable_version();
+    ensure!(
+        version >= min_readable_version,
+        "{} version {} is pruned, min available version is {}.",
+        data_type,
+        version,
+        min_readable_version
+    );
     Ok(())
 }
 
@@ -263,9 +265,8 @@ pub struct AptosDB {
     state_store: Arc<StateStore>,
     system_store: Arc<SystemStore>,
     transaction_store: Arc<TransactionStore>,
-    pruner_config: StoragePrunerConfig,
-    state_pruner: Option<StatePrunerManager>,
-    ledger_pruner: Option<LedgerPrunerManager>,
+    state_pruner: StatePrunerManager,
+    ledger_pruner: LedgerPrunerManager,
     _rocksdb_property_reporter: RocksdbPropertyReporter,
     ledger_commit_lock: std::sync::Mutex<()>,
     indexer: Option<Indexer>,
@@ -281,23 +282,10 @@ impl AptosDB {
     ) -> Self {
         let arc_ledger_rocksdb = Arc::new(ledger_rocksdb);
         let arc_state_merkle_rocksdb = Arc::new(state_merkle_rocksdb);
-        let pruner_config = storage_pruner_config;
-        let state_pruner = if pruner_config.state_store_prune_window.is_none() {
-            None
-        } else {
-            Some(StatePrunerManager::new(
-                Arc::clone(&arc_state_merkle_rocksdb),
-                pruner_config,
-            ))
-        };
-        let ledger_pruner = if pruner_config.ledger_prune_window.is_none() {
-            None
-        } else {
-            Some(LedgerPrunerManager::new(
-                Arc::clone(&arc_ledger_rocksdb),
-                pruner_config,
-            ))
-        };
+        let state_pruner =
+            StatePrunerManager::new(Arc::clone(&arc_state_merkle_rocksdb), storage_pruner_config);
+        let ledger_pruner =
+            LedgerPrunerManager::new(Arc::clone(&arc_ledger_rocksdb), storage_pruner_config);
 
         AptosDB {
             ledger_db: Arc::clone(&arc_ledger_rocksdb),
@@ -312,7 +300,6 @@ impl AptosDB {
             )),
             system_store: Arc::new(SystemStore::new(Arc::clone(&arc_ledger_rocksdb))),
             transaction_store: Arc::new(TransactionStore::new(Arc::clone(&arc_ledger_rocksdb))),
-            pruner_config,
             state_pruner,
             ledger_pruner,
             _rocksdb_property_reporter: RocksdbPropertyReporter::new(
@@ -597,9 +584,8 @@ impl AptosDB {
         ledger_version: Version,
         fetch_events: bool,
     ) -> Result<TransactionWithProof> {
-        if let Some(ledger_pruner) = &self.ledger_pruner {
-            error_if_version_is_pruned(ledger_pruner, "Transaction", version)?;
-        }
+        error_if_version_is_pruned(&self.ledger_pruner, "Transaction", version)?;
+
         let proof = self
             .ledger_store
             .get_transaction_info_with_proof(version, ledger_version)?;
@@ -807,12 +793,8 @@ impl AptosDB {
     }
 
     fn wake_pruner(&self, latest_version: Version) {
-        if let Some(pruner) = self.state_pruner.as_ref() {
-            pruner.maybe_wake_pruner(latest_version)
-        }
-        if let Some(pruner) = self.ledger_pruner.as_ref() {
-            pruner.maybe_wake_pruner(latest_version)
-        }
+        self.state_pruner.maybe_wake_pruner(latest_version);
+        self.ledger_pruner.maybe_wake_pruner(latest_version);
     }
 
     fn get_table_info_option(&self, handle: TableHandle) -> Result<Option<TableInfo>> {
@@ -960,9 +942,7 @@ impl DbReader for AptosDB {
             if start_version > ledger_version || limit == 0 {
                 return Ok(TransactionListWithProof::new_empty());
             }
-            if let Some(ledger_pruner) = &self.ledger_pruner {
-                error_if_version_is_pruned(ledger_pruner, "Transaction", start_version)?;
-            }
+            error_if_version_is_pruned(&self.ledger_pruner, "Transaction", start_version)?;
 
             let limit = std::cmp::min(limit, ledger_version - start_version + 1);
 
@@ -1002,24 +982,14 @@ impl DbReader for AptosDB {
     /// Get the first version that txn starts existent.
     fn get_first_txn_version(&self) -> Result<Option<Version>> {
         gauged_api("get_first_txn_version", || {
-            if let Some(pruner) = self.ledger_pruner.as_ref() {
-                // If pruning is enabled, we can get the min readable version from the pruner.
-                Ok(pruner.get_min_readable_version())
-            } else {
-                self.transaction_store.get_first_txn_version()
-            }
+            self.transaction_store.get_first_txn_version()
         })
     }
 
     /// Get the first version that write set starts existent.
     fn get_first_write_set_version(&self) -> Result<Option<Version>> {
         gauged_api("get_first_write_set_version", || {
-            if let Some(pruner) = self.ledger_pruner.as_ref() {
-                // If pruning is enabled, we can get the min readable version from the pruner.
-                Ok(pruner.get_min_readable_version())
-            } else {
-                self.transaction_store.get_first_write_set_version()
-            }
+            self.transaction_store.get_first_write_set_version()
         })
     }
 
@@ -1042,9 +1012,7 @@ impl DbReader for AptosDB {
                 return Ok(TransactionOutputListWithProof::new_empty());
             }
 
-            if let Some(ledger_pruner) = &self.ledger_pruner {
-                error_if_version_is_pruned(ledger_pruner, "Transaction", start_version)?;
-            }
+            error_if_version_is_pruned(&self.ledger_pruner, "Transaction", start_version)?;
 
             let limit = std::cmp::min(limit, ledger_version - start_version + 1);
 
@@ -1092,9 +1060,7 @@ impl DbReader for AptosDB {
         end_version: Version,
     ) -> Result<Vec<WriteSet>> {
         gauged_api("get_write_sets", || {
-            if let Some(ledger_pruner) = &self.ledger_pruner {
-                error_if_version_is_pruned(ledger_pruner, "Write set", begin_version)?;
-            }
+            error_if_version_is_pruned(&self.ledger_pruner, "Write set", begin_version)?;
 
             self.transaction_store
                 .get_write_sets(begin_version, end_version)
@@ -1160,9 +1126,7 @@ impl DbReader for AptosDB {
         version: Version,
     ) -> Result<Option<StateValue>> {
         gauged_api("get_state_value_by_version", || {
-            if let Some(state_pruner) = &self.state_pruner {
-                error_if_version_is_pruned(state_pruner, "State", version)?;
-            }
+            error_if_version_is_pruned(&self.state_pruner, "State", version)?;
 
             self.state_store
                 .get_state_value_by_version(state_store_key, version)
@@ -1176,9 +1140,7 @@ impl DbReader for AptosDB {
         version: Version,
     ) -> Result<SparseMerkleProof> {
         gauged_api("get_proof_by_version", || {
-            if let Some(state_pruner) = &self.state_pruner {
-                error_if_version_is_pruned(state_pruner, "State", version)?;
-            }
+            error_if_version_is_pruned(&self.state_pruner, "State", version)?;
 
             self.state_store
                 .get_state_proof_by_version(state_key, version)
@@ -1241,9 +1203,7 @@ impl DbReader for AptosDB {
         version: Version,
     ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
         gauged_api("get_state_value_with_proof_by_version", || {
-            if let Some(state_pruner) = &self.state_pruner {
-                error_if_version_is_pruned(state_pruner, "State", version)?;
-            }
+            error_if_version_is_pruned(&self.state_pruner, "State", version)?;
 
             self.state_store
                 .get_state_value_with_proof_by_version(state_store_key, version)
@@ -1372,25 +1332,13 @@ impl DbReader for AptosDB {
 
     fn get_state_prune_window(&self) -> Result<Option<usize>> {
         gauged_api("get_state_prune_window", || {
-            let mut pruner_window = None;
-            if let Some(pruner) = self.state_pruner.as_ref() {
-                if let Some(window) = pruner.get_pruner_window() {
-                    pruner_window = Some(window as usize);
-                }
-            }
-            Ok(pruner_window)
+            Ok(self.state_pruner.get_pruner_window().map(|x| x as usize))
         })
     }
 
     fn get_ledger_prune_window(&self) -> Result<Option<usize>> {
         gauged_api("get_ledger_prune_window", || {
-            let mut pruner_window = None;
-            if let Some(pruner) = self.ledger_pruner.as_ref() {
-                if let Some(window) = pruner.get_pruner_window() {
-                    pruner_window = Some(window as usize);
-                }
-            }
-            Ok(pruner_window)
+            Ok(self.ledger_pruner.get_pruner_window().map(|x| x as usize))
         })
     }
 
@@ -1651,25 +1599,24 @@ impl DbWriter for AptosDB {
 
     fn delete_genesis(&self) -> Result<()> {
         gauged_api("delete_genesis", || {
-            // Create all the db pruners
-            let state_pruner_option =
-                utils::create_state_pruner(Arc::clone(&self.state_merkle_db), self.pruner_config);
-            let ledger_pruner_option =
-                utils::create_ledger_pruner(Arc::clone(&self.ledger_db), self.pruner_config);
-
             // Execute each pruner to clean up the genesis state
             let target_version = 1; // The genesis version is 0. Delete [0,1) (exclusive).
             let max_version = 1; // We should only really be pruning at a single version.
 
-            if let Some(state_pruner) = state_pruner_option {
-                state_pruner.lock().set_target_version(target_version);
-                state_pruner.lock().prune(max_version)?;
-            }
+            // Create all the db pruners
+            let state_pruner = StateStorePruner::new(Arc::clone(&self.state_merkle_db));
+            let ledger_pruner = LedgerPruner::new(
+                Arc::clone(&self.ledger_db),
+                Arc::new(TransactionStore::new(Arc::clone(&self.ledger_db))),
+                Arc::new(EventStore::new(Arc::clone(&self.ledger_db))),
+                Arc::new(LedgerStore::new(Arc::clone(&self.ledger_db))),
+            );
 
-            if let Some(ledger_pruner) = ledger_pruner_option {
-                ledger_pruner.lock().set_target_version(target_version);
-                ledger_pruner.lock().prune(max_version)?;
-            }
+            state_pruner.set_target_version(target_version);
+            state_pruner.prune(max_version)?;
+
+            ledger_pruner.set_target_version(target_version);
+            ledger_pruner.prune(max_version)?;
             Ok(())
         })
     }

--- a/storage/aptosdb/src/pruner/db_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_pruner.rs
@@ -6,7 +6,7 @@ use aptos_types::transaction::Version;
 use std::{cmp::min, thread::sleep, time::Duration};
 
 /// Defines the trait for pruner for different DB
-pub trait DBPruner {
+pub trait DBPruner: Send + Sync {
     /// Find out the first undeleted item in the stale node index.
     ///
     /// Seeking from the beginning (version 0) is potentially costly, we do it once upon worker
@@ -68,12 +68,15 @@ pub trait DBPruner {
     fn is_pruning_pending(&self) -> bool {
         self.target_version() > self.min_readable_version()
     }
+
+    /// (For tests only.) Updates the minimal readable version kept by pruner.
+    fn testonly_update_min_version(&self, version: Version);
 }
 
 pub enum Command {
     Quit,
     Prune {
         /// The target DB version for the pruner.
-        target_db_version: Option<Version>,
+        target_db_version: Version,
     },
 }

--- a/storage/aptosdb/src/pruner/db_sub_pruner.rs
+++ b/storage/aptosdb/src/pruner/db_sub_pruner.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use schemadb::SchemaBatch;
+use std::fmt::Debug;
 
 /// Defines the trait for sub-pruner of a parent DB pruner
-pub trait DBSubPruner {
+pub trait DBSubPruner: Debug {
     /// Performs the actual pruning, a target version is passed, which is the target the pruner
     /// tries to prune.
     fn prune(

--- a/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/event_store/event_store_pruner.rs
@@ -4,6 +4,7 @@ use crate::{pruner::db_sub_pruner::DBSubPruner, EventStore};
 use schemadb::SchemaBatch;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct EventStorePruner {
     event_store: Arc<EventStore>,
 }

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -102,15 +102,6 @@ fn verify_event_store_pruner_disabled(events: Vec<Vec<ContractEvent>>) {
     let event_store = &aptos_db.event_store;
     let mut cs = ChangeSet::new();
     let num_versions = events.len();
-    let pruner = LedgerPrunerManager::new(
-        Arc::clone(&aptos_db.ledger_db),
-        StoragePrunerConfig {
-            state_store_prune_window: Some(0),
-            ledger_prune_window: None,
-            ledger_pruning_batch_size: 1,
-            state_store_pruning_batch_size: 100,
-        },
-    );
 
     // Write events to DB
     for (version, events_for_version) in events.iter().enumerate() {
@@ -122,7 +113,6 @@ fn verify_event_store_pruner_disabled(events: Vec<Vec<ContractEvent>>) {
 
     // Verify no pruning has happened.
     for _i in (0..=num_versions).step_by(2) {
-        pruner.ensure_disabled().unwrap();
         // ensure that all events up to i * 2 are valid in DB
         for version in 0..num_versions {
             verify_events_in_store(&events, version as u64, event_store);

--- a/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
@@ -7,8 +7,11 @@ use aptos_config::config::StoragePrunerConfig;
 use aptos_infallible::Mutex;
 
 use crate::pruner::db_pruner;
+use crate::pruner::db_pruner::DBPruner;
 use crate::pruner::ledger_pruner_worker::LedgerPrunerWorker;
+use crate::pruner::ledger_store::ledger_store_pruner::LedgerPruner;
 use crate::pruner::pruner_manager::PrunerManager;
+use crate::utils;
 use aptos_types::transaction::Version;
 use schemadb::DB;
 use std::{
@@ -25,18 +28,18 @@ pub struct LedgerPrunerManager {
     /// DB version window, which dictates how many version of other stores like transaction, ledger
     /// info, events etc to keep.
     prune_window: Option<Version>,
+    /// Ledger pruner. Is always initialized regardless if the pruner is enabled to keep tracks
+    /// of the min_readable_version.
+    pruner: Arc<LedgerPruner>,
     /// The worker thread handle for ledger_pruner, created upon Pruner instance construction and
-    /// joined upon its destruction. It only becomes `None` after joined in `drop()`.
-    pruner_worker_thread: Option<JoinHandle<()>>,
-    /// The sender side of the channel talking to the ledger pruner worker thread.
-    pruner_command_sender: Mutex<Sender<db_pruner::Command>>,
-    /// A way for the worker thread to inform the `Pruner` the pruning progress. If it
-    /// sets value to `V`, all versions before `V` can no longer be accessed. This is protected by
-    /// Mutex as this is accessed both by the Pruner thread and the worker thread.
-    #[allow(dead_code)]
-    pruner_min_readable_version: Arc<Mutex<Option<Version>>>,
+    /// joined upon its destruction. It is `None` when the ledger pruner is not enabled or it only
+    /// becomes `None` after joined in `drop()`.
+    worker_thread: Option<JoinHandle<()>>,
+    /// The sender side of the channel talking to the ledger pruner worker thread. Is `None` when
+    /// the ledger pruner is not enabled.
+    command_sender: Option<Mutex<Sender<db_pruner::Command>>>,
     /// We send a batch of version to the underlying pruners for performance reason. This tracks the
-    /// last version we sent to the pruners.
+    /// last version we sent to the pruners. Will only be set if the pruner is enabled.
     pub(crate) last_version_sent_to_pruner: Arc<Mutex<Version>>,
     /// Ideal batch size of the versions to be sent to the ledger pruner
     pruning_batch_size: usize,
@@ -49,8 +52,8 @@ impl PrunerManager for LedgerPrunerManager {
         self.prune_window
     }
 
-    fn get_min_readable_version(&self) -> Option<Version> {
-        self.pruner_min_readable_version.lock().map(|x| x)
+    fn get_min_readable_version(&self) -> Version {
+        self.pruner.as_ref().min_readable_version()
     }
 
     /// Sends pruning command to the worker thread when necessary.
@@ -59,18 +62,24 @@ impl PrunerManager for LedgerPrunerManager {
 
         // Only wake up the ledger pruner if there are `ledger_pruner_pruning_batch_size` pending
         // versions.
-        if latest_version
-            >= *self.last_version_sent_to_pruner.as_ref().lock() + self.pruning_batch_size as u64
+        if self.prune_window.is_some()
+            && latest_version
+                >= *self.last_version_sent_to_pruner.as_ref().lock()
+                    + self.pruning_batch_size as u64
         {
             self.wake_pruner(latest_version);
             *self.last_version_sent_to_pruner.as_ref().lock() = latest_version;
         }
     }
     fn wake_pruner(&self, latest_version: Version) {
-        self.pruner_command_sender
+        assert!(self.prune_window.is_some());
+        assert!(self.command_sender.is_some());
+        self.command_sender
+            .as_ref()
+            .unwrap()
             .lock()
             .send(db_pruner::Command::Prune {
-                target_db_version: self.prune_window.map(|x| latest_version.saturating_sub(x)),
+                target_db_version: latest_version.saturating_sub(self.prune_window.unwrap()),
             })
             .expect("Receiver should not destruct prematurely.");
     }
@@ -99,7 +108,10 @@ impl PrunerManager for LedgerPrunerManager {
             let end = Instant::now() + TIMEOUT;
 
             while Instant::now() < end {
-                if self.pruner_min_readable_version.lock().unwrap() >= min_readable_ledger_version {
+                if self.get_min_readable_version() >= min_readable_ledger_version {
+                    // A hack to make sure the items have been removed from DB as we update the
+                    // min_readable_version before finishing deleting items from DB.
+                    sleep(Duration::from_millis(100));
                     return Ok(());
                 }
                 sleep(Duration::from_millis(1));
@@ -108,32 +120,14 @@ impl PrunerManager for LedgerPrunerManager {
         }
         Ok(())
     }
-
-    /// (For tests only.) Ensure a pruner is disabled.
-    #[cfg(test)]
-    fn ensure_disabled(&self) -> anyhow::Result<()> {
-        assert!(self.pruner_min_readable_version.lock().is_none());
-        Ok(())
-    }
-
-    /// (For tests only.) Updates the minimal readable version kept by pruner.
-    #[cfg(test)]
-    fn testonly_update_min_version(&mut self, version: Option<Version>) {
-        self.pruner_min_readable_version = Arc::new(Mutex::new(version));
-    }
 }
 
 impl LedgerPrunerManager {
     /// Creates a worker thread that waits on a channel for pruning commands.
     pub fn new(ledger_rocksdb: Arc<DB>, storage_pruner_config: StoragePrunerConfig) -> Self {
-        let (ledger_pruner_command_sender, ledger_pruner_command_receiver) = channel();
+        let ledger_db_clone = Arc::clone(&ledger_rocksdb);
 
-        let ledger_pruner_min_readable_version = Arc::new(Mutex::new(
-            storage_pruner_config.ledger_prune_window.map(|_| 0),
-        ));
-
-        let ledger_pruner_min_readable_version_clone =
-            Arc::clone(&ledger_pruner_min_readable_version);
+        let ledger_pruner = utils::create_ledger_pruner(ledger_db_clone);
 
         PRUNER_WINDOW
             .with_label_values(&["ledger_pruner"])
@@ -143,40 +137,58 @@ impl LedgerPrunerManager {
             .with_label_values(&["ledger_pruner"])
             .set(storage_pruner_config.ledger_pruning_batch_size as i64);
 
-        let ledger_pruner_worker = LedgerPrunerWorker::new(
-            ledger_rocksdb,
-            ledger_pruner_command_receiver,
-            ledger_pruner_min_readable_version,
-            storage_pruner_config,
-        );
+        let mut command_sender = None;
+        let ledger_pruner_worker_thread = if storage_pruner_config.ledger_prune_window.is_some() {
+            let (ledger_pruner_command_sender, ledger_pruner_command_receiver) = channel();
+            command_sender = Some(Mutex::new(ledger_pruner_command_sender));
+            let ledger_pruner_worker = LedgerPrunerWorker::new(
+                Arc::clone(&ledger_pruner),
+                ledger_pruner_command_receiver,
+                storage_pruner_config,
+            );
+            Some(
+                std::thread::Builder::new()
+                    .name("aptosdb_ledger_pruner".into())
+                    .spawn(move || ledger_pruner_worker.work())
+                    .expect("Creating ledger pruner thread should succeed."),
+            )
+        } else {
+            None
+        };
 
-        let ledger_pruner_worker_thread = std::thread::Builder::new()
-            .name("aptosdb_ledger_pruner".into())
-            .spawn(move || ledger_pruner_worker.work())
-            .expect("Creating ledger pruner thread should succeed.");
+        let min_readable_version = ledger_pruner.min_readable_version();
 
         Self {
             prune_window: storage_pruner_config.ledger_prune_window,
-            pruner_worker_thread: Some(ledger_pruner_worker_thread),
-            pruner_command_sender: Mutex::new(ledger_pruner_command_sender),
-            pruner_min_readable_version: ledger_pruner_min_readable_version_clone,
-            last_version_sent_to_pruner: Arc::new(Mutex::new(0)),
+            pruner: ledger_pruner,
+            worker_thread: ledger_pruner_worker_thread,
+            command_sender,
+            last_version_sent_to_pruner: Arc::new(Mutex::new(min_readable_version)),
             pruning_batch_size: storage_pruner_config.ledger_pruning_batch_size,
-            latest_version: Arc::new(Mutex::new(0)),
+            latest_version: Arc::new(Mutex::new(min_readable_version)),
         }
+    }
+
+    #[cfg(test)]
+    pub fn testonly_update_min_version(&self, version: Version) {
+        self.pruner.testonly_update_min_version(version);
     }
 }
 
 impl Drop for LedgerPrunerManager {
     fn drop(&mut self) {
-        self.pruner_command_sender
-            .lock()
-            .send(db_pruner::Command::Quit)
-            .expect("Ledger pruner receiver should not destruct.");
-        self.pruner_worker_thread
-            .take()
-            .expect("Ledger pruner worker thread must exist.")
-            .join()
-            .expect("Ledger pruner worker thread should join peacefully.");
+        if let Some(command_sender) = &self.command_sender {
+            command_sender
+                .lock()
+                .send(db_pruner::Command::Quit)
+                .expect("Ledger pruner receiver should not destruct.");
+        }
+        if self.worker_thread.is_some() {
+            self.worker_thread
+                .take()
+                .expect("Ledger pruner worker thread must exist.")
+                .join()
+                .expect("Ledger pruner worker thread should join peacefully.");
+        }
     }
 }

--- a/storage/aptosdb/src/pruner/ledger_pruner_worker.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_worker.rs
@@ -1,24 +1,16 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-use aptos_types::transaction::Version;
-use schemadb::DB;
-
-use crate::pruner::{db_pruner, db_pruner::DBPruner, utils};
+use crate::pruner::ledger_store::ledger_store_pruner::LedgerPruner;
+use crate::pruner::{db_pruner, db_pruner::DBPruner};
 use aptos_config::config::StoragePrunerConfig;
-use aptos_infallible::Mutex;
 use std::sync::{mpsc::Receiver, Arc};
 
 /// Maintains the ledger pruner and periodically calls the db_pruner's prune method to prune the DB.
 /// This also exposes API to report the progress to the parent thread.
 pub struct LedgerPrunerWorker {
     command_receiver: Receiver<db_pruner::Command>,
-    /// Ledger pruner. If a pruner is not enabled, its value will be None.
-    ledger_pruner: Option<Mutex<Arc<dyn DBPruner + Send + Sync>>>,
-    /// Keeps a record of the pruning progress. If this equals to version `V`, we know versions
-    /// smaller than `V` are no longer readable.
-    /// This being an atomic value is to communicate the info with the Pruner thread (for tests).
-    /// If the pruner is disabled, its value will be None.
-    min_readable_version: Arc<Mutex<Option<Version>>>,
+    /// Ledger pruner.
+    pruner: Arc<LedgerPruner>,
     /// Indicates if there's NOT any pending work to do currently, to hint
     /// `Self::receive_commands()` to `recv()` blocking-ly.
     blocking_recv: bool,
@@ -29,16 +21,13 @@ pub struct LedgerPrunerWorker {
 
 impl LedgerPrunerWorker {
     pub(crate) fn new(
-        ledger_db: Arc<DB>,
+        ledger_pruner: Arc<LedgerPruner>,
         command_receiver: Receiver<db_pruner::Command>,
-        min_readable_version: Arc<Mutex<Option<Version>>>,
         storage_pruner_config: StoragePrunerConfig,
     ) -> Self {
-        let ledger_pruner = utils::create_ledger_pruner(ledger_db, storage_pruner_config);
         Self {
-            ledger_pruner,
+            pruner: ledger_pruner,
             command_receiver,
-            min_readable_version,
             blocking_recv: true,
             ledger_store_max_versions_to_prune_per_batch: storage_pruner_config
                 .ledger_pruning_batch_size
@@ -51,34 +40,18 @@ impl LedgerPrunerWorker {
             // Process a reasonably small batch of work before trying to receive commands again,
             // in case `Command::Quit` is received (that's when we should quit.)
             let mut error_in_pruning = false;
-            let mut pruning_pending = false;
 
-            if let Some(ledger_pruner) = &self.ledger_pruner {
-                let ledger_pruner = ledger_pruner.lock();
-                ledger_pruner
-                    .prune(self.ledger_store_max_versions_to_prune_per_batch as usize)
-                    .map_err(|_| error_in_pruning = true)
-                    .ok();
+            self.pruner
+                .prune(self.ledger_store_max_versions_to_prune_per_batch as usize)
+                .map_err(|_| error_in_pruning = true)
+                .ok();
 
-                if ledger_pruner.is_pruning_pending() {
-                    pruning_pending = true;
-                }
-            }
-
-            if !pruning_pending || error_in_pruning {
+            if !self.pruner.is_pruning_pending() || error_in_pruning {
                 self.blocking_recv = true;
             } else {
                 self.blocking_recv = false;
             }
-            self.record_progress();
         }
-    }
-
-    fn record_progress(&mut self) {
-        *self.min_readable_version.lock() = self
-            .ledger_pruner
-            .as_ref()
-            .map(|ledger_pruner| ledger_pruner.lock().min_readable_version());
     }
 
     /// Tries to receive all pending commands, blocking waits for the next command if no work needs
@@ -107,19 +80,12 @@ impl LedgerPrunerWorker {
                 // On `Command::Quit` inform the outer loop to quit by returning `false`.
                 db_pruner::Command::Quit => return false,
                 db_pruner::Command::Prune { target_db_version } => {
-                    if let Some(ledger_pruner_target_version) = target_db_version {
-                        if let Some(ledger_pruner) = &self.ledger_pruner {
-                            if ledger_pruner_target_version > ledger_pruner.lock().target_version()
-                            {
-                                // Switch to non-blocking to allow some work to be done after the
-                                // channel has drained.
-                                self.blocking_recv = false;
-                            }
-                            ledger_pruner
-                                .lock()
-                                .set_target_version(ledger_pruner_target_version);
-                        }
+                    if target_db_version > self.pruner.target_version() {
+                        // Switch to non-blocking to allow some work to be done after the
+                        // channel has drained.
+                        self.blocking_recv = false;
                     }
+                    self.pruner.set_target_version(target_db_version);
                 }
             }
         }

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_counter_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_counter_pruner.rs
@@ -4,6 +4,7 @@ use crate::{pruner::db_sub_pruner::DBSubPruner, LedgerStore};
 use schemadb::SchemaBatch;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct LedgerCounterPruner {
     /// Keeps track of the target version that the pruner needs to achieve.
     ledger_store: Arc<LedgerStore>,

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -20,6 +20,8 @@ use std::sync::{atomic::Ordering, Arc};
 
 pub const LEDGER_PRUNER_NAME: &str = "ledger pruner";
 
+#[derive(Debug)]
+/// Responsible for pruning everything except for the state tree.
 pub struct LedgerPruner {
     db: Arc<DB>,
     /// Keeps track of the target version that the pruner needs to achieve.
@@ -65,6 +67,8 @@ impl DBPruner for LedgerPruner {
             current_target_version,
         )?;
 
+        // Record progress first to make sure API won't return error values
+        // when a version is being pruned.
         self.record_progress(current_target_version);
         // Commit all the changes to DB atomically
         self.db.write_schemas(db_batch)?;
@@ -97,10 +101,15 @@ impl DBPruner for LedgerPruner {
             .with_label_values(&["ledger_pruner"])
             .set(min_readable_version as i64);
     }
+
+    /// (For tests only.) Updates the minimal readable version kept by pruner.
+    fn testonly_update_min_version(&self, version: Version) {
+        self.min_readable_version.store(version, Ordering::Relaxed)
+    }
 }
 
 impl LedgerPruner {
-    pub(in crate::pruner) fn new(
+    pub fn new(
         db: Arc<DB>,
         transaction_store: Arc<TransactionStore>,
         event_store: Arc<EventStore>,

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-mod db_pruner;
+pub(crate) mod db_pruner;
 pub(crate) mod db_sub_pruner;
 pub(crate) mod event_store;
 pub(crate) mod ledger_pruner_worker;
-mod ledger_store;
+pub(crate) mod ledger_store;
 pub(crate) mod pruner_manager;
 pub(crate) mod state_pruner_worker;
 pub(crate) mod state_store;

--- a/storage/aptosdb/src/pruner/pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/pruner_manager.rs
@@ -15,7 +15,7 @@ use std::fmt::Debug;
 pub trait PrunerManager: Debug + Sync {
     fn get_pruner_window(&self) -> Option<Version>;
 
-    fn get_min_readable_version(&self) -> Option<Version>;
+    fn get_min_readable_version(&self) -> Version;
 
     /// Sends pruning command to the worker thread when necessary.
     fn maybe_wake_pruner(&self, latest_version: Version);
@@ -26,12 +26,4 @@ pub trait PrunerManager: Debug + Sync {
     /// an internal counter.
     #[cfg(test)]
     fn wake_and_wait_pruner(&self, latest_version: Version) -> anyhow::Result<()>;
-
-    /// (For tests only.) Ensure a pruner is disabled.
-    #[cfg(test)]
-    fn ensure_disabled(&self) -> anyhow::Result<()>;
-
-    /// (For tests only.) Updates the minimal readable version kept by pruner.
-    #[cfg(test)]
-    fn testonly_update_min_version(&mut self, version: Option<Version>);
 }

--- a/storage/aptosdb/src/pruner/state_pruner_worker.rs
+++ b/storage/aptosdb/src/pruner/state_pruner_worker.rs
@@ -1,24 +1,16 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
-use aptos_types::transaction::Version;
-use schemadb::DB;
-
-use crate::pruner::{db_pruner, db_pruner::DBPruner, utils};
+use crate::pruner::state_store::StateStorePruner;
+use crate::pruner::{db_pruner, db_pruner::DBPruner};
 use aptos_config::config::StoragePrunerConfig;
-use aptos_infallible::Mutex;
 use std::sync::{mpsc::Receiver, Arc};
 
 /// Maintains the state store pruner and periodically calls the db_pruner's prune method to prune
 /// the DB. This also exposes API to report the progress to the parent thread.
 pub struct StatePrunerWorker {
     command_receiver: Receiver<db_pruner::Command>,
-    /// State store pruner. If a pruner is not enabled, its value will be None.
-    state_pruner: Option<Mutex<Arc<dyn DBPruner + Send + Sync>>>,
-    /// Keeps a record of the pruning progress. If this equals to version `V`, we know versions
-    /// smaller than `V` are no longer readable.
-    /// This being an atomic value is to communicate the info with the Pruner thread (for tests).
-    /// If the pruner is disabled, its value will be None.
-    min_readable_version: Arc<Mutex<Option<Version>>>,
+    /// State store pruner.
+    pruner: Arc<StateStorePruner>,
     /// Indicates if there's NOT any pending work to do currently, to hint
     /// `Self::receive_commands()` to `recv()` blocking-ly.
     blocking_recv: bool,
@@ -28,16 +20,13 @@ pub struct StatePrunerWorker {
 
 impl StatePrunerWorker {
     pub(crate) fn new(
-        state_merkle_db: Arc<DB>,
+        state_pruner: Arc<StateStorePruner>,
         command_receiver: Receiver<db_pruner::Command>,
-        min_readable_version: Arc<Mutex<Option<Version>>>,
         storage_pruner_config: StoragePrunerConfig,
     ) -> Self {
-        let state_pruner = utils::create_state_pruner(state_merkle_db, storage_pruner_config);
         Self {
-            state_pruner,
+            pruner: state_pruner,
             command_receiver,
-            min_readable_version,
             blocking_recv: true,
             state_store_max_nodes_to_prune_per_batch: storage_pruner_config
                 .state_store_pruning_batch_size
@@ -50,34 +39,18 @@ impl StatePrunerWorker {
             // Process a reasonably small batch of work before trying to receive commands again,
             // in case `Command::Quit` is received (that's when we should quit.)
             let mut error_in_pruning = false;
-            let mut pruning_pending = false;
 
-            if let Some(state_pruner) = &self.state_pruner {
-                let state_store_pruner = state_pruner.lock();
-                state_store_pruner
-                    .prune(self.state_store_max_nodes_to_prune_per_batch as usize)
-                    .map_err(|_| error_in_pruning = true)
-                    .ok();
+            self.pruner
+                .prune(self.state_store_max_nodes_to_prune_per_batch as usize)
+                .map_err(|_| error_in_pruning = true)
+                .ok();
 
-                if state_store_pruner.is_pruning_pending() {
-                    pruning_pending = true;
-                }
-            }
-
-            if !pruning_pending || error_in_pruning {
+            if !self.pruner.is_pruning_pending() || error_in_pruning {
                 self.blocking_recv = true;
             } else {
                 self.blocking_recv = false;
             }
-            self.record_progress();
         }
-    }
-
-    fn record_progress(&mut self) {
-        *self.min_readable_version.lock() = self
-            .state_pruner
-            .as_ref()
-            .map(|state_pruner| state_pruner.lock().min_readable_version());
     }
 
     /// Tries to receive all pending commands, blocking waits for the next command if no work needs
@@ -106,18 +79,12 @@ impl StatePrunerWorker {
                 // On `Command::Quit` inform the outer loop to quit by returning `false`.
                 db_pruner::Command::Quit => return false,
                 db_pruner::Command::Prune { target_db_version } => {
-                    if let Some(state_pruner_target_version) = target_db_version {
-                        if let Some(state_pruner) = &self.state_pruner {
-                            if state_pruner_target_version > state_pruner.lock().target_version() {
-                                // Switch to non-blocking to allow some work to be done after the
-                                // channel has drained.
-                                self.blocking_recv = false;
-                            }
-                            state_pruner
-                                .lock()
-                                .set_target_version(state_pruner_target_version);
-                        }
+                    if target_db_version > self.pruner.target_version() {
+                        // Switch to non-blocking to allow some work to be done after the
+                        // channel has drained.
+                        self.blocking_recv = false;
                     }
+                    self.pruner.set_target_version(target_db_version);
                 }
             }
         }

--- a/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/transaction_store_pruner.rs
@@ -5,6 +5,7 @@ use aptos_types::transaction::{Transaction, Version};
 use schemadb::SchemaBatch;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct TransactionStorePruner {
     transaction_store: Arc<TransactionStore>,
 }

--- a/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/write_set_pruner.rs
@@ -4,6 +4,7 @@ use crate::{pruner::db_sub_pruner::DBSubPruner, TransactionStore};
 use schemadb::SchemaBatch;
 use std::sync::Arc;
 
+#[derive(Debug)]
 pub struct WriteSetPruner {
     transaction_store: Arc<TransactionStore>,
 }

--- a/storage/aptosdb/src/pruner/utils.rs
+++ b/storage/aptosdb/src/pruner/utils.rs
@@ -4,43 +4,23 @@
 //! This module provides common utilities for the DB pruner.
 
 use crate::{
-    pruner::{
-        db_pruner::DBPruner, ledger_store::ledger_store_pruner::LedgerPruner,
-        state_store::StateStorePruner,
-    },
+    pruner::{ledger_store::ledger_store_pruner::LedgerPruner, state_store::StateStorePruner},
     EventStore, LedgerStore, TransactionStore,
 };
-use aptos_config::config::StoragePrunerConfig;
-use aptos_infallible::Mutex;
+
 use schemadb::DB;
 use std::sync::Arc;
 
 /// Utility functions to instantiate pruners.
-pub fn create_state_pruner(
-    state_merkle_db: Arc<DB>,
-    storage_pruner_config: StoragePrunerConfig,
-) -> Option<Mutex<Arc<dyn DBPruner + Send + Sync>>> {
-    if storage_pruner_config.state_store_prune_window.is_some() {
-        Some(Mutex::new(Arc::new(StateStorePruner::new(Arc::clone(
-            &state_merkle_db,
-        )))))
-    } else {
-        None
-    }
+pub fn create_state_pruner(state_merkle_db: Arc<DB>) -> Arc<StateStorePruner> {
+    Arc::new(StateStorePruner::new(Arc::clone(&state_merkle_db)))
 }
 
-pub fn create_ledger_pruner(
-    ledger_db: Arc<DB>,
-    storage_pruner_config: StoragePrunerConfig,
-) -> Option<Mutex<Arc<dyn DBPruner + Send + Sync>>> {
-    if storage_pruner_config.ledger_prune_window.is_some() {
-        Some(Mutex::new(Arc::new(LedgerPruner::new(
-            Arc::clone(&ledger_db),
-            Arc::new(TransactionStore::new(Arc::clone(&ledger_db))),
-            Arc::new(EventStore::new(Arc::clone(&ledger_db))),
-            Arc::new(LedgerStore::new(Arc::clone(&ledger_db))),
-        ))))
-    } else {
-        None
-    }
+pub fn create_ledger_pruner(ledger_db: Arc<DB>) -> Arc<LedgerPruner> {
+    Arc::new(LedgerPruner::new(
+        Arc::clone(&ledger_db),
+        Arc::new(TransactionStore::new(Arc::clone(&ledger_db))),
+        Arc::new(EventStore::new(Arc::clone(&ledger_db))),
+        Arc::new(LedgerStore::new(Arc::clone(&ledger_db))),
+    ))
 }


### PR DESCRIPTION
### Description
- Always initialize pruners in order to keep track of the right min_readable_version. More details in the sceenshot. Get rid of `Some(...` in code.
- When pruner is disabled, do not spawn the thread to run the running command.
- Do not keep track min_readable_version in pruner manager and pruner worker but use the pruner as the source of truth.
- Change `get_first_txn_version` and `get_first_write_set_version` to get their values from `transaction_store`.
- In state store, record the progress (i.e. update the min_readable_version) before deleting the items from DB to avoid the edge case that API queries the wrong min_readable_version when pruning is in progress.

### Next Step
- Change the threading model of pruners to be continuous.
- Add bool configs to explicitly enable/disable pruners.
- A lower pri optimization is to use generic for the pruner related classes.
### Test Plan
Existing UTs.
![Screen Shot 2022-08-01 at 11 50 49 AM](https://user-images.githubusercontent.com/107430656/182492230-0978935e-ae4e-4698-9748-32229c37fc10.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2466)
<!-- Reviewable:end -->
