### PR TITLE
[Code Owners] Add code owners for consensus, storage and state-sync.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,9 @@
 /crates/aptos-crypto-derive/ @alinush
 # Owners for the `/api` directory and all its subdirectories.
 /api/ @banool @gregnazario
+# Owners for the `/state-sync` directory and all its subdirectories.
+/state-sync/ @joshlind
+# Owners for the `/consensus` directory and all its subdirectories.
+/consensus/ @zekun000
+# Owners for the `/storage` directory and all its subdirectories.
+/storage/ @msmouse


### PR DESCRIPTION
### Description

This PR adds code owners for consensus, storage and state-sync. Feel free to add more people in follow-up PRs, but let's start the party 🥳 

### Test Plan
None.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2674)
<!-- Reviewable:end -->
