### PR TITLE
[api] Change accept type handling

### DIFF
--- a/api/src/poem_backend/accept_type.rs
+++ b/api/src/poem_backend/accept_type.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use poem::{http::StatusCode, web::Accept, Error, FromRequest, Request, RequestBody, Result};
+use crate::poem_backend::bcs_payload;
+use poem::{web::Accept, FromRequest, Request, RequestBody, Result};
 
 #[derive(PartialEq)]
 pub enum AcceptType {
@@ -19,20 +20,12 @@ impl<'a> FromRequest<'a> for AcceptType {
     }
 }
 
-// Check that the accept type is one of the allowed variants. If there is no
-// accept type and nothing explicitly not allowed, default to JSON.
+/// Check that the accept type is one of the allowed variants. If there is no
+/// overriding explicit accept type, default to JSON.
 fn parse_accept(accept: &Accept) -> Result<AcceptType> {
     for mime in &accept.0 {
-        match mime.as_ref() {
-            "application/json" => return Ok(AcceptType::Json),
-            "application/x-bcs" => return Ok(AcceptType::Bcs),
-            "*/*" => {}
-            wildcard => {
-                return Err(Error::from_string(
-                    &format!("Unsupported Accept type: {:?}", wildcard),
-                    StatusCode::NOT_ACCEPTABLE,
-                ));
-            }
+        if bcs_payload::CONTENT_TYPE == mime.as_ref() {
+            return Ok(AcceptType::Bcs);
         }
     }
 


### PR DESCRIPTION
### Description
Now if there is a BCS accept type, BCS will be returned.  Otherwise,
for any other combination of types, JSON will be returned.

### Test Plan
Current tests

#### Via Chrome
```
http://localhost:8080/v1/accounts/0x1

{"sequence_number":"0","authentication_key":"0x0000000000000000000000000000000000000000000000000000000000000001"}
```

#### Via CURL
```
// JSON is also accepted as JSON
$ curl -H"Accept: application/json" localhost:8080/v1
{"chain_id":4,"epoch":"4","ledger_version":"515","oldest_ledger_version":"0","ledger_timestamp":"1659831099801124","node_role":"validator"}%

// Text (Via chrome etc.). is JSON
$ curl -H"Accept: text/html" localhost:8080/v1
{"chain_id":4,"epoch":"4","ledger_version":"535","oldest_ledger_version":"0","ledger_timestamp":"1659831106374266","node_role":"validator"}%

// Any header is JSON
$ curl -H"Accept: */*" localhost:8080/v1
{"chain_id":4,"epoch":"4","ledger_version":"556","oldest_ledger_version":"0","ledger_timestamp":"1659831113622978","node_role":"validator"}%

// BCS works properly on its own
$ curl -H"Accept: application/x-bcs" localhost:8080/v1 --output -
epochchain_id	node_roleledger_version618ledger_timestamp1659831135236340oldest_ledger_version0

// Multiple headers means the BCS is used
$ curl -H"Accept: application/json" -H"Accept: application/x-bcs" localhost:8080/v1 --output -
epochchain_id	node_roleledger_version1099ledger_timestamp1659831297855148oldest_ledger_version0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2625)
<!-- Reviewable:end -->
