### PR TITLE
feat: expose a method to build TransactionPayload in ABI transaction builder

### DIFF
--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -155,7 +155,7 @@ export class TransactionBuilderABI {
    * @param abis List of binary ABIs.
    * @param builderConfig Configs for creating a raw transaction.
    */
-  constructor(abis: Bytes[], builderConfig: ABIBuilderConfig) {
+  constructor(abis: Bytes[], builderConfig?: ABIBuilderConfig) {
     this.abiMap = new Map<string, ScriptABI>();
 
     abis.forEach((abi) => {
@@ -211,32 +211,16 @@ export class TransactionBuilderABI {
   }
 
   /**
-   * Builds a RawTransaction
+   * Builds a TransactionPayload. For dapps, chain ID and account sequence numbers are only known to the wallet.
+   * Instead of building a RawTransaction (requires chainID and sequenceNumber), dapps can build a TransactionPayload
+   * and pass the payload to the wallet for signing and sending.
    * @param func Fully qualified func names, e.g. 0x1::Coin::transfer
-   * @param ty_tags TypeTag strings.
-   * @example Below are valid value examples
-   * ```
-   * // Structs are in format `AccountAddress::ModuleName::StructName`
-   * 0x1::aptos_coin::AptosCoin
-   * // Vectors are in format `vector<other_tag_string>`
-   * vector<0x1::aptos_coin::AptosCoin>
-   * bool
-   * u8
-   * u64
-   * u128
-   * address
-   * ```
+   * @param ty_tags TypeTag strings
    * @param args Function arguments
-   * @returns RawTransaction
+   * @returns TransactionPayload
    */
-  build(func: string, ty_tags: string[], args: any[]): RawTransaction {
-    const { sender, sequenceNumber, gasUnitPrice, maxGasAmount, expSecFromNow, chainId } = this.builderConfig;
-
-    const senderAccount = sender instanceof HexString ? AccountAddress.fromHex(sender) : sender;
-
+  buildTransactionPayload(func: string, ty_tags: string[], args: any[]): TransactionPayload {
     const typeTags = ty_tags.map((ty_arg) => new TypeTagParser(ty_arg).parseTypeTag());
-
-    const expTimetampSec = BigInt(Math.floor(Date.now() / 1000) + Number(expSecFromNow));
 
     let payload: TransactionPayload;
 
@@ -260,6 +244,35 @@ export class TransactionBuilderABI {
 
       payload = new TransactionPayloadScript(new Script(funcABI.code, typeTags, scriptArgs));
     }
+
+    return payload;
+  }
+
+  /**
+   * Builds a RawTransaction
+   * @param func Fully qualified func names, e.g. 0x1::Coin::transfer
+   * @param ty_tags TypeTag strings.
+   * @example Below are valid value examples
+   * ```
+   * // Structs are in format `AccountAddress::ModuleName::StructName`
+   * 0x1::aptos_coin::AptosCoin
+   * // Vectors are in format `vector<other_tag_string>`
+   * vector<0x1::aptos_coin::AptosCoin>
+   * bool
+   * u8
+   * u64
+   * u128
+   * address
+   * ```
+   * @param args Function arguments
+   * @returns RawTransaction
+   */
+  build(func: string, ty_tags: string[], args: any[]): RawTransaction {
+    const { sender, sequenceNumber, gasUnitPrice, maxGasAmount, expSecFromNow, chainId } = this.builderConfig;
+
+    const senderAccount = sender instanceof HexString ? AccountAddress.fromHex(sender) : sender;
+    const expTimetampSec = BigInt(Math.floor(Date.now() / 1000) + Number(expSecFromNow));
+    const payload = this.buildTransactionPayload(func, ty_tags, args);
 
     if (payload) {
       return new RawTransaction(


### PR DESCRIPTION
### Description
When building dapps, chain ID and account sequence numbers are only known to the wallet. Instead of building a RawTransaction (requires chainID and sequenceNumber), dapps can build a TransactionPayload and pass the payload to the wallet for signing and sending.

### Test Plan
yarn test (tests are currently broken due to other changes, will update the test plan later)
