### PR TITLE
Add guide for the local testnet dev flow

### DIFF
--- a/developer-docs-site/docs/guides/guide-for-system-integrators.md
+++ b/developer-docs-site/docs/guides/guide-for-system-integrators.md
@@ -3,7 +3,7 @@ title: "System Integrators' Guide"
 slug: "guide-for-system-integrators"
 ---
 
-:::tip 
+:::tip
 This is documentation is currently under construction with more being added on a regular basis.
 :::
 
@@ -40,6 +40,9 @@ Other areas worth being familiar with:
 * [Python SDK](../sdks/python-sdk)
 * [REST API](../rest-api)
 
+Useful guides:
+* [Local testnet development flow](./local-testnet-dev-flow)
+
 :::tip
 Not all SDKs and tools respect those environment flags though they will in due time.
 :::
@@ -68,13 +71,13 @@ This is covered in depth in the [Accounts](https://aptos.dev/concepts/basics-acc
 
 ### Rotating the keys
 
-An Account on Aptos has the ability to rotate keys so that potentially compromised keys cannot be used to access the accounts. 
+An Account on Aptos has the ability to rotate keys so that potentially compromised keys cannot be used to access the accounts.
 
 :::tip Read more
 See more in [Account address](http://aptos.dev/concepts/basics-accounts#account-address).
 :::
 
-Refreshing the keys is generally regarded as good hygiene in the security field. However, this presents a challenge for system integrators who are used to using a mnemonic to represent both a private key and its associated account. To simplify this for the system integrators, Aptos will provide an on-chain mapping, before the launch of the mainnet. The on-chain data maps an effective account address as defined by the current mnemonic to the actual account address. 
+Refreshing the keys is generally regarded as good hygiene in the security field. However, this presents a challenge for system integrators who are used to using a mnemonic to represent both a private key and its associated account. To simplify this for the system integrators, Aptos will provide an on-chain mapping, before the launch of the mainnet. The on-chain data maps an effective account address as defined by the current mnemonic to the actual account address.
 
 ### Preventing replay attacks
 
@@ -97,13 +100,13 @@ A transaction may end in one of the following states:
 3. Discarded during transaction submission due to a validation check such as insufficient gas, invalid transaction format, or incorrect key.
 4. Discarded after transaction submission but before attempted execution. This could be due to timeouts or insufficient gas due to other transactions affecting the account.
 
-The sender’s account will be charged gas for any committed transactions. 
+The sender’s account will be charged gas for any committed transactions.
 
-During transaction submission, the submitter is notified of successful submission or a reason for failing validations otherwise. 
+During transaction submission, the submitter is notified of successful submission or a reason for failing validations otherwise.
 
-A transaction that is successfully submitted but ultimately discarded may have no visible state in any accessible Aptos node or within the Aptos network. A user can attempt to resubmit the same transaction to re-validate the transaction. If the submitting node believes that this transaction is still valid, this will return an error stating that there exists an identical transaction already submitted. 
+A transaction that is successfully submitted but ultimately discarded may have no visible state in any accessible Aptos node or within the Aptos network. A user can attempt to resubmit the same transaction to re-validate the transaction. If the submitting node believes that this transaction is still valid, this will return an error stating that there exists an identical transaction already submitted.
 
-The submitter can try to increase the gas cost by a trivial amount to help make progress and adjust for whatever may have been causing the discarding of the transaction further downstream. 
+The submitter can try to increase the gas cost by a trivial amount to help make progress and adjust for whatever may have been causing the discarding of the transaction further downstream.
 
 On the Aptos devnet, the time between submission and confirmation is within seconds.
 
@@ -126,7 +129,7 @@ JSON-encoded transactions can be generated via the [REST API](https://aptos.dev
 - The output of the above contains an object containing a `message` and this must be signed with the sender’s private key locally.
 - Finally, the original JSON payload is extended with the signature information and posted to the `/transactions` [endpoint](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/python/sdk/aptos_sdk/client.py#L127). This will return back a transaction submission result that, if successful, contains a transaction hash in the `hash` [field](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/python/sdk/aptos_sdk/client.py#L138).
 
-JSON-encoded transactions allow for rapid development and support seamless ABI conversions of transaction arguments to native types. However, most system integrators prefer to generate transactions within their own tech stack. Both the [TypeScript SDK](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/typescript/sdk/src/aptos_client.ts#L259) and [Python SDK](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/python/sdk/aptos_sdk/client.py#L202) support generating BCS transactions. 
+JSON-encoded transactions allow for rapid development and support seamless ABI conversions of transaction arguments to native types. However, most system integrators prefer to generate transactions within their own tech stack. Both the [TypeScript SDK](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/typescript/sdk/src/aptos_client.ts#L259) and [Python SDK](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/python/sdk/aptos_sdk/client.py#L202) support generating BCS transactions.
 
 #### BCS-encoded transactions
 
@@ -138,7 +141,7 @@ Within a given transaction, the target of execution can be one of two types: an 
 
 ### Status of a transaction
 
-Transaction status can be obtained by querying the API `/transactions/{hash}` with the hash returned during the submission of the transaction. 
+Transaction status can be obtained by querying the API `/transactions/{hash}` with the hash returned during the submission of the transaction.
 
 A reasonable strategy for submitting transactions is to limit their lifetime to 30 to 60 seconds, and polling that API at regular intervals until success or a several seconds after that time has elapsed. If there is no commitment on-chain, the transaction was likely discarded.
 
@@ -156,9 +159,9 @@ See the following documentation for generating valid transactions:
 
 ### Evaluating transactions
 
-To facilitate evaluation of transactions, Aptos supports a simulation API that does not require and should not contain valid signatures on transactions. 
+To facilitate evaluation of transactions, Aptos supports a simulation API that does not require and should not contain valid signatures on transactions.
 
-The simulation API works identical to the transaction submission API, except that it executes the transaction and returns back the results along with the gas used. The simulation API can be accessed by submitting a transaction to [`/transactions/simulate`](https://aptos.dev/rest-api/#tag/transactions/operation/simulate_transaction). 
+The simulation API works identical to the transaction submission API, except that it executes the transaction and returns back the results along with the gas used. The simulation API can be accessed by submitting a transaction to [`/transactions/simulate`](https://aptos.dev/rest-api/#tag/transactions/operation/simulate_transaction).
 
 :::tip Read more
 Here's an example showing how to use the simulation API in the [Typescript SDK](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/typescript/sdk/src/aptos_client.ts#L413). Note that the gas use may change based upon the state of the account. We recommend that the maximum gas amount be larger than the amount quoted by this API.

--- a/developer-docs-site/docs/guides/index.md
+++ b/developer-docs-site/docs/guides/index.md
@@ -6,7 +6,7 @@ hidden: false
 
 # Guides
 
-Start here to get into the core concepts of the Aptos Blockchain. 
+Start here to get into the core concepts of the Aptos Blockchain.
 
 - ### [Life of a Transaction](basics-life-of-txn.md)
 
@@ -19,5 +19,7 @@ Start here to get into the core concepts of the Aptos Blockchain.
 - ### [Building the Wallet Extension](building-wallet-extension.md)
 
 - ### [Guide for System Integrators](guide-for-system-integrators.md)
+
+- ### [Local testnet development flow](local-testnet-dev-flow.md)
 
 

--- a/developer-docs-site/docs/guides/local-testnet-dev-flow.md
+++ b/developer-docs-site/docs/guides/local-testnet-dev-flow.md
@@ -1,0 +1,86 @@
+---
+title: "Local testnet development flow"
+slug: "local-testnet-dev-flow"
+---
+
+This guide describes the end-to-end flow for developing with a local testnet.
+
+:::caution CLI from source, not from GitHub
+This guide is not correct if you're using the `aptos` CLI from a GitHub release or from `cargo install`, only if you build it yourself from `aptos-core` as described below.
+:::
+
+Please read this guide carefully. This guide specifically addresses the local testnet development flow. This flow will not work if you're building against devnet.
+
+## Run a local testnet from `aptos-core`
+
+Pull and go into `aptos-core`:
+```
+git clone git@github.com:aptos-labs/aptos-core.git ~/aptos-core && cd ~/aptos-core
+```
+
+Run a local testnet:
+```
+cargo run -p aptos -- node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
+```
+You may add the `--release` flag after `cargo run` if you want to build a release version of the CLI for running the local testnet.
+
+You are now running a local testnet built from `aptos-core` main.
+
+## Typescript: Use the SDK from `aptos-core`
+**Important**: With this development flow, it is essential that you do not use the SDK from npmjs. Instead, you must use the same SDK as the `aptos` CLI is built from, which we describe below.
+
+This guide assumes you have done the previous local testnet step. We also assume you have `yarn` installed.
+
+First, go into `aptos-core` and build the SDK:
+```
+cd ~/aptos-core/ecosystem/typescript/sdk
+yarn install
+yarn build
+```
+
+Make a new project if you don't have one already:
+```
+mkdir ~/project && cd ~/project
+yarn init
+```
+
+Make your project target the SDK from your local `aptos-core`:
+```
+yarn add ../aptos-core/ecosystem/typescript/sdk
+```
+You could also use the absolute path, e.g. `/home/daniel/aptos-core/ecosystem/typescript/sdk`.
+
+Install everything:
+```
+yarn install
+```
+
+Now you're set up! You should see in `package.json` that your project targets your local `aptos-core`:
+```json
+{
+  "name": "project",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "aptos": "../a/core/ecosystem/typescript/sdk/"
+  }
+}
+```
+
+This way your local testnet and the SDK you're using match, meaning you won't see any compatability issues.
+
+Now you can use the aptos module like this in your code:
+```ts
+import { AptosClient, AptosAccount, FaucetClient } from "aptos";
+
+const NODE_URL = "https://127.0.0.1:8080/v1";
+const FAUCET_URL = "https://127.0.0.1:8081";
+
+(async () => {
+  const client = new AptosClient(NODE_URL);
+  const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+})();
+```
+
+**Note**: See that this code builds clients that talk to your local testnet, not devnet.

--- a/developer-docs-site/docs/nodes/aptos-deployments.md
+++ b/developer-docs-site/docs/nodes/aptos-deployments.md
@@ -13,12 +13,14 @@ Make sure to see the row describing **What not to do**.
 
 :::
 
-|Description |Aptos Devnet | Local Testnet | Aptos Incentivized Testnet (AIT)|
+|Description | Aptos Devnet | Local Testnet | Aptos Incentivized Testnet (AIT)|
 |---|---|---|---|
-|**Network runs where**| Validators run on Aptos servers. FullNodes are run by both Aptos and you (i.e., the Aptos community).| Validators and FullNodes run locally on your computer, entirely independent from devnet. | Some Validators run on Aptos servers, others are run by the Aptos community. FullNodes are run by Aptos and the community.|
-|**Who is responsible for the network**|Managed by Aptos Team. | Deployed, managed and upgraded by you.| Aptos Incentivized Testnet (AIT) is managed by Aptos and the community.|
+|**Network runs where**| Validators run on Aptos Labs servers. FullNodes are run by both Aptos Labs and you (i.e., the Aptos community).| Validators and FullNodes run locally on your computer, entirely independent from devnet. | Some Validators run on Aptos servers, others are run by the Aptos community. FullNodes are run by Aptos Labs and the community.|
+|**Who is responsible for the network**|Managed by Aptos Team. | Deployed, managed and upgraded by you.| Aptos Incentivized Testnet (AIT) is managed by Aptos Labs and the community.|
 |**Purpose of the network**|The devnet is built to experiment with new ideas, improve performance and enhance the user experience.| The local testnet is for your development purposes and runs on your local computer.| For executing the Aptos Incentivized Testnet programs for the community.|
 |**Network status**|Mostly live, with brief interruptions during regular updates. | On your local computer. | **Live only during Incentivized Testnet drives**. |
 |**Type of nodes** (also see the row **Network runs where**) |Validators and FullNodes. | Validators and FullNodes. | Validators and FullNodes.|
+|**How to run a node**| N/A, run by Aptos Labs team. | See the [tutorial](local-testnet/using-cli-to-run-a-local-testnet.md). | If you've been invited to an AIT, see [the guide](ait/index.md).|
 |**How to connect to the network**|<ul><li> You can transact directly with devnet without a local testnet. See, for example, [Your first transaction](../tutorials/first-transaction.md).</li><li> You can run FullNodes locally on your computer and synchronize with devnet. See [Run a FullNode](/nodes/full-node/fullnode-for-devnet).</li></ul>| You can start a Validator and FullNode locally and connect with your local testnet for development purposes. | You must start both a local AIT Validator node locally to connect to the AIT. Optionally, FullNodes can also be run locally and connected to AIT.|
+|**TS / JS SDK to use**|The latest version of the [aptos](https://www.npmjs.com/package/aptos) package. The package on npmjs is tested and released with devnet. | Use the TS / JS SDK built from the same commit as the local testnet. See [this document](../guides/local-testnet-dev-flow) for an end-to-end guide explaining this flow. | N/A, do not develop against AIT. |
 |**What not to do**| Do not attempt to sync your local AIT FullNode or AIT Validator node with devnet. | Do not attempt to sync your local testnet Validator node with Aptos Incentivized Testnet. | Make sure you deploy your local AIT FullNode and AIT Validator node in the test mode, and follow the instructions in [AIT-2](/nodes/ait/ait-2).|

--- a/developer-docs-site/docs/nodes/local-testnet/using-cli-to-run-a-local-testnet.md
+++ b/developer-docs-site/docs/nodes/local-testnet/using-cli-to-run-a-local-testnet.md
@@ -41,7 +41,7 @@ Aptos is running, press ctrl-c to exit
 Faucet is running.  Faucet endpoint: 0.0.0.0:8081
 ```
 
-The above command will use the default configuration for the validator node.  
+The above command will use the default configuration for the validator node.
 
 :::caution Do not use two instances of the same command at the same time
 Note that two instances of the same command cannot run at the same time. This will result in a conflict on ports for the validator node.
@@ -81,7 +81,7 @@ Aptos is now set up for account 7100C5295ED4F9F39DCC28D309654E291845984518307D3E
 
 From now on you should add `--profile local` to the commands to run them on the local testnet.
 
-## Creating and funding accounts 
+## Creating and funding accounts
 
 To create new accounts on the local testnet, we recommend using the above instructions with different profile names:
 
@@ -145,7 +145,7 @@ If you updated your codebase with backwards incompatible changes, or just want t
 the command with the `--force-restart` flag:
 
 ```bash
-aptos node run-local-testnet --with-faucet
+aptos node run-local-testnet --with-faucet --force-restart
 ```
 
 It will then prompt you if you really want to restart the chain, to ensure that you do not delete your work by accident.

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -62,6 +62,7 @@ const sidebars = {
         "guides/interacting-with-the-blockchain",
         "guides/building-wallet-extension",
         "guides/guide-for-system-integrators",
+        "guides/local-testnet-dev-flow",
         {
           type: "category",
           label: "Move Guides",


### PR DESCRIPTION
## Description
There are two main correct dev flows:
1. devnet + sponsored version on npmjs (with each devnet we should say “use this SDK version”)
2. local testnet on main (or any commit on aptos-core really) and the SDK from that same commit (as in, not from npmjs)

Some devs mix and match the network and SDK in ways other than these two, which leads to incompatibilities. This PR is a start at making clear these options. As part of this, I add a guide for flow number 2.

There is still more work to do here, but this is a start.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2677)
<!-- Reviewable:end -->
