### PR TITLE
[gas] revert the default gas numbers back

### DIFF
--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_script_function_payload.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_script_function_payload.json
@@ -185,7 +185,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "0",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -199,7 +199,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x04f1d9fc30e4a767eaae37430f83bf99999f57c589677e4bacce6f1cba3b2d4be49e534bd5ab0c50766a53c529a8ed986045aee884bd3767d61eeedebb79e803"
+      "signature": "0x38eebd8c3cdabfa70a4b55701c7b2be90cd0699b279a1394e18b43068f67f0a971dfce486f0f1b140b7bd8651b2f88ac95d36fdf0335ed89b77973c179b6040e"
     },
     "events": [
       {

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
@@ -198,7 +198,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "12",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -212,7 +212,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0xe4000f3c0c11738bf87c6a7552eb8e9c5131e57720955a4b693c0937b476c1c062040d714f12121bb61e243fe0edcb7d9f510f30b8c3a8d056f470574d1cfe0b"
+      "signature": "0x8d300035e9a7f3978472d6567ebba01f52f604ec139216fabc97991c376967bec5be82095fc269eaf6a1c947a9bad8d2abf77173cb67fb6c96b472e0bbfc6c08"
     },
     "events": [
       {
@@ -429,7 +429,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "13",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -443,7 +443,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x13cbcc64c0c7b8657f69d47d78093e3d940f178e147045af824e61673b95eeb1efdc51d9c49cc1a50de59a03ce24db3c37a282538f4c237db7a21ce77b6d0c0f"
+      "signature": "0xa58db3bce60a42cfacc578168d5796d9dfef32ecb024642f9babd23dc96e8258cdbdaf63fed7e7400eb351727d392d743606ba8380981f0fe16af06ef49aac00"
     },
     "events": [
       {
@@ -660,7 +660,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "14",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -674,7 +674,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x6305cc65b00eaffb966de878934eeb4c38ba3760d306a31adeffca755fb35a1ea5ae016c2351375290ced893870559727709144e5d14c89192a4b76eabcbea0e"
+      "signature": "0x11151ed3ebe76d03b638a68fd56260843bc872c05e5fa312b24b61eb61986a494a17e3ac1078d81a208fa565e9b9fe8877b2d5cf5651b17fe5b275cd7386dd0b"
     },
     "events": [
       {
@@ -891,7 +891,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "15",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -905,7 +905,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x1f14da222683ddd48d6c8d6278a9d85d94c5ecdb531fade78a8be2342ca602d6b95e9febf315395875e8fde99a841a9037729fc41714a10f02bc4e651c6f1100"
+      "signature": "0x86f1402e5182f1bafbfaff5ac8bb56140e6d3ffd659675792f0b43580010e0eb33f8d5307f142bf596ea044e01beea92b34cbe164045169f9a6d80fdf0b8d20d"
     },
     "events": [
       {
@@ -1122,7 +1122,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "16",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1136,7 +1136,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x42bc578d010b1c42a87303294f5588f3f189020c7f9cec45c1114abbbabd36bb918ade84ad967ac20a8a0a8b6b7acbc04f7467c088b2e570cbde5f94b5c2f70f"
+      "signature": "0x561d1eef2cd09aaa1d5776f42a91aab0b1b520d56c94246b50886181bdbcd4eb50179c897ad544ea486d83133b7106029b3ef15bcf5500a448d113de6bd5e80c"
     },
     "events": [
       {
@@ -1353,7 +1353,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "17",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1367,7 +1367,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x9e0c805b066eba7fab96418da864885519f46f21e5a2c6e6a89d1364f72bdd20fd785243699913d5795afc218e7539641bfd6026f6b0748944689ac16b9aa201"
+      "signature": "0xcb1512869c14c14aa015f88577331e15d89d864f196a144c5b9f2a3d174f0a9ec5ecc3dede3d077a65e7440176876a78290b54582adc5b4126b28e788687f005"
     },
     "events": [
       {
@@ -1584,7 +1584,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "18",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1598,7 +1598,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x3fc43f8560e94e8761c69e659155facf4aba431f44cd0b4ad192ea391a3881be1a93740905446d39f24376b440a02e8a63d290c924eb84ec6c564df5f370690a"
+      "signature": "0x1cc4688a0309f1e0ad31caa9f787df2e0f8e7cef8d663bd75bf1806a17f9ae370a8f7e10e22e6870c53ed4babbde6f52572575870e8a7cc10de2e31ad923cf0b"
     },
     "events": [
       {
@@ -1815,7 +1815,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "19",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1829,7 +1829,7 @@
     "signature": {
       "type": "ed25519_signature",
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0xa313c4f766ec0e41a769c21fd7d059929510199e8ac8a7e61252dd4fa2c45390e1cd0a9efcb48065e00dc6a6998b618d7056f03ba6d09097304befa29b4bb805"
+      "signature": "0xaedde14838018ee8c56d30f4d5ffa21bfb26f9512a6ab94614d1f8b0d9d83b9a76220b33918cbd57cc736e3e4ae150b32b0bcf8bf05e514adc194a8f99055a0f"
     },
     "events": [
       {

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_module_payload_bytecode.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_module_payload_bytecode.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -48,7 +48,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x78bf845eb1dc9cebc2361124f87f81a67baa180d5e65131359b82568c44a2c0a73e15f5ddfe43dfac0caa61960a2ec749d43ed746925bd7944679baf2bfbdd05"
+    "signature": "0xd81d745f9595ef481907796ee853a15bb6c0fb4f8c18fcf25fc3461739c00f40cf6da86eb78727ca03390a04360733ae9f31475f45858809e933164444e96d00"
   },
   "events": [],
   "timestamp": "1"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_address.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_address.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -50,7 +50,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x4e4f7c65c9fe8419d5a3f0572b1fd8b7e046ff41f1b612447fcd935683bc0205399fb546fa59bfc4db133a9011e316d742f3dc984aff69c5994306e4350cbf03"
+    "signature": "0x0607e8c7524c32ba89772e0ca634078e127ef253e28a1ae92d4c9d30cef521d7e6181cc5e36c42c53139b08e9abf774c315cba798ce87aa433932bdd5b382303"
   },
   "events": [],
   "timestamp": "1"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_arguments.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_arguments.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -50,7 +50,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x5394355a01cf0e9dd4fe1e32825429f2b208d1a17ee053ed3873aebeb54a7c8ea551b3a3d2035b606f0f4eab126425b9786c1126d8beb9374506e6f907ee9104"
+    "signature": "0x3c35dac714b10a5f491970adea109f1f8fc739e56fa7d66810ac01455639188517ebb4cbdfd3c34e773d6ab637afa1a4817f0882308020ba5dd4f8e32d805907"
   },
   "events": [],
   "timestamp": "1"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_module_name.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_module_name.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -50,7 +50,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x755647fa37ded3161f035bdfd161179edc917085ad6e020f6bcc80dc47aeff22168e7390f6410c85f640632d62acd75df91b74e35ca2e902630c15fdf7d14c0f"
+    "signature": "0xce0f038aee667085097ae3bf9c6da94272a902e20ec63fee415777ebebab03d7463d9426bf9033c6327be504e1aaeb87e244cfd028936204935bde99d4d59c09"
   },
   "events": [],
   "timestamp": "1"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_name.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_name.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -50,7 +50,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x9462a044084b88aea7412052893eb45c28962571e37f9f36cc209b69241cfcc69cef49fe0c6ecc2b52a418dc67d87b1809548ec57dd8b20a1c2d4932b8295709"
+    "signature": "0xa2483d6054aeb114308883f1581a705b240b78567e0780176a9f97a665e9a4b242153f22f75de34558903a50a81eb6c95968626bae95f207a25bbf6006d85600"
   },
   "events": [],
   "timestamp": "1"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_payload_bytecode.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_payload_bytecode.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -48,7 +48,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x0bfa9f63e494724ef8cf3101978632c2742cd78e61d726ac630105c60b18ac11beeb751ca8db7ed32841063770710ed8fdf4fd9494f1bf5479db8663d4a7bc05"
+    "signature": "0x03b95571547a2042f4685974a4f4a6e7188aef8149be2cfb46b0b2f6f41f392cf6b9be21b23c25df6241d0247e1b921efdd7c9d392ecf27e51723a960bfff404"
   },
   "events": [],
   "timestamp": "1"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_missing_script_function_arguments.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_missing_script_function_arguments.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -49,7 +49,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x5ceb809a80133436a76a83be66c898221c19878a3c90cb984592e33cde3e17e8ff241314b39fd93a715706f31f9e256fb0ae0028239dfe4f55283dc378c29306"
+    "signature": "0xbe54dd48c85c7fb517e8f902fcade8d43344fa5053e17bda22d9cb3fb6cfa8a73bd6c510555a4fae04e3951aa68a20e4a0d8c42251fed90e75b321adaeaa8f06"
   },
   "events": [],
   "timestamp": "1"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
@@ -33,7 +33,7 @@
   ],
   "sender": "0x34bf7e2d17674feb234371a7ea58efd715f0e56ba20ebf13789480d9d643afaf",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -50,7 +50,7 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0xd5a781494d2bf1a174ddffde1e02cb8881cff6dab70e61cbdef393deac0ce639",
-    "signature": "0xf07b1cb7279d46ea0f8eb3de1767025ce6ea7bee369cb8123da5160309a63a56987a60db449c9572abb3d776114023aa890e72ebedebc4ab8d3947932cc51a0a"
+    "signature": "0x8eeb6a69f8f2534b378651d3fd2c0428818cb1a87cb305cb87791528be14d47e7573ef1f2a3a7c812a201e152e34a2f662aa7ea950600609d438357032e3e804"
   },
   "events": [],
   "timestamp": "2"

--- a/api/goldens/v0/aptos_api__tests__transactions_test__test_post_bcs_format_transaction.json
+++ b/api/goldens/v0/aptos_api__tests__transactions_test__test_post_bcs_format_transaction.json
@@ -3,7 +3,7 @@
   "hash": "",
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -17,6 +17,6 @@
   "signature": {
     "type": "ed25519_signature",
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x04f1d9fc30e4a767eaae37430f83bf99999f57c589677e4bacce6f1cba3b2d4be49e534bd5ab0c50766a53c529a8ed986045aee884bd3767d61eeedebb79e803"
+    "signature": "0x38eebd8c3cdabfa70a4b55701c7b2be90cd0699b279a1394e18b43068f67f0a971dfce486f0f1b140b7bd8651b2f88ac95d36fdf0335ed89b77973c179b6040e"
   }
 }

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_script_function_payload.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_script_function_payload.json
@@ -184,7 +184,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "0",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -197,7 +197,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x04f1d9fc30e4a767eaae37430f83bf99999f57c589677e4bacce6f1cba3b2d4be49e534bd5ab0c50766a53c529a8ed986045aee884bd3767d61eeedebb79e803",
+      "signature": "0x38eebd8c3cdabfa70a4b55701c7b2be90cd0699b279a1394e18b43068f67f0a971dfce486f0f1b140b7bd8651b2f88ac95d36fdf0335ed89b77973c179b6040e",
       "type": "ed25519_signature"
     },
     "events": [

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_transactions_returns_last_page_when_start_version_is_not_specified.json
@@ -197,7 +197,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "12",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -210,7 +210,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0xe4000f3c0c11738bf87c6a7552eb8e9c5131e57720955a4b693c0937b476c1c062040d714f12121bb61e243fe0edcb7d9f510f30b8c3a8d056f470574d1cfe0b",
+      "signature": "0x8d300035e9a7f3978472d6567ebba01f52f604ec139216fabc97991c376967bec5be82095fc269eaf6a1c947a9bad8d2abf77173cb67fb6c96b472e0bbfc6c08",
       "type": "ed25519_signature"
     },
     "events": [
@@ -428,7 +428,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "13",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -441,7 +441,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x13cbcc64c0c7b8657f69d47d78093e3d940f178e147045af824e61673b95eeb1efdc51d9c49cc1a50de59a03ce24db3c37a282538f4c237db7a21ce77b6d0c0f",
+      "signature": "0xa58db3bce60a42cfacc578168d5796d9dfef32ecb024642f9babd23dc96e8258cdbdaf63fed7e7400eb351727d392d743606ba8380981f0fe16af06ef49aac00",
       "type": "ed25519_signature"
     },
     "events": [
@@ -659,7 +659,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "14",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -672,7 +672,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x6305cc65b00eaffb966de878934eeb4c38ba3760d306a31adeffca755fb35a1ea5ae016c2351375290ced893870559727709144e5d14c89192a4b76eabcbea0e",
+      "signature": "0x11151ed3ebe76d03b638a68fd56260843bc872c05e5fa312b24b61eb61986a494a17e3ac1078d81a208fa565e9b9fe8877b2d5cf5651b17fe5b275cd7386dd0b",
       "type": "ed25519_signature"
     },
     "events": [
@@ -890,7 +890,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "15",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -903,7 +903,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x1f14da222683ddd48d6c8d6278a9d85d94c5ecdb531fade78a8be2342ca602d6b95e9febf315395875e8fde99a841a9037729fc41714a10f02bc4e651c6f1100",
+      "signature": "0x86f1402e5182f1bafbfaff5ac8bb56140e6d3ffd659675792f0b43580010e0eb33f8d5307f142bf596ea044e01beea92b34cbe164045169f9a6d80fdf0b8d20d",
       "type": "ed25519_signature"
     },
     "events": [
@@ -1121,7 +1121,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "16",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1134,7 +1134,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x42bc578d010b1c42a87303294f5588f3f189020c7f9cec45c1114abbbabd36bb918ade84ad967ac20a8a0a8b6b7acbc04f7467c088b2e570cbde5f94b5c2f70f",
+      "signature": "0x561d1eef2cd09aaa1d5776f42a91aab0b1b520d56c94246b50886181bdbcd4eb50179c897ad544ea486d83133b7106029b3ef15bcf5500a448d113de6bd5e80c",
       "type": "ed25519_signature"
     },
     "events": [
@@ -1352,7 +1352,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "17",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1365,7 +1365,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x9e0c805b066eba7fab96418da864885519f46f21e5a2c6e6a89d1364f72bdd20fd785243699913d5795afc218e7539641bfd6026f6b0748944689ac16b9aa201",
+      "signature": "0xcb1512869c14c14aa015f88577331e15d89d864f196a144c5b9f2a3d174f0a9ec5ecc3dede3d077a65e7440176876a78290b54582adc5b4126b28e788687f005",
       "type": "ed25519_signature"
     },
     "events": [
@@ -1583,7 +1583,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "18",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1596,7 +1596,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0x3fc43f8560e94e8761c69e659155facf4aba431f44cd0b4ad192ea391a3881be1a93740905446d39f24376b440a02e8a63d290c924eb84ec6c564df5f370690a",
+      "signature": "0x1cc4688a0309f1e0ad31caa9f787df2e0f8e7cef8d663bd75bf1806a17f9ae370a8f7e10e22e6870c53ed4babbde6f52572575870e8a7cc10de2e31ad923cf0b",
       "type": "ed25519_signature"
     },
     "events": [
@@ -1814,7 +1814,7 @@
     ],
     "sender": "0xa550c18",
     "sequence_number": "19",
-    "max_gas_amount": "4000000",
+    "max_gas_amount": "2000",
     "gas_unit_price": "0",
     "expiration_timestamp_secs": "18446744073709551615",
     "payload": {
@@ -1827,7 +1827,7 @@
     },
     "signature": {
       "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-      "signature": "0xa313c4f766ec0e41a769c21fd7d059929510199e8ac8a7e61252dd4fa2c45390e1cd0a9efcb48065e00dc6a6998b618d7056f03ba6d09097304befa29b4bb805",
+      "signature": "0xaedde14838018ee8c56d30f4d5ffa21bfb26f9512a6ab94614d1f8b0d9d83b9a76220b33918cbd57cc736e3e4ae150b32b0bcf8bf05e514adc194a8f99055a0f",
       "type": "ed25519_signature"
     },
     "events": [

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_module_payload_bytecode.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_module_payload_bytecode.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -46,7 +46,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x78bf845eb1dc9cebc2361124f87f81a67baa180d5e65131359b82568c44a2c0a73e15f5ddfe43dfac0caa61960a2ec749d43ed746925bd7944679baf2bfbdd05",
+    "signature": "0xd81d745f9595ef481907796ee853a15bb6c0fb4f8c18fcf25fc3461739c00f40cf6da86eb78727ca03390a04360733ae9f31475f45858809e933164444e96d00",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_address.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_address.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -48,7 +48,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x4e4f7c65c9fe8419d5a3f0572b1fd8b7e046ff41f1b612447fcd935683bc0205399fb546fa59bfc4db133a9011e316d742f3dc984aff69c5994306e4350cbf03",
+    "signature": "0x0607e8c7524c32ba89772e0ca634078e127ef253e28a1ae92d4c9d30cef521d7e6181cc5e36c42c53139b08e9abf774c315cba798ce87aa433932bdd5b382303",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_arguments.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_arguments.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -48,7 +48,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x5394355a01cf0e9dd4fe1e32825429f2b208d1a17ee053ed3873aebeb54a7c8ea551b3a3d2035b606f0f4eab126425b9786c1126d8beb9374506e6f907ee9104",
+    "signature": "0x3c35dac714b10a5f491970adea109f1f8fc739e56fa7d66810ac01455639188517ebb4cbdfd3c34e773d6ab637afa1a4817f0882308020ba5dd4f8e32d805907",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_module_name.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_module_name.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -48,7 +48,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x755647fa37ded3161f035bdfd161179edc917085ad6e020f6bcc80dc47aeff22168e7390f6410c85f640632d62acd75df91b74e35ca2e902630c15fdf7d14c0f",
+    "signature": "0xce0f038aee667085097ae3bf9c6da94272a902e20ec63fee415777ebebab03d7463d9426bf9033c6327be504e1aaeb87e244cfd028936204935bde99d4d59c09",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_name.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_function_name.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -48,7 +48,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x9462a044084b88aea7412052893eb45c28962571e37f9f36cc209b69241cfcc69cef49fe0c6ecc2b52a418dc67d87b1809548ec57dd8b20a1c2d4932b8295709",
+    "signature": "0xa2483d6054aeb114308883f1581a705b240b78567e0780176a9f97a665e9a4b242153f22f75de34558903a50a81eb6c95968626bae95f207a25bbf6006d85600",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_payload_bytecode.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_invalid_script_payload_bytecode.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -46,7 +46,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x0bfa9f63e494724ef8cf3101978632c2742cd78e61d726ac630105c60b18ac11beeb751ca8db7ed32841063770710ed8fdf4fd9494f1bf5479db8663d4a7bc05",
+    "signature": "0x03b95571547a2042f4685974a4f4a6e7188aef8149be2cfb46b0b2f6f41f392cf6b9be21b23c25df6241d0247e1b921efdd7c9d392ecf27e51723a960bfff404",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_missing_script_function_arguments.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_missing_script_function_arguments.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -47,7 +47,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x5ceb809a80133436a76a83be66c898221c19878a3c90cb984592e33cde3e17e8ff241314b39fd93a715706f31f9e256fb0ae0028239dfe4f55283dc378c29306",
+    "signature": "0xbe54dd48c85c7fb517e8f902fcade8d43344fa5053e17bda22d9cb3fb6cfa8a73bd6c510555a4fae04e3951aa68a20e4a0d8c42251fed90e75b321adaeaa8f06",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_get_txn_execute_failed_by_script_function_validation.json
@@ -32,7 +32,7 @@
   ],
   "sender": "0x34bf7e2d17674feb234371a7ea58efd715f0e56ba20ebf13789480d9d643afaf",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -48,7 +48,7 @@
   },
   "signature": {
     "public_key": "0xd5a781494d2bf1a174ddffde1e02cb8881cff6dab70e61cbdef393deac0ce639",
-    "signature": "0xf07b1cb7279d46ea0f8eb3de1767025ce6ea7bee369cb8123da5160309a63a56987a60db449c9572abb3d776114023aa890e72ebedebc4ab8d3947932cc51a0a",
+    "signature": "0x8eeb6a69f8f2534b378651d3fd2c0428818cb1a87cb305cb87791528be14d47e7573ef1f2a3a7c812a201e152e34a2f662aa7ea950600609d438357032e3e804",
     "type": "ed25519_signature"
   },
   "events": [],

--- a/api/goldens/v1/aptos_api__tests__transactions_test__test_post_bcs_format_transaction.json
+++ b/api/goldens/v1/aptos_api__tests__transactions_test__test_post_bcs_format_transaction.json
@@ -2,7 +2,7 @@
   "hash": "",
   "sender": "0xa550c18",
   "sequence_number": "0",
-  "max_gas_amount": "4000000",
+  "max_gas_amount": "2000",
   "gas_unit_price": "0",
   "expiration_timestamp_secs": "18446744073709551615",
   "payload": {
@@ -15,7 +15,7 @@
   },
   "signature": {
     "public_key": "0x14418f867a0bd6d42abb2daa50cd68a5a869ce208282481f57504f630510d0d3",
-    "signature": "0x04f1d9fc30e4a767eaae37430f83bf99999f57c589677e4bacce6f1cba3b2d4be49e534bd5ab0c50766a53c529a8ed986045aee884bd3767d61eeedebb79e803",
+    "signature": "0x38eebd8c3cdabfa70a4b55701c7b2be90cd0699b279a1394e18b43068f67f0a971dfce486f0f1b140b7bd8651b2f88ac95d36fdf0335ed89b77973c179b6040e",
     "type": "ed25519_signature"
   }
 }

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -20,7 +20,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
             ..Default::default()
         },
         // TODO(Gas): double check if this is correct
-        UnitTestingConfig::default_with_bound(Some(1_000_000)),
+        UnitTestingConfig::default_with_bound(Some(100_000)),
         aptos_test_natives(),
         /* compute_coverage */ false,
         &mut std::io::stdout(),

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use clap::Parser;
 
 // TODO(Gas): double check if this is correct
-pub const DEFAULT_FUNDED_COINS: u64 = 100_000_000;
+pub const DEFAULT_FUNDED_COINS: u64 = 10_000;
 
 /// Command to create a new account on-chain
 ///

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -970,7 +970,7 @@ impl FaucetOptions {
 }
 
 // TODO(Gas): double check if this is correct
-pub const DEFAULT_MAX_GAS: u64 = 4_000_000;
+pub const DEFAULT_MAX_GAS: u64 = 1_000;
 pub const DEFAULT_GAS_UNIT_PRICE: u64 = 1;
 
 /// Gas price options for manipulating how to prioritize transactions

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -203,8 +203,8 @@ mod tests {
         crate::db_generator::run(
             25, /* num_accounts */
             // TODO(Gas): double check if this is correct
-            1_000_000_000, /* init_account_balance */
-            5,             /* block_size */
+            10_000, /* init_account_balance */
+            5,      /* block_size */
             storage_dir.as_ref(),
             NO_OP_STORAGE_PRUNER_CONFIG, /* prune_window */
             true,

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -187,7 +187,7 @@ impl TransactionGenerator {
             .with_transaction_expiration_time(300)
             .with_gas_unit_price(1)
             // TODO(Gas): double check if this is correct
-            .with_max_gas_amount(4_000_000)
+            .with_max_gas_amount(1_000)
     }
 
     // Write metadata

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -82,8 +82,8 @@ pub struct TransactionFactory {
 impl TransactionFactory {
     pub fn new(chain_id: ChainId) -> Self {
         Self {
-            // TODO: double check if this right
-            max_gas_amount: 4_000_000,
+            // TODO(Gas): double check if this right
+            max_gas_amount: 2_000,
             gas_unit_price: 0,
             transaction_expiration_time: 30,
             chain_id,

--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -173,7 +173,7 @@ impl<'t> AptosPublicInfo<'t> {
         TransactionFactory::new(self.chain_id)
             .with_gas_unit_price(1)
             // TODO(Gas): double check if this is correct
-            .with_max_gas_amount(4_000_000)
+            .with_max_gas_amount(1_000)
     }
 
     pub async fn get_balance(&self, address: AccountAddress) -> Option<u64> {

--- a/testsuite/smoke-test/src/aptos/account_creation.rs
+++ b/testsuite/smoke-test/src/aptos/account_creation.rs
@@ -21,7 +21,7 @@ impl AptosTest for AccountCreation {
             let local_account = ctx.random_account();
             ctx.create_user_account(local_account.public_key()).await?;
             // TODO(Gas): double check this
-            ctx.mint(local_account.address(), 10_000_000).await?;
+            ctx.mint(local_account.address(), 10_000).await?;
             accounts.push(local_account);
         }
         // created by user account

--- a/testsuite/smoke-test/src/aptos/gas_check.rs
+++ b/testsuite/smoke-test/src/aptos/gas_check.rs
@@ -35,16 +35,13 @@ impl AptosTest for GasCheck {
         assert!(format!("{:?}", err).contains("INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE"));
 
         // TODO(Gas): double check this
-        ctx.mint(account1.address(), 4_000_000).await?;
-        ctx.mint(account2.address(), 4_000_000).await?;
+        ctx.mint(account1.address(), 1_000).await?;
+        ctx.mint(account2.address(), 1_000).await?;
 
         let transfer_too_much = account2.sign_with_transaction_builder(
             // TODO(Gas): double check this
             ctx.aptos_transaction_factory()
-                .payload(aptos_stdlib::aptos_coin_transfer(
-                    account1.address(),
-                    4_000_000,
-                )),
+                .payload(aptos_stdlib::aptos_coin_transfer(account1.address(), 1_000)),
         );
 
         let err = ctx

--- a/testsuite/smoke-test/src/aptos/mint_transfer.rs
+++ b/testsuite/smoke-test/src/aptos/mint_transfer.rs
@@ -21,7 +21,7 @@ impl AptosTest for MintTransfer {
         ctx.create_user_account(account2.public_key()).await?;
 
         // TODO(Gas): double check this
-        ctx.mint(account1.address(), 100_000_000).await?;
+        ctx.mint(account1.address(), 10_000).await?;
 
         let transfer_txn = account1.sign_with_transaction_builder(
             ctx.aptos_transaction_factory()

--- a/testsuite/smoke-test/src/fullnode.rs
+++ b/testsuite/smoke-test/src/fullnode.rs
@@ -57,7 +57,7 @@ impl LaunchFullnode {
             .create_user_account(account1.public_key())
             .await?;
         // TODO(Gas): double check if this is correct
-        chain_info.mint(account1.address(), 4_000_000).await?;
+        chain_info.mint(account1.address(), 1_000).await?;
         chain_info
             .create_user_account(account2.public_key())
             .await?;

--- a/testsuite/smoke-test/src/indexer.rs
+++ b/testsuite/smoke-test/src/indexer.rs
@@ -147,8 +147,8 @@ impl AptosTest for Indexer {
 
         // Set up accounts, generate some traffic
         // TODO(Gas): double check this
-        let mut account1 = ctx.create_and_fund_user_account(100_000_000).await.unwrap();
-        let account2 = ctx.create_and_fund_user_account(100_000_000).await.unwrap();
+        let mut account1 = ctx.create_and_fund_user_account(50_000).await.unwrap();
+        let account2 = ctx.create_and_fund_user_account(50_000).await.unwrap();
         // This transfer should emit events
         let t_tx = ctx.transfer(&mut account1, &account2, 717).await.unwrap();
         // test NFT creation event indexing

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -38,9 +38,9 @@ impl AptosTest for BasicClient {
         client.get_ledger_information().await?;
 
         // TODO(Gas): double check if this is correct
-        let mut account1 = ctx.create_and_fund_user_account(4_000_000).await?;
+        let mut account1 = ctx.create_and_fund_user_account(10_000).await?;
         // TODO(Gas): double check if this is correct
-        let account2 = ctx.create_and_fund_user_account(4_000_000).await?;
+        let account2 = ctx.create_and_fund_user_account(10_000).await?;
 
         let tx = account1.sign_with_transaction_builder(
             ctx.transaction_factory()

--- a/testsuite/smoke-test/src/transaction.rs
+++ b/testsuite/smoke-test/src/transaction.rs
@@ -35,17 +35,17 @@ impl AptosTest for ExternalTransactionSigner {
         let sender_address = sender_auth_key.derived_address();
         ctx.create_user_account(&public_key).await?;
         // TODO(Gas): double check if this is correct
-        ctx.mint(sender_address, 1_000_000_000).await?;
+        ctx.mint(sender_address, 10_000_000).await?;
 
         let receiver = ctx.random_account();
         ctx.create_user_account(receiver.public_key()).await?;
         // TODO(Gas): double check if this is correct
-        ctx.mint(receiver.address(), 1_000_000_000).await?;
+        ctx.mint(receiver.address(), 1_000_000).await?;
 
         let amount = 1_000_000;
         let test_gas_unit_price = 1;
         // TODO(Gas): double check if this is correct
-        let test_max_gas_amount = 4_000_000;
+        let test_max_gas_amount = 1_000_000;
 
         // prepare transfer transaction
         let test_sequence_number = client


### PR DESCRIPTION
### Description
Previously these numbers were bumped up due to the gas scaling factor not working. Now since that has been fixed, it's time to revert these back to avoid confusion at client side.

### Test Plan
CI

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2771)
<!-- Reviewable:end -->
