### PR TITLE
[merkle_deletion] SMT and JMT deletion

### DIFF
--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -117,10 +117,10 @@ impl<'a> DebuggerStateView<'a> {
         state_key: &StateKey,
         version: Version,
     ) -> Result<Option<Vec<u8>>> {
-        match self.db.get_state_value_by_version(state_key, version)? {
-            None => Ok(None),
-            Some(state_value) => Ok(state_value.maybe_bytes),
-        }
+        Ok(self
+            .db
+            .get_state_value_by_version(state_key, version)?
+            .map(|v| v.maybe_bytes))
     }
 }
 

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -12,6 +12,7 @@ use aptos_crypto::{
     hash::{EventAccumulatorHasher, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
+use aptos_types::proof::SparseMerkleProofExt;
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
@@ -297,11 +298,11 @@ impl StateComputeResult {
 }
 
 pub struct ProofReader {
-    proofs: HashMap<HashValue, SparseMerkleProof>,
+    proofs: HashMap<HashValue, SparseMerkleProofExt>,
 }
 
 impl ProofReader {
-    pub fn new(proofs: HashMap<HashValue, SparseMerkleProof>) -> Self {
+    pub fn new(proofs: HashMap<HashValue, SparseMerkleProofExt>) -> Self {
         ProofReader { proofs }
     }
 
@@ -311,7 +312,7 @@ impl ProofReader {
 }
 
 impl ProofRead for ProofReader {
-    fn get_proof(&self, key: HashValue) -> Option<&SparseMerkleProof> {
+    fn get_proof(&self, key: HashValue) -> Option<&SparseMerkleProofExt> {
         self.proofs.get(&key)
     }
 }

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -12,12 +12,11 @@ use aptos_crypto::{
     hash::{EventAccumulatorHasher, TransactionAccumulatorHasher, ACCUMULATOR_PLACEHOLDER_HASH},
     HashValue,
 };
-use aptos_types::proof::SparseMerkleProofExt;
 use aptos_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
-    proof::{accumulator::InMemoryAccumulator, AccumulatorExtensionProof},
+    proof::{accumulator::InMemoryAccumulator, AccumulatorExtensionProof, SparseMerkleProofExt},
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::{
         Transaction, TransactionInfo, TransactionListWithProof, TransactionOutputListWithProof,
@@ -34,8 +33,6 @@ mod error;
 mod executed_chunk;
 pub mod in_memory_state_calculator;
 mod parsed_transaction_output;
-
-type SparseMerkleProof = aptos_types::proof::SparseMerkleProof;
 
 pub trait ChunkExecutorTrait: Send + Sync {
     /// Verifies the transactions based on the provided proofs and ledger info. If the transactions
@@ -323,7 +320,7 @@ impl ProofRead for ProofReader {
 pub struct TransactionData {
     /// Each entry in this map represents the new value of a store store object touched by this
     /// transaction.
-    state_updates: HashMap<StateKey, StateValue>,
+    state_updates: HashMap<StateKey, Option<StateValue>>,
 
     /// The writeset generated from this transaction.
     write_set: WriteSet,
@@ -352,7 +349,7 @@ pub struct TransactionData {
 
 impl TransactionData {
     pub fn new(
-        state_updates: HashMap<StateKey, StateValue>,
+        state_updates: HashMap<StateKey, Option<StateValue>>,
         write_set: WriteSet,
         events: Vec<ContractEvent>,
         reconfig_events: Vec<ContractEvent>,
@@ -375,7 +372,7 @@ impl TransactionData {
         }
     }
 
-    pub fn state_updates(&self) -> &HashMap<StateKey, StateValue> {
+    pub fn state_updates(&self) -> &HashMap<StateKey, Option<StateValue>> {
         &self.state_updates
     }
 

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -140,7 +140,7 @@ impl ApplyChunkOutput {
 
     fn assemble_ledger_diff(
         to_keep: Vec<(Transaction, ParsedTransactionOutput)>,
-        state_updates_vec: Vec<HashMap<StateKey, StateValue>>,
+        state_updates_vec: Vec<HashMap<StateKey, Option<StateValue>>>,
         state_checkpoint_hashes: Vec<Option<HashValue>>,
     ) -> (Vec<(Transaction, TransactionData)>, Vec<HashValue>) {
         let mut to_commit = vec![];

--- a/execution/executor/src/tests/mod.rs
+++ b/execution/executor/src/tests/mod.rs
@@ -473,8 +473,6 @@ fn test_deleted_key_from_state_store() {
         .get_state_value_with_proof_by_version(&dummy_state_key1, 5)
         .unwrap()
         .0
-        .unwrap()
-        .maybe_bytes
         .is_none());
 
     // Ensure the key that was not touched by the transaction is not accidentally deleted

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -72,7 +72,7 @@ use aptos_types::{
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     proof::{
-        accumulator::InMemoryAccumulator, AccumulatorConsistencyProof, SparseMerkleProof,
+        accumulator::InMemoryAccumulator, AccumulatorConsistencyProof, SparseMerkleProof, SparseMerkleProofExt
         TransactionInfoListWithProof,
     },
     state_proof::StateProof,
@@ -1154,11 +1154,11 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_state_value_with_proof_by_version(
+    fn get_state_value_with_proof_by_version_ext(
         &self,
         state_store_key: &StateKey,
         version: Version,
-    ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
+    ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
         gauged_api("get_state_value_with_proof_by_version", || {
             error_if_version_is_pruned(&self.state_pruner, "State", version)?;
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -72,7 +72,7 @@ use aptos_types::{
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     proof::{
-        accumulator::InMemoryAccumulator, AccumulatorConsistencyProof, SparseMerkleProof, SparseMerkleProofExt
+        accumulator::InMemoryAccumulator, AccumulatorConsistencyProof, SparseMerkleProofExt,
         TransactionInfoListWithProof,
     },
     state_proof::StateProof,
@@ -1141,16 +1141,16 @@ impl DbReader for AptosDB {
     }
 
     /// Returns the proof of the given state key and version.
-    fn get_state_proof_by_version(
+    fn get_state_proof_by_version_ext(
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> Result<SparseMerkleProof> {
+    ) -> Result<SparseMerkleProofExt> {
         gauged_api("get_proof_by_version", || {
             error_if_version_is_pruned(&self.state_pruner, "State", version)?;
 
             self.state_store
-                .get_state_proof_by_version(state_key, version)
+                .get_state_proof_by_version_ext(state_key, version)
         })
     }
 
@@ -1159,11 +1159,11 @@ impl DbReader for AptosDB {
         state_store_key: &StateKey,
         version: Version,
     ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
-        gauged_api("get_state_value_with_proof_by_version", || {
+        gauged_api("get_state_value_with_proof_by_version_ext", || {
             error_if_version_is_pruned(&self.state_pruner, "State", version)?;
 
             self.state_store
-                .get_state_value_with_proof_by_version(state_store_key, version)
+                .get_state_value_with_proof_by_version_ext(state_store_key, version)
         })
     }
 

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -27,7 +27,7 @@ fn put_value_set(
 ) -> HashValue {
     let value_set: HashMap<_, _> = value_set
         .iter()
-        .map(|(key, value)| (key.clone(), value.clone()))
+        .map(|(key, value)| (key.clone(), Some(value.clone())))
         .collect();
     let jmt_updates = jmt_updates(&value_set);
 

--- a/storage/aptosdb/src/schema/state_value/mod.rs
+++ b/storage/aptosdb/src/schema/state_value/mod.rs
@@ -29,7 +29,12 @@ use std::{io::Write, mem::size_of};
 
 type Key = (StateKey, Version);
 
-define_schema!(StateValueSchema, Key, StateValue, STATE_VALUE_CF_NAME);
+define_schema!(
+    StateValueSchema,
+    Key,
+    Option<StateValue>,
+    STATE_VALUE_CF_NAME
+);
 
 impl KeyCodec<StateValueSchema> for Key {
     fn encode_key(&self) -> Result<Vec<u8>> {
@@ -50,7 +55,7 @@ impl KeyCodec<StateValueSchema> for Key {
     }
 }
 
-impl ValueCodec<StateValueSchema> for StateValue {
+impl ValueCodec<StateValueSchema> for Option<StateValue> {
     fn encode_value(&self) -> Result<Vec<u8>> {
         bcs::to_bytes(self).map_err(Into::into)
     }

--- a/storage/aptosdb/src/schema/state_value/test.rs
+++ b/storage/aptosdb/src/schema/state_value/test.rs
@@ -10,7 +10,7 @@ proptest! {
     fn test_encode_decode(
         state_key in any::<StateKey>(),
         version in any::<Version>(),
-        v in any::<StateValue>(),
+        v in any::<Option<StateValue>>(),
     ) {
         assert_encode_decode::<StateValueSchema>(&(state_key, version), &v);
     }

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -9,6 +9,7 @@ use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_jellyfish_merkle::{
     node_type::NodeKey, JellyfishMerkleTree, TreeReader, TreeUpdateBatch, TreeWriter,
 };
+use aptos_types::proof::SparseMerkleProofExt;
 use aptos_types::{
     nibble::{nibble_path::NibblePath, ROOT_NIBBLE_HEIGHT},
     proof::{SparseMerkleProof, SparseMerkleRangeProof},
@@ -44,6 +45,17 @@ impl StateMerkleDb {
         version: Version,
     ) -> Result<(Option<(HashValue, (StateKey, Version))>, SparseMerkleProof)> {
         JellyfishMerkleTree::new(self).get_with_proof(state_key.hash(), version)
+    }
+
+    pub fn get_with_proof_ext(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<(
+        Option<(HashValue, (StateKey, Version))>,
+        SparseMerkleProofExt,
+    )> {
+        JellyfishMerkleTree::new(self).get_with_proof_ext(state_key.hash(), version)
     }
 
     pub fn get_range_proof(

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -12,7 +12,7 @@ use aptos_jellyfish_merkle::{
 use aptos_types::proof::SparseMerkleProofExt;
 use aptos_types::{
     nibble::{nibble_path::NibblePath, ROOT_NIBBLE_HEIGHT},
-    proof::{SparseMerkleProof, SparseMerkleRangeProof},
+    proof::SparseMerkleRangeProof,
     state_store::state_key::StateKey,
     transaction::Version,
 };
@@ -37,14 +37,6 @@ impl Deref for StateMerkleDb {
 impl StateMerkleDb {
     pub fn new(state_merkle_rocksdb: Arc<DB>) -> Self {
         Self(state_merkle_rocksdb)
-    }
-
-    pub fn get_with_proof(
-        &self,
-        state_key: &StateKey,
-        version: Version,
-    ) -> Result<(Option<(HashValue, (StateKey, Version))>, SparseMerkleProof)> {
-        JellyfishMerkleTree::new(self).get_with_proof(state_key.hash(), version)
     }
 
     pub fn get_with_proof_ext(
@@ -76,7 +68,7 @@ impl StateMerkleDb {
 
     pub fn batch_put_value_set(
         &self,
-        value_set: Vec<(HashValue, &(HashValue, StateKey))>,
+        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         persisted_version: Option<Version>,
         version: Version,
@@ -111,7 +103,7 @@ impl StateMerkleDb {
     /// hashes for each write set.
     pub fn merklize_value_set(
         &self,
-        value_set: Vec<(HashValue, &(HashValue, StateKey))>,
+        value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         version: Version,
         base_version: Option<Version>,

--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -147,7 +147,9 @@ impl BufferedState {
 
     pub fn update(
         &mut self,
-        updates_until_next_checkpoint_since_current_option: Option<HashMap<StateKey, StateValue>>,
+        updates_until_next_checkpoint_since_current_option: Option<
+            HashMap<StateKey, Option<StateValue>>,
+        >,
         mut new_state_after_checkpoint: StateDelta,
         sync_commit: bool,
     ) -> Result<()> {

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -16,6 +16,7 @@ use aptos_logger::info;
 use aptos_state_view::StateViewId;
 #[cfg(test)]
 use aptos_types::nibble::nibble_path::NibblePath;
+use aptos_types::proof::SparseMerkleProofExt;
 use aptos_types::{
     proof::{definition::LeafCount, SparseMerkleProof, SparseMerkleRangeProof},
     state_store::{
@@ -124,12 +125,14 @@ impl DbReader for StateDb {
     }
 
     /// Get the state value with proof given the state key and version
-    fn get_state_value_with_proof_by_version(
+    fn get_state_value_with_proof_by_version_ext(
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
-        let (leaf_data, proof) = self.state_merkle_db.get_with_proof(state_key, version)?;
+    ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
+        let (leaf_data, proof) = self
+            .state_merkle_db
+            .get_with_proof_ext(state_key, version)?;
         Ok((
             match leaf_data {
                 Some((_, (key, version))) => Some(self.expect_value_by_version(&key, version)?),
@@ -169,14 +172,14 @@ impl DbReader for StateStore {
         self.deref().get_state_proof_by_version(state_key, version)
     }
 
-    /// Get the state value with proof given the state key and version
-    fn get_state_value_with_proof_by_version(
+    /// Get the state value with proof extension given the state key and version
+    fn get_state_value_with_proof_by_version_ext(
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
+    ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
         self.deref()
-            .get_state_value_with_proof_by_version(state_key, version)
+            .get_state_value_with_proof_by_version_ext(state_key, version)
     }
 }
 

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -27,7 +27,7 @@ fn put_value_set(
 ) -> HashValue {
     let value_set: HashMap<_, _> = value_set
         .iter()
-        .map(|(key, value)| (key.clone(), value.clone()))
+        .map(|(key, value)| (key.clone(), Some(value.clone())))
         .collect();
     let jmt_updates = jmt_updates(&value_set);
 
@@ -777,7 +777,7 @@ fn update_store(
     first_version: Version,
 ) {
     for (i, (key, value)) in input.enumerate() {
-        let value_state_set = vec![(key, value)].into_iter().collect();
+        let value_state_set = vec![(key, Some(value))].into_iter().collect();
         let jmt_updates = jmt_updates(&value_state_set);
         let version = first_version + i as Version;
         store

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -136,7 +136,10 @@ impl TreeWriter<StateKey> for MockStore {
 }
 
 impl StateValueWriter<StateKey, StateValue> for MockStore {
-    fn write_kv_batch(&self, _kv_batch: &StateValueBatch<StateKey, StateValue>) -> Result<()> {
+    fn write_kv_batch(
+        &self,
+        _kv_batch: &StateValueBatch<StateKey, Option<StateValue>>,
+    ) -> Result<()> {
         Ok(())
     }
 }

--- a/storage/jellyfish-merkle/src/iterator/iterator_test.rs
+++ b/storage/jellyfish-merkle/src/iterator/iterator_test.rs
@@ -40,7 +40,7 @@ fn test_n_leaves_same_version(n: usize) {
     let mut btree = BTreeMap::new();
     for (index, _) in values.iter().enumerate() {
         let key = HashValue::random_with_rng(&mut rng);
-        assert_eq!(btree.insert(key, &values[index]), None);
+        assert_eq!(btree.insert(key, Some(&values[index])), None);
     }
 
     let (_root_hash, batch) = tree
@@ -50,7 +50,7 @@ fn test_n_leaves_same_version(n: usize) {
     let btree: BTreeMap<_, _> = btree
         .clone()
         .into_iter()
-        .map(|(x, y)| (x, y.clone()))
+        .filter_map(|(x, y)| y.map(|y| (x, y.clone())))
         .collect();
 
     run_tests(db, &btree, 0 /* version */);
@@ -67,7 +67,7 @@ fn test_n_leaves_multiple_versions(n: usize) {
         let key = HashValue::random_with_rng(&mut rng);
         let value = gen_value();
         let (_root_hash, batch) = tree
-            .put_value_set_test(vec![(key, &value)], i as Version)
+            .put_value_set_test(vec![(key, Some(&value))], i as Version)
             .unwrap();
         assert_eq!(btree.insert(key, value), None);
         db.write_tree_update_batch(batch).unwrap();
@@ -81,7 +81,7 @@ fn test_n_consecutive_addresses(n: usize) {
     let values: Vec<_> = (0..n).map(|_i| gen_value()).collect();
 
     let btree: BTreeMap<_, _> = (0..n)
-        .map(|i| (HashValue::from_u64(i as u64), &values[i]))
+        .map(|i| (HashValue::from_u64(i as u64), Some(&values[i])))
         .collect();
 
     let (_root_hash, batch) = tree
@@ -91,7 +91,7 @@ fn test_n_consecutive_addresses(n: usize) {
     let btree: BTreeMap<_, _> = btree
         .clone()
         .into_iter()
-        .map(|(x, y)| (x, y.clone()))
+        .filter_map(|(x, y)| y.map(|y| (x, y.clone())))
         .collect();
 
     run_tests(db, &btree, 0 /* version */);

--- a/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
+++ b/storage/jellyfish-merkle/src/jellyfish_merkle_test.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::test_helper::{
-    arb_existent_kvs_and_nonexistent_keys, arb_kv_pair_with_distinct_last_nibble,
-    arb_tree_with_index, gen_value, test_get_leaf_count, test_get_range_proof, test_get_with_proof,
-    test_get_with_proof_with_distinct_last_nibble, ValueBlob,
+use crate::{
+    node_type::NodeType,
+    test_helper::{
+        arb_existent_kvs_and_nonexistent_keys, arb_kv_pair_with_distinct_last_nibble,
+        arb_tree_with_index, gen_value, test_get_leaf_count, test_get_range_proof,
+        test_get_with_proof, test_get_with_proof_with_distinct_last_nibble, ValueBlob,
+    },
 };
 use aptos_crypto::HashValue;
 use aptos_types::nibble::Nibble;
@@ -42,7 +45,10 @@ fn test_insert_to_empty_tree() {
 
     // batch version
     let (_new_root_hash, batch) = tree
-        .put_value_set_test(vec![(key, &(value_hash, state_key))], 0 /* version */)
+        .put_value_set_test(
+            vec![(key, Some(&(value_hash, state_key)))],
+            0, /* version */
+        )
         .unwrap();
     assert!(batch
         .stale_node_index_batch
@@ -54,6 +60,11 @@ fn test_insert_to_empty_tree() {
     db.write_tree_update_batch(batch).unwrap();
 
     assert_eq!(tree.get(key, 0).unwrap().unwrap(), value_hash);
+
+    // We don't support empty tree.
+    assert!(tree
+        .put_value_set_test(vec![(key, None)], 1 /* version */)
+        .is_err());
 }
 
 #[test]
@@ -64,8 +75,8 @@ fn test_insert_at_leaf_with_internal_created() {
     let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
     let value1 = gen_value();
 
-    let (_root0_hash, batch) = tree
-        .put_value_set_test(vec![(key1, &value1)], 0 /* version */)
+    let (root0_hash, batch) = tree
+        .put_value_set_test(vec![(key1, Some(&value1))], 0 /* version */)
         .unwrap();
 
     assert!(batch
@@ -83,9 +94,9 @@ fn test_insert_at_leaf_with_internal_created() {
     let value2 = gen_value();
 
     let (_root1_hash, batch) = tree
-        .put_value_set_test(vec![(key2, &value2)], 1 /* version */)
+        .put_value_set_test(vec![(key2, Some(&value2))], 1 /* version */)
         .unwrap();
-    assert_eq!(batch.stale_node_index_batch.len(), 1);
+    assert_eq!(batch.num_stale_node(), 1);
     db.write_tree_update_batch(batch).unwrap();
 
     assert_eq!(tree.get(key1, 0).unwrap().unwrap(), value1.0);
@@ -121,6 +132,21 @@ fn test_insert_at_leaf_with_internal_created() {
         leaf2
     );
     assert_eq!(db.get_node(&internal_node_key).unwrap(), internal);
+
+    // Deletion
+    let (root2_hash, batch) = tree
+        .put_value_set_test(vec![(key2, None)], 2 /* version */)
+        .unwrap();
+    assert_eq!(batch.num_stale_node(), 3);
+    db.write_tree_update_batch(batch).unwrap();
+
+    assert_eq!(tree.get(key1, 0).unwrap().unwrap(), value1.0);
+    assert!(tree.get(key2, 0).unwrap().is_none());
+    assert_eq!(tree.get(key2, 1).unwrap().unwrap(), value2.0);
+    assert!(tree.get(key2, 2).unwrap().is_none());
+    assert_eq!(root0_hash, root2_hash);
+    // get # of nodes
+    assert_eq!(db.num_nodes(), 5 /* 1 + 3 + 1 */);
 }
 
 #[test]
@@ -133,7 +159,7 @@ fn test_insert_at_leaf_with_multiple_internals_created() {
     let value1 = gen_value();
 
     let (_root0_hash, batch) = tree
-        .put_value_set_test(vec![(key1, &value1)], 0 /* version */)
+        .put_value_set_test(vec![(key1, Some(&value1))], 0 /* version */)
         .unwrap();
     db.write_tree_update_batch(batch).unwrap();
     assert_eq!(tree.get(key1, 0).unwrap().unwrap(), value1.0);
@@ -144,7 +170,7 @@ fn test_insert_at_leaf_with_multiple_internals_created() {
     let value2 = gen_value();
 
     let (_root1_hash, batch) = tree
-        .put_value_set_test(vec![(key2, &value2)], 1 /* version */)
+        .put_value_set_test(vec![(key2, Some(&value2))], 1 /* version */)
         .unwrap();
     db.write_tree_update_batch(batch).unwrap();
     assert_eq!(tree.get(key1, 0).unwrap().unwrap(), value1.0);
@@ -203,7 +229,7 @@ fn test_insert_at_leaf_with_multiple_internals_created() {
     // 3. Update leaf2 with new value
     let value2_update = gen_value();
     let (_root2_hash, batch) = tree
-        .put_value_set_test(vec![(key2, &value2_update)], 2 /* version */)
+        .put_value_set_test(vec![(key2, Some(&value2_update))], 2 /* version */)
         .unwrap();
     db.write_tree_update_batch(batch).unwrap();
     assert!(tree.get(key2, 0).unwrap().is_none());
@@ -220,6 +246,17 @@ fn test_insert_at_leaf_with_multiple_internals_created() {
     assert_eq!(db.num_nodes(), 4);
     assert_eq!(tree.get(key1, 2).unwrap().unwrap(), value1.0);
     assert_eq!(tree.get(key2, 2).unwrap().unwrap(), value2_update.0);
+
+    // 4. Delete leaf2
+    let (_root2_hash, batch) = tree
+        .put_value_set_test(vec![(key2, None)], 3 /* version */)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    // Get # of nodes.
+    assert_eq!(db.num_nodes(), 5);
+    db.purge_stale_nodes(3).unwrap();
+    assert_eq!(db.num_nodes(), 1);
+    assert_eq!(tree.get(key1, 3).unwrap().unwrap(), value1.0);
 }
 
 #[test]
@@ -261,13 +298,13 @@ fn test_batch_insertion() {
     let value6 = gen_value();
 
     let batches = vec![
-        vec![(key1, &value1)],
-        vec![(key2, &value2)],
-        vec![(key3, &value3)],
-        vec![(key4, &value4)],
-        vec![(key5, &value5)],
-        vec![(key6, &value6)],
-        vec![(key2, &value2_update)],
+        vec![(key1, Some(&value1))],
+        vec![(key2, Some(&value2))],
+        vec![(key3, Some(&value3))],
+        vec![(key4, Some(&value4))],
+        vec![(key5, Some(&value5))],
+        vec![(key6, Some(&value6))],
+        vec![(key2, Some(&value2_update))],
     ];
     let one_batch = batches.iter().flatten().cloned().collect::<Vec<_>>();
 
@@ -278,7 +315,7 @@ fn test_batch_insertion() {
                      version: Version| {
         to_verify
             .iter()
-            .for_each(|(k, v)| assert_eq!(tree.get(*k, version).unwrap().unwrap(), v.0))
+            .for_each(|(k, v)| assert_eq!(tree.get(*k, version).unwrap().unwrap(), v.unwrap().0))
     };
 
     // Insert as one batch and update one by one.
@@ -400,6 +437,95 @@ fn test_batch_insertion() {
 }
 
 #[test]
+fn test_deletion() {
+    // ```text
+    //                             internal(root)
+    //                            /        \
+    //                       internal       2        <- nibble 0
+    //                      /   |   \
+    //              internal    3    4               <- nibble 1
+    //                 |
+    //              internal                         <- nibble 2
+    //              /      \
+    //        internal      6                        <- nibble 3
+    //           |
+    //        internal                               <- nibble 4
+    //        /      \
+    //       1        5                              <- nibble 5
+    //
+    // Total: 12 nodes
+    // ```
+    let key1 = HashValue::new([0x00u8; HashValue::LENGTH]);
+    let value1 = gen_value();
+
+    let key2 = update_nibble(&key1, 0, 2);
+    let value2 = gen_value();
+
+    let key3 = update_nibble(&key1, 1, 3);
+    let value3 = gen_value();
+
+    let key4 = update_nibble(&key1, 1, 4);
+    let value4 = gen_value();
+
+    let key5 = update_nibble(&key1, 5, 5);
+    let value5 = gen_value();
+
+    let key6 = update_nibble(&key1, 3, 6);
+    let value6 = gen_value();
+
+    let batches = vec![
+        vec![(key1, Some(&value1))],
+        vec![(key2, Some(&value2))],
+        vec![(key3, Some(&value3))],
+        vec![(key4, Some(&value4))],
+        vec![(key5, Some(&value5))],
+        vec![(key6, Some(&value6))],
+    ];
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+    let mut idx = batches.len() as u64;
+
+    for (idx, kvs) in batches.into_iter().enumerate() {
+        let (_roots, batch) = tree.put_value_set_test(kvs, idx as Version).unwrap();
+        db.write_tree_update_batch(batch).unwrap();
+    }
+    db.purge_stale_nodes(6).unwrap();
+    assert_eq!(db.num_nodes(), 12);
+
+    // Delete key3
+    let (_roots, batch) = tree
+        .put_value_set_test(vec![(key3, None)], idx as Version)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(db.num_nodes(), 14 /* 12 + 2 */);
+    db.purge_stale_nodes(idx).unwrap();
+    assert_eq!(db.num_nodes(), 11);
+
+    idx += 1;
+    // Delete key1
+    let (_roots, batch) = tree
+        .put_value_set_test(vec![(key1, None)], idx as Version)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(db.num_nodes(), 16 /* 11 + 5 */);
+    db.purge_stale_nodes(idx).unwrap();
+    assert_eq!(db.num_nodes(), 8);
+
+    idx += 1;
+    // Delete key5, key6 and key4
+    let (_roots, batch) = tree
+        .put_value_set_test(
+            vec![(key4, None), (key5, None), (key6, None)],
+            idx as Version,
+        )
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    assert_eq!(db.num_nodes(), 9 /* 8 + 1 */);
+    db.purge_stale_nodes(idx).unwrap();
+    assert_eq!(db.num_nodes(), 1);
+}
+
+#[test]
 fn test_non_existence() {
     let db = MockTreeStore::default();
     let tree = JellyfishMerkleTree::new(&db);
@@ -424,7 +550,11 @@ fn test_non_existence() {
 
     let (root, batch) = tree
         .put_value_set_test(
-            vec![(key1, &value1), (key2, &value2), (key3, &value3)],
+            vec![
+                (key1, Some(&value1)),
+                (key2, Some(&value2)),
+                (key3, Some(&value3)),
+            ],
             0, /* version */
         )
         .unwrap();
@@ -487,7 +617,7 @@ fn many_keys_get_proof_and_verify_tree_root(seed: &[u8], num_keys: usize) {
 
     for (index, _) in values.iter().enumerate() {
         let key = HashValue::random_with_rng(&mut rng);
-        kvs.push((key, &values[index]));
+        kvs.push((key, Some(&values[index])));
     }
 
     let (root, batch) = tree
@@ -497,9 +627,64 @@ fn many_keys_get_proof_and_verify_tree_root(seed: &[u8], num_keys: usize) {
 
     for (k, v) in &kvs {
         let (value, proof) = tree.get_with_proof(*k, 0).unwrap();
-        assert_eq!(value.as_ref().unwrap().0, v.0);
-        assert_eq!(value.as_ref().unwrap().1 .0, v.1);
-        assert!(proof.verify_by_hash(root, *k, Some(v.0)).is_ok());
+        assert_eq!(value.as_ref().unwrap().0, v.unwrap().0);
+        assert_eq!(value.as_ref().unwrap().1 .0, v.unwrap().1);
+        assert!(proof.verify_by_hash(root, *k, v.map(|x| x.0)).is_ok());
+    }
+}
+
+fn many_keys_deletion(seed: &[u8], num_keys: usize) {
+    assert!(seed.len() < 32);
+    let mut actual_seed = [0u8; 32];
+    actual_seed[..seed.len()].copy_from_slice(seed);
+    let mut rng: StdRng = StdRng::from_seed(actual_seed);
+
+    let db = MockTreeStore::default();
+    let tree = JellyfishMerkleTree::new(&db);
+
+    let mut first_batch = vec![];
+
+    let values: Vec<_> = (0..2 * num_keys).map(|_i| gen_value()).collect();
+
+    for (index, _) in values.iter().enumerate() {
+        let key = HashValue::random_with_rng(&mut rng);
+        first_batch.push((key, Some(&values[index])));
+    }
+
+    let mut second_batch = first_batch[..num_keys]
+        .iter()
+        .map(|(k, _)| (*k, None))
+        .collect::<Vec<_>>();
+
+    let values: Vec<_> = (0..num_keys).map(|_i| gen_value()).collect();
+    for (index, _) in values.iter().enumerate() {
+        let key = HashValue::random_with_rng(&mut rng);
+        second_batch.push((key, Some(&values[index])));
+    }
+
+    let (_root, batch) = tree
+        .put_value_set_test(first_batch.clone(), 0 /* version */)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+    let (root, batch) = tree
+        .put_value_set_test(second_batch.clone(), 1 /* version */)
+        .unwrap();
+    db.write_tree_update_batch(batch).unwrap();
+
+    for (k, v) in first_batch[num_keys..]
+        .iter()
+        .chain(second_batch[num_keys..].iter())
+    {
+        let (value, proof) = tree.get_with_proof(*k, 1).unwrap();
+        assert_eq!(value.as_ref().unwrap().0, v.unwrap().0);
+        assert_eq!(value.as_ref().unwrap().1 .0, v.unwrap().1);
+        assert!(proof.verify_by_hash(root, *k, v.map(|x| x.0)).is_ok());
+    }
+
+    for (k, _v) in first_batch[0..num_keys].iter() {
+        let (value, proof) = tree.get_with_proof(*k, 1).unwrap();
+        assert!(value.is_none());
+        assert!(proof.verify_by_hash(root, *k, None).is_ok());
     }
 }
 
@@ -507,6 +692,12 @@ fn many_keys_get_proof_and_verify_tree_root(seed: &[u8], num_keys: usize) {
 fn test_1000_keys() {
     let seed: &[_] = &[1, 2, 3, 4];
     many_keys_get_proof_and_verify_tree_root(seed, 1000);
+}
+
+#[test]
+fn test_2000_keys_deletion() {
+    let seed: &[_] = &[1, 2, 3, 4];
+    many_keys_deletion(seed, 2000);
 }
 
 fn many_versions_get_proof_and_verify_tree_root(seed: &[u8], num_versions: usize) {
@@ -527,7 +718,7 @@ fn many_versions_get_proof_and_verify_tree_root(seed: &[u8], num_versions: usize
 
     for i in 0..num_versions {
         let key = HashValue::random_with_rng(&mut rng);
-        kvs.push((key, &values[i], &new_values[i]));
+        kvs.push((key, Some(&values[i]), Some(&new_values[i])));
     }
 
     for (idx, kvs) in kvs.iter().enumerate() {
@@ -551,20 +742,20 @@ fn many_versions_get_proof_and_verify_tree_root(seed: &[u8], num_versions: usize
     for (i, (k, v, _)) in kvs.iter().enumerate() {
         let random_version = rng.gen_range(i, i + num_versions);
         let (value, proof) = tree.get_with_proof(*k, random_version as Version).unwrap();
-        assert_eq!(value.as_ref().unwrap().0, v.0);
-        assert_eq!(value.as_ref().unwrap().1 .0, v.1);
+        assert_eq!(value.as_ref().unwrap().0, v.unwrap().0);
+        assert_eq!(value.as_ref().unwrap().1 .0, v.unwrap().1);
         assert!(proof
-            .verify_by_hash(roots[random_version], *k, Some(v.0))
+            .verify_by_hash(roots[random_version], *k, v.map(|x| x.0))
             .is_ok());
     }
 
     for (i, (k, _, v)) in kvs.iter().enumerate() {
         let random_version = rng.gen_range(i + num_versions, 2 * num_versions);
         let (value, proof) = tree.get_with_proof(*k, random_version as Version).unwrap();
-        assert_eq!(value.as_ref().unwrap().0, v.0);
-        assert_eq!(value.as_ref().unwrap().1 .0, v.1);
+        assert_eq!(value.as_ref().unwrap().0, v.unwrap().0);
+        assert_eq!(value.as_ref().unwrap().1 .0, v.unwrap().1);
         assert!(proof
-            .verify_by_hash(roots[random_version], *k, Some(v.0))
+            .verify_by_hash(roots[random_version], *k, v.map(|x| x.0))
             .is_ok());
     }
 }
@@ -594,7 +785,7 @@ proptest! {
     }
 
     #[test]
-    fn proptest_get_leaf_count(keys in hash_set(any::<HashValue>(), 1..1000)) {
+    fn proptest_get_leaf_count(keys in hash_set(any::<HashValue>(), 3..2000)) {
         test_get_leaf_count(keys)
     }
 }

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -82,6 +82,7 @@ pub mod test_helper;
 use crate::metrics::APTOS_JELLYFISH_LEAF_COUNT;
 use anyhow::{bail, ensure, format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_types::proof::SparseMerkleProofExt;
 use aptos_types::{
     nibble::{nibble_path::NibblePath, Nibble, ROOT_NIBBLE_HEIGHT},
     proof::{SparseMerkleProof, SparseMerkleRangeProof},
@@ -681,6 +682,15 @@ where
         key: HashValue,
         version: Version,
     ) -> Result<(Option<(HashValue, (K, Version))>, SparseMerkleProof)> {
+        self.get_with_proof_ext(key, version)
+            .map(|_value, proof_ext| proof_ext.into())
+    }
+
+    pub fn get_with_proof_ext(
+        &self,
+        key: HashValue,
+        version: Version,
+    ) -> Result<(Option<(HashValue, (K, Version))>, SparseMerkleProofExt)> {
         // Empty tree just returns proof with no sibling hash.
         let mut next_node_key = NodeKey::new_empty_path(version);
         let mut siblings = vec![];
@@ -702,15 +712,15 @@ where
                     let queried_child_index = nibble_iter
                         .next()
                         .ok_or_else(|| format_err!("ran out of nibbles"))?;
-                    let (child_node_key, mut siblings_in_internal) =
-                        internal_node.get_child_with_siblings(&next_node_key, queried_child_index);
+                    let (child_node_key, mut siblings_in_internal) = internal_node
+                        .get_child_with_siblings(&next_node_key, queried_child_index, &self.reader);
                     siblings.append(&mut siblings_in_internal);
                     next_node_key = match child_node_key {
                         Some(node_key) => node_key,
                         None => {
                             return Ok((
                                 None,
-                                SparseMerkleProof::new(None, {
+                                SparseMerkleProofExt::new(None, {
                                     siblings.reverse();
                                     siblings
                                 }),
@@ -725,7 +735,7 @@ where
                         } else {
                             None
                         },
-                        SparseMerkleProof::new(Some(leaf_node.into()), {
+                        SparseMerkleProofExt::new(Some(leaf_node.into()), {
                             siblings.reverse();
                             siblings
                         }),

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -89,7 +89,7 @@ use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
-use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey, NodeType};
+use node_type::{Child, Children, InternalNode, LeafNode, Node, NodeKey};
 use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::arbitrary::Arbitrary;
@@ -145,7 +145,7 @@ pub trait TreeWriter<K>: Send + Sync {
 
 pub trait StateValueWriter<K, V>: Send + Sync {
     /// Writes a kv batch into storage.
-    fn write_kv_batch(&self, kv_batch: &StateValueBatch<K, V>) -> Result<()>;
+    fn write_kv_batch(&self, kv_batch: &StateValueBatch<K, Option<V>>) -> Result<()>;
 }
 
 /// `Key` defines the types of data key that can be stored in a Jellyfish Merkle tree.
@@ -210,7 +210,10 @@ pub struct TreeUpdateBatch<K> {
     pub num_stale_leaves: usize,
 }
 
-impl<K> TreeUpdateBatch<K> {
+impl<K> TreeUpdateBatch<K>
+where
+    K: Key,
+{
     pub fn new() -> Self {
         Self {
             node_batch: vec![vec![]],
@@ -234,19 +237,35 @@ impl<K> TreeUpdateBatch<K> {
         self.num_stale_leaves += num_stale_leaves;
     }
 
-    pub fn inc_num_new_leaves(&mut self) {
+    #[cfg(test)]
+    pub fn num_stale_node(&self) -> usize {
+        self.stale_node_index_batch.iter().map(Vec::len).sum()
+    }
+
+    fn inc_num_new_leaves(&mut self) {
         self.num_new_leaves += 1;
     }
 
-    pub fn inc_num_stale_leaves(&mut self) {
+    fn inc_num_stale_leaves(&mut self) {
         self.num_stale_leaves += 1;
     }
 
     pub fn put_node(&mut self, node_key: NodeKey, node: Node<K>) {
+        if node.is_leaf() {
+            self.inc_num_new_leaves();
+        }
         self.node_batch[0].push((node_key, node))
     }
 
-    pub fn put_stale_node(&mut self, node_key: NodeKey, stale_since_version: Version) {
+    pub fn put_stale_node(
+        &mut self,
+        node_key: NodeKey,
+        stale_since_version: Version,
+        node: &Node<K>,
+    ) {
+        if node.is_leaf() {
+            self.inc_num_stale_leaves();
+        }
         self.stale_node_index_batch[0].push(StaleNodeIndex {
             node_key,
             stale_since_version,
@@ -377,7 +396,7 @@ where
     /// the batch is not reachable from public interfaces before being committed.
     pub fn batch_put_value_set(
         &self,
-        value_set: Vec<(HashValue, &(HashValue, K))>,
+        value_set: Vec<(HashValue, Option<&(HashValue, K)>)>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         persisted_version: Option<Version>,
         version: Version,
@@ -389,50 +408,53 @@ where
             .collect::<Vec<_>>();
 
         let mut batch = TreeUpdateBatch::new();
-        let (_root_node_key, root_node) = if let Some(persisted_version) = persisted_version {
+        let root_node = if let Some(persisted_version) = persisted_version {
             IO_POOL.install(|| {
                 self.batch_insert_at(
-                    NodeKey::new_empty_path(persisted_version),
+                    &NodeKey::new_empty_path(persisted_version),
                     version,
-                    &deduped_and_sorted_kvs,
+                    deduped_and_sorted_kvs.as_slice(),
                     0,
                     &node_hashes,
                     &mut batch,
                 )
             })?
         } else {
-            self.batch_create_subtree(
-                NodeKey::new_empty_path(version),
+            self.batch_update_subtree(
+                &NodeKey::new_empty_path(version),
                 version,
-                &deduped_and_sorted_kvs,
+                deduped_and_sorted_kvs.as_slice(),
                 0,
                 &node_hashes,
                 &mut batch,
             )?
-        };
+        }
+        .ok_or_else(|| format_err!("Empty tree is impossible."))?;
+
+        let node_key = NodeKey::new_empty_path(version);
+        let root_hash = root_node.hash();
 
         APTOS_JELLYFISH_LEAF_COUNT.set(root_node.leaf_count() as i64);
+        batch.put_node(node_key, root_node);
 
-        Ok((root_node.hash(), batch))
+        Ok((root_hash, batch))
     }
 
     fn batch_insert_at(
         &self,
-        mut node_key: NodeKey,
+        node_key: &NodeKey,
         version: Version,
-        kvs: &[(HashValue, &(HashValue, K))],
+        kvs: &[(HashValue, Option<&(HashValue, K)>)],
         depth: usize,
         hash_cache: &Option<&HashMap<NibblePath, HashValue>>,
         batch: &mut TreeUpdateBatch<K>,
-    ) -> Result<(NodeKey, Node<K>)> {
-        let node = self.reader.get_node(&node_key)?;
-        batch.put_stale_node(node_key.clone(), version);
+    ) -> Result<Option<Node<K>>> {
+        let node = self.reader.get_node(node_key)?;
+        batch.put_stale_node(node_key.clone(), version, &node);
 
-        Ok(match node {
+        match node {
             Node::Internal(internal_node) => {
-                // Reuse the current `InternalNode` in memory to create a new internal node.
-                let mut children: Children = internal_node.clone().into();
-
+                // There is a small possibility that the old internal node is intact.
                 // Traverse all the path touched by `kvs` from this internal node.
                 let range_iter = NibbleRangeIterator::new(kvs, depth);
                 let new_children: Vec<_> = if depth <= MAX_PARALLELIZABLE_DEPTH {
@@ -443,7 +465,7 @@ where
                             let mut sub_batch = TreeUpdateBatch::new();
                             Ok((
                                 self.insert_at_child(
-                                    &node_key,
+                                    node_key,
                                     &internal_node,
                                     version,
                                     kvs,
@@ -467,7 +489,7 @@ where
                     range_iter
                         .map(|(left, right)| {
                             self.insert_at_child(
-                                &node_key,
+                                node_key,
                                 &internal_node,
                                 version,
                                 kvs,
@@ -480,22 +502,62 @@ where
                         })
                         .collect::<Result<_>>()?
                 };
-                children.extend(new_children.into_iter());
 
-                let new_internal_node = InternalNode::new(children);
-                node_key.set_version(version);
-                batch.put_node(node_key.clone(), new_internal_node.clone().into());
+                // Reuse the current `InternalNode` in memory to create a new internal node.
+                let mut old_children: Children = internal_node.into();
+                let mut new_created_children = HashMap::new();
+                for (child_nibble, child_option) in new_children {
+                    if let Some(child) = child_option {
+                        new_created_children.insert(child_nibble, child);
+                    } else {
+                        old_children.remove(&child_nibble);
+                    }
+                }
 
-                (node_key, new_internal_node.into())
+                if old_children.is_empty() && new_created_children.is_empty() {
+                    return Ok(None);
+                } else if old_children.len() <= 1 && new_created_children.len() <= 1 {
+                    if let Some((new_nibble, new_child)) = new_created_children.iter().next() {
+                        if let Some((old_nibble, _old_child)) = old_children.iter().next() {
+                            if old_nibble == new_nibble && new_child.is_leaf() {
+                                return Ok(Some(new_child.clone()));
+                            }
+                        } else if new_child.is_leaf() {
+                            return Ok(Some(new_child.clone()));
+                        }
+                    } else {
+                        let (old_child_nibble, old_child) =
+                            old_children.iter().next().expect("must exist");
+                        if old_child.is_leaf() {
+                            let old_child_node_key =
+                                node_key.gen_child_node_key(old_child.version, *old_child_nibble);
+                            let old_child_node = self.reader.get_node(&old_child_node_key)?;
+                            batch.put_stale_node(old_child_node_key, version, &old_child_node);
+                            return Ok(Some(old_child_node));
+                        }
+                    }
+                }
+
+                let mut new_children = old_children;
+                for (child_index, new_child_node) in new_created_children {
+                    let new_child_node_key = node_key.gen_child_node_key(version, child_index);
+                    new_children.insert(
+                        child_index,
+                        Child::new(
+                            Self::get_hash(&new_child_node_key, &new_child_node, hash_cache),
+                            version,
+                            new_child_node.node_type(),
+                        ),
+                    );
+                    batch.put_node(new_child_node_key, new_child_node);
+                }
+                let new_internal_node = InternalNode::new(new_children);
+                Ok(Some(new_internal_node.into()))
             }
-            Node::Leaf(leaf_node) => {
-                batch.inc_num_stale_leaves();
-                node_key.set_version(version);
-                self.batch_create_subtree_with_existing_leaf(
-                    node_key, version, leaf_node, kvs, depth, hash_cache, batch,
-                )?
-            }
-        })
+            Node::Leaf(leaf_node) => self.batch_update_subtree_with_existing_leaf(
+                node_key, version, leaf_node, kvs, depth, hash_cache, batch,
+            ),
+        }
     }
 
     fn insert_at_child(
@@ -503,27 +565,27 @@ where
         node_key: &NodeKey,
         internal_node: &InternalNode,
         version: Version,
-        kvs: &[(HashValue, &(HashValue, K))],
+        kvs: &[(HashValue, Option<&(HashValue, K)>)],
         left: usize,
         right: usize,
         depth: usize,
         hash_cache: &Option<&HashMap<NibblePath, HashValue>>,
         batch: &mut TreeUpdateBatch<K>,
-    ) -> Result<(Nibble, Child)> {
+    ) -> Result<(Nibble, Option<Node<K>>)> {
         let child_index = kvs[left].0.get_nibble(depth);
         let child = internal_node.child(child_index);
 
-        let (node_key, node) = match child {
+        let new_child_node_option = match child {
             Some(child) => self.batch_insert_at(
-                node_key.gen_child_node_key(child.version, child_index),
+                &node_key.gen_child_node_key(child.version, child_index),
                 version,
                 &kvs[left..=right],
                 depth + 1,
                 hash_cache,
                 batch,
             )?,
-            None => self.batch_create_subtree(
-                node_key.gen_child_node_key(version, child_index),
+            None => self.batch_update_subtree(
+                &node_key.gen_child_node_key(version, child_index),
                 version,
                 &kvs[left..=right],
                 depth + 1,
@@ -532,49 +594,40 @@ where
             )?,
         };
 
-        Ok((
-            child_index,
-            Child::new(
-                Self::get_hash(&node_key, &node, hash_cache),
-                version,
-                node.node_type(),
-            ),
-        ))
+        Ok((child_index, new_child_node_option))
     }
 
-    fn batch_create_subtree_with_existing_leaf(
+    fn batch_update_subtree_with_existing_leaf(
         &self,
-        node_key: NodeKey,
+        node_key: &NodeKey,
         version: Version,
         existing_leaf_node: LeafNode<K>,
-        kvs: &[(HashValue, &(HashValue, K))],
+        kvs: &[(HashValue, Option<&(HashValue, K)>)],
         depth: usize,
         hash_cache: &Option<&HashMap<NibblePath, HashValue>>,
         batch: &mut TreeUpdateBatch<K>,
-    ) -> Result<(NodeKey, Node<K>)> {
+    ) -> Result<Option<Node<K>>> {
         let existing_leaf_key = existing_leaf_node.account_key();
 
         if kvs.len() == 1 && kvs[0].0 == existing_leaf_key {
-            let new_leaf_node = Node::new_leaf(
-                existing_leaf_key,
-                kvs[0].1 .0,
-                (kvs[0].1 .1.clone(), version),
-            );
-            batch.put_node(node_key.clone(), new_leaf_node.clone());
-            batch.inc_num_new_leaves();
             // TODO(lightmark): Add the purge logic the value here.
-            Ok((node_key, new_leaf_node))
+            if let (key, Some((value_hash, state_key))) = kvs[0] {
+                let new_leaf_node = Node::new_leaf(key, *value_hash, (state_key.clone(), version));
+                Ok(Some(new_leaf_node))
+            } else {
+                Ok(None)
+            }
         } else {
             let existing_leaf_bucket = existing_leaf_key.get_nibble(depth);
             let mut isolated_existing_leaf = true;
-            let mut children = Children::new();
+            let mut children = vec![];
             for (left, right) in NibbleRangeIterator::new(kvs, depth) {
                 let child_index = kvs[left].0.get_nibble(depth);
                 let child_node_key = node_key.gen_child_node_key(version, child_index);
-                let (new_child_node_key, new_child_node) = if existing_leaf_bucket == child_index {
+                if let Some(new_child_node) = if existing_leaf_bucket == child_index {
                     isolated_existing_leaf = false;
-                    self.batch_create_subtree_with_existing_leaf(
-                        child_node_key,
+                    self.batch_update_subtree_with_existing_leaf(
+                        &child_node_key,
                         version,
                         existing_leaf_node.clone(),
                         &kvs[left..=right],
@@ -583,83 +636,119 @@ where
                         batch,
                     )?
                 } else {
-                    self.batch_create_subtree(
-                        child_node_key,
+                    self.batch_update_subtree(
+                        &child_node_key,
                         version,
                         &kvs[left..=right],
                         depth + 1,
                         hash_cache,
                         batch,
                     )?
-                };
-                children.insert(
-                    child_index,
-                    Child::new(
-                        Self::get_hash(&new_child_node_key, &new_child_node, hash_cache),
-                        version,
-                        new_child_node.node_type(),
-                    ),
-                );
+                } {
+                    children.push((child_index, new_child_node));
+                }
             }
             if isolated_existing_leaf {
-                let existing_leaf_node_key =
-                    node_key.gen_child_node_key(version, existing_leaf_bucket);
-                children.insert(
-                    existing_leaf_bucket,
-                    Child::new(existing_leaf_node.hash(), version, NodeType::Leaf),
-                );
-                batch.inc_num_new_leaves();
-                batch.put_node(existing_leaf_node_key, existing_leaf_node.into());
+                children.push((existing_leaf_bucket, existing_leaf_node.into()));
             }
 
-            let new_internal_node = InternalNode::new(children);
-            batch.put_node(node_key.clone(), new_internal_node.clone().into());
-
-            Ok((node_key, new_internal_node.into()))
+            if children.is_empty() {
+                Ok(None)
+            } else if children.len() == 1 && children[0].1.is_leaf() {
+                let (_, child) = children.pop().expect("Must exist");
+                Ok(Some(child))
+            } else {
+                let new_internal_node = InternalNode::new(
+                    children
+                        .into_iter()
+                        .map(|(child_index, new_child_node)| {
+                            let new_child_node_key =
+                                node_key.gen_child_node_key(version, child_index);
+                            let result = (
+                                child_index,
+                                Child::new(
+                                    Self::get_hash(
+                                        &new_child_node_key,
+                                        &new_child_node,
+                                        hash_cache,
+                                    ),
+                                    version,
+                                    new_child_node.node_type(),
+                                ),
+                            );
+                            batch.put_node(new_child_node_key, new_child_node);
+                            result
+                        })
+                        .collect(),
+                );
+                Ok(Some(new_internal_node.into()))
+            }
         }
     }
 
-    fn batch_create_subtree(
+    fn batch_update_subtree(
         &self,
-        node_key: NodeKey,
+        node_key: &NodeKey,
         version: Version,
-        kvs: &[(HashValue, &(HashValue, K))],
+        kvs: &[(HashValue, Option<&(HashValue, K)>)],
         depth: usize,
         hash_cache: &Option<&HashMap<NibblePath, HashValue>>,
         batch: &mut TreeUpdateBatch<K>,
-    ) -> Result<(NodeKey, Node<K>)> {
+    ) -> Result<Option<Node<K>>> {
         if kvs.len() == 1 {
-            let new_leaf_node =
-                Node::new_leaf(kvs[0].0, kvs[0].1 .0, (kvs[0].1 .1.clone(), version));
-            batch.put_node(node_key.clone(), new_leaf_node.clone());
-            batch.inc_num_new_leaves();
-            Ok((node_key, new_leaf_node))
+            if let (key, Some((value_hash, state_key))) = kvs[0] {
+                let new_leaf_node = Node::new_leaf(key, *value_hash, (state_key.clone(), version));
+                Ok(Some(new_leaf_node))
+            } else {
+                Ok(None)
+            }
         } else {
-            let mut children = Children::new();
+            let mut children = vec![];
             for (left, right) in NibbleRangeIterator::new(kvs, depth) {
                 let child_index = kvs[left].0.get_nibble(depth);
                 let child_node_key = node_key.gen_child_node_key(version, child_index);
-                let (new_child_node_key, new_child_node) = self.batch_create_subtree(
-                    child_node_key,
+                if let Some(new_child_node) = self.batch_update_subtree(
+                    &child_node_key,
                     version,
                     &kvs[left..=right],
                     depth + 1,
                     hash_cache,
                     batch,
-                )?;
-                children.insert(
-                    child_index,
-                    Child::new(
-                        Self::get_hash(&new_child_node_key, &new_child_node, hash_cache),
-                        version,
-                        new_child_node.node_type(),
-                    ),
-                );
+                )? {
+                    children.push((child_index, new_child_node))
+                }
             }
-            let new_internal_node = InternalNode::new(children);
-
-            batch.put_node(node_key.clone(), new_internal_node.clone().into());
-            Ok((node_key, new_internal_node.into()))
+            if children.is_empty() {
+                Ok(None)
+            } else if children.len() == 1 && children[0].1.is_leaf() {
+                let (_, child) = children.pop().expect("Must exist");
+                Ok(Some(child))
+            } else {
+                let new_internal_node = InternalNode::new(
+                    children
+                        .into_iter()
+                        .map(|(child_index, new_child_node)| {
+                            let new_child_node_key =
+                                node_key.gen_child_node_key(version, child_index);
+                            let result = (
+                                child_index,
+                                Child::new(
+                                    Self::get_hash(
+                                        &new_child_node_key,
+                                        &new_child_node,
+                                        hash_cache,
+                                    ),
+                                    version,
+                                    new_child_node.node_type(),
+                                ),
+                            );
+                            batch.put_node(new_child_node_key, new_child_node);
+                            result
+                        })
+                        .collect(),
+                );
+                Ok(Some(new_internal_node.into()))
+            }
         }
     }
 
@@ -670,10 +759,15 @@ where
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn put_value_set_test(
         &self,
-        value_set: Vec<(HashValue, &(HashValue, K))>,
+        value_set: Vec<(HashValue, Option<&(HashValue, K)>)>,
         version: Version,
     ) -> Result<(HashValue, TreeUpdateBatch<K>)> {
-        self.batch_put_value_set(value_set, None, version.checked_sub(1), version)
+        self.batch_put_value_set(
+            value_set.into_iter().map(|(k, v)| (k, v)).collect(),
+            None,
+            version.checked_sub(1),
+            version,
+        )
     }
 
     /// Returns the value (if applicable) and the corresponding merkle proof.
@@ -683,7 +777,7 @@ where
         version: Version,
     ) -> Result<(Option<(HashValue, (K, Version))>, SparseMerkleProof)> {
         self.get_with_proof_ext(key, version)
-            .map(|_value, proof_ext| proof_ext.into())
+            .map(|(value, proof_ext)| (value, proof_ext.into()))
     }
 
     pub fn get_with_proof_ext(
@@ -713,7 +807,11 @@ where
                         .next()
                         .ok_or_else(|| format_err!("ran out of nibbles"))?;
                     let (child_node_key, mut siblings_in_internal) = internal_node
-                        .get_child_with_siblings(&next_node_key, queried_child_index, &self.reader);
+                        .get_child_with_siblings(
+                            &next_node_key,
+                            queried_child_index,
+                            Some(self.reader),
+                        )?;
                     siblings.append(&mut siblings_in_internal);
                     next_node_key = match child_node_key {
                         Some(node_key) => node_key,

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -720,7 +720,7 @@ impl<K: crate::Key + Hash + Eq, V: crate::Value> StateValueRestore<K, V> {
     pub fn add_chunk(&mut self, chunk: Vec<(K, V)>) -> Result<()> {
         let kv_batch = chunk
             .into_iter()
-            .map(|(k, v)| ((k, self.version), v))
+            .map(|(k, v)| ((k, self.version), Some(v)))
             .collect();
         self.db.write_kv_batch(&kv_batch)
     }

--- a/storage/jellyfish-merkle/src/restore/restore_test.rs
+++ b/storage/jellyfish-merkle/src/restore/restore_test.rs
@@ -45,9 +45,13 @@ where
     K: TestKey,
     V: TestValue,
 {
-    fn write_kv_batch(&self, kv_batch: &StateValueBatch<K, V>) -> Result<()> {
+    fn write_kv_batch(&self, kv_batch: &StateValueBatch<K, Option<V>>) -> Result<()> {
         for (k, v) in kv_batch {
-            self.kv_store.write().insert(k.clone(), v.clone());
+            if let Some(v) = v {
+                self.kv_store.write().insert(k.clone(), v.clone());
+            } else {
+                self.kv_store.write().remove(k);
+            }
         }
         Ok(())
     }

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -89,7 +89,7 @@ use aptos_crypto::{
     HashValue,
 };
 use aptos_infallible::Mutex;
-use aptos_types::{nibble::nibble_path::NibblePath, proof::SparseMerkleProof};
+use aptos_types::{nibble::nibble_path::NibblePath, proof::SparseMerkleProofExt};
 use std::sync::MutexGuard;
 use std::{
     borrow::Borrow,
@@ -401,7 +401,7 @@ where
 {
     pub fn batch_update(
         &self,
-        updates: Vec<(HashValue, &V)>,
+        updates: Vec<(HashValue, Option<&V>)>,
         proof_reader: &impl ProofRead,
     ) -> Result<Self, UpdateError> {
         self.clone()
@@ -567,7 +567,7 @@ where
     /// new, returned tree.
     pub fn batch_update(
         &self,
-        updates: Vec<(HashValue, &V)>,
+        updates: Vec<(HashValue, Option<&V>)>,
         proof_reader: &impl ProofRead,
     ) -> Result<Self, UpdateError> {
         // Flatten, dedup and sort the updates with a btree map since the updates between different
@@ -635,7 +635,7 @@ where
 /// A type that implements `ProofRead` can provide proof for keys in persistent storage.
 pub trait ProofRead: Sync {
     /// Gets verified proof for this key in persistent storage.
-    fn get_proof(&self, key: HashValue) -> Option<&SparseMerkleProof>;
+    fn get_proof(&self, key: HashValue) -> Option<&SparseMerkleProofExt>;
 }
 
 /// All errors `update` can possibly return.

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -10,8 +10,9 @@ use aptos_crypto::{
     hash::{CryptoHash, TestOnlyHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
+use aptos_types::proof::definition::NodeInProof;
 use aptos_types::{
-    proof::{SparseMerkleLeafNode, SparseMerkleProof},
+    proof::{SparseMerkleLeafNode, SparseMerkleProofExt},
     state_store::state_value::StateValue,
 };
 use once_cell::sync::Lazy;
@@ -45,9 +46,13 @@ fn test_replace_in_mem_leaf() {
     let new_value: StateValue = vec![1, 2, 3].into();
     let root_hash = hash_leaf(key, new_value.hash());
     let updated = smt
-        .batch_update(vec![(key, &new_value)], &ProofReader::default())
+        .batch_update(vec![(key, Some(&new_value))], &ProofReader::default())
         .unwrap();
     assert_eq!(updated.root_hash(), root_hash);
+    let updated = updated
+        .batch_update(vec![(key, None)], &ProofReader::default())
+        .unwrap();
+    assert_eq!(updated.root_hash(), *SPARSE_MERKLE_PLACEHOLDER_HASH);
 }
 
 #[test]
@@ -55,6 +60,7 @@ fn test_split_in_mem_leaf() {
     let key1 = HashValue::from_slice(&[0; 32]).unwrap();
     let value1_hash = b"hello".test_only_hash();
     let leaf1 = SubTree::new_leaf_with_value_hash(key1, value1_hash, 0 /* generation */);
+    let old_root_hash = leaf1.hash();
     let smt = SparseMerkleTree::new_with_root(leaf1);
 
     let key2 = HashValue::from_slice(&[0xff; 32]).unwrap();
@@ -62,9 +68,13 @@ fn test_split_in_mem_leaf() {
 
     let root_hash = hash_internal(hash_leaf(key1, value1_hash), hash_leaf(key2, value2.hash()));
     let updated = smt
-        .batch_update(vec![(key2, &value2)], &ProofReader::default())
+        .batch_update(vec![(key2, Some(&value2))], &ProofReader::default())
         .unwrap();
     assert_eq!(updated.root_hash(), root_hash);
+    let updated = updated
+        .batch_update(vec![(key2, None)], &ProofReader::default())
+        .unwrap();
+    assert_eq!(updated.root_hash(), old_root_hash);
 }
 
 #[test]
@@ -88,7 +98,7 @@ fn test_insert_at_in_mem_empty() {
 
     let root_hash = hash_internal(internal_hash, hash_leaf(key3, value3.hash()));
     let updated = smt
-        .batch_update(vec![(key3, &value3)], &ProofReader::default())
+        .batch_update(vec![(key3, Some(&value3))], &ProofReader::default())
         .unwrap();
     assert_eq!(updated.root_hash(), root_hash);
 }
@@ -98,20 +108,33 @@ fn test_replace_persisted_leaf() {
     let key = b"hello".test_only_hash();
     let value_hash = b"world".test_only_hash();
     let leaf = SparseMerkleLeafNode::new(key, value_hash);
-    let proof = SparseMerkleProof::new(Some(leaf), Vec::new());
+    let proof = SparseMerkleProofExt::new(Some(leaf), Vec::new());
     let proof_reader = ProofReader::new(vec![(key, proof)]);
 
     let smt = SparseMerkleTree::new(leaf.hash());
     let new_value: StateValue = vec![1, 2, 3].into();
     let root_hash = hash_leaf(key, new_value.hash());
     let updated = smt
-        .batch_update(vec![(key, &new_value)], &proof_reader)
+        .batch_update(vec![(key, Some(&new_value))], &proof_reader)
         .unwrap();
     assert_eq!(updated.root_hash(), root_hash);
 }
 
 #[test]
-fn test_split_persisted_leaf() {
+fn test_delete_persisted_leaf() {
+    let key = b"hello".test_only_hash();
+    let value_hash = b"world".test_only_hash();
+    let leaf = SparseMerkleLeafNode::new(key, value_hash);
+    let proof = SparseMerkleProofExt::new(Some(leaf), Vec::new());
+    let proof_reader = ProofReader::new(vec![(key, proof)]);
+
+    let smt = SparseMerkleTree::new(leaf.hash());
+    let updated = smt.batch_update(vec![(key, None)], &proof_reader).unwrap();
+    assert_eq!(updated.root_hash(), *SPARSE_MERKLE_PLACEHOLDER_HASH);
+}
+
+#[test]
+fn test_split_persisted_leaf_and_then_delete() {
     let key1 = HashValue::from_slice(&[0; 32]).unwrap();
     let value_hash1 = b"hello".test_only_hash();
     let leaf1 = SparseMerkleLeafNode::new(key1, value_hash1);
@@ -120,14 +143,19 @@ fn test_split_persisted_leaf() {
 
     let key2 = HashValue::from_slice(&[0xff; 32]).unwrap();
     let value2: StateValue = vec![1, 2, 3].into();
-    let proof = SparseMerkleProof::new(Some(leaf1), Vec::new());
+    let proof = SparseMerkleProofExt::new(Some(leaf1), Vec::new());
     let proof_reader = ProofReader::new(vec![(key2, proof)]);
 
-    let root_hash = hash_internal(leaf1.hash(), hash_leaf(key2, value2.hash()));
+    let leaf2_hash = hash_leaf(key2, value2.hash());
+    let root_hash = hash_internal(leaf1.hash(), leaf2_hash);
     let updated = smt
-        .batch_update(vec![(key2, &value2)], &proof_reader)
+        .batch_update(vec![(key2, Some(&value2))], &proof_reader)
         .unwrap();
     assert_eq!(updated.root_hash(), root_hash);
+    let updated = updated
+        .batch_update(vec![(key1, None)], &proof_reader)
+        .unwrap();
+    assert_eq!(updated.root_hash(), leaf2_hash);
 }
 
 #[test]
@@ -141,14 +169,14 @@ fn test_insert_at_persisted_empty() {
     let value3: StateValue = vec![1, 2, 3].into();
 
     let sibling_hash = hash_internal(hash_leaf(key1, value1_hash), hash_leaf(key2, value2_hash));
-    let proof = SparseMerkleProof::new(None, vec![sibling_hash]);
+    let proof = SparseMerkleProofExt::new(None, vec![NodeInProof::Other(sibling_hash)]);
     let proof_reader = ProofReader::new(vec![(key3, proof)]);
     let old_root_hash = hash_internal(sibling_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
     let smt = SparseMerkleTree::new(old_root_hash);
 
     let root_hash = hash_internal(sibling_hash, hash_leaf(key3, value3.hash()));
     let updated = smt
-        .batch_update(vec![(key3, &value3)], &proof_reader)
+        .batch_update(vec![(key3, Some(&value3))], &proof_reader)
         .unwrap();
     assert_eq!(updated.root_hash(), root_hash);
 }
@@ -178,22 +206,22 @@ fn test_update_256_siblings_in_proof() {
     let value2 = StateValue::from(String::from("test_val2").into_bytes());
     let value1_hash = value1.hash();
     let value2_hash = value2.hash();
-    let leaf1_hash = hash_leaf(key1, value1_hash);
-    let leaf2_hash = hash_leaf(key2, value2_hash);
+    let leaf1 = SparseMerkleLeafNode::new(key1, value1_hash);
+    let leaf2 = SparseMerkleLeafNode::new(key2, value2_hash);
 
-    let mut siblings: Vec<_> = std::iter::repeat(*SPARSE_MERKLE_PLACEHOLDER_HASH)
-        .take(255)
-        .collect();
-    siblings.push(leaf2_hash);
+    let mut siblings: Vec<_> =
+        std::iter::repeat(NodeInProof::Other(*SPARSE_MERKLE_PLACEHOLDER_HASH))
+            .take(255)
+            .collect();
+    siblings.push(leaf2.into());
     siblings.reverse();
-    let proof_of_key1 = SparseMerkleProof::new(
-        Some(SparseMerkleLeafNode::new(key1, value1_hash)),
-        siblings.clone(),
-    );
+    let proof_of_key1 = SparseMerkleProofExt::new(Some(leaf1.clone()), siblings.clone());
 
-    let old_root_hash = siblings.iter().fold(leaf1_hash, |previous_hash, hash| {
-        hash_internal(previous_hash, *hash)
-    });
+    let old_root_hash = siblings
+        .iter()
+        .fold(leaf1.hash(), |previous_hash, node_in_proof| {
+            hash_internal(previous_hash, node_in_proof.hash())
+        });
     assert!(proof_of_key1
         .verify(old_root_hash, key1, Some(&value1))
         .is_ok());
@@ -202,21 +230,23 @@ fn test_update_256_siblings_in_proof() {
     let proof_reader = ProofReader::new(vec![(key1, proof_of_key1)]);
     let smt = SparseMerkleTree::new(old_root_hash);
     let new_smt = smt
-        .batch_update(vec![(key1, &new_value1)], &proof_reader)
+        .batch_update(vec![(key1, Some(&new_value1))], &proof_reader)
         .unwrap();
 
     let new_value1_hash = new_value1.hash();
     let new_leaf1_hash = hash_leaf(key1, new_value1_hash);
-    let new_root_hash = siblings.iter().fold(new_leaf1_hash, |previous_hash, hash| {
-        hash_internal(previous_hash, *hash)
-    });
+    let new_root_hash = siblings
+        .iter()
+        .fold(new_leaf1_hash, |previous_hash, node_in_proof| {
+            hash_internal(previous_hash, node_in_proof.hash())
+        });
     assert_eq!(new_smt.root_hash(), new_root_hash);
 
     assert_eq!(
         new_smt.get(key1),
         StateStoreStatus::ExistsInScratchPad(new_value1)
     );
-    assert_eq!(new_smt.get(key2), StateStoreStatus::Unknown);
+    assert_eq!(new_smt.get(key2), StateStoreStatus::ExistsInDB);
 }
 
 #[test]
@@ -264,13 +294,15 @@ fn test_update() {
     let value4 = StateValue::from(String::from("test_val4").into_bytes());
     // Create a proof for this new key.
     let leaf1 = SparseMerkleLeafNode::new(key1, value1_hash);
-    let leaf1_hash = leaf1.hash();
-    let leaf2_hash = hash_leaf(key2, value2_hash);
-    let leaf3_hash = hash_leaf(key3, value3_hash);
-    let x_hash = hash_internal(leaf1_hash, leaf2_hash);
+    let leaf2 = SparseMerkleLeafNode::new(key2, value2_hash);
+    let leaf3 = SparseMerkleLeafNode::new(key3, value3_hash);
+    let x_hash = hash_internal(leaf1.hash(), leaf2.hash());
     let y_hash = hash_internal(x_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH);
-    let old_root_hash = hash_internal(y_hash, leaf3_hash);
-    let proof = SparseMerkleProof::new(None, vec![x_hash, leaf3_hash]);
+    let old_root_hash = hash_internal(y_hash, leaf3.hash());
+    let proof = SparseMerkleProofExt::new(
+        None,
+        vec![NodeInProof::Other(x_hash), NodeInProof::Leaf(leaf3)],
+    );
     assert!(proof
         .verify::<StateValue>(old_root_hash, key4, None)
         .is_ok());
@@ -278,7 +310,7 @@ fn test_update() {
     // Create the old tree and update the tree with new value and proof.
     let proof_reader = ProofReader::new(vec![(key4, proof)]);
     let smt1 = SparseMerkleTree::new(old_root_hash)
-        .batch_update(vec![(key4, &value4)], &proof_reader)
+        .batch_update(vec![(key4, Some(&value4))], &proof_reader)
         .unwrap();
 
     // Now smt1 should look like this:
@@ -289,7 +321,7 @@ fn test_update() {
     //         x   key4
     assert_eq!(smt1.get(key1), StateStoreStatus::Unknown);
     assert_eq!(smt1.get(key2), StateStoreStatus::Unknown);
-    assert_eq!(smt1.get(key3), StateStoreStatus::Unknown);
+    assert_eq!(smt1.get(key3), StateStoreStatus::ExistsInDB);
     assert_eq!(
         smt1.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4.clone())
@@ -303,47 +335,42 @@ fn test_update() {
     let value4_hash = value4.hash();
     let leaf4_hash = hash_leaf(key4, value4_hash);
     let y_hash = hash_internal(x_hash, leaf4_hash);
-    let root_hash = hash_internal(y_hash, leaf3_hash);
+    let root_hash = hash_internal(y_hash, leaf3.hash());
     assert_eq!(smt1.root_hash(), root_hash);
 
     // Verify oldest ancestor
     assert!(Arc::ptr_eq(&smt1.get_oldest_ancestor().inner, &smt1.inner));
 
-    // Next, we are going to modify key1. Create a proof for key1.
-    let proof = SparseMerkleProof::new(
+    // Next, we are going to delete key1. Create a proof for key1.
+    let proof = SparseMerkleProofExt::new(
         Some(leaf1),
-        vec![leaf2_hash, *SPARSE_MERKLE_PLACEHOLDER_HASH, leaf3_hash],
+        vec![
+            leaf2.into(),
+            (*SPARSE_MERKLE_PLACEHOLDER_HASH).into(),
+            leaf3.into(),
+        ],
     );
     assert!(proof.verify(old_root_hash, key1, Some(&value1)).is_ok());
 
-    let value1 = StateValue::from(String::from("test_val1111").into_bytes());
     let proof_reader = ProofReader::new(vec![(key1, proof)]);
     let smt2 = smt1
-        .batch_update(vec![(key1, &value1)], &proof_reader)
+        .batch_update(vec![(key1, None)], &proof_reader)
         .unwrap();
 
     // smt2 looks like:
-    //              root
-    //             /    \
-    //            y      key3 (unknown, weak)
-    //           / \
-    //          x   key4 (weak data)
-    //         / \
-    //     key1    key2 (unknown)
-    assert_eq!(
-        smt2.get(key1),
-        StateStoreStatus::ExistsInScratchPad(value1.clone())
-    );
-    assert_eq!(smt2.get(key2), StateStoreStatus::Unknown);
-    assert_eq!(smt2.get(key3), StateStoreStatus::Unknown);
+    //                root
+    //               /    \
+    //              y      key3 (indb, weak)
+    //             / \
+    //    key2(indb)  key4 (weak data)
+    assert_eq!(smt2.get(key1), StateStoreStatus::DoesNotExist,);
+    assert_eq!(smt2.get(key2), StateStoreStatus::ExistsInDB);
+    assert_eq!(smt2.get(key3), StateStoreStatus::ExistsInDB);
     assert_eq!(smt2.get(key4), StateStoreStatus::ExistsInScratchPad(value4));
 
     // Verify root hash.
-    let value1_hash = value1.hash();
-    let leaf1_hash = hash_leaf(key1, value1_hash);
-    let x_hash = hash_internal(leaf1_hash, leaf2_hash);
-    let y_hash = hash_internal(x_hash, leaf4_hash);
-    let root_hash = hash_internal(y_hash, leaf3_hash);
+    let y_hash = hash_internal(leaf2.hash(), leaf4_hash);
+    let root_hash = hash_internal(y_hash, leaf3.hash());
     assert_eq!(smt2.root_hash(), root_hash);
 
     // Verify oldest ancestor
@@ -355,18 +382,17 @@ fn test_update() {
     // key4 already exists in the tree.
     let proof_reader = ProofReader::default();
     let smt22 = smt1
-        .batch_update(vec![(key4, &value4)], &proof_reader)
+        .batch_update(vec![(key4, Some(&value4))], &proof_reader)
         .unwrap();
 
     // smt22 is like:
     //             root
     //            /    \
-    //           y'      key3 (unknown, weak)
+    //           y'      key3 (indb, weak)
     //          / \
     // (weak) x   key4
-    assert_eq!(smt22.get(key1), StateStoreStatus::Unknown);
     assert_eq!(smt22.get(key2), StateStoreStatus::Unknown);
-    assert_eq!(smt22.get(key3), StateStoreStatus::Unknown);
+    assert_eq!(smt22.get(key3), StateStoreStatus::ExistsInDB);
     assert_eq!(
         smt22.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4.clone())
@@ -382,18 +408,17 @@ fn test_update() {
     assert_eq_pointee(&smt2.get_oldest_ancestor(), &smt2);
     assert_eq_pointee(&smt22.get_oldest_ancestor(), &smt22);
 
-    // For smt2, only key1 should be available since smt2 was constructed by updating smt1 with
-    // key1.
-    assert_eq!(smt2.get(key1), StateStoreStatus::ExistsInScratchPad(value1));
-    assert_eq!(smt2.get(key2), StateStoreStatus::Unknown);
-    assert_eq!(smt2.get(key3), StateStoreStatus::Unknown);
+    // For smt2, no key should be available since smt2 was constructed by deleting key1.
+    assert_eq!(smt2.get(key1), StateStoreStatus::DoesNotExist);
+    assert_eq!(smt2.get(key2), StateStoreStatus::ExistsInDB);
+    assert_eq!(smt2.get(key3), StateStoreStatus::ExistsInDB);
     assert_eq!(smt2.get(key4), StateStoreStatus::ExistsInDB);
 
     // For smt22, only key4 should be available since smt22 was constructed by updating smt1 with
     // key4.
     assert_eq!(smt22.get(key1), StateStoreStatus::Unknown);
     assert_eq!(smt22.get(key2), StateStoreStatus::Unknown);
-    assert_eq!(smt22.get(key3), StateStoreStatus::Unknown);
+    assert_eq!(smt22.get(key3), StateStoreStatus::ExistsInDB);
     assert_eq!(
         smt22.get(key4),
         StateStoreStatus::ExistsInScratchPad(value4)
@@ -406,12 +431,12 @@ static VALUE: Lazy<StateValue> =
 static LEAF: Lazy<SparseMerkleLeafNode> =
     Lazy::new(|| SparseMerkleLeafNode::new(*KEY, VALUE.hash()));
 static PROOF_READER: Lazy<ProofReader> = Lazy::new(|| {
-    let proof = SparseMerkleProof::new(Some(*LEAF), vec![]);
+    let proof = SparseMerkleProofExt::new(Some(*LEAF), vec![]);
     ProofReader::new(vec![(*KEY, proof)])
 });
 
 fn update(smt: &SparseMerkleTree) -> SparseMerkleTree {
-    smt.batch_update(vec![(*KEY, &VALUE)], &*PROOF_READER)
+    smt.batch_update(vec![(*KEY, Some(&VALUE))], &*PROOF_READER)
         .unwrap()
 }
 
@@ -584,7 +609,7 @@ fn test_drop() {
             .batch_update(
                 vec![(
                     HashValue::zero(),
-                    &StateValue::from(String::from("test_val").into_bytes()),
+                    Some(&StateValue::from(String::from("test_val").into_bytes())),
                 )],
                 &proof_reader,
             )

--- a/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
+++ b/storage/scratchpad/src/sparse_merkle/sparse_merkle_test.rs
@@ -215,7 +215,7 @@ fn test_update_256_siblings_in_proof() {
             .collect();
     siblings.push(leaf2.into());
     siblings.reverse();
-    let proof_of_key1 = SparseMerkleProofExt::new(Some(leaf1.clone()), siblings.clone());
+    let proof_of_key1 = SparseMerkleProofExt::new(Some(leaf1), siblings.clone());
 
     let old_root_hash = siblings
         .iter()

--- a/storage/scratchpad/src/sparse_merkle/test_utils/naive_smt.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/naive_smt.rs
@@ -127,7 +127,7 @@ impl NaiveSmt {
             if let Some(value) = value_option {
                 leaves.insert(*key, value.hash());
             } else {
-                leaves.remove(key).unwrap();
+                leaves.remove(key);
             }
         }
 

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proof_reader.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proof_reader.rs
@@ -3,20 +3,20 @@
 
 use crate::ProofRead;
 use aptos_crypto::HashValue;
-use aptos_types::proof::SparseMerkleProof;
+use aptos_types::proof::SparseMerkleProofExt;
 use std::collections::HashMap;
 
 #[derive(Default)]
-pub struct ProofReader(HashMap<HashValue, SparseMerkleProof>);
+pub struct ProofReader(HashMap<HashValue, SparseMerkleProofExt>);
 
 impl ProofReader {
-    pub fn new(key_with_proof: Vec<(HashValue, SparseMerkleProof)>) -> Self {
+    pub fn new(key_with_proof: Vec<(HashValue, SparseMerkleProofExt)>) -> Self {
         ProofReader(key_with_proof.into_iter().collect())
     }
 }
 
 impl ProofRead for ProofReader {
-    fn get_proof(&self, key: HashValue) -> Option<&SparseMerkleProof> {
+    fn get_proof(&self, key: HashValue) -> Option<&SparseMerkleProofExt> {
         self.0.get(&key)
     }
 }

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
@@ -13,15 +13,22 @@ use proptest::{
     prelude::*,
     sample::Index,
 };
+use std::collections::HashSet;
 use std::{collections::VecDeque, sync::Arc};
 
-type TxnOutput = Vec<(HashValue, StateValue)>;
+type TxnOutput = Vec<(HashValue, Option<StateValue>)>;
 type BlockOutput = Vec<TxnOutput>;
 
 #[derive(Debug)]
 pub enum Action {
     Commit,
     Execute(BlockOutput),
+}
+
+#[derive(Clone, Debug)]
+enum Op {
+    Delete(Vec<u8>),
+    Write(Vec<u8>),
 }
 
 pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
@@ -33,18 +40,25 @@ pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
                     // txns
                     vec(
                         // txn updates
-                        (any::<Index>(), any::<Vec<u8>>()),
-                        1..4,
+                        (
+                            any::<Index>(),
+                            prop_oneof![
+                                any::<Vec<u8>>().prop_map(Op::Delete),
+                                any::<Vec<u8>>().prop_map(Op::Write)
+                            ]
+                        ),
+                        1..20,
                     ),
                     1..10,
                 ),
                 Just(vec![]),
             ],
-            1..10,
+            1..20,
         ),
     )
         .prop_map(|(keys, commit_or_execute)| {
             let keys: Vec<_> = keys.into_iter().collect();
+            let mut existing = HashSet::<HashValue>::new();
             commit_or_execute
                 .into_iter()
                 .map(|txns| {
@@ -56,7 +70,25 @@ pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
                                 .map(|updates| {
                                     updates
                                         .into_iter()
-                                        .map(|(k_idx, v)| (*k_idx.get(&keys), v.to_vec().into()))
+                                        .map(|(k_idx, v)| {
+                                            let key = *k_idx.get(&keys);
+                                            match v {
+                                                Op::Write(value) => {
+                                                    existing.insert(key);
+                                                    (key, Some(value.to_vec().into()))
+                                                }
+                                                Op::Delete(backup_write) => {
+                                                    if existing.contains(&key) {
+                                                        existing.remove(&key);
+                                                        println!("delete");
+                                                        (key, None)
+                                                    } else {
+                                                        existing.insert(key);
+                                                        (key, Some(backup_write.to_vec().into()))
+                                                    }
+                                                }
+                                            }
+                                        })
                                         .collect()
                                 })
                                 .collect::<Vec<_>>(),
@@ -84,9 +116,9 @@ pub fn test_smt_correctness_impl(input: Vec<Action>) {
             Action::Execute(block) => {
                 let updates = block
                     .iter()
-                    .map(|txn_updates| txn_updates.iter().map(|(k, v)| (*k, v)).collect())
-                    .collect::<Vec<Vec<_>>>();
-                let updates_flat_batch = updates.iter().flatten().cloned().collect::<Vec<_>>();
+                    .map(|txn_updates| txn_updates.iter().map(|(k, v)| (*k, v.as_ref())).collect::<Vec<_>>())
+                    .collect::<Vec<_>>();
+                let updates_flat_batch = updates.into_iter().flatten().collect::<Vec<_>>();
 
                 let committed = naive_q.front_mut().unwrap();
                 let proofs = updates_flat_batch

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
@@ -13,7 +13,6 @@ use proptest::{
     prelude::*,
     sample::Index,
 };
-use std::collections::HashSet;
 use std::{collections::VecDeque, sync::Arc};
 
 type TxnOutput = Vec<(HashValue, Option<StateValue>)>;
@@ -25,12 +24,6 @@ pub enum Action {
     Execute(BlockOutput),
 }
 
-#[derive(Clone, Debug)]
-enum Op {
-    Delete(Vec<u8>),
-    Write(Vec<u8>),
-}
-
 pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
     (
         hash_set(any::<HashValue>(), 1..100), // keys
@@ -40,13 +33,7 @@ pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
                     // txns
                     vec(
                         // txn updates
-                        (
-                            any::<Index>(),
-                            prop_oneof![
-                                any::<Vec<u8>>().prop_map(Op::Delete),
-                                any::<Vec<u8>>().prop_map(Op::Write)
-                            ]
-                        ),
+                        (any::<Index>(), any::<Option<Vec<u8>>>()),
                         1..20,
                     ),
                     1..10,
@@ -58,7 +45,6 @@ pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
     )
         .prop_map(|(keys, commit_or_execute)| {
             let keys: Vec<_> = keys.into_iter().collect();
-            let mut existing = HashSet::<HashValue>::new();
             commit_or_execute
                 .into_iter()
                 .map(|txns| {
@@ -72,22 +58,7 @@ pub fn arb_smt_correctness_case() -> impl Strategy<Value = Vec<Action>> {
                                         .into_iter()
                                         .map(|(k_idx, v)| {
                                             let key = *k_idx.get(&keys);
-                                            match v {
-                                                Op::Write(value) => {
-                                                    existing.insert(key);
-                                                    (key, Some(value.to_vec().into()))
-                                                }
-                                                Op::Delete(backup_write) => {
-                                                    if existing.contains(&key) {
-                                                        existing.remove(&key);
-                                                        println!("delete");
-                                                        (key, None)
-                                                    } else {
-                                                        existing.insert(key);
-                                                        (key, Some(backup_write.to_vec().into()))
-                                                    }
-                                                }
-                                            }
+                                            (key, v.map(|v| v.into()))
                                         })
                                         .collect()
                                 })
@@ -116,7 +87,12 @@ pub fn test_smt_correctness_impl(input: Vec<Action>) {
             Action::Execute(block) => {
                 let updates = block
                     .iter()
-                    .map(|txn_updates| txn_updates.iter().map(|(k, v)| (*k, v.as_ref())).collect::<Vec<_>>())
+                    .map(|txn_updates| {
+                        txn_updates
+                            .iter()
+                            .map(|(k, v)| (*k, v.as_ref()))
+                            .collect::<Vec<_>>()
+                    })
                     .collect::<Vec<_>>();
                 let updates_flat_batch = updates.into_iter().flatten().collect::<Vec<_>>();
 

--- a/storage/scratchpad/src/sparse_merkle/updater.rs
+++ b/storage/scratchpad/src/sparse_merkle/updater.rs
@@ -13,7 +13,8 @@ use aptos_crypto::{
     hash::{CryptoHash, SPARSE_MERKLE_PLACEHOLDER_HASH},
     HashValue,
 };
-use aptos_types::proof::{SparseMerkleLeafNode, SparseMerkleProof};
+use aptos_types::proof::definition::NodeInProof;
+use aptos_types::proof::{SparseMerkleLeafNode, SparseMerkleProofExt};
 use std::cmp::Ordering;
 
 type Result<T> = std::result::Result<T, UpdateError>;
@@ -87,9 +88,9 @@ impl<V: Clone + CryptoHash> InMemSubTreeInfo<V> {
         // If there's a only leaf in the subtree,
         // rollup the leaf, otherwise create an internal node.
         match (&left, &right) {
-            (Self::Empty, Self::Leaf { .. }) => right,
+            (Self::Empty, Self::Empty) => Self::Empty,
             (Self::Leaf { .. }, Self::Empty) => left,
-            (Self::Empty, Self::Empty) => unreachable!(),
+            (Self::Empty, Self::Leaf { .. }) => right,
             _ => InMemSubTreeInfo::create_internal(left, right, generation),
         }
     }
@@ -97,7 +98,7 @@ impl<V: Clone + CryptoHash> InMemSubTreeInfo<V> {
 
 #[derive(Clone)]
 enum PersistedSubTreeInfo<'a> {
-    ProofPathInternal { proof: &'a SparseMerkleProof },
+    ProofPathInternal { proof: &'a SparseMerkleProofExt },
     ProofSibling { hash: HashValue },
     Leaf { leaf: SparseMerkleLeafNode },
 }
@@ -117,15 +118,20 @@ impl<'a, V: Clone + CryptoHash> SubTreeInfo<'a, V> {
         Self::Persisted(PersistedSubTreeInfo::Leaf { leaf })
     }
 
-    fn new_proof_sibling(hash: HashValue) -> Self {
-        if hash == *SPARSE_MERKLE_PLACEHOLDER_HASH {
-            Self::InMem(InMemSubTreeInfo::Empty)
-        } else {
-            Self::Persisted(PersistedSubTreeInfo::ProofSibling { hash })
+    fn new_proof_sibling(node_in_proof: &NodeInProof) -> Self {
+        match node_in_proof {
+            NodeInProof::Leaf(leaf) => Self::new_proof_leaf(leaf.clone()),
+            NodeInProof::Other(hash) => {
+                if *hash == *SPARSE_MERKLE_PLACEHOLDER_HASH {
+                    Self::InMem(InMemSubTreeInfo::Empty)
+                } else {
+                    Self::Persisted(PersistedSubTreeInfo::ProofSibling { hash: *hash })
+                }
+            }
         }
     }
 
-    fn new_on_proof_path(proof: &'a SparseMerkleProof, depth: usize) -> Self {
+    fn new_on_proof_path(proof: &'a SparseMerkleProofExt, depth: usize) -> Self {
         match proof.siblings().len().cmp(&depth) {
             Ordering::Greater => Self::Persisted(PersistedSubTreeInfo::ProofPathInternal { proof }),
             Ordering::Equal => match proof.leaf() {
@@ -240,7 +246,7 @@ impl<'a, V: Clone + CryptoHash> SubTreeInfo<'a, V> {
                     let siblings = proof.siblings();
                     assert!(siblings.len() > depth);
                     let sibling_child =
-                        SubTreeInfo::new_proof_sibling(siblings[siblings.len() - depth - 1]);
+                        SubTreeInfo::new_proof_sibling(&siblings[siblings.len() - depth - 1]);
                     let on_path_child = SubTreeInfo::new_on_proof_path(proof, depth + 1);
                     swap_if(on_path_child, sibling_child, a_descendent_key.bit(depth))
                 }
@@ -270,14 +276,14 @@ impl<'a, V: Clone + CryptoHash> SubTreeInfo<'a, V> {
 pub struct SubTreeUpdater<'a, V> {
     depth: usize,
     info: SubTreeInfo<'a, V>,
-    updates: &'a [(HashValue, &'a V)],
+    updates: &'a [(HashValue, Option<&'a V>)],
     generation: u64,
 }
 
 impl<'a, V: Send + Sync + Clone + CryptoHash> SubTreeUpdater<'a, V> {
     pub(crate) fn update(
         root: InMemSubTree<V>,
-        updates: &'a [(HashValue, &'a V)],
+        updates: &'a [(HashValue, Option<&'a V>)],
         proof_reader: &'a impl ProofRead,
         generation: u64,
     ) -> Result<InMemSubTree<V>> {
@@ -298,7 +304,7 @@ impl<'a, V: Send + Sync + Clone + CryptoHash> SubTreeUpdater<'a, V> {
 
         let generation = self.generation;
         let depth = self.depth;
-        match self.maybe_end_recursion() {
+        match self.maybe_end_recursion()? {
             Either::A(ended) => Ok(ended),
             Either::B(myself) => {
                 let (left, right) = myself.into_children(proof_reader)?;
@@ -316,30 +322,61 @@ impl<'a, V: Send + Sync + Clone + CryptoHash> SubTreeUpdater<'a, V> {
         }
     }
 
-    fn maybe_end_recursion(self) -> Either<InMemSubTreeInfo<V>, Self> {
-        match self.updates.len() {
+    fn maybe_end_recursion(self) -> Result<Either<InMemSubTreeInfo<V>, Self>> {
+        Ok(match self.updates.len() {
             0 => Either::A(self.info.materialize(self.generation)),
-            1 => match &self.info {
-                SubTreeInfo::InMem(in_mem_info) => match in_mem_info {
-                    InMemSubTreeInfo::Empty => Either::A(
-                        InMemSubTreeInfo::create_leaf_with_update(self.updates[0], self.generation),
-                    ),
-                    InMemSubTreeInfo::Leaf { key, .. } => Either::or(
-                        *key == self.updates[0].0,
-                        InMemSubTreeInfo::create_leaf_with_update(self.updates[0], self.generation),
-                        self,
-                    ),
+            1 => {
+                let (key_to_update, update) = &self.updates[0];
+                match &self.info {
+                    SubTreeInfo::InMem(in_mem_info) => match in_mem_info {
+                        InMemSubTreeInfo::Empty => match update {
+                            Some(value) => Either::A(InMemSubTreeInfo::create_leaf_with_update(
+                                (*key_to_update, value),
+                                self.generation,
+                            )),
+                            None => Either::A(self.info.materialize(self.generation)),
+                        },
+                        InMemSubTreeInfo::Leaf { key, .. } => match update {
+                            Some(value) => Either::or(
+                                key == key_to_update,
+                                InMemSubTreeInfo::create_leaf_with_update(
+                                    (*key_to_update, value),
+                                    self.generation,
+                                ),
+                                self,
+                            ),
+                            None => {
+                                if key == key_to_update {
+                                    Either::A(InMemSubTreeInfo::Empty)
+                                } else {
+                                    Either::A(self.info.materialize(self.generation))
+                                }
+                            }
+                        },
+                        _ => Either::B(self),
+                    },
+                    SubTreeInfo::Persisted(PersistedSubTreeInfo::Leaf { leaf }) => match update {
+                        Some(value) => Either::or(
+                            leaf.key() == *key_to_update,
+                            InMemSubTreeInfo::create_leaf_with_update(
+                                (*key_to_update, value),
+                                self.generation,
+                            ),
+                            self,
+                        ),
+                        None => {
+                            if leaf.key() == *key_to_update {
+                                Either::A(InMemSubTreeInfo::Empty)
+                            } else {
+                                Either::A(self.info.materialize(self.generation))
+                            }
+                        }
+                    },
                     _ => Either::B(self),
-                },
-                SubTreeInfo::Persisted(PersistedSubTreeInfo::Leaf { leaf }) => Either::or(
-                    leaf.key() == self.updates[0].0,
-                    InMemSubTreeInfo::create_leaf_with_update(self.updates[0], self.generation),
-                    self,
-                ),
-                _ => Either::B(self),
-            },
+                }
+            }
             _ => Either::B(self),
-        }
+        })
     }
 
     fn into_children(self, proof_reader: &'a impl ProofRead) -> Result<(Self, Self)> {

--- a/storage/scratchpad/src/sparse_merkle/updater.rs
+++ b/storage/scratchpad/src/sparse_merkle/updater.rs
@@ -120,7 +120,7 @@ impl<'a, V: Clone + CryptoHash> SubTreeInfo<'a, V> {
 
     fn new_proof_sibling(node_in_proof: &NodeInProof) -> Self {
         match node_in_proof {
-            NodeInProof::Leaf(leaf) => Self::new_proof_leaf(leaf.clone()),
+            NodeInProof::Leaf(leaf) => Self::new_proof_leaf(*leaf),
             NodeInProof::Other(hash) => {
                 if *hash == *SPARSE_MERKLE_PLACEHOLDER_HASH {
                     Self::InMem(InMemSubTreeInfo::Empty)

--- a/storage/state-view/src/account_with_state_cache.rs
+++ b/storage/state-view/src/account_with_state_cache.rs
@@ -29,7 +29,7 @@ impl<'a> AccountView for AccountWithStateCache<'a> {
         Ok(self
             .state_cache
             .get(state_key)
-            .and_then(|x| x.maybe_bytes.clone()))
+            .map(|x| x.maybe_bytes.clone()))
     }
 
     fn get_account_address(&self) -> anyhow::Result<Option<AccountAddress>> {

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -7,7 +7,7 @@ use anyhow::{format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_state_view::{StateView, StateViewId};
 use aptos_types::{
-    proof::SparseMerkleProof,
+    proof::SparseMerkleProofExt,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
     write_set::WriteSet,
@@ -72,7 +72,7 @@ pub struct CachedStateView {
     /// completely and migrate to fine grained storage. A value of None in this cache reflects that
     /// the corresponding key has been deleted. This is a temporary hack until we support deletion
     /// in JMT node.
-    state_cache: RwLock<HashMap<StateKey, StateValue>>,
+    state_cache: RwLock<HashMap<StateKey, Option<StateValue>>>,
     proof_fetcher: Arc<dyn ProofFetcher>,
 }
 
@@ -160,8 +160,8 @@ impl CachedStateView {
 
 pub struct StateCache {
     pub frozen_base: FrozenSparseMerkleTree<StateValue>,
-    pub state_cache: HashMap<StateKey, StateValue>,
-    pub proofs: HashMap<HashValue, SparseMerkleProof>,
+    pub state_cache: HashMap<StateKey, Option<StateValue>>,
+    pub proofs: HashMap<HashValue, SparseMerkleProofExt>,
 }
 
 impl StateView for CachedStateView {
@@ -173,15 +173,15 @@ impl StateView for CachedStateView {
         // First check if the cache has the state value.
         if let Some(contents) = self.state_cache.read().get(state_key) {
             // This can return None, which means the value has been deleted from the DB.
-            return Ok(contents.maybe_bytes.as_ref().cloned());
+            return Ok(contents.map(|v| v.maybe_bytes.clone()));
         }
         let state_value_option = self.get_state_value_internal(state_key)?;
         // Update the cache if still empty
         let mut cache = self.state_cache.write();
         let new_value = cache
             .entry(state_key.clone())
-            .or_insert_with(|| state_value_option.unwrap_or_default());
-        Ok(new_value.maybe_bytes.as_ref().cloned())
+            .or_insert_with(state_value_option);
+        Ok(new_value.map(|v| v.maybe_bytes.clone()))
     }
 
     fn is_genesis(&self) -> bool {

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -173,15 +173,13 @@ impl StateView for CachedStateView {
         // First check if the cache has the state value.
         if let Some(contents) = self.state_cache.read().get(state_key) {
             // This can return None, which means the value has been deleted from the DB.
-            return Ok(contents.map(|v| v.maybe_bytes.clone()));
+            return Ok(contents.as_ref().map(|v| v.maybe_bytes.clone()));
         }
         let state_value_option = self.get_state_value_internal(state_key)?;
         // Update the cache if still empty
         let mut cache = self.state_cache.write();
-        let new_value = cache
-            .entry(state_key.clone())
-            .or_insert_with(state_value_option);
-        Ok(new_value.map(|v| v.maybe_bytes.clone()))
+        let new_value = cache.entry(state_key.clone()).or_insert(state_value_option);
+        Ok(new_value.as_ref().map(|v| v.maybe_bytes.clone()))
     }
 
     fn is_genesis(&self) -> bool {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -365,11 +365,11 @@ pub trait DbReader: Send + Sync {
     }
 
     /// Returns the proof of the given state key and version.
-    fn get_state_proof_by_version(
+    fn get_state_proof_by_version_ext(
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> Result<SparseMerkleProof> {
+    ) -> Result<SparseMerkleProofExt> {
         unimplemented!()
     }
 
@@ -393,9 +393,9 @@ pub trait DbReader: Send + Sync {
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
+    ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
         self.get_state_value_with_proof_by_version_ext(state_key, version)
-            .map(|(value, proof_ext)| proof_ext.into())
+            .map(|(value, proof_ext)| (value, proof_ext.into()))
     }
 
     /// Gets the latest ExecutedTrees no matter if db has been bootstrapped.
@@ -520,9 +520,8 @@ impl MoveStorage for &dyn DbReader {
             self.get_state_value_by_version(&StateKey::AccessPath(access_path), version)?;
 
         state_value
-            .ok_or_else(|| format_err!("no value found in DB"))?
-            .maybe_bytes
             .ok_or_else(|| format_err!("no value found in DB"))
+            .map(|value| value.maybe_bytes)
     }
 
     fn fetch_config_by_version(&self, config_id: ConfigID, version: Version) -> Result<Vec<u8>> {
@@ -534,7 +533,7 @@ impl MoveStorage for &dyn DbReader {
             version,
         )?;
         config_value_option
-            .and_then(|x| x.maybe_bytes)
+            .map(|x| x.maybe_bytes)
             .ok_or_else(|| anyhow!("no config {} found in aptos root account state", config_id))
     }
 
@@ -679,16 +678,16 @@ impl SaveTransactionsRequest {
 }
 
 pub fn jmt_updates(
-    state_updates: &HashMap<StateKey, StateValue>,
-) -> Vec<(HashValue, (HashValue, StateKey))> {
+    state_updates: &HashMap<StateKey, Option<StateValue>>,
+) -> Vec<(HashValue, Option<(HashValue, StateKey)>)> {
     state_updates
         .iter()
-        .map(|(k, v)| (k.hash(), (v.hash(), (*k).clone())))
+        .map(|(k, v_opt)| (k.hash(), v_opt.as_ref().map(|v| (v.hash(), k.clone()))))
         .collect()
 }
 
-pub fn jmt_update_refs(
-    jmt_updates: &[(HashValue, (HashValue, StateKey))],
-) -> Vec<(HashValue, &(HashValue, StateKey))> {
-    jmt_updates.iter().map(|(x, y)| (*x, y)).collect()
+pub fn jmt_update_refs<K>(
+    jmt_updates: &[(HashValue, Option<(HashValue, K)>)],
+) -> Vec<(HashValue, Option<&(HashValue, K)>)> {
+    jmt_updates.iter().map(|(x, y)| (*x, y.as_ref())).collect()
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -17,8 +17,8 @@ use aptos_types::{
     move_resource::MoveStorage,
     on_chain_config::{access_path_for_config, ConfigID},
     proof::{
-        AccumulatorConsistencyProof, SparseMerkleProof, SparseMerkleRangeProof,
-        TransactionAccumulatorSummary,
+        AccumulatorConsistencyProof, SparseMerkleProof, SparseMerkleProofExt,
+        SparseMerkleRangeProof, TransactionAccumulatorSummary,
     },
     state_proof::StateProof,
     state_store::{
@@ -381,12 +381,21 @@ pub trait DbReader: Send + Sync {
     /// ../aptosdb/struct.AptosDB.html#method.get_account_state_with_proof_by_version
     ///
     /// This is used by aptos core (executor) internally.
+    fn get_state_value_with_proof_by_version_ext(
+        &self,
+        state_key: &StateKey,
+        version: Version,
+    ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
+        unimplemented!()
+    }
+
     fn get_state_value_with_proof_by_version(
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> Result<(Option<StateValue>, SparseMerkleProof)> {
-        unimplemented!()
+    ) -> Result<(Option<StateValue>, SparseMerkleProofExt)> {
+        self.get_state_value_with_proof_by_version_ext(state_key, version)
+            .map(|(value, proof_ext)| proof_ext.into())
     }
 
     /// Gets the latest ExecutedTrees no matter if db has been bootstrapped.

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -10,7 +10,7 @@ use aptos_types::{
     account_config::AccountResource,
     account_state::AccountState,
     event::EventHandle,
-    proof::SparseMerkleProof,
+    proof::SparseMerkleProofExt,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
@@ -53,12 +53,12 @@ impl DbReader for MockDbReaderWriter {
         Ok(self.get_latest_state_value(state_key.clone()).unwrap())
     }
 
-    fn get_state_proof_by_version(
+    fn get_state_proof_by_version_ext(
         &self,
         _state_key: &StateKey,
         _version: Version,
-    ) -> Result<SparseMerkleProof> {
-        Ok(SparseMerkleProof::new(None, vec![]))
+    ) -> Result<SparseMerkleProofExt> {
+        Ok(SparseMerkleProofExt::new(None, vec![]))
     }
 }
 

--- a/storage/storage-interface/src/proof_fetcher.rs
+++ b/storage/storage-interface/src/proof_fetcher.rs
@@ -3,7 +3,7 @@
 
 use aptos_crypto::HashValue;
 use aptos_types::{
-    proof::SparseMerkleProof,
+    proof::SparseMerkleProofExt,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
@@ -16,8 +16,8 @@ pub trait ProofFetcher: Sync + Send {
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> anyhow::Result<(Option<StateValue>, Option<SparseMerkleProof>)>;
+    ) -> anyhow::Result<(Option<StateValue>, Option<SparseMerkleProofExt>)>;
 
     /// API to return all the proofs fetched by the proof fetcher so far.
-    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProof>;
+    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProofExt>;
 }

--- a/storage/storage-interface/src/state_delta.rs
+++ b/storage/storage-interface/src/state_delta.rs
@@ -22,7 +22,7 @@ pub struct StateDelta {
     pub base_version: Option<Version>,
     pub current: SparseMerkleTree<StateValue>,
     pub current_version: Option<Version>,
-    pub updates_since_base: HashMap<StateKey, StateValue>,
+    pub updates_since_base: HashMap<StateKey, Option<StateValue>>,
 }
 
 impl StateDelta {
@@ -31,7 +31,7 @@ impl StateDelta {
         base_version: Option<Version>,
         current: SparseMerkleTree<StateValue>,
         current_version: Option<Version>,
-        updates_since_base: HashMap<StateKey, StateValue>,
+        updates_since_base: HashMap<StateKey, Option<StateValue>>,
     ) -> Self {
         assert!(base_version.map_or(0, |v| v + 1) <= current_version.map_or(0, |v| v + 1));
         Self {

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -14,16 +14,13 @@ pub struct DbStateView {
 
 impl DbStateView {
     fn get(&self, key: &StateKey) -> Result<Option<Vec<u8>>> {
-        if let Some(version) = self.version {
+        Ok(if let Some(version) = self.version {
             self.db
-                .get_state_value_by_version(key, version)
-                .map(|value_opt| {
-                    // Hack: `v.maybe_bytes == None` represents deleted value, deemed non-existent
-                    value_opt.and_then(|value| value.maybe_bytes)
-                })
+                .get_state_value_by_version(key, version)?
+                .map(|value| value.maybe_bytes)
         } else {
-            Ok(None)
-        }
+            None
+        })
     }
 }
 

--- a/storage/storage-interface/src/sync_proof_fetcher.rs
+++ b/storage/storage-interface/src/sync_proof_fetcher.rs
@@ -4,7 +4,7 @@
 use crate::{proof_fetcher::ProofFetcher, DbReader};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_types::{
-    proof::SparseMerkleProof,
+    proof::SparseMerkleProofExt,
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
@@ -15,7 +15,7 @@ use std::{collections::HashMap, sync::Arc};
 /// storage.
 pub struct SyncProofFetcher {
     reader: Arc<dyn DbReader>,
-    state_proof_cache: RwLock<HashMap<HashValue, SparseMerkleProof>>,
+    state_proof_cache: RwLock<HashMap<HashValue, SparseMerkleProofExt>>,
 }
 
 impl SyncProofFetcher {
@@ -32,10 +32,10 @@ impl ProofFetcher for SyncProofFetcher {
         &self,
         state_key: &StateKey,
         version: Version,
-    ) -> anyhow::Result<(Option<StateValue>, Option<SparseMerkleProof>)> {
+    ) -> anyhow::Result<(Option<StateValue>, Option<SparseMerkleProofExt>)> {
         let (state_value, proof) = self
             .reader
-            .get_state_value_with_proof_by_version(state_key, version)?;
+            .get_state_value_with_proof_by_version_ext(state_key, version)?;
         // multiple threads may enter this code, and another thread might add
         // an address before this one. Thus the insertion might return a None here.
         self.state_proof_cache
@@ -45,7 +45,7 @@ impl ProofFetcher for SyncProofFetcher {
         Ok((state_value, Some(proof)))
     }
 
-    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProof> {
+    fn get_proof_cache(&self) -> HashMap<HashValue, SparseMerkleProofExt> {
         self.state_proof_cache
             .read()
             .iter()

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -133,12 +133,7 @@ impl TryFrom<&StateValue> for AccountState {
     type Error = Error;
 
     fn try_from(state_value: &StateValue) -> Result<Self> {
-        let bytes = state_value
-            .maybe_bytes
-            .as_ref()
-            .ok_or_else(|| anyhow!("Empty state value passed"))?;
-
-        AccountState::try_from(bytes).map_err(Into::into)
+        AccountState::try_from(&state_value.maybe_bytes).map_err(Into::into)
     }
 }
 
@@ -184,9 +179,7 @@ impl TryFrom<(AccountAddress, &HashMap<StateKey, StateValue>)> for AccountState 
         for (key, value) in key_value_map {
             match key {
                 StateKey::AccessPath(access_path) => {
-                    if let Some(bytes) = &value.maybe_bytes {
-                        btree_map.insert(access_path.path.clone(), bytes.clone());
-                    }
+                    btree_map.insert(access_path.path.clone(), value.maybe_bytes.clone());
                 }
                 _ => return Err(anyhow!("Encountered unexpected key type {:?}", key)),
             }

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -30,9 +30,9 @@ use std::marker::PhantomData;
 
 pub use self::definition::{
     AccumulatorConsistencyProof, AccumulatorExtensionProof, AccumulatorProof,
-    AccumulatorRangeProof, SparseMerkleProof, SparseMerkleRangeProof, TransactionAccumulatorProof,
-    TransactionAccumulatorRangeProof, TransactionAccumulatorSummary, TransactionInfoListWithProof,
-    TransactionInfoWithProof,
+    AccumulatorRangeProof, SparseMerkleProof, SparseMerkleProofExt, SparseMerkleRangeProof,
+    TransactionAccumulatorProof, TransactionAccumulatorRangeProof, TransactionAccumulatorSummary,
+    TransactionInfoListWithProof, TransactionInfoWithProof,
 };
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -847,7 +847,7 @@ impl TransactionToCommitGen {
                     .map(move |(key, value)| {
                         let state_key = StateKey::AccessPath(AccessPath::new(address, key));
                         (
-                            (state_key.clone(), StateValue::from(value.clone())),
+                            (state_key.clone(), Some(StateValue::from(value.clone()))),
                             (state_key, WriteOp::Value(value)),
                         )
                     })

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -22,9 +22,7 @@ pub struct StateValue {
 impl Arbitrary for StateValue {
     type Parameters = ();
     fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
-        any::<Vec<u8>>()
-            .prop_map(|maybe_bytes| StateValue::new(maybe_bytes))
-            .boxed()
+        any::<Vec<u8>>().prop_map(StateValue::new).boxed()
     }
 
     type Strategy = BoxedStrategy<Self>;
@@ -95,15 +93,5 @@ impl StateValueChunkWithProof {
         right_siblings
             .iter()
             .all(|sibling| *sibling == *SPARSE_MERKLE_PLACEHOLDER_HASH)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::state_store::state_value::StateValue;
-
-    #[test]
-    fn test_empty_state_value() {
-        StateValue::new(None);
     }
 }

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1109,7 +1109,7 @@ impl Display for TransactionInfo {
 pub struct TransactionToCommit {
     transaction: Transaction,
     transaction_info: TransactionInfo,
-    state_updates: HashMap<StateKey, StateValue>,
+    state_updates: HashMap<StateKey, Option<StateValue>>,
     write_set: WriteSet,
     events: Vec<ContractEvent>,
     is_reconfig: bool,
@@ -1119,7 +1119,7 @@ impl TransactionToCommit {
     pub fn new(
         transaction: Transaction,
         transaction_info: TransactionInfo,
-        state_updates: HashMap<StateKey, StateValue>,
+        state_updates: HashMap<StateKey, Option<StateValue>>,
         write_set: WriteSet,
         events: Vec<ContractEvent>,
         is_reconfig: bool,
@@ -1151,7 +1151,7 @@ impl TransactionToCommit {
         self.transaction_info = txn_info
     }
 
-    pub fn state_updates(&self) -> &HashMap<StateKey, StateValue> {
+    pub fn state_updates(&self) -> &HashMap<StateKey, Option<StateValue>> {
         &self.state_updates
     }
 


### PR DESCRIPTION
### Description

This PR fully supports deletion on both SMT and JMT. Specifically,
1. Changed the default proof format to be a list of either non-leaf node hash or leaf node itself. We need the whole leaf node information in proof for smt update because "lifting" leaf siblings cannot be done with only its hash.
2. Supports deletion on SMT by passing in `None` for a key.
3. Supports deletion on JMT by passing in `None` for a key.
4. unit tests.

### Test Plan
ut

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2519)
<!-- Reviewable:end -->
