### PR TITLE
[Genesis] Make rewards and governance params configurable and set reasonable defaults in tests

### DIFF
--- a/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -812,7 +812,7 @@
     "data": {
       "min_voting_threshold": "0",
       "required_proposer_stake": "0",
-      "voting_period_secs": "604800"
+      "voting_duration_secs": "3600"
     }
   },
   {

--- a/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -911,7 +911,7 @@
     "data": {
       "min_voting_threshold": "0",
       "required_proposer_stake": "0",
-      "voting_period_secs": "604800"
+      "voting_duration_secs": "3600"
     }
   },
   {

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -48,7 +48,7 @@ module aptos_framework::aptos_governance {
     struct GovernanceConfig has key {
         min_voting_threshold: u128,
         required_proposer_stake: u64,
-        voting_period_secs: u64,
+        voting_duration_secs: u64,
     }
 
     struct RecordKey has copy, drop, store {
@@ -91,7 +91,7 @@ module aptos_framework::aptos_governance {
     struct UpdateConfigEvent has drop, store {
         min_voting_threshold: u128,
         required_proposer_stake: u64,
-        voting_period_secs: u64,
+        voting_duration_secs: u64,
     }
 
     /// Stores the signer capability for 0x1.
@@ -117,13 +117,13 @@ module aptos_framework::aptos_governance {
         aptos_framework: &signer,
         min_voting_threshold: u128,
         required_proposer_stake: u64,
-        voting_period_secs: u64,
+        voting_duration_secs: u64,
     ) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         voting::register<GovernanceProposal>(aptos_framework);
         move_to(aptos_framework, GovernanceConfig {
-            voting_period_secs,
+            voting_duration_secs,
             min_voting_threshold,
             required_proposer_stake,
         });
@@ -143,10 +143,10 @@ module aptos_framework::aptos_governance {
         _proposal: GovernanceProposal,
         min_voting_threshold: u128,
         required_proposer_stake: u64,
-        voting_period_secs: u64,
+        voting_duration_secs: u64,
     ) acquires GovernanceConfig, GovernanceEvents {
         let governance_config = borrow_global_mut<GovernanceConfig>(@aptos_framework);
-        governance_config.voting_period_secs = voting_period_secs;
+        governance_config.voting_duration_secs = voting_duration_secs;
         governance_config.min_voting_threshold = min_voting_threshold;
         governance_config.required_proposer_stake = required_proposer_stake;
 
@@ -156,7 +156,7 @@ module aptos_framework::aptos_governance {
             UpdateConfigEvent {
                 min_voting_threshold,
                 required_proposer_stake,
-                voting_period_secs
+                voting_duration_secs
             },
         );
     }
@@ -184,7 +184,7 @@ module aptos_framework::aptos_governance {
 
         // The proposer's stake needs to be locked up at least as long as the proposal's voting period.
         let current_time = timestamp::now_seconds();
-        let proposal_expiration = current_time + governance_config.voting_period_secs;
+        let proposal_expiration = current_time + governance_config.voting_duration_secs;
         assert!(
             stake::get_lockup_secs(stake_pool) >= proposal_expiration,
             error::invalid_argument(EINSUFFICIENT_STAKE_LOCKUP),

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -259,7 +259,7 @@ where
             .with_init_genesis_config(Some(Arc::new(|genesis_config| {
                 genesis_config.allow_new_validators = true;
                 genesis_config.epoch_duration_secs = EPOCH_LENGTH_SECS;
-                genesis_config.recurring_lockup_duration_secs = 86400;
+                genesis_config.recurring_lockup_duration_secs = 7200;
             })))
             .with_randomize_first_validator_ports(random_ports);
 

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -34,14 +34,22 @@ pub struct Layout {
     /// Whether to allow new validators to join the set after genesis
     #[serde(default)]
     pub allow_new_validators: bool,
+    /// Duration of an epoch
+    pub epoch_duration_secs: u64,
     /// Minimum stake to be in the validator set
     pub min_stake: u64,
+    /// Minimum number of votes to consider a proposal valid.
+    pub min_voting_threshold: u128,
     /// Maximum stake to be in the validator set
     pub max_stake: u64,
     /// Minimum number of seconds to lockup staked coins
     pub recurring_lockup_duration_secs: u64,
-    /// Duration of an epoch
-    pub epoch_duration_secs: u64,
+    /// Required amount of stake to create proposals.
+    pub required_proposer_stake: u64,
+    /// Percentage of stake given out as rewards a year (0-100%).
+    pub rewards_apy_percentage: u64,
+    /// Voting duration for a proposal in seconds.
+    pub voting_duration_secs: u64,
 }
 
 impl Layout {

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -32,18 +32,27 @@ pub struct GenesisInfo {
     validators: Vec<Validator>,
     /// Compiled bytecode of framework modules
     modules: Vec<Vec<u8>>,
+    /// The genesis transaction, once it's been generated
+    genesis: Option<Transaction>,
+
     /// Whether to allow new validators to join the set after genesis
     pub allow_new_validators: bool,
+    /// Duration of an epoch
+    pub epoch_duration_secs: u64,
     /// Minimum stake to be in the validator set
     pub min_stake: u64,
+    /// Minimum number of votes to consider a proposal valid.
+    pub min_voting_threshold: u128,
     /// Maximum stake to be in the validator set
     pub max_stake: u64,
     /// Minimum number of seconds to lockup staked coins
     pub recurring_lockup_duration_secs: u64,
-    /// Duration of an epoch
-    pub epoch_duration_secs: u64,
-    /// The genesis transaction, once it's been generated
-    genesis: Option<Transaction>,
+    /// Required amount of stake to create proposals.
+    pub required_proposer_stake: u64,
+    /// Percentage of stake given out as rewards a year (0-100%).
+    pub rewards_apy_percentage: u64,
+    /// Voting duration for a proposal in seconds.
+    pub voting_duration_secs: u64,
 }
 
 impl GenesisInfo {
@@ -53,10 +62,14 @@ impl GenesisInfo {
         configs: Vec<ValidatorConfiguration>,
         modules: Vec<Vec<u8>>,
         allow_new_validators: bool,
+        epoch_duration_secs: u64,
         min_stake: u64,
+        min_voting_threshold: u128,
         max_stake: u64,
         recurring_lockup_duration_secs: u64,
-        epoch_duration_secs: u64,
+        required_proposer_stake: u64,
+        rewards_apy_percentage: u64,
+        voting_duration_secs: u64,
     ) -> anyhow::Result<GenesisInfo> {
         let mut validators = Vec::new();
 
@@ -69,12 +82,16 @@ impl GenesisInfo {
             root_key,
             validators,
             modules,
+            genesis: None,
             allow_new_validators,
+            epoch_duration_secs,
             min_stake,
+            min_voting_threshold,
             max_stake,
             recurring_lockup_duration_secs,
-            epoch_duration_secs,
-            genesis: None,
+            required_proposer_stake,
+            rewards_apy_percentage,
+            voting_duration_secs,
         })
     }
 
@@ -93,12 +110,16 @@ impl GenesisInfo {
             &self.validators,
             &self.modules,
             self.chain_id,
-            vm_genesis::GenesisConfigurations {
+            vm_genesis::GenesisConfiguration {
+                allow_new_validators: self.allow_new_validators,
                 epoch_duration_secs: self.epoch_duration_secs,
                 min_stake: self.min_stake,
+                min_voting_threshold: self.min_voting_threshold,
                 max_stake: self.max_stake,
                 recurring_lockup_duration_secs: self.recurring_lockup_duration_secs,
-                allow_new_validators: self.allow_new_validators,
+                required_proposer_stake: self.required_proposer_stake,
+                rewards_apy_percentage: self.rewards_apy_percentage,
+                voting_duration_secs: self.voting_duration_secs,
             },
         )
     }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -135,10 +135,14 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
         validators,
         modules,
         layout.allow_new_validators,
+        layout.epoch_duration_secs,
         layout.min_stake,
+        layout.min_voting_threshold,
         layout.max_stake,
         layout.recurring_lockup_duration_secs,
-        layout.epoch_duration_secs,
+        layout.required_proposer_stake,
+        layout.rewards_apy_percentage,
+        layout.voting_duration_secs,
     )?)
 }
 

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -135,10 +135,14 @@ fn create_layout_file(
         users,
         chain_id,
         allow_new_validators: false,
+        epoch_duration_secs: 86400,
         min_stake: 0,
+        min_voting_threshold: 0,
         max_stake: u64::MAX,
-        recurring_lockup_duration_secs: 86400, // One day
-        epoch_duration_secs: 86400,            // One day
+        recurring_lockup_duration_secs: 86400,
+        required_proposer_stake: 0,
+        rewards_apy_percentage: 1,
+        voting_duration_secs: 1,
     };
     let file = TempPath::new();
     file.create_as_file().unwrap();

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -13,12 +13,16 @@ data:
     - {{ printf "%s-%d" $.Values.genesis.username_prefix $i | squote }}
     {{- end }}
     chain_id: {{ .Values.chain.chain_id | int }}
-    min_stake: {{ .Values.chain.min_stake | int }}
-    max_stake: {{ .Values.chain.max_stake | int }}
-    recurring_lockup_duration_secs: {{ .Values.chain.recurring_lockup_duration_secs | int }}
+    allow_new_validators: {{ .Values.chain.allow_new_validators }}
     epoch_duration_secs: {{ .Values.chain.epoch_duration_secs | int }}
     min_price_per_gas_unit: {{ .Values.chain.min_price_per_gas_unit }}
-    allow_new_validators: {{ .Values.chain.allow_new_validators }}
+    min_stake: {{ .Values.chain.min_stake | int }}
+    min_voting_threshold: {{ .Values.chain.min_voting_threshold | int }}
+    max_stake: {{ .Values.chain.max_stake | int }}
+    recurring_lockup_duration_secs: {{ .Values.chain.recurring_lockup_duration_secs | int }}
+    required_proposer_stake: {{ .Values.chain.required_proposer_stake | int }}
+    rewards_apy_percentage: {{ .Values.chain.rewards_apy_percentage | int }}
+    voting_duration_secs: {{ .Values.chain.voting_duration_secs | int }}
 
 ---
 

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -3,15 +3,16 @@ chain:
   era: 1
   chain_id: 4
   root_key: '0x5243ca72b0766d9e9cbf2debf6153443b01a1e0e6d086c7ea206eaf6f8043956'
-  min_stake: 0
-  max_stake: 100000
-  epoch_duration_secs: 86400 # 1 day
-  recurring_lockup_duration_secs: 86400 # 1 day
-  # instead of specifying "initial_lockup_timestamp", just take the delta between
-  # the current timestamp
-  initial_lockup_duration: 1d
-  min_price_per_gas_unit: 1
   allow_new_validators: false
+  epoch_duration_secs: 86400 # 1 day
+  min_price_per_gas_unit: 1
+  min_stake: 0
+  min_voting_threshold: 0
+  max_stake: 100000000000000000 # 1B APTOS coins with 8 decimals
+  recurring_lockup_duration_secs: 86400 # 1 day
+  required_proposer_stake: 100000000000 # 1M APTOS coins with 8 decimals
+  rewards_apy_percentage: 10
+  voting_duration_secs: 43200 # 12 hours
 
 imageTag: testnet
 

--- a/testsuite/smoke-test/src/aptos_cli.rs
+++ b/testsuite/smoke-test/src/aptos_cli.rs
@@ -192,8 +192,9 @@ async fn test_join_and_leave_validator() {
         }))
         .with_init_genesis_config(Arc::new(|genesis_config| {
             genesis_config.allow_new_validators = true;
-            genesis_config.epoch_duration_secs = 3600;
-            genesis_config.recurring_lockup_duration_secs = 2;
+            genesis_config.epoch_duration_secs = 5;
+            genesis_config.recurring_lockup_duration_secs = 10;
+            genesis_config.voting_duration_secs = 5;
         }))
         .build_with_cli(0)
         .await;
@@ -312,7 +313,7 @@ async fn test_join_and_leave_validator() {
     );
 
     // Conservatively wait until the recurring lockup is over.
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
     let withdraw_stake = 2;
     gas_used += get_gas(


### PR DESCRIPTION
### Description

Reward rate and on chian governance params are currently hardcoded. This makes them configurable in genesis configurations. Reasonable defaults are also set for tests and local node setup.

### Test Plan
Existing e2e, smoke tests and Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2641)
<!-- Reviewable:end -->
