### PR TITLE
[forge] Remove duplicate continuous job, increase frequency, reduce duration

### DIFF
--- a/.github/workflows/pre-release-continuous-test.yaml
+++ b/.github/workflows/pre-release-continuous-test.yaml
@@ -10,8 +10,8 @@ on:
     branches:
       - pre-release-continuous-test
   schedule:
-    # Run every 2 hours - TODO: Decrease the frequency once things stabilizes
-    - cron: "0 */2 * * *"
+    # Run every hour - TODO: Decrease the frequency once things stabilizes
+    - cron: "0 */1 * * *"
 
 jobs:
   # run two concurrent forge test jobs on the same cluster
@@ -22,11 +22,17 @@ jobs:
     with:
       FORGE_NAMESPACE: forge-continuous-0
       FORGE_CLUSTER_NAME: aptos-forge-1
-      FORGE_RUNNER_DURATION_SECS: 2700  # Run for 45 minutes for now
-  run-forge-1:
-    uses: ./.github/workflows/run-forge.yaml
-    secrets: inherit
-    with:
-      FORGE_NAMESPACE: forge-continuous-1
-      FORGE_CLUSTER_NAME: aptos-forge-1
-      FORGE_RUNNER_DURATION_SECS: 2700  # Run for 45 minutes for now
+      # Run for 30 minutes
+      FORGE_RUNNER_DURATION_SECS: 1800
+      # We expect slightly lower tps on longer timeline
+      FORGE_RUNNER_TPS_THRESHOLD: 5000
+  # Example new forge nightly test, simply add this block below to schedule your own forge job
+  # run-forge-example:
+  #   uses: ./.github/workflows/run-forge.yaml
+  #   secrets: inherit
+  #   with:
+  #     FORGE_NAMESPACE: forge-continuous-1
+  #     FORGE_CLUSTER_NAME: aptos-forge-1
+  #     FORGE_RUNNER_DURATION_SECS: 2700  # Run for 45 minutes for now
+  #     # We expect slightly lower tps on longer timeline
+  #     FORGE_RUNNER_TPS_THRESHOLD: 5000

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -22,6 +22,11 @@ on:
         type: string
         default: 480
         description: Duration of the forge test run
+      FORGE_RUNNER_TPS_THRESHOLD:
+        required: false
+        type: string
+        default: 6000
+        description: Minimum required avg tps to pass forge
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
@@ -38,7 +43,7 @@ env:
   FORGE_PRE_COMMENT: forge_pre_comment.txt
   FORGE_RUNNER_MODE: k8s
   FORGE_RUNNER_DURATION_SECS: ${{ inputs.FORGE_RUNNER_DURATION_SECS }}
-  FORGE_RUNNER_TPS_THRESHOLD: 6000
+  FORGE_RUNNER_TPS_THRESHOLD: ${{ inputs.FORGE_RUNNER_TPS_THRESHOLD }}
   FORGE_NAMESPACE: ${{ inputs.FORGE_NAMESPACE }}
 
 jobs:


### PR DESCRIPTION
Remove duplicate continuous job, instead make it the template for adding a new continuous test

Adding new continuous test is going to also require plumbing suite name through which is not set yet but I'm trying to KISS

Also reduce the continuous TPS success criteria because we want to be able to reasonably success and expectations for TPS in longer run is lower than shorter run. Not that that is noit a problem, but for now set a realistic goal for success.

Test Plan:

gh workflow run -r forgery pre-release-continuous-test.yaml

https://github.com/aptos-labs/aptos-core/actions/runs/2799804929

#e2e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2544)
<!-- Reviewable:end -->
