### PR TITLE
[Aptos Framework][Governance] Add a generic map to store signer caps for addresses under on-chain governance's control

### DIFF
--- a/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -850,8 +850,15 @@
   {
     "type": "0x1::aptos_governance::GovernanceResponsbility",
     "data": {
-      "signer_cap": {
-        "account": "0x1"
+      "signer_caps": {
+        "data": [
+          {
+            "key": "0x1",
+            "value": {
+              "account": "0x1"
+            }
+          }
+        ]
       }
     }
   },

--- a/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -959,8 +959,15 @@
       "generic_type_params": []
     },
     "data": {
-      "signer_cap": {
-        "account": "0x1"
+      "signer_caps": {
+        "data": [
+          {
+            "key": "0x1",
+            "value": {
+              "account": "0x1"
+            }
+          }
+        ]
       }
     }
   },

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -62,7 +62,7 @@ module aptos_framework::genesis {
         );
 
         // Give the decentralized on-chain governance control over the core framework account.
-        aptos_governance::store_signer_cap(&aptos_framework_account, framework_signer_cap);
+        aptos_governance::store_signer_cap(&aptos_framework_account, @aptos_framework, framework_signer_cap);
 
         // Consensus config setup
         consensus_config::initialize(&aptos_framework_account);

--- a/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_block_transactions_work.json
+++ b/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_block_transactions_work.json
@@ -8,7 +8,7 @@
       "eventRootHash": "YPVlJld+KeJV8TgWig4e7McIG/o+rxMn60yg554WVK8=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "6xRzK6VM6fLD315J3XseepU0a5SPAGeqMEsnUAxZ19M=",
+      "accumulatorRootHash": "LuWFGe7gdE4jtieONc/d9siQWA3h5Z4sUqxLY+P+aL0=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -96,7 +96,7 @@
       "gasUsed": "42",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "gepZ5tGQXFZ0mcZ34/Iq9UpCP2pbdZAUNULFEreKTao=",
+      "accumulatorRootHash": "E4BWtWeNbhcKLRlJCeyTOolBIg31JtKaAwuqYf280XQ=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -225,7 +225,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "dQKd7Ntydqygwtm3nQVkcAzhYloHR2s+9o39J6vySKw="
+      "accumulatorRootHash": "HUdvbEON9X1Lwz1Z472BQGaalbZtF3uH3oQlJZ11mYY="
     },
     "blockHeight": "1",
     "type": "STATE_CHECKPOINT",

--- a/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_table_item_parsing_works.json
+++ b/sf-stream/goldens/sf_v1/aptos_sf_stream__tests__proto_converter_tests__test_table_item_parsing_works.json
@@ -8,7 +8,7 @@
       "eventRootHash": "YPVlJld+KeJV8TgWig4e7McIG/o+rxMn60yg554WVK8=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "6xRzK6VM6fLD315J3XseepU0a5SPAGeqMEsnUAxZ19M=",
+      "accumulatorRootHash": "LuWFGe7gdE4jtieONc/d9siQWA3h5Z4sUqxLY+P+aL0=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -96,7 +96,7 @@
       "gasUsed": "42",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "gepZ5tGQXFZ0mcZ34/Iq9UpCP2pbdZAUNULFEreKTao=",
+      "accumulatorRootHash": "E4BWtWeNbhcKLRlJCeyTOolBIg31JtKaAwuqYf280XQ=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -225,7 +225,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "dQKd7Ntydqygwtm3nQVkcAzhYloHR2s+9o39J6vySKw="
+      "accumulatorRootHash": "HUdvbEON9X1Lwz1Z472BQGaalbZtF3uH3oQlJZ11mYY="
     },
     "blockHeight": "1",
     "type": "STATE_CHECKPOINT",
@@ -240,7 +240,7 @@
       "eventRootHash": "xQa4qACFHx4YpbLjBVf8UKi4CXw95t7b2M90GQXvP8Y=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "CaloljYs1wAA0NhA5O0lMtIpCX9QW5W/db2mEUS9OkI=",
+      "accumulatorRootHash": "WYRzafd5tzWFDl5unkNqFsrCyWDe1Z4qaZCC23uU2+A=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -328,7 +328,7 @@
       "gasUsed": "5",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "Bd57Q9lKus1oY7iZjgAYkoZEYLNKRePhKPCVqfcvZbU=",
+      "accumulatorRootHash": "JfF/v74cn7UrDXGaln7nlEaX9OXGHmdZrJuW+Gsm+nk=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -947,7 +947,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "zE98kG3N7pgU00dZnHmHJlIa15IlIZqfxWvvp+HJLWo="
+      "accumulatorRootHash": "7v67SpHX+r0jAMM+2YZE7yw1xSvtLLfeXvfzTHbo05g="
     },
     "blockHeight": "2",
     "type": "STATE_CHECKPOINT",
@@ -962,7 +962,7 @@
       "eventRootHash": "dliD7Dy093TZN3Zy5Vpvn9Jb7Q3dr30c4Jc4Sa/Z7Ew=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "ygOQZwcab7Hmd/iXgMOS9ZiB0m8tknj4OaIVAgWS3Dk=",
+      "accumulatorRootHash": "CkWXiLrlkLC2mKwr6msmDhtGpMEWC9SbP7EvgOSflSg=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -1050,7 +1050,7 @@
       "gasUsed": "29",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "6xIZiZTG5BnVSEzUGMVSf1U5btBBHaPgBRpDRQh3VeQ=",
+      "accumulatorRootHash": "kjmCFKJaCBVs5OY8Cvk3+7k5uqCM8ZV4O25Jr1/1gtE=",
       "changes": [
         {
           "type": "WRITE_RESOURCE",
@@ -1290,7 +1290,7 @@
       "eventRootHash": "QUNDVU1VTEFUT1JfUExBQ0VIT0xERVJfSEFTSAAAAAA=",
       "success": true,
       "vmStatus": "Executed successfully",
-      "accumulatorRootHash": "oT/DGRsVi0sQMAW9fqZhNe2CcVEKvPd7UabLugc+u3c="
+      "accumulatorRootHash": "QFrdINg3BxFAeHweILQDJ67a+4SlxFvAOrjn7DMP+bQ="
     },
     "blockHeight": "3",
     "type": "STATE_CHECKPOINT",


### PR DESCRIPTION
### Description
Currently the governance only stores the signer cap for 0x1. This change allows storing signer caps for multiple addresses under the on-chain governance's control.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2620)
<!-- Reviewable:end -->
