### PR TITLE
First transaction is broken in the newest version of Typescript sdk

### DIFF
--- a/developer-docs-site/static/examples/typescript/first_transaction.ts
+++ b/developer-docs-site/static/examples/typescript/first_transaction.ts
@@ -43,7 +43,12 @@ const client = new AptosClient(NODE_URL);
 //:!:>section_5
 /** Helper method returns the coin balance associated with the account */
 export async function accountBalance(accountAddress: MaybeHexString): Promise<number | null> {
-  const resource = await client.getAccountResource(accountAddress, "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>");
+  const resource = await client.getAccountResource(accountAddress, {
+    address: "0x1",
+    module: "coin",
+    name: "CoinStore",
+    generic_type_params: ["0x1::aptos_coin::AptosCoin"],
+  });
   if (resource == null) {
     return null;
   }

--- a/ecosystem/typescript/sdk/src/generated/services/TransactionsService.ts
+++ b/ecosystem/typescript/sdk/src/generated/services/TransactionsService.ts
@@ -95,7 +95,7 @@ export class TransactionsService {
     ): CancelablePromise<Transaction> {
         return this.httpRequest.request({
             method: 'GET',
-            url: '/transactions/by_hash/{txn_hash}',
+            url: '/transactions/{txn_hash}',
             path: {
                 'txn_hash': txnHash,
             },


### PR DESCRIPTION
### Description
Two issues appeared when I tried to execute the program after following the documentation's instructions in Typescript for my first transaction:
1. The resourceType param in the getAccountResource function should be the MoveStructTag type instead of String in the old version, which is the first error. 
2. My transaction timed out without receiving any results, which was caused by the typescript SDK's getTransactionByHash method post to the url "/transactions/by_hash/{txn_hash}". When I looked at the rust and python versions, they post to the url "/transaction/{txn_hash}", so I changed it and everything worked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2689)
<!-- Reviewable:end -->
