### PR TITLE
[aptos-stdlib] Typed Property Tables

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/type_map.move
+++ b/aptos-move/framework/aptos-framework/sources/type_map.move
@@ -1,0 +1,37 @@
+module aptos_framework::type_map {
+    use aptos_std::simple_map::{Self, SimpleMap};
+    use aptos_std::type_info::{Self, TypeInfo};
+    use std::bcs;
+    use aptos_framework::util;
+
+    struct TypeMap has drop, copy, store {
+        inner: SimpleMap<TypeInfo, vector<u8>>
+    }
+
+    public fun new(): TypeMap {
+        TypeMap { inner: simple_map::create() }
+    }
+
+    public fun contains<T>(map: &TypeMap): bool {
+        let ty_info = type_info::type_of<T>();
+        simple_map::contains_key(&map.inner, &ty_info)
+    }
+
+    public fun move_in<T: drop>(map: &mut TypeMap, value: T) {
+        let ty_info = type_info::type_of<T>();
+        let value_bcs = bcs::to_bytes(&value);
+        simple_map::add(&mut map.inner, ty_info, value_bcs);
+    }
+
+    public fun clone<T: copy>(map: &mut TypeMap): T {
+        let ty_info = type_info::type_of<T>();
+        let bcs = *simple_map::borrow_mut(&mut map.inner, &ty_info);
+        util::from_bytes<T>(bcs)
+    }
+
+    public fun move_out<T>(map: &mut TypeMap): T {
+        let ty_info = type_info::type_of<T>();
+        let (_, bcs) = simple_map::remove(&mut map.inner, &ty_info);
+        util::from_bytes<T>(bcs)
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/util.move
+++ b/aptos-move/framework/aptos-framework/sources/util.move
@@ -2,9 +2,14 @@
 module aptos_framework::util {
     friend aptos_framework::code;
     friend aptos_framework::gas_schedule;
+    friend aptos_framework::type_map;
 
     /// Native function to deserialize a type T.
-    /// TODO: may want to move it in extra module if needed also in other places inside of the Fx.
-    /// However, should not make this function public outside of the Fx.
-    public(friend) native fun from_bytes<T: copy + drop>(bytes: vector<u8>): T;
+    /// TODO: this function actually belongs to the aptos-stdlib layer, but friend functions cannot be
+    /// referenced between packages.
+    ///
+    /// Note that this function does not put any constraint on `T`. If code uses this function to
+    /// deserialized a linear value, its their responsibility that the data they deserialize is
+    /// owned.
+    public(friend) native fun from_bytes<T>(bytes: vector<u8>): T;
 }

--- a/aptos-move/framework/aptos-framework/sources/util.move
+++ b/aptos-move/framework/aptos-framework/sources/util.move
@@ -5,8 +5,6 @@ module aptos_framework::util {
     friend aptos_framework::type_map;
 
     /// Native function to deserialize a type T.
-    /// TODO: this function actually belongs to the aptos-stdlib layer, but friend functions cannot be
-    /// referenced between packages.
     ///
     /// Note that this function does not put any constraint on `T`. If code uses this function to
     /// deserialized a linear value, its their responsibility that the data they deserialize is

--- a/aptos-move/framework/aptos-stdlib/sources/any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/any.move
@@ -1,0 +1,54 @@
+module aptos_std::any {
+    use aptos_std::type_info::{Self, TypeInfo};
+    use std::bcs;
+    use std::error;
+
+    friend aptos_std::type_map;
+
+    const ETYPE_MISMATCH: u64 = 0;
+
+    /// A type which can represent a value of any type. This allows for representation of 'unknown' future
+    /// values. For example, to define a resource such that it can be later be extended without breaking
+    /// changes one can do
+    ///
+    /// ```move
+    ///   struct Resource {
+    ///      field: Type,
+    ///      ...
+    ///      extension: Option<Any>
+    ///   }
+    /// ```
+    ///
+    /// TODO: currently this is restricted to structs, we may want to relax this. Restriction comes from TypeInfo.
+    struct Any has drop, store {
+        type_info: TypeInfo,
+        data: vector<u8>
+    }
+
+    /// Pack a value into the `Any` representation. Because Any can be stored and dropped, this is
+    /// also required from `T`.
+    public fun pack<T: drop + store>(x: T): Any {
+        Any {
+            type_info: type_info::type_of<T>(),
+            data: bcs::to_bytes(&x)
+        }
+    }
+
+    /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
+    public fun unpack<T>(x: Any): T {
+        assert!(type_info::type_of<T>() == x.type_info, error::invalid_argument(ETYPE_MISMATCH));
+        from_bytes<T>(x.data)
+    }
+
+    /// Returns the type info of this Any
+    public fun type_info(x: &Any): TypeInfo {
+        x.type_info
+    }
+
+    /// Native function to deserialize a type T.
+    ///
+    /// Note that this function does not put any constraint on `T`. If code uses this function to
+    /// deserialized a linear value, its their responsibility that the data they deserialize is
+    /// owned.
+    public(friend) native fun from_bytes<T>(bytes: vector<u8>): T;
+}

--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.move
@@ -13,11 +13,11 @@ module aptos_std::simple_map {
     const EKEY_ALREADY_EXISTS: u64 = 0;
     const EKEY_NOT_FOUND: u64 = 1;
 
-    struct SimpleMap<Key, Value> has drop, store {
+    struct SimpleMap<Key, Value> has drop, store, copy {
         data: vector<Element<Key, Value>>,
     }
 
-    struct Element<Key, Value> has drop, store {
+    struct Element<Key, Value> has drop, store, copy {
         key: Key,
         value: Value,
     }

--- a/aptos-move/framework/aptos-stdlib/sources/type_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_map.move
@@ -1,14 +1,15 @@
-module aptos_framework::type_map {
+module aptos_std::type_map {
     use aptos_std::simple_map::{Self, SimpleMap};
     use aptos_std::type_info::{Self, TypeInfo};
+    use aptos_std::any;
+
     use std::bcs;
-    use aptos_framework::util;
 
     struct TypeMap has drop, copy, store {
         inner: SimpleMap<TypeInfo, vector<u8>>
     }
 
-    public fun new(): TypeMap {
+    public fun create(): TypeMap {
         TypeMap { inner: simple_map::create() }
     }
 
@@ -26,12 +27,12 @@ module aptos_framework::type_map {
     public fun clone<T: copy>(map: &mut TypeMap): T {
         let ty_info = type_info::type_of<T>();
         let bcs = *simple_map::borrow_mut(&mut map.inner, &ty_info);
-        util::from_bytes<T>(bcs)
+        any::from_bytes<T>(bcs)
     }
 
     public fun move_out<T>(map: &mut TypeMap): T {
         let ty_info = type_info::type_of<T>();
         let (_, bcs) = simple_map::remove(&mut map.inner, &ty_info);
-        util::from_bytes<T>(bcs)
+        any::from_bytes<T>(bcs)
     }
 }

--- a/aptos-move/framework/src/natives/any.rs
+++ b/aptos-move/framework/src/natives/any.rs
@@ -1,0 +1,17 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::natives::{util, GasParameters};
+use move_deps::move_vm_runtime::native_functions::NativeFunction;
+
+// The Any module hijacks just one function, from_bytes, from the util module. This
+// is a friend function which cannot be used across packages, so we have it both
+// in aptos_std and aptos_framework.
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [(
+        "from_bytes",
+        util::make_native_from_bytes(gas_params.from_bytes),
+    )];
+
+    crate::natives::helpers::make_module_natives(natives)
+}

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod account;
+pub mod any;
 pub mod code;
 pub mod event;
 pub mod hash;
@@ -125,6 +126,7 @@ pub fn all_natives(
     add_natives_from_module!("hash", hash::make_all(gas_params.hash));
     add_natives_from_module!("type_info", type_info::make_all(gas_params.type_info));
     add_natives_from_module!("util", util::make_all(gas_params.util));
+    add_natives_from_module!("any", util::make_all(gas_params.util));
     add_natives_from_module!(
         "transaction_context",
         transaction_context::make_all(gas_params.transaction_context)


### PR DESCRIPTION
This is a sketch of a type-indexed map which would belong into our stdlib. This is related to PR #2673 about property maps for the token framework.

Type indexed maps have been know since long to integrate dynamic extensibility into statically typed languages. Move's global storage model uses a variation of this approach. The basic advantage is that indexing by type guarantees you get an instance of that type which satisfies all relevant invariants.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2692)
<!-- Reviewable:end -->
