### PR TITLE
fix: remove default devnet urls for TS SDK tests

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -15,6 +15,13 @@ const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
 const coinTransferFunction = "0x1::coin::transfer";
 
+test("node url empty", () => {
+  expect(() => {
+    const client = new AptosClient("");
+    client.getAccount("0x1");
+  }).toThrow("Node URL cannot be empty.");
+});
+
 test("gets genesis account", async () => {
   const client = new AptosClient(NODE_URL);
   const genesisAccount = await client.getAccount("0x1");

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -26,6 +26,9 @@ export class AptosClient {
    * @param config Additional configuration options for the generated Axios client.
    */
   constructor(nodeUrl: string, config?: Partial<Gen.OpenAPIConfig>, doNotFixNodeUrl: boolean = false) {
+    if (!nodeUrl) {
+      throw new Error("Node URL cannot be empty.");
+    }
     const conf = config === undefined || config === null ? {} : { ...config };
     if (doNotFixNodeUrl) {
       conf.BASE = nodeUrl;

--- a/ecosystem/typescript/sdk/src/faucet_client.test.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.test.ts
@@ -11,6 +11,13 @@ import { NODE_URL, FAUCET_URL } from "./util.test";
 
 const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
+test("faucet url empty", () => {
+  expect(() => {
+    const faucetClient = new FaucetClient("http://localhost:8080", "");
+    faucetClient.getAccount("0x1");
+  }).toThrow("Faucet URL cannot be empty.");
+});
+
 test(
   "full tutorial faucet flow",
   async () => {

--- a/ecosystem/typescript/sdk/src/faucet_client.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.ts
@@ -22,6 +22,10 @@ export class FaucetClient extends AptosClient {
    */
   constructor(nodeUrl: string, faucetUrl: string, config?: OpenAPIConfig) {
     super(nodeUrl, config);
+
+    if (!faucetUrl) {
+      throw new Error("Faucet URL cannot be empty.");
+    }
     // Build a requester configured to talk to the faucet.
     this.faucetRequester = new AxiosHttpRequest({
       BASE: faucetUrl,

--- a/ecosystem/typescript/sdk/src/util.test.ts
+++ b/ecosystem/typescript/sdk/src/util.test.ts
@@ -3,8 +3,8 @@
 
 import { AptosClient } from "./aptos_client";
 
-export const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com/v1";
-export const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
+export const NODE_URL = process.env.APTOS_NODE_URL;
+export const FAUCET_URL = process.env.APTOS_FAUCET_URL;
 
 test("noop", () => {
   // All TS files are compiled by default into the npm package


### PR DESCRIPTION
### Description
To avoid confusion, we don't default the SDK tests against devnet anymore. Developers and contributors should explicitly provide the node and faucet URLs. 

### Test Plan
Added tests to verify correct messages are thrown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2769)
<!-- Reviewable:end -->
