### PR TITLE
[community] Improve nav click behavior.

### DIFF
--- a/ecosystem/platform/server/app/components/header_component.html.erb
+++ b/ecosystem/platform/server/app/components/header_component.html.erb
@@ -7,18 +7,18 @@
   <nav class="hidden md:flex md:h-full items-center text-base flex-row flex-wrap md:justify-end mr-16 lg:mr-32 font-mono text-sm open:flex open:absolute open:max-h-[calc(100vh-4rem)] open:overflow-y-auto open:top-16 open:left-0 open:right-0 open:gap-2 open:p-10 open:bg-neutral-800 open:m-0" data-header-target="nav">
     <ul class="flex flex-col md:flex-row md:gap-8 w-full md:h-full">
     <% nav_groups.each do |group| %>
-      <li class="group py-4 first:pt-0 last:pb-0 md:first:pt-4 md:last:pb-4 relative md:flex items-center border-b border-neutral-700 last:border-none md:border-none" data-action="mouseover->header#navGroupHover">
-        <%= content_tag :a, group.item.name, href: group.item.url, title: group.item.title, class: 'text-base text-neutral-100 hover:text-teal-400 md:hover:text-white', target: group.item.url.starts_with?('http') ? '_blank' : '' %>
+      <li class="group py-4 first:pt-0 last:pb-0 md:first:pt-4 md:last:pb-4 relative md:flex items-center border-b border-neutral-700 last:border-none md:border-none" data-action="mouseover->header#navGroupHover click->header#navGroupToggle">
+        <%= content_tag :a, group.item.name, href: group.item.url, title: group.item.title, class: 'text-base text-neutral-100 hover:text-teal-400 md:hover:text-white', target: group.item.url.starts_with?('http') ? '_blank' : '', data: { action: group.item.url == '#' ? 'click->header#preventDefault' : nil } %>
         <% if group.children.length > 0 %>
         <div class="absolute hidden md:group-focus-within:flex md:group-hover:flex h-[3px] bottom-0 left-0 right-0 rounded bg-teal-400"></div>
-        <button class="md:hidden float-right mt-[5px] rotate-180" data-action="header#navGroupToggle">
+        <button class="md:hidden float-right mt-[5px] rotate-180">
           <%= render IconComponent.new(:accordion_arrow, size: :small) %>
         </button>
         <div class="hidden open:flex md:group-focus-within:flex md:group-hover:flex md:absolute md:top-full md:-ml-8">
           <ul class="flex-1 md:mt-[1px] md:bg-neutral-800 md:rounded md:p-8 md:min-w-[270px] md:shadow">
             <% group.children.each do |item| %>
               <li class="my-4 md:py-4 md:my-0 last:mb-0 text-base ml-4 md:ml-0 md:border-b border-neutral-700 last:border-none">
-                <%= content_tag :a, item.name, href: item.url, title: item.title, class: 'text-neutral-100 hover:text-teal-400', target: item.url.starts_with?('http') ? '_blank' : '' %>
+                <%= content_tag :a, item.name, href: item.url, title: item.title, class: 'text-neutral-100 hover:text-teal-400 block w-full', target: item.url.starts_with?('http') ? '_blank' : '' %>
               </li>
             <% end %>
           </ul>

--- a/ecosystem/platform/server/app/javascript/controllers/header_controller.ts
+++ b/ecosystem/platform/server/app/javascript/controllers/header_controller.ts
@@ -38,9 +38,11 @@ export default class extends Controller {
   }
 
   navGroupToggle(event: Event) {
-    if (!(event.target instanceof Element)) return;
-    const button = event.target?.closest('button');
+    if (!(event.currentTarget instanceof HTMLElement)) return;
+    const button = event.currentTarget.querySelector('button');
     if (!(button instanceof HTMLElement)) return;
+    if (button.offsetParent == null) return;
+    if (event.target instanceof HTMLAnchorElement && event.target.parentElement != event.currentTarget) return;
     button.classList.toggle('rotate-180');
     const navGroup = button.nextElementSibling;
     navGroup?.toggleAttribute("open");
@@ -50,5 +52,9 @@ export default class extends Controller {
     if (this.navTarget.hasAttribute('open')) {
       this.toggleNav();
     }
+  }
+
+  preventDefault(event: Event) {
+    event.preventDefault();
   }
 }


### PR DESCRIPTION
### Description

- Don't navigate to `#` when top-level links are clicked (exception - Currents)
- On mobile, toggle nav group when anywhere in the group is clicked, not just the toggle button (exception - don't toggle when nav items are clicked)
- Increase nav item click target to span the full width

### Test Plan
Tested manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2531)
<!-- Reviewable:end -->
