### PR TITLE
[API] Ensure hex strings are wrapped in quotes in the spec

### DIFF
--- a/api/types/src/derives.rs
+++ b/api/types/src/derives.rs
@@ -13,6 +13,11 @@
 //! For potential future improvements here, see:
 //! https://github.com/aptos-labs/aptos-core/issues/2319.
 
+// READ ME: You'll see that some of the examples (specifically those for hex
+// strings) have a space at the end. This is necessary to make sure the UI
+// displays the example value correctly. See more here:
+// https://github.com/aptos-labs/aptos-core/pull/2703
+
 use aptos_openapi::{impl_poem_parameter, impl_poem_type};
 use serde_json::json;
 
@@ -28,7 +33,7 @@ impl_poem_type!(
     "string",
     (
         example = Some(serde_json::Value::String(
-            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1".to_string()
+            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 ".to_string()
         )),
         format = Some("hex"),
         description = Some("Hex encoded 32 byte Aptos account address")
@@ -40,7 +45,7 @@ impl_poem_type!(
     "string",
     (
         example = Some(serde_json::Value::String(
-            "0x000000000000000088fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1"
+            "0x000000000000000088fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 "
                 .to_string()
         )),
         format = Some("hex"),
@@ -65,7 +70,7 @@ impl_poem_type!(
     "string",
     (
         example = Some(serde_json::Value::String(
-            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1".to_string()
+            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 ".to_string()
         )),
         format = Some("hex"),
         description = Some(indoc! {"

--- a/execution/executor-test-helpers/Cargo.toml
+++ b/execution/executor-test-helpers/Cargo.toml
@@ -23,7 +23,7 @@ aptos-transaction-builder = { path = "../../sdk/transaction-builder" }
 aptos-types = { path = "../../types", features = ["fuzzing"] }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
 aptosdb = { path = "../../storage/aptosdb", features = ["fuzzing"] }
-consensus-types = { path = "../../consensus/consensus-types"}
+consensus-types = { path = "../../consensus/consensus-types" }
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }
 move-deps = { path = "../../aptos-move/move-deps", features = ["address32"] }


### PR DESCRIPTION
## Description
Addressing https://github.com/aptos-labs/aptos-core/issues/2562. In short, we need to make sure the example ends up wrapped with strings.

This is a bit of a hack, the YAML generator should just wrap it in a string, or the stoplight UI should treat it as a string regardless of whether it has quotes around it (since type is string). But it works for now, the examples are only used for the UI / docs (visual inspection, nothing programmatic) so this should be okay.

## Test Plan
```
$ cargo run -p aptos-openapi-spec-generator -- -f yaml | grep -A 8 HexEncodedBytes:
    HexEncodedBytes:
      type: string
      format: hex
      description: |
        All bytes (Vec<u8>) data is represented as hex-encoded string prefixed with `0x` and fulfilled with
        two hex digits per byte.

        Unlike the `Address` type, HexEncodedBytes will not trim any zeros.
      example: '0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 '
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2703)
<!-- Reviewable:end -->
