### PR TITLE
[Indexer] Stream full blocks instead of transactions

### DIFF
--- a/sf-stream/src/metrics.rs
+++ b/sf-stream/src/metrics.rs
@@ -4,6 +4,14 @@
 use aptos_metrics_core::{register_int_counter, IntCounter};
 use once_cell::sync::Lazy;
 
+pub static TRANSACTIONS_SENT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_sf_stream_transactions_sent_count",
+        "Transactions converted and printed out to stdout, picked up by the StreamingFast indexer",
+    )
+    .unwrap()
+});
+
 pub static BLOCKS_SENT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_sf_stream_blocks_sent_count",

--- a/sf-stream/src/metrics.rs
+++ b/sf-stream/src/metrics.rs
@@ -4,10 +4,10 @@
 use aptos_metrics_core::{register_int_counter, IntCounter};
 use once_cell::sync::Lazy;
 
-pub static TRANSACTIONS_SENT: Lazy<IntCounter> = Lazy::new(|| {
+pub static BLOCKS_SENT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
-        "aptos_sf_stream_transactions_sent_count",
-        "Transactions converted and printed out to stdout, picked up by the StreamingFast indexer",
+        "aptos_sf_stream_blocks_sent_count",
+        "Blocks converted and printed out to stdout, picked up by the StreamingFast indexer",
     )
     .unwrap()
 });

--- a/sf-stream/src/runtime.rs
+++ b/sf-stream/src/runtime.rs
@@ -5,6 +5,7 @@ use crate::metrics;
 use crate::pb::extractor;
 
 use crate::convert::convert_transaction;
+use anyhow::{bail, ensure};
 use aptos_api::context::Context;
 use aptos_api_types::{AsConverter, Transaction};
 use aptos_config::config::NodeConfig;
@@ -12,8 +13,10 @@ use aptos_logger::{debug, error, warn};
 use aptos_mempool::MempoolClientSender;
 use aptos_types::chain_id::ChainId;
 use aptos_vm::data_cache::RemoteStorageOwned;
+use extractor::{transaction::TransactionType, Transaction as TransactionPB};
 use futures::channel::mpsc::channel;
 use prost::Message;
+use std::convert::TryInto;
 use std::sync::Arc;
 use std::time::Duration;
 use storage_interface::state_view::DbStateView;
@@ -58,9 +61,8 @@ pub fn bootstrap(
 
 pub struct SfStreamer {
     pub context: Arc<Context>,
-    pub current_version: u64,
     pub resolver: Arc<RemoteStorageOwned<DbStateView>>,
-    pub block_height: u64,
+    pub current_block_height: u64,
     pub current_epoch: u64,
     // This is only ever used for testing
     pub mp_sender: MempoolClientSender,
@@ -73,33 +75,15 @@ impl SfStreamer {
         mp_client_sender: Option<MempoolClientSender>,
     ) -> Self {
         let resolver = Arc::new(context.move_resolver().unwrap());
-        let latest = context.get_latest_ledger_info().unwrap();
-        let block_info = context
-            .get_block_info(starting_version, latest.ledger_version.0)
+        let (_block_start_version, _block_last_versionn, block_event) = context
+            .db
+            .get_block_info(starting_version)
             .unwrap_or_else(|_| {
                 panic!(
-                    "Could not get block_info for starting version {} and ledger_version {}",
-                    starting_version, latest.ledger_version.0
+                    "Could not get block_info for starting version {}",
+                    starting_version,
                 )
             });
-        let starting_txn = context
-            .get_transaction_by_version(block_info.start_version, latest.ledger_version.0)
-            .unwrap_or_else(|_| {
-                panic!(
-                    "Could not get starting_txn for starting version {} and ledger_version {}",
-                    starting_version, latest.ledger_version.0
-                )
-            });
-
-        let (version, epoch) = match starting_txn.transaction {
-            aptos_types::transaction::Transaction::BlockMetadata(bmt) => {
-                (starting_txn.version, bmt.epoch())
-            }
-            aptos_types::transaction::Transaction::GenesisTransaction(_gt) => (0, 0),
-            _ => panic!(
-                "[sf-stream] first transaction is not a block metadata or genesis transaction"
-            ),
-        };
 
         // fake mempool client/sender, if we need to, so we can use the same code for both api and sf-streamer
         let mp_client_sender = mp_client_sender.unwrap_or_else(|| {
@@ -109,80 +93,83 @@ impl SfStreamer {
 
         Self {
             context,
-            current_version: version,
             resolver,
-            block_height: block_info.block_height,
-            current_epoch: epoch,
+            current_block_height: block_event.height(),
+            current_epoch: block_event.epoch(),
             mp_sender: mp_client_sender,
         }
     }
 
     pub async fn start(&mut self) {
+        println!("DMLOG INIT aptos v1");
         loop {
-            self.batch_convert(100).await;
+            self.convert_next_block().await;
         }
     }
 
-    pub async fn batch_convert(&mut self, batch_size: u16) -> Vec<extractor::Transaction> {
-        let mut result: Vec<extractor::Transaction> = vec![];
-        match &self.context.db.get_first_txn_version() {
-            Ok(version_result) => match version_result {
-                Some(oldest_version) => {
-                    if oldest_version > &self.current_version {
-                        panic!(
-                            "[sf-stream] oldest txn version is {} but requested version is {}",
-                            oldest_version, &self.current_version
-                        );
-                    }
-                }
-                None => {
-                    return vec![];
-                }
-            },
+    pub async fn convert_next_block(&mut self) -> Vec<TransactionPB> {
+        let mut result: Vec<TransactionPB> = vec![];
+        let block_start_version;
+        let block_last_version;
+        match self
+            .context
+            .db
+            .get_block_info_by_height(self.current_block_height)
+        {
+            Ok(block_info) => {
+                (block_start_version, block_last_version, _) = block_info;
+            }
             Err(err) => {
-                warn!("[sf-stream] failed to get first txn version: {}", err);
+                // TODO: If block has been pruned, panic
+                warn!(
+                    "[sf-stream] failed to get block info for block_height={}. Error: {}",
+                    self.current_block_height, err
+                );
                 sleep(Duration::from_millis(300)).await;
                 return vec![];
             }
-        };
+        }
 
         let ledger_info = self.context.get_latest_ledger_info().unwrap();
-        match self
-            .context
-            .get_transactions(self.current_version, batch_size, ledger_info.version())
-        {
+        match self.context.get_transactions(
+            block_start_version,
+            (block_last_version - block_start_version + 1)
+                .try_into()
+                .unwrap(),
+            ledger_info.version(),
+        ) {
             Ok(transactions) => {
                 if transactions.is_empty() {
                     debug!("[sf-stream] no transactions to send");
                     sleep(Duration::from_millis(100)).await;
-                    return result;
+                    return vec![];
                 }
-                // TODO: there might be an off by one (tx version fetched)
                 debug!(
-                    "[sf-stream] got {} transactions from {} to {} [{}]",
+                    "[sf-stream] got {} transactions from {} to {} [version on last actual transaction {}]",
                     transactions.len(),
-                    self.current_version,
-                    self.current_version + transactions.len() as u64,
+                    block_start_version,
+                    block_last_version,
                     transactions.last().map(|txn| txn.version).unwrap_or(0)
                 );
+                let mut block_timestamp = None;
                 for onchain_txn in transactions {
-                    // TODO: assert txn.version == &self.current_version + 1?
-                    // TODO: return a `Result` & check to ensure we pushed before incrementing
+                    if block_timestamp.is_none() {
+                        block_timestamp = Some(
+                            self.context
+                                .get_block_timestamp(onchain_txn.version)
+                                .unwrap_or_else(|_| {
+                                    panic!(
+                                        "Could not get timestamp for version {}",
+                                        onchain_txn.version
+                                    )
+                                }),
+                        );
+                    }
                     let txn_version = onchain_txn.version;
-                    // Todo: since the timestamp is per block, only calculate this value once per block
-                    let timestamp = self
-                        .context
-                        .get_block_timestamp(onchain_txn.version)
-                        .unwrap_or_else(|_| {
-                            panic!(
-                                "Could not get timestamp for version {}",
-                                onchain_txn.version
-                            )
-                        });
                     let txn = self
                         .resolver
                         .as_converter(self.context.db.clone())
-                        .try_into_onchain_transaction(timestamp, onchain_txn)
+                        .try_into_onchain_transaction(block_timestamp.unwrap(), onchain_txn)
                         .unwrap_or_else(|e| {
                             panic!(
                                 "Could not convert onchain transaction version {} into transaction: {:?}",
@@ -191,11 +178,8 @@ impl SfStreamer {
                         });
 
                     let txn_proto = self.convert_transaction(txn);
-                    self.print_transaction(&txn_proto).await;
                     result.push(txn_proto);
-                    self.current_version = txn_version;
                 }
-                self.current_version += 1;
             }
             Err(err) => {
                 error!("[sf-stream] failed to get transactions: {}", err);
@@ -203,22 +187,80 @@ impl SfStreamer {
                 return vec![];
             }
         }
-        result
-    }
-
-    pub fn maybe_update_from_block_metadata(&mut self, transaction: &Transaction) {
-        if let Transaction::BlockMetadataTransaction(bmt) = transaction {
-            // TODO: ADD BLOCK HEIGHT UPDATES ONCE ITS IN BMT
-            self.block_height += 1;
-            self.current_epoch = bmt.epoch.0
+        match self.get_encoded_transactions_with_validation(
+            &result,
+            block_start_version,
+            block_last_version,
+        ) {
+            Ok(encoded_txns) => {
+                self.print_block(&encoded_txns, block_start_version).await;
+                self.current_block_height += 1;
+                result
+            }
+            Err(err) => {
+                error!("[sf-stream] Validation failed: {}", err);
+                sleep(Duration::from_millis(500)).await;
+                vec![]
+            }
         }
     }
 
-    pub fn convert_transaction(&mut self, transaction: Transaction) -> extractor::Transaction {
-        self.maybe_update_from_block_metadata(&transaction);
-        convert_transaction(&transaction, self.block_height, self.current_epoch)
+    pub fn convert_transaction(&self, transaction: Transaction) -> TransactionPB {
+        convert_transaction(&transaction, self.current_block_height, self.current_epoch)
     }
-    pub async fn print_transaction(&self, transaction: &extractor::Transaction) {
+
+    /// We can consider a block height as valid if these conditions are met:
+    /// 1. first transaction is a block metadata or genesis 2. versions are monotonically increasing 3. start and end versions match block boundaries
+    fn get_encoded_transactions_with_validation(
+        &self,
+        converted_txns: &Vec<TransactionPB>,
+        block_start_version: u64,
+        block_last_version: u64,
+    ) -> anyhow::Result<Vec<String>> {
+        let mut encoded_txns = vec![];
+        if converted_txns.is_empty() {
+            bail!("No transactions")
+        }
+        let mut curr_version = block_start_version;
+        for (index, txn) in converted_txns.iter().enumerate() {
+            // First transaction has to be bmt or genesis
+            if index == 0 {
+                let success = match txn.r#type() {
+                    TransactionType::BlockMetadata => true,
+                    TransactionType::Genesis => true,
+                    TransactionType::User => false,
+                    TransactionType::StateCheckpoint => false,
+                };
+                if !success {
+                    bail!(
+                        "First transaction has to be block metadata for block {}, found {}",
+                        self.current_block_height,
+                        txn.r#type
+                    )
+                }
+            }
+            // Start version has to be first version and versions have to be monotonically increasing
+            ensure!(
+                curr_version == txn.version,
+                "Missing version {} for block {}",
+                block_start_version,
+                self.current_block_height
+            );
+            encoded_txns.push(self.get_encoded_txn(txn));
+            curr_version += 1
+        }
+        // Last version has to match last version of transaction
+        ensure!(
+            curr_version - 1 == block_last_version,
+            "Last version supposed to be {} but getting {} for block {}",
+            block_start_version,
+            curr_version - 1,
+            self.current_block_height
+        );
+        Ok(encoded_txns)
+    }
+
+    fn get_encoded_txn(&self, transaction: &TransactionPB) -> String {
         let mut buf = vec![];
         transaction.encode(&mut buf).unwrap_or_else(|_| {
             panic!(
@@ -226,8 +268,18 @@ impl SfStreamer {
                 transaction
             )
         });
-        let pb_b64 = &base64::encode(buf);
-        println!("DMLOG TRX {}", pb_b64);
-        metrics::TRANSACTIONS_SENT.inc();
+        base64::encode(buf)
+    }
+
+    pub async fn print_block(&self, encoded_txns: &Vec<String>, block_start_version: u64) {
+        println!(
+            "DMLOG BLOCK_START {} {}",
+            self.current_block_height, block_start_version
+        );
+        for encoded_txn in encoded_txns {
+            println!("DMLOG TRX {}", encoded_txn);
+        }
+        println!("DMLOG BLOCK_END");
+        metrics::BLOCKS_SENT.inc();
     }
 }


### PR DESCRIPTION
### Description
Stream full blocks in the format of
```
DMLOG BLOCK_START <height> <version>
DMLOG TRX <transaction proto base64>
DMLOG TRX <transaction proto base64>
…
DMLOG BLOCK_END
```
Added validation for the transactions to ensure correctness before we stream the data out. If anything is wrong with any of the transactions within a block, we fail the entire block and do not stream anything. 

### Test Plan
cargo test
ensure `cargo run -p aptos -- node run-local-testnet --with-faucet` works as expected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2748)
<!-- Reviewable:end -->
