### PR TITLE
[Indexer] Remove golden from streamingfast tests

### DIFF
--- a/sf-stream/src/tests/golden_output.rs
+++ b/sf-stream/src/tests/golden_output.rs
@@ -10,8 +10,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+// TODO: Remove after we add back golden
+#[allow(dead_code)]
 pub const GOLDEN_DIR_PATH: &str = "goldens";
 
+// TODO: Remove after we add back golden
+#[allow(dead_code)]
 #[derive(Clone)]
 pub(crate) struct GoldenOutputs {
     #[allow(dead_code)]
@@ -19,6 +23,8 @@ pub(crate) struct GoldenOutputs {
     file: Arc<Mutex<File>>,
 }
 
+// TODO: Remove after we add back golden
+#[allow(dead_code)]
 fn golden_path(version_dir: &str) -> PathBuf {
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push(GOLDEN_DIR_PATH);
@@ -26,6 +32,8 @@ fn golden_path(version_dir: &str) -> PathBuf {
     path
 }
 
+// TODO: Remove after we add back golden
+#[allow(dead_code)]
 impl GoldenOutputs {
     pub fn new(name: String, version_dir: &str) -> Self {
         let mut mint = Mint::new(golden_path(version_dir));

--- a/sf-stream/src/tests/mod.rs
+++ b/sf-stream/src/tests/mod.rs
@@ -26,10 +26,14 @@ macro_rules! current_function_name {
     }};
 }
 
+// TODO: Remove after we add back golden
+#[allow(dead_code)]
 pub fn convert_protubuf_txn_to_serde_value(txn: &extractor::Transaction) -> serde_json::Value {
     serde_json::from_str(&protobuf_json_mapping::print_to_string(txn).unwrap()).unwrap()
 }
 
+// TODO: Remove after we add back golden
+#[allow(dead_code)]
 pub fn convert_protubuf_txn_arr_to_serde_value(
     txns: &[extractor::Transaction],
 ) -> serde_json::Value {

--- a/sf-stream/src/tests/proto_converter_tests.rs
+++ b/sf-stream/src/tests/proto_converter_tests.rs
@@ -9,7 +9,7 @@ use crate::{
         write_set_change::Change::WriteTableItem,
     },
     runtime::SfStreamer,
-    tests::{convert_protubuf_txn_arr_to_serde_value, new_test_context, TestContext},
+    tests::{new_test_context, TestContext},
 };
 use aptos_sdk::types::{account_config::aptos_root_address, LocalAccount};
 use move_deps::{
@@ -85,7 +85,8 @@ async fn test_block_transactions_work() {
         }
     }
 
-    test_context.check_golden_output(convert_protubuf_txn_arr_to_serde_value(&converted_1));
+    // TODO: Add golden back after code freeze (removing now to avoid merge conflicts)
+    // test_context.check_golden_output(convert_protubuf_txn_arr_to_serde_value(&converted_1));
 
     // state checkpoint expected
     let txn = converted_1[2].clone();
@@ -198,7 +199,8 @@ async fn test_table_item_parsing_works() {
         assert_eq!(table_kv.get(&expected_k).unwrap(), &expected_v);
     }
 
-    test_context.check_golden_output(convert_protubuf_txn_arr_to_serde_value(&converted[1..]));
+    // TODO: Add golden back after code freeze (removing now to avoid merge conflicts)
+    // test_context.check_golden_output(convert_protubuf_txn_arr_to_serde_value(&converted[1..]));
 }
 
 async fn make_test_tables(ctx: &mut TestContext, account: &mut LocalAccount) {

--- a/sf-stream/src/tests/test_context.rs
+++ b/sf-stream/src/tests/test_context.rs
@@ -81,6 +81,7 @@ pub fn new_test_context(test_name: &str, fake_start_time_usecs: u64) -> TestCont
     )
 }
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct TestContext {
     pub context: Context,
@@ -96,6 +97,8 @@ pub struct TestContext {
     fake_time_usecs: u64,
 }
 
+// TODO: Remove after we add back golden
+#[allow(dead_code)]
 impl TestContext {
     pub fn new(
         context: Context,


### PR DESCRIPTION
### Description
Golden is causing merge conflicts due to changes between now and mainnet. Let's remove it for now and add it back later when the contracts are finalized. 

### Test Plan
```
> cargo test
running 4 tests
test tests::proto_converter_tests::test_genesis_works ... ok
test tests::proto_converter_tests::test_block_transactions_work ... ok
test tests::proto_converter_tests::test_block_height_and_ts_work ... ok
test tests::proto_converter_tests::test_table_item_parsing_works ... ok
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2619)
<!-- Reviewable:end -->
