### PR TITLE
[aptos-rosetta/aptos-cli] Fix Gas price handling

### DIFF
--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions};
+use aptos_rest_client::aptos_api_types::HashValue;
 use aptos_rest_client::{
     aptos_api_types::{WriteResource, WriteSetChange},
     Transaction,
@@ -49,35 +50,29 @@ const SUPPORTED_COINS: [&str; 2] = [
 ];
 
 /// A shortened transaction output
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct TransferSummary {
-    pub gas_used: Option<u64>,
+    pub gas_unit_price: u64,
+    pub gas_used: u64,
     pub balance_changes: BTreeMap<AccountAddress, serde_json::Value>,
-    pub sender: Option<AccountAddress>,
+    pub sender: AccountAddress,
     pub success: bool,
-    pub version: Option<u64>,
+    pub version: u64,
     pub vm_status: String,
+    pub transaction_hash: HashValue,
 }
 
 impl From<Transaction> for TransferSummary {
     fn from(transaction: Transaction) -> Self {
-        let mut summary = TransferSummary {
-            success: transaction.success(),
-            version: transaction.version(),
-            vm_status: transaction.vm_status(),
-            ..Default::default()
-        };
-
         if let Transaction::UserTransaction(txn) = transaction {
-            summary.sender = Some(*txn.request.sender.inner());
-            summary.gas_used = Some(
-                txn.info
-                    .gas_used
-                    .0
-                    .saturating_mul(txn.request.gas_unit_price.0),
-            );
-            summary.version = Some(txn.info.version.0);
-            summary.balance_changes = txn
+            let vm_status = txn.info.vm_status;
+            let success = txn.info.success;
+            let sender = *txn.request.sender.inner();
+            let gas_unit_price = txn.request.gas_unit_price.0;
+            let gas_used = txn.info.gas_used.0;
+            let transaction_hash = txn.info.hash;
+            let version = txn.info.version.0;
+            let balance_changes = txn
                 .info
                 .changes
                 .iter()
@@ -95,8 +90,19 @@ impl From<Transaction> for TransferSummary {
                     _ => None,
                 })
                 .collect();
-        }
 
-        summary
+            TransferSummary {
+                gas_unit_price,
+                gas_used,
+                balance_changes,
+                sender,
+                success,
+                version,
+                vm_status,
+                transaction_hash,
+            }
+        } else {
+            panic!("Can't call From<Transaction> for a non UserTransaction")
+        }
     }
 }

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -70,7 +70,12 @@ impl From<Transaction> for TransferSummary {
 
         if let Transaction::UserTransaction(txn) = transaction {
             summary.sender = Some(*txn.request.sender.inner());
-            summary.gas_used = Some(txn.info.gas_used.0);
+            summary.gas_used = Some(
+                txn.info
+                    .gas_used
+                    .0
+                    .saturating_mul(txn.request.gas_unit_price.0),
+            );
             summary.version = Some(txn.info.version.0);
             summary.balance_changes = txn
                 .info

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{account_address_from_public_key, FaucetOptions};
+use crate::common::types::{account_address_from_public_key, FaucetOptions, GasOptions};
 use crate::node::{
     AddStake, IncreaseLockup, JoinValidatorSet, LeaveValidatorSet, OperatorArgs,
     RegisterValidatorCandidate, ShowValidatorConfig, ShowValidatorSet, ShowValidatorStake,
@@ -36,6 +36,8 @@ use reqwest::Url;
 use serde_json::Value;
 use std::{str::FromStr, time::Duration};
 use tokio::time::{sleep, Instant};
+
+pub const INVALID_ACCOUNT: &str = "0xDEADBEEFCAFEBABE";
 
 /// A framework for testing the CLI
 pub struct CliTestFramework {
@@ -73,7 +75,7 @@ impl CliTestFramework {
         let client = aptos_rest_client::Client::new(self.endpoint.clone());
         let address = self.account_id(index);
         if client.get_account(address).await.is_err() {
-            self.fund_account(index).await?;
+            self.fund_account(index, None).await?;
             warn!("Funded account {:?}", address);
         } else {
             warn!("Account {:?} already exists", address);
@@ -121,12 +123,12 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn fund_account(&self, index: usize) -> CliTypedResult<String> {
+    pub async fn fund_account(&self, index: usize, amount: Option<u64>) -> CliTypedResult<String> {
         FundAccount {
             profile_options: Default::default(),
             account: self.account_id(index),
             faucet_options: self.faucet_options(),
-            num_coins: DEFAULT_FUNDED_COINS,
+            num_coins: amount.unwrap_or(DEFAULT_FUNDED_COINS),
         }
         .execute()
         .await
@@ -148,10 +150,26 @@ impl CliTestFramework {
         sender_index: usize,
         receiver_index: usize,
         amount: u64,
+        gas_options: Option<GasOptions>,
     ) -> CliTypedResult<TransferSummary> {
         TransferCoins {
-            txn_options: self.transaction_options(sender_index),
+            txn_options: self.transaction_options(sender_index, gas_options),
             account: self.account_id(receiver_index),
+            amount,
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn transfer_invalid_addr(
+        &self,
+        sender_index: usize,
+        amount: u64,
+        gas_options: Option<GasOptions>,
+    ) -> CliTypedResult<TransferSummary> {
+        TransferCoins {
+            txn_options: self.transaction_options(sender_index, gas_options),
+            account: AccountAddress::from_hex_literal(INVALID_ACCOUNT).unwrap(),
             amount,
         }
         .execute()
@@ -198,7 +216,7 @@ impl CliTestFramework {
         validator_network_public_key: x25519::PublicKey,
     ) -> CliTypedResult<Transaction> {
         RegisterValidatorCandidate {
-            txn_options: self.transaction_options(index),
+            txn_options: self.transaction_options(index, None),
             validator_config_args: ValidatorConfigArgs {
                 validator_config_file: None,
                 consensus_public_key: Some(consensus_public_key),
@@ -215,7 +233,7 @@ impl CliTestFramework {
 
     pub async fn add_stake(&self, index: usize, amount: u64) -> CliTypedResult<Transaction> {
         AddStake {
-            txn_options: self.transaction_options(index),
+            txn_options: self.transaction_options(index, None),
             amount,
         }
         .execute()
@@ -224,7 +242,7 @@ impl CliTestFramework {
 
     pub async fn unlock_stake(&self, index: usize, amount: u64) -> CliTypedResult<Transaction> {
         UnlockStake {
-            txn_options: self.transaction_options(index),
+            txn_options: self.transaction_options(index, None),
             amount,
         }
         .execute()
@@ -233,7 +251,7 @@ impl CliTestFramework {
 
     pub async fn withdraw_stake(&self, index: usize, amount: u64) -> CliTypedResult<Transaction> {
         WithdrawStake {
-            node_op_options: self.transaction_options(index),
+            node_op_options: self.transaction_options(index, None),
             amount,
         }
         .execute()
@@ -242,7 +260,7 @@ impl CliTestFramework {
 
     pub async fn increase_lockup(&self, index: usize) -> CliTypedResult<Transaction> {
         IncreaseLockup {
-            txn_options: self.transaction_options(index),
+            txn_options: self.transaction_options(index, None),
         }
         .execute()
         .await
@@ -250,7 +268,7 @@ impl CliTestFramework {
 
     pub async fn join_validator_set(&self, index: usize) -> CliTypedResult<Transaction> {
         JoinValidatorSet {
-            txn_options: self.transaction_options(index),
+            txn_options: self.transaction_options(index, None),
             operator_args: self.operator_args(index),
         }
         .execute()
@@ -259,7 +277,7 @@ impl CliTestFramework {
 
     pub async fn leave_validator_set(&self, index: usize) -> CliTypedResult<Transaction> {
         LeaveValidatorSet {
-            txn_options: self.transaction_options(index),
+            txn_options: self.transaction_options(index, None),
             operator_args: self.operator_args(index),
         }
         .execute()
@@ -273,7 +291,7 @@ impl CliTestFramework {
         validator_network_public_key: x25519::PublicKey,
     ) -> CliTypedResult<Transaction> {
         UpdateValidatorNetworkAddresses {
-            txn_options: self.transaction_options(index),
+            txn_options: self.transaction_options(index, None),
             operator_args: self.operator_args(index),
             validator_config_args: ValidatorConfigArgs {
                 validator_config_file: None,
@@ -370,11 +388,16 @@ impl CliTestFramework {
         FaucetOptions::new(Some(self.faucet_endpoint.clone()))
     }
 
-    fn transaction_options(&self, index: usize) -> TransactionOptions {
+    fn transaction_options(
+        &self,
+        index: usize,
+        gas_options: Option<GasOptions>,
+    ) -> TransactionOptions {
         TransactionOptions {
             private_key_options: PrivateKeyInputOptions::from_private_key(self.private_key(index))
                 .unwrap(),
             rest_options: self.rest_options(),
+            gas_options: gas_options.unwrap_or_default(),
             ..Default::default()
         }
     }

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -172,7 +172,7 @@ async fn test_account_balance() {
         )
         .await
         .unwrap();
-    account_1_balance -= TRANSFER_AMOUNT + response.gas_used.unwrap();
+    account_1_balance -= TRANSFER_AMOUNT + response.gas_used * response.gas_unit_price;
     account_2_balance += TRANSFER_AMOUNT;
     account_has_balance(&rosetta_client, chain_id, account_1, account_1_balance)
         .await
@@ -394,7 +394,7 @@ async fn test_block_transactions() {
     let sender = cli.account_id(0);
     let receiver = cli.account_id(1);
 
-    let transfer_version = response.version.unwrap();
+    let transfer_version = response.version;
 
     let validator = swarm.validators().next().unwrap();
     let rest_client = validator.rest_client();


### PR DESCRIPTION
### Description
Gas unit price wasn't being used in calculations (because it defaulted to 1).  Now it will properly handle gas by adding the appropriate fields and calculations.  Additionally added more tests for rosetta

### Test Plan
Now there are ton more tests in rosetta covering these cases for failed transactions and variable gas price

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2547)
<!-- Reviewable:end -->
