### PR TITLE
[smoke-tests][cli] Fix flaky CLI smoke tests using FundAccount through faucet

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -48,6 +48,7 @@ impl CliCommand<String> for CreateAccount {
                 self.account,
             )
             .await
+            .map(|_| ())
         } else {
             self.create_account_with_key(address).await
         }

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -178,10 +178,8 @@ async fn test_join_and_leave_validator() {
 
     assert_validator_set_sizes(&cli, 1, 0, 0).await;
 
-    assert_eq!(
-        DEFAULT_FUNDED_COINS - gas_used,
-        cli.account_balance(validator_cli_index).await.unwrap()
-    );
+    cli.assert_account_balance_now(validator_cli_index, DEFAULT_FUNDED_COINS - gas_used)
+        .await;
 
     let stake_coins = 7;
     gas_used += get_gas(
@@ -190,10 +188,11 @@ async fn test_join_and_leave_validator() {
             .unwrap(),
     );
 
-    assert_eq!(
+    cli.assert_account_balance_now(
+        validator_cli_index,
         DEFAULT_FUNDED_COINS - stake_coins - gas_used,
-        cli.account_balance(validator_cli_index).await.unwrap()
-    );
+    )
+    .await;
 
     reconfig(
         &rest_client,
@@ -246,10 +245,12 @@ async fn test_join_and_leave_validator() {
 
     assert_validator_set_sizes(&cli, 1, 0, 0).await;
 
-    assert_eq!(
+    cli.assert_account_balance_now(
+        validator_cli_index,
         DEFAULT_FUNDED_COINS - stake_coins - gas_used,
-        cli.account_balance(validator_cli_index).await.unwrap()
-    );
+    )
+    .await;
+
     let unlock_stake = 3;
 
     // Unlock stake.
@@ -269,10 +270,11 @@ async fn test_join_and_leave_validator() {
             .unwrap(),
     );
 
-    assert_eq!(
+    cli.assert_account_balance_now(
+        validator_cli_index,
         DEFAULT_FUNDED_COINS - stake_coins + withdraw_stake - gas_used,
-        cli.account_balance(validator_cli_index).await.unwrap()
-    );
+    )
+    .await;
 }
 
 fn dns_name(addr: &str) -> DnsName {
@@ -312,10 +314,9 @@ async fn init_validator_account(
         .add_cli_account(validator_node_keys.account_private_key.clone())
         .await
         .unwrap();
-    assert_eq!(
-        DEFAULT_FUNDED_COINS,
-        cli.account_balance(validator_cli_index).await.unwrap()
-    );
+
+    cli.assert_account_balance_now(validator_cli_index, DEFAULT_FUNDED_COINS)
+        .await;
     (validator_cli_index, validator_node_keys)
 }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -388,8 +388,10 @@ async fn test_block_transactions() {
     let chain_id = swarm.chain_id();
 
     // Make sure first that there's money to transfer
-    assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(0).await.unwrap());
-    assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(1).await.unwrap());
+    cli.assert_account_balance_now(0, DEFAULT_FUNDED_COINS)
+        .await;
+    cli.assert_account_balance_now(1, DEFAULT_FUNDED_COINS)
+        .await;
 
     // Now let's see some transfers
     const TRANSFER_AMOUNT: u64 = 5000;
@@ -507,7 +509,8 @@ async fn test_invalid_transaction_gas_charged() {
     let chain_id = swarm.chain_id();
 
     // Make sure first that there's money to transfer
-    assert_eq!(DEFAULT_FUNDED_COINS, cli.account_balance(0).await.unwrap());
+    cli.assert_account_balance_now(0, DEFAULT_FUNDED_COINS)
+        .await;
 
     // Now let's see some transfers
     const TRANSFER_AMOUNT: u64 = 5000;

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -105,7 +105,10 @@ impl SwarmBuilder {
             num_cli_accounts,
         )
         .await;
-
+        println!(
+            "Created CLI with {} accounts for LocalSwarm",
+            num_cli_accounts
+        );
         (swarm, tool, faucet)
     }
 }


### PR DESCRIPTION
### Description

*  cli tests (aptos_cli and rosseta) were flaky, because FundAccount CLI command didn't wait to finish, and because funding through fauced is two transactions - creating account and minting. Unit test waited for account to exist to assert balance. Under extreme load, those two transactions would be in a different block, and so test would fail.
* all CLI commands wait for completion - so making FundAccount do the same
* we really should be waiting on transactions - not on accounts and balances. so removed those functions from CliTestFramework, and made functions check for balance now. this way current test (without FundAccount waiting) fails consistently (even without load)
* and added assert_account_balance_now function that when accounts don't match, print more details on the discrepancy, to allow easier debugging.


### Test Plan
Improved unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2700)
<!-- Reviewable:end -->
