### PR TITLE
Make NewBlockEvent::new accessible without a feature

### DIFF
--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -64,7 +64,6 @@ impl NewBlockEvent {
         bcs::from_bytes(bytes).map_err(Into::into)
     }
 
-    #[cfg(any(test, feature = "fuzzing"))]
     pub fn new(
         epoch: u64,
         round: u64,


### PR DESCRIPTION
## Description
Seems like this issue slipped through from https://github.com/aptos-labs/aptos-core/pull/2582, we probably need to be testing with all feature permutations.

## Test Plan
Before (from within `crates/aptos-rest-client`):
```
$ cargo build
warning: patch for `diesel` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
    Blocking waiting for file lock on build directory
   Compiling aptos-rest-client v0.0.0 (/Users/dport/a/core/crates/aptos-rest-client)
error[E0599]: no function or associated item named `new` found for struct `NewBlockEvent` in the current scope
   --> crates/aptos-rest-client/src/lib.rs:403:47
    |
403 | ...                   Ok(NewBlockEvent::new(
    |                                         ^^^ function or associated item not found in `NewBlockEvent`

For more information about this error, try `rustc --explain E0599`.
error: could not compile `aptos-rest-client` due to previous error
```

After:
```
$ cargo build
warning: patch for `diesel` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
    Finished dev [unoptimized + debuginfo] target(s) in 0.79s
$ echo $?
0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2720)
<!-- Reviewable:end -->
