### PR TITLE
[Parallel Execution] Publishing support: Module Read & Write intersection and seq fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,11 +879,14 @@ dependencies = [
 name = "aptos-parallel-executor"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-infallible",
+ "aptos-types",
  "arc-swap",
  "criterion",
  "crossbeam",
  "crossbeam-queue",
+ "dashmap",
  "mvhashmap",
  "num_cpus",
  "once_cell",

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -907,11 +907,12 @@ impl VMExecutor for AptosVM {
 
         let concurrency_level = Self::get_concurrency_level();
         if concurrency_level > 1 {
-            let (result, _) = crate::parallel_executor::ParallelAptosVM::execute_block(
+            let (result, err) = crate::parallel_executor::ParallelAptosVM::execute_block(
                 transactions,
                 state_view,
                 concurrency_level,
             )?;
+            debug!("Parallel execution error {:?}", err);
             Ok(result)
         } else {
             let output = Self::execute_block_and_keep_vm_status(transactions, state_view)?;

--- a/aptos-move/aptos-vm/src/parallel_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/parallel_executor/mod.rs
@@ -86,7 +86,7 @@ impl ParallelAptosVM {
                     .collect(),
                 None,
             )),
-            Err(err @ Error::InferencerError) | Err(err @ Error::UnestimatedWrite) => {
+            Err(err @ Error::ModulePathReadWrite) => {
                 let output = AptosVM::execute_block_and_keep_vm_status(transactions, state_view)?;
                 Ok((
                     output

--- a/aptos-move/parallel-executor/Cargo.toml
+++ b/aptos-move/parallel-executor/Cargo.toml
@@ -10,10 +10,12 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.57"
 arc-swap = "1.5.0"
 criterion = { version = "0.3.5", optional = true }
 crossbeam = "0.8.1"
 crossbeam-queue = "0.3.5"
+dashmap = "5.2.0"
 num_cpus = "1.13.1"
 once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
@@ -21,6 +23,7 @@ proptest-derive = { version = "0.3.0", optional = true }
 rayon = "1.5.2"
 
 aptos-infallible = { path = "../../crates/aptos-infallible" }
+aptos-types = { path = "../../types" }
 
 mvhashmap = { path = "../mvhashmap" }
 

--- a/aptos-move/parallel-executor/src/errors.rs
+++ b/aptos-move/parallel-executor/src/errors.rs
@@ -1,16 +1,17 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Error<E> {
     /// Invariant violation that happens internally inside of scheduler, usually an indication of
     /// implementation error.
     InvariantViolation,
-    /// The inference can't get the read/write set of a transaction, abort the entire execution pipeline.
-    InferencerError,
-    /// A transaction write to a key that wasn't estimated by the inferencer, abort the execution
-    /// because we don't have a good way of handling read-after-write dependency. Will relax this limitation later.
-    UnestimatedWrite,
+    /// The same module access path for module was both read & written during speculative executions.
+    /// This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
+    /// aborting the parallel execution pipeline and falling back to the sequential execution.
+    /// TODO: (short-med term) relax the limitation, and (mid-long term) provide proper multi-versioning
+    /// for code (like data) for the cache.
+    ModulePathReadWrite,
     /// Execution of a thread yields a non-recoverable error, such error will be propagated back to
     /// the caller.
     UserError(E),

--- a/aptos-move/parallel-executor/src/proptest_types/tests.rs
+++ b/aptos-move/parallel-executor/src/proptest_types/tests.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    errors::Error,
     executor::ParallelTransactionExecutor,
     proptest_types::types::{
-        ExpectedOutput, Task, Transaction, TransactionGen, TransactionGenParams,
+        ExpectedOutput, KeyType, Task, Transaction, TransactionGen, TransactionGenParams,
     },
 };
 use num_cpus;
@@ -18,11 +19,12 @@ use proptest::{
 use std::{fmt::Debug, hash::Hash};
 
 fn run_transactions<K, V>(
-    key_universe: Vec<K>,
+    key_universe: &[K],
     transaction_gens: Vec<TransactionGen<V>>,
     abort_transactions: Vec<Index>,
     skip_rest_transactions: Vec<Index>,
     num_repeat: usize,
+    module_access: (bool, bool),
 ) -> bool
 where
     K: Hash + Clone + Debug + Eq + Send + Sync + PartialOrd + Ord + 'static,
@@ -30,7 +32,7 @@ where
 {
     let mut transactions: Vec<_> = transaction_gens
         .into_iter()
-        .map(|txn_gen| txn_gen.materialize(&key_universe))
+        .map(|txn_gen| txn_gen.materialize(key_universe, module_access))
         .collect();
 
     let length = transactions.len();
@@ -46,8 +48,15 @@ where
     let mut ret = true;
     for _ in 0..num_repeat {
         let output =
-            ParallelTransactionExecutor::<Transaction<K, V>, Task<K, V>>::new(num_cpus::get())
-                .execute_transactions_parallel((), transactions.clone());
+            ParallelTransactionExecutor::<Transaction<KeyType<K>, V>, Task<KeyType<K>, V>>::new(
+                num_cpus::get(),
+            )
+            .execute_transactions_parallel((), transactions.clone());
+
+        if module_access.0 && module_access.1 {
+            assert_eq!(output.unwrap_err(), Error::ModulePathReadWrite);
+            continue;
+        }
 
         let baseline = ExpectedOutput::generate_baseline(&transactions);
 
@@ -65,7 +74,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 0),
         skip_rest_transactions in vec(any::<Index>(), 0),
     ) {
-        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, 1));
+        prop_assert!(run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false)));
     }
 
     #[test]
@@ -75,7 +84,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 5),
         skip_rest_transactions in vec(any::<Index>(), 0),
     ) {
-        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, 1));
+        prop_assert!(run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false)));
     }
 
     #[test]
@@ -85,7 +94,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 0),
         skip_rest_transactions in vec(any::<Index>(), 5),
     ) {
-        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, 1));
+        prop_assert!(run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false)));
     }
 
     #[test]
@@ -95,7 +104,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 5),
         skip_rest_transactions in vec(any::<Index>(), 5),
     ) {
-        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, 1));
+        prop_assert!(run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false)));
     }
 
     #[test]
@@ -105,7 +114,7 @@ proptest! {
         abort_transactions in vec(any::<Index>(), 3),
         skip_rest_transactions in vec(any::<Index>(), 3),
     ) {
-        prop_assert!(run_transactions(universe, transaction_gen, abort_transactions, skip_rest_transactions, 1));
+        prop_assert!(run_transactions(&universe, transaction_gen, abort_transactions, skip_rest_transactions, 1, (false, false)));
     }
 }
 
@@ -126,11 +135,12 @@ fn dynamic_read_writes() {
     .current();
 
     assert!(run_transactions(
-        universe,
+        &universe,
         transaction_gen,
         vec![],
         vec![],
-        100
+        100,
+        (false, false),
     ));
 }
 
@@ -152,10 +162,53 @@ fn dynamic_read_writes_contended() {
     .current();
 
     assert!(run_transactions(
-        universe,
+        &universe,
         transaction_gen,
         vec![],
         vec![],
-        100
+        100,
+        (false, false),
+    ));
+}
+
+#[test]
+fn module_publishing_fallback() {
+    let mut runner = TestRunner::default();
+
+    let universe = vec(any::<[u8; 32]>(), 100)
+        .new_tree(&mut runner)
+        .expect("creating a new value should succeed")
+        .current();
+    let transaction_gen = vec(
+        any_with::<TransactionGen<[u8; 32]>>(TransactionGenParams::new_dynamic()),
+        3000,
+    )
+    .new_tree(&mut runner)
+    .expect("creating a new value should succeed")
+    .current();
+
+    assert!(run_transactions(
+        &universe,
+        transaction_gen.clone(),
+        vec![],
+        vec![],
+        2,
+        (false, true),
+    ));
+    assert!(run_transactions(
+        &universe,
+        transaction_gen.clone(),
+        vec![],
+        vec![],
+        2,
+        (false, true),
+    ));
+    assert!(run_transactions(
+        &universe,
+        transaction_gen,
+        vec![],
+        vec![],
+        2,
+        (true, true),
     ));
 }

--- a/aptos-move/parallel-executor/src/task.rs
+++ b/aptos-move/parallel-executor/src/task.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::executor::MVHashMapView;
+use aptos_types::{access_path::AccessPath, state_store::state_key::StateKey};
 use std::{fmt::Debug, hash::Hash};
 
 /// The execution result of a transaction
@@ -17,10 +18,25 @@ pub enum ExecutionStatus<T, E> {
     SkipRest(T),
 }
 
+pub trait ModulePath {
+    fn module_path(&self) -> Option<AccessPath>;
+}
+
+impl ModulePath for StateKey {
+    fn module_path(&self) -> Option<AccessPath> {
+        if let StateKey::AccessPath(ap) = self {
+            if ap.is_code() {
+                return Some(ap.clone());
+            }
+        }
+        None
+    }
+}
+
 /// Trait that defines a transaction that could be parallel executed by the scheduler. Each
 /// transaction will write to a key value storage as their side effect.
 pub trait Transaction: Sync + Send + 'static {
-    type Key: PartialOrd + Send + Sync + Clone + Hash + Eq;
+    type Key: PartialOrd + Send + Sync + Clone + Hash + Eq + ModulePath;
     type Value: Send + Sync;
 }
 

--- a/aptos-move/parallel-executor/src/txn_last_input_output.rs
+++ b/aptos-move/parallel-executor/src/txn_last_input_output.rs
@@ -4,10 +4,13 @@
 use crate::{
     errors::Error,
     scheduler::{Incarnation, TxnIndex, Version},
-    task::{ExecutionStatus, Transaction, TransactionOutput},
+    task::{ExecutionStatus, ModulePath, Transaction, TransactionOutput},
 };
+use anyhow::{bail, Result};
+use aptos_types::access_path::AccessPath;
 use arc_swap::ArcSwapOption;
 use crossbeam::utils::CachePadded;
+use dashmap::DashSet;
 use std::{collections::HashSet, sync::Arc};
 
 type TxnInput<K> = Vec<ReadDescriptor<K>>;
@@ -30,7 +33,7 @@ pub struct ReadDescriptor<K> {
     kind: ReadKind,
 }
 
-impl<K> ReadDescriptor<K> {
+impl<K: ModulePath> ReadDescriptor<K> {
     pub fn from(access_path: K, txn_idx: TxnIndex, incarnation: Incarnation) -> Self {
         Self {
             access_path,
@@ -43,6 +46,10 @@ impl<K> ReadDescriptor<K> {
             access_path,
             kind: ReadKind::Storage,
         }
+    }
+
+    fn module_path(&self) -> Option<AccessPath> {
+        self.access_path.module_path()
     }
 
     pub fn path(&self) -> &K {
@@ -65,9 +72,15 @@ pub struct TxnLastInputOutput<K, T, E> {
     inputs: Vec<CachePadded<ArcSwapOption<TxnInput<K>>>>, // txn_idx -> input.
 
     outputs: Vec<CachePadded<ArcSwapOption<TxnOutput<T, E>>>>, // txn_idx -> output.
+
+    // Record all writes and reads to access paths corresponding to modules (code) in any
+    // (speculative) executions. Used to avoid a potential race with module publishing and
+    // Move-VM loader cache - see 'record' function comment for more information.
+    module_writes: DashSet<AccessPath>,
+    module_reads: DashSet<AccessPath>,
 }
 
-impl<K, T: TransactionOutput, E: Send + Clone> TxnLastInputOutput<K, T, E> {
+impl<K: ModulePath, T: TransactionOutput, E: Send + Clone> TxnLastInputOutput<K, T, E> {
     pub fn new(num_txns: usize) -> Self {
         Self {
             inputs: (0..num_txns)
@@ -76,17 +89,62 @@ impl<K, T: TransactionOutput, E: Send + Clone> TxnLastInputOutput<K, T, E> {
             outputs: (0..num_txns)
                 .map(|_| CachePadded::new(ArcSwapOption::empty()))
                 .collect(),
+            module_writes: DashSet::new(),
+            module_reads: DashSet::new(),
         }
     }
 
+    fn append_and_check(
+        paths: Vec<AccessPath>,
+        set_to_append: &DashSet<AccessPath>,
+        set_to_check: &DashSet<AccessPath>,
+    ) -> Result<()> {
+        for path in paths {
+            // Standard flags, first show, then look.
+            set_to_append.insert(path.clone());
+
+            if set_to_check.contains(&path) {
+                bail!("Module published and also read");
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns an error if a module path that was read was previously written to, and vice versa.
+    /// Since parallel executor is instantiated per block, any module that is in the Move-VM loader
+    /// cache must previously be read and would be recorded in the 'module_reads' set. Any module
+    /// that is written (published or re-published) goes through transaction output write-set and
+    /// gets recorded in the 'module_writes' set. If these sets have an intersection, it is currently
+    /// possible that Move-VM loader cache loads a module and incorrectly uses it for another
+    /// transaction (e.g. a smaller transaction, or if the speculative execution of the publishing
+    /// transaction later aborts). The intersection is guaranteed to be found because we first
+    /// record the paths then check the other set (flags principle), and in this case we return an
+    /// error that ensures a fallback to a correct sequential execution.
+    /// When the sets do not have an intersection, it is impossible for the race to occur as any
+    /// module in the loader cache may not be published by a transaction in the ongoing block.
     pub fn record(
         &self,
         txn_idx: TxnIndex,
         input: Vec<ReadDescriptor<K>>,
         output: ExecutionStatus<T, Error<E>>,
-    ) {
+    ) -> Result<()> {
+        let read_modules: Vec<AccessPath> =
+            input.iter().filter_map(|desc| desc.module_path()).collect();
+        let written_modules: Vec<AccessPath> = match &output {
+            ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => output
+                .get_writes()
+                .into_iter()
+                .filter_map(|(k, _)| k.module_path())
+                .collect(),
+            ExecutionStatus::Abort(_) => Vec::new(),
+        };
+
+        Self::append_and_check(read_modules, &self.module_reads, &self.module_writes)?;
+        Self::append_and_check(written_modules, &self.module_writes, &self.module_reads)?;
+
         self.inputs[txn_idx].store(Some(Arc::new(input)));
         self.outputs[txn_idx].store(Some(Arc::new(output)));
+        Ok(())
     }
 
     pub fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<Vec<ReadDescriptor<K>>>> {

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -102,6 +102,10 @@ impl AccessPath {
             Path::Code(_) => None,
         }
     }
+
+    pub fn is_code(&self) -> bool {
+        matches!(self.get_path(), Path::Code(_))
+    }
 }
 
 impl fmt::Debug for AccessPath {


### PR DESCRIPTION
Adjusted existing tests, ensured ModuleReadWrite error is returned when module read and write paths intersect.

In a later diff: split large blocks into smaller chunks, in ParallelAptosVM.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2627)
<!-- Reviewable:end -->
