### PR TITLE
[Fix] Remove "requires" in pruner flags for executor-benchmark.

### DIFF
--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -18,10 +18,10 @@ struct PrunerOpt {
     #[structopt(long)]
     enable_ledger_pruner: bool,
 
-    #[structopt(long, default_value = "100000", requires = "enable_state_store_pruner")]
+    #[structopt(long, default_value = "100000")]
     state_prune_window: u64,
 
-    #[structopt(long, default_value = "100000", requires = "enable_ledger_pruner")]
+    #[structopt(long, default_value = "100000")]
     ledger_prune_window: u64,
 
     #[structopt(long, default_value = "500")]


### PR DESCRIPTION
### Description
It works differently than I was expecting...

### Test Plan
Manually tested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2731)
<!-- Reviewable:end -->
