### PR TITLE
[smoke-test] Try to fix flaky aptos_cli smoke test

### DIFF
--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -27,6 +27,7 @@ use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_crypto::{bls12381, x25519, PrivateKey};
 use aptos_genesis::config::HostAndPort;
 use aptos_keygen::KeyGen;
+use aptos_logger::warn;
 use aptos_rest_client::Transaction;
 use aptos_sdk::move_types::account_address::AccountAddress;
 use aptos_types::validator_info::ValidatorInfo;
@@ -50,9 +51,8 @@ impl CliTestFramework {
             endpoint,
             faucet_endpoint,
         };
-        let mut keygen = KeyGen::from_seed([9; 32]);
+        let mut keygen = KeyGen::from_os_rng();
 
-        // TODO: Make this allow a passed in random seed
         for _ in 0..num_accounts {
             framework
                 .add_cli_account(keygen.generate_ed25519_private_key())
@@ -74,6 +74,9 @@ impl CliTestFramework {
         let address = self.account_id(index);
         if client.get_account(address).await.is_err() {
             self.fund_account(index).await?;
+            warn!("Funded account {:?}", address);
+        } else {
+            warn!("Account {:?} already exists", address);
         }
 
         Ok(index)


### PR DESCRIPTION
Or at least add more logs to see why it is failing.

Basically one of the two cli accounts that we create don't have needed funding.

Not sure if we hit the same address as one of the nodes (so making it generate truly random addresses), or there is something else going on (like interaction with another test?). Tried a few times locally, it always succeeds. (12 failures in a day is probably very low failure rate to catch locally)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2537)
<!-- Reviewable:end -->
