### PR TITLE
[api] expose versioned events for event specific APIs

### DIFF
--- a/api/goldens/v0/aptos_api__tests__events_test__test_get_events_by_account_event_handle.json
+++ b/api/goldens/v0/aptos_api__tests__events_test__test_get_events_by_account_event_handle.json
@@ -1,5 +1,6 @@
 [
   {
+    "version": "0",
     "key": "0x01000000000000000000000000000000000000000000000000000000000000000000000000000001",
     "sequence_number": "0",
     "type": "0x1::reconfiguration::NewEpochEvent",

--- a/api/goldens/v1/aptos_api__tests__events_test__test_get_events_by_account_event_handle.json
+++ b/api/goldens/v1/aptos_api__tests__events_test__test_get_events_by_account_event_handle.json
@@ -1,5 +1,6 @@
 [
   {
+    "version": "0",
     "key": "0x01000000000000000000000000000000000000000000000000000000000000000000000000000001",
     "sequence_number": "0",
     "type": "0x1::reconfiguration::NewEpochEvent",

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -13,7 +13,7 @@ use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     account_state::AccountState,
     chain_id::ChainId,
-    contract_event::ContractEvent,
+    contract_event::EventWithVersion,
     event::EventKey,
     ledger_info::LedgerInfoWithSignatures,
     state_store::{state_key::StateKey, state_key_prefix::StateKeyPrefix, state_value::StateValue},
@@ -408,14 +408,13 @@ impl Context {
         start: u64,
         limit: u16,
         ledger_version: u64,
-    ) -> Result<Vec<ContractEvent>> {
+    ) -> Result<Vec<EventWithVersion>> {
         let events = self
             .db
             .get_events(event_key, start, Order::Ascending, limit as u64)?;
         Ok(events
             .into_iter()
             .filter(|event| event.transaction_version <= ledger_version)
-            .map(|event| event.event)
             .collect::<Vec<_>>())
     }
 

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -133,7 +133,7 @@ impl Events {
     }
 
     pub fn list(self, page: Page, accept_type: AcceptType) -> Result<impl Reply, Error> {
-        let contract_events = self.context.get_events(
+        let events = self.context.get_events(
             &self.key,
             page.start(0, u64::MAX)?,
             page.limit()?,
@@ -145,10 +145,10 @@ impl Events {
                 let resolver = self.context.move_resolver()?;
                 let events = resolver
                     .as_converter(self.context.db.clone())
-                    .try_into_events(&contract_events)?;
+                    .try_into_versioned_events(&events)?;
                 Response::new(self.ledger_info, &events)
             }
-            AcceptType::Bcs => Response::new_bcs(self.ledger_info, &contract_events),
+            AcceptType::Bcs => Response::new_bcs(self.ledger_info, &events),
         }
     }
 }

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -46,7 +46,7 @@ pub use transaction::{
     ScriptPayload, ScriptWriteSet, SubmitTransactionRequest, Transaction, TransactionData,
     TransactionId, TransactionInfo, TransactionOnChainData, TransactionPayload,
     TransactionSignature, TransactionSigningMessage, UserCreateSigningMessageRequest,
-    UserTransaction, UserTransactionRequest, WriteModule, WriteResource, WriteSet, WriteSetChange,
-    WriteSetPayload, WriteTableItem,
+    UserTransaction, UserTransactionRequest, VersionedEvent, WriteModule, WriteResource, WriteSet,
+    WriteSetChange, WriteSetPayload, WriteTableItem,
 };
 pub use wrappers::{IdentifierWrapper, MoveStructTagParam};


### PR DESCRIPTION
without a version, events are of very limited use.
with a version, one can query the transaction that emitted the event and
the timestamp when that transaction was committed.
this makes it effectively possible to graph the entirety of a user
through events -- if events represent a canonical flow for the resources
they involve which should be true for Coin and Token.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2618)
<!-- Reviewable:end -->
