### PR TITLE
[framework] do not expose token::transfer

### DIFF
--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -466,7 +466,7 @@ module aptos_token::token {
     }
 
     /// Transfers `amount` of tokens from `from` to `to`.
-    public fun transfer(
+    fun transfer(
         from: &signer,
         id: TokenId,
         to: address,


### PR DESCRIPTION
This can not be exposed before devnet cut as we should make sure that
the user opts into receiving unsolicited NFTs. The world is divided on
what the right approach is but this is a one way door as is.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2474)
<!-- Reviewable:end -->
