### PR TITLE
[community] Update button styles, Change max-sm breakpoint size

### DIFF
--- a/ecosystem/platform/server/app/components/button_component.rb
+++ b/ecosystem/platform/server/app/components/button_component.rb
@@ -5,16 +5,19 @@
 
 class ButtonComponent < ViewComponent::Base
   SCHEME_CLASSES = {
-    primary: 'bg-teal-400 hover:brightness-105 text-neutral-800 font-mono uppercase font-bold flex ' \
-             'items-center justify-center disabled:opacity-50',
-    secondary: 'border border-teal-400 hover:border-teal-300 text-white font-mono uppercase flex ' \
-               'items-center justify-center'
+    primary: 'bg-teal-400 hover:brightness-105 text-neutral-800 font-mono uppercase flex ' \
+             'items-center justify-center disabled:opacity-50 subpixel-antialiased font-normal ' \
+             'active:brightness-95',
+    secondary: 'whitespace-nowrap bg-transparent ring-1 text-teal-300 ring-teal-400 hover:ring-2 ' \
+               'hover:bg-teal-400 hover:brightness-105 hover:ring-teal-400 hover:text-neutral-900 ' \
+               'uppercase font-normal uppercase font-mono active:brightness-95 font-normal ' \
+               'hover:subpixel-antialiased'
   }.freeze
 
   SIZE_CLASSES = {
     large: 'px-8 py-4 text-lg rounded-lg gap-4',
     medium: 'px-8 py-2 text-lg rounded-lg gap-2',
-    small: 'px-4 py-1 text-sm rounded-lg gap-1'
+    small: 'px-4 py-1.5 text-sm rounded-lg gap-1'
   }.freeze
 
   def initialize(scheme: :primary,

--- a/ecosystem/platform/server/app/components/footer_component.html.erb
+++ b/ecosystem/platform/server/app/components/footer_component.html.erb
@@ -28,12 +28,12 @@
       </div>
 
       <div>
-        <h5 class="text-xl font-mono font-bold block uppercase text-white mb-2">Connect</h5>
+        <h5 class="text-xl font-mono block uppercase text-white mb-2">Connect</h5>
         <%= render DividerComponent.new(class: 'mb-4') %>
         <div class="flex flex-col gap-8">
           <%= form_with url: 'https://aptoslabs.us18.list-manage.com/subscribe/post?u=5456bc936272125ed825d0218&amp;id=a15b523910', method: 'post', html: { target: '_blank' }, data: { turbo: false }, class: 'flex flex-col xl:flex-row gap-2 !text-sm', builder: AptosFormBuilder do |form| %>
             <%= form.email_field :EMAIL, required: true, class: '!text-sm', placeholder: 'Enter Email' %>
-            <%= form.submit 'Subscribe', size: :small, class: 'whitespace-nowrap bg-transparent border border-teal-400 text-teal-300 ring-teal-400 hover:ring-1 hover:bg-neutral-800 hover:text-teal-300 uppercase font-normal uppercase' %>
+            <%= form.submit 'Subscribe', size: :small, scheme: :secondary %>
           <% end %>
           <div class="flex gap-4 items-center">
             <a href="https://github.com/aptos-labs" title="Git">

--- a/ecosystem/platform/server/app/components/header_component.html.erb
+++ b/ecosystem/platform/server/app/components/header_component.html.erb
@@ -31,7 +31,7 @@
 
   <% if @user %>
     <div class="relative">
-      <button data-action="click->header#toggleUser" class="w-8 h-8 bg-transparent border border-1 border-teal-400 ring-teal-400 hover:ring-1 hover:bg-neutral-800 text-teal-300 font-semibold rounded-lg inline-flex items-center justify-center overflow-hidden">
+      <button data-action="click->header#toggleUser" class="w-8 h-8 bg-transparent ring-1 ring-teal-400 hover:ring-2 hover:bg-teal-400 hover:text-neutral-900 hover:brightness-105 active:brightness-95 text-teal-300 font-semibold rounded-lg inline-flex items-center justify-center overflow-hidden">
         <span>
         <% if @user&.username? %>
         <%= @user.username&.first&.upcase %>
@@ -41,10 +41,10 @@
         </span>
       </button>
       <div data-header-target="user" class="hidden open:flex absolute top-full right-0 mt-4 origin-top-right transition-opacity duration-150 cursor-default">
-        <div class="text-gray-700 p-2 bg-neutral-800 border-neutral-800 rounded-b-lg min-w-fit shadow whitespace-nowrap w-48 flex flex-col gap-2 shadow-2xl">
+        <div class="text-gray-700 p-2 bg-neutral-800 border-neutral-800 rounded-lg min-w-fit shadow whitespace-nowrap w-48 flex flex-col gap-2 shadow-2xl">
         <% if @user&.username? %>
           <div class="text-neutral-50 px-3 py-2 font-mono"><%= @user.username %></div>
-          <div class="block h-px bg-neutral-500"></div>
+          <div class="block h-px bg-neutral-700"></div>
         <% end %>
           <ul>
             <% user_nav_items.each do |item| %>
@@ -55,7 +55,9 @@
       </div>
     </div>
   <% else %>
-    <a title="Sign in" href="<%= new_user_session_path %>" class="h-8 font-mono font-normal text-sm flex items-center justify-center leading-none py-1 px-8 rounded-lg border border-teal-400 text-teal-300 ring-teal-400 hover:ring-1 hover:bg-neutral-800 hover:text-teal-300 uppercase z-20">Sign in</a>
+    <%= render ButtonComponent.new(href: new_user_session_path, title: 'Sign in', size: :small, scheme: :secondary, class: 'z-10') do %>
+      Sign in
+    <% end %>
   <% end %>
 
   <button class="md:hidden flex-nowrap hover:text-neutral-300" aria-label="Toggle navigation" data-header-target="navButton" data-action="click->header#toggleNav">

--- a/ecosystem/platform/server/app/form_builders/aptos_form_builder.rb
+++ b/ecosystem/platform/server/app/form_builders/aptos_form_builder.rb
@@ -8,9 +8,10 @@ class AptosFormBuilder < ActionView::Helpers::FormBuilder
   TEXT_FIELDS.each do |field|
     define_method field do |method, options = {}|
       options[:class] = [
-        'font-mono text-neutral-100 placeholder:text-neutral-400 text-lg bg-neutral-800 appearance-none border ' \
-        'border-neutral-600 rounded-lg w-full py-2 px-4 focus:ring-0 focus:border-teal-400',
-        { 'border-red-500': @object && @object.errors[method].present? },
+        'font-mono text-neutral-100 placeholder:text-neutral-400 text-lg bg-neutral-800 ' \
+        'ring-neutral-700 ring-1 hover:ring-teal-800 appearance-none rounded-lg ' \
+        'w-full py-2 px-4 border-0 focus:ring-2 focus:ring-teal-700 focus:border-0',
+        { 'ring-red-500': @object && @object.errors[method].present? },
         options[:class]
       ]
       super(method, options)

--- a/ecosystem/platform/server/app/views/settings/profile.html.erb
+++ b/ecosystem/platform/server/app/views/settings/profile.html.erb
@@ -1,11 +1,10 @@
-<% content_for(:page_title, 'Profile Settings') %>
+<% content_for(:page_title, 'Account Settings') %>
 <h3 class="text-4xl mb-8 font-display font-light">Profile</h3>
 <%= form_with(model: @user, url: settings_profile_url, builder: AptosFormBuilder) do |f| %>
   <% if @user.errors.any? %>
     <div id="error_explanation" class="flex p-4 mb-4 bg-red-100 rounded-lg lg:w-96" role="alert">
       <div class="ml-3 text-sm font-medium text-red-700">
         <h2><%= pluralize(@user.errors.count, 'error') %> prohibited this from being saved:</h2>
-
         <ul>
           <% @user.errors.each do |error| %>
             <li><%= error.full_message %></li>
@@ -17,12 +16,12 @@
 
   <div class="mb-6">
     <%= f.label :username, class: 'font-mono uppercase block mb-2' %>
-    <ul class="font-mono text-xs mb-2">
+    <%= f.text_field :username, autofocus: true, spellcheck: false, pattern: User::USERNAME_REGEX_JS, minlength: 3, maxlength: 20 %>
+    <ul class="list-disc list-inside text-neutral-400 text-xs font-light mt-4 block">
       <li>Allowed Characters: a-z, A-Z, 0-9, _, -</li>
       <li>Must begin and end alphanumerically</li>
       <li>May not have two consecutive _ or -</li>
     </ul>
-    <%= f.text_field :username, autofocus: true, spellcheck: false, pattern: User::USERNAME_REGEX_JS, minlength: 3, maxlength: 20 %>
   </div>
 
   <div class="mb-6">
@@ -36,43 +35,41 @@
 <% delete_account_dialog = DialogComponent.new(id: 'delete_account_dialog')
    verif_number = Random.rand(10_000..100_000) %>
 
-<div class="mt-16">
-  <div>
-    <%= render ButtonComponent.new(size: :small, scheme: :secondary, class: 'border-white-100 p-4', dialog: delete_account_dialog) do %>
-      delete account
-    <% end %>
-
-    <%= render delete_account_dialog do |dialog| %>
-      <%= dialog.with_title do %>
-        Delete Account
-      <% end %>
-      <%= dialog.with_body do %>
-        <div class="flex flex-col gap-3 outline-none font-light" autofocus tabindex="-1">
-          <div>
-            <span class="font-bold text-red-600">WARNING:</span> Your account cannot be recovered once it has been
-            deleted.
-          </div>
-          <div>
-            Please type <span class="text-red-600 font-bold select-none">delete my account <%= verif_number %></span> to confirm.
-          </div>
-
-          <%= form_with(model: @user, url: settings_delete_account_url, builder: AptosFormBuilder, method: :delete) do |f| %>
-
-            <%= f.hidden_field :verification_number, value: verif_number %>
-
-            <div class="text-center">
-              <div class="mb-6">
-                <%= f.text_field :verification_text, autofocus: true, autocomplete: 'off', spellcheck: false %>
-              </div>
-              <div class="flex flex-row items-center justify-center">
-                <%= f.submit 'Delete' %>
-              </div>
-            </div>
-
-          <% end %>
-
-        </div>
-      <% end %>
-    <% end %>
-  </div>
+<div class="flex justify-end mt-10">
+  <%= render ButtonComponent.new(size: :small, class: 'bg-transparent text-red-400 uppercase font-normal px-0 py-0', dialog: delete_account_dialog) do %>
+    delete account
+  <% end %>
 </div>
+
+<%= render delete_account_dialog do |dialog| %>
+  <%= dialog.with_title do %>
+    Delete Account
+  <% end %>
+  <%= dialog.with_body do %>
+    <div class="flex flex-col gap-3 outline-none font-light">
+      <div>
+        <span class="font-bold text-red-400">WARNING:</span> Your account cannot be recovered once it has been
+        deleted.
+      </div>
+      <div>
+        Please type <span class="text-red-400 font-bold select-none">delete my account <%= verif_number %></span> to confirm.
+      </div>
+
+      <%= form_with(model: @user, url: settings_delete_account_url, builder: AptosFormBuilder, method: :delete) do |f| %>
+
+        <%= f.hidden_field :verification_number, value: verif_number %>
+
+        <div class="text-center">
+          <div class="mb-6">
+            <%= f.text_field :verification_text, autofocus: true, autocomplete: 'off', spellcheck: false, class: 'focus:border-red-400' %>
+          </div>
+          <div class="flex flex-row items-center justify-center">
+            <%= f.submit 'Delete', class: 'rounded-lg bg-red-400 w-full text-neutral-900' %>
+          </div>
+        </div>
+
+      <% end %>
+
+    </div>
+  <% end %>
+<% end %>

--- a/ecosystem/platform/server/tailwind.config.js
+++ b/ecosystem/platform/server/tailwind.config.js
@@ -37,7 +37,7 @@ module.exports = {
         display: ["apparat-semicond", ...defaultTheme.fontFamily.sans],
       },
       screens: {
-        'max-sm': {'max': '639px'},
+        'max-sm': {'max': '767px'},
       }
     },
     container: {


### PR DESCRIPTION
### Description

- Adjust `max-sm` breakpoint within tailwind.config.js as the specified size was not allowing for dropdown items to be clicked at any window size larger than this this
- Update Header / Footer ghost buttons to utilize button component (secondary scheme)
- Tweak ghost button styling
- Adjust font-weight as the browser was compensating for a **font-bold** which didn't exist for mono font, 
- Adjust Font smoothing (only when text is on colored background buttons converts to `subpixel-antialiased` as to not appear so thin due to the font-weight adjustment
- Utilize `ring` instead of `border` for ghost buttons and form fields
- Small tweaks to Profile Settings buttons - Any action to Delete Account is now red to signify danger. Initial "Delete Account" is now Tertiary style without background / outline. 

### Test Plan

Manual review:

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/98909677/183776356-3d131db8-0b43-4799-86cd-d3c7cab80089.png">

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/98909677/183775048-b8b0bef8-6d99-4af4-b34b-9592232f4b37.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2729)
<!-- Reviewable:end -->
