### PR TITLE
[aptos-telemetry] telemetry service client integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,9 @@ dependencies = [
  "aptos-types",
  "aptosdb",
  "consensus",
+ "const_format",
  "futures",
+ "httpmock",
  "network",
  "once_cell",
  "prometheus",
@@ -1184,6 +1186,7 @@ dependencies = [
  "state-sync-driver",
  "sysinfo",
  "tokio",
+ "tokio-retry",
  "tokio-stream",
  "uuid",
 ]
@@ -1531,6 +1534,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term 0.7.0",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde 1.0.141",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_approx_eq"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1563,128 @@ name = "assert_unordered"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89464e809410174509672bc79d06dec8cde36332819c9bfd0e6eee2b4e0b50e0"
+
+[[package]]
+name = "async-channel"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "871f9bb5e0a22eeb7e8cf16641feb87c9dc67032ccf8ff49e772eb9941d3a965"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
+dependencies = [
+ "concurrent-queue",
+ "futures-lite",
+ "libc",
+ "log",
+ "once_cell",
+ "parking",
+ "polling",
+ "slab",
+ "socket2",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb901c30ebc2fc4ab46395bbfbdba9542c16559d853645d75190c3056caf3bc"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "libc",
+ "once_cell",
+ "signal-hook",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
 
 [[package]]
 name = "async-stream"
@@ -1564,6 +1708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1723,12 @@ dependencies = [
  "quote 1.0.20",
  "syn 1.0.98",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atty"
@@ -1730,6 +1886,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "basic-cookies"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb53b6b315f924c7f113b162e53b3901c05fc9966baf84d201dfcc7432a4bb38"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
+
+[[package]]
 name = "bcs"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +2045,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
+name = "blocking"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ccb65d468978a086b69884437ded69a90faab3bbe6e67f242173ea728acccc"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,6 +2158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
+name = "cache-padded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
+
+[[package]]
 name = "cached-framework-packages"
 version = "0.1.0"
 dependencies = [
@@ -2002,6 +2189,12 @@ name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
@@ -2228,6 +2421,15 @@ checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
 dependencies = [
  "bytes 1.2.1",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af4780a44ab5696ea9e28294517f1fffb421a83a25af521333c838635509db9c"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -2737,6 +2939,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "curl"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.56+curl-7.83.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093e169dd4de29e468fa649fbae11cdcd5551c81fe5bf1b0677adad7ef3d26f"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
+name = "ena"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3166,6 +3408,12 @@ name = "ethnum"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f4ea34740bd5042b688060cbff8b010f5a324719d5e111284d648035bccc47"
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-notifications"
@@ -3565,6 +3813,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3763,6 +4026,18 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4006,6 +4281,34 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "httpmock"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c159c4fc205e6c1a9b325cb7ec135d13b5f47188ce175dabb76ec847f331d9bd"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-trait",
+ "base64 0.13.0",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper",
+ "isahc",
+ "lazy_static 1.4.0",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde 1.0.141",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "humansize"
@@ -4265,6 +4568,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
+name = "isahc"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+dependencies = [
+ "async-channel",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener",
+ "futures-lite",
+ "http",
+ "log",
+ "mime",
+ "once_cell",
+ "polling",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4407,6 +4737,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30455341b0e18f276fa64540aff54deafb54c589de6aca68659c63dd2d5d823"
+dependencies = [
+ "ascii-canvas",
+ "atty",
+ "bit-set",
+ "diff",
+ "ena",
+ "itertools",
+ "lalrpop-util",
+ "petgraph 0.6.2",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term 0.7.0",
+ "tiny-keccak",
+ "unicode-xid 0.2.3",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf796c978e9b4d983414f4caedc9273aa33ee214c5b887bd55fde84c85d2dc4"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "language-e2e-tests"
 version = "0.1.0"
 dependencies = [
@@ -4479,6 +4850,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
+
+[[package]]
 name = "lexical-core"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4515,6 +4892,16 @@ checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
  "cfg-if 1.0.0",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.7+1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -4598,6 +4985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -4634,6 +5022,7 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
  "serde 1.0.141",
+ "value-bag",
 ]
 
 [[package]]
@@ -5789,6 +6178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6127,6 +6522,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
+
+[[package]]
 name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6381,7 +6782,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.0",
 ]
 
 [[package]]
@@ -6391,7 +6792,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32ba0c43d7a1b6492b2924a62290cfd83987828af037b0743b38e6ab092aee58"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.0",
 ]
 
 [[package]]
@@ -6400,8 +6801,17 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.0",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6413,6 +6823,12 @@ dependencies = [
  "siphasher",
  "uncased",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -6570,6 +6986,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "log",
+ "wepoll-ffi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "polyval"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6595,6 +7024,12 @@ checksum = "3b845d6d8ec554f972a2c5298aad68953fd64e7441e846075450b44656a016d1"
 dependencies = [
  "vcpkg",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -6669,7 +7104,7 @@ dependencies = [
  "csv",
  "encode_unicode",
  "lazy_static 1.4.0",
- "term",
+ "term 0.5.2",
  "unicode-width",
 ]
 
@@ -7745,6 +8180,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde 1.0.141",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8021,6 +8466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8253,6 +8709,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8449,6 +8918,17 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs 1.0.5",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
  "winapi 0.3.9",
 ]
 
@@ -9316,6 +9796,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
+dependencies = [
+ "ctor",
+ "version_check",
+]
+
+[[package]]
 name = "variant_count"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9397,6 +9887,12 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -9600,6 +10096,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "wepoll-ffi"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,12 +1160,16 @@ dependencies = [
 name = "aptos-telemetry"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "aptos-api",
  "aptos-config",
+ "aptos-crypto",
  "aptos-infallible",
  "aptos-logger",
  "aptos-mempool",
  "aptos-metrics-core",
+ "aptos-telemetry-service",
+ "aptos-types",
  "aptosdb",
  "consensus",
  "futures",

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -721,10 +721,8 @@ pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle>
     }
 
     // Create the telemetry service
-    let telemetry_runtime = aptos_telemetry::service::start_telemetry_service(
-        node_config.clone(),
-        chain_id.to_string(),
-    );
+    let telemetry_runtime =
+        aptos_telemetry::service::start_telemetry_service(node_config.clone(), chain_id);
 
     Ok(AptosHandle {
         _api: api_runtime,

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -279,6 +279,20 @@ impl NodeConfig {
         }
     }
 
+    pub fn identity_key(&self) -> Option<x25519::PrivateKey> {
+        match self.base.role {
+            RoleType::Validator => self
+                .validator_network
+                .as_ref()
+                .map(NetworkConfig::identity_key),
+            RoleType::FullNode => self
+                .full_node_networks
+                .iter()
+                .find(|config| config.network_id == NetworkId::Public)
+                .map(NetworkConfig::identity_key),
+        }
+    }
+
     /// Checks `NetworkConfig` setups so that they exist on proper networks
     /// Additionally, handles any strange missing default cases
     fn validate_network_configs(mut self) -> Result<NodeConfig, Error> {

--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -108,7 +108,7 @@ pub async fn handle_auth(
         .map_err(|_| reject::reject())?;
 
     Ok(reply::json(&AuthResponse {
-        handshake_msg: Some(server_response.to_owned()),
+        handshake_msg: server_response,
     }))
 }
 

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -3,7 +3,7 @@
 
 use std::{convert::Infallible, sync::Arc};
 
-use crate::{validator_cache::ValidatorSetCache, AptosTelemetryServiceConfig, GCPBigQueryConfig};
+use crate::{validator_cache::ValidatorSetCache, GCPBigQueryConfig, TelemetryServiceConfig};
 use aptos_crypto::noise;
 use gcp_bigquery_client::Client as BQClient;
 use jsonwebtoken::{DecodingKey, EncodingKey};
@@ -23,7 +23,7 @@ pub struct Context {
 
 impl Context {
     pub fn new(
-        config: &AptosTelemetryServiceConfig,
+        config: &TelemetryServiceConfig,
         validator_cache: ValidatorSetCache,
         gcp_bigquery_client: Option<BQClient>,
     ) -> Self {

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -6,8 +6,7 @@ use std::time::Duration;
 use crate::{
     auth::with_auth,
     context::Context,
-    error,
-    types::auth::{Claims, TelemetryDump},
+    types::{auth::Claims, telemetry::TelemetryDump}, error,
 };
 use aptos_config::config::PeerRole;
 use aptos_logger::{error, info};
@@ -30,9 +29,13 @@ pub fn custom_event(context: Context) -> BoxedFilter<(impl Reply,)> {
 
 pub async fn handle_custom_event(
     context: Context,
-    _claims: Claims,
+    claims: Claims,
     body: TelemetryDump,
 ) -> anyhow::Result<impl Reply, Rejection> {
+    if body.user_id != claims.peer_id.to_string() {
+        return Err(reject::reject());
+    }
+
     let mut insert_request = TableDataInsertAllRequest::new();
 
     if body.events.is_empty() {

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -6,10 +6,11 @@ use std::time::Duration;
 use crate::{
     auth::with_auth,
     context::Context,
-    types::{auth::Claims, telemetry::TelemetryDump}, error,
+    error,
+    types::{auth::Claims, telemetry::TelemetryDump},
 };
 use aptos_config::config::PeerRole;
-use aptos_logger::{error, info};
+use aptos_logger::{debug, error};
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
 use serde_json::json;
 use warp::{filters::BoxedFilter, reject, reply, Filter, Rejection, Reply};
@@ -36,13 +37,13 @@ pub async fn handle_custom_event(
         return Err(reject::reject());
     }
 
-    let mut insert_request = TableDataInsertAllRequest::new();
-
     if body.events.is_empty() {
         return Err(reject::custom(error::Error::InvalidCustomEvent));
     }
 
-    let telemetry_event = body.events[0].clone();
+    let mut insert_request = TableDataInsertAllRequest::new();
+
+    let telemetry_event = &body.events[0];
     let event_params: Vec<serde_json::Value> = telemetry_event
         .params
         .iter()
@@ -68,7 +69,7 @@ pub async fn handle_custom_event(
     });
 
     insert_request
-        .add_row(None, row.clone())
+        .add_row(None, &row)
         .map_err(|_| reject::reject())?;
 
     context
@@ -87,7 +88,7 @@ pub async fn handle_custom_event(
             reject::custom(error::Error::GCPInsertError)
         })?;
 
-    info!("insert succeeded {:?}", row.to_string());
+    debug!("insert succeeded {:?}", &row);
 
     Ok(reply::reply())
 }

--- a/crates/aptos-telemetry-service/src/error.rs
+++ b/crates/aptos-telemetry-service/src/error.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_logger::error;
 use serde::Serialize;
 use std::convert::Infallible;
 use thiserror::Error;
@@ -14,6 +15,8 @@ pub enum Error {
     InvalidCustomEvent,
     #[error("gcp insert error")]
     GCPInsertError,
+    #[error("jwt token not valid")]
+    JWTTokenError,
 }
 
 #[derive(Serialize, Debug)]
@@ -35,6 +38,7 @@ pub async fn handle_rejection(err: Rejection) -> std::result::Result<impl Reply,
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal Server Error".to_string(),
             ),
+            Error::JWTTokenError => (StatusCode::UNAUTHORIZED, e.to_string()),
         }
     } else if err.find::<warp::reject::MethodNotAllowed>().is_some() {
         (
@@ -42,7 +46,7 @@ pub async fn handle_rejection(err: Rejection) -> std::result::Result<impl Reply,
             "Method Not Allowed".to_string(),
         )
     } else {
-        eprintln!("unhandled error: {:?}", err);
+        error!("unhandled error: {:?}", err);
         (
             StatusCode::INTERNAL_SERVER_ERROR,
             "Internal Server Error".to_string(),

--- a/crates/aptos-telemetry-service/src/index.rs
+++ b/crates/aptos-telemetry-service/src/index.rs
@@ -3,10 +3,24 @@
 
 use crate::{auth, context::Context, custom_event, error};
 use std::convert::Infallible;
-use warp::{Filter, Reply};
+use warp::{filters::BoxedFilter, reply, Filter, Rejection, Reply};
 
 pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
-    auth::auth(context.clone())
+    index(context.clone())
+        .or(auth::auth(context.clone()))
         .or(custom_event::custom_event(context))
         .recover(error::handle_rejection)
+}
+
+fn index(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path::end()
+        .and(warp::get())
+        .and(context.filter())
+        .and_then(handle_index)
+        .boxed()
+}
+
+async fn handle_index(context: Context) -> anyhow::Result<impl Reply, Rejection> {
+    let resp = reply::json(&context.noise_config().public_key());
+    Ok(resp)
 }

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -43,7 +43,7 @@ impl AptosTelemetryServiceArgs {
     pub async fn run(self) {
         // Load the config file
         let config =
-            AptosTelemetryServiceConfig::load(self.config_path.clone()).unwrap_or_else(|error| {
+            TelemetryServiceConfig::load(self.config_path.clone()).unwrap_or_else(|error| {
                 panic!(
                     "Failed to load config file: {:?}. Error: {:?}",
                     self.config_path, error
@@ -61,7 +61,7 @@ impl AptosTelemetryServiceArgs {
         Self::serve(&config, routes(context)).await;
     }
 
-    async fn serve<F>(config: &AptosTelemetryServiceConfig, routes: F)
+    async fn serve<F>(config: &TelemetryServiceConfig, routes: F)
     where
         F: Filter<Error = Infallible> + Clone + Sync + Send + 'static,
         F::Extract: Reply,
@@ -82,7 +82,7 @@ impl AptosTelemetryServiceArgs {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
-pub struct AptosTelemetryServiceConfig {
+pub struct TelemetryServiceConfig {
     pub address: SocketAddr,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls_cert_path: Option<String>,
@@ -96,7 +96,7 @@ pub struct AptosTelemetryServiceConfig {
     pub gcp_bq_config: GCPBigQueryConfig,
 }
 
-impl AptosTelemetryServiceConfig {
+impl TelemetryServiceConfig {
     pub fn load(path: PathBuf) -> Result<Self, anyhow::Error> {
         let mut file = File::open(&path).map_err(|e| {
             anyhow::anyhow!(

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::x25519;
+use aptos_logger::info;
 use aptos_types::chain_id::ChainId;
 use clap::Parser;
 use gcp_bigquery_client::Client;
@@ -28,7 +29,7 @@ mod jwt_auth;
 mod rest_client;
 #[cfg(any(test))]
 pub(crate) mod tests;
-pub(crate) mod types;
+pub mod types;
 mod validator_cache;
 
 #[derive(Clone, Debug, Parser)]
@@ -48,7 +49,7 @@ impl AptosTelemetryServiceArgs {
                     self.config_path, error
                 )
             });
-        println!("Using config {:?}", &config);
+        info!("Using config {:?}", &config);
 
         let cache = ValidatorSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
         let gcp_bigquery_client =

--- a/crates/aptos-telemetry-service/src/tests/auth_test.rs
+++ b/crates/aptos-telemetry-service/src/tests/auth_test.rs
@@ -80,7 +80,7 @@ async fn test_auth() {
     let resp: AuthResponse = serde_json::from_value(resp).unwrap();
 
     let (response_payload, _) = initiator
-        .finalize_connection(initiator_state, resp.handshake_msg.unwrap().as_slice())
+        .finalize_connection(initiator_state, resp.handshake_msg.as_slice())
         .unwrap();
 
     let jwt = String::from_utf8(response_payload).unwrap();
@@ -169,6 +169,6 @@ async fn test_auth_wrong_key() {
     let resp: AuthResponse = serde_json::from_value(resp).unwrap();
 
     initiator
-        .finalize_connection(initiator_state, resp.handshake_msg.unwrap().as_slice())
+        .finalize_connection(initiator_state, resp.handshake_msg.as_slice())
         .unwrap();
 }

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -4,9 +4,7 @@
 use std::collections::HashMap;
 
 use crate::GCPBigQueryConfig;
-use crate::{
-    context::Context, index, validator_cache::ValidatorSetCache, AptosTelemetryServiceConfig,
-};
+use crate::{context::Context, index, validator_cache::ValidatorSetCache, TelemetryServiceConfig};
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::{x25519, Uniform};
 use aptos_rest_client::aptos_api_types::mime_types;
@@ -20,7 +18,7 @@ pub async fn new_test_context() -> TestContext {
     let mut rng = ::rand::rngs::StdRng::from_seed([0u8; 32]);
     let server_private_key = x25519::PrivateKey::generate(&mut rng);
 
-    let config = &AptosTelemetryServiceConfig {
+    let config = &TelemetryServiceConfig {
         address: format!("{}:{}", "127.0.0.1", 80).parse().unwrap(),
         tls_cert_path: None,
         tls_key_path: None,

--- a/crates/aptos-telemetry-service/src/types/auth.rs
+++ b/crates/aptos-telemetry-service/src/types/auth.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
-
 use aptos_config::config::PeerRole;
 use aptos_crypto::x25519;
 use aptos_types::{chain_id::ChainId, PeerId};
@@ -18,7 +16,7 @@ pub struct AuthRequest {
 
 #[derive(Serialize, Deserialize)]
 pub struct AuthResponse {
-    pub handshake_msg: Option<Vec<u8>>,
+    pub handshake_msg: Vec<u8>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -29,20 +27,4 @@ pub struct Claims {
     pub epoch: u64,
     pub exp: usize,
     pub iat: usize,
-}
-
-/// A useful struct for serialization a telemetry event
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct TelemetryEvent {
-    pub name: String,
-    pub params: BTreeMap<String, String>,
-}
-
-/// A useful struct for serializing a telemetry dump
-#[derive(Debug, Serialize, Deserialize)]
-pub struct TelemetryDump {
-    pub client_id: String,
-    pub user_id: String,
-    pub timestamp_micros: String,
-    pub events: Vec<TelemetryEvent>,
 }

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -2,4 +2,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod auth;
+pub mod telemetry;
 pub mod validator_set;

--- a/crates/aptos-telemetry-service/src/types/telemetry.rs
+++ b/crates/aptos-telemetry-service/src/types/telemetry.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A useful struct for serialization a telemetry event
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TelemetryEvent {
+    pub name: String,
+    pub params: BTreeMap<String, String>,
+}
+
+/// A useful struct for serializing a telemetry dump
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TelemetryDump {
+    pub client_id: String,
+    pub user_id: String,
+    pub timestamp_micros: String,
+    pub events: Vec<TelemetryEvent>,
+}

--- a/crates/aptos-telemetry-service/src/types/validator_set.rs
+++ b/crates/aptos-telemetry-service/src/types/validator_set.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_rest_client::types::{deserialize_from_prefixed_hex_string, deserialize_from_string};
+use aptos_rest_client::types::deserialize_from_string;
 use aptos_types::{account_address::AccountAddress, network_address::NetworkAddress};
 use hex::FromHex;
 use serde::{Deserialize, Serialize};
@@ -28,7 +28,7 @@ impl ValidatorConfig {
 /// Consensus information per validator, stored in ValidatorSet.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ValidatorInfo {
-    #[serde(deserialize_with = "deserialize_from_prefixed_hex_string")]
+    #[serde(deserialize_with = "deserialize_from_string")]
     addr: AccountAddress,
     #[serde(deserialize_with = "deserialize_from_string")]
     voting_power: u64,

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -3,13 +3,13 @@
 
 use aptos_config::config::{Peer, PeerRole, PeerSet};
 use aptos_infallible::RwLock;
-use aptos_logger::error;
+use aptos_logger::{debug, error};
 use aptos_types::chain_id::ChainId;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time;
 use url::Url;
 
-use crate::{rest_client::RestClient, AptosTelemetryServiceConfig};
+use crate::{rest_client::RestClient, TelemetryServiceConfig};
 
 pub type EpochNum = u64;
 pub type ValidatorSetCache = Arc<RwLock<HashMap<ChainId, (EpochNum, PeerSet)>>>;
@@ -23,7 +23,7 @@ pub struct ValidatorSetCacheUpdater {
 }
 
 impl ValidatorSetCacheUpdater {
-    pub fn new(cache: ValidatorSetCache, config: &AptosTelemetryServiceConfig) -> Self {
+    pub fn new(cache: ValidatorSetCache, config: &TelemetryServiceConfig) -> Self {
         Self {
             cache,
             query_addresses: Arc::new(config.trusted_full_node_addresses.clone()),
@@ -65,6 +65,11 @@ impl ValidatorSetCacheUpdater {
                             )
                         })
                         .collect();
+
+                    debug!(
+                        "Validator set for chain id {} at epoch {}: {:?}",
+                        chain_id, state.epoch, peer_set
+                    );
 
                     store.insert(*chain_id, (state.epoch, peer_set));
                 }

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.57"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-telemetry-service = { path = "../../crates/aptos-telemetry-service" }
 aptos-types = { path = "../../types" }
+const_format = "0.2.26"
 futures = "0.3.21"
 once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }
@@ -24,6 +25,7 @@ serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = "1.0.81"
 sysinfo = "0.24.2"
 tokio = { version = "1.18.2" }
+tokio-retry = "0.3"
 tokio-stream = "0.1.8"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
@@ -38,3 +40,6 @@ aptosdb = { path = "../../storage/aptosdb" }
 consensus = { path = "../../consensus" }
 network = { path = "../../network" }
 state-sync-driver = { path = "../../state-sync/state-sync-v2/state-sync-driver" }
+
+[dev-dependencies]
+httpmock = "0.6"

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -10,6 +10,10 @@ publish = false
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.57"
+aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-telemetry-service = { path = "../../crates/aptos-telemetry-service" }
+aptos-types = { path = "../../types" }
 futures = "0.3.21"
 once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }

--- a/crates/aptos-telemetry/src/build_information.rs
+++ b/crates/aptos-telemetry/src/build_information.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_telemetry_service::types::telemetry::TelemetryEvent;
+
 use crate as aptos_telemetry;
-use crate::{service::TelemetryEvent, utils};
+use crate::utils;
 use std::collections::BTreeMap;
 
 /// Build information event name

--- a/crates/aptos-telemetry/src/cli_metrics.rs
+++ b/crates/aptos-telemetry/src/cli_metrics.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{service, service::TelemetryEvent, utils};
+use crate::{service, utils};
 use aptos_logger::error;
+use aptos_telemetry_service::types::telemetry::TelemetryEvent;
 use std::{collections::BTreeMap, time::Duration};
 
 /// CLI metrics event name
@@ -36,7 +37,7 @@ pub async fn send_cli_telemetry_event(
 
     // Send the event (we block on the join handle to ensure the
     // event is processed before terminating the cli command).
-    let join_handle = service::send_telemetry_event_with_ip(user_id, telemetry_event).await;
+    let join_handle = service::send_telemetry_event_with_ip(user_id, None, telemetry_event).await;
     if let Err(error) = join_handle.await {
         error!(
             "Failed to send telemetry event with join error: {:?}",

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -18,6 +18,7 @@ pub(crate) const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
 // See: https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#transport
 pub(crate) const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
 pub(crate) const HTTPBIN_URL: &str = "https://httpbin.org/ip";
+pub(crate) const TELEMETRY_SERVICE_URL: &str = "https://telemetry.aptoslabs.com";
 
 // Frequencies for the various metrics and pushes
 pub(crate) const NODE_CORE_METRICS_FREQ_SECS: u64 = 30; // 30 seconds

--- a/crates/aptos-telemetry/src/core_metrics.rs
+++ b/crates/aptos-telemetry/src/core_metrics.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{service::TelemetryEvent, utils, utils::sum_all_histogram_counts};
+use crate::{utils, utils::sum_all_histogram_counts};
 use aptos_config::config::NodeConfig;
+use aptos_telemetry_service::types::telemetry::TelemetryEvent;
 use prometheus::core::Collector;
 use state_sync_driver::metrics::StorageSynchronizerOperations;
 use std::collections::BTreeMap;

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -9,6 +9,7 @@ mod constants;
 mod core_metrics;
 mod metrics;
 mod network_metrics;
+mod sender;
 pub mod service;
 mod system_information;
 pub mod utils;

--- a/crates/aptos-telemetry/src/metrics.rs
+++ b/crates/aptos-telemetry/src/metrics.rs
@@ -5,6 +5,25 @@ use aptos_metrics_core::{register_int_counter_vec, IntCounterVec};
 use once_cell::sync::Lazy;
 
 /// Counter for successful telemetry events
+pub(crate) static APTOS_TELEMETRY_SERVICE_SUCCESS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_telemetry_service_success",
+        "Number of telemetry events successfully sent to telemetry service",
+        &["event_name"]
+    )
+    .unwrap()
+});
+
+/// Counter for failed telemetry events
+pub(crate) static APTOS_TELEMETRY_SERVICE_FAILURE: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_telemetry_service_failure",
+        "Number of telemetry events that failed to send to telemetry service",
+        &["event_name"]
+    )
+    .unwrap()
+});
+
 pub(crate) static APTOS_TELEMETRY_SUCCESS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_telemetry_success",
@@ -34,6 +53,20 @@ pub(crate) fn increment_telemetry_successes(event_name: &str) {
 /// Increments the number of failed telemetry events
 pub(crate) fn increment_telemetry_failures(event_name: &str) {
     APTOS_TELEMETRY_FAILURE
+        .with_label_values(&[event_name])
+        .inc();
+}
+
+/// Increments the number of successful telemetry events
+pub(crate) fn increment_telemetry_service_successes(event_name: &str) {
+    APTOS_TELEMETRY_SERVICE_SUCCESS
+        .with_label_values(&[event_name])
+        .inc();
+}
+
+/// Increments the number of failed telemetry events
+pub(crate) fn increment_telemetry_service_failures(event_name: &str) {
+    APTOS_TELEMETRY_SERVICE_FAILURE
         .with_label_values(&[event_name])
         .inc();
 }

--- a/crates/aptos-telemetry/src/metrics.rs
+++ b/crates/aptos-telemetry/src/metrics.rs
@@ -4,7 +4,7 @@
 use aptos_metrics_core::{register_int_counter_vec, IntCounterVec};
 use once_cell::sync::Lazy;
 
-/// Counter for successful telemetry events
+/// Counter for successful telemetry events sent from Telemetry Sender to Telemetry Service
 pub(crate) static APTOS_TELEMETRY_SERVICE_SUCCESS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_telemetry_service_success",
@@ -14,7 +14,7 @@ pub(crate) static APTOS_TELEMETRY_SERVICE_SUCCESS: Lazy<IntCounterVec> = Lazy::n
     .unwrap()
 });
 
-/// Counter for failed telemetry events
+/// Counter for failed telemetry events sent from Telemetry Sender to Telemetry Service
 pub(crate) static APTOS_TELEMETRY_SERVICE_FAILURE: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_telemetry_service_failure",
@@ -24,6 +24,8 @@ pub(crate) static APTOS_TELEMETRY_SERVICE_FAILURE: Lazy<IntCounterVec> = Lazy::n
     .unwrap()
 });
 
+/// Counter for successful telemetry events sent to GA
+/// /// TODO: Clean up when cleaning up telemetry exporter to GA
 pub(crate) static APTOS_TELEMETRY_SUCCESS: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_telemetry_success",
@@ -33,7 +35,8 @@ pub(crate) static APTOS_TELEMETRY_SUCCESS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Counter for failed telemetry events
+/// Counter for failed telemetry events sent to GA
+/// TODO: Clean up when cleaning up telemetry exporter to GA
 pub(crate) static APTOS_TELEMETRY_FAILURE: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "aptos_telemetry_failure",
@@ -43,28 +46,28 @@ pub(crate) static APTOS_TELEMETRY_FAILURE: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// Increments the number of successful telemetry events
+/// Increments the number of successful telemetry events sent to GA
 pub(crate) fn increment_telemetry_successes(event_name: &str) {
     APTOS_TELEMETRY_SUCCESS
         .with_label_values(&[event_name])
         .inc();
 }
 
-/// Increments the number of failed telemetry events
+/// Increments the number of failed telemetry events sent to GA
 pub(crate) fn increment_telemetry_failures(event_name: &str) {
     APTOS_TELEMETRY_FAILURE
         .with_label_values(&[event_name])
         .inc();
 }
 
-/// Increments the number of successful telemetry events
+/// Increments the number of successful telemetry events sent to Telemetry service
 pub(crate) fn increment_telemetry_service_successes(event_name: &str) {
     APTOS_TELEMETRY_SERVICE_SUCCESS
         .with_label_values(&[event_name])
         .inc();
 }
 
-/// Increments the number of failed telemetry events
+/// Increments the number of failed telemetry events sent to Telemetry service
 pub(crate) fn increment_telemetry_service_failures(event_name: &str) {
     APTOS_TELEMETRY_SERVICE_FAILURE
         .with_label_values(&[event_name])

--- a/crates/aptos-telemetry/src/network_metrics.rs
+++ b/crates/aptos-telemetry/src/network_metrics.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{service::TelemetryEvent, utils};
+use crate::utils;
+use aptos_telemetry_service::types::telemetry::TelemetryEvent;
 use prometheus::core::Collector;
 use std::collections::BTreeMap;
 

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -1,0 +1,224 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metrics;
+use anyhow::{anyhow, Error};
+use aptos_config::config::NodeConfig;
+use aptos_crypto::{
+    noise::{self, NoiseConfig},
+    x25519,
+};
+use aptos_infallible::{Mutex, RwLock};
+use aptos_logger::{debug, error};
+use aptos_telemetry_service::types::{
+    auth::{AuthRequest, AuthResponse},
+    telemetry::TelemetryDump,
+};
+use aptos_types::{chain_id::ChainId, PeerId};
+use reqwest::{StatusCode, Url};
+use std::sync::Arc;
+
+// const METRICS_ENDPOINT: &str = "https://aptos.dev/telemetry/";
+// const AUTH_URL: &str = "https://aptos.dev/telemetry/auth";
+// const METRICS_URL: &str = "https://aptos.dev/telemetry/telemetry";
+
+const METRICS_ENDPOINT: &str = "http://localhost:8081/";
+const AUTH_URL: &str = "http://localhost:8081/auth";
+const METRICS_URL: &str = "http://localhost:8081/telemetry";
+const MAX_RETRIES: i32 = 5;
+
+struct AuthContext {
+    noise_config: Option<NoiseConfig>,
+    token: RwLock<Option<String>>,
+    server_public_key: Mutex<Option<x25519::PublicKey>>,
+}
+
+impl AuthContext {
+    fn new(node_config: &NodeConfig) -> Self {
+        Self {
+            noise_config: node_config.identity_key().map(NoiseConfig::new),
+            token: RwLock::new(None),
+            server_public_key: Mutex::new(None),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TelemetrySender {
+    chain_id: ChainId,
+    peer_id: PeerId,
+    client: reqwest::Client,
+    auth_context: Arc<AuthContext>,
+}
+
+impl TelemetrySender {
+    pub fn new(chain_id: ChainId, node_config: &NodeConfig) -> Self {
+        Self {
+            chain_id,
+            peer_id: node_config.peer_id().unwrap_or(PeerId::ZERO),
+            client: reqwest::Client::new(),
+            auth_context: Arc::new(AuthContext::new(node_config)),
+        }
+    }
+
+    pub async fn send_metrics(&self, event_name: String, telemetry_dump: TelemetryDump) {
+        for i in 1..MAX_RETRIES {
+            match self.post_metrics(&telemetry_dump).await {
+                Ok(_) => {
+                    debug!(
+                        "Sent telemetry event {}, data: {:?}",
+                        &event_name, &telemetry_dump
+                    );
+                    metrics::increment_telemetry_service_successes(&event_name);
+                    return;
+                }
+                Err(error) => {
+                    if error.to_string().contains("Unauthorized") && i < MAX_RETRIES {
+                        debug!("Retrying failed send telemetry event: Error: {}.", error);
+                        continue;
+                    }
+                    error!("Failed to send telemetry event: Error: {}", error);
+                    metrics::increment_telemetry_service_failures(&event_name);
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn post_metrics(&self, telemetry_dump: &TelemetryDump) -> Result<(), anyhow::Error> {
+        let token = self.get_token().await?;
+
+        // Send the request and wait for a response
+        let send_result = self
+            .client
+            .post(METRICS_URL)
+            .json::<TelemetryDump>(telemetry_dump)
+            .bearer_auth(token)
+            .send()
+            .await;
+
+        // Process the response
+        match send_result {
+            Ok(response) => {
+                let status_code = response.status();
+                if status_code.is_success() {
+                    Ok(())
+                } else if status_code == StatusCode::UNAUTHORIZED {
+                    self.reset_token();
+                    Err(anyhow!("Unauthorized"))
+                } else {
+                    Err(anyhow!("Error status received: {}", status_code))
+                }
+            }
+            Err(error) => Err(anyhow!("Error sending metrics. Err: {}", error)),
+        }
+    }
+
+    async fn get_token(&self) -> Result<String, Error> {
+        // Try to read the token holding a read lock
+        let token = { self.auth_context.token.read().as_ref().cloned() };
+        match token {
+            Some(token) => Ok(token),
+            None => {
+                let token = self.authenticate().await?;
+                *self.auth_context.token.write() = Some(token.clone());
+                Ok(token)
+            }
+        }
+    }
+
+    async fn get_public_key_from_server(&self) -> Result<x25519::PublicKey, anyhow::Error> {
+        let url = Url::parse(METRICS_ENDPOINT)?;
+        let response = self.client.get(url).send().await?;
+
+        match response.error_for_status() {
+            Ok(response) => {
+                let public_key = response.json::<x25519::PublicKey>().await?;
+                Ok(public_key)
+            }
+            Err(err) => Err(anyhow!("Error getting server public key. {}", err)),
+        }
+    }
+
+    async fn server_public_key(&self) -> Result<x25519::PublicKey, anyhow::Error> {
+        let server_public_key = { *self.auth_context.server_public_key.lock() };
+        match server_public_key {
+            Some(key) => Ok(key),
+            None => {
+                let public_key = self.get_public_key_from_server().await?;
+                *self.auth_context.server_public_key.lock() = Some(public_key);
+                Ok(public_key)
+            }
+        }
+    }
+
+    fn reset_token(&self) {
+        *self.auth_context.token.write() = None
+    }
+
+    pub async fn authenticate(&self) -> Result<String, anyhow::Error> {
+        let noise_config = match &self.auth_context.noise_config {
+            Some(config) => config,
+            None => return Err(anyhow!("Cannot send telemetry without private key")),
+        };
+        let server_public_key = self.server_public_key().await?;
+
+        // buffer to first noise handshake message
+        let mut client_noise_msg = vec![0; noise::handshake_init_msg_len(0)];
+
+        // build the prologue (chain_id | peer_id | server_public_key)
+        const CHAIN_ID_LENGTH: usize = 1;
+        const ID_SIZE: usize = CHAIN_ID_LENGTH + PeerId::LENGTH;
+        const PROLOGUE_SIZE: usize = CHAIN_ID_LENGTH + PeerId::LENGTH + x25519::PUBLIC_KEY_SIZE;
+        let mut prologue = [0; PROLOGUE_SIZE];
+        prologue[..CHAIN_ID_LENGTH].copy_from_slice(&[self.chain_id.id()]);
+        prologue[CHAIN_ID_LENGTH..ID_SIZE].copy_from_slice(self.peer_id.as_ref());
+        prologue[ID_SIZE..PROLOGUE_SIZE].copy_from_slice(server_public_key.as_slice());
+
+        let mut rng = rand::rngs::OsRng;
+
+        // craft first handshake message  (-> e, es, s, ss)
+        let initiator_state = noise_config
+            .initiate_connection(
+                &mut rng,
+                &prologue,
+                server_public_key,
+                None,
+                &mut client_noise_msg,
+            )
+            .unwrap();
+
+        let auth_request = AuthRequest {
+            chain_id: self.chain_id,
+            peer_id: self.peer_id,
+            server_public_key,
+            handshake_msg: client_noise_msg,
+        };
+
+        let response = self
+            .client
+            .post(AUTH_URL)
+            .json::<AuthRequest>(&auth_request)
+            .send()
+            .await?;
+
+        let resp = match response.error_for_status() {
+            Ok(response) => Ok(response.json::<AuthResponse>().await?),
+            Err(err) => {
+                error!(
+                    "[telemetry-client] Error sending authentication request: {}",
+                    err
+                );
+                Err(anyhow!("error {}", err))
+            }
+        }?;
+
+        let (response_payload, _) = noise_config
+            .finalize_connection(initiator_state, resp.handshake_msg.as_slice())
+            .unwrap();
+
+        let jwt = String::from_utf8(response_payload)?;
+
+        Ok(jwt)
+    }
+}

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -15,17 +15,12 @@ use aptos_telemetry_service::types::{
     telemetry::TelemetryDump,
 };
 use aptos_types::{chain_id::ChainId, PeerId};
-use reqwest::{StatusCode, Url};
+use reqwest::StatusCode;
 use std::sync::Arc;
-
-// const METRICS_ENDPOINT: &str = "https://aptos.dev/telemetry/";
-// const AUTH_URL: &str = "https://aptos.dev/telemetry/auth";
-// const METRICS_URL: &str = "https://aptos.dev/telemetry/telemetry";
-
-const METRICS_ENDPOINT: &str = "http://localhost:8081/";
-const AUTH_URL: &str = "http://localhost:8081/auth";
-const METRICS_URL: &str = "http://localhost:8081/telemetry";
-const MAX_RETRIES: i32 = 5;
+use tokio_retry::{
+    strategy::{jitter, ExponentialBackoff},
+    Retry,
+};
 
 struct AuthContext {
     noise_config: Option<NoiseConfig>,
@@ -45,6 +40,7 @@ impl AuthContext {
 
 #[derive(Clone)]
 pub(crate) struct TelemetrySender {
+    base_url: String,
     chain_id: ChainId,
     peer_id: PeerId,
     client: reqwest::Client,
@@ -52,8 +48,9 @@ pub(crate) struct TelemetrySender {
 }
 
 impl TelemetrySender {
-    pub fn new(chain_id: ChainId, node_config: &NodeConfig) -> Self {
+    pub fn new(base_url: &str, chain_id: ChainId, node_config: &NodeConfig) -> Self {
         Self {
+            base_url: base_url.into(),
             chain_id,
             peer_id: node_config.peer_id().unwrap_or(PeerId::ZERO),
             client: reqwest::Client::new(),
@@ -62,25 +59,26 @@ impl TelemetrySender {
     }
 
     pub async fn send_metrics(&self, event_name: String, telemetry_dump: TelemetryDump) {
-        for i in 1..MAX_RETRIES {
-            match self.post_metrics(&telemetry_dump).await {
-                Ok(_) => {
-                    debug!(
-                        "Sent telemetry event {}, data: {:?}",
-                        &event_name, &telemetry_dump
-                    );
-                    metrics::increment_telemetry_service_successes(&event_name);
-                    return;
-                }
-                Err(error) => {
-                    if error.to_string().contains("Unauthorized") && i < MAX_RETRIES {
-                        debug!("Retrying failed send telemetry event: Error: {}.", error);
-                        continue;
-                    }
-                    error!("Failed to send telemetry event: Error: {}", error);
-                    metrics::increment_telemetry_service_failures(&event_name);
-                    return;
-                }
+        let retry_strategy = ExponentialBackoff::from_millis(10)
+            .map(jitter) // add jitter to delays
+            .take(4); // limit to 4 retries
+
+        let result = Retry::spawn(retry_strategy, || async {
+            self.post_metrics(&telemetry_dump.clone()).await
+        })
+        .await;
+
+        match result {
+            Ok(_) => {
+                debug!(
+                    "Sent telemetry event {}, data: {:?}",
+                    &event_name, &telemetry_dump
+                );
+                metrics::increment_telemetry_service_successes(&event_name);
+            }
+            Err(error) => {
+                error!("Failed to send telemetry event: Error: {}", error);
+                metrics::increment_telemetry_service_failures(&event_name);
             }
         }
     }
@@ -91,7 +89,7 @@ impl TelemetrySender {
         // Send the request and wait for a response
         let send_result = self
             .client
-            .post(METRICS_URL)
+            .post(format!("{}/custom_event", self.base_url))
             .json::<TelemetryDump>(telemetry_dump)
             .bearer_auth(token)
             .send()
@@ -128,8 +126,7 @@ impl TelemetrySender {
     }
 
     async fn get_public_key_from_server(&self) -> Result<x25519::PublicKey, anyhow::Error> {
-        let url = Url::parse(METRICS_ENDPOINT)?;
-        let response = self.client.get(url).send().await?;
+        let response = self.client.get(self.base_url.to_string()).send().await?;
 
         match response.error_for_status() {
             Ok(response) => {
@@ -153,7 +150,8 @@ impl TelemetrySender {
     }
 
     fn reset_token(&self) {
-        *self.auth_context.token.write() = None
+        *self.auth_context.token.write() = None;
+        *self.auth_context.server_public_key.lock() = None;
     }
 
     pub async fn authenticate(&self) -> Result<String, anyhow::Error> {
@@ -197,7 +195,7 @@ impl TelemetrySender {
 
         let response = self
             .client
-            .post(AUTH_URL)
+            .post(format!("{}/auth", self.base_url))
             .json::<AuthRequest>(&auth_request)
             .send()
             .await?;
@@ -220,5 +218,146 @@ impl TelemetrySender {
         let jwt = String::from_utf8(response_payload)?;
 
         Ok(jwt)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{
+        collections::BTreeMap,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use crate::metrics::{APTOS_TELEMETRY_SERVICE_FAILURE, APTOS_TELEMETRY_SERVICE_SUCCESS};
+
+    use super::*;
+    use aptos_crypto::Uniform;
+    use aptos_telemetry_service::types::telemetry::TelemetryEvent;
+    use httpmock::MockServer;
+
+    #[tokio::test]
+    async fn test_server_public_key() {
+        let mut rng = rand::thread_rng();
+        let private_key = x25519::PrivateKey::generate(&mut rng);
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("GET").path("/");
+            then.status(200).json_body_obj(&private_key.public_key());
+        });
+
+        let node_config = NodeConfig::default();
+        let client = TelemetrySender::new(&server.base_url(), ChainId::default(), &node_config);
+
+        let result1 = client.server_public_key().await;
+        let result2 = client.server_public_key().await;
+
+        println!("{:?}", result1);
+
+        // Should call the server once and cache the key
+        assert_eq!(mock.hits(), 1);
+        assert_eq!(result1.is_ok(), true);
+        assert_eq!(result1.unwrap(), private_key.public_key());
+        assert_eq!(result2.is_ok(), true);
+        assert_eq!(result2.unwrap(), private_key.public_key());
+
+        client.reset_token();
+
+        let result3 = client.server_public_key().await;
+        assert_eq!(mock.hits(), 2);
+        assert_eq!(result3.is_ok(), true);
+        assert_eq!(result3.unwrap(), private_key.public_key());
+    }
+
+    #[tokio::test]
+    async fn test_post_metrics() {
+        let mut telemetry_event = TelemetryEvent {
+            name: "sample-event".into(),
+            params: BTreeMap::new(),
+        };
+        telemetry_event
+            .params
+            .insert("key-1".into(), "value-1".into());
+        let telemetry_dump = TelemetryDump {
+            client_id: "client-1".into(),
+            user_id: "user-1".into(),
+            timestamp_micros: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+                .to_string(),
+            events: vec![],
+        };
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .header("Authorization", "Bearer SECRET_JWT_TOKEN")
+                .path("/custom_event")
+                .json_body_obj(&telemetry_dump);
+            then.status(200);
+        });
+
+        let node_config = NodeConfig::default();
+        let client = TelemetrySender::new(&server.base_url(), ChainId::default(), &node_config);
+        {
+            *client.auth_context.token.write() = Some("SECRET_JWT_TOKEN".into());
+        }
+
+        let result = client.post_metrics(&telemetry_dump).await;
+
+        mock.assert();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_send_metrics_retry() {
+        let event_name = "sample-event";
+        let mut telemetry_event = TelemetryEvent {
+            name: event_name.into(),
+            params: BTreeMap::new(),
+        };
+        telemetry_event
+            .params
+            .insert("key-1".into(), "value-1".into());
+        let telemetry_dump = TelemetryDump {
+            client_id: "client-1".into(),
+            user_id: "user-1".into(),
+            timestamp_micros: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_micros()
+                .to_string(),
+            events: vec![],
+        };
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("POST").path("/custom_event");
+            then.status(400);
+        });
+
+        let node_config = NodeConfig::default();
+        let client = TelemetrySender::new(&server.base_url(), ChainId::default(), &node_config);
+        {
+            *client.auth_context.token.write() = Some("SECRET_JWT_TOKEN".into());
+        }
+
+        client.send_metrics(event_name.into(), telemetry_dump).await;
+
+        mock.assert_hits(5);
+        assert_eq!(
+            APTOS_TELEMETRY_SERVICE_SUCCESS
+                .with_label_values(&[event_name])
+                .get(),
+            0
+        );
+        assert_eq!(
+            APTOS_TELEMETRY_SERVICE_FAILURE
+                .with_label_values(&[event_name])
+                .get(),
+            1
+        );
     }
 }

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -13,17 +13,19 @@ use crate::{
     core_metrics::create_core_metric_telemetry_event,
     metrics,
     network_metrics::create_network_metric_telemetry_event,
+    sender::TelemetrySender,
     system_information::create_system_info_telemetry_event,
 };
 use aptos_config::config::NodeConfig;
 use aptos_logger::prelude::*;
+use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
+use aptos_types::chain_id::ChainId;
 use futures::StreamExt;
 use once_cell::sync::Lazy;
 use rand::Rng;
 use rand_core::OsRng;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{
-    collections::BTreeMap,
     env,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -54,7 +56,7 @@ fn telemetry_is_disabled() -> bool {
 
 /// Starts the telemetry service and returns the execution runtime.
 /// Note: The service will not be created if telemetry is disabled.
-pub fn start_telemetry_service(node_config: NodeConfig, chain_id: String) -> Option<Runtime> {
+pub fn start_telemetry_service(node_config: NodeConfig, chain_id: ChainId) -> Option<Runtime> {
     // Don't start the service if telemetry has been disabled
     if telemetry_is_disabled() {
         warn!("Aptos telemetry is disabled!");
@@ -87,9 +89,16 @@ fn fetch_peer_id(node_config: &NodeConfig) -> String {
 }
 
 /// Spawns the dedicated telemetry service that operates periodically
-async fn spawn_telemetry_service(peer_id: String, chain_id: String, node_config: NodeConfig) {
+async fn spawn_telemetry_service(peer_id: String, chain_id: ChainId, node_config: NodeConfig) {
+    let telemetry_sender = TelemetrySender::new(chain_id, &node_config);
+
     // Send build information once (only on startup)
-    send_build_information(peer_id.clone(), chain_id.clone()).await;
+    send_build_information(
+        peer_id.clone(),
+        chain_id.to_string().clone(),
+        telemetry_sender.clone(),
+    )
+    .await;
 
     // Periodically send node core metrics
     let mut core_metrics_interval = IntervalStream::new(tokio::time::interval(
@@ -113,40 +122,52 @@ async fn spawn_telemetry_service(peer_id: String, chain_id: String, node_config:
     loop {
         futures::select! {
             _ = system_information_interval.select_next_some() => {
-                send_system_information(peer_id.clone()).await;
+                send_system_information(peer_id.clone(), telemetry_sender.clone()).await;
             }
             _ = core_metrics_interval.select_next_some() => {
-                send_node_core_metrics(peer_id.clone(), &node_config).await;
+                send_node_core_metrics(peer_id.clone(), &node_config, telemetry_sender.clone()).await;
             }
             _ = network_metrics_interval.select_next_some() => {
-                send_node_network_metrics(peer_id.clone()).await;
+                send_node_network_metrics(peer_id.clone(), telemetry_sender.clone()).await;
             }
         }
     }
 }
 
 /// Collects and sends the build information via telemetry
-async fn send_build_information(peer_id: String, chain_id: String) {
+async fn send_build_information(
+    peer_id: String,
+    chain_id: String,
+    telemetry_sender: TelemetrySender,
+) {
     let telemetry_event = create_build_info_telemetry_event(chain_id).await;
-    let _join_handle = send_telemetry_event_with_ip(peer_id, telemetry_event).await;
+    let _join_handle =
+        send_telemetry_event_with_ip(peer_id, Some(telemetry_sender), telemetry_event).await;
 }
 
 /// Collects and sends the core node metrics via telemetry
-async fn send_node_core_metrics(peer_id: String, node_config: &NodeConfig) {
+async fn send_node_core_metrics(
+    peer_id: String,
+    node_config: &NodeConfig,
+    telemetry_sender: TelemetrySender,
+) {
     let telemetry_event = create_core_metric_telemetry_event(node_config).await;
-    let _join_handle = send_telemetry_event_with_ip(peer_id, telemetry_event).await;
+    let _join_handle =
+        send_telemetry_event_with_ip(peer_id, Some(telemetry_sender), telemetry_event).await;
 }
 
 /// Collects and sends the node network metrics via telemetry
-async fn send_node_network_metrics(peer_id: String) {
+async fn send_node_network_metrics(peer_id: String, telemetry_sender: TelemetrySender) {
     let telemetry_event = create_network_metric_telemetry_event().await;
-    let _join_handle = send_telemetry_event_with_ip(peer_id, telemetry_event).await;
+    let _join_handle =
+        send_telemetry_event_with_ip(peer_id, Some(telemetry_sender), telemetry_event).await;
 }
 
 /// Collects and sends the system information via telemetry
-async fn send_system_information(peer_id: String) {
+async fn send_system_information(peer_id: String, telemetry_sender: TelemetrySender) {
     let telemetry_event = create_system_info_telemetry_event().await;
-    let _join_handle = send_telemetry_event_with_ip(peer_id, telemetry_event).await;
+    let _join_handle =
+        send_telemetry_event_with_ip(peer_id, Some(telemetry_sender), telemetry_event).await;
 }
 
 /// Fetches the IP address and sends the given telemetry event
@@ -154,6 +175,7 @@ async fn send_system_information(peer_id: String) {
 /// token to help correlate metrics across events.
 pub(crate) async fn send_telemetry_event_with_ip(
     peer_id: String,
+    telemetry_sender: Option<TelemetrySender>,
     telemetry_event: TelemetryEvent,
 ) -> JoinHandle<()> {
     // Update the telemetry event with the ip address and random token
@@ -163,7 +185,7 @@ pub(crate) async fn send_telemetry_event_with_ip(
     let telemetry_event = TelemetryEvent { name, params };
 
     // Send the telemetry event
-    send_telemetry_event(peer_id, telemetry_event).await
+    send_telemetry_event(peer_id, telemetry_sender, telemetry_event).await
 }
 
 /// Gets the IP origin of the machine by pinging a url.
@@ -180,7 +202,11 @@ async fn get_origin_ip() -> String {
 }
 
 /// Sends the given event and params to the telemetry endpoint
-async fn send_telemetry_event(peer_id: String, telemetry_event: TelemetryEvent) -> JoinHandle<()> {
+async fn send_telemetry_event(
+    peer_id: String,
+    telemetry_sender: Option<TelemetrySender>,
+    telemetry_event: TelemetryEvent,
+) -> JoinHandle<()> {
     // Parse the Google analytics env variables
     let api_secret =
         env::var(ENV_GA_API_SECRET).unwrap_or_else(|_| APTOS_GA_API_SECRET.to_string());
@@ -199,7 +225,28 @@ async fn send_telemetry_event(peer_id: String, telemetry_event: TelemetryEvent) 
         timestamp_micros,
         events: vec![telemetry_event],
     };
+    let _handle = spawn_telemetry_service_event_sender(
+        event_name.clone(),
+        telemetry_sender,
+        telemetry_dump.clone(),
+    );
     spawn_telemetry_event_sender(api_secret, measurement_id, event_name, telemetry_dump)
+}
+
+fn spawn_telemetry_service_event_sender(
+    event_name: String,
+    telemetry_sender: Option<TelemetrySender>,
+    telemetry_dump: TelemetryDump,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if telemetry_sender.is_none() {
+            return;
+        }
+        telemetry_sender
+            .unwrap()
+            .send_metrics(event_name, telemetry_dump)
+            .await;
+    })
 }
 
 /// Spawns the telemetry event sender on a new thread to avoid blocking
@@ -258,20 +305,4 @@ fn spawn_telemetry_event_sender(
 #[derive(Deserialize)]
 struct OriginIP {
     origin: String,
-}
-
-/// A useful struct for serialization a telemetry event
-#[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct TelemetryEvent {
-    pub(crate) name: String,
-    pub(crate) params: BTreeMap<String, String>,
-}
-
-/// A useful struct for serializing a telemetry dump
-#[derive(Debug, Serialize, Deserialize)]
-struct TelemetryDump {
-    client_id: String,
-    user_id: String,
-    timestamp_micros: String,
-    events: Vec<TelemetryEvent>,
 }

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -9,6 +9,7 @@ use crate::{
         APTOS_GA_API_SECRET, APTOS_GA_MEASUREMENT_ID, ENV_APTOS_DISABLE_TELEMETRY,
         ENV_GA_API_SECRET, ENV_GA_MEASUREMENT_ID, GA4_URL, HTTPBIN_URL,
         NODE_CORE_METRICS_FREQ_SECS, NODE_NETWORK_METRICS_FREQ_SECS, NODE_SYS_INFO_FREQ_SECS,
+        TELEMETRY_SERVICE_URL,
     },
     core_metrics::create_core_metric_telemetry_event,
     metrics,
@@ -90,7 +91,7 @@ fn fetch_peer_id(node_config: &NodeConfig) -> String {
 
 /// Spawns the dedicated telemetry service that operates periodically
 async fn spawn_telemetry_service(peer_id: String, chain_id: ChainId, node_config: NodeConfig) {
-    let telemetry_sender = TelemetrySender::new(chain_id, &node_config);
+    let telemetry_sender = TelemetrySender::new(TELEMETRY_SERVICE_URL, chain_id, &node_config);
 
     // Send build information once (only on startup)
     send_build_information(

--- a/crates/aptos-telemetry/src/system_information.rs
+++ b/crates/aptos-telemetry/src/system_information.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{service::TelemetryEvent, utils};
+use crate::utils;
 use aptos_infallible::Mutex;
+use aptos_telemetry_service::types::telemetry::TelemetryEvent;
 use once_cell::sync::Lazy;
 use std::collections::BTreeMap;
 use sysinfo::{CpuExt, DiskExt, System, SystemExt};


### PR DESCRIPTION
### Description

This PR implements a sender to send telemetry to the telemetry web service in an authenticated way.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Run in one terminal `cargo run -p aptos-telemetry-service -- -f telemetry-service.yaml`

Run in another terminal: `cargo run -p aptos-node -- --test`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2763)
<!-- Reviewable:end -->
