### PR TITLE
Simplified the `stake` module

### DIFF
--- a/types/src/on_chain_config/validator_set.rs
+++ b/types/src/on_chain_config/validator_set.rs
@@ -6,12 +6,7 @@ use crate::{on_chain_config::OnChainConfig, validator_info::ValidatorInfo};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt,
-    iter::{Chain, IntoIterator},
-    vec,
-    vec::IntoIter,
-};
+use std::{fmt, iter::IntoIterator, vec, vec::IntoIter};
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -25,7 +20,8 @@ pub enum ConsensusScheme {
 pub struct ValidatorSet {
     scheme: ConsensusScheme,
     pub active_validators: Vec<ValidatorInfo>,
-    pub pending_inactive: Vec<ValidatorInfo>,
+    //pub pending_inactive: Vec<ValidatorInfo>,
+    pub num_pending_inactive: u64,
     pub pending_active: Vec<ValidatorInfo>,
 }
 
@@ -48,15 +44,13 @@ impl ValidatorSet {
         Self {
             scheme: ConsensusScheme::Ed25519,
             active_validators: payload,
-            pending_inactive: vec![],
+            num_pending_inactive: 0,
             pending_active: vec![],
         }
     }
 
     pub fn payload(&self) -> impl Iterator<Item = &ValidatorInfo> {
-        self.active_validators
-            .iter()
-            .chain(self.pending_inactive.iter())
+        self.active_validators.iter()
     }
 
     pub fn empty() -> Self {
@@ -88,11 +82,9 @@ impl OnChainConfig for ValidatorSet {
 
 impl IntoIterator for ValidatorSet {
     type Item = ValidatorInfo;
-    type IntoIter = Chain<IntoIter<Self::Item>, IntoIter<Self::Item>>;
+    type IntoIter = IntoIter<Self::Item>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.active_validators
-            .into_iter()
-            .chain(self.pending_inactive.into_iter())
+        self.active_validators.into_iter()
     }
 }

--- a/types/src/validator_info.rs
+++ b/types/src/validator_info.rs
@@ -26,6 +26,9 @@ pub struct ValidatorInfo {
     consensus_voting_power: u64,
     // Validator config
     config: ValidatorConfig,
+    pending_inactive: bool,
+    successful_proposals: u64,
+    failed_proposals: u64,
 }
 
 impl fmt::Display for ValidatorInfo {
@@ -48,6 +51,9 @@ impl ValidatorInfo {
             account_address,
             consensus_voting_power,
             config,
+            pending_inactive: false,
+            successful_proposals: 0,
+            failed_proposals: 0,
         }
     }
 
@@ -69,6 +75,9 @@ impl ValidatorInfo {
             account_address,
             consensus_voting_power,
             config,
+            pending_inactive: false,
+            successful_proposals: 0,
+            failed_proposals: 0,
         }
     }
 


### PR DESCRIPTION
### Description

- Merged `validator_set.pending_inactive` into `validator_set.active_validators` so that the indexes of `validator_set.active_validators` stay intact during a single epoch period.
- Added `pending_inactive: bool` into `ValidatorInfo` to mark the validators which are currently active but pending to leave.
- `ValidatorInfo` now directly holds The fields of `IndividualValidatorPerformance` (i.e., successful_proposals, failed_proposals).
- The `ValidatorPerformance` resource is no longer used, so removed.
- `validator_index` is moved into the `StakePool` from `ValidatorConfig` because it doesn't need to be duplicated and included in `validator_set`.
- Simplified the flow of `on_new_epoch`.
- Sorted the validator set using their stake pool addresses because they are uniquely identified.
- Updated the unit tests.

- This update should improve the runtime efficiency because it minimizes the vector copy/move and things to covert to bytes for comparison in sorting.

### Test Plan
cargo test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2660)
<!-- Reviewable:end -->
