### PR TITLE
[API] Add warning about adding stuff to v0 API

### DIFF
--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+//
+// If you plan to change this file, please speak to @dport or @gregnazario
+// first. This file contains endpoint handlers for the v0 API. This API is
+// now locked except for critical security fixes. All new feature development
+// should be made to the v1 API. You can find this code under `poem_backend`.
+// The v0 API is deprecated and will be removed in September 1st.
+// See https://github.com/aptos-labs/aptos-core/issues/2590
+//
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+
 use crate::{
     context::Context,
     failpoint::fail_point,

--- a/api/src/blocks.rs
+++ b/api/src/blocks.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+//
+// If you plan to change this file, please speak to @dport or @gregnazario
+// first. This file contains endpoint handlers for the v0 API. This API is
+// now locked except for critical security fixes. All new feature development
+// should be made to the v1 API. You can find this code under `poem_backend`.
+// The v0 API is deprecated and will be removed in September 1st.
+// See https://github.com/aptos-labs/aptos-core/issues/2590
+//
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+
 use crate::{context::Context, failpoint::fail_point, metrics::metrics, param::LedgerVersionParam};
 use anyhow::Result;
 use aptos_api_types::{Error, LedgerInfo, Response, TransactionId, U64};

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+//
+// If you plan to change this file, please speak to @dport or @gregnazario
+// first. This file contains endpoint handlers for the v0 API. This API is
+// now locked except for critical security fixes. All new feature development
+// should be made to the v1 API. You can find this code under `poem_backend`.
+// The v0 API is deprecated and will be removed in September 1st.
+// See https://github.com/aptos-labs/aptos-core/issues/2590
+//
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+
 use crate::{
     accept_type::AcceptType,
     accounts::Account,

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+//
+// If you plan to change this file, please speak to @dport or @gregnazario
+// first. This file contains endpoint handlers for the v0 API. This API is
+// now locked except for critical security fixes. All new feature development
+// should be made to the v1 API. You can find this code under `poem_backend`.
+// The v0 API is deprecated and will be removed in September 1st.
+// See https://github.com/aptos-labs/aptos-core/issues/2590
+//
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+
 #[cfg(feature = "failpoints")]
 use crate::set_failpoints;
 use crate::{

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+//
+// If you plan to change this file, please speak to @dport or @gregnazario
+// first. This file contains endpoint handlers for the v0 API. This API is
+// now locked except for critical security fixes. All new feature development
+// should be made to the v1 API. You can find this code under `poem_backend`.
+// The v0 API is deprecated and will be removed in September 1st.
+// See https://github.com/aptos-labs/aptos-core/issues/2590
+//
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+
 use crate::{
     context::Context,
     failpoint::fail_point,

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+//
+// If you plan to change this file, please speak to @dport or @gregnazario
+// first. This file contains endpoint handlers for the v0 API. This API is
+// now locked except for critical security fixes. All new feature development
+// should be made to the v1 API. You can find this code under `poem_backend`.
+// The v0 API is deprecated and will be removed in September 1st.
+// See https://github.com/aptos-labs/aptos-core/issues/2590
+//
+// READ ME
+// READ ME
+// READ ME
+// READ ME
+
 use crate::{
     accept_type::AcceptType,
     context::Context,


### PR DESCRIPTION
## Description
So folks know that the v0 API is being deprecated and don't develop on it.

## Test Plan
CI

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2591)
<!-- Reviewable:end -->
