### PR TITLE
[storage] backup-cli: state snapshots taken at epoch ending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3213,6 +3213,7 @@ dependencies = [
  "aptos-types",
  "aptos-vm",
  "aptosdb",
+ "consensus-types",
  "executor",
  "executor-types",
  "move-deps",

--- a/execution/executor-test-helpers/Cargo.toml
+++ b/execution/executor-test-helpers/Cargo.toml
@@ -22,8 +22,8 @@ aptos-temppath = { path = "../../crates/aptos-temppath" }
 aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types", features = ["fuzzing"] }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
-
 aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
+consensus-types = { path = "../../consensus/consensus-types"}
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
 move-deps = { path = "../../aptos-move/move-deps", features = ["address32"] }

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -13,6 +13,7 @@ use crate::{
     },
 };
 
+use aptos_types::event::EventKey;
 pub use aptos_types::*;
 
 #[derive(Debug)]
@@ -116,6 +117,14 @@ impl LocalAccount {
 
     pub fn rotate_key<T: Into<AccountKey>>(&mut self, new_key: T) -> AccountKey {
         std::mem::replace(&mut self.key, new_key.into())
+    }
+
+    pub fn received_event_key(&self) -> EventKey {
+        EventKey::new(1, self.address)
+    }
+
+    pub fn sent_event_key(&self) -> EventKey {
+        EventKey::new(2, self.address)
     }
 }
 

--- a/storage/aptosdb/src/event_store/mod.rs
+++ b/storage/aptosdb/src/event_store/mod.rs
@@ -108,9 +108,12 @@ impl EventStore {
         event_key: &EventKey,
         seq_num: u64,
         ledger_version: Version,
-    ) -> Result<ContractEvent> {
+    ) -> Result<(Version, ContractEvent)> {
         let (version, index) = self.lookup_event_by_key(event_key, seq_num, ledger_version)?;
-        self.get_event_by_version_and_index(version, index)
+        Ok((
+            version,
+            self.get_event_by_version_and_index(version, index)?,
+        ))
     }
 
     /// Get the latest sequence number on `event_key` considering all transactions with versions
@@ -204,6 +207,72 @@ impl EventStore {
         Ok((version, index))
     }
 
+    pub fn lookup_event_before_or_at_version(
+        &self,
+        event_key: &EventKey,
+        version: Version,
+    ) -> Result<
+        Option<(
+            Version, // version
+            u64,     // index
+            u64,     // sequence number
+        )>,
+    > {
+        let mut iter = self
+            .db
+            .iter::<EventByVersionSchema>(ReadOptions::default())?;
+        iter.seek_for_prev(&(*event_key, version, u64::MAX))?;
+
+        match iter.next().transpose()? {
+            None => Ok(None),
+            Some(((key, ver, seq_num), idx)) => {
+                if key == *event_key {
+                    Ok(Some((ver, idx, seq_num)))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    pub fn lookup_event_after_version(
+        &self,
+        event_key: &EventKey,
+        version: Version,
+    ) -> Result<
+        Option<(
+            Version, // version
+            u64,     // index
+            u64,     // sequence number
+        )>,
+    > {
+        let mut iter = self
+            .db
+            .iter::<EventByVersionSchema>(ReadOptions::default())?;
+        iter.seek(&(*event_key, version + 1, 0))?;
+
+        match iter.next().transpose()? {
+            None => Ok(None),
+            Some(((key, ver, seq_num), idx)) => {
+                if key == *event_key {
+                    Ok(Some((ver, idx, seq_num)))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    pub fn get_block_metadata(&self, version: Version) -> Result<(Version, NewBlockEvent)> {
+        let (first_version, event_index, seq_num) = self
+            .lookup_event_before_or_at_version(&new_block_event_key(), version)?
+            .ok_or_else(|| AptosDbError::NotFound("NewBlockEvent".to_string()))?;
+
+        let new_block_event = self.get_event_by_version_and_index(first_version, event_index)?;
+        let payload = bcs::from_bytes(new_block_event.event_data())?;
+        Ok((first_version, payload))
+    }
+
     /// Save contract events yielded by the transaction at `version` and return root hash of the
     /// event accumulator formed by these events.
     pub fn put_events(
@@ -287,7 +356,7 @@ impl EventStore {
             while count > 0 {
                 let step = count / 2;
                 let mid = begin + step;
-                let event = self.get_event_by_key(event_key, mid, ledger_version)?;
+                let (_version, event) = self.get_event_by_key(event_key, mid, ledger_version)?;
                 if comp(&event)? {
                     begin = mid + 1;
                     count -= step + 1;

--- a/storage/aptosdb/src/event_store/test.rs
+++ b/storage/aptosdb/src/event_store/test.rs
@@ -356,6 +356,8 @@ fn test_get_last_version_before_timestamp_impl(new_block_events: Vec<(Version, C
 }
 
 proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
     #[test]
     fn test_get_last_version_before_timestamp(new_block_events in arb_new_block_events()) {
         test_get_last_version_before_timestamp_impl(new_block_events)

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -65,6 +65,7 @@ use aptos_config::config::{
 use aptos_crypto::hash::HashValue;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
+use aptos_types::account_config::{new_block_event_key, NewBlockEvent};
 use aptos_types::state_store::table::{TableHandle, TableInfo};
 use aptos_types::{
     account_address::AccountAddress,
@@ -569,7 +570,7 @@ impl AptosDB {
             lis.len() == (paging_epoch - start_epoch) as usize,
             "DB corruption: missing epoch ending ledger info for epoch {}",
             lis.last()
-                .map(|li| li.ledger_info().next_block_epoch())
+                .map(|li| li.ledger_info().next_block_epoch() - 1)
                 .unwrap_or(start_epoch),
         );
         Ok((lis, more))
@@ -1193,19 +1194,55 @@ impl DbReader for AptosDB {
 
     fn get_block_timestamp(&self, version: u64) -> Result<u64> {
         gauged_api("get_block_timestamp", || {
-            let ts = match self.transaction_store.get_block_metadata(version)? {
-                Some((_v, block_meta)) => block_meta.timestamp_usecs(),
-                // genesis timestamp is 0
-                None => 0,
-            };
-            Ok(ts)
+            error_if_version_is_pruned(&self.ledger_pruner, "NewBlockEvent", version)?;
+            ensure!(version <= self.get_latest_version()?);
+
+            let (_first_version, new_block_event) = self.event_store.get_block_metadata(version)?;
+            Ok(new_block_event.proposed_time())
         })
     }
 
-    fn get_block_boundaries(&self, version: u64, latest_ledger_version: u64) -> Result<(u64, u64)> {
-        gauged_api("get_block_boundaries", || {
-            self.transaction_store
-                .get_block_boundaries(version, latest_ledger_version)
+    fn get_block_info(&self, version: Version) -> Result<(Version, Version, NewBlockEvent)> {
+        gauged_api("get_block_info", || {
+            let latest_li = self.get_latest_ledger_info()?;
+            let committed_version = latest_li.ledger_info().version();
+            ensure!(
+                version <= committed_version,
+                "Requested version {} > committed version {}",
+                version,
+                committed_version
+            );
+
+            let (first_version, new_block_event) = self.event_store.get_block_metadata(version)?;
+
+            let last_version = self
+                .event_store
+                .lookup_event_after_version(&new_block_event_key(), version)?
+                .map_or(committed_version, |(v, _, _)| v - 1);
+
+            Ok((first_version, last_version, new_block_event))
+        })
+    }
+
+    fn get_block_info_by_height(&self, height: u64) -> Result<(Version, Version, NewBlockEvent)> {
+        gauged_api("get_block_info_by_height", || {
+            let latest_li = self.get_latest_ledger_info()?;
+            let committed_version = latest_li.ledger_info().version();
+
+            let event_key = new_block_event_key();
+            let (first_version, new_block_event) =
+                self.event_store
+                    .get_event_by_key(&event_key, height, committed_version)?;
+            let last_version = self
+                .event_store
+                .lookup_event_after_version(&event_key, first_version)?
+                .map_or(committed_version, |(v, _, _)| v - 1);
+
+            Ok((
+                first_version,
+                last_version,
+                bcs::from_bytes(new_block_event.event_data())?,
+            ))
         })
     }
 

--- a/storage/aptosdb/src/test_helper.rs
+++ b/storage/aptosdb/src/test_helper.rs
@@ -90,8 +90,8 @@ prop_compose! {
         let mut txn_accumulator = TxnAccumulator::new_empty();
         let mut result = Vec::new();
 
-    let mut in_memory_state = StateDelta::new_empty();
-    let _ancester = in_memory_state.current.clone().freeze();
+        let mut in_memory_state = StateDelta::new_empty();
+        let _ancester = in_memory_state.current.clone().freeze();
 
         for block_gen in block_gens {
             let (mut txns_to_commit, mut ledger_info) = block_gen.materialize(&mut universe);

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/backup.rs
@@ -59,7 +59,7 @@ impl StateSnapshotBackupController {
     }
 
     pub async fn run(self) -> Result<FileHandle> {
-        info!("State snapshot backup started, for epoch {}.", self.epoch,);
+        info!("State snapshot backup started, for epoch {}.", self.epoch);
         let ret = self
             .run_impl()
             .await

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/manifest.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/manifest.rs
@@ -31,6 +31,8 @@ pub struct StateSnapshotChunk {
 pub struct StateSnapshotBackup {
     /// Version at which this state snapshot is taken.
     pub version: Version,
+    /// Epoch in which this state snapshot is taken.
+    pub epoch: u64,
     /// Hash of the state tree root.
     pub root_hash: HashValue,
     /// All account blobs in chunks.

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -28,20 +28,38 @@ fn end_to_end() {
     backup_dir.create_as_dir().unwrap();
     let store: Arc<dyn BackupStorage> = Arc::new(LocalFs::new(backup_dir.path().to_path_buf()));
 
-    let latest_executed_trees = src_db.get_latest_executed_trees().unwrap();
-    let version = latest_executed_trees.version().unwrap();
-    let state_root_hash = latest_executed_trees.state().base_root_hash();
+    let epoch = src_db
+        .get_latest_ledger_info()
+        .unwrap()
+        .ledger_info()
+        .next_block_epoch()
+        - 1;
+    let latest_epoch_ending_li = src_db
+        .get_epoch_ending_ledger_infos(epoch, epoch + 1)
+        .unwrap()
+        .ledger_info_with_sigs
+        .pop()
+        .unwrap();
+    let version = latest_epoch_ending_li.ledger_info().version();
+    let state_root_hash = src_db
+        .get_transactions(version, 1, version, false)
+        .unwrap()
+        .proof
+        .transaction_infos
+        .pop()
+        .unwrap()
+        .state_checkpoint_hash()
+        .unwrap();
 
     let (rt, port) = start_local_backup_service(src_db);
     let client = Arc::new(BackupServiceClient::new(format!(
         "http://localhost:{}",
         port
     )));
-
     let manifest_handle = rt
         .block_on(
             StateSnapshotBackupController::new(
-                StateSnapshotBackupOpt { version },
+                StateSnapshotBackupOpt { epoch },
                 GlobalBackupOpt {
                     max_chunk_size: 500,
                 },
@@ -80,9 +98,8 @@ fn end_to_end() {
         tgt_db
             .get_state_snapshot_before(version + 1) // We cannot use get_latest_snapshot() because it searches backward from the latest txn_info version
             .unwrap()
-            .map(|(_, hash)| hash)
             .unwrap(),
-        state_root_hash,
+        (version, state_root_hash)
     );
 
     rt.shutdown_timeout(Duration::from_secs(1));

--- a/storage/backup/backup-cli/src/coordinators/backup.rs
+++ b/storage/backup/backup-cli/src/coordinators/backup.rs
@@ -54,13 +54,6 @@ impl BackupCoordinatorOpt {
             self.state_snapshot_interval_epochs > 0 && self.transaction_batch_size > 0,
             "Backup interval and batch size must be greater than 0."
         );
-        ensure!(
-            self.state_snapshot_interval_epochs % self.transaction_batch_size == 0,
-            "State snapshot interval should be N x transaction_batch_size, N >= 1. \
-             Otherwise there can be edge case where the only snapshot is taken at a version  \
-             that's not yet in a transaction backup, resulting in replaying all transactions \
-             at restore time."
-        );
         Ok(())
     }
 }

--- a/storage/backup/backup-cli/src/metadata/mod.rs
+++ b/storage/backup/backup-cli/src/metadata/mod.rs
@@ -35,8 +35,12 @@ impl Metadata {
         })
     }
 
-    pub fn new_state_snapshot_backup(version: Version, manifest: FileHandle) -> Self {
-        Self::StateSnapshotBackup(StateSnapshotBackupMeta { version, manifest })
+    pub fn new_state_snapshot_backup(epoch: u64, version: Version, manifest: FileHandle) -> Self {
+        Self::StateSnapshotBackup(StateSnapshotBackupMeta {
+            epoch,
+            version,
+            manifest,
+        })
     }
 
     pub fn new_transaction_backup(
@@ -81,6 +85,7 @@ pub struct EpochEndingBackupMeta {
 
 #[derive(Clone, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct StateSnapshotBackupMeta {
+    pub epoch: u64,
     pub version: Version,
     pub manifest: FileHandle,
 }

--- a/storage/backup/backup-cli/src/metadata/view.rs
+++ b/storage/backup/backup-cli/src/metadata/view.rs
@@ -19,8 +19,7 @@ impl MetadataView {
     pub fn get_storage_state(&self) -> BackupStorageState {
         let latest_epoch_ending_epoch =
             self.epoch_ending_backups.iter().map(|e| e.last_epoch).max();
-        let latest_state_snapshot_version =
-            self.state_snapshot_backups.iter().map(|s| s.version).max();
+        let latest_state_snapshot_epoch = self.state_snapshot_backups.iter().map(|s| s.epoch).max();
         let latest_transaction_version = self
             .transaction_backups
             .iter()
@@ -29,7 +28,7 @@ impl MetadataView {
 
         BackupStorageState {
             latest_epoch_ending_epoch,
-            latest_state_snapshot_epoch: latest_state_snapshot_version,
+            latest_state_snapshot_epoch,
             latest_transaction_version,
         }
     }
@@ -137,7 +136,7 @@ impl fmt::Display for BackupStorageState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "latest_epoch_ending_epoch: {}, latest_state_snapshot_version: {}, latest_transaction_version: {}",
+            "latest_epoch_ending_epoch: {}, latest_state_snapshot_epoch: {}, latest_transaction_version: {}",
             self.latest_epoch_ending_epoch.as_ref().map_or("none".to_string(), u64::to_string),
             self.latest_state_snapshot_epoch.as_ref().map_or("none".to_string(), Version::to_string),
             self.latest_transaction_version.as_ref().map_or("none".to_string(), Version::to_string),
@@ -165,7 +164,7 @@ impl FromStr for BackupStorageState {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let captures = regex::Regex::new(
-            r"latest_epoch_ending_epoch: (none|\d+), latest_state_snapshot_version: (none|\d+), latest_transaction_version: (none|\d+)",
+            r"latest_epoch_ending_epoch: (none|\d+), latest_state_snapshot_epoch: (none|\d+), latest_transaction_version: (none|\d+)",
         )?.captures(s).ok_or_else(|| anyhow!("Not in BackupStorageState display format: {}", s))?;
 
         Ok(Self {

--- a/storage/backup/backup-cli/src/metadata/view.rs
+++ b/storage/backup/backup-cli/src/metadata/view.rs
@@ -29,7 +29,7 @@ impl MetadataView {
 
         BackupStorageState {
             latest_epoch_ending_epoch,
-            latest_state_snapshot_version,
+            latest_state_snapshot_epoch: latest_state_snapshot_version,
             latest_transaction_version,
         }
     }
@@ -129,7 +129,7 @@ impl From<Vec<Metadata>> for MetadataView {
 
 pub struct BackupStorageState {
     pub latest_epoch_ending_epoch: Option<u64>,
-    pub latest_state_snapshot_version: Option<Version>,
+    pub latest_state_snapshot_epoch: Option<Version>,
     pub latest_transaction_version: Option<Version>,
 }
 
@@ -139,7 +139,7 @@ impl fmt::Display for BackupStorageState {
             f,
             "latest_epoch_ending_epoch: {}, latest_state_snapshot_version: {}, latest_transaction_version: {}",
             self.latest_epoch_ending_epoch.as_ref().map_or("none".to_string(), u64::to_string),
-            self.latest_state_snapshot_version.as_ref().map_or("none".to_string(), Version::to_string),
+            self.latest_state_snapshot_epoch.as_ref().map_or("none".to_string(), Version::to_string),
             self.latest_transaction_version.as_ref().map_or("none".to_string(), Version::to_string),
         )
     }
@@ -170,7 +170,7 @@ impl FromStr for BackupStorageState {
 
         Ok(Self {
             latest_epoch_ending_epoch: captures.get(1).parse_option_u64()?,
-            latest_state_snapshot_version: captures.get(2).parse_option_u64()?,
+            latest_state_snapshot_epoch: captures.get(2).parse_option_u64()?,
             latest_transaction_version: captures.get(3).parse_option_u64()?,
         })
     }

--- a/storage/backup/backup-cli/src/metrics/backup.rs
+++ b/storage/backup/backup-cli/src/metrics/backup.rs
@@ -20,10 +20,10 @@ pub static EPOCH_ENDING_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static STATE_SNAPSHOT_VERSION: Lazy<IntGauge> = Lazy::new(|| {
+pub static STATE_SNAPSHOT_EPOCH: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
-        "aptos_db_backup_coordinator_state_snapshot_version",
-        "The version of the latest state snapshot taken."
+        "aptos_db_backup_coordinator_state_snapshot_epoch",
+        "The epoch at the end of which the latest state snapshot was taken."
     )
     .unwrap()
 });

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -3,6 +3,7 @@
 
 use anyhow::{anyhow, format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
+use aptos_types::account_config::NewBlockEvent;
 use aptos_types::state_store::table::{TableHandle, TableInfo};
 use aptos_types::{
     access_path::AccessPath,
@@ -202,15 +203,19 @@ pub trait DbReader: Send + Sync {
     ///
     /// [AptosDB::get_block_timestamp]:
     /// ../aptosdb/struct.AptosDB.html#method.get_block_timestamp
-    fn get_block_timestamp(&self, version: u64) -> Result<u64> {
+    fn get_block_timestamp(&self, version: Version) -> Result<u64> {
         unimplemented!()
     }
 
-    /// See [AptosDB::get_block_boundaries].
-    ///
-    /// [AptosDB::get_block_boundaries]:
-    /// ../aptosdb/struct.AptosDB.html#method.get_block_boundaries
-    fn get_block_boundaries(&self, version: u64, latest_ledger_version: u64) -> Result<(u64, u64)> {
+    /// Returns the start_version, end_version and NewBlockEvent of the block containing the input
+    /// transaction version.
+    fn get_block_info(&self, version: Version) -> Result<(Version, Version, NewBlockEvent)> {
+        unimplemented!()
+    }
+
+    /// Returns the start_version, end_version and NewBlockEvent of the block containing the input
+    /// transaction version.
+    fn get_block_info_by_height(&self, height: u64) -> Result<(Version, Version, NewBlockEvent)> {
         unimplemented!()
     }
 

--- a/terraform/helm/fullnode/templates/backup.yaml
+++ b/terraform/helm/fullnode/templates/backup.yaml
@@ -49,7 +49,7 @@ spec:
         - "http://{{ include "backup.backupService" . }}"
         {{- with .Values.backup }}
         - "--state-snapshot-interval"
-        - "{{ int .config.state_snapshot_interval }}"
+        - "{{ int .config.state_snapshot_interval_epochs }}"
         - "--transaction-batch-size"
         - "{{ int .config.transaction_batch_size }}"
         - "command-adapter"

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -81,7 +81,7 @@ backup:
       account:
       container:
       sas:
-    state_snapshot_interval: 200000
+    state_snapshot_interval_epochs: 24
     transaction_batch_size: 100000
 
 backup_verify:

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -205,7 +205,7 @@ fn wait_for_backups(
         let state: BackupStorageState = std::str::from_utf8(&output)?.parse()?;
         if state.latest_epoch_ending_epoch.is_some()
             && state.latest_transaction_version.is_some()
-            && state.latest_state_snapshot_version.is_some()
+            && state.latest_state_snapshot_epoch.is_some()
             && state.latest_epoch_ending_epoch.unwrap() >= target_epoch
             && state.latest_transaction_version.unwrap() >= target_version
         {
@@ -224,7 +224,7 @@ pub(crate) fn db_backup(
     target_epoch: u64,
     target_version: Version,
     transaction_batch_size: usize,
-    state_snapshot_interval: usize,
+    state_snapshot_interval_epochs: usize,
     trusted_waypoints: &[Waypoint],
 ) -> TempPath {
     let now = Instant::now();
@@ -247,8 +247,8 @@ pub(crate) fn db_backup(
             &format!("http://localhost:{}", backup_service_port),
             "--transaction-batch-size",
             &transaction_batch_size.to_string(),
-            "--state-snapshot-interval",
-            &state_snapshot_interval.to_string(),
+            "--state-snapshot-interval-epochs",
+            &state_snapshot_interval_epochs.to_string(),
             "--metadata-cache-dir",
             metadata_cache_path1.path().to_str().unwrap(),
             "local-fs",

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -108,29 +108,13 @@ pub async fn assert_balance(client: &RestClient, account: &LocalAccount, balance
 /// require a SmokeTestEnvironment, as it provides a generic interface across
 /// AptosSwarms, regardless of if the swarm is a validator swarm, validator full
 /// node swarm, or a public full node swarm.
+#[cfg(test)]
 pub mod swarm_utils {
-    use aptos_config::config::{NodeConfig, SecureBackend, WaypointConfig};
-    use aptos_secure_storage::{KVStorage, Storage};
+    use aptos_config::config::{NodeConfig, WaypointConfig};
     use aptos_types::waypoint::Waypoint;
 
     pub fn insert_waypoint(node_config: &mut NodeConfig, waypoint: Waypoint) {
-        let f = |backend: &SecureBackend| {
-            let mut storage: Storage = backend.into();
-            storage
-                .set(aptos_global_constants::WAYPOINT, waypoint)
-                .expect("Unable to write waypoint");
-            storage
-                .set(aptos_global_constants::GENESIS_WAYPOINT, waypoint)
-                .expect("Unable to write waypoint");
-        };
-        let backend = &node_config.consensus.safety_rules.backend;
-        f(backend);
-        match &node_config.base.waypoint {
-            WaypointConfig::FromStorage(backend) => {
-                f(backend);
-            }
-            _ => panic!("unexpected waypoint from node config"),
-        }
+        node_config.base.waypoint = WaypointConfig::FromConfig(waypoint);
     }
 }
 

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -37,6 +37,10 @@ impl NewBlockEvent {
         self.round
     }
 
+    pub fn height(&self) -> u64 {
+        self.height
+    }
+
     pub fn previous_block_votes(&self) -> &Vec<bool> {
         &self.previous_block_votes
     }


### PR DESCRIPTION
### Description

now the state snapshot backup controller takes an epoch as the input and takes the snapshot at the end of it.
Since we guarantee at end of epochs a snapshot is persisted, this makes the backup coordinator work again.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2551)
<!-- Reviewable:end -->
