### PR TITLE
[Stake] Rearranged the rewards formula in the stake module

### DIFF
--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__drop_txn_after_reconfiguration_version_4.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__drop_txn_after_reconfiguration_version_4.exp
@@ -84,7 +84,7 @@ Ok(
                 ContractEvent { key: EventKey { creation_number: 8, account_address: D1126CE48BD65FB72190DBD9A6EAA65BA973F1E1664AC0CFBA4DB1D071FD0C36 }, index: 0, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("stake"), name: Identifier("DistributeRewardsEvent"), type_params: [] }), event_data: "d1126ce48bd65fb72190dbd9a6eaa65ba973f1e1664ac0cfba4db1d071fd0c360000000000000000" },
                 ContractEvent { key: EventKey { creation_number: 1, account_address: 0000000000000000000000000000000000000000000000000000000000000001 }, index: 1, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("reconfiguration"), name: Identifier("NewEpochEvent"), type_params: [] }), event_data: "0200000000000000" },
             ],
-            gas_used: 22,
+            gas_used: 23,
             status: Keep(
                 Success,
             ),

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__initial_aptos_version_version_4.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__initial_aptos_version_version_4.exp
@@ -84,7 +84,7 @@ Ok(
                 ContractEvent { key: EventKey { creation_number: 8, account_address: D1126CE48BD65FB72190DBD9A6EAA65BA973F1E1664AC0CFBA4DB1D071FD0C36 }, index: 0, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("stake"), name: Identifier("DistributeRewardsEvent"), type_params: [] }), event_data: "d1126ce48bd65fb72190dbd9a6eaa65ba973f1e1664ac0cfba4db1d071fd0c360000000000000000" },
                 ContractEvent { key: EventKey { creation_number: 1, account_address: 0000000000000000000000000000000000000000000000000000000000000001 }, index: 1, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("reconfiguration"), name: Identifier("NewEpochEvent"), type_params: [] }), event_data: "0200000000000000" },
             ],
-            gas_used: 22,
+            gas_used: 23,
             status: Keep(
                 Success,
             ),


### PR DESCRIPTION
### Description

- Rearranged the rewards formula in the stake module to avoid the arithmetic overflow and minimize the rounding error

### Test Plan
cargo test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2722)
<!-- Reviewable:end -->
