### PR TITLE
[code publishing] Make new flow the default

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -311,10 +311,10 @@ pub struct PublishPackage {
     move_options: MovePackageDir,
     #[clap(flatten)]
     txn_options: TransactionOptions,
-    /// Whether to use the new publishing flow.
+    /// Whether to use the legacy publishing flow. This will be soon removed.
     #[clap(long)]
-    new_flow: bool,
-    /// The upgrade policy used for the published package (new flow only). One of
+    legacy_flow: bool,
+    /// The upgrade policy used for the published package. One of
     /// `arbitrary`, `compatible`, or `immutable`. Defaults to `compatible`.
     #[clap(long)]
     upgrade_policy: Option<UpgradePolicy>,
@@ -330,15 +330,16 @@ impl CliCommand<TransactionSummary> for PublishPackage {
         let PublishPackage {
             move_options,
             txn_options,
-            new_flow,
+            legacy_flow,
             upgrade_policy,
         } = self;
         let package = BuiltPackage::build(move_options, true, true)?;
         let compiled_units = package.extract_code();
-        if !new_flow {
+        if legacy_flow {
             if upgrade_policy.is_some() {
                 return Err(CliError::CommandArgumentError(
-                    "`--upgrade-policy` can only be used with the `--new-flow` option".to_owned(),
+                    "`--upgrade-policy` can only be used without the `--legacy-flow` option"
+                        .to_owned(),
                 ));
             }
             // Send the compiled module using a module bundle


### PR DESCRIPTION

### Description

The new publishing flow should be the default now so we are getting some feedback how it works. The old flow is still reachable for a bit using `--legacy-flow`. Once we remove that flag, we should also remove the transaction type of module bundle publishing; at that point, no one can publish code unless going over `aptos_framework:code` module.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

NA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2610)
<!-- Reviewable:end -->
