### PR TITLE
Ensure `rust-all` Dockerfile is being run with appropriate builder

### DIFF
--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -20,6 +20,8 @@ variable "GIT_BRANCH" {}
 
 variable "GIT_TAG" {}
 
+variable "BUILT_VIA_BUILDKIT" {}
+
 variable "LAST_GREEN_COMMIT" {}
 
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
@@ -47,9 +49,10 @@ target "builder" {
   cache-to   = generate_cache_to("builder")
   tags       = generate_tags("builder")
   args       = {
-    GIT_SHA = "${GIT_SHA}"
+    GIT_SHA         = "${GIT_SHA}"
     GIT_BRANCH      = "${GIT_BRANCH}"
     GIT_TAG         = "${GIT_TAG}"
+    BUILT_VIA_BUILDKIT = "true"
   }
 }
 
@@ -81,6 +84,12 @@ target "_common" {
     "org.label-schema.schema-version" = "1.0",
     "org.label-schema.build-date"     = "${BUILD_DATE}"
     "org.label-schema.git-sha"        = "${GIT_SHA}"
+  }
+  args = {
+    GIT_SHA         = "${GIT_SHA}"
+    GIT_BRANCH      = "${GIT_BRANCH}"
+    GIT_TAG         = "${GIT_TAG}"
+    BUILT_VIA_BUILDKIT = "true"
   }
 }
 

--- a/docker/docker-bake-rust-all.sh
+++ b/docker/docker-bake-rust-all.sh
@@ -15,6 +15,7 @@ export GIT_SHA=$(git rev-parse HEAD)
 export GIT_BRANCH=$(git symbolic-ref --short HEAD)
 export GIT_TAG=$(git tag -l --contains HEAD)
 export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+export BUILT_VIA_BUILDKIT="true"
 
 if [ "$CI" == "true" ]; then
   # builder target is the one that builds the rust binaries and is the most expensive.

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -13,7 +13,14 @@ RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-
 
 ### Build Rust code ###
 FROM rust-base as builder
-COPY --link . /aptos/
+
+# Confirm that this Dockerfile is being invoked from an appropriate builder.
+# See https://github.com/aptos-labs/aptos-core/pull/2471
+# See https://github.com/aptos-labs/aptos-core/pull/2472
+ARG BUILT_VIA_BUILDKIT
+ENV BUILT_VIA_BUILDKIT $BUILT_VIA_BUILDKIT
+
+RUN test -n "$BUILT_VIA_BUILDKIT" || (printf "===\nREAD ME\n===\n\nYou likely just tried run a docker build using this Dockerfile using\nthe standard docker builder (e.g. docker build). The standard docker\nbuild command uses a builder that does not respect our .dockerignore\nfile, which will lead to a build failure. To build, you should instead\nrun a command like one of these:\n\ndocker/docker-bake-rust-all.sh\ndocker/docker-bake-rust-all.sh indexer\n\nIf you are 100 percent sure you know what you're doing, you can add this flag:\n--build-arg BUILT_VIA_BUILDKIT=true\n\nFor more information, see https://github.com/aptos-labs/aptos-core/pull/2472\n\nThanks!" && false)
 
 ARG GIT_SHA
 ENV GIT_SHA ${GIT_SHA}
@@ -23,6 +30,8 @@ ENV GIT_BRANCH ${GIT_BRANCH}
 
 ARG GIT_TAG
 ENV GIT_TAG ${GIT_TAG}
+
+COPY --link . /aptos/
 
 RUN --mount=type=cache,target=/aptos/target --mount=type=cache,target=$CARGO_HOME/registry docker/build-rust-all.sh && rm -rf $CARGO_HOME/registry/index
 


### PR DESCRIPTION
## Description
It turns out the regular docker builder doesn't respect our `.dockerignore` properly: https://github.com/aptos-labs/aptos-core/pull/2471. This PR makes it impossible to use the regular builder, you must invoke the docker build from a script that sets an arg. It also tells you how to get around it if you're 100% sure you know what you're doing.

## Test Plan
```
$ docker build -f docker/rust-all.Dockerfile -t rust-all .
#10 0.379
#10 0.379 ===
#10 0.379 READ ME
#10 0.379 ===
#10 0.379
#10 0.379 You likely just tried run a docker build using this Dockerfile using
#10 0.379 the standard docker builder (e.g. docker build). The standard docker
#10 0.379 build command uses a builder that does not respect our .dockerignore
#10 0.379 file, which will lead to a build failure. To build, you should instead
#10 0.379 run a command like one of these:
#10 0.379
#10 0.379 docker/docker-bake-rust-all.sh
#10 0.379 docker/docker-bake-rust-all.sh indexer
#10 0.379
#10 0.379 If you are 100 percent sure you know what you're doing, you can add this flag:
#10 0.379 --build-arg CORRECT_DOCKER_BUILDER=true
#10 0.379
#10 0.379 For more information, see https://github.com/aptos-labs/aptos-core/pull/2472
#10 0.379
#10 0.379 Thanks!
------
```

```
$ docker build -f docker/rust-all.Dockerfile -t rust-all . --build-arg BUILT_VIA_BUILDKIT=true
#21 0.270 error: failed to load manifest for workspace member `/aptos/api`
#21 0.270
#21 0.270 Caused by:
#21 0.270   failed to parse manifest at `/aptos/api/Cargo.toml`
#21 0.270
#21 0.270 Caused by:
#21 0.270   no targets specified in the manifest
#21 0.270   either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present
```

```
$ docker/docker-bake-rust-all.sh indexer
# It builds correctly.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2472)
<!-- Reviewable:end -->
