### PR TITLE
[community] Enable gzip for HTTP responses.

### DIFF
--- a/ecosystem/platform/server/config/application.rb
+++ b/ecosystem/platform/server/config/application.rb
@@ -25,5 +25,9 @@ module CommunityPlatform
     # config.eager_load_paths << Rails.root.join("extras")
 
     # config.debug_exception_response_format = :api
+
+    # Enable gzip compression for HTTP responses.
+    # TODO: Remove when the CDN handles compression.
+    config.middleware.use Rack::Deflater
   end
 end


### PR DESCRIPTION
### Description

Enables gzip for HTTP responses via Rack middleware. Ideally the CDN would handle this instead.

Before

![2022-08-03-153949_1077x104_scrot](https://user-images.githubusercontent.com/310773/182695107-7d640855-29e5-4a67-977a-c52d7e6401ea.png)

After

![2022-08-03-153917_1079x107_scrot](https://user-images.githubusercontent.com/310773/182695119-0304e649-9fa9-45b9-b666-19ff1b9af8c0.png)



### Test Plan
Manual

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2496)
<!-- Reviewable:end -->
