### PR TITLE
[aptos-rosetta] Add sequence number to account balance lookups

### DIFF
--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -35,8 +35,15 @@ pub struct AccountBalanceResponse {
     pub block_identifier: BlockIdentifier,
     /// Balances of all known currencies
     pub balances: Vec<Amount>,
+    /// Metadata of account, must have sequence number
+    pub metadata: AccountBalanceMetadata,
 }
 
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AccountBalanceMetadata {
+    /// Sequence number of the account
+    pub sequence_number: u64,
+}
 /// Reqyest a block (version) on the account
 ///
 /// With neither value for PartialBlockIdentifier, get the latest version


### PR DESCRIPTION
### Description
As requested, metadata is required saying the sequence number as in here https://www.rosetta-api.org/docs/models/AccountBalanceResponse.html

### Test Plan
Updated the current test for it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2594)
<!-- Reviewable:end -->
