### PR TITLE
add ingress support to fullnode helm chart

### DIFF
--- a/terraform/helm/fullnode/templates/ingress.yaml
+++ b/terraform/helm/fullnode/templates/ingress.yaml
@@ -3,9 +3,15 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "aptos-fullnode.fullname" . }}-ingress
+  labels:
+    {{- include "aptos-fullnode.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  {{ if .Values.ingress.class }}
-  ingressClassName: {{ .Values.ingress.class }} 
+  {{ if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }} 
   {{ end }}
   rules:
   - host: {{ .Values.ingress.hostName }} 

--- a/terraform/helm/fullnode/templates/ingress.yaml
+++ b/terraform/helm/fullnode/templates/ingress.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "aptos-fullnode.fullname" . }}-ingress
+spec:
+  {{ if .Values.ingress.class }}
+  ingressClassName: {{ .Values.ingress.class }} 
+  {{ end }}
+  rules:
+  - host: {{ .Values.ingress.hostName }} 
+    http:
+      paths:
+      - path: /
+        backend:
+          service:
+            name: {{ include "aptos-fullnode.fullname" . }}-lb
+            port:
+              number: 80
+        pathType: ImplementationSpecific
+{{- end -}}

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -49,7 +49,8 @@ ingress:
   enabled: false
   hostName: #aptos-fullnode.example.com
   #leaving class empty will result in an ingress that implicity uses the default ingress class
-  class: #nginx
+  ingressClassName: #nginx
+  annotations: {}
 
 
 serviceAccount:

--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -44,6 +44,14 @@ service:
   loadBalancerSourceRanges: []
   annotations: {}
 
+ingress:
+  #change enabled to true and fill out the rest of the fields to expose the REST API externally via your ingress controller
+  enabled: false
+  hostName: #aptos-fullnode.example.com
+  #leaving class empty will result in an ingress that implicity uses the default ingress class
+  class: #nginx
+
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
### Description
For operators that are running a kubernetes cluster, it is common to have many services exposed publicly via ingress resources. This PR enables these operators to leverage their existing ingress controller for fullnode deployments.

### Test Plan
I have these changes deployed to my cluster already and everything is working as expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2651)
<!-- Reviewable:end -->
