### PR TITLE
Make test_block smoke test less flaky

### DIFF
--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -352,7 +352,7 @@ async fn test_block() {
     };
 
     let start = Instant::now();
-    let max_wait = Duration::from_secs(1);
+    let max_wait = Duration::from_secs(5);
     let mut successful = false;
     while start.elapsed() < max_wait {
         if rosetta_client
@@ -361,12 +361,12 @@ async fn test_block() {
             .unwrap()
             .current_block_identifier
             .index
-            == latest_block.block_identifier.index
+            >= latest_block.block_identifier.index
         {
             successful = true;
             break;
         }
-        tokio::time::sleep(Duration::from_micros(10)).await
+        tokio::time::sleep(Duration::from_micros(50)).await
     }
 
     assert!(successful, "Failed to get the next block");


### PR DESCRIPTION
### Description
This is flaky, it's only been passing because of retries. This helps.

### Test Plan
```
cargo nextest run --package smoke-test --test-threads 8 test_block --profile ci
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2723)
<!-- Reviewable:end -->
