### PR TITLE
[aptos-cli] Bump CLI version to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "aptos-config",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"


### PR DESCRIPTION
### Description
Bump for the upcoming devnet release
@sherry-x push this when we make a devnet cut.

### Test Plan
None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2770)
<!-- Reviewable:end -->
