### PR TITLE
[community] Remove dialog polyfill.

### DIFF
--- a/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
+++ b/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
@@ -12,45 +12,6 @@
   font-variant-ligatures: none;
 }
 
-dialog {
-  position: absolute;
-  left: 0; right: 0;
-  width: -moz-fit-content;
-  width: -webkit-fit-content;
-  width: fit-content;
-  height: -moz-fit-content;
-  height: -webkit-fit-content;
-  height: fit-content;
-  margin: auto;
-  border: solid;
-  padding: 1em;
-  background: white;
-  color: black;
-  display: block;
-}
-
-dialog:not([open]) {
-  display: none;
-}
-
-dialog + .backdrop {
-  position: fixed;
-  top: 0; right: 0; bottom: 0; left: 0;
-  background: rgba(0,0,0,0.75);
-}
-
-._dialog_overlay {
-  position: fixed;
-  top: 0; right: 0; bottom: 0; left: 0;
-}
-
-dialog.fixed {
-  position: fixed;
-  top: 50%;
-  transform: translate(0, -50%);
-  margin: 0 auto;
-}
-
 dialog::backdrop {
   background: rgba(0,0,0,0.75);
 }

--- a/ecosystem/platform/server/app/components/dialog_component.rb
+++ b/ecosystem/platform/server/app/components/dialog_component.rb
@@ -12,7 +12,7 @@ class DialogComponent < ViewComponent::Base
   def initialize(**rest)
     @rest = rest
     @rest[:class] = [
-      'rounded-xl border-none bg-neutral-900 text-white w-96 fixed p-0',
+      'rounded-xl border-none bg-neutral-900 text-white w-96 p-0',
       @rest[:class]
     ]
 

--- a/ecosystem/platform/server/app/javascript/controllers/dialog_controller.ts
+++ b/ecosystem/platform/server/app/javascript/controllers/dialog_controller.ts
@@ -2,14 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Controller } from "./controller";
-import dialogPolyfill from "dialog-polyfill";
 
 // Connects to data-controller="dialog"
 export default class extends Controller<HTMLDialogElement> {
-  connect() {
-    dialogPolyfill.registerDialog(this.element);
-  }
-
   handleClick(e: Event) {
     if (e.target === this.element) {
       this.element.close();

--- a/ecosystem/platform/server/package.json
+++ b/ecosystem/platform/server/package.json
@@ -8,7 +8,6 @@
     "@tailwindcss/typography": "^0.5.2",
     "aptos": "^1.0.0",
     "autoprefixer": "^10.4.7",
-    "dialog-polyfill": "^0.5.6",
     "esbuild": "^0.14.39",
     "postcss": "^8.4.13",
     "tailwindcss": "^3.1.0"

--- a/ecosystem/platform/server/yarn.lock
+++ b/ecosystem/platform/server/yarn.lock
@@ -320,11 +320,6 @@ detective@^5.2.1:
     defined "^1.0.0"
     minimist "^1.2.6"
 
-dialog-polyfill@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/dialog-polyfill/-/dialog-polyfill-0.5.6.tgz#7507b4c745a82fcee0fa07ce64d835979719599a"
-  integrity sha512-ZbVDJI9uvxPAKze6z146rmfUZjBqNEwcnFTVamQzXH+svluiV7swmVIGr7miwADgfgt1G2JQIytypM9fbyhX4w==
-
 didyoumean@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"


### PR DESCRIPTION
### Description

This is no longer necessary since the last two versions of Safari support `<dialog>`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2493)
<!-- Reviewable:end -->
