### PR TITLE
[aptos-telemetry] pull build env variables at runtime

### DIFF
--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -89,6 +89,7 @@ target "_common" {
     GIT_SHA         = "${GIT_SHA}"
     GIT_BRANCH      = "${GIT_BRANCH}"
     GIT_TAG         = "${GIT_TAG}"
+    BUILD_DATE      = "${BUILD_DATE}"
     BUILT_VIA_BUILDKIT = "true"
   }
 }

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -59,6 +59,8 @@ ENV RUST_BACKTRACE 1
 ENV RUST_LOG_FORMAT=json
 
 # add build info
+ARG BUILD_DATE
+ENV BUILD_DATE ${BUILD_DATE}
 ARG GIT_TAG
 ENV GIT_TAG ${GIT_TAG}
 ARG GIT_BRANCH
@@ -79,6 +81,8 @@ COPY --link --from=builder /aptos/dist/aptos-indexer /usr/local/bin/aptos-indexe
 ENV RUST_LOG_FORMAT=json
 
 # add build info
+ARG BUILD_DATE
+ENV BUILD_DATE ${BUILD_DATE}
 ARG GIT_TAG
 ENV GIT_TAG ${GIT_TAG}
 ARG GIT_BRANCH
@@ -99,6 +103,8 @@ COPY --link --from=builder /aptos/dist/aptos-node-checker /usr/local/bin/aptos-n
 ENV RUST_LOG_FORMAT=json
 
 # add build info
+ARG BUILD_DATE
+ENV BUILD_DATE ${BUILD_DATE}
 ARG GIT_TAG
 ENV GIT_TAG ${GIT_TAG}
 ARG GIT_BRANCH
@@ -143,6 +149,8 @@ RUN mv /aptos-framework/move/build/AptosFramework/bytecode_modules/dependencies/
 RUN rm -rf /aptos-framework/move/build
 
 # add build info
+ARG BUILD_DATE
+ENV BUILD_DATE ${BUILD_DATE}
 ARG GIT_TAG
 ENV GIT_TAG ${GIT_TAG}
 ARG GIT_BRANCH
@@ -169,6 +177,8 @@ EXPOSE 8000
 ENV RUST_LOG_FORMAT=json
 
 # add build info
+ARG BUILD_DATE
+ENV BUILD_DATE ${BUILD_DATE}
 ARG GIT_TAG
 ENV GIT_TAG ${GIT_TAG}
 ARG GIT_BRANCH
@@ -197,6 +207,8 @@ COPY --link --from=builder /aptos/dist/forge /usr/local/bin/forge
 ENV RUST_LOG_FORMAT=json
 
 # add build info
+ARG BUILD_DATE
+ENV BUILD_DATE ${BUILD_DATE}
 ARG GIT_TAG
 ENV GIT_TAG ${GIT_TAG}
 ARG GIT_BRANCH


### PR DESCRIPTION
### Description

Since #2512, we are now defining build environment variables in the post binary build stage in the `Dockerfile`, so these variables should be read at runtime. This commit changes from compile-time env resolution to runtime resolution.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added unit test to verify that env variables are read properly if present.

`cargo test --lib`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2713)
<!-- Reviewable:end -->
