### PR TITLE
Allow .mv files in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 
 !**/Cargo.toml
 !**/Cargo.lock
+!**/*.mv
 !**/*.rs
 !config/src/config/test_data
 !aptos-move/framework/


### PR DESCRIPTION
## Description
See https://aptoslabs.pagerduty.com/incidents/Q25RRHTAYP052P.

## Test Plan
This was failing before:
```
docker context create builders
docker context use builders
docker buildx create --driver docker-container --use --builder builders --name builder-dda7b2c6-4289-4ae5-9b50-38624dae0f9f --buildkitd-flags '--allow-insecure-entitlement security.insecure --allow-insecure-entitlement network.host'
docker buildx inspect --bootstrap --builder builder-dda7b2c6-4289-4ae5-9b50-38624dae0f9f
export LAST_GREEN_COMMIT=25e4d7320a0a4dac20b4c07e353350636a8c3d01
docker/docker-bake-rust-all.sh
```
These steps capture what CI was doing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2486)
<!-- Reviewable:end -->
