### PR TITLE
[forge] support K8SNode start,stop,clear_storage and metrics port

### DIFF
--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-values.yaml
@@ -1,4 +1,6 @@
 # This file is loaded in by Forge test runner at runtime and templated
+# These are meant to be Forge-specific overrides. If you have a new config, please add
+# it to the base helm values at terraform/helm/aptos-node/values.yaml
 
 # the number of validators to deploy
 numValidators: {num_validators}

--- a/testsuite/forge/src/backend/k8s/helm-values/genesis-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/genesis-values.yaml
@@ -1,4 +1,6 @@
 # This file is loaded in by Forge test runner at runtime and templated
+# These are meant to be Forge-specific overrides. If you have a new config, please add
+# it to the base helm values at terraform/helm/genesis/values.yaml
 
 imageTag: {image_tag}
 

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -223,7 +223,7 @@ impl Node for LocalNode {
         self.start()
     }
 
-    fn stop(&mut self) -> Result<()> {
+    async fn stop(&mut self) -> Result<()> {
         self.stop();
         Ok(())
     }

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -55,7 +55,7 @@ pub trait Node: Send + Sync {
 
     /// Stop this Node.
     /// This should be a noop if the Node isn't running.
-    fn stop(&mut self) -> Result<()>;
+    async fn stop(&mut self) -> Result<()>;
 
     /// Clears this Node's Storage
     fn clear_storage(&mut self) -> Result<()>;
@@ -143,7 +143,7 @@ pub trait NodeExt: Node {
 
     /// Restarts this Node by calling Node::Stop followed by Node::Start
     async fn restart(&mut self) -> Result<()> {
-        self.stop()?;
+        self.stop().await?;
         self.start().await
     }
 

--- a/testsuite/testcases/src/forge_setup_test.rs
+++ b/testsuite/testcases/src/forge_setup_test.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::thread;
+
+use aptos_logger::info;
+use forge::{FullNode, NetworkContext, NetworkTest, Result, Test};
+use rand::{
+    rngs::{OsRng, StdRng},
+    seq::IteratorRandom,
+    Rng, SeedableRng,
+};
+use tokio::runtime::Runtime;
+
+const STATE_SYNC_VERSION_COUNTER_NAME: &str = "aptos_state_sync_version";
+
+pub struct ForgeSetupTest;
+
+impl Test for ForgeSetupTest {
+    fn name(&self) -> &'static str {
+        "verify_forge_setup"
+    }
+}
+
+async fn wipe_fullnode(fullnode: &mut dyn FullNode) -> Result<()> {
+    fullnode.stop().await?;
+    info!("Clear its storage");
+    fullnode.clear_storage()?;
+    info!("Start it up again");
+    if let Err(e) = fullnode.start().await {
+        info!("Error on fullnode startup: {}", e);
+    } else {
+        info!("Fullnode started successfully");
+    }
+    Ok(())
+}
+
+impl NetworkTest for ForgeSetupTest {
+    fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        let mut rng = StdRng::from_seed(OsRng.gen());
+        let runtime = Runtime::new().unwrap();
+
+        let swarm = ctx.swarm();
+
+        let all_fullnodes = swarm.full_nodes().map(|v| v.peer_id()).collect::<Vec<_>>();
+        let fullnode_id = all_fullnodes.iter().choose(&mut rng).unwrap();
+
+        info!("Pick one fullnode to stop");
+        let fullnode = swarm.full_node_mut(*fullnode_id).unwrap();
+        runtime.block_on(wipe_fullnode(fullnode))?;
+
+        let fullnode = swarm.full_node(*fullnode_id).unwrap();
+        let fullnode_name = fullnode.name();
+
+        for _ in 0..10 {
+            let query = format!(
+                "{}{{instance=\"{}\",type=\"synced\"}}",
+                STATE_SYNC_VERSION_COUNTER_NAME, &fullnode_name
+            );
+            info!("PromQL Query {}", query);
+            let r = runtime.block_on(swarm.query_metrics(&query, None, None))?;
+            let ivs = r.as_instant().unwrap();
+            for iv in ivs {
+                info!(
+                    "{}: {}",
+                    STATE_SYNC_VERSION_COUNTER_NAME,
+                    iv.sample().value()
+                );
+            }
+            thread::sleep(std::time::Duration::from_secs(5));
+        }
+
+        Ok(())
+    }
+}

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod compatibility_test;
+pub mod forge_setup_test;
 pub mod gas_price_test;
 pub mod network_bandwidth_test;
 pub mod network_latency_test;

--- a/testsuite/testcases/src/partial_nodes_down_test.rs
+++ b/testsuite/testcases/src/partial_nodes_down_test.rs
@@ -16,6 +16,7 @@ impl Test for PartialNodesDown {
 
 impl NetworkTest for PartialNodesDown {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        let runtime = Runtime::new()?;
         let duration = Duration::from_secs(120);
         let all_validators = ctx
             .swarm()
@@ -27,7 +28,7 @@ impl NetworkTest for PartialNodesDown {
         for n in &down_nodes {
             let node = ctx.swarm().validator_mut(*n).unwrap();
             println!("Node {} is going to stop", node.name());
-            node.stop()?;
+            runtime.block_on(node.stop())?;
         }
         thread::sleep(Duration::from_secs(5));
 
@@ -35,7 +36,6 @@ impl NetworkTest for PartialNodesDown {
         let txn_stat = generate_traffic(ctx, &up_nodes, duration, 1)?;
         ctx.report
             .report_txn_stats(self.name().to_string(), &txn_stat, duration);
-        let runtime = Runtime::new()?;
         for n in &down_nodes {
             let node = ctx.swarm().validator_mut(*n).unwrap();
             println!("Node {} is going to restart", node.name());


### PR DESCRIPTION
### Description

Resurrect the ability to start, stop (reboot), and clear the storage for `K8sNode`. This will help in getting the state sync performance tests back! (and other tests that require poking running nodes)

A few changes to how this works vs how it was done previously:
* `Node::stop` is now `async`, and guarantees that the process has completely stopped, rather than just issuing to the API that it will stop.
* Use the kube API directly, mostly to scale the underlying `StatefulSet`, rather than issuing calls to `kubectl` 
* When the `StatefulSet` status is unavailable, try to get the underlying `Pod` status. This will tell us whether things are `Pending` (e.g. sometimes indefinitely in case of autoscaler issue), etc.

Bonus:
* Also start to add back the ability to query metrics directly off of a node's metrics port. Ideally, we should be able to get metrics now off of the metrics port, as well as a prometheus server. The latter is not available in the Forge local backend, so the former is preferred when writing tests that target both backends. It's not a high priority atm though
* General cleanup and more descriptive errors and logs

### Test Plan

Wrote a `forge_setup_test` test in Forge that does a basic fullnode wipe and reboot, and checks prometheus for state sync progress. I'll use this test for testing some more core Forge infra interactions. It will also serve as an example test that uses many Forge features.

```
$ FORGE_RUNNER_MODE=local FORGE_NAMESPACE=forge-rustielin FORGE_TEST_SUITE=setup_test ./testsuite/run_forge.sh
...
2022-08-08T17:29:30.443820Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-10-validator has phase Pending
2022-08-08T17:29:31.523808Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-10-validator has phase Pending
2022-08-08T17:29:33.108172Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-10-validator has phase Pending
2022-08-08T17:29:35.441493Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-10-validator has phase Pending
2022-08-08T17:29:38.899020Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-10-validator has phase Pending
2022-08-08T17:29:44.042776Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-10-validator has phase Running
2022-08-08T17:29:51.680135Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-10-validator has scaled to 1
2022-08-08T17:29:51.717869Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-17-validator has scaled to 1
2022-08-08T17:29:51.751941Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-19-validator has scaled to 1
2022-08-08T17:29:51.786097Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-15-validator has scaled to 1
2022-08-08T17:29:51.822080Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-8-validator has scaled to 1
2022-08-08T17:29:51.856816Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-7-validator has scaled to 1
2022-08-08T17:29:51.893247Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-9-validator has scaled to 1
2022-08-08T17:29:51.928666Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-18-validator has scaled to 1
2022-08-08T17:29:51.962904Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-24-validator has scaled to 1
2022-08-08T17:29:51.997576Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-1-validator has scaled to 1
2022-08-08T17:29:52.032243Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-13-validator has scaled to 1
2022-08-08T17:29:52.067627Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-11-validator has scaled to 1
2022-08-08T17:29:52.102837Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-22-validator has scaled to 1
2022-08-08T17:29:52.137601Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-14-validator has scaled to 1
2022-08-08T17:29:52.173272Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-25-validator has scaled to 1
2022-08-08T17:29:52.209817Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-5-validator has scaled to 1
2022-08-08T17:29:52.245039Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-16-validator has scaled to 1
2022-08-08T17:29:52.280674Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-27-validator has scaled to 1
2022-08-08T17:29:52.316590Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-21-validator has scaled to 1
2022-08-08T17:29:52.351101Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-2-validator has scaled to 1
2022-08-08T17:29:52.386659Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-20-validator has scaled to 1
2022-08-08T17:29:52.422493Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-0-validator has scaled to 1
2022-08-08T17:29:52.457331Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-26-validator has scaled to 1
2022-08-08T17:29:52.491708Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-4-validator has scaled to 1
2022-08-08T17:29:52.528442Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-3-validator has scaled to 1
2022-08-08T17:29:52.563872Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-12-validator has scaled to 1
2022-08-08T17:29:52.597898Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-23-validator has scaled to 1
2022-08-08T17:29:52.634693Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-6-validator has scaled to 1
2022-08-08T17:29:52.669818Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-29-validator has scaled to 1
2022-08-08T17:29:52.703126Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-28-validator has scaled to 1
2022-08-08T17:29:52.894880Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-0-fullnode-eforge142 has scaled to 1
2022-08-08T17:29:53.896013Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-10 @ 127.0.0.1 from 49477 --> 8080
2022-08-08T17:29:54.911486Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-17 @ 127.0.0.1 from 49484 --> 8080
2022-08-08T17:29:55.923289Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-19 @ 127.0.0.1 from 49486 --> 8080
2022-08-08T17:29:56.937275Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-15 @ 127.0.0.1 from 49482 --> 8080
2022-08-08T17:29:57.952740Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-8 @ 127.0.0.1 from 49503 --> 8080
2022-08-08T17:29:58.969376Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-7 @ 127.0.0.1 from 49502 --> 8080
2022-08-08T17:29:59.986370Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-9 @ 127.0.0.1 from 49504 --> 8080
2022-08-08T17:30:00.995164Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-18 @ 127.0.0.1 from 49485 --> 8080
2022-08-08T17:30:02.008857Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-24 @ 127.0.0.1 from 49492 --> 8080
2022-08-08T17:30:03.022567Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-1 @ 127.0.0.1 from 49476 --> 8080
2022-08-08T17:30:04.028744Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-13 @ 127.0.0.1 from 49480 --> 8080
2022-08-08T17:30:05.034419Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-11 @ 127.0.0.1 from 49478 --> 8080
2022-08-08T17:30:06.050200Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-22 @ 127.0.0.1 from 49490 --> 8080
2022-08-08T17:30:07.065397Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-14 @ 127.0.0.1 from 49481 --> 8080
2022-08-08T17:30:08.074945Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-25 @ 127.0.0.1 from 49493 --> 8080
2022-08-08T17:30:09.081160Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-5 @ 127.0.0.1 from 49500 --> 8080
2022-08-08T17:30:10.091799Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-16 @ 127.0.0.1 from 49483 --> 8080
2022-08-08T17:30:11.099800Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-27 @ 127.0.0.1 from 49495 --> 8080
2022-08-08T17:30:12.109271Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-21 @ 127.0.0.1 from 49489 --> 8080
2022-08-08T17:30:13.117258Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-2 @ 127.0.0.1 from 49487 --> 8080
2022-08-08T17:30:14.132079Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-20 @ 127.0.0.1 from 49488 --> 8080
2022-08-08T17:30:15.143432Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-0 @ 127.0.0.1 from 49475 --> 8080
2022-08-08T17:30:16.150373Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-26 @ 127.0.0.1 from 49494 --> 8080
2022-08-08T17:30:17.166936Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-4 @ 127.0.0.1 from 49499 --> 8080
2022-08-08T17:30:18.172970Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-3 @ 127.0.0.1 from 49498 --> 8080
2022-08-08T17:30:19.188433Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-12 @ 127.0.0.1 from 49479 --> 8080
2022-08-08T17:30:20.204988Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-23 @ 127.0.0.1 from 49491 --> 8080
2022-08-08T17:30:21.215779Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-6 @ 127.0.0.1 from 49501 --> 8080
2022-08-08T17:30:22.230620Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-29 @ 127.0.0.1 from 49497 --> 8080
2022-08-08T17:30:23.238716Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for validator-28 @ 127.0.0.1 from 49496 --> 8080
2022-08-08T17:30:24.241248Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for fullnode-0 @ 127.0.0.1 from 49532 --> 8080
2022-08-08T17:30:24.442259Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-10 healthy @ version 255 > 100
2022-08-08T17:30:24.539893Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-17 healthy @ version 257 > 100
2022-08-08T17:30:24.805920Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-19 healthy @ version 259 > 100
2022-08-08T17:30:24.931604Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-15 healthy @ version 261 > 100
2022-08-08T17:30:25.032955Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-8 healthy @ version 261 > 100
2022-08-08T17:30:25.329392Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-7 healthy @ version 263 > 100
2022-08-08T17:30:25.431017Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-9 healthy @ version 265 > 100
2022-08-08T17:30:25.551549Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-18 healthy @ version 267 > 100
2022-08-08T17:30:25.662201Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-24 healthy @ version 269 > 100
2022-08-08T17:30:25.937707Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-1 healthy @ version 271 > 100
2022-08-08T17:30:26.053176Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-13 healthy @ version 273 > 100
2022-08-08T17:30:26.152855Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-11 healthy @ version 273 > 100
2022-08-08T17:30:26.476220Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-22 healthy @ version 277 > 100
2022-08-08T17:30:26.599367Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-14 healthy @ version 277 > 100
2022-08-08T17:30:26.715264Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-25 healthy @ version 279 > 100
2022-08-08T17:30:26.970361Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-5 healthy @ version 281 > 100
2022-08-08T17:30:27.078152Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-16 healthy @ version 283 > 100
2022-08-08T17:30:27.182881Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-27 healthy @ version 283 > 100
2022-08-08T17:30:27.505568Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-21 healthy @ version 287 > 100
2022-08-08T17:30:27.623647Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-2 healthy @ version 289 > 100
2022-08-08T17:30:27.723355Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-20 healthy @ version 289 > 100
2022-08-08T17:30:27.984765Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-0 healthy @ version 291 > 100
2022-08-08T17:30:28.097350Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-26 healthy @ version 293 > 100
2022-08-08T17:30:28.198572Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-4 healthy @ version 293 > 100
2022-08-08T17:30:28.513869Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-3 healthy @ version 297 > 100
2022-08-08T17:30:28.625604Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-12 healthy @ version 299 > 100
2022-08-08T17:30:28.730429Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-23 healthy @ version 299 > 100
2022-08-08T17:30:28.838192Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-6 healthy @ version 301 > 100
2022-08-08T17:30:29.084674Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-29 healthy @ version 303 > 100
2022-08-08T17:30:29.189275Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node validator-28 healthy @ version 305 > 100
2022-08-08T17:30:29.286798Z [main] INFO testsuite/forge/src/backend/k8s/swarm.rs:469 Node fullnode-0 healthy @ version 305 > 100
2022-08-08T17:30:29.677614Z [main] INFO testsuite/forge/src/backend/k8s/prometheus.rs:14 Attempting to create prometheus client with: http://127.0.0.1:9090
2022-08-08T17:30:29.679015Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:48 Pick one fullnode to stop
2022-08-08T17:30:29.679098Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:180 going to stop node aptos-node-0-fullnode-eforge142
2022-08-08T17:30:31.537073Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-0-fullnode-eforge142 has scaled to 0
2022-08-08T17:30:31.537340Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:27 Clear its storage
2022-08-08T17:30:31.537397Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:192 ["delete", "pvc", "fn-aptos-node-0-fullnode-eforge142-0"]
persistentvolumeclaim "fn-aptos-node-0-fullnode-eforge142-0" deleted
2022-08-08T17:30:32.260799Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:29 Start it up again
2022-08-08T17:30:32.863834Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-0-fullnode-eforge142 has phase Pending
2022-08-08T17:30:33.950844Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-0-fullnode-eforge142 has phase Pending
2022-08-08T17:30:35.533906Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-0-fullnode-eforge142 has phase Pending
2022-08-08T17:30:37.890456Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-0-fullnode-eforge142 has phase Pending
2022-08-08T17:30:41.347527Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-0-fullnode-eforge142 has phase Pending
2022-08-08T17:30:46.495896Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:195 StatefulSet aptos-node-0-fullnode-eforge142 has phase Running
2022-08-08T17:30:54.204572Z [main] INFO testsuite/forge/src/backend/k8s/cluster_helper.rs:182 StatefulSet aptos-node-0-fullnode-eforge142 has scaled to 1
2022-08-08T17:30:55.217679Z [main] INFO testsuite/forge/src/backend/k8s/node.rs:99 Port-forward started for fullnode-0 @ 127.0.0.1 from 49887 --> 8080
2022-08-08T17:30:55.847349Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:33 Fullnode started successfully
2022-08-08T17:30:55.847565Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:30:56.014170Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 263
2022-08-08T17:31:01.024390Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:01.105920Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 611
2022-08-08T17:31:06.114692Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:06.199541Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 611
2022-08-08T17:31:11.209363Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:11.284166Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 611
2022-08-08T17:31:16.295813Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:16.374990Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 765
2022-08-08T17:31:21.383840Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:21.454824Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 765
2022-08-08T17:31:26.463862Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:26.533355Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 765
2022-08-08T17:31:31.543172Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:31.616246Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 919
2022-08-08T17:31:36.621192Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:36.699543Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 919
2022-08-08T17:31:41.709205Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:60 PromQL Query aptos_state_sync_version{instance="fullnode-0",type="synced"}
2022-08-08T17:31:41.781708Z [main] INFO testsuite/testcases/src/forge_setup_test.rs:64 aptos_state_sync_version: 919
test verify_forge_setup ... ok
```

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2545)
<!-- Reviewable:end -->
