### PR TITLE
[SDK][TS] Re-expose BCS and builder items from root of module

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
+## 1.3.5 (2022-08-08)
+- Re-expose BCS and items from `transaction_builder/builder` from the root of the module.
+
 ## 1.3.4 (2022-08-07)
 - Downscaled default value for `max_gas`.
 

--- a/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
@@ -3,7 +3,7 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import { AptosClient, AptosAccount, FaucetClient, TransactionBuilder, TxnBuilderTypes } from "aptos";
+import { AptosClient, AptosAccount, FaucetClient, BCS, TxnBuilderTypes } from "aptos";
 import { aptosCoin } from "./constants";
 import isEqual from "lodash/isEqual";
 import assert from "assert";
@@ -11,7 +11,6 @@ import assert from "assert";
 const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
 const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
 
-const { BCS } = TransactionBuilder;
 const {
   AccountAddress,
   TypeTagStruct,

--- a/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
@@ -3,15 +3,13 @@
 import dotenv from "dotenv";
 dotenv.config();
 
-import { AptosClient, AptosAccount, FaucetClient, TransactionBuilder, TxnBuilderTypes } from "aptos";
+import { AptosClient, AptosAccount, FaucetClient, BCS, TransactionBuilderMultiEd25519, TxnBuilderTypes } from "aptos";
 import { aptosCoin } from "./constants";
 import isEqual from "lodash/isEqual";
 import assert from "assert";
 
 const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com";
 const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
-
-const { BCS, TransactionBuilderMultiEd25519 } = TransactionBuilder;
 
 /**
  * This code example demonstrates the process of moving test coins from one multisig

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -62,5 +62,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
-  "version": "1.3.4"
+  "version": "1.3.5"
 }

--- a/ecosystem/typescript/sdk/src/index.ts
+++ b/ecosystem/typescript/sdk/src/index.ts
@@ -4,7 +4,6 @@ export * from "./hex_string";
 export * from "./aptos_client";
 export * from "./faucet_client";
 export * from "./token_client";
+export * from "./transaction_builder";
 export * as TokenTypes from "./token_types";
 export * as Types from "./generated/index";
-export * as TransactionBuilder from "./transaction_builder";
-export * as TxnBuilderTypes from "./transaction_builder/aptos_types";


### PR DESCRIPTION
## Description
The transaction_builder index file already re-exported stuff in namespaces, no need to add another layer.

## Test Plan
```
cd ecosystem/typescript/sdk
yarn test
cd examples/typescript
yarn test
cd ../javascript
yarn test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2653)
<!-- Reviewable:end -->
