### PR TITLE
Ensure there is only one rev for serde-reflection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,7 +1029,7 @@ dependencies = [
  "move-deps",
  "regex",
  "serde-generate",
- "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb)",
+ "serde-reflection",
  "serde_yaml 0.8.26",
  "structopt 0.3.26",
  "tempfile",
@@ -3603,7 +3603,7 @@ dependencies = [
  "network",
  "rand 0.7.3",
  "serde 1.0.141",
- "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb)",
+ "serde-reflection",
  "serde_yaml 0.8.26",
  "structopt 0.3.26",
 ]
@@ -4855,7 +4855,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "petgraph 0.5.1",
- "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba)",
+ "serde-reflection",
 ]
 
 [[package]]
@@ -7570,7 +7570,7 @@ dependencies = [
 [[package]]
 name = "serde-generate"
 version = "0.20.6"
-source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb#839aed62a20ddccf043c08961cfe74875741ccba"
+source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "bcs",
  "bincode",
@@ -7578,7 +7578,7 @@ dependencies = [
  "include_dir 0.6.2",
  "maplit",
  "serde 1.0.141",
- "serde-reflection 0.3.5 (git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb)",
+ "serde-reflection",
  "serde_bytes",
  "serde_yaml 0.8.26",
  "structopt 0.3.26",
@@ -7603,16 +7603,6 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
- "serde 1.0.141",
- "thiserror",
-]
-
-[[package]]
-name = "serde-reflection"
-version = "0.3.5"
-source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccb#839aed62a20ddccf043c08961cfe74875741ccba"
-dependencies = [
- "once_cell",
  "serde 1.0.141",
  "thiserror",
 ]

--- a/aptos-move/aptos-sdk-builder/Cargo.toml
+++ b/aptos-move/aptos-sdk-builder/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 heck = "0.3.2"
 regex = "1.5.5"
-serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccb" }
-serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccb" }
+serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
+serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 textwrap = "0.15.0"

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 bcs = "0.1.3"
 rand = "0.7.3"
 serde = { version = "1.0.137", features = ["derive"] }
-serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccb" }
+serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 


### PR DESCRIPTION
### Description

Duplicate identifiers for serde-reflection's git revision causes `cargo vendor` to break, causing my build tools to break.

### Test Plan
Cargo build works. Check the `Cargo.lock` to see that the new lockfile is more sensible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2741)
<!-- Reviewable:end -->
