### PR TITLE
[State Sync] Make fast sync crash fault tolerant (Step 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7987,6 +7987,7 @@ dependencies = [
  "reqwest",
  "serde_json",
  "serde_yaml 0.8.26",
+ "state-sync-driver",
  "tokio",
 ]
 
@@ -8051,6 +8052,7 @@ dependencies = [
  "move-deps",
  "network",
  "once_cell",
+ "schemadb",
  "scratchpad",
  "serde 1.0.141",
  "storage-interface",

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -43,6 +43,7 @@ use network_builder::builder::NetworkBuilder;
 use rand::{rngs::StdRng, SeedableRng};
 use state_sync_driver::driver_factory::DriverFactory;
 use state_sync_driver::driver_factory::StateSyncRuntimes;
+use state_sync_driver::metadata_storage::PersistentMetadataStorage;
 use std::{
     boxed::Box,
     collections::{HashMap, HashSet},
@@ -353,8 +354,9 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
         aptos_data_client.clone(),
     )?;
 
-    // Create the chunk executor
+    // Create the chunk executor and persistent storage
     let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
+    let metadata_storage = PersistentMetadataStorage::new(&node_config.storage.dir());
 
     // Create the state sync driver factory
     let state_sync = DriverFactory::create_and_spawn_driver(
@@ -364,6 +366,7 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
         db_rw,
         chunk_executor,
         mempool_notifier,
+        metadata_storage,
         consensus_listener,
         event_subscription_service,
         aptos_data_client,

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -64,6 +64,7 @@ pub struct StateSyncDriverConfig {
     pub max_consecutive_stream_notifications: u64, // The max number of notifications to process per driver loop
     pub max_pending_data_chunks: u64, // The max number of data chunks pending execution or commit
     pub max_stream_wait_time_ms: u64, // The max time (ms) to wait for a data stream notification
+    pub num_versions_to_skip_snapshot_sync: u64, // The version lag we'll tolerate before snapshot syncing
 }
 
 /// The default state sync driver config will be the one that gets (and keeps)
@@ -79,6 +80,7 @@ impl Default for StateSyncDriverConfig {
             max_consecutive_stream_notifications: 10,
             max_pending_data_chunks: 100,
             max_stream_wait_time_ms: 5000,
+            num_versions_to_skip_snapshot_sync: 10_000_000, // At 1k TPS, this allows a node to fail for about 3 hours.
         }
     }
 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -53,7 +53,7 @@ pub const MAX_REAL_TRANSACTION_OUTPUT: u64 = MAX_REAL_TRANSACTION;
 pub const MAX_RESPONSE_ID: u64 = 100000;
 
 /// Test timeout constant
-pub const MAX_NOTIFICATION_TIMEOUT_SECS: u64 = 20;
+pub const MAX_NOTIFICATION_TIMEOUT_SECS: u64 = 40;
 
 /// A simple mock of the Aptos Data Client
 #[derive(Clone, Debug)]

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.52"
+bcs = "0.1.3"
 futures = "0.3.21"
 once_cell = "1.10.0"
 serde = { version = "1.0.137", default-features = false }
@@ -30,6 +32,7 @@ data-streaming-service = { path = "../data-streaming-service" }
 event-notifications = { path = "../../inter-component/event-notifications" }
 executor-types = { path = "../../../execution/executor-types" }
 mempool-notifications = { path = "../../inter-component/mempool-notifications" }
+schemadb = { path = "../../../storage/schemadb" }
 scratchpad = { path = "../../../storage/scratchpad" }
 storage-interface = { path = "../../../storage/storage-interface" }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -4,6 +4,7 @@
 use crate::{
     driver::{DriverConfiguration, StateSyncDriver},
     driver_client::{ClientNotificationListener, DriverClient, DriverNotification},
+    metadata_storage::MetadataStorageInterface,
     notification_handlers::{
         CommitNotificationListener, ConsensusNotificationHandler, ErrorNotificationListener,
         MempoolNotificationHandler,
@@ -37,6 +38,7 @@ impl DriverFactory {
     pub fn create_and_spawn_driver<
         ChunkExecutor: ChunkExecutorTrait + 'static,
         MempoolNotifier: MempoolNotificationSender + 'static,
+        MetadataStorage: MetadataStorageInterface + Clone + Send + Sync + 'static,
     >(
         create_runtime: bool,
         node_config: &NodeConfig,
@@ -44,6 +46,7 @@ impl DriverFactory {
         storage: DbReaderWriter,
         chunk_executor: Arc<ChunkExecutor>,
         mempool_notification_sender: MempoolNotifier,
+        metadata_storage: MetadataStorage,
         consensus_listener: ConsensusNotificationListener,
         mut event_subscription_service: EventSubscriptionService,
         aptos_data_client: AptosNetDataClient,
@@ -98,6 +101,7 @@ impl DriverFactory {
             error_notification_sender,
             event_subscription_service.clone(),
             mempool_notification_handler.clone(),
+            metadata_storage.clone(),
             storage.clone(),
             driver_runtime.as_ref(),
         );
@@ -118,6 +122,7 @@ impl DriverFactory {
             error_notification_listener,
             event_subscription_service,
             mempool_notification_handler,
+            metadata_storage,
             storage_synchronizer,
             aptos_data_client,
             streaming_service_client,

--- a/state-sync/state-sync-v2/state-sync-driver/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/lib.rs
@@ -10,6 +10,7 @@ mod driver_client;
 pub mod driver_factory;
 mod error;
 mod logging;
+pub mod metadata_storage;
 pub mod metrics;
 mod notification_handlers;
 mod storage_synchronizer;

--- a/state-sync/state-sync-v2/state-sync-driver/src/metadata_storage.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/metadata_storage.rs
@@ -1,0 +1,293 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    error::Error,
+    metadata_storage::database_schema::{MetadataKey, MetadataSchema, MetadataValue},
+};
+use anyhow::{anyhow, Result};
+use aptos_logger::prelude::*;
+use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+    ColumnFamilyName, Options, SchemaBatch, DB,
+};
+use serde::{Deserialize, Serialize};
+use std::{path::Path, sync::Arc, time::Instant};
+
+/// The metadata storage interface required by state sync. This enables
+/// state sync to handle failures and reboots during critical parts
+/// of the syncing process, where a failure may cause an inconsistent
+/// state to remain in the database on startup.
+pub trait MetadataStorageInterface {
+    /// Returns true iff a state snapshot was successfully committed for the
+    /// specified target. If no snapshot progress is found, an error is returned.
+    fn is_snapshot_sync_complete(
+        &self,
+        target_ledger_info: &LedgerInfoWithSignatures,
+    ) -> Result<bool, Error>;
+
+    /// Gets the last persisted state value index for the snapshot sync at the
+    /// specified version. If no snapshot progress is found, an error is returned.
+    fn get_last_persisted_state_value_index(
+        &self,
+        target_ledger_info: &LedgerInfoWithSignatures,
+    ) -> Result<u64, Error>;
+
+    /// Returns the target ledger info of any state snapshot sync that has previously
+    /// started. If no snapshot sync started, None is returned.
+    fn previous_snapshot_sync_target(&self) -> Result<Option<LedgerInfoWithSignatures>, Error>;
+
+    /// Updates the last persisted state value index for the state snapshot
+    /// sync at the specified target ledger info.
+    fn update_last_persisted_state_value_index(
+        &self,
+        target_ledger_info: &LedgerInfoWithSignatures,
+        last_persisted_state_value_index: u64,
+        snapshot_sync_completed: bool,
+    ) -> Result<(), Error>;
+}
+
+/// The name of the state sync db file
+pub const STATE_SYNC_DB_NAME: &str = "state_sync_db";
+
+/// The name of the metadata column family
+const METADATA_CF_NAME: ColumnFamilyName = "metadata";
+
+/// A metadata storage implementation that uses a RocksDB backend to persist data
+#[derive(Clone)]
+pub struct PersistentMetadataStorage {
+    database: Arc<DB>,
+}
+
+impl PersistentMetadataStorage {
+    pub fn new<P: AsRef<Path> + Clone>(db_root_path: P) -> Self {
+        // Set the options to create the database if it's missing
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        options.create_missing_column_families(true);
+
+        // Open the database
+        let state_sync_db_path = db_root_path.as_ref().join(STATE_SYNC_DB_NAME);
+        let instant = Instant::now();
+        let database = DB::open(
+            state_sync_db_path.clone(),
+            "state_sync",
+            vec![METADATA_CF_NAME],
+            &options,
+        )
+        .unwrap_or_else(|_| {
+            panic!(
+                "Failed to open/create the state sync database at: {:?}",
+                state_sync_db_path
+            )
+        });
+        info!(
+            "Opened the state sync database at: {:?}, in {:?} ms",
+            state_sync_db_path,
+            instant.elapsed().as_millis()
+        );
+
+        let database = Arc::new(database);
+        Self { database }
+    }
+
+    /// Returns the existing snapshot sync progress. Returns None if no progress is found.
+    fn get_snapshot_progress(&self) -> Result<Option<StateSnapshotProgress>, Error> {
+        let metadata_key = MetadataKey::StateSnapshotSync;
+        let maybe_metadata_value =
+            self.database
+                .get::<MetadataSchema>(&metadata_key)
+                .map_err(|error| {
+                    Error::StorageError(format!(
+                        "Failed to read metadata value for key: {:?}. Error: {:?}",
+                        metadata_key, error
+                    ))
+                })?;
+        match maybe_metadata_value {
+            Some(metadata_value) => {
+                let MetadataValue::StateSnapshotSync(snapshot_progress) = metadata_value;
+                Ok(Some(snapshot_progress))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Returns the snapshot sync progress recorded for the specified version.
+    /// Returns an error if no progress was found.
+    fn get_snapshot_progress_at_target(
+        &self,
+        target_ledger_info: &LedgerInfoWithSignatures,
+    ) -> Result<StateSnapshotProgress, Error> {
+        match self.get_snapshot_progress()? {
+            Some(snapshot_progress) => {
+                if &snapshot_progress.target_ledger_info != target_ledger_info {
+                    Err(Error::UnexpectedError(format!(
+                        "Expected a snapshot progress for target {:?}, but found {:?}!",
+                        target_ledger_info, snapshot_progress.target_ledger_info
+                    )))
+                } else {
+                    Ok(snapshot_progress)
+                }
+            }
+            None => Err(Error::StorageError(
+                "No state snapshot progress was found!".into(),
+            )),
+        }
+    }
+
+    /// Write the key value pair to the database
+    fn commit_key_value(
+        &self,
+        metadata_key: MetadataKey,
+        metadata_value: MetadataValue,
+    ) -> Result<(), Error> {
+        // Create the schema batch
+        let batch = SchemaBatch::new();
+        batch
+            .put::<MetadataSchema>(&metadata_key, &metadata_value)
+            .map_err(|error| {
+                Error::StorageError(format!(
+                    "Failed to batch put the metadata key and value. Key: {:?}, Value: {:?}. Error: {:?}", metadata_key, metadata_value, error
+                ))
+            })?;
+
+        // Write the schema batch to the database
+        self.database.write_schemas(batch).map_err(|error| {
+            Error::StorageError(format!(
+                "Failed to write the metadata schema. Error: {:?}",
+                error
+            ))
+        })
+    }
+}
+
+impl MetadataStorageInterface for PersistentMetadataStorage {
+    fn is_snapshot_sync_complete(&self, target: &LedgerInfoWithSignatures) -> Result<bool, Error> {
+        let snapshot_progress = self.get_snapshot_progress_at_target(target)?;
+        Ok(snapshot_progress.snapshot_sync_completed)
+    }
+
+    fn get_last_persisted_state_value_index(
+        &self,
+        target: &LedgerInfoWithSignatures,
+    ) -> Result<u64, Error> {
+        let snapshot_progress = self.get_snapshot_progress_at_target(target)?;
+        Ok(snapshot_progress.last_persisted_state_value_index)
+    }
+
+    fn previous_snapshot_sync_target(&self) -> Result<Option<LedgerInfoWithSignatures>, Error> {
+        Ok(self
+            .get_snapshot_progress()?
+            .map(|snapshot_progress| snapshot_progress.target_ledger_info))
+    }
+
+    fn update_last_persisted_state_value_index(
+        &self,
+        target_ledger_info: &LedgerInfoWithSignatures,
+        last_persisted_state_value_index: u64,
+        snapshot_sync_completed: bool,
+    ) -> Result<(), Error> {
+        // Ensure that if any previous snapshot progress exists, it has the same target
+        if let Some(snapshot_progress) = self.get_snapshot_progress()? {
+            if target_ledger_info != &snapshot_progress.target_ledger_info {
+                return Err(Error::StorageError(format!("Failed to update the last persisted state value index! \
+                The given target does not match the previously stored target. Given target: {:?}, stored target: {:?}",
+                    target_ledger_info, snapshot_progress.target_ledger_info
+                )));
+            }
+        }
+
+        // Create the key/value pair
+        let metadata_key = MetadataKey::StateSnapshotSync;
+        let metadata_value = MetadataValue::StateSnapshotSync(StateSnapshotProgress {
+            last_persisted_state_value_index,
+            snapshot_sync_completed,
+            target_ledger_info: target_ledger_info.clone(),
+        });
+
+        // Insert the new key/value pair
+        self.commit_key_value(metadata_key, metadata_value)
+    }
+}
+
+/// A simple struct for recording the progress of a state snapshot sync
+#[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct StateSnapshotProgress {
+    pub target_ledger_info: LedgerInfoWithSignatures,
+    pub last_persisted_state_value_index: u64,
+    pub snapshot_sync_completed: bool,
+}
+
+/// The raw schema format used by the database
+pub mod database_schema {
+    use super::*;
+
+    // This defines a physical storage schema for any metadata.
+    //
+    // The key will be a bcs serialized MetadataKey type.
+    // The value will be a bcs serialized MetadataValue type.
+    //
+    // |<-------key------->|<-----value----->|
+    // |   metadata key    | metadata value  |
+    define_schema!(MetadataSchema, MetadataKey, MetadataValue, METADATA_CF_NAME);
+
+    /// A metadata key that can be inserted into the database
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[repr(u8)]
+    pub enum MetadataKey {
+        StateSnapshotSync, // A state snapshot sync that was started
+    }
+
+    /// A metadata value that can be inserted into the database
+    #[derive(Debug, Deserialize, Eq, PartialEq, Serialize)]
+    #[repr(u8)]
+    pub enum MetadataValue {
+        StateSnapshotSync(StateSnapshotProgress), // A state snapshot sync progress marker
+    }
+
+    impl KeyCodec<MetadataSchema> for MetadataKey {
+        fn encode_key(&self) -> Result<Vec<u8>> {
+            bcs::to_bytes(self).map_err(|error| {
+                anyhow!(
+                    "Failed to encode metadata key: {:?}. Error: {:?}",
+                    self,
+                    error
+                )
+            })
+        }
+
+        fn decode_key(data: &[u8]) -> Result<Self> {
+            bcs::from_bytes::<MetadataKey>(data).map_err(|error| {
+                anyhow!(
+                    "Failed to decode metadata key: {:?}. Error: {:?}",
+                    data,
+                    error
+                )
+            })
+        }
+    }
+
+    impl ValueCodec<MetadataSchema> for MetadataValue {
+        fn encode_value(&self) -> Result<Vec<u8>> {
+            bcs::to_bytes(self).map_err(|error| {
+                anyhow!(
+                    "Failed to encode metadata value: {:?}. Error: {:?}",
+                    self,
+                    error
+                )
+            })
+        }
+
+        fn decode_value(data: &[u8]) -> Result<Self> {
+            bcs::from_bytes::<MetadataValue>(data).map_err(|error| {
+                anyhow!(
+                    "Failed to decode metadata value: {:?}. Error: {:?}",
+                    data,
+                    error
+                )
+            })
+        }
+    }
+}

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::metadata_storage::PersistentMetadataStorage;
 use crate::{
     driver_factory::DriverFactory,
     tests::utils::{
@@ -274,6 +275,9 @@ async fn create_driver_for_tests(
         None,
     );
 
+    // Create the metadata storage
+    let metadata_storage = PersistentMetadataStorage::new(db_path.path());
+
     // Create and spawn the driver
     let driver_factory = DriverFactory::create_and_spawn_driver(
         false,
@@ -282,6 +286,7 @@ async fn create_driver_for_tests(
         db_rw,
         chunk_executor,
         mempool_notifier,
+        metadata_storage,
         consensus_listener,
         event_subscription_service,
         aptos_data_client,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver_factory.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::driver_factory::DriverFactory;
+use crate::metadata_storage::PersistentMetadataStorage;
 use aptos_config::config::TARGET_SNAPSHOT_SIZE;
 use aptos_config::{
     config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG},
@@ -78,6 +79,7 @@ fn test_new_initialized_configs() {
 
     // Create the state sync driver factory
     let chunk_executor = Arc::new(ChunkExecutor::<AptosVM>::new(db_rw.clone()));
+    let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
     let _ = DriverFactory::create_and_spawn_driver(
         true,
         &node_config,
@@ -85,6 +87,7 @@ fn test_new_initialized_configs() {
         db_rw,
         chunk_executor,
         mempool_notifier,
+        metadata_storage,
         consensus_listener,
         event_subscription_service,
         aptos_data_client,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/metadata_storage.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/metadata_storage.rs
@@ -1,0 +1,167 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metadata_storage::database_schema::{MetadataKey, MetadataSchema, MetadataValue};
+use crate::metadata_storage::{
+    MetadataStorageInterface, PersistentMetadataStorage, StateSnapshotProgress,
+};
+use crate::tests::utils::{create_epoch_ending_ledger_info, create_ledger_info_at_version};
+use aptos_temppath::TempPath;
+use claim::{assert_err, assert_none};
+use schemadb::schema::fuzzing::assert_encode_decode;
+
+#[test]
+fn test_create_then_open() {
+    // Create a new metadata storage
+    let tmp_dir = TempPath::new();
+    let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
+
+    // Verify the storage is empty
+    assert_none!(metadata_storage.previous_snapshot_sync_target().unwrap());
+
+    // Insert a new state value entry for the target
+    let target_ledger_info = create_ledger_info_at_version(12345);
+    let last_persisted_state_value = 100000;
+    let snapshot_sync_completed = false;
+    metadata_storage
+        .update_last_persisted_state_value_index(
+            &target_ledger_info,
+            last_persisted_state_value,
+            snapshot_sync_completed,
+        )
+        .unwrap();
+
+    // Drop the handle to the storage (mimic a reboot)
+    drop(metadata_storage);
+
+    // Create another storage (it should reopen the existing file) and verify the state
+    let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
+    assert_eq!(
+        Some(target_ledger_info.clone()),
+        metadata_storage.previous_snapshot_sync_target().unwrap()
+    );
+    assert_eq!(
+        last_persisted_state_value,
+        metadata_storage
+            .get_last_persisted_state_value_index(&target_ledger_info)
+            .unwrap()
+    );
+    assert_eq!(
+        snapshot_sync_completed,
+        metadata_storage
+            .is_snapshot_sync_complete(&target_ledger_info)
+            .unwrap()
+    );
+
+    // Insert the next state value entry for the target
+    let last_persisted_state_value = 200000;
+    let snapshot_sync_completed = true;
+    metadata_storage
+        .update_last_persisted_state_value_index(
+            &target_ledger_info,
+            last_persisted_state_value,
+            snapshot_sync_completed,
+        )
+        .unwrap();
+
+    // Drop the handle to the storage (mimic a reboot)
+    drop(metadata_storage);
+
+    // Create another storage (it should reopen the existing file) and verify the state
+    let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
+    assert_eq!(
+        Some(target_ledger_info.clone()),
+        metadata_storage.previous_snapshot_sync_target().unwrap()
+    );
+    assert_eq!(
+        last_persisted_state_value,
+        metadata_storage
+            .get_last_persisted_state_value_index(&target_ledger_info)
+            .unwrap()
+    );
+    assert_eq!(
+        snapshot_sync_completed,
+        metadata_storage
+            .is_snapshot_sync_complete(&target_ledger_info)
+            .unwrap()
+    );
+}
+
+#[test]
+fn test_metadata_schema_encode_decode() {
+    assert_encode_decode::<MetadataSchema>(
+        &MetadataKey::StateSnapshotSync,
+        &MetadataValue::StateSnapshotSync(StateSnapshotProgress {
+            target_ledger_info: create_epoch_ending_ledger_info(),
+            last_persisted_state_value_index: 5678,
+            snapshot_sync_completed: false,
+        }),
+    );
+}
+
+#[test]
+fn test_multiple_reads_and_writes() {
+    // Create a new metadata storage
+    let tmp_dir = TempPath::new();
+    let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
+
+    // Verify the storage is empty
+    let target_ledger_info = create_ledger_info_at_version(100000);
+    assert_none!(metadata_storage.previous_snapshot_sync_target().unwrap());
+    assert_err!(metadata_storage.is_snapshot_sync_complete(&target_ledger_info));
+    assert_err!(metadata_storage.get_last_persisted_state_value_index(&target_ledger_info));
+
+    // Do multiple writes
+    for index in 0..100 {
+        // Insert a new state value entry for the target
+        let last_persisted_state_value = 50000 + index;
+        let snapshot_sync_completed = false;
+        metadata_storage
+            .update_last_persisted_state_value_index(
+                &target_ledger_info,
+                last_persisted_state_value,
+                snapshot_sync_completed,
+            )
+            .unwrap();
+
+        // Fetch and verify the last state value entry
+        assert_eq!(
+            Some(target_ledger_info.clone()),
+            metadata_storage.previous_snapshot_sync_target().unwrap()
+        );
+        assert_eq!(
+            last_persisted_state_value,
+            metadata_storage
+                .get_last_persisted_state_value_index(&target_ledger_info)
+                .unwrap()
+        );
+        assert_eq!(
+            snapshot_sync_completed,
+            metadata_storage
+                .is_snapshot_sync_complete(&target_ledger_info)
+                .unwrap()
+        );
+    }
+}
+
+#[test]
+fn test_writes_to_different_targets() {
+    // Create a new metadata storage
+    let tmp_dir = TempPath::new();
+    let metadata_storage = PersistentMetadataStorage::new(tmp_dir.path());
+
+    // Verify the storage is empty
+    assert_none!(metadata_storage.previous_snapshot_sync_target().unwrap());
+
+    // Write a new progress entry into the storage
+    let target_ledger_info = create_ledger_info_at_version(100);
+    metadata_storage
+        .update_last_persisted_state_value_index(&target_ledger_info, 10101, false)
+        .unwrap();
+
+    // Write another progress entry with a different target and verify that it fails
+    let target_ledger_info = create_ledger_info_at_version(200);
+    metadata_storage
+        .update_last_persisted_state_value_index(&target_ledger_info, 10101, false)
+        .unwrap_err();
+}

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -3,6 +3,7 @@
 
 use crate::tests::utils::{create_empty_epoch_state, create_epoch_ending_ledger_info};
 use crate::{
+    error::Error, metadata_storage::MetadataStorageInterface,
     storage_synchronizer::StorageSynchronizerInterface, tests::utils::create_transaction_info,
 };
 use anyhow::Result;
@@ -320,6 +321,35 @@ mock! {
         ) -> Result<()>;
 
         fn delete_genesis(&self) -> Result<()>;
+    }
+}
+
+// This automatically creates a MockMetadataStorage.
+mock! {
+    pub MetadataStorage {}
+    impl MetadataStorageInterface for MetadataStorage {
+        fn is_snapshot_sync_complete(
+            &self,
+            target_ledger_info: &LedgerInfoWithSignatures,
+        ) -> Result<bool, Error>;
+
+        fn get_last_persisted_state_value_index(
+            &self,
+            target_ledger_info: &LedgerInfoWithSignatures,
+        ) -> Result<u64, Error>;
+
+        fn previous_snapshot_sync_target(&self) -> Result<Option<LedgerInfoWithSignatures>, Error>;
+
+        fn update_last_persisted_state_value_index(
+            &self,
+            target_ledger_info: &LedgerInfoWithSignatures,
+            last_persisted_state_value_index: u64,
+            snapshot_sync_completed: bool,
+        ) -> Result<(), Error>;
+    }
+
+    impl Clone for MetadataStorage {
+        fn clone(&self) -> Self;
     }
 }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod bootstrapper;
 mod continuous_syncer;
 mod driver;
 mod driver_factory;
+mod metadata_storage;
 mod mocks;
 mod storage_synchronizer;
 mod utils;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::metadata_storage::PersistentMetadataStorage;
 use crate::{
     error::Error,
     notification_handlers::{
@@ -232,57 +233,6 @@ async fn test_execute_transactions_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_initialize_state_synchronizer() {
-    // Create test data
-    let target_ledger_info = create_epoch_ending_ledger_info();
-    let output_list_with_proof = create_output_list_with_proof();
-
-    // Setup the mock snapshot receiver
-    let mut snapshot_receiver = create_mock_receiver();
-    snapshot_receiver
-        .expect_add_chunk()
-        .with(always(), always())
-        .returning(|_, _| Ok(()));
-
-    // Setup the mock db writer
-    let mut db_writer = create_mock_db_writer();
-    db_writer
-        .expect_get_state_snapshot_receiver()
-        .with(
-            eq(target_ledger_info.ledger_info().version()),
-            eq(output_list_with_proof.proof.transaction_infos[0]
-                .ensure_state_checkpoint_hash()
-                .unwrap()),
-        )
-        .return_once(move |_, _| Ok(Box::new(snapshot_receiver)));
-
-    // Create the storage synchronizer
-    let (mut commit_listener, _, _, _, mut storage_synchronizer, _, _) =
-        create_storage_synchronizer(
-            create_mock_executor(),
-            create_mock_reader_writer(None, Some(db_writer)),
-        );
-
-    // Initialize the state synchronizer
-    let _ = storage_synchronizer
-        .initialize_state_synchronizer(
-            vec![target_ledger_info.clone()],
-            target_ledger_info,
-            output_list_with_proof,
-        )
-        .unwrap();
-
-    // Save a state chunk and verify we get a commit notification
-    storage_synchronizer
-        .save_state_values(0, create_state_value_chunk_with_proof(false))
-        .unwrap();
-    assert_matches!(
-        commit_listener.select_next_some().await,
-        CommitNotification::CommittedStates(_)
-    );
-}
-
-#[tokio::test(flavor = "multi_thread")]
 #[should_panic]
 async fn test_initialize_state_synchronizer_missing_info() {
     // Create test data that is missing transaction infos
@@ -403,13 +353,10 @@ async fn test_save_states_completion() {
         )
         .unwrap();
 
-    // Save a state chunk and verify we get a commit notification
+    // Save multiple state chunks (including the last chunk)
     storage_synchronizer
         .save_state_values(0, create_state_value_chunk_with_proof(false))
         .unwrap();
-    verify_state_commit_notification(&mut commit_listener, false, None).await;
-
-    // Save a state chunk that is the last chunk
     storage_synchronizer
         .save_state_values(1, create_state_value_chunk_with_proof(true))
         .unwrap();
@@ -420,10 +367,10 @@ async fn test_save_states_completion() {
         events: vec![expected_event.clone()],
         transactions: vec![expected_transaction.clone()],
     };
-    verify_state_commit_notification(
+
+    verify_snapshot_commit_notification(
         &mut commit_listener,
-        true,
-        Some(expected_committed_transactions.clone()),
+        expected_committed_transactions.clone(),
     )
     .await;
 
@@ -464,10 +411,10 @@ async fn test_save_states_dropped_error_listener() {
         )
         .unwrap();
 
-    // Save a state chunk
+    // Save the last state chunk
     let notification_id = 0;
     storage_synchronizer
-        .save_state_values(notification_id, create_state_value_chunk_with_proof(false))
+        .save_state_values(notification_id, create_state_value_chunk_with_proof(true))
         .unwrap();
 
     // The handler should panic as the commit listener was dropped
@@ -536,7 +483,7 @@ fn create_storage_synchronizer(
     ErrorNotificationListener,
     Arc<Mutex<EventSubscriptionService>>,
     MempoolNotificationListener,
-    StorageSynchronizer<MockChunkExecutor>,
+    StorageSynchronizer<MockChunkExecutor, PersistentMetadataStorage>,
     JoinHandle<()>,
     JoinHandle<()>,
 ) {
@@ -558,6 +505,10 @@ fn create_storage_synchronizer(
         mempool_notifications::new_mempool_notifier_listener_pair();
     let mempool_notification_handler = MempoolNotificationHandler::new(mempool_notification_sender);
 
+    // Create the metadata storage
+    let db_path = aptos_temppath::TempPath::new();
+    let metadata_storage = PersistentMetadataStorage::new(db_path.path());
+
     // Create the storage synchronizer
     let (storage_synchronizer, executor_handle, committer_handle) = StorageSynchronizer::new(
         StateSyncDriverConfig::default(),
@@ -566,6 +517,7 @@ fn create_storage_synchronizer(
         error_notification_sender,
         event_subscription_service.clone(),
         mempool_notification_handler,
+        metadata_storage,
         mock_reader_writer,
         None,
     );
@@ -581,17 +533,15 @@ fn create_storage_synchronizer(
     )
 }
 
-/// Verifies that the expected state commit notification is received by the listener
-async fn verify_state_commit_notification(
+/// Verifies that the expected snapshot commit notification is received by the listener
+async fn verify_snapshot_commit_notification(
     commit_listener: &mut CommitNotificationListener,
-    expected_all_synced: bool,
-    expected_committed_transactions: Option<CommittedTransactions>,
+    expected_committed_transactions: CommittedTransactions,
 ) {
-    let CommitNotification::CommittedStates(committed_states) =
+    let CommitNotification::CommittedStateSnapshot(committed_snapshot) =
         commit_listener.select_next_some().await;
-    assert_eq!(committed_states.all_states_synced, expected_all_synced);
     assert_eq!(
-        committed_states.committed_transaction,
+        committed_snapshot.committed_transaction,
         expected_committed_transactions
     );
 }
@@ -609,7 +559,9 @@ async fn verify_error_notification(
 /// Verifies that no pending data remains in the storage synchronizer.
 /// Note: due to asynchronous execution, we might need to wait some
 /// time for the pipelines to drain.
-fn verify_no_pending_data(storage_synchronizer: &StorageSynchronizer<MockChunkExecutor>) {
+fn verify_no_pending_data(
+    storage_synchronizer: &StorageSynchronizer<MockChunkExecutor, PersistentMetadataStorage>,
+) {
     let max_drain_time_secs = 10;
     for _ in 0..max_drain_time_secs {
         if !storage_synchronizer.pending_storage_data() {

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -40,6 +40,7 @@ consensus = { path = "../../consensus" }
 forge = { path = "../forge" }
 framework = { path = "../../aptos-move/framework" }
 move-deps = { path = "../../aptos-move/move-deps" }
+state-sync-driver = { path = "../../state-sync/state-sync-v2/state-sync-driver" }
 
 [dev-dependencies]
 base64 = "0.13.0"


### PR DESCRIPTION
Note: 65% of this PR is just new unit tests 😱 

### Description

This PR takes the first step towards making fast sync crash fault tolerant (i.e., able to recover after a reboot while synchronizing state keys and values). To achieve this, the PR:
1. Adds a new persistent metadata storage for state sync (i.e., `state_sync_db`) that persists the sync progress to the local file system (similar to other persistent storage files, e.g., `consensus_db`).
2. Updates the bootstrapper to read from the persistent storage when handling reboots and restarting new data streams. This includes ensuring at least one item overlap in the state key/value chunks after reboots (as required by the snapshot receiver, 'cc @msmouse).
3. Updates the storage synchronizer to write to the persistent storage file when new state keys and values have been persisted.
4. Updates the bootstrapper to identify and handle situations where a node operator will create gaps in transaction data, e.g., they synchronize normally up to version `X`, turn off their node (for some time) and then attempt to fast sync again at `Y`. This would create a gap in transaction data between `X` and `Y`. We handle this in the following way:
    1. If the gap between `X` and `Y` is larger than `num_versions_to_skip_snapshot_sync`, we'll panic and tell the operator that this is unsupported.
    2. Otherwise, if the gap is less than `num_versions_to_skip_snapshot_sync`, we'll skip the fast sync and process all transaction data normally  starting at `X`.
 
Notes:
1. Once this lands, I'll do the second step of making fast sync crash fault tolerant, i.e., ensuring that all final reads and writes to the database (after we've fetched all keys and values) happens atomically, so there's no race conditions there 😄 
4. As a part of doing this refactoring, I've also optimized some of the code paths so that we're able to fast sync more quickly!

### Test Plan
New unit tests have been added, including tests specifically for the new storage implementation and for the new bootstrapper logic. Existing smoke tests also cover some of this functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2650)
<!-- Reviewable:end -->
