### PR TITLE
[community] Fix redirect for devise + admin routes.

### DIFF
--- a/ecosystem/platform/server/config/routes.rb
+++ b/ecosystem/platform/server/config/routes.rb
@@ -4,6 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Rails.application.routes.draw do
+  # Redirect community.aptoslabs.com to aptoslabs.com
+  constraints host: /community.aptoslabs.com/ do
+    match '/*path' => redirect { |params, _req| "https://aptoslabs.com/#{params[:path]}" }, via: %i[get post]
+    match '/' => redirect { |_params, _req| 'https://aptoslabs.com/community' }, via: %i[get post]
+  end
+
   devise_for :users, {
     controllers: {
       omniauth_callbacks: 'users/omniauth_callbacks',
@@ -17,12 +23,6 @@ Rails.application.routes.draw do
 
   namespace :user do
     root to: redirect('/it2') # creates user_root_path, where users go after confirming email
-  end
-
-  # Redirect community.aptoslabs.com to aptoslabs.com
-  constraints host: /community.aptoslabs.com/ do
-    match '/*path' => redirect { |params, _req| "https://aptoslabs.com/#{params[:path]}" }, via: %i[get post]
-    match '/' => redirect { |_params, _req| 'https://aptoslabs.com/community' }, via: %i[get post]
   end
 
   # CMS


### PR DESCRIPTION
### Description

Some routes like `/users/sign_in` weren't getting redirected because they had precedence over the redirect.

### Test Plan
Tested manually with curl + host header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2481)
<!-- Reviewable:end -->
