### PR TITLE
[Txn-emitter] Fix account_generation.

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -19,9 +19,8 @@ use itertools::zip;
 use once_cell::sync::Lazy;
 use rand::prelude::SliceRandom;
 use rand_core::SeedableRng;
-use std::cmp::max;
 use std::{
-    cmp::min,
+    cmp::{max, min},
     collections::HashSet,
     num::NonZeroU64,
     sync::{
@@ -277,10 +276,9 @@ impl<'t> TxnEmitter<'t> {
                 self.txn_factory.clone(),
                 SEND_AMOUNT,
             )),
-            TransactionType::AccountGeneration => Box::new(AccountGeneratorCreator::new(
-                self.from_rng(),
-                self.txn_factory.clone(),
-            )),
+            TransactionType::AccountGeneration => {
+                Box::new(AccountGeneratorCreator::new(self.txn_factory.clone()))
+            }
             TransactionType::NftMint => Box::new(
                 NFTMintGeneratorCreator::new(
                     self.from_rng(),


### PR DESCRIPTION
### Description
0. Fix wrong address of the new account.
1. Use different rng for different generators.

### Test Plan
Manually tested on Alden-net.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2733)
<!-- Reviewable:end -->
