### PR TITLE
[aptos-cli] use aptos-transaction-builder instead of hand written functions

### DIFF
--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -237,14 +237,9 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn increase_lockup(
-        &self,
-        index: usize,
-        lockup_duration: Duration,
-    ) -> CliTypedResult<Transaction> {
+    pub async fn increase_lockup(&self, index: usize) -> CliTypedResult<Transaction> {
         IncreaseLockup {
             txn_options: self.transaction_options(index),
-            lockup_duration,
         }
         .execute()
         .await


### PR DESCRIPTION
hand written functions provide no guarantees and we can see that
increase lockup was actually broken.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2529)
<!-- Reviewable:end -->
