### PR TITLE
[aptos-telemetry] Remove println

### DIFF
--- a/crates/aptos-telemetry/src/build_information.rs
+++ b/crates/aptos-telemetry/src/build_information.rs
@@ -29,7 +29,6 @@ pub const BUILD_VERSION: &str = "build_version";
 #[macro_export]
 macro_rules! collect_build_information {
     () => {{
-        println!("calling collect {:?}", std::env::var("GIT_SHA"));
         // Collect and return the build information
         let mut build_information: std::collections::BTreeMap<String, String> = BTreeMap::new();
 


### PR DESCRIPTION
### Description
This println ends up printing all the time, which is weird e.g. `calling collect Err(NotPresent)`

Removed it accordingly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2746)
<!-- Reviewable:end -->
