### PR TITLE
[mempool] make broadcast peer prioritization random between fullnodes

### DIFF
--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -596,7 +596,7 @@ impl PrioritizedPeersComparator {
                 let role_a = peer_a.1;
                 let role_b = peer_b.1;
                 match role_a.cmp(&role_b) {
-                    // Tiebreak by hash_peer_id. Stable within a mempool instance but random between instances.
+                    // Tiebreak by hash_peer_id.
                     Ordering::Equal => {
                         let hash_a = self.hash_peer_id(&peer_network_id_a.peer_id());
                         let hash_b = self.hash_peer_id(&peer_network_id_b.peer_id());
@@ -610,6 +610,7 @@ impl PrioritizedPeersComparator {
         }
     }
 
+    /// Stable within a mempool instance but random between instances.
     fn hash_peer_id(&self, peer_id: &PeerId) -> u64 {
         let mut hasher = self.random_state.build_hasher();
         hasher.write(peer_id.as_ref());

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -355,16 +355,8 @@ impl MempoolNetworkInterface {
                 .find_position(|peer_network_id| *peer_network_id == &peer)
                 .map_or(usize::MAX, |(pos, _)| pos);
             if priority > self.mempool_config.default_failovers {
-                warn!(
-                    "BCHO: PeerNotPrioritized: {}, {} > {}",
-                    peer, priority, self.mempool_config.default_failovers
-                );
                 return Err(BroadcastError::PeerNotPrioritized(peer, priority));
             }
-            warn!(
-                "BCHO: Peer: {}, {}, {}",
-                peer, priority, self.mempool_config.default_failovers
-            );
         }
         Ok(())
     }


### PR DESCRIPTION
### Description

Peer prioritization is used to broadcast transactions from a fullnode to a subset of outbound connections.

Add some randomness between fullnodes for deciding peer prioritization, by using a simple hash. (Within a fullnode, the prioritization sorting is still stable.)

Before the change, because fullnodes did the same sorting, fullnode connections could be skewed. Most notably if `NetworkConfig.max_outbound_connections` > `MempoolConfig.default_failovers`.

### Test Plan

Ran a modified smoke test with 10 validators and VFNs and `NetworkConfig.max_outbound_connections=10` and `MempoolConfig.default_failovers = 1`. Before the change, a single VFN (with smallest peerId) was the outbound broadcast node for most VFNs; now the connections are more evenly spread out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2469)
<!-- Reviewable:end -->
