### PR TITLE
[storage/api] Ensure oldest version provided to users can be queried

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -103,15 +103,12 @@ impl Context {
     }
 
     pub fn get_latest_ledger_info(&self) -> Result<LedgerInfo, Error> {
-        if let Some(oldest_version) = self.db.get_first_txn_version()? {
-            Ok(LedgerInfo::new(
-                &self.chain_id(),
-                &self.get_latest_ledger_info_with_signatures()?,
-                oldest_version,
-            ))
-        } else {
-            return Err(anyhow! {"Failed to retrieve oldest version"}.into());
-        }
+        let oldest_version = self.db.get_first_viable_txn_version()?;
+        Ok(LedgerInfo::new(
+            &self.chain_id(),
+            &self.get_latest_ledger_info_with_signatures()?,
+            oldest_version,
+        ))
     }
 
     // TODO: Add error codes to these errors.

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -94,7 +94,7 @@ pub const NO_OP_STORAGE_PRUNER_CONFIG: StoragePrunerConfig = StoragePrunerConfig
     ledger_prune_window: 0,
     ledger_pruning_batch_size: 10_000,
     state_store_pruning_batch_size: 10_000,
-    user_pruning_window_offset: 2000,
+    user_pruning_window_offset: 0,
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -94,6 +94,7 @@ pub const NO_OP_STORAGE_PRUNER_CONFIG: StoragePrunerConfig = StoragePrunerConfig
     ledger_prune_window: 0,
     ledger_pruning_batch_size: 10_000,
     state_store_pruning_batch_size: 10_000,
+    user_pruning_window_offset: 2000,
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -118,6 +119,8 @@ pub struct StoragePrunerConfig {
     /// Similar to the variable above but for state store pruner. It means the number of stale
     /// nodes to prune a time.
     pub state_store_pruning_batch_size: usize,
+    /// The offset for user pruning window to adjust
+    pub user_pruning_window_offset: u64,
 }
 
 impl StoragePrunerConfig {
@@ -136,6 +139,7 @@ impl StoragePrunerConfig {
             ledger_prune_window: ledger_store_prune_window,
             ledger_pruning_batch_size,
             state_store_pruning_batch_size,
+            user_pruning_window_offset: ledger_store_prune_window / 5,
         }
     }
 }
@@ -162,6 +166,7 @@ impl Default for StorageConfig {
                 // A 10k transaction block (touching 60k state values, in the case of the account
                 // creation benchmark) on a 4B items DB (or 1.33B accounts) yields 300k JMT nodes
                 state_store_pruning_batch_size: 1_000,
+                user_pruning_window_offset: 2_000_000,
             },
             data_dir: PathBuf::from("/opt/aptos/data"),
             // Default read/write/connection timeout, in milliseconds

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -123,27 +123,6 @@ pub struct StoragePrunerConfig {
     pub user_pruning_window_offset: u64,
 }
 
-impl StoragePrunerConfig {
-    pub fn new(
-        enable_state_store_pruner: bool,
-        enable_ledger_pruner: bool,
-        state_store_prune_window: u64,
-        ledger_store_prune_window: u64,
-        ledger_pruning_batch_size: usize,
-        state_store_pruning_batch_size: usize,
-    ) -> Self {
-        StoragePrunerConfig {
-            enable_state_store_pruner,
-            enable_ledger_pruner,
-            state_store_prune_window,
-            ledger_prune_window: ledger_store_prune_window,
-            ledger_pruning_batch_size,
-            state_store_pruning_batch_size,
-            user_pruning_window_offset: ledger_store_prune_window / 5,
-        }
-    }
-}
-
 impl Default for StorageConfig {
     fn default() -> StorageConfig {
         StorageConfig {
@@ -166,7 +145,7 @@ impl Default for StorageConfig {
                 // A 10k transaction block (touching 60k state values, in the case of the account
                 // creation benchmark) on a 4B items DB (or 1.33B accounts) yields 300k JMT nodes
                 state_store_pruning_batch_size: 1_000,
-                user_pruning_window_offset: 2_000_000,
+                user_pruning_window_offset: 200_000,
             },
             data_dir: PathBuf::from("/opt/aptos/data"),
             // Default read/write/connection timeout, in milliseconds

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -40,6 +40,7 @@ impl PrunerOpt {
             ledger_prune_window: self.ledger_prune_window,
             ledger_pruning_batch_size: self.ledger_pruning_batch_size,
             state_store_pruning_batch_size: self.state_store_pruning_batch_size,
+            user_pruning_window_offset: 0,
         }
     }
 }

--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -94,6 +94,7 @@ fn test_error_if_version_is_pruned() {
             ledger_prune_window: 0,
             ledger_pruning_batch_size: 1,
             state_store_pruning_batch_size: 1,
+            user_pruning_window_offset: 0,
         },
     );
 
@@ -106,6 +107,7 @@ fn test_error_if_version_is_pruned() {
             ledger_prune_window: 0,
             ledger_pruning_batch_size: 1,
             state_store_pruning_batch_size: 1,
+            user_pruning_window_offset: 0,
         },
     );
     state_pruner.testonly_update_min_version(5);

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -983,6 +983,13 @@ impl DbReader for AptosDB {
         })
     }
 
+    /// Get the first version that will likely not be pruned soon
+    fn get_first_viable_txn_version(&self) -> Result<Version> {
+        gauged_api("get_first_viable_txn_version", || {
+            Ok(self.ledger_pruner.get_min_viable_version())
+        })
+    }
+
     /// Get the first version that write set starts existent.
     fn get_first_write_set_version(&self) -> Result<Option<Version>> {
         gauged_api("get_first_write_set_version", || {

--- a/storage/aptosdb/src/pruner/event_store/test.rs
+++ b/storage/aptosdb/src/pruner/event_store/test.rs
@@ -67,6 +67,7 @@ fn verify_event_store_pruner(events: Vec<Vec<ContractEvent>>) {
             ledger_prune_window: 0,
             ledger_pruning_batch_size: 1,
             state_store_pruning_batch_size: 100,
+            user_pruning_window_offset: 0,
         },
     );
 

--- a/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
@@ -70,7 +70,7 @@ impl PrunerManager for LedgerPrunerManager {
                 .prune_window
                 .saturating_sub(self.user_pruning_window_offset);
             let adjusted_cutoff = self.latest_version.lock().saturating_sub(adjusted_window);
-            std::cmp::min(min_version, adjusted_cutoff)
+            std::cmp::max(min_version, adjusted_cutoff)
         } else {
             min_version
         }

--- a/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
@@ -46,6 +46,8 @@ pub struct LedgerPrunerManager {
     pruning_batch_size: usize,
     /// latest version
     latest_version: Arc<Mutex<Version>>,
+    /// Offset for displaying to users
+    user_pruning_window_offset: u64,
 }
 
 impl PrunerManager for LedgerPrunerManager {
@@ -62,12 +64,11 @@ impl PrunerManager for LedgerPrunerManager {
     }
 
     fn get_min_viable_version(&self) -> Version {
-        let pruner_window = self.get_pruner_window();
         let min_version = self.get_min_readable_version();
-        let window_cutoff_with_buffer = self
-            .latest_version
-            .lock()
-            .saturating_sub((9 * pruner_window) / 10);
+        let window_cutoff_with_buffer = self.latest_version.lock().saturating_sub(
+            self.prune_window
+                .saturating_sub(self.user_pruning_window_offset),
+        );
         std::cmp::max(min_version, window_cutoff_with_buffer)
     }
 
@@ -181,6 +182,7 @@ impl LedgerPrunerManager {
             last_version_sent_to_pruner: Arc::new(Mutex::new(min_readable_version)),
             pruning_batch_size: storage_pruner_config.ledger_pruning_batch_size,
             latest_version: Arc::new(Mutex::new(min_readable_version)),
+            user_pruning_window_offset: storage_pruner_config.user_pruning_window_offset,
         }
     }
 

--- a/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
@@ -61,6 +61,16 @@ impl PrunerManager for LedgerPrunerManager {
         self.pruner.as_ref().min_readable_version()
     }
 
+    fn get_min_viable_version(&self) -> Version {
+        let pruner_window = self.get_pruner_window();
+        let min_version = self.get_min_readable_version();
+        let window_cutoff_with_buffer = self
+            .latest_version
+            .lock()
+            .saturating_sub((9 * pruner_window) / 10);
+        std::cmp::max(min_version, window_cutoff_with_buffer)
+    }
+
     /// Sends pruning command to the worker thread when necessary.
     fn maybe_wake_pruner(&self, latest_version: Version) {
         *self.latest_version.lock() = latest_version;

--- a/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
@@ -65,11 +65,15 @@ impl PrunerManager for LedgerPrunerManager {
 
     fn get_min_viable_version(&self) -> Version {
         let min_version = self.get_min_readable_version();
-        let window_cutoff_with_buffer = self.latest_version.lock().saturating_sub(
-            self.prune_window
-                .saturating_sub(self.user_pruning_window_offset),
-        );
-        std::cmp::max(min_version, window_cutoff_with_buffer)
+        if self.is_pruner_enabled() {
+            let window_cutoff_with_buffer = self.latest_version.lock().saturating_sub(
+                self.prune_window
+                    .saturating_sub(self.user_pruning_window_offset),
+            );
+            std::cmp::max(min_version, window_cutoff_with_buffer)
+        } else {
+            min_version
+        }
     }
 
     /// Sends pruning command to the worker thread when necessary.

--- a/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner_manager.rs
@@ -66,11 +66,11 @@ impl PrunerManager for LedgerPrunerManager {
     fn get_min_viable_version(&self) -> Version {
         let min_version = self.get_min_readable_version();
         if self.is_pruner_enabled() {
-            let window_cutoff_with_buffer = self.latest_version.lock().saturating_sub(
-                self.prune_window
-                    .saturating_sub(self.user_pruning_window_offset),
-            );
-            std::cmp::max(min_version, window_cutoff_with_buffer)
+            let adjusted_window = self
+                .prune_window
+                .saturating_sub(self.user_pruning_window_offset);
+            let adjusted_cutoff = self.latest_version.lock().saturating_sub(adjusted_window);
+            std::cmp::min(min_version, adjusted_cutoff)
         } else {
             min_version
         }

--- a/storage/aptosdb/src/pruner/pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/pruner_manager.rs
@@ -17,6 +17,8 @@ pub trait PrunerManager: Debug + Sync {
 
     fn get_pruner_window(&self) -> Version;
 
+    fn get_min_viable_version(&self) -> Version;
+
     fn get_min_readable_version(&self) -> Version;
 
     /// Sends pruning command to the worker thread when necessary.

--- a/storage/aptosdb/src/pruner/state_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_pruner_manager.rs
@@ -72,11 +72,15 @@ impl PrunerManager for StatePrunerManager {
 
     fn get_min_viable_version(&self) -> Version {
         let min_version = self.get_min_readable_version();
-        let window_cutoff_with_buffer = self.latest_version.lock().saturating_sub(
-            self.prune_window
-                .saturating_sub(self.user_pruning_window_offset),
-        );
-        std::cmp::max(min_version, window_cutoff_with_buffer)
+        if self.is_pruner_enabled() {
+            let window_cutoff_with_buffer = self.latest_version.lock().saturating_sub(
+                self.prune_window
+                    .saturating_sub(self.user_pruning_window_offset),
+            );
+            std::cmp::max(min_version, window_cutoff_with_buffer)
+        } else {
+            min_version
+        }
     }
 
     /// Sends pruning command to the worker thread when necessary.

--- a/storage/aptosdb/src/pruner/state_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_pruner_manager.rs
@@ -77,7 +77,7 @@ impl PrunerManager for StatePrunerManager {
                 .prune_window
                 .saturating_sub(self.user_pruning_window_offset);
             let adjusted_cutoff = self.latest_version.lock().saturating_sub(adjusted_window);
-            std::cmp::min(min_version, adjusted_cutoff)
+            std::cmp::max(min_version, adjusted_cutoff)
         } else {
             min_version
         }

--- a/storage/aptosdb/src/pruner/state_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_pruner_manager.rs
@@ -73,11 +73,11 @@ impl PrunerManager for StatePrunerManager {
     fn get_min_viable_version(&self) -> Version {
         let min_version = self.get_min_readable_version();
         if self.is_pruner_enabled() {
-            let window_cutoff_with_buffer = self.latest_version.lock().saturating_sub(
-                self.prune_window
-                    .saturating_sub(self.user_pruning_window_offset),
-            );
-            std::cmp::max(min_version, window_cutoff_with_buffer)
+            let adjusted_window = self
+                .prune_window
+                .saturating_sub(self.user_pruning_window_offset);
+            let adjusted_cutoff = self.latest_version.lock().saturating_sub(adjusted_window);
+            std::cmp::min(min_version, adjusted_cutoff)
         } else {
             min_version
         }

--- a/storage/aptosdb/src/pruner/state_pruner_manager.rs
+++ b/storage/aptosdb/src/pruner/state_pruner_manager.rs
@@ -68,6 +68,16 @@ impl PrunerManager for StatePrunerManager {
         self.pruner.as_ref().min_readable_version()
     }
 
+    fn get_min_viable_version(&self) -> Version {
+        let pruner_window = self.get_pruner_window();
+        let min_version = self.get_min_readable_version();
+        let window_cutoff_with_buffer = self
+            .latest_version
+            .lock()
+            .saturating_sub((9 * pruner_window) / 10);
+        std::cmp::max(min_version, window_cutoff_with_buffer)
+    }
+
     /// Sends pruning command to the worker thread when necessary.
     fn maybe_wake_pruner(&self, latest_version: Version) {
         *self.latest_version.lock() = latest_version;

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -86,6 +86,7 @@ fn test_state_store_pruner() {
             ledger_prune_window: 0,
             ledger_pruning_batch_size: prune_batch_size,
             state_store_pruning_batch_size: prune_batch_size,
+            user_pruning_window_offset: 0,
         },
     );
 
@@ -176,6 +177,7 @@ fn test_state_store_pruner_partial_version() {
             ledger_prune_window: 0,
             ledger_pruning_batch_size: prune_batch_size,
             state_store_pruning_batch_size: prune_batch_size,
+            user_pruning_window_offset: 0,
         },
     );
 
@@ -349,6 +351,7 @@ fn test_worker_quit_eagerly() {
                 ledger_prune_window: 1,
                 ledger_pruning_batch_size: 100,
                 state_store_pruning_batch_size: 100,
+                user_pruning_window_offset: 0,
             },
         );
         command_sender

--- a/storage/aptosdb/src/pruner/transaction_store/test.rs
+++ b/storage/aptosdb/src/pruner/transaction_store/test.rs
@@ -62,6 +62,7 @@ fn verify_write_set_pruner(write_sets: Vec<WriteSet>) {
             ledger_prune_window: 0,
             ledger_pruning_batch_size: 1,
             state_store_pruning_batch_size: 100,
+            user_pruning_window_offset: 0,
         },
     );
 
@@ -110,6 +111,7 @@ fn verify_txn_store_pruner(
             ledger_prune_window: 0,
             ledger_pruning_batch_size: 1,
             state_store_pruning_batch_size: 100,
+            user_pruning_window_offset: 0,
         },
     );
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -157,6 +157,13 @@ pub trait DbReader: Send + Sync {
         unimplemented!()
     }
 
+    /// See [AptosDB::get_first_viable_txn_version].
+    ///
+    /// [AptosDB::get_first_viable_txn_version]: ../aptosdb/struct.AptosDB.html#method.get_first_viable_txn_version
+    fn get_first_viable_txn_version(&self) -> Result<Version> {
+        unimplemented!()
+    }
+
     /// See [AptosDB::get_first_write_set_version].
     ///
     /// [AptosDB::get_first_write_set_version]: ../aptosdb/struct.AptosDB.html#method.get_first_write_set_version


### PR DESCRIPTION
### Description
There is a non-zero amount of time between requesting the oldest version
and making a second request to get that information.  This causes issues
where the data is already pruned at that point.  This should ensure that
there's at least a buffer for users.

We can improve the calculation of the buffer at a later time.

### Test Plan
CI :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2768)
<!-- Reviewable:end -->
