### PR TITLE
[community] Redirect www to non-www to avoid https conflicts

### DIFF
--- a/ecosystem/platform/server/config/routes.rb
+++ b/ecosystem/platform/server/config/routes.rb
@@ -4,6 +4,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Rails.application.routes.draw do
+  # Redirect www to non-www
+  constraints(host: /^www\./i) do
+    match '(*any)', via: :all, to: redirect { |_, request|
+      # parse the current request url & tap in and remove www.
+      URI.parse(request.url).tap { |uri| uri.host.sub!(/^www\./i, '') }.to_s
+    }
+  end
+
   # Redirect community.aptoslabs.com to aptoslabs.com
   constraints host: /community.aptoslabs.com/ do
     match '/*path' => redirect { |params, _req| "https://aptoslabs.com/#{params[:path]}" }, via: %i[get post]

--- a/ecosystem/platform/server/config/routes.rb
+++ b/ecosystem/platform/server/config/routes.rb
@@ -5,11 +5,8 @@
 
 Rails.application.routes.draw do
   # Redirect www to non-www
-  constraints(host: /^www\./i) do
-    match '(*any)', via: :all, to: redirect { |_, request|
-      # parse the current request url & tap in and remove www.
-      URI.parse(request.url).tap { |uri| uri.host.sub!(/^www\./i, '') }.to_s
-    }
+  constraints(host: /www\.aptoslabs\.com/) do
+    match '/(*path)' => redirect { |params, _req| "https://aptoslabs.com/#{params[:path]}" }, via: %i[get post]
   end
 
   # Redirect community.aptoslabs.com to aptoslabs.com


### PR DESCRIPTION
### Description
Create redirect for attempting to access via www

- Will fix https errors
- Redirecting requests from a non-preferred domain is important because search engines consider URLs with and without “www” as two different websites. Without the redirect It creates a duplicate entry, which is not suitable for SEO.

<img width="1555" alt="image" src="https://user-images.githubusercontent.com/98909677/182999670-fd2ae48b-5d44-4836-a31c-062c41d54925.png">

### Test Plan
Prepend url with www and ensure redirect is working.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2556)
<!-- Reviewable:end -->
