### PR TITLE
Use regular UTF-8 strings instead of hex-encoded strings with token modules

### DIFF
--- a/developer-docs-site/static/examples/python/first_nft.py
+++ b/developer-docs-site/static/examples/python/first_nft.py
@@ -26,9 +26,9 @@ class TokenClient(RestClient):
             "function": f"0x3::token::create_collection_script",
             "type_arguments": [],
             "arguments": [
-                name.encode("utf-8").hex(),
-                description.encode("utf-8").hex(),
-                uri.encode("utf-8").hex(),
+                name.encode("utf-8"),
+                description.encode("utf-8"),
+                uri.encode("utf-8"),
                 str(U64_MAX),
                 mutate_setting
             ]

--- a/developer-docs-site/static/examples/typescript/first_nft.ts
+++ b/developer-docs-site/static/examples/typescript/first_nft.ts
@@ -24,9 +24,9 @@ async function createCollection(account: AptosAccount, name: string, description
       "create_collection_script",
       [],
       [
-        BCS.bcsSerializeStr(name),
-        BCS.bcsSerializeStr(description),
-        BCS.bcsSerializeStr(uri),
+        name,
+        description,
+        uri,
         BCS.bcsSerializeUint64(NUMBER_MAX),
         serializeVectorBool([false, false, false]),
       ],

--- a/ecosystem/python/sdk/aptos_sdk/client.py
+++ b/ecosystem/python/sdk/aptos_sdk/client.py
@@ -275,9 +275,9 @@ class RestClient:
         """Creates a new collection within the specified account"""
 
         transaction_arguments = [
-            TransactionArgument(name, Serializer.str),
-            TransactionArgument(description, Serializer.str),
-            TransactionArgument(uri, Serializer.str),
+            name,
+            description,
+            uri,
             TransactionArgument(U64_MAX, Serializer.u64),
             TransactionArgument(
                 [False, False, False], Serializer.sequence_serializer(Serializer.bool)

--- a/ecosystem/typescript/sdk/src/token_client.test.ts
+++ b/ecosystem/typescript/sdk/src/token_client.test.ts
@@ -52,8 +52,8 @@ test(
     const tokenId = {
       token_data_id: {
         creator: alice.address().hex(),
-        collection: Buffer.from(collectionName).toString("hex"),
-        name: Buffer.from(tokenName).toString("hex"),
+        collection: collectionName,
+        name: tokenName,
       },
       property_version: "0",
     };

--- a/ecosystem/typescript/sdk/src/token_client.ts
+++ b/ecosystem/typescript/sdk/src/token_client.ts
@@ -57,9 +57,9 @@ export class TokenClient {
       },
       type_arguments: [],
       arguments: [
-        Buffer.from(name).toString("hex"),
-        Buffer.from(description).toString("hex"),
-        Buffer.from(uri).toString("hex"),
+        name,
+        description,
+        uri,
         NUMBER_MAX.toString(),
         [false, false, false],
       ],


### PR DESCRIPTION
This is incomplete, we'd have to update the create_token stuff too. See https://aptos-org.slack.com/archives/C03N83P7QUC/p1659715179492969.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2574)
<!-- Reviewable:end -->
