### PR TITLE
[gas] initial gas algebra impl that enforce checked addition/subtraction and type-safe multiplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "move-core-types",
  "move-stdlib",
  "move-vm-types",
+ "serde 1.0.141",
 ]
 
 [[package]]

--- a/aptos-move/aptos-gas/Cargo.toml
+++ b/aptos-move/aptos-gas/Cargo.toml
@@ -10,6 +10,8 @@ publish = false
 edition = "2021"
 
 [dependencies]
+serde = { version = "1.0.137", default-features = false }
+
 move-binary-format = { git = "https://github.com/move-language/move", rev = "e97dc204943776e80a16255432ee4e92c4e08652" }
 move-core-types = { git = "https://github.com/move-language/move", rev = "e97dc204943776e80a16255432ee4e92c4e08652" }
 move-stdlib = { git = "https://github.com/move-language/move", rev = "e97dc204943776e80a16255432ee4e92c4e08652" }

--- a/aptos-move/aptos-gas/src/algebra.rs
+++ b/aptos-move/aptos-gas/src/algebra.rs
@@ -1,0 +1,226 @@
+use serde::{Deserialize, Serialize};
+use std::cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd};
+use std::convert::From;
+use std::fmt::{self, Debug, Display};
+use std::marker::PhantomData;
+use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
+
+/***************************************************************************************************
+ * Units of Measurement
+ *
+ **************************************************************************************************/
+/// Unit of (external) gas.
+pub enum GasUnit {}
+
+/// Unit of internal gas.
+pub enum InternalGasUnit {}
+
+/// Unit for counting bytes.
+pub enum Byte {}
+
+/// Unit of gas currency. 1 octa = 10^-8 Aptos coins.
+pub enum Octa {}
+
+// Unit of abstract memory usage in the Move VM.
+pub enum AbstractMemoryUnit {}
+
+/// A drived unit resulted from the division of two given units.
+/// This is used to permit type-safe multiplications.
+///
+/// A real life example: 3 m/s * 5 s = 15 m
+pub struct UnitDiv<U1, U2> {
+    phantom: PhantomData<(U1, U2)>,
+}
+
+/***************************************************************************************************
+ * Gas Quantities
+ *
+ **************************************************************************************************/
+/// An opqaue representation of a certain quantity, with the unit being encoded in the type.
+/// This type implements checked addition and subtraction, and only permits type-safe multiplication.
+#[derive(Serialize, Deserialize)]
+pub struct GasQuantity<U> {
+    val: u64,
+    phantom: PhantomData<U>,
+}
+
+pub type Gas = GasQuantity<GasUnit>;
+
+pub type InternalGas = GasQuantity<InternalGasUnit>;
+
+pub type NumBytes = GasQuantity<Byte>;
+
+pub type InternalGasPerByte = GasQuantity<UnitDiv<InternalGasUnit, Byte>>;
+
+pub type InternalGasPerAbstractMemoryUnit =
+    GasQuantity<UnitDiv<InternalGasUnit, AbstractMemoryUnit>>;
+
+pub type AbstractMemorySize = GasQuantity<AbstractMemoryUnit>;
+
+pub type GasScalingFactor = GasQuantity<UnitDiv<InternalGasUnit, GasUnit>>;
+
+pub type Fee = GasQuantity<Octa>;
+
+pub type FeePerGasUnit = GasQuantity<UnitDiv<Octa, GasUnit>>;
+
+/***************************************************************************************************
+ * Constructors
+ *
+ **************************************************************************************************/
+impl<U> GasQuantity<U> {
+    pub fn new(val: u64) -> Self {
+        Self {
+            val,
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn zero() -> Self {
+        Self::new(0)
+    }
+}
+
+/***************************************************************************************************
+ * Conversion
+ *
+ **************************************************************************************************/
+impl<U> From<u64> for GasQuantity<U> {
+    fn from(val: u64) -> Self {
+        Self::new(val)
+    }
+}
+
+// TODO(Gas): This allows the gas value to escape the monad, which weakens the type-level
+//            protection it provides. It's currently needed for practical reasons but
+//            we should look for ways to get rid of it.
+impl<U> From<GasQuantity<U>> for u64 {
+    fn from(gas: GasQuantity<U>) -> Self {
+        gas.val
+    }
+}
+
+/***************************************************************************************************
+ * Clone & Copy
+ *
+ **************************************************************************************************/
+impl<U> Clone for GasQuantity<U> {
+    fn clone(&self) -> Self {
+        Self::new(self.val)
+    }
+}
+
+impl<U> Copy for GasQuantity<U> {}
+
+/***************************************************************************************************
+ * Display & Debug
+ *
+ **************************************************************************************************/
+impl<U> Display for GasQuantity<U> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.val)
+    }
+}
+
+impl<U> Debug for GasQuantity<U> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} ({})", self.val, std::any::type_name::<U>())
+    }
+}
+
+/***************************************************************************************************
+ * Comparison
+ *
+ **************************************************************************************************/
+impl<U> GasQuantity<U> {
+    fn cmp_impl(&self, other: &Self) -> Ordering {
+        self.val.cmp(&other.val)
+    }
+}
+
+impl<U> PartialEq for GasQuantity<U> {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(self.cmp_impl(other), Ordering::Equal)
+    }
+}
+
+impl<U> Eq for GasQuantity<U> {}
+
+impl<U> PartialOrd for GasQuantity<U> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp_impl(other))
+    }
+}
+
+impl<U> Ord for GasQuantity<U> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.cmp_impl(other)
+    }
+}
+
+/***************************************************************************************************
+ * Addition & Subtraction
+ *
+ **************************************************************************************************/
+impl<U> Add<GasQuantity<U>> for GasQuantity<U> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::new(
+            self.val
+                .checked_add(rhs.val)
+                .unwrap_or_else(|| panic!("overflow when calculating ({:?}) + ({:?})", self, rhs)),
+        )
+    }
+}
+
+impl<U> AddAssign<GasQuantity<U>> for GasQuantity<U> {
+    fn add_assign(&mut self, rhs: GasQuantity<U>) {
+        *self = *self + rhs
+    }
+}
+
+impl<U> Sub<GasQuantity<U>> for GasQuantity<U> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::new(
+            self.val
+                .checked_sub(rhs.val)
+                .unwrap_or_else(|| panic!("underflow when calculating ({:?}) - ({:?})", self, rhs)),
+        )
+    }
+}
+
+impl<U> SubAssign<GasQuantity<U>> for GasQuantity<U> {
+    fn sub_assign(&mut self, rhs: GasQuantity<U>) {
+        *self = *self - rhs
+    }
+}
+
+/***************************************************************************************************
+ * Multiplication
+ *
+ **************************************************************************************************/
+fn mul_impl<U1, U2>(x: GasQuantity<U2>, y: GasQuantity<UnitDiv<U1, U2>>) -> GasQuantity<U1> {
+    GasQuantity::new(
+        x.val
+            .checked_mul(y.val)
+            .unwrap_or_else(|| panic!("overflow when calculating ({:?}) * ({:?})", x, y)),
+    )
+}
+
+impl<U1, U2> Mul<GasQuantity<UnitDiv<U1, U2>>> for GasQuantity<U2> {
+    type Output = GasQuantity<U1>;
+
+    fn mul(self, rhs: GasQuantity<UnitDiv<U1, U2>>) -> Self::Output {
+        mul_impl(self, rhs)
+    }
+}
+
+impl<U1, U2> Mul<GasQuantity<U2>> for GasQuantity<UnitDiv<U1, U2>> {
+    type Output = GasQuantity<U1>;
+
+    fn mul(self, rhs: GasQuantity<U2>) -> Self::Output {
+        mul_impl(rhs, self)
+    }
+}

--- a/aptos-move/aptos-gas/src/instr.rs
+++ b/aptos-move/aptos-gas/src/instr.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+//! This module defines all the gas parameters and formulae for instructions, along with their
+//! initial values in the genesis and a mapping between the Rust representation and the on-chain
+//! gas schedule.
+
 use crate::gas_meter::{FromOnChainGasSchedule, InitialGasSchedule, ToOnChainGasSchedule};
 use move_binary_format::{
     errors::{PartialVMError, PartialVMResult},

--- a/aptos-move/aptos-gas/src/lib.rs
+++ b/aptos-move/aptos-gas/src/lib.rs
@@ -1,6 +1,23 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+//! This crate is the core of the gas metering system of the Aptos blockchain.
+//!
+//! More specifically, it
+//!   - Is home to the gas meter implementation
+//!   - Defines the gas parameters and formulae for instructions
+//!   - Defines the gas parameters for transactions
+//!   - Sets the initial values for all gas parameters, including the instruction, transaction
+//!     move-stdlib and aptos-framework ones.
+//!   - Defines a bi-directional mapping between the (Rust) gas parameter structs and their
+//!     corresponding representation on-chain.
+//!
+//! The reason why we need two different representations is that they serve different purposes:
+//!   - The Rust structs are used for quick (static) lookups by the gas meter and native functions
+//!     when calculating gas costs.
+//!   - The on-chain gas schedule needs to be extensible and unordered so we can upgrate it easily
+//!     in the future.
+
 #[macro_use]
 mod natives;
 

--- a/aptos-move/aptos-gas/src/lib.rs
+++ b/aptos-move/aptos-gas/src/lib.rs
@@ -21,12 +21,18 @@
 #[macro_use]
 mod natives;
 
+mod algebra;
 mod aptos_framework;
 mod gas_meter;
 mod instr;
 mod move_stdlib;
 mod transaction;
 
+pub use algebra::{
+    AbstractMemorySize, AbstractMemoryUnit, Byte, Fee, FeePerGasUnit, Gas, GasQuantity, GasUnit,
+    InternalGas, InternalGasPerAbstractMemoryUnit, InternalGasPerByte, InternalGasUnit, NumBytes,
+    Octa, UnitDiv,
+};
 pub use gas_meter::{
     AptosGasMeter, AptosGasParameters, FromOnChainGasSchedule, InitialGasSchedule,
     NativeGasParameters, ToOnChainGasSchedule,

--- a/aptos-move/aptos-gas/src/natives.rs
+++ b/aptos-move/aptos-gas/src/natives.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-// Here are some macros to help implement the mapping between the on-chain gas schedule and its
-// rust representation.
+//! This module defines some macros to help implement the mapping between the on-chain gas schedule
+//! and its rust representation.
 
 macro_rules! expand_get {
     (test_only $(.$field: ident)+, $key: literal, $initial_val: expr, $param_ty: ty, $package_name: literal, $params: ident, $gas_schedule: ident) => {

--- a/aptos-move/aptos-gas/src/transaction.rs
+++ b/aptos-move/aptos-gas/src/transaction.rs
@@ -1,5 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
+
+//! This module defines all the gas parameters for transactions, along with their initial values
+//! in the genesis and a mapping between the Rust representation and the on-chain gas schedule.
+
 use crate::gas_meter::{FromOnChainGasSchedule, InitialGasSchedule, ToOnChainGasSchedule};
 use std::collections::BTreeMap;
 
@@ -94,7 +98,7 @@ impl TransactionGasParameters {
         }
     }
 
-    /// Calculate the intrinsic gas for the transaction based upon its size in bytes/words.
+    /// Calculate the intrinsic gas for the transaction based upon its size in bytes.
     pub fn calculate_intrinsic_gas(&self, transaction_size: u64) -> u64 {
         let min_transaction_fee = self.min_transaction_gas_units;
 

--- a/aptos-move/aptos-gas/src/transaction.rs
+++ b/aptos-move/aptos-gas/src/transaction.rs
@@ -4,36 +4,39 @@
 //! This module defines all the gas parameters for transactions, along with their initial values
 //! in the genesis and a mapping between the Rust representation and the on-chain gas schedule.
 
+use crate::algebra::{
+    FeePerGasUnit, Gas, GasScalingFactor, InternalGas, InternalGasPerByte, NumBytes,
+};
 use crate::gas_meter::{FromOnChainGasSchedule, InitialGasSchedule, ToOnChainGasSchedule};
 use std::collections::BTreeMap;
 
 macro_rules! define_gas_parameters_for_transaction {
-    ($([$name: ident, $key: literal, $initial: expr $(,)?]),* $(,)?) => {
+    ($([$name: ident : $ty: ty, $key: literal, $initial: expr $(,)?]),* $(,)?) => {
         /// Transaction-level gas parameters.
         ///
         /// Note: due to performance considerations, this is represented as a fixed struct instead of
         /// some other data structures that require complex lookups.
         #[derive(Debug, Clone)]
         pub struct TransactionGasParameters {
-            $(pub $name : u64),*
+            $(pub $name : $ty),*
         }
 
         impl FromOnChainGasSchedule for TransactionGasParameters {
             fn from_on_chain_gas_schedule(gas_schedule: &BTreeMap<String, u64>) -> Option<Self> {
-                Some(Self { $($name: gas_schedule.get(&format!("txn.{}", $key)).cloned()?),* })
+                Some(Self { $($name: gas_schedule.get(&format!("txn.{}", $key)).cloned()?.into()),* })
             }
         }
 
         impl ToOnChainGasSchedule for TransactionGasParameters {
             fn to_on_chain_gas_schedule(&self) -> Vec<(String, u64)> {
-                vec![$((format!("txn.{}", $key), self.$name)),*]
+                vec![$((format!("txn.{}", $key), self.$name.into())),*]
             }
         }
 
         impl TransactionGasParameters {
             pub fn zeros() -> Self {
                 Self {
-                    $($name: 0),*
+                    $($name: 0.into()),*
                 }
             }
         }
@@ -41,7 +44,7 @@ macro_rules! define_gas_parameters_for_transaction {
         impl InitialGasSchedule for TransactionGasParameters {
             fn initial() -> Self {
                 Self {
-                    $($name: $initial),*
+                    $($name: $initial.into()),*
                 }
             }
         }
@@ -60,46 +63,73 @@ macro_rules! define_gas_parameters_for_transaction {
 define_gas_parameters_for_transaction!(
     // The flat minimum amount of gas required for any transaction.
     // Charged at the start of execution.
-    [min_transaction_gas_units, "min_transaction_gas_units", 600],
+    [
+        min_transaction_gas_units: InternalGas,
+        "min_transaction_gas_units",
+        600
+    ],
     // Any transaction over this size will be charged an additional amount per byte.
-    [large_transaction_cutoff, "large_transaction_cutoff", 600],
+    [
+        large_transaction_cutoff: NumBytes,
+        "large_transaction_cutoff",
+        600
+    ],
     // The units of gas that to be charged per byte over the `large_transaction_cutoff` in addition to
     // `min_transaction_gas_units` for transactions whose size exceeds `large_transaction_cutoff`.
-    [intrinsic_gas_per_byte, "intrinsic_gas_per_byte", 8],
+    [
+        intrinsic_gas_per_byte: InternalGasPerByte,
+        "intrinsic_gas_per_byte",
+        8
+    ],
     // ~5 microseconds should equal one unit of computational gas. We bound the maximum
     // computational time of any given transaction at roughly 20 seconds. We want this number and
     // `MAX_PRICE_PER_GAS_UNIT` to always satisfy the inequality that
     // MAXIMUM_NUMBER_OF_GAS_UNITS * MAX_PRICE_PER_GAS_UNIT < min(u64::MAX, GasUnits<GasCarrier>::MAX)
     [
-        maximum_number_of_gas_units,
+        maximum_number_of_gas_units: Gas,
         "maximum_number_of_gas_units",
         4_000_000
     ],
     // The minimum gas price that a transaction can be submitted with.
     // TODO(Gas): should probably change this to something > 0
-    [min_price_per_gas_unit, "min_price_per_gas_unit", 0],
-    // The maximum gas unit price that a transaction can be submitted with.
-    [max_price_per_gas_unit, "max_price_per_gas_unit", 10_000],
     [
-        max_transaction_size_in_bytes,
+        min_price_per_gas_unit: FeePerGasUnit,
+        "min_price_per_gas_unit",
+        0
+    ],
+    // The maximum gas unit price that a transaction can be submitted with.
+    [
+        max_price_per_gas_unit: FeePerGasUnit,
+        "max_price_per_gas_unit",
+        10_000
+    ],
+    [
+        max_transaction_size_in_bytes: NumBytes,
         "max_transaction_size_in_bytes",
         8192
     ],
-    [gas_unit_scaling_factor, "gas_unit_scaling_factor", 1000],
+    [
+        gas_unit_scaling_factor: GasScalingFactor,
+        "gas_unit_scaling_factor",
+        1000
+    ],
 );
 
 impl TransactionGasParameters {
     // TODO(Gas): Right now we are relying on this to avoid div by zero errors when using the all-zero
     //            gas parameters. See if there's a better way we can handle this.
-    fn scaling_factor(&self) -> u64 {
-        match self.gas_unit_scaling_factor {
-            0 => 1,
-            x => x,
+    fn scaling_factor(&self) -> GasScalingFactor {
+        match u64::from(self.gas_unit_scaling_factor) {
+            0 => 1.into(),
+            x => x.into(),
         }
     }
 
     /// Calculate the intrinsic gas for the transaction based upon its size in bytes.
-    pub fn calculate_intrinsic_gas(&self, transaction_size: u64) -> u64 {
+    pub fn calculate_intrinsic_gas(&self, transaction_size: usize) -> InternalGas {
+        // TODO(Gas): Is this conversion safe?
+        let transaction_size = NumBytes::new(transaction_size as u64);
+
         let min_transaction_fee = self.min_transaction_gas_units;
 
         if transaction_size > self.large_transaction_cutoff {
@@ -110,11 +140,21 @@ impl TransactionGasParameters {
         }
     }
 
-    pub fn to_external_units(&self, internal_units: u64) -> u64 {
-        internal_units / self.scaling_factor()
+    pub fn to_external_units_round_up(&self, internal_units: InternalGas) -> Gas {
+        let n = u64::from(internal_units);
+        let d = u64::from(self.scaling_factor());
+
+        let r = n / d;
+        let m = n % d;
+
+        Gas::new(r + if m == 0 { 0 } else { 1 })
     }
 
-    pub fn to_internal_units(&self, external_units: u64) -> u64 {
+    pub fn to_external_units_round_down(&self, internal_units: InternalGas) -> Gas {
+        (u64::from(internal_units) / u64::from(self.scaling_factor())).into()
+    }
+
+    pub fn to_internal_units(&self, external_units: Gas) -> InternalGas {
         external_units * self.scaling_factor()
     }
 }

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -446,10 +446,13 @@ impl<'a> AptosTestAdapter<'a> {
             Some(max_gas_amount) => max_gas_amount,
             None => {
                 if gas_unit_price == 0 {
-                    max_number_of_gas_units
+                    max_number_of_gas_units.into()
                 } else {
                     let account_balance = self.fetch_account_balance(signer_addr).unwrap();
-                    std::cmp::min(max_number_of_gas_units, account_balance / gas_unit_price)
+                    std::cmp::min(
+                        max_number_of_gas_units.into(),
+                        account_balance / gas_unit_price,
+                    )
                 }
             }
         };

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -516,7 +516,7 @@ impl AptosVM {
         };
 
         let gas_usage = txn_data.max_gas_amount() - gas_meter.balance();
-        TXN_GAS_USAGE.observe(gas_usage as f64);
+        TXN_GAS_USAGE.observe(u64::from(gas_usage) as f64);
 
         match result {
             Ok(output) => output,
@@ -670,7 +670,7 @@ impl AptosVM {
 
         let txn_data = TransactionMetadata {
             sender: account_config::reserved_vm_address(),
-            max_gas_amount: 0,
+            max_gas_amount: 0.into(),
             ..Default::default()
         };
         let mut gas_meter = UnmeteredGasMeter;
@@ -693,8 +693,13 @@ impl AptosVM {
             })?;
         SYSTEM_TRANSACTIONS_EXECUTED.inc();
 
-        let output =
-            get_transaction_output(&mut (), session, 0, &txn_data, ExecutionStatus::Success)?;
+        let output = get_transaction_output(
+            &mut (),
+            session,
+            0.into(),
+            &txn_data,
+            ExecutionStatus::Success,
+        )?;
         Ok((VMStatus::Executed, output))
     }
 

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -12,7 +12,7 @@ use crate::{
     transaction_metadata::TransactionMetadata,
 };
 use aptos_crypto::HashValue;
-use aptos_gas::{AptosGasParameters, FromOnChainGasSchedule, NativeGasParameters};
+use aptos_gas::{AptosGasParameters, FromOnChainGasSchedule, Gas, NativeGasParameters};
 use aptos_logger::prelude::*;
 use aptos_state_view::StateView;
 use aptos_types::{
@@ -25,7 +25,6 @@ use fail::fail_point;
 use move_deps::{
     move_binary_format::{errors::VMResult, CompiledModule},
     move_core_types::{
-        gas_schedule::GasAlgebra,
         language_storage::ModuleId,
         move_resource::MoveStructType,
         resolver::ResourceResolver,
@@ -141,31 +140,33 @@ impl AptosVMImpl {
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
-        let gas_constants = &self.get_gas_parameters(log_context)?.txn;
+        let txn_gas_params = &self.get_gas_parameters(log_context)?.txn;
         let raw_bytes_len = txn_data.transaction_size;
         // The transaction is too large.
-        if txn_data.transaction_size > gas_constants.max_transaction_size_in_bytes {
+        if txn_data.transaction_size as u64
+            > u64::from(txn_gas_params.max_transaction_size_in_bytes)
+        {
             warn!(
                 *log_context,
                 "[VM] Transaction size too big {} (max {})",
                 raw_bytes_len,
-                gas_constants.max_transaction_size_in_bytes,
+                txn_gas_params.max_transaction_size_in_bytes,
             );
             return Err(VMStatus::Error(StatusCode::EXCEEDED_MAX_TRANSACTION_SIZE));
         }
 
         // Check is performed on `txn.raw_txn_bytes_len()` which is the same as
         // `raw_bytes_len`
-        assume!(raw_bytes_len <= gas_constants.max_transaction_size_in_bytes);
+        assume!(raw_bytes_len as u64 <= u64::from(txn_gas_params.max_transaction_size_in_bytes));
 
         // The submitted max gas units that the transaction can consume is greater than the
         // maximum number of gas units bound that we have set for any
         // transaction.
-        if txn_data.max_gas_amount() > gas_constants.maximum_number_of_gas_units {
+        if txn_data.max_gas_amount() > txn_gas_params.maximum_number_of_gas_units {
             warn!(
                 *log_context,
                 "[VM] Gas unit error; max {}, submitted {}",
-                gas_constants.maximum_number_of_gas_units,
+                txn_gas_params.maximum_number_of_gas_units,
                 txn_data.max_gas_amount(),
             );
             return Err(VMStatus::Error(
@@ -176,17 +177,8 @@ impl AptosVMImpl {
         // The submitted transactions max gas units needs to be at least enough to cover the
         // intrinsic cost of the transaction as calculated against the size of the
         // underlying `RawTransaction`
-        let min_txn_fee = {
-            let min_transaction_fee = gas_constants.min_transaction_gas_units;
-
-            if raw_bytes_len > gas_constants.large_transaction_cutoff {
-                let excess = raw_bytes_len - gas_constants.large_transaction_cutoff;
-                min_transaction_fee + gas_constants.intrinsic_gas_per_byte * excess
-            } else {
-                min_transaction_fee
-            }
-        };
-        let min_txn_fee = gas_constants.to_external_units(min_txn_fee);
+        let min_txn_fee = txn_gas_params
+            .to_external_units_round_down(txn_gas_params.calculate_intrinsic_gas(raw_bytes_len));
 
         if txn_data.max_gas_amount() < min_txn_fee {
             warn!(
@@ -204,25 +196,24 @@ impl AptosVMImpl {
         // NB: MIN_PRICE_PER_GAS_UNIT may equal zero, but need not in the future. Hence why
         // we turn off the clippy warning.
         #[allow(clippy::absurd_extreme_comparisons)]
-        let below_min_bound =
-            txn_data.gas_unit_price().get() < gas_constants.min_price_per_gas_unit;
+        let below_min_bound = txn_data.gas_unit_price() < txn_gas_params.min_price_per_gas_unit;
         if below_min_bound {
             warn!(
                 *log_context,
                 "[VM] Gas unit error; min {}, submitted {}",
-                gas_constants.min_price_per_gas_unit,
-                txn_data.gas_unit_price().get(),
+                txn_gas_params.min_price_per_gas_unit,
+                txn_data.gas_unit_price(),
             );
             return Err(VMStatus::Error(StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND));
         }
 
         // The submitted gas price is greater than the maximum gas unit price set by the VM.
-        if txn_data.gas_unit_price().get() > gas_constants.max_price_per_gas_unit {
+        if txn_data.gas_unit_price() > txn_gas_params.max_price_per_gas_unit {
             warn!(
                 *log_context,
                 "[VM] Gas unit error; min {}, submitted {}",
-                gas_constants.max_price_per_gas_unit,
-                txn_data.gas_unit_price().get(),
+                txn_gas_params.max_price_per_gas_unit,
+                txn_data.gas_unit_price(),
             );
             return Err(VMStatus::Error(StatusCode::GAS_UNIT_PRICE_ABOVE_MAX_BOUND));
         }
@@ -241,7 +232,7 @@ impl AptosVMImpl {
         let gas_currency = vec![];
         let txn_sequence_number = txn_data.sequence_number();
         let txn_public_key = txn_data.authentication_key_preimage().to_vec();
-        let txn_gas_price = txn_data.gas_unit_price().get();
+        let txn_gas_price = txn_data.gas_unit_price();
         let txn_max_gas_units = txn_data.max_gas_amount();
         let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
@@ -258,8 +249,8 @@ impl AptosVMImpl {
                 MoveValue::vector_u8(txn_public_key),
                 MoveValue::vector_address(txn_data.secondary_signers()),
                 MoveValue::Vector(secondary_public_key_hashes),
-                MoveValue::U64(txn_gas_price),
-                MoveValue::U64(txn_max_gas_units),
+                MoveValue::U64(txn_gas_price.into()),
+                MoveValue::U64(txn_max_gas_units.into()),
                 MoveValue::U64(txn_expiration_timestamp_secs),
                 MoveValue::U8(chain_id.id()),
             ]
@@ -268,8 +259,8 @@ impl AptosVMImpl {
                 MoveValue::Signer(txn_data.sender),
                 MoveValue::U64(txn_sequence_number),
                 MoveValue::vector_u8(txn_public_key),
-                MoveValue::U64(txn_gas_price),
-                MoveValue::U64(txn_max_gas_units),
+                MoveValue::U64(txn_gas_price.into()),
+                MoveValue::U64(txn_max_gas_units.into()),
                 MoveValue::U64(txn_expiration_timestamp_secs),
                 MoveValue::U8(chain_id.id()),
                 MoveValue::vector_u8(txn_data.script_hash.clone()),
@@ -306,7 +297,7 @@ impl AptosVMImpl {
         let gas_currency = vec![];
         let txn_sequence_number = txn_data.sequence_number();
         let txn_public_key = txn_data.authentication_key_preimage().to_vec();
-        let txn_gas_price = txn_data.gas_unit_price().get();
+        let txn_gas_price = txn_data.gas_unit_price();
         let txn_max_gas_units = txn_data.max_gas_amount();
         let txn_expiration_timestamp_secs = txn_data.expiration_timestamp_secs();
         let chain_id = txn_data.chain_id();
@@ -320,8 +311,8 @@ impl AptosVMImpl {
                     MoveValue::Signer(txn_data.sender),
                     MoveValue::U64(txn_sequence_number),
                     MoveValue::vector_u8(txn_public_key),
-                    MoveValue::U64(txn_gas_price),
-                    MoveValue::U64(txn_max_gas_units),
+                    MoveValue::U64(txn_gas_price.into()),
+                    MoveValue::U64(txn_max_gas_units.into()),
                     MoveValue::U64(txn_expiration_timestamp_secs),
                     MoveValue::U8(chain_id.id()),
                 ]),
@@ -337,7 +328,7 @@ impl AptosVMImpl {
     pub(crate) fn run_success_epilogue<S: MoveResolverExt>(
         &self,
         session: &mut SessionExt<S>,
-        gas_remaining: u64,
+        gas_remaining: Gas,
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
@@ -350,7 +341,7 @@ impl AptosVMImpl {
         let gas_currency = vec![];
         let chain_specific_info = self.chain_info();
         let txn_sequence_number = txn_data.sequence_number();
-        let txn_gas_price = txn_data.gas_unit_price().get();
+        let txn_gas_price = txn_data.gas_unit_price();
         let txn_max_gas_units = txn_data.max_gas_amount();
         session
             .execute_function_bypass_visibility(
@@ -360,9 +351,9 @@ impl AptosVMImpl {
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),
                     MoveValue::U64(txn_sequence_number),
-                    MoveValue::U64(txn_gas_price),
-                    MoveValue::U64(txn_max_gas_units),
-                    MoveValue::U64(gas_remaining),
+                    MoveValue::U64(txn_gas_price.into()),
+                    MoveValue::U64(txn_max_gas_units.into()),
+                    MoveValue::U64(gas_remaining.into()),
                 ]),
                 &mut UnmeteredGasMeter,
             )
@@ -376,14 +367,14 @@ impl AptosVMImpl {
     pub(crate) fn run_failure_epilogue<S: MoveResolverExt>(
         &self,
         session: &mut SessionExt<S>,
-        gas_remaining: u64,
+        gas_remaining: Gas,
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
         let gas_currency = vec![];
         let chain_specific_info = self.chain_info();
         let txn_sequence_number = txn_data.sequence_number();
-        let txn_gas_price = txn_data.gas_unit_price().get();
+        let txn_gas_price = txn_data.gas_unit_price();
         let txn_max_gas_units = txn_data.max_gas_amount();
         session
             .execute_function_bypass_visibility(
@@ -393,9 +384,9 @@ impl AptosVMImpl {
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),
                     MoveValue::U64(txn_sequence_number),
-                    MoveValue::U64(txn_gas_price),
-                    MoveValue::U64(txn_max_gas_units),
-                    MoveValue::U64(gas_remaining),
+                    MoveValue::U64(txn_gas_price.into()),
+                    MoveValue::U64(txn_max_gas_units.into()),
+                    MoveValue::U64(gas_remaining.into()),
                 ]),
                 &mut UnmeteredGasMeter,
             )
@@ -542,18 +533,22 @@ impl<'a> AptosVMInternals<'a> {
 pub(crate) fn get_transaction_output<A: AccessPathCache, S: MoveResolverExt>(
     ap_cache: &mut A,
     session: SessionExt<S>,
-    gas_left: u64,
+    gas_left: Gas,
     txn_data: &TransactionMetadata,
     status: ExecutionStatus,
 ) -> Result<TransactionOutputExt, VMStatus> {
-    let gas_used: u64 = txn_data.max_gas_amount() - gas_left;
+    let gas_used = txn_data.max_gas_amount() - gas_left;
 
     let session_out = session.finish().map_err(|e| e.into_vm_status())?;
     let (delta_change_set, change_set) = session_out.into_change_set_ext(ap_cache)?.into_inner();
     let (write_set, events) = change_set.into_inner();
 
-    let txn_output =
-        TransactionOutput::new(write_set, events, gas_used, TransactionStatus::Keep(status));
+    let txn_output = TransactionOutput::new(
+        write_set,
+        events,
+        gas_used.into(),
+        TransactionStatus::Keep(status),
+    );
 
     Ok(TransactionOutputExt::new(delta_change_set, txn_output))
 }

--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey};
+use aptos_gas::{FeePerGasUnit, Gas};
 use aptos_types::{
     account_address::AccountAddress,
     chain_id::ChainId,
@@ -9,7 +10,6 @@ use aptos_types::{
         authenticator::AuthenticationKeyPreimage, SignedTransaction, TransactionPayload,
     },
 };
-use move_deps::move_core_types::gas_schedule::{GasAlgebra, GasCarrier, GasPrice};
 use std::convert::TryFrom;
 
 pub struct TransactionMetadata {
@@ -18,9 +18,9 @@ pub struct TransactionMetadata {
     pub secondary_signers: Vec<AccountAddress>,
     pub secondary_authentication_key_preimages: Vec<Vec<u8>>,
     pub sequence_number: u64,
-    pub max_gas_amount: u64,
-    pub gas_unit_price: GasPrice<GasCarrier>,
-    pub transaction_size: u64,
+    pub max_gas_amount: Gas,
+    pub gas_unit_price: FeePerGasUnit,
+    pub transaction_size: usize,
     pub expiration_timestamp_secs: u64,
     pub chain_id: ChainId,
     pub script_hash: Vec<u8>,
@@ -43,9 +43,9 @@ impl TransactionMetadata {
                 .map(|account_auth| account_auth.authentication_key_preimage().into_vec())
                 .collect(),
             sequence_number: txn.sequence_number(),
-            max_gas_amount: txn.max_gas_amount(),
-            gas_unit_price: GasPrice::new(txn.gas_unit_price()),
-            transaction_size: txn.raw_txn_bytes_len() as u64,
+            max_gas_amount: txn.max_gas_amount().into(),
+            gas_unit_price: txn.gas_unit_price().into(),
+            transaction_size: txn.raw_txn_bytes_len(),
             expiration_timestamp_secs: txn.expiration_timestamp_secs(),
             chain_id: txn.chain_id(),
             script_hash: match txn.payload() {
@@ -57,11 +57,11 @@ impl TransactionMetadata {
         }
     }
 
-    pub fn max_gas_amount(&self) -> u64 {
+    pub fn max_gas_amount(&self) -> Gas {
         self.max_gas_amount
     }
 
-    pub fn gas_unit_price(&self) -> GasPrice<GasCarrier> {
+    pub fn gas_unit_price(&self) -> FeePerGasUnit {
         self.gas_unit_price
     }
 
@@ -81,7 +81,7 @@ impl TransactionMetadata {
         self.sequence_number
     }
 
-    pub fn transaction_size(&self) -> u64 {
+    pub fn transaction_size(&self) -> usize {
         self.transaction_size
     }
 
@@ -109,8 +109,8 @@ impl Default for TransactionMetadata {
             secondary_signers: vec![],
             secondary_authentication_key_preimages: vec![],
             sequence_number: 0,
-            max_gas_amount: 100_000_000,
-            gas_unit_price: GasPrice::new(0),
+            max_gas_amount: 100_000_000.into(),
+            gas_unit_price: 0.into(),
             transaction_size: 0,
             expiration_timestamp_secs: 0,
             chain_id: ChainId::test(),

--- a/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -17,10 +17,7 @@ use language_e2e_tests::{
     common_transactions::peer_to_peer_txn, test_with_different_versions,
     versioning::CURRENT_RELEASE_VERSIONS,
 };
-use move_deps::move_core_types::{
-    gas_schedule::{GasAlgebra, GasPrice},
-    vm_status::StatusCode::TYPE_MISMATCH,
-};
+use move_deps::move_core_types::vm_status::StatusCode::TYPE_MISMATCH;
 
 #[test]
 fn failed_transaction_cleanup_test() {
@@ -36,8 +33,8 @@ fn failed_transaction_cleanup_test() {
 
         let txn_data = TransactionMetadata {
             sender: *sender.address(),
-            max_gas_amount: 100_000,
-            gas_unit_price: GasPrice::new(0),
+            max_gas_amount: 100_000.into(),
+            gas_unit_price: 0.into(),
             sequence_number: 10,
             ..Default::default()
         };

--- a/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
+++ b/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
@@ -337,7 +337,7 @@ fn verify_simple_payment() {
         // Test for a max_gas_amount that is insufficient to pay the minimum fee.
         // Find the minimum transaction gas units and subtract 1.
         let mut gas_limit = txn_gas_params
-            .to_external_units(txn_gas_params.min_transaction_gas_units)
+            .to_external_units_round_down(txn_gas_params.min_transaction_gas_units)
             ;
         if gas_limit > 0 {
             gas_limit -= 1;


### PR DESCRIPTION
This adds a gas algebra module that offers primitives for checked addition/subtraction and type-safe multiplication.

More specifically, this
1. Defines some uninhabitable types representing various units of measurement 
2. Defines a `struct GasQuantity<U>`, which is a wrapper around `u64` but is parametric over the unit types. This struct
  a. Always uses checked addition and subtraction and will panic if overflow/underflow
  b. Only permits multiplication when the units matche (e.g. 3 gas units/byte * 5 bytes = 15 gas units)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2704)
<!-- Reviewable:end -->
