### PR TITLE
Update CHANGELOG for TS SDK

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -1,117 +1,63 @@
-# Changelog
+# Aptos TS SDK Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to the Aptos Node SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-Note: This changelog is generated automatically.
+**Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
+## 1.3.2 (2022-08-04)
+This special entry does not conform to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) as there are noteworthy breaking changes with necessary rationale. Future entries will follow this format.
 
-### 1.3.1 (2022-08-04)
+This release updates the SDK to work with V1 of the Aptos Node API. There are some key changes between V0 and V1 that you can read about in the [API changelog](https://github.com/aptos-labs/aptos-core/blob/main/api/doc/v1/CHANGELOG.md), refer to the notes for version 1.0.0. Accordingly, this SDK version represents breaking changes compared to 1.2.1.
 
+- The SDK now communicates by default with the `/v1` path of the API. It will not work correctly with the v0 API. If you provide a path yourself when instantiating a client, make sure you include `/v1`, e.g. http://fullnode.devnet.aptoslabs.com/v1.
+- As of this release, the API, API spec, client generated from that spec, SDK wrapper, and examples are all tested together in CI. Previously it was possible for these to be out of sync, or in some cases, they would test against a different deployment entirely, such as devnet. Now we make the guarantee that all these pieces from the same commit work together. Notably this means exactly that; there is no guarantee that the latest version of the SDK will work with a particular Aptos network, such as devnet, except for a network built from the same commit as the SDK.
+- The generated client within the SDK is generated using a different tool, [openapi-typescript-codegen](https://www.npmjs.com/package/openapi-typescript-codegen). Most of these changes are transparent to the user, as we continue to wrap the generated client, but some of the generated types are different, which we mention here.
+- Token types are no longer exposed from the generated client (under `Types`) as they are no longer part of the API (indeed, they never truly were). Instead you can find these definitions exposed at `TokenTypes`.
+- Some functions, such as for getting account resources and events, no longer accept resource types as concatenated strings. For example:
+```tsx
+# Before:
+const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
+# After
+const aptosCoin = const aptosCoin = {
+    address: "0x1",
+    module: "coin",
+    name: "CoinStore",
+    generic_type_params: ["0x1::aptos_coin::AptosCoin"],
+};
+```
+- Similarly, some endpoints no longer return this data as a string, but in a structured format, e.g. `MoveStructTag`. Remember to use something like `lodash.isEqual` to do equality checks with these structs.
+- To help work with these different formats, functions for converting between them have been added to `utils`.
+- A new function, `waitForTransactionWithResult`, has been added to help wait for a transaction and then get access to the response from the server once the function exits.
 
-### Features
+For help with migration, we recommend you see the updated examples under `examples/`, they demonstrate how to deal with some of these changes, such as the more structured responses. We are also available to assist in the [Aptos Discord](https://discord.com/invite/aptoslabs).
 
-* add ABI interfaces to aptos client ([1d0fe29](https://github.com/aptos-labs/aptos-core/commit/1d0fe29cc4d2c7b9bd1b19f95059e532ef4a4936))
-* add abi support to TS SDK ([f0214b4](https://github.com/aptos-labs/aptos-core/commit/f0214b4deec4f3ab401782c7f4d793431f1f3e9c))
-* add UserTransaction and hashing capability ([9168969](https://github.com/aptos-labs/aptos-core/commit/916896947c629fe02588d5c5977bff2fecf587ac))
-* allow TransactionBuilder to build raw transactions with binary ABI ([fe0c325](https://github.com/aptos-labs/aptos-core/commit/fe0c325a3e853ba5bf809a3878a8edaa350a2068))
-* deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
-* expose more BCS helpers ([#2369](https://github.com/aptos-labs/aptos-core/issues/2369)) ([a733a9e](https://github.com/aptos-labs/aptos-core/commit/a733a9e49b639d70a089ca172c744e4725e13512))
-* memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
-* **mutiagent:** support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
-* reimplement type tag parser ([67473a1](https://github.com/aptos-labs/aptos-core/commit/67473a1c35616733442a38055aa2c0440aa1315f))
-* support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
-* **ts-sdk:** accepts string parameter as vec<u8> ([0daade4](https://github.com/aptos-labs/aptos-core/commit/0daade4f734d1ba29a896b00d7ddde2249e87970))
-* **ts-sdk:** add a transaction builder that supports ABI ([95296a7](https://github.com/aptos-labs/aptos-core/commit/95296a7b75c5765214005054975b71d5d2215263))
-* **ts-sdk:** e2e test for ABI interface ([edad199](https://github.com/aptos-labs/aptos-core/commit/edad1994b2e7501733256d20251e45b0d46646da))
-* update move to latest version ([23a953b](https://github.com/aptos-labs/aptos-core/commit/23a953b3f1a222a71d496222f0dcd8ce17fc8cac))
+**Deprecation Notice**: On September 1st we will remove the v0 API from the running nodes. As a user of the TS SDK, the best way you can migrate prior to this is by upgrading to version 1.3.2 or higher of the SDK. We will repeatedly remind developers of this upcoming deprecation as we approach that date.
 
-
-### Bug Fixes
-
-* get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
-* **ts-sdk:** fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
+## 1.3.1 (2022-08-04)
+See release notes for 1.3.2.
 
 ## 1.3.0 (2022-08-03)
+See release notes for 1.3.2.
 
-
-### Features
-
-* add ABI interfaces to aptos client ([1d0fe29](https://github.com/aptos-labs/aptos-core/commit/1d0fe29cc4d2c7b9bd1b19f95059e532ef4a4936))
-* add abi support to TS SDK ([f0214b4](https://github.com/aptos-labs/aptos-core/commit/f0214b4deec4f3ab401782c7f4d793431f1f3e9c))
-* add UserTransaction and hashing capability ([9168969](https://github.com/aptos-labs/aptos-core/commit/916896947c629fe02588d5c5977bff2fecf587ac))
-* allow TransactionBuilder to build raw transactions with binary ABI ([fe0c325](https://github.com/aptos-labs/aptos-core/commit/fe0c325a3e853ba5bf809a3878a8edaa350a2068))
-* deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
-* expose more BCS helpers ([#2369](https://github.com/aptos-labs/aptos-core/issues/2369)) ([a733a9e](https://github.com/aptos-labs/aptos-core/commit/a733a9e49b639d70a089ca172c744e4725e13512))
-* memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
-* **mutiagent:** support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
-* reimplement type tag parser ([67473a1](https://github.com/aptos-labs/aptos-core/commit/67473a1c35616733442a38055aa2c0440aa1315f))
-* support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
-* **ts-sdk:** accepts string parameter as vec<u8> ([0daade4](https://github.com/aptos-labs/aptos-core/commit/0daade4f734d1ba29a896b00d7ddde2249e87970))
-* **ts-sdk:** add a transaction builder that supports ABI ([95296a7](https://github.com/aptos-labs/aptos-core/commit/95296a7b75c5765214005054975b71d5d2215263))
-* **ts-sdk:** e2e test for ABI interface ([edad199](https://github.com/aptos-labs/aptos-core/commit/edad1994b2e7501733256d20251e45b0d46646da))
-* update move to latest version ([23a953b](https://github.com/aptos-labs/aptos-core/commit/23a953b3f1a222a71d496222f0dcd8ce17fc8cac))
-
-
-### Bug Fixes
-
-* get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
-* **ts-sdk:** fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
-
-### 1.2.2 (2022-07-27)
-
+## 1.2.1 (2022-07-23)
+**Note:** This entry and earlier do not conform to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Features
-
-* add ABI interfaces to aptos client ([1d0fe29](https://github.com/aptos-labs/aptos-core/commit/1d0fe29cc4d2c7b9bd1b19f95059e532ef4a4936))
-* add abi support to TS SDK ([f0214b4](https://github.com/aptos-labs/aptos-core/commit/f0214b4deec4f3ab401782c7f4d793431f1f3e9c))
-* add UserTransaction and hashing capability ([9168969](https://github.com/aptos-labs/aptos-core/commit/916896947c629fe02588d5c5977bff2fecf587ac))
-* allow TransactionBuilder to build raw transactions with binary ABI ([fe0c325](https://github.com/aptos-labs/aptos-core/commit/fe0c325a3e853ba5bf809a3878a8edaa350a2068))
-* deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
-* memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
-* **mutiagent:** support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
-* reimplement type tag parser ([67473a1](https://github.com/aptos-labs/aptos-core/commit/67473a1c35616733442a38055aa2c0440aa1315f))
-* support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
-* **ts-sdk:** accepts string parameter as vec<u8> ([0daade4](https://github.com/aptos-labs/aptos-core/commit/0daade4f734d1ba29a896b00d7ddde2249e87970))
-* **ts-sdk:** add a transaction builder that supports ABI ([95296a7](https://github.com/aptos-labs/aptos-core/commit/95296a7b75c5765214005054975b71d5d2215263))
-* **ts-sdk:** e2e test for ABI interface ([edad199](https://github.com/aptos-labs/aptos-core/commit/edad1994b2e7501733256d20251e45b0d46646da))
-* update move to latest version ([23a953b](https://github.com/aptos-labs/aptos-core/commit/23a953b3f1a222a71d496222f0dcd8ce17fc8cac))
-
+- Deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
+- Memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
+- **Multiagent:** Support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
+- Support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
 
 ### Bug Fixes
-
-* get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
-* **ts-sdk:** fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
-
-### 1.2.1 (2022-07-23)
-
-
-### Features
-
-* deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
-* memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
-* **mutiagent:** support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
-* support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
-
-
-### Bug Fixes
-
-* get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
-* **ts-sdk:** fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
+- Get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
 
 ## 1.2.0 (2022-06-28)
-
 ### Features
-
-- deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
-- memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
-- **mutiagent:** support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
-- support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
-- vector tests for transaction signing ([6210c10](https://github.com/aptos-labs/aptos-core/commit/6210c10d3192fd0417b35709545fae850099e4d4))
-- add royalty support for NFT tokens ([93a2cd0](https://github.com/aptos-labs/aptos-core/commit/93a2cd0bfd644725ac524f419e94077e0b16343b))
-- add transaction builder examples ([a710a50](https://github.com/aptos-labs/aptos-core/commit/a710a50e8177258d9c0766762b3c2959fc231259))
-- support transaction simulation ([93073bf](https://github.com/aptos-labs/aptos-core/commit/93073bf1b508d00cfa1f8bb441ed57085fd08a82))
+- Vector tests for transaction signing ([6210c10](https://github.com/aptos-labs/aptos-core/commit/6210c10d3192fd0417b35709545fae850099e4d4))
+- Add royalty support for NFT tokens ([93a2cd0](https://github.com/aptos-labs/aptos-core/commit/93a2cd0bfd644725ac524f419e94077e0b16343b))
+- Add transaction builder examples ([a710a50](https://github.com/aptos-labs/aptos-core/commit/a710a50e8177258d9c0766762b3c2959fc231259))
+- Support transaction simulation ([93073bf](https://github.com/aptos-labs/aptos-core/commit/93073bf1b508d00cfa1f8bb441ed57085fd08a82))
 
 ### Bug Fixes
-
-- **ts-sdk:** fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
+- Fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
 - Fix Javascript example ([5781fee](https://github.com/aptos-labs/aptos-core/commit/5781fee74b8f2b065e7f04c2f76952026860751d)), closes [#1405](https://github.com/aptos-labs/aptos-core/issues/1405)

--- a/ecosystem/typescript/sdk/README.md
+++ b/ecosystem/typescript/sdk/README.md
@@ -93,6 +93,6 @@ yarn lint
 yarn fmt
 ```
 
-3. Ensure your commit message adheres to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. TODO, provide an example of how to do this, this is not very well known.
-4. Bump the version in `package.json` according to [semver](https://semver.org/).
-5. Once you're confident everything is correct, submit your PR. Once it is approved and lands in main, CI will detect that the version has changed, build a new package, generate a changelog update, and upload it automatically.
+3. Bump the version in `package.json` according to [semver](https://semver.org/).
+4. Add an entry in the CHANGELOG for the version. We adhere to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+5. Once you're confident everything is correct, submit your PR. The CI will ensure that you have followed all the previous steps, specifically ensuring that the API, API spec, and SDK client are all compatible, that you've updated the changelog, that the tests pass, etc. Once it is approved and lands in main, CI will detect that the version has changed, build a new package, and upload it automatically to npmjs.

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -15,7 +15,6 @@
     "fmt": "yarn _fmt --write",
     "fmt:check": "yarn _fmt --check",
     "cov:clean": "rm -rf coverage",
-    "changelog": "standard-version --skip.bump --skip.commit --skip.tag",
     "generate-client": "openapi -i ../../../api/doc/v1/spec.yaml -o ./src/generated -c axios --name AptosGeneratedClient --exportSchemas true",
     "checked-publish": "./checked_publish.sh"
   },
@@ -63,5 +62,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/ecosystem/typescript/sdk/src/index.ts
+++ b/ecosystem/typescript/sdk/src/index.ts
@@ -4,6 +4,7 @@ export * from "./hex_string";
 export * from "./aptos_client";
 export * from "./faucet_client";
 export * from "./token_client";
+export * as TokenTypes from "./token_types";
 export * as Types from "./generated/index";
 export * as TransactionBuilder from "./transaction_builder";
 export * as TxnBuilderTypes from "./transaction_builder/aptos_types";


### PR DESCRIPTION
## Description
The current changelog is a total mess because the tool we're using doesn't seem to be able to figure out which commits belong in which version. Beyond that the formatting is gross. Then beyond that, building your changelog out of just git commits is not a great user experience (https://keepachangelog.com/en/1.0.0/).

In this PR I rewrite the changelog manually for now until we come up with a better solution.

## Test Plan
```
./check.sh
```
Then CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2543)
<!-- Reviewable:end -->
