### PR TITLE
Update fullnode-source-code-or-docker.md

### DIFF
--- a/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
+++ b/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
@@ -175,8 +175,9 @@ If M1/M2 support is important to you, please comment on and follow this issue: h
 
 4. Finally, start the fullnode via docker:
    ```bash
-    docker run --pull=always --rm -p 8080:8080 -p 9101:9101 -v $(pwd):/opt/aptos/etc -v $(pwd)/data:/opt/aptos/data --workdir /opt/aptos/etc --name=aptos-fullnode aptoslabs/validator:devnet aptos-node -f /opt/aptos/etc/public_full_node.yaml
+    docker run --pull=always --rm -p 8080:8080 -p 9101:9101 -p 6180:6180 -v $(pwd):/opt/aptos/etc -v $(pwd)/data:/opt/aptos/data --workdir /opt/aptos/etc --name=aptos-fullnode aptoslabs/validator:devnet aptos-node -f /opt/aptos/etc/public_full_node.yaml
    ```
+Ensure you have opened the relevant ports - 8080, 9101 and 6180 and you may also need to update the 127.0.0.1 with 0.0.0.0 in the public_full_node.yaml - listen_address and api\address
 
 ## Verify the correctness of your FullNode
 


### PR DESCRIPTION
added the 6180 port to the docker command. also updated the documentation to suggest opening relevant ports and updating the public_full_node.yaml file to replace 127.0.0.1 with 0.0.0.0 to prevent issues with docker not allowing traffic on those ports

### Description
Just an update to documentation based on my experience

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2640)
<!-- Reviewable:end -->
