### PR TITLE
Update .dockerignore file to fix rust-all dockerfile invocation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,21 +1,23 @@
-# list of files to ignore from docker's perspective
-# The more we can exclude the higher likelihood we can reuse cached layers
+# List of files to ignore from docker's perspective.
+# The more we can exclude the higher likelihood we can reuse cached layers.
 
-# exclude everything
-**/*
+# Be careful about excluding a lot (e.g. with **/*) and then including files:
+# https://github.com/moby/moby/issues/30018
+# As such, this dockerignore only explicitly excludes targeted items.
 
-# explicitly include stuff we actually need via negation
+**/goldens
+**/target
 
-!docker/build-rust-all.sh
-!docker/tools/boto.cfg
+**/.aptos
+**/.cargo
+**/.config
+**/.git
+**/.github
+**/*.md
 
-!**/Cargo.toml
-!**/Cargo.lock
-!**/*.rs
-!config/src/config/test_data
-!aptos-move/framework/
-!api/doc/
-!ecosystem/indexer/migrations/**/*.sql
-!terraform/helm/aptos-node/
-!terraform/helm/genesis/
-!testsuite/forge/src/backend/k8s/
+/dashboards
+/developer-docs-site
+/documentation
+/ecosystem/indexer-server/typescript
+/ecosystem/python
+/ecosystem/typescript


### PR DESCRIPTION
## Description
Previously if you ran the following:
```
docker build -f docker/rust-all.Dockerfile .
```
It would fail, because the source code was missing. After some digging, I found that the dockerignore wasn't working how we expected. Previously it tried to exclude everything and then opt in to things to include, but this doesn't actually work how we'd expect with subdirectories: https://github.com/moby/moby/issues/30018.

This PR changes the dockerignore to just exclude stuff directly, rather than attempting to exclude everything and then include stuff.

The context with this change is 31.6mb, up from 1.9mb. I could tighten it up further if we feel it's important.

## Test Plan
```
docker build -f docker/rust-all.Dockerfile .
```
This works now. Given this is all Rust, if it compiles, it's probably good to go.

Still, I should:
1. Try run some stuff from this image, just to double check
2. Ensure other images build happily.

I'm pretty sure the new context is a strict superset of the previous one though, so it should be fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2471)
<!-- Reviewable:end -->
