### PR TITLE
[aptos-cli] Allow empty config in global config

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -166,6 +166,7 @@ impl From<bcs::Error> for CliError {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CliConfig {
     /// Map of profile configs
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub profiles: Option<HashMap<String, ProfileConfig>>,
 }
 
@@ -177,14 +178,19 @@ pub const CONFIG_FOLDER: &str = ".aptos";
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ProfileConfig {
     /// Private key for commands.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub private_key: Option<Ed25519PrivateKey>,
     /// Public key for commands
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub public_key: Option<Ed25519PublicKey>,
     /// Account for commands
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<AccountAddress>,
     /// URL for the Aptos rest endpoint
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rest_url: Option<String>,
     /// URL for the Faucet endpoint (if applicable)
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub faucet_url: Option<String>,
 }
 


### PR DESCRIPTION
### Description
Fixes https://github.com/aptos-labs/aptos-core/issues/2642

### Test Plan
Tested manually that CLI no longer is required to load full config

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2685)
<!-- Reviewable:end -->
