### PR TITLE
[smoke-tests] Speed up LocalSwarm startup 15s => 5s (remove statesync 10s wait time)

### DIFF
--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -4,6 +4,7 @@
 use crate::{ChainInfo, FullNode, NodeExt, Result, SwarmChaos, Validator, Version};
 use anyhow::{anyhow, bail};
 use aptos_config::config::NodeConfig;
+use aptos_logger::info;
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::types::PeerId;
 use futures::future::try_join_all;
@@ -113,7 +114,7 @@ pub trait SwarmExt: Swarm {
 
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
-
+        info!("Swarm liveness check passed");
         Ok(())
     }
 
@@ -138,7 +139,7 @@ pub trait SwarmExt: Swarm {
 
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
-
+        info!("Swarm connectivity check passed");
         Ok(())
     }
 


### PR DESCRIPTION
### Description

we should check the right config for >1 nodes swarms, but this is a start

### Test Plan
client.test_latest_events_and_transactions now starts swarm in 5s (instead of 15s)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2743)
<!-- Reviewable:end -->
