### PR TITLE
Replace JSON txn submittion interface with BCS interface for token client

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
+## 1.3.3 (2022-08-05)
+
+- Update the token clients to submit transactions through BCS interface. The new token client doesn't hex-code "name", "decription" and "uri" any more. String properties are passed and saved just as strings.
+- Expose `buildTransactionPayload` from ABI transaction builder. In some scenarios, developers just want to get a TransactionPayload rather than a RawTransaction.
+
 ## 1.3.2 (2022-08-04)
+
 This special entry does not conform to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) as there are noteworthy breaking changes with necessary rationale. Future entries will follow this format.
 
 This release updates the SDK to work with V1 of the Aptos Node API. There are some key changes between V0 and V1 that you can read about in the [API changelog](https://github.com/aptos-labs/aptos-core/blob/main/api/doc/v1/CHANGELOG.md), refer to the notes for version 1.0.0. Accordingly, this SDK version represents breaking changes compared to 1.2.1.
@@ -14,6 +20,7 @@ This release updates the SDK to work with V1 of the Aptos Node API. There are so
 - The generated client within the SDK is generated using a different tool, [openapi-typescript-codegen](https://www.npmjs.com/package/openapi-typescript-codegen). Most of these changes are transparent to the user, as we continue to wrap the generated client, but some of the generated types are different, which we mention here.
 - Token types are no longer exposed from the generated client (under `Types`) as they are no longer part of the API (indeed, they never truly were). Instead you can find these definitions exposed at `TokenTypes`.
 - Some functions, such as for getting account resources and events, no longer accept resource types as concatenated strings. For example:
+
 ```tsx
 # Before:
 const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
@@ -25,6 +32,7 @@ const aptosCoin = const aptosCoin = {
     generic_type_params: ["0x1::aptos_coin::AptosCoin"],
 };
 ```
+
 - Similarly, some endpoints no longer return this data as a string, but in a structured format, e.g. `MoveStructTag`. Remember to use something like `lodash.isEqual` to do equality checks with these structs.
 - To help work with these different formats, functions for converting between them have been added to `utils`.
 - A new function, `waitForTransactionWithResult`, has been added to help wait for a transaction and then get access to the response from the server once the function exits.
@@ -34,30 +42,38 @@ For help with migration, we recommend you see the updated examples under `exampl
 **Deprecation Notice**: On September 1st we will remove the v0 API from the running nodes. As a user of the TS SDK, the best way you can migrate prior to this is by upgrading to version 1.3.2 or higher of the SDK. We will repeatedly remind developers of this upcoming deprecation as we approach that date.
 
 ## 1.3.1 (2022-08-04)
+
 See release notes for 1.3.2.
 
 ## 1.3.0 (2022-08-03)
+
 See release notes for 1.3.2.
 
 ## 1.2.1 (2022-07-23)
+
 **Note:** This entry and earlier do not conform to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Features
+
 - Deprecate getTokenBalance api in SDK ([2ec554e](https://github.com/aptos-labs/aptos-core/commit/2ec554e6e40a81cee4e760f6f84ef7362c570240))
 - Memoize chain id in aptos client ([#1589](https://github.com/aptos-labs/aptos-core/issues/1589)) ([4a6453b](https://github.com/aptos-labs/aptos-core/commit/4a6453bf0e620247557854053b661446bff807a7))
 - **Multiagent:** Support multiagent transaction submission ([#1543](https://github.com/aptos-labs/aptos-core/issues/1543)) ([0f0c70e](https://github.com/aptos-labs/aptos-core/commit/0f0c70e8ed2fefa952f0c89b7edb78edc174cb49))
 - Support retrieving token balance for any account ([7f93c21](https://github.com/aptos-labs/aptos-core/commit/7f93c2100f8b8e848461a0b5a395bfb76ade8667))
 
 ### Bug Fixes
+
 - Get rid of "natual" calls ([#1678](https://github.com/aptos-labs/aptos-core/issues/1678)) ([54601f7](https://github.com/aptos-labs/aptos-core/commit/54601f79206ea0f8b8b1b0d6599d31832fc4d195))
 
 ## 1.2.0 (2022-06-28)
+
 ### Features
+
 - Vector tests for transaction signing ([6210c10](https://github.com/aptos-labs/aptos-core/commit/6210c10d3192fd0417b35709545fae850099e4d4))
 - Add royalty support for NFT tokens ([93a2cd0](https://github.com/aptos-labs/aptos-core/commit/93a2cd0bfd644725ac524f419e94077e0b16343b))
 - Add transaction builder examples ([a710a50](https://github.com/aptos-labs/aptos-core/commit/a710a50e8177258d9c0766762b3c2959fc231259))
 - Support transaction simulation ([93073bf](https://github.com/aptos-labs/aptos-core/commit/93073bf1b508d00cfa1f8bb441ed57085fd08a82))
 
 ### Bug Fixes
+
 - Fix a typo, natual now becomes natural ([1b7d295](https://github.com/aptos-labs/aptos-core/commit/1b7d2957b79a5d2821ada0c5096cf43c412e0c2d)), closes [#1526](https://github.com/aptos-labs/aptos-core/issues/1526)
 - Fix Javascript example ([5781fee](https://github.com/aptos-labs/aptos-core/commit/5781fee74b8f2b065e7f04c2f76952026860751d)), closes [#1405](https://github.com/aptos-labs/aptos-core/issues/1405)

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -62,5 +62,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
-  "version": "1.3.2"
+  "version": "1.3.3"
 }

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -380,6 +380,7 @@ test.skip(
       "Alice's simple token",
       1,
       "https://aptos.dev/img/nyan.jpeg",
+      1000,
       alice.address(),
       0,
       0,

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -1,7 +1,6 @@
 import isEqual from "lodash/isEqual";
 
 import { AptosClient } from "./aptos_client";
-import { AnyObject } from "./util";
 import * as Gen from "./generated/index";
 import { FAUCET_URL, NODE_URL } from "./util.test";
 import { FaucetClient } from "./faucet_client";
@@ -33,9 +32,9 @@ const coinTransferFunction = {
 
 test("gets genesis account", async () => {
   const client = new AptosClient(NODE_URL);
-  const account = await client.getAccount("0x1");
-  expect(account.authentication_key.length).toBe(66);
-  expect(account.sequence_number).not.toBeNull();
+  const genesisAccount = await client.getAccount("0x1");
+  expect(genesisAccount.authentication_key.length).toBe(66);
+  expect(genesisAccount.sequence_number).not.toBeNull();
 });
 
 test("gets transactions", async () => {
@@ -48,11 +47,13 @@ test("gets genesis resources", async () => {
   const client = new AptosClient(NODE_URL);
   const resources = await client.getAccountResources("0x1");
   const accountResource = resources.find((r) => isEqual(r.type, account));
+  expect(accountResource).toBeDefined();
 });
 
 test("gets the Account resource", async () => {
   const client = new AptosClient(NODE_URL);
   const accountResource = await client.getAccountResource("0x1", account);
+  expect(accountResource).toBeDefined();
 });
 
 test("gets ledger info", async () => {

--- a/ecosystem/typescript/sdk/src/token_client.test.ts
+++ b/ecosystem/typescript/sdk/src/token_client.test.ts
@@ -23,7 +23,7 @@ test(
     const tokenName = "Alice Token";
 
     // Create collection and token on Alice's account
-    let txnHash1 = await tokenClient.createCollection(
+    const txnHash1 = await tokenClient.createCollection(
       alice,
       collectionName,
       "Alice's simple collection",
@@ -32,7 +32,7 @@ test(
     const txn1 = await client.waitForTransactionWithResult(txnHash1);
     expect((txn1 as any)?.success).toBe(true);
 
-    let txnHash2 = await tokenClient.createToken(
+    const txnHash2 = await tokenClient.createToken(
       alice,
       collectionName,
       tokenName,

--- a/ecosystem/typescript/sdk/src/token_client.test.ts
+++ b/ecosystem/typescript/sdk/src/token_client.test.ts
@@ -41,6 +41,7 @@ test(
         "Alice's simple token",
         1,
         "https://aptos.dev/img/nyan.jpeg",
+        1000,
         alice.address(),
         0,
         0,

--- a/ecosystem/typescript/sdk/src/token_client.ts
+++ b/ecosystem/typescript/sdk/src/token_client.ts
@@ -56,9 +56,16 @@ export class TokenClient {
    * @param name Collection name
    * @param description Collection description
    * @param uri URL to additional info about collection
+   * @param maxAmount Maximum number of `token_data` allowed within this collection
    * @returns A hash of transaction
    */
-  async createCollection(account: AptosAccount, name: string, description: string, uri: string): Promise<string> {
+  async createCollection(
+    account: AptosAccount,
+    name: string,
+    description: string,
+    uri: string,
+    maxAmount: BCS.AnyNumber = MAX_U64_BIG_INT,
+  ): Promise<string> {
     const payload = new TxnBuilderTypes.TransactionPayloadScriptFunction(
       TxnBuilderTypes.ScriptFunction.natural(
         "0x3::token",
@@ -68,7 +75,7 @@ export class TokenClient {
           BCS.bcsSerializeStr(name),
           BCS.bcsSerializeStr(description),
           BCS.bcsSerializeStr(uri),
-          BCS.bcsSerializeUint64(MAX_U64_BIG_INT),
+          BCS.bcsSerializeUint64(maxAmount),
           BCS.serializeVectorWithFunc([false, false, false], "serializeBool"),
         ],
       ),
@@ -85,6 +92,7 @@ export class TokenClient {
    * @param description Token description
    * @param supply Token supply
    * @param uri URL to additional info about token
+   * @param max The maxium of tokens can be minted from this token
    * @param royalty_payee_address the address to receive the royalty, the address can be a shared account address.
    * @param royalty_points_denominator the denominator for calculating royalty
    * @param royalty_points_numerator the numerator for calculating royalty
@@ -100,6 +108,7 @@ export class TokenClient {
     description: string,
     supply: number,
     uri: string,
+    max: BCS.AnyNumber = MAX_U64_BIG_INT,
     royalty_payee_address: MaybeHexString = account.address(),
     royalty_points_denominator: number = 0,
     royalty_points_numerator: number = 0,
@@ -117,7 +126,7 @@ export class TokenClient {
           BCS.bcsSerializeStr(name),
           BCS.bcsSerializeStr(description),
           BCS.bcsSerializeUint64(supply),
-          BCS.bcsSerializeUint64(MAX_U64_BIG_INT),
+          BCS.bcsSerializeUint64(max),
           BCS.bcsSerializeStr(uri),
           BCS.bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(royalty_payee_address)),
           BCS.bcsSerializeUint64(royalty_points_denominator),

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.test.ts
@@ -13,6 +13,7 @@ import {
   bcsToBytes,
   deserializeVector,
   serializeVector,
+  serializeVectorWithFunc,
 } from "./helper";
 import { Serializer } from "./serializer";
 
@@ -85,4 +86,8 @@ test("bcsSerializeFixedBytes", () => {
   expect(bcsSerializeFixedBytes(new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]))).toEqual(
     new Uint8Array([0x41, 0x70, 0x74, 0x6f, 0x73]),
   );
+});
+
+test("serializeVectorWithFunc", () => {
+  expect(serializeVectorWithFunc([false, true], "serializeBool")).toEqual(new Uint8Array([0x2, 0x0, 0x1]));
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.ts
@@ -17,6 +17,20 @@ export function serializeVector<T extends Serializable>(value: Seq<T>, serialize
 }
 
 /**
+ * Serializes a vector with specified item serializaiton function.
+ * Very dynamic function and bypasses static typechecking.
+ */
+export function serializeVectorWithFunc(value: any[], func: string): Bytes {
+  const serializer = new Serializer();
+  serializer.serializeU32AsUleb128(value.length);
+  const f = (serializer as any)[func];
+  value.forEach((item) => {
+    f.call(serializer, item);
+  });
+  return serializer.getBytes();
+}
+
+/**
  * Deserializes a vector of values.
  */
 export function deserializeVector(deserializer: Deserializer, cls: any): any[] {


### PR DESCRIPTION
### Description
JSON txn submission interface is going to be deprecated from SDK. This PR updates the token client to use BCS txn submission interface.

### Test Plan
Make sure all the tests still pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2596)
<!-- Reviewable:end -->
