### PR TITLE
Fix move examples

### DIFF
--- a/aptos-move/framework/move-stdlib/sources/offer.move
+++ b/aptos-move/framework/move-stdlib/sources/offer.move
@@ -1,0 +1,135 @@
+/// Provides a way to transfer structs from one account to another in two transactions.
+/// Unlike many languages, Move cannot move data from one account to another with
+/// single-signer transactions. As of this writing, ordinary transactions can only have
+/// a single signer, and Move code can only store to an address (via `move_to`) if it
+/// can supply a reference to a signer for the destination address (there are special case
+/// exceptions in Genesis and DiemAccount where there can temporarily be multiple signers).
+///
+/// Offer solves this problem by providing an `Offer` resource.  To move a struct `T` from
+/// account A to B, account A first publishes an `Offer<T>` resource at `address_of(A)`,
+/// using the `offer::create` function.
+/// Then account B, in a separate transaction, can move the struct `T` from the `Offer` at
+/// A's address to the desired destination. B accesses the resource using the `redeem` function,
+/// which aborts unless the `for` field is B's address (preventing other addresses from
+/// accessing the `T` that is intended only for B). A can also redeem the `T` value if B hasn't
+/// redeemed it.
+module std::offer {
+  use std::signer;
+  use std::error;
+
+  /// A wrapper around value `offered` that can be claimed by the address stored in `for`.
+  struct Offer<Offered> has key { offered: Offered, for: address }
+
+  /// An offer of the specified type for the account does not exist
+  const EOFFER_DNE_FOR_ACCOUNT: u64 = 0;
+
+  /// Address already has an offer of this type.
+  const EOFFER_ALREADY_CREATED: u64 = 1;
+
+  /// Address does not have an offer of this type to redeem.
+  const EOFFER_DOES_NOT_EXIST: u64 = 2;
+
+  /// Publish a value of type `Offered` under the sender's account. The value can be claimed by
+  /// either the `for` address or the transaction sender.
+  public fun create<Offered: store>(account: &signer, offered: Offered, for: address) {
+    assert!(!exists<Offer<Offered>>(signer::address_of(account)), error::already_exists(EOFFER_ALREADY_CREATED));
+    move_to(account, Offer<Offered> { offered, for });
+  }
+  spec create {
+    /// Offer a struct to the account under address `for` by
+    /// placing the offer under the signer's address
+    aborts_if exists<Offer<Offered>>(signer::address_of(account));
+    ensures exists<Offer<Offered>>(signer::address_of(account));
+    ensures global<Offer<Offered>>(signer::address_of(account)) == Offer<Offered> { offered: offered, for: for };
+  }
+
+  /// Claim the value of type `Offered` published at `offer_address`.
+  /// Only succeeds if the sender is the intended recipient stored in `for` or the original
+  /// publisher `offer_address`.
+  /// Also fails if there is no `Offer<Offered>` published.
+  public fun redeem<Offered: store>(account: &signer, offer_address: address): Offered acquires Offer {
+    assert!(exists<Offer<Offered>>(offer_address), error::not_found(EOFFER_DOES_NOT_EXIST));
+    let Offer<Offered> { offered, for } = move_from<Offer<Offered>>(offer_address);
+    let sender = signer::address_of(account);
+    assert!(sender == for || sender == offer_address, error::invalid_argument(EOFFER_DNE_FOR_ACCOUNT));
+    offered
+  }
+  spec redeem {
+    /// Aborts if there is no offer under `offer_address` or if the account
+    /// cannot redeem the offer.
+    /// Ensures that the offered struct under `offer_address` is removed.
+    aborts_if !exists<Offer<Offered>>(offer_address);
+    aborts_if !is_allowed_recipient<Offered>(offer_address, signer::address_of(account));
+    ensures !exists<Offer<Offered>>(offer_address);
+    ensures result == old(global<Offer<Offered>>(offer_address).offered);
+  }
+
+  // Returns true if an offer of type `Offered` exists at `offer_address`.
+  public fun exists_at<Offered: store>(offer_address: address): bool {
+    exists<Offer<Offered>>(offer_address)
+  }
+  spec exists_at {
+    aborts_if false;
+    /// Returns whether or not an `Offer` resource is under the given address `offer_address`.
+    ensures result == exists<Offer<Offered>>(offer_address);
+  }
+
+
+  // Returns the address of the `Offered` type stored at `offer_address.
+  // Fails if no such `Offer` exists.
+  public fun address_of<Offered: store>(offer_address: address): address acquires Offer {
+    assert!(exists<Offer<Offered>>(offer_address), error::not_found(EOFFER_DOES_NOT_EXIST));
+    borrow_global<Offer<Offered>>(offer_address).for
+  }
+  spec address_of {
+    /// Aborts is there is no offer resource `Offer` at the `offer_address`.
+    /// Returns the address of the intended recipient of the Offer
+    /// under the `offer_address`.
+    aborts_if !exists<Offer<Offered>>(offer_address);
+    ensures result == global<Offer<Offered>>(offer_address).for;
+  }
+
+// =================================================================
+// Module Specification
+
+  spec module {} // switch documentation context back to module level
+
+  /// # Access Control
+
+  /// ## Creation of Offers
+
+  spec schema NoOfferCreated<Offered> {
+    /// Says no offer is created for any address. Later, it is applied to all functions
+    /// except `create`
+    ensures forall addr: address where !old(exists<Offer<Offered>>(addr)) : !exists<Offer<Offered>>(addr);
+  }
+  spec module {
+    /// Apply OnlyCreateCanCreateOffer to every function except `create`
+    apply NoOfferCreated<Offered> to *<Offered>, * except create;
+  }
+
+  /// ## Removal of Offers
+
+  spec schema NoOfferRemoved<Offered> {
+    /// Says no offer is removed for any address. Applied below to everything except `redeem`
+    ensures forall addr: address where old(exists<Offer<Offered>>(addr)) :
+              (exists<Offer<Offered>>(addr) && global<Offer<Offered>>(addr) == old(global<Offer<Offered>>(addr)));
+  }
+  spec module {
+    /// Only `redeem` can remove an offer from the global store.
+    apply NoOfferRemoved<Offered> to *<Offered>, * except redeem;
+  }
+
+  /// # Helper Functions
+
+  spec module {
+    /// Returns true if the recipient is allowed to redeem `Offer<Offered>` at `offer_address`
+    /// and false otherwise.
+    fun is_allowed_recipient<Offered>(offer_addr: address, recipient: address): bool {
+      recipient == global<Offer<Offered>>(offer_addr).for || recipient == offer_addr
+    }
+  }
+
+
+
+}

--- a/aptos-move/move-examples/hello_blockchain/Move.toml
+++ b/aptos-move/move-examples/hello_blockchain/Move.toml
@@ -3,7 +3,7 @@ name = "Examples"
 version = "0.0.0"
 
 [addresses]
-HelloBlockchain = "_"
+HelloBlockchain = "0x1"
 
 [dependencies]
 AptosFramework = { local = "../../framework/aptos-framework" }

--- a/aptos-move/move-examples/hello_blockchain/sources/HelloBlockchain.move
+++ b/aptos-move/move-examples/hello_blockchain/sources/HelloBlockchain.move
@@ -14,7 +14,7 @@ module HelloBlockchain::message {
         to_message: string::String,
     }
 
-    /// There is no message present
+    /// There is no message presenut
     const ENO_MESSAGE: u64 = 0;
 
     public fun get_message(addr: address): string::String acquires MessageHolder {

--- a/aptos-move/move-examples/messageboard/Move.toml
+++ b/aptos-move/move-examples/messageboard/Move.toml
@@ -7,4 +7,4 @@ AptosFramework = { local = "../../framework/aptos-framework" }
 
 [addresses]
 Std = "0x1"
-MessageBoard = "_"
+MessageBoard = "0x2"

--- a/aptos-move/move-examples/moon_coin/Move.toml
+++ b/aptos-move/move-examples/moon_coin/Move.toml
@@ -2,5 +2,8 @@
 name = "Examples"
 version = "0.0.0"
 
+[dependencies]
+AptosFramework = { local = "../../framework/aptos-framework" }
+
 [addresses]
-MoonCoinType = "_"
+MoonCoinType = "0x1"

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -146,21 +146,6 @@ impl BufferManager {
         CountedRequest::new(req, self.ongoing_tasks.clone())
     }
 
-    fn spawn_retry_request<T: Send + 'static>(
-        mut sender: Sender<T>,
-        request: T,
-        duration: Duration,
-    ) {
-        counters::BUFFER_MANAGER_RETRY_COUNT.inc();
-        tokio::spawn(async move {
-            tokio::time::sleep(duration).await;
-            sender
-                .send(request)
-                .await
-                .expect("Failed to send retry request");
-        });
-    }
-
     /// process incoming ordered blocks
     /// push them into the buffer and update the roots if they are none.
     fn process_ordered_blocks(&mut self, ordered_blocks: OrderedBlocks) {
@@ -191,15 +176,10 @@ impl BufferManager {
         if self.execution_root.is_some() {
             let ordered_blocks = self.buffer.get(&self.execution_root).get_blocks().clone();
             let request = self.create_new_request(ExecutionRequest { ordered_blocks });
-            if cursor == self.execution_root {
-                let sender = self.execution_phase_tx.clone();
-                Self::spawn_retry_request(sender, request, Duration::from_millis(100));
-            } else {
-                self.execution_phase_tx
-                    .send(request)
-                    .await
-                    .expect("Failed to send execution request")
-            }
+            self.execution_phase_tx
+                .send(request)
+                .await
+                .expect("Failed to send execution request")
         }
     }
 
@@ -223,15 +203,10 @@ impl BufferManager {
                 ordered_ledger_info: executed_item.ordered_proof.clone(),
                 commit_ledger_info: executed_item.commit_proof.ledger_info().clone(),
             });
-            if cursor == self.signing_root {
-                let sender = self.signing_phase_tx.clone();
-                Self::spawn_retry_request(sender, request, Duration::from_millis(100));
-            } else {
-                self.signing_phase_tx
-                    .send(request)
-                    .await
-                    .expect("Failed to send signing request");
-            }
+            self.signing_phase_tx
+                .send(request)
+                .await
+                .expect("Failed to send signing request");
         }
     }
 


### PR DESCRIPTION
### Description
Current move-examples doesn't compile and throw two kind of err: unresolved addr
and missing module in movestdlib (std), the fix is pretty trivial, after the fix
all examples pass all existing tests with `move test` command

### Test Plan
Enter into each `aptos-move/move-examples/*` and run `move test` to see all tests pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2480)
<!-- Reviewable:end -->
