### PR TITLE
[aptos-move-framework] fix empty big_vector contains

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/big_vector.move
+++ b/aptos-move/framework/aptos-stdlib/sources/big_vector.move
@@ -130,6 +130,7 @@ module aptos_std::big_vector {
 
     /// Return true if `val` is in the vector `v`.
     public fun contains<T>(v: &BigVector<T>, val: &T): bool {
+        if (is_empty(v)) return false;
         let (exist, _) = index_of(v, val);
         exist
     }
@@ -298,6 +299,13 @@ module aptos_std::big_vector {
             i = i - 1;
         };
         shrink_to_fit(&mut v);
+        destroy_empty(v);
+    }
+
+    #[test]
+    fun big_vector_empty_contains() {
+        let v = new<u64> (10);
+        assert!(!contains<u64>(&v, &(1 as u64)), 0);
         destroy_empty(v);
     }
 }


### PR DESCRIPTION
### Description
Currently implementation of aptos_std::big_vector doesn't check whether a passed big_vector is empty in `contains`, so it aborts when an empty big_vector passed in `contains`, a more reasonable behavior is `return false`.
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Unit test added, Run `aptos move test --filter big_vector` in directory to see 4 tests of big_vector all pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2525)
<!-- Reviewable:end -->
