### PR TITLE
[Aptos Framework][Governance] Update voting power to take into account pending_inactive stake

### DIFF
--- a/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_block_transactions_work.json
+++ b/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_block_transactions_work.json
@@ -8,7 +8,7 @@
       "eventRootHash": "YPVlJld+KeJV8TgWig4e7McIG/o+rxMn60yg554WVK8=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "+frUKK1tqTQDiSDscNcfEnCgRHXRX3WzYPGZFbegB0c=",
+      "accumulatorRootHash": "DJwD1vywXfYH81YFO+4eRwl/8qx5qHRtX82owmq5Rhk=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -96,7 +96,7 @@
       "gasUsed": "41112",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "Raok5XaHEuw/DgmG++27qw3R6aMHAOGM/eVJ994si3c=",
+      "accumulatorRootHash": "oN+6BcMKulsaHxaMg+0dBIkVVn/Z10ElLFyxvPZdkac=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -225,7 +225,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "eTMY0bnqb1UA9vJ6mIW7lnaYcPEiWM3RX/mX8cn+PkQ="
+      "accumulatorRootHash": "QPYcjat45egxozSCjeSZKFyUuBeK/imrqmmNyuG/Sp8="
     },
     "blockHeight": "1",
     "type": "STATE_CHECKPOINT",

--- a/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_table_item_parsing_works.json
+++ b/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_table_item_parsing_works.json
@@ -8,7 +8,7 @@
       "eventRootHash": "YPVlJld+KeJV8TgWig4e7McIG/o+rxMn60yg554WVK8=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "+frUKK1tqTQDiSDscNcfEnCgRHXRX3WzYPGZFbegB0c=",
+      "accumulatorRootHash": "DJwD1vywXfYH81YFO+4eRwl/8qx5qHRtX82owmq5Rhk=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -96,7 +96,7 @@
       "gasUsed": "41112",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "Raok5XaHEuw/DgmG++27qw3R6aMHAOGM/eVJ994si3c=",
+      "accumulatorRootHash": "oN+6BcMKulsaHxaMg+0dBIkVVn/Z10ElLFyxvPZdkac=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -225,7 +225,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "eTMY0bnqb1UA9vJ6mIW7lnaYcPEiWM3RX/mX8cn+PkQ="
+      "accumulatorRootHash": "QPYcjat45egxozSCjeSZKFyUuBeK/imrqmmNyuG/Sp8="
     },
     "blockHeight": "1",
     "type": "STATE_CHECKPOINT",
@@ -240,7 +240,7 @@
       "eventRootHash": "xQa4qACFHx4YpbLjBVf8UKi4CXw95t7b2M90GQXvP8Y=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "7l+4R74xY84/TYdh6f/miZ7pn4TOMC1FnkaWZJ4LvHc=",
+      "accumulatorRootHash": "EatHQ3WGg/CkfAyRrG/RzFmYyd8hvZhvDSwQUP/1UuM=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -328,7 +328,7 @@
       "gasUsed": "4496",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "Ii62AdxObVnTHk6GCmKy2QajuQMXcLYpYPv4ch3uUFI=",
+      "accumulatorRootHash": "vxIEHhTn0UOxVczHStRzEWoyt2Hx8TTVNWrI5M2DXxU=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -947,7 +947,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "LKrTIC/x+CYcbDxr83jHzsOKP8l3tqt8AiZra4uC3lQ="
+      "accumulatorRootHash": "hOGrtkW6IhsI8ZVRpTWwaeJvSJFn3o/ShjY1ONuVNqs="
     },
     "blockHeight": "2",
     "type": "STATE_CHECKPOINT",
@@ -962,7 +962,7 @@
       "eventRootHash": "dliD7Dy093TZN3Zy5Vpvn9Jb7Q3dr30c4Jc4Sa/Z7Ew=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "lgrNeOB1v3saEUOMX7rkvqUN1s776kUMgxL1dAxmhzI=",
+      "accumulatorRootHash": "BW5hZslxLNDMwrREY9UK6wbihuaI+jDuxj4MwyPBvVY=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -1050,7 +1050,7 @@
       "gasUsed": "28029",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "GwkxYMlJ49S8cRn9Ih0i35oiPTI+cJ0JEv/ZE0hssjA=",
+      "accumulatorRootHash": "rj3VtsTHq7EMnCsSYW3Aoc+S3hok1q5gs5bnB/12S4M=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -1290,7 +1290,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "Fqyx7GdOAQ96rkoKDBo2eadPPist4CXL0via9IicvzQ="
+      "accumulatorRootHash": "kXbcwzNhfvbbxtio8ghrof5gU166DneLyh74pYqXf3k="
     },
     "blockHeight": "3",
     "type": "STATE_CHECKPOINT",


### PR DESCRIPTION
### Description

Currently for on chain governance voting, only an active validator's active stake is taken into account. This diverges from consensus where both active and pending_inactive stakes are counted. This is more of a problem now after we switch to the recurring lockup model in staking where pending_inactive can remain so for a long time (before it's cleared at the end of every epoch. Now it's only cleared at the end of the validator's lockup period). 

### Test Plan
Unit tests. Will add e2e tests for governance in a separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2532)
<!-- Reviewable:end -->
