### PR TITLE
Fix TS examples in docs site

### DIFF
--- a/developer-docs-site/static/examples/typescript/package.json
+++ b/developer-docs-site/static/examples/typescript/package.json
@@ -17,14 +17,14 @@
   "keywords": [],
   "dependencies": {
     "@types/node": "^17.0.21",
-    "aptos": "^1.2.2",
+    "aptos": "1.2.2",
     "cross-fetch": "^3.1.5",
     "fmt": "^2.0.0",
     "js-sha3": "^0.8.0",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "ts-node": "^10.7.0",
-    "typescript": "^4.6.4"
+    "ts-node": "^10.9.1",
+    "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
## Description
This fixes the docs site examples for TS to work with the current devnet.

## Test Plan
```
yarn first_transaction
yarn first_nft
yarn first_coin
yarn hello_blockchain
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2705)
<!-- Reviewable:end -->
