### PR TITLE
[address] Make address outputs consistent

### DIFF
--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -365,10 +365,7 @@ impl TestContext {
         name: &str,
     ) -> serde_json::Value {
         let resources = self
-            .get(&format!(
-                "/accounts/{}/resources",
-                account.address().to_hex_literal()
-            ))
+            .get(&format!("/accounts/{}/resources", account.address()))
             .await;
         let vals: Vec<serde_json::Value> = serde_json::from_value(resources).unwrap();
         match self.api_specific_config {
@@ -404,12 +401,7 @@ impl TestContext {
         let (typ, function) = match self.api_specific_config {
             ApiSpecificConfig::V0 => (
                 "script_function_payload",
-                json!(format!(
-                    "{}::{}::{}",
-                    account.address().to_hex_literal(),
-                    module,
-                    func
-                )),
+                json!(format!("{}::{}::{}", account.address(), module, func)),
             ),
             ApiSpecificConfig::V1(_) => (
                 "script_function_payload",

--- a/api/src/tests/v0/accounts_test.rs
+++ b/api/src/tests/v0/accounts_test.rs
@@ -113,7 +113,7 @@ async fn test_get_account_resources_by_ledger_version() {
 
     let ledger_version_1_resources = context
         .get(&account_resources(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
         ))
         .await;
     let root_account = find_value(&ledger_version_1_resources, |f| {
@@ -123,7 +123,7 @@ async fn test_get_account_resources_by_ledger_version() {
 
     let ledger_version_0_resources = context
         .get(&account_resources_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             0,
         ))
         .await;
@@ -139,7 +139,7 @@ async fn test_get_account_resources_by_ledger_version_is_too_large() {
     let resp = context
         .expect_status_code(404)
         .get(&account_resources_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             1000000000000000000,
         ))
         .await;
@@ -152,7 +152,7 @@ async fn test_get_account_resources_by_invalid_ledger_version() {
     let resp = context
         .expect_status_code(400)
         .get(&account_resources_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             -1,
         ))
         .await;
@@ -174,7 +174,7 @@ async fn test_get_account_modules_by_ledger_version() {
     context.commit_block(&vec![txn.clone()]).await;
     let modules = context
         .get(&account_modules(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
         ))
         .await;
 
@@ -182,7 +182,7 @@ async fn test_get_account_modules_by_ledger_version() {
 
     let modules = context
         .get(&account_modules_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             0,
         ))
         .await;

--- a/api/src/tests/v0/state_test.rs
+++ b/api/src/tests/v0/state_test.rs
@@ -109,7 +109,7 @@ async fn test_get_table_item() {
     let tt = ctx
         .api_get_account_resource(
             acc,
-            &acc.address().to_hex_literal(),
+            &acc.address().to_string(),
             "TableTestData",
             "TestTables",
         )

--- a/api/src/tests/v0/string_resource_test.rs
+++ b/api/src/tests/v0/string_resource_test.rs
@@ -49,7 +49,7 @@ async fn test_renders_move_acsii_string_into_utf8_string() {
     let message = context
         .api_get_account_resource(
             &account,
-            &account.address().to_hex_literal(),
+            &account.address().to_string(),
             "Message",
             "MessageHolder",
         )

--- a/api/src/tests/v1/accounts_test.rs
+++ b/api/src/tests/v1/accounts_test.rs
@@ -113,7 +113,7 @@ async fn test_get_account_resources_by_ledger_version() {
 
     let ledger_version_1_resources = context
         .get(&account_resources(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
         ))
         .await;
     let root_account = find_value(&ledger_version_1_resources, |f| {
@@ -129,7 +129,7 @@ async fn test_get_account_resources_by_ledger_version() {
 
     let ledger_version_0_resources = context
         .get(&account_resources_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             0,
         ))
         .await;
@@ -151,7 +151,7 @@ async fn test_get_account_resources_by_ledger_version_is_too_large() {
     let resp = context
         .expect_status_code(404)
         .get(&account_resources_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             1000000000000000000,
         ))
         .await;
@@ -164,7 +164,7 @@ async fn test_get_account_resources_by_invalid_ledger_version() {
     let resp = context
         .expect_status_code(400)
         .get(&account_resources_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             -1,
         ))
         .await;
@@ -186,7 +186,7 @@ async fn test_get_account_modules_by_ledger_version() {
     context.commit_block(&vec![txn.clone()]).await;
     let modules = context
         .get(&account_modules(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
         ))
         .await;
 
@@ -194,7 +194,7 @@ async fn test_get_account_modules_by_ledger_version() {
 
     let modules = context
         .get(&account_modules_with_ledger_version(
-            &context.root_account().address().to_hex_literal(),
+            &context.root_account().address().to_string(),
             0,
         ))
         .await;

--- a/api/src/tests/v1/state_test.rs
+++ b/api/src/tests/v1/state_test.rs
@@ -106,7 +106,7 @@ async fn test_get_table_item() {
     let tt = ctx
         .api_get_account_resource(
             acc,
-            &acc.address().to_hex_literal(),
+            &acc.address().to_string(),
             "TableTestData",
             "TestTables",
         )

--- a/api/src/tests/v1/string_resource_test.rs
+++ b/api/src/tests/v1/string_resource_test.rs
@@ -49,7 +49,7 @@ async fn test_renders_move_acsii_string_into_utf8_string() {
     let message = context
         .api_get_account_resource(
             &account,
-            &account.address().to_hex_literal(),
+            &account.address().to_string(),
             "Message",
             "MessageHolder",
         )

--- a/api/types/src/address.rs
+++ b/api/types/src/address.rs
@@ -17,7 +17,7 @@ impl Address {
 
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0.to_hex_literal())
+        write!(f, "{}", self.0)
     }
 }
 

--- a/crates/aptos-faucet-cli/src/main.rs
+++ b/crates/aptos-faucet-cli/src/main.rs
@@ -94,23 +94,15 @@ impl FaucetCliArgs {
                 MintParams {
                     amount: self.amount,
                     auth_key: None,
-                    address: Some(account.to_hex_literal()),
+                    address: Some(account.to_string()),
                     pub_key: None,
                     return_txns: None,
                 },
             )
             .await;
             match response {
-                Ok(response) => println!(
-                    "SUCCESS: Account: {} Response: {:?}",
-                    account.to_hex_literal(),
-                    response
-                ),
-                Err(response) => println!(
-                    "FAILURE: Account: {} Response: {:?}",
-                    account.to_hex_literal(),
-                    response
-                ),
+                Ok(response) => println!("SUCCESS: Account: {} Response: {:?}", account, response),
+                Err(response) => println!("FAILURE: Account: {} Response: {:?}", account, response),
             }
         }
     }

--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -267,7 +267,7 @@ pub async fn delegate_mint_account(
                     .authentication_key()
                     .clone()
                     .derived_address()
-                    .to_hex_literal(),
+                    .to_string(),
             ),
             pub_key: None,
             return_txns: Some(true),

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -118,7 +118,7 @@ impl CliCommand<()> for InitPackage {
             .named_addresses
             .clone()
             .into_iter()
-            .map(|(key, value)| (key, value.account_address.to_hex_literal()))
+            .map(|(key, value)| (key, value.account_address.to_string()))
             .collect();
 
         // TODO: Support Git as default when Github credentials are properly handled from GH CLI

--- a/ecosystem/indexer/src/models/transactions.rs
+++ b/ecosystem/indexer/src/models/transactions.rs
@@ -305,7 +305,7 @@ impl UserTransaction {
         Self {
             hash: tx.info.hash.to_string(),
             signature: serde_json::to_value(&tx.request.signature).unwrap(),
-            sender: tx.request.sender.inner().to_hex_literal(),
+            sender: tx.request.sender.inner().to_string(),
             sequence_number: *tx.request.sequence_number.inner() as i64,
             max_gas_amount: *tx.request.max_gas_amount.inner() as i64,
             expiration_timestamp_secs: parse_timestamp_secs(
@@ -346,7 +346,7 @@ impl BlockMetadataTransaction {
             round: *tx.round.inner() as i64,
             // TODO: Deprecated, use previous_block_votes_bitmap instead. Column kept to not break indexer users (e.g., explorer), writing an empty vector.
             previous_block_votes: serde_json::to_value(vec![] as Vec<Address>).unwrap(),
-            proposer: tx.proposer.inner().to_hex_literal(),
+            proposer: tx.proposer.inner().to_string(),
             // time is in milliseconds, but chronos wants seconds
             timestamp: parse_timestamp(tx.timestamp, tx.info.version),
             inserted_at: chrono::Utc::now().naive_utc(),

--- a/testsuite/smoke-test/src/transaction.rs
+++ b/testsuite/smoke-test/src/transaction.rs
@@ -99,7 +99,7 @@ impl AptosTest for ExternalTransactionSigner {
                             .into_iter()
                             .map(|arg| arg.as_str().unwrap().to_owned())
                             .collect::<Vec<String>>(),
-                        vec![receiver.address().to_hex_literal(), amount.to_string(),]
+                        vec![receiver.address().to_string(), amount.to_string(),]
                     );
                 } else {
                     bail!("unexpected transaction playload")


### PR DESCRIPTION
### Description
These will now be all whatever the value is in AccountAddress
as the Display implementation.

With this change: https://github.com/move-language/move/pull/340 it will make all outputs the same no matter what, though accept multiple input types.

### Test Plan
TBD waiting on other PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2504)
<!-- Reviewable:end -->
