### PR TITLE
[community] Remove underline from footer navigation links

### DIFF
--- a/ecosystem/platform/server/app/components/footer_component.html.erb
+++ b/ecosystem/platform/server/app/components/footer_component.html.erb
@@ -14,21 +14,21 @@
 
       <div class="flex flex-col gap-2 font-mono text-sm whitespace-nowrap">
         <% nav_items.each do |item| %>
-          <%= content_tag :a, item.name, href: item.url, class: 'hover:text-teal-400 transition duration-150 ease-in-out underline decoration-solid decoration-white/50 decoration-1 underline-offset-2', target: item.url.starts_with?('http') ? '_blank' : '' %>
+          <%= content_tag :a, item.name, href: item.url, class: 'hover:text-teal-400 transition duration-150 ease-in-out', target: item.url.starts_with?('http') ? '_blank' : '' %>
         <% end %>
       </div>
 
       <div>
-        <h5 class="text-xl font-mono font-bold block uppercase text-white mb-2">Contact</h5>
+        <h5 class="text-xl font-mono block uppercase text-white mb-2">Contact</h5>
         <%= render DividerComponent.new(class: 'mb-4') %>
         <div class="flex flex-col gap-2 font-mono text-sm">
-          <a href="mailto:info@aptoslabs.com" class="hover:text-teal-400 transition duration-150 ease-in-out underline decoration-solid decoration-white/50 decoration-1 underline-offset-2">info@aptoslabs.com</a>
-          <a href="mailto:press@aptoslabs.com" class="hover:text-teal-400 transition duration-150 ease-in-out underline decoration-solid decoration-white/50 decoration-1 underline-offset-2">press@aptoslabs.com</a>
+          <a href="mailto:info@aptoslabs.com" class="hover:text-teal-400 transition duration-150 ease-in-out">info@aptoslabs.com</a>
+          <a href="mailto:press@aptoslabs.com" class="hover:text-teal-400 transition duration-150 ease-in-out">press@aptoslabs.com</a>
         </div>
       </div>
 
       <div>
-        <h5 class="text-xl font-mono font-bold block uppercase text-white mb-2">Subscribe</h5>
+        <h5 class="text-xl font-mono block uppercase text-white mb-2">Subscribe</h5>
         <%= render DividerComponent.new(class: 'mb-4') %>
         <div class="flex flex-col gap-8">
           <%= form_with url: 'https://aptoslabs.us18.list-manage.com/subscribe/post?u=5456bc936272125ed825d0218&amp;id=a15b523910', method: 'post', html: { target: '_blank' }, data: { turbo: false }, class: 'flex flex-col xl:flex-row gap-2 !text-sm', builder: AptosFormBuilder do |form| %>


### PR DESCRIPTION
### Description
Remove those pesky footer navigation link underlines as these should only be used within paragraph content. 

### Test Plan
Ensure no underlines exist below links in footer navigation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2558)
<!-- Reviewable:end -->
