### PR TITLE
[forge] resurrect set image tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3680,6 +3680,7 @@ dependencies = [
  "inspection-service",
  "k8s-openapi",
  "kube",
+ "once_cell",
  "prometheus-http-query",
  "rand 0.7.3",
  "rayon",

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -75,7 +75,7 @@ enum TestCommand {
 
 #[derive(StructOpt, Debug)]
 enum OperatorCommand {
-    SetValidator(SetValidator),
+    SetNodeImageTag(SetNodeImageTag),
     CleanUp(CleanUp),
     Resize(Resize),
 }
@@ -95,10 +95,10 @@ struct K8sSwarm {
     image_tag: String,
     #[structopt(
         long,
-        help = "Image tag for validator software to do backward compatibility test",
+        help = "For supported tests, the image tag for validators to upgrade to",
         default_value = "devnet"
     )]
-    base_image_tag: String,
+    upgrade_image_tag: String,
     #[structopt(
         long,
         help = "Path to flattened directory containing compiled Move modules"
@@ -124,9 +124,12 @@ struct K8sSwarm {
 }
 
 #[derive(StructOpt, Debug)]
-struct SetValidator {
-    validator_name: String,
-    #[structopt(long, help = "Override the image tag used for upgrade validators")]
+struct SetNodeImageTag {
+    #[structopt(long, help = "The name of the node StatefulSet to update")]
+    stateful_set_name: String,
+    #[structopt(long, help = "The name of the container to update")]
+    container_name: String,
+    #[structopt(long, help = "The docker image tag to use for the node")]
     image_tag: String,
     #[structopt(long, help = "The kubernetes namespace to clean up")]
     namespace: String,
@@ -234,7 +237,7 @@ fn main() -> Result<()> {
                         K8sFactory::new(
                             k8s.namespace.clone(),
                             k8s.image_tag.clone(),
-                            k8s.base_image_tag.clone(),
+                            k8s.upgrade_image_tag.clone(),
                             k8s.port_forward,
                             k8s.reuse,
                             k8s.keep,
@@ -252,11 +255,15 @@ fn main() -> Result<()> {
         }
         // cmd input for cluster operations
         CliCommand::Operator(op_cmd) => match op_cmd {
-            OperatorCommand::SetValidator(set_validator) => set_validator_image_tag(
-                set_validator.validator_name,
-                set_validator.image_tag,
-                set_validator.namespace,
-            ),
+            OperatorCommand::SetNodeImageTag(set_stateful_set_image_tag_config) => {
+                runtime.block_on(set_stateful_set_image_tag(
+                    set_stateful_set_image_tag_config.stateful_set_name,
+                    set_stateful_set_image_tag_config.container_name,
+                    set_stateful_set_image_tag_config.image_tag,
+                    set_stateful_set_image_tag_config.namespace,
+                ))?;
+                Ok(())
+            }
             OperatorCommand::CleanUp(cleanup) => {
                 if let Some(namespace) = cleanup.namespace {
                     runtime.block_on(uninstall_testnet_resources(namespace))?;
@@ -407,7 +414,11 @@ fn k8s_test_suite() -> ForgeConfig<'static> {
         .with_initial_validator_count(NonZeroUsize::new(30).unwrap())
         .with_aptos_tests(&[&FundAccount, &TransferCoins])
         .with_admin_tests(&[&GetMetadata])
-        .with_network_tests(&[&EmitTransaction, &SimpleValidatorUpgrade])
+        .with_network_tests(&[
+            &EmitTransaction,
+            &SimpleValidatorUpgrade,
+            &PerformanceBenchmark,
+        ])
 }
 
 fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
@@ -418,7 +429,9 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
         "state_sync" => config
             .with_initial_fullnode_count(1)
             .with_network_tests(&[&StateSyncPerformance]),
-        "compat" => config.with_network_tests(&[&SimpleValidatorUpgrade]),
+        "compat" => config
+            .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
+            .with_network_tests(&[&SimpleValidatorUpgrade]),
         "config" => config.with_network_tests(&[&ReconfigurationTest]),
         "network_partition" => config.with_network_tests(&[&NetworkPartitionTest]),
         "network_latency" => config.with_network_tests(&[&NetworkLatencyTest]),

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -18,7 +18,7 @@ spec:
     - -c
     - |
       ulimit -n 1048576
-      forge --suite {FORGE_TEST_SUITE} --duration-secs {FORGE_RUNNER_DURATION_SECS} --avg-tps {FORGE_RUNNER_TPS_THRESHOLD} test k8s-swarm --image-tag {IMAGE_TAG} --namespace {FORGE_NAMESPACE} {REUSE_ARGS} {KEEP_ARGS} {ENABLE_HAPROXY_ARGS}
+      forge --suite {FORGE_TEST_SUITE} --duration-secs {FORGE_RUNNER_DURATION_SECS} --avg-tps {FORGE_RUNNER_TPS_THRESHOLD} test k8s-swarm --image-tag {IMAGE_TAG} --upgrade-image-tag {UPGRADE_IMAGE_TAG} --namespace {FORGE_NAMESPACE} {REUSE_ARGS} {KEEP_ARGS} {ENABLE_HAPROXY_ARGS}
     env:
     - name: FORGE_TRIGGERED_BY
       value: {FORGE_TRIGGERED_BY}

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -20,6 +20,7 @@ hyper = { version = "0.14.18", features = ["full"] }
 hyper-tls = "0.5.0"
 k8s-openapi = { version = "0.11.0", default-features = false, features = ["v1_15"] }
 kube = "0.51.0"
+once_cell = "1.10.0"
 prometheus-http-query = "0.5.2"
 rand = "0.7.3"
 rayon = "1.5.2"

--- a/testsuite/forge/src/backend/k8s/constants.rs
+++ b/testsuite/forge/src/backend/k8s/constants.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+/// A collection of constants and default values for configuring various Forge components.
+
+// These are test keys for forge ephemeral networks. Do not use these elsewhere!
+pub const DEFAULT_ROOT_KEY: &str =
+    "48136DF3174A3DE92AFDB375FFE116908B69FF6FAB9B1410E548A33FEA1D159D";
+pub const DEFAULT_ROOT_PRIV_KEY: &str =
+    "E25708D90C72A53B400B27FC7602C4D546C7B7469FA6E12544F0EBFB2F16AE19";
+
+// binaries expected to be present on test runner
+pub const HELM_BIN: &str = "helm";
+pub const KUBECTL_BIN: &str = "kubectl";
+
+// helm release names and helm chart paths
+pub const APTOS_NODE_HELM_RELEASE_NAME: &str = "aptos-node";
+pub const GENESIS_HELM_RELEASE_NAME: &str = "genesis";
+pub const APTOS_NODE_HELM_CHART_PATH: &str = "terraform/helm/aptos-node";
+pub const GENESIS_HELM_CHART_PATH: &str = "terraform/helm/genesis";
+
+// cleanup namespaces after 30 minutes unless "keep = true"
+pub const NAMESPACE_CLEANUP_THRESHOLD_SECS: u64 = 1800;
+// Leave a buffer of around 20 minutes for test provisioning and cleanup to be done before cleaning
+// up underlying resources.
+pub const NAMESPACE_CLEANUP_DURATION_BUFFER_SECS: u64 = 1200;
+pub const POD_CLEANUP_THRESHOLD_SECS: u64 = 86400;
+pub const MANAGEMENT_CONFIGMAP_PREFIX: &str = "forge-management";
+
+// this is the port on the validator service itself, as opposed to 80 on the validator haproxy service
+pub const NODE_METRIC_PORT: u32 = 9101;
+pub const REST_API_SERVICE_PORT: u32 = 8080;
+pub const REST_API_HAPROXY_SERVICE_PORT: u32 = 80;
+// when we interact with the node over port-forward
+pub const LOCALHOST: &str = "127.0.0.1";
+
+// kubernetes service names
+pub const VALIDATOR_SERVICE_SUFFIX: &str = "validator";
+pub const FULLNODE_SERVICE_SUFFIX: &str = "fullnode";
+pub const VALIDATOR_HAPROXY_SERVICE_SUFFIX: &str = "validator-lb";
+pub const FULLNODE_HAPROXY_SERVICE_SUFFIX: &str = "fullnode-lb";
+pub const HAPROXY_SERVICE_SUFFIX: &str = "lb";

--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-values.yaml
@@ -44,3 +44,6 @@ service:
 labels:
   forge-namespace: {namespace}
   forge-image-tag: {image_tag}
+
+# always assume we're spinning up a testnet and doing genesis rather than using the single validator test mode
+loadTestGenesis: false

--- a/testsuite/forge/src/backend/k8s/kube_api.rs
+++ b/testsuite/forge/src/backend/k8s/kube_api.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use async_trait::async_trait;
+
+use kube::{
+    api::{Api, Meta, PostParams},
+    client::Client as K8sClient,
+    Error as KubeError,
+};
+use serde::{de::DeserializeOwned, Serialize};
+
+// Create kube API wrapper traits such that they are testable
+
+#[derive(Clone)]
+pub struct K8sApi<K> {
+    api: Api<K>,
+}
+
+impl<K> K8sApi<K>
+where
+    K: k8s_openapi::Resource + Send + Sync + Clone + DeserializeOwned + Meta + Serialize,
+{
+    pub fn from_client(kube_client: K8sClient, kube_namespace: Option<String>) -> Self {
+        if let Some(kube_namespace) = kube_namespace {
+            K8sApi {
+                api: Api::namespaced(kube_client, &kube_namespace),
+            }
+        } else {
+            K8sApi {
+                api: Api::all(kube_client),
+            }
+        }
+    }
+}
+
+#[async_trait]
+pub trait Get<K>: Send + Sync {
+    async fn get(&self, name: &str) -> Result<K, KubeError>;
+}
+
+#[async_trait]
+pub trait Create<K>: Send + Sync {
+    async fn create(&self, pp: &PostParams, k: &K) -> Result<K, KubeError>;
+}
+
+#[async_trait]
+impl<K> Get<K> for Api<K>
+where
+    K: k8s_openapi::Resource,
+{
+    async fn get(&self, name: &str) -> Result<K, KubeError> {
+        self.get(name).await
+    }
+}
+
+#[async_trait]
+impl<K> Get<K> for K8sApi<K>
+where
+    K: k8s_openapi::Resource + Send + Sync + Clone + DeserializeOwned + Meta + Serialize,
+{
+    async fn get(&self, name: &str) -> Result<K, KubeError> {
+        self.api.get(name).await
+    }
+}
+
+#[async_trait]
+impl<K> Create<K> for Api<K>
+where
+    K: k8s_openapi::Resource + Send + Sync + Clone + DeserializeOwned + Meta + Serialize,
+{
+    async fn create(&self, pp: &PostParams, k: &K) -> Result<K, KubeError> {
+        self.create(pp, k).await
+    }
+}
+
+#[async_trait]
+impl<K> Create<K> for K8sApi<K>
+where
+    K: k8s_openapi::Resource + Send + Sync + Clone + DeserializeOwned + Meta + Serialize,
+{
+    async fn create(&self, pp: &PostParams, k: &K) -> Result<K, KubeError> {
+        self.api.create(pp, k).await
+    }
+}

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -10,12 +10,18 @@ use std::{convert::TryInto, num::NonZeroUsize};
 
 pub mod chaos;
 mod cluster_helper;
+pub mod constants;
+pub mod kube_api;
 pub mod node;
 pub mod prometheus;
+mod stateful_set;
 mod swarm;
 
 pub use cluster_helper::*;
+pub use constants::*;
+pub use kube_api::*;
 pub use node::K8sNode;
+pub use stateful_set::*;
 pub use swarm::*;
 
 use aptos_sdk::crypto::ed25519::ED25519_PRIVATE_KEY_LENGTH;
@@ -23,7 +29,7 @@ use aptos_sdk::crypto::ed25519::ED25519_PRIVATE_KEY_LENGTH;
 pub struct K8sFactory {
     root_key: [u8; ED25519_PRIVATE_KEY_LENGTH],
     image_tag: String,
-    base_image_tag: String,
+    upgrade_image_tag: String,
     kube_namespace: String,
     use_port_forward: bool,
     reuse: bool,
@@ -31,17 +37,11 @@ pub struct K8sFactory {
     enable_haproxy: bool,
 }
 
-// These are test keys for forge ephemeral networks. Do not use these elsewhere!
-pub const DEFAULT_ROOT_KEY: &str =
-    "48136DF3174A3DE92AFDB375FFE116908B69FF6FAB9B1410E548A33FEA1D159D";
-const DEFAULT_ROOT_PRIV_KEY: &str =
-    "E25708D90C72A53B400B27FC7602C4D546C7B7469FA6E12544F0EBFB2F16AE19";
-
 impl K8sFactory {
     pub fn new(
         kube_namespace: String,
         image_tag: String,
-        base_image_tag: String,
+        upgrade_image_tag: String,
         use_port_forward: bool,
         reuse: bool,
         keep: bool,
@@ -68,7 +68,7 @@ impl K8sFactory {
         Ok(Self {
             root_key,
             image_tag,
-            base_image_tag,
+            upgrade_image_tag,
             kube_namespace,
             use_port_forward,
             reuse,
@@ -82,8 +82,8 @@ impl K8sFactory {
 impl Factory for K8sFactory {
     fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a> {
         let version = vec![
-            Version::new(0, self.base_image_tag.clone()),
-            Version::new(1, self.image_tag.clone()),
+            Version::new(0, self.image_tag.clone()),
+            Version::new(1, self.upgrade_image_tag.clone()),
         ];
         Box::new(version.into_iter())
     }
@@ -153,7 +153,7 @@ impl Factory for K8sFactory {
         let swarm = K8sSwarm::new(
             &self.root_key,
             &self.image_tag,
-            &self.base_image_tag,
+            &self.upgrade_image_tag,
             &self.kube_namespace,
             validators,
             fullnodes,

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -3,7 +3,8 @@
 
 use crate::{
     get_free_port, scale_stateful_set_replicas, FullNode, HealthCheckError, Node, NodeExt, Result,
-    Validator, Version, KUBECTL_BIN,
+    Validator, Version, KUBECTL_BIN, LOCALHOST, NODE_METRIC_PORT, REST_API_HAPROXY_SERVICE_PORT,
+    REST_API_SERVICE_PORT,
 };
 use anyhow::{anyhow, format_err};
 use aptos_config::config::NodeConfig;
@@ -19,15 +20,6 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-
-const NODE_METRIC_PORT: u32 = 9101;
-
-// this is the port on the validator service itself, as opposed to 80 on the validator haproxy service
-pub const REST_API_SERVICE_PORT: u32 = 8080;
-pub const REST_API_HAPROXY_SERVICE_PORT: u32 = 80;
-
-// when we interact with the node over port-forward
-const LOCALHOST: &str = "127.0.0.1";
 
 pub struct K8sNode {
     pub(crate) name: String,
@@ -129,40 +121,12 @@ impl K8sNode {
 
 #[async_trait::async_trait]
 impl Node for K8sNode {
-    fn peer_id(&self) -> PeerId {
-        self.peer_id
-    }
-
     fn name(&self) -> &str {
         &self.name
     }
 
-    fn version(&self) -> Version {
-        self.version.clone()
-    }
-
-    fn rest_api_endpoint(&self) -> Url {
-        let host = if self.port_forward_enabled {
-            LOCALHOST
-        } else {
-            &self.service_name
-        };
-        Url::from_str(&format!("http://{}:{}/v1", host, self.rest_api_port()))
-            .expect("Invalid URL.")
-    }
-
-    // TODO: verify this still works
-    fn inspection_service_endpoint(&self) -> Url {
-        Url::parse(&format!(
-            "http://{}:{}",
-            &self.service_name(),
-            self.rest_api_port()
-        ))
-        .unwrap()
-    }
-
-    fn config(&self) -> &NodeConfig {
-        todo!()
+    fn peer_id(&self) -> PeerId {
+        self.peer_id
     }
 
     async fn start(&mut self) -> Result<()> {
@@ -182,6 +146,20 @@ impl Node for K8sNode {
         scale_stateful_set_replicas(self.stateful_set_name(), self.namespace(), 0).await
     }
 
+    fn version(&self) -> Version {
+        self.version.clone()
+    }
+
+    fn rest_api_endpoint(&self) -> Url {
+        let host = if self.port_forward_enabled {
+            LOCALHOST
+        } else {
+            &self.service_name
+        };
+        Url::from_str(&format!("http://{}:{}/v1", host, self.rest_api_port()))
+            .expect("Invalid URL.")
+    }
+
     fn clear_storage(&mut self) -> Result<()> {
         let sts_name = self.stateful_set_name.clone();
         let pvc_name = if sts_name.contains("fullnode") {
@@ -191,7 +169,7 @@ impl Node for K8sNode {
         };
         let delete_pvc_args = ["delete", "pvc", &pvc_name];
         info!("{:?}", delete_pvc_args);
-        let cleanup_output = Command::new("kubectl")
+        let cleanup_output = Command::new(KUBECTL_BIN)
             .stdout(Stdio::inherit())
             .args(&delete_pvc_args)
             .output()
@@ -205,14 +183,8 @@ impl Node for K8sNode {
         Ok(())
     }
 
-    async fn health_check(&mut self) -> Result<(), HealthCheckError> {
-        self.rest_client()
-            .get_ledger_information()
-            .await
-            .map(|_| ())
-            .map_err(|e| {
-                HealthCheckError::Failure(format_err!("K8s node health_check failed: {}", e))
-            })
+    fn config(&self) -> &NodeConfig {
+        todo!()
     }
 
     // TODO: replace this with prometheus query?
@@ -244,6 +216,26 @@ impl Node for K8sNode {
         self.port_forward(port, NODE_METRIC_PORT)?;
 
         Ok(port as u64)
+    }
+
+    async fn health_check(&mut self) -> Result<(), HealthCheckError> {
+        self.rest_client()
+            .get_ledger_information()
+            .await
+            .map(|_| ())
+            .map_err(|e| {
+                HealthCheckError::Failure(format_err!("K8s node health_check failed: {}", e))
+            })
+    }
+
+    // TODO: verify this still works
+    fn inspection_service_endpoint(&self) -> Url {
+        Url::parse(&format!(
+            "http://{}:{}",
+            &self.service_name(),
+            self.rest_api_port()
+        ))
+        .unwrap()
     }
 }
 

--- a/testsuite/forge/src/backend/k8s/stateful_set.rs
+++ b/testsuite/forge/src/backend/k8s/stateful_set.rs
@@ -1,0 +1,406 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{Get, K8sApi, Result, KUBECTL_BIN};
+use std::{process::Command, sync::Arc, time::Duration};
+
+use anyhow::bail;
+use aptos_retrier::ExponentWithLimitDelay;
+use k8s_openapi::api::{apps::v1::StatefulSet, core::v1::Pod};
+
+use again::RetryPolicy;
+use aptos_logger::info;
+use kube::{
+    api::{Api, Meta, Patch, PatchParams},
+    client::Client as K8sClient,
+};
+use thiserror::Error;
+
+use crate::create_k8s_client;
+
+#[derive(Error, Debug)]
+#[error("{0}")]
+enum WorkloadScalingError {
+    RetryableError(String),
+    FinalError(String),
+}
+
+pub struct KubeImage {
+    pub name: String,
+    pub tag: String,
+}
+
+pub fn get_stateful_set_image(stateful_set: &StatefulSet) -> Result<KubeImage> {
+    let s = stateful_set
+        .spec
+        .as_ref()
+        .expect("Failed to get StatefulSet spec")
+        .template
+        .spec
+        .as_ref()
+        .expect("Failed to get StatefulSet pod spec")
+        .containers[0]
+        .image
+        .as_ref()
+        .expect("Failed to get StatefulSet image")
+        .split(':')
+        .collect::<Vec<&str>>();
+
+    Ok(KubeImage {
+        name: s[0].to_string(),
+        tag: s[1].to_string(),
+    })
+}
+
+/// Waits for a single K8s StatefulSet to be ready
+pub async fn wait_stateful_set(
+    kube_client: &K8sClient,
+    kube_namespace: &str,
+    sts_name: &str,
+    desired_replicas: u64,
+    retry_policy: RetryPolicy,
+) -> Result<()> {
+    let stateful_set_api = Arc::new(K8sApi::<StatefulSet>::from_client(
+        kube_client.clone(),
+        Some(kube_namespace.to_string()),
+    ));
+    let pod_api = Arc::new(K8sApi::<Pod>::from_client(
+        kube_client.clone(),
+        Some(kube_namespace.to_string()),
+    ));
+    retry_policy
+        .retry_if(
+            move || {
+                check_stateful_set_status(
+                    stateful_set_api.clone(),
+                    pod_api.clone(),
+                    sts_name,
+                    desired_replicas,
+                )
+            },
+            |e: &WorkloadScalingError| matches!(e, WorkloadScalingError::RetryableError(_)),
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Checks the status of a single K8s StatefulSet. Also inspects the pods to make sure they are all ready.
+async fn check_stateful_set_status(
+    stateful_set_api: Arc<dyn Get<StatefulSet>>,
+    pod_api: Arc<dyn Get<Pod>>,
+    sts_name: &str,
+    desired_replicas: u64,
+) -> Result<(), WorkloadScalingError> {
+    match stateful_set_api.get(sts_name).await {
+        Ok(s) => {
+            let sts_name = &s.name();
+            // get the StatefulSet status
+            if let Some(sts_status) = s.status {
+                let ready_replicas = sts_status.ready_replicas.unwrap_or(0) as u64;
+                let replicas = sts_status.replicas as u64;
+                if ready_replicas == replicas && replicas == desired_replicas {
+                    info!(
+                        "StatefulSet {} has scaled to {}",
+                        sts_name, desired_replicas
+                    );
+                    return Ok(());
+                }
+                info!(
+                    "StatefulSet {} has {}/{} replicas",
+                    sts_name, ready_replicas, desired_replicas
+                );
+            }
+            let pod_name = format!("{}-0", sts_name);
+            // Get the StatefulSet's Pod status
+            if let Some(status) = pod_api
+                .get(&pod_name)
+                .await
+                .map_err(|e| WorkloadScalingError::RetryableError(e.to_string()))?
+                .status
+            {
+                if let Some(container_statuses) = status.container_statuses {
+                    if let Some(container_status) = container_statuses.last() {
+                        if let Some(state) = &container_status.state {
+                            if let Some(waiting) = &state.waiting {
+                                if let Some(waiting_reason) = &waiting.reason {
+                                    match waiting_reason.as_str() {
+                                        "ImagePullBackOff" => {
+                                            info!("Pod {} has ImagePullBackOff", &pod_name);
+                                            return Err(WorkloadScalingError::FinalError(
+                                                "ImagePullBackOff".to_string(),
+                                            ));
+                                        }
+                                        "CrashLoopBackOff" => {
+                                            info!("Pod {} has CrashLoopBackOff", &pod_name);
+                                            return Err(WorkloadScalingError::FinalError(
+                                                "CrashLoopBackOff".to_string(),
+                                            ));
+                                        }
+                                        "ErrImagePull" => {
+                                            info!("Pod {} has ErrImagePull", &pod_name);
+                                            return Err(WorkloadScalingError::FinalError(
+                                                "ErrImagePull".to_string(),
+                                            ));
+                                        }
+                                        _ => {
+                                            info!("Waiting for pod {}", &pod_name);
+                                            return Err(WorkloadScalingError::RetryableError(
+                                                format!("Waiting for pod {}", &pod_name),
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                if let Some(phase) = status.phase.as_ref() {
+                    info!("Pod {} at phase {}", &pod_name, phase)
+                }
+                return Err(WorkloadScalingError::RetryableError(format!(
+                    "Retry due to pod {} status",
+                    &pod_name
+                )));
+            } else {
+                return Err(WorkloadScalingError::FinalError(format!(
+                    "Pod {} status not found",
+                    &pod_name
+                )));
+            }
+        }
+        Err(e) => {
+            info!("Failed to get StatefulSet: {}", e);
+            return Err(WorkloadScalingError::RetryableError(format!(
+                "Failed to get StatefulSet: {}",
+                e
+            )));
+        }
+    }
+}
+
+/// Given the name of a node's StatefulSet, sets the node's image tag. Assumes that the StatefulSet has only one container
+/// Note that this function will not wait for the StatefulSet to be ready.
+pub async fn set_stateful_set_image_tag(
+    stateful_set_name: String,
+    container_name: String,
+    image_tag: String,
+    kube_namespace: String,
+) -> Result<()> {
+    let kube_client: K8sClient = create_k8s_client().await;
+    let sts_api: Api<StatefulSet> = Api::namespaced(kube_client.clone(), &kube_namespace);
+    let sts = sts_api.get(&stateful_set_name).await?;
+    let image_repo = get_stateful_set_image(&sts)?.name;
+
+    // replace the image tag
+    let new_image = format!("{}:{}", &image_repo, &image_tag);
+
+    // set the image using kubectl
+    // patching the node spec may not work
+    Command::new(KUBECTL_BIN)
+        .args([
+            "-n",
+            &kube_namespace,
+            "set",
+            "image",
+            &format!("statefulset/{}", &stateful_set_name),
+            &format!("{}={}", &container_name, &new_image),
+        ])
+        .status()
+        .expect("Failed to set image for StatefulSet");
+
+    Ok(())
+}
+
+/// Scales the given StatefulSet to the given number of replicas
+pub async fn scale_stateful_set_replicas(
+    sts_name: &str,
+    kube_namespace: &str,
+    replica_num: u64,
+) -> Result<()> {
+    let kube_client = create_k8s_client().await;
+    let stateful_set_api: Api<StatefulSet> = Api::namespaced(kube_client.clone(), kube_namespace);
+    let pp = PatchParams::apply("forge").force();
+    let patch = serde_json::json!({
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "metadata": {
+            "name": sts_name,
+        },
+        "spec": {
+            "replicas": replica_num,
+        }
+    });
+    let patch = Patch::Apply(&patch);
+    stateful_set_api.patch(sts_name, &pp, &patch).await?;
+    // retry for ~5 min at a fixed interval
+    let retry_policy = RetryPolicy::fixed(Duration::from_secs(10)).with_max_retries(6 * 5);
+    wait_stateful_set(
+        &kube_client,
+        kube_namespace,
+        sts_name,
+        replica_num,
+        retry_policy,
+    )
+    .await?;
+
+    Ok(())
+}
+
+pub async fn check_for_container_restart(
+    kube_client: &K8sClient,
+    kube_namespace: &str,
+    sts_name: &str,
+) -> Result<()> {
+    aptos_retrier::retry_async(
+        ExponentWithLimitDelay::new(1000, 10 * 1000, 60 * 1000),
+        || {
+            let pod_api: Api<Pod> = Api::namespaced(kube_client.clone(), kube_namespace);
+            Box::pin(async move {
+                // Get the StatefulSet's Pod status
+                return if let Some(status) = pod_api
+                    .get_status(format!("{}-0", sts_name).as_str())
+                    .await?
+                    .status
+                {
+                    if let Some(container_statuses) = status.container_statuses {
+                        for container_status in container_statuses {
+                            if container_status.restart_count > 0 {
+                                bail!(
+                                    "Container {} restarted {} times ",
+                                    container_status.name,
+                                    container_status.restart_count
+                                );
+                            }
+                        }
+                        return Ok(());
+                    }
+                    // In case of no restarts, k8 apis returns no container statuses
+                    Ok(())
+                } else {
+                    bail!("Can't query the pod status for {}", sts_name)
+                };
+            })
+        },
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use k8s_openapi::api::apps::v1::StatefulSet;
+    use k8s_openapi::api::apps::v1::{StatefulSetSpec, StatefulSetStatus};
+    use k8s_openapi::api::core::v1::{
+        ContainerState, ContainerStateWaiting, ContainerStatus, PodStatus,
+    };
+    use kube::{api::ObjectMeta, Error as KubeError};
+
+    struct MockStatefulSetApi {
+        stateful_set: StatefulSet,
+    }
+
+    impl MockStatefulSetApi {
+        fn from_stateful_set(stateful_set: StatefulSet) -> Self {
+            MockStatefulSetApi { stateful_set }
+        }
+    }
+
+    #[async_trait]
+    impl Get<StatefulSet> for MockStatefulSetApi {
+        async fn get(&self, _name: &str) -> Result<StatefulSet, KubeError> {
+            Ok(self.stateful_set.clone())
+        }
+    }
+
+    struct MockPodApi {
+        pod: Pod,
+    }
+
+    impl MockPodApi {
+        fn from_pod(pod: Pod) -> Self {
+            MockPodApi { pod }
+        }
+    }
+
+    #[async_trait]
+    impl Get<Pod> for MockPodApi {
+        async fn get(&self, _name: &str) -> Result<Pod, KubeError> {
+            Ok(self.pod.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_stateful_set_status() {
+        // mock a StatefulSet with 0/1 replicas
+        // this should then mean we check the underlying pod to see what's up
+        let stateful_set_api = Arc::new(MockStatefulSetApi::from_stateful_set(StatefulSet {
+            metadata: ObjectMeta {
+                name: Some("test-stateful-set".to_string()),
+                ..ObjectMeta::default()
+            },
+            spec: Some(StatefulSetSpec {
+                replicas: Some(1),
+                ..StatefulSetSpec::default()
+            }),
+            status: Some(StatefulSetStatus {
+                replicas: 1,
+                ready_replicas: Some(0),
+                ..StatefulSetStatus::default()
+            }),
+        }));
+
+        // we should retry if the pod status is not explicitly bad
+        let pod_default_api = Arc::new(MockPodApi::from_pod(Pod {
+            status: Some(PodStatus::default()),
+            ..Pod::default()
+        }));
+        let ret = check_stateful_set_status(
+            stateful_set_api.clone(),
+            pod_default_api.clone(),
+            "test-stateful-set",
+            1,
+        )
+        .await;
+        assert!(matches!(
+            ret.err(),
+            Some(WorkloadScalingError::RetryableError(_))
+        ));
+
+        // the pod explicitly has a bad status, so we should fail fast
+        let pod_default_api = Arc::new(MockPodApi::from_pod(Pod {
+            metadata: ObjectMeta {
+                name: Some("test-stateful-set-0".to_string()),
+                ..ObjectMeta::default()
+            },
+            status: Some(PodStatus {
+                container_statuses: Some(vec![ContainerStatus {
+                    name: "test-container".to_string(),
+                    restart_count: 0,
+                    state: Some(ContainerState {
+                        waiting: Some(ContainerStateWaiting {
+                            reason: Some("CrashLoopBackOff".to_string()),
+                            ..ContainerStateWaiting::default()
+                        }),
+                        ..ContainerState::default()
+                    }),
+                    ..ContainerStatus::default()
+                }]),
+                ..PodStatus::default()
+            }),
+            ..Pod::default()
+        }));
+        let ret = check_stateful_set_status(
+            stateful_set_api.clone(),
+            pod_default_api.clone(),
+            "test-stateful-set",
+            1,
+        )
+        .await;
+        assert!(matches!(
+            ret.err(),
+            Some(WorkloadScalingError::FinalError(_))
+        ));
+    }
+}

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -433,7 +433,7 @@ impl Swarm for LocalSwarm {
             .map(|v| v as &mut dyn Validator)
     }
 
-    fn upgrade_validator(&mut self, id: PeerId, version: &Version) -> Result<()> {
+    async fn upgrade_validator(&mut self, id: PeerId, version: &Version) -> Result<()> {
         let version = self
             .versions
             .get(version)

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -34,7 +34,7 @@ pub trait Swarm: Sync {
     fn validator_mut(&mut self, id: PeerId) -> Option<&mut dyn Validator>;
 
     /// Upgrade a Validator to run specified `Version`
-    fn upgrade_validator(&mut self, id: PeerId, version: &Version) -> Result<()>;
+    async fn upgrade_validator(&mut self, id: PeerId, version: &Version) -> Result<()>;
 
     /// Returns an Iterator of references to all the FullNodes in the Swarm
     fn full_nodes<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn FullNode> + 'a>;

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -201,7 +201,7 @@ impl<'cfg> Default for ForgeConfig<'cfg> {
             network_tests: &[],
             initial_validator_count: NonZeroUsize::new(1).unwrap(),
             initial_fullnode_count: 0,
-            initial_version: InitialVersion::Newest,
+            initial_version: InitialVersion::Oldest,
             genesis_config: None,
         }
     }

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -164,6 +164,9 @@ HUMIO_LOGS_LINK="https://cloud.us.humio.com/k8s/search?query=%24forgeLogs%28vali
 
 # set the image tag in IMAGE_TAG
 set_image_tag
+if [ -z "$UPGRADE_IMAGE_TAG" ]; then
+    UPGRADE_IMAGE_TAG=$IMAGE_TAG
+fi
 
 # set the o11y resource locations in
 # ES_DEFAULT_INDEX, ES_BASE_URL, GRAFANA_BASE_URL
@@ -198,6 +201,7 @@ if [ "$FORGE_RUNNER_MODE" = "local" ]; then
         --max-latency-ms $LOCAL_P99_LATENCY_MS_THRESHOLD --duration-secs $FORGE_RUNNER_DURATION_SECS \
         test k8s-swarm \
         --image-tag $IMAGE_TAG \
+        --upgrade-image-tag $UPGRADE_IMAGE_TAG \
         --namespace $FORGE_NAMESPACE \
         --port-forward $REUSE_ARGS $KEEP_ARGS $ENABLE_HAPROXY_ARGS | tee $FORGE_OUTPUT
 
@@ -227,6 +231,7 @@ elif [ "$FORGE_RUNNER_MODE" = "k8s" ]; then
         -e "s/{FORGE_RUNNER_DURATION_SECS}/${FORGE_RUNNER_DURATION_SECS}/g" \
         -e "s/{FORGE_RUNNER_TPS_THRESHOLD}/${FORGE_RUNNER_TPS_THRESHOLD}/g" \
         -e "s/{IMAGE_TAG}/${IMAGE_TAG}/g" \
+        -e "s/{UPGRADE_IMAGE_TAG}/${UPGRADE_IMAGE_TAG}/g" \
         -e "s/{AWS_ACCOUNT_NUM}/${AWS_ACCOUNT_NUM}/g" \
         -e "s/{AWS_REGION}/${AWS_REGION}/g" \
         -e "s/{FORGE_NAMESPACE}/${FORGE_NAMESPACE}/g" \

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -27,7 +27,7 @@ async fn batch_update(
     version: &Version,
 ) -> Result<()> {
     for validator in validators_to_update {
-        ctx.swarm().upgrade_validator(*validator, version)?;
+        ctx.swarm().upgrade_validator(*validator, version).await?;
     }
 
     ctx.swarm().health_check().await?;


### PR DESCRIPTION
### Description

Give Forge k8s the ability to upgrade validator StatefulSet image tags, which lets us write tests that roll out a new image tag upgrade across the cluster, while maintaining backwards compatibility.

#### Set image tags
Give Forge k8s the ability to upgrade validator StatefulSet image tags. This can be invoked via a a test or via the command line. For example, you can now do:

```
$ cargo run -p forge-cli -- operator set-node-image-tag \
  --image-tag 5da07eed1df564a0b28b1183a6ea32515b9af16e \
  --namespace forge-rustielin \
  --stateful-set-name aptos-node-28-validator \
  --container-name validator
```

Under the hood, we're just invoking `kubectl set image`, and then running a healthcheck against the node.

#### Compat test 

Also bring back the `compat` test, which runs with a lower number of validators (5), since this test is only for validating correctness. The test performs validator upgrades in this order, generating txn traffic between each step:
* spin up the network as version A
* upgrade 1 validator to version B
* upgrade half to version B
* upgrade rest to version B

Note that because network configuration is done outside of tests themselves, the `forge-cli` now has `--upgrade-image-tag` in addition to `--image-tag`

#### StatefulSet Cleanup

Also move a bunch of kube StatefulSet helper functions to a separate file `stateful_set.rs`, as `cluster_helper.rs` was getting bloated and hard to read. Improves the logs and errors in all the logic that waits on StatefulSets too. For example, we will now fail-fast if we see `ImagePullBackoff`, `CrashLoopBackOff`, etc.

### Test Plan

Run Forge locally:

```
$ IMAGE_TAG=daab3b690cd4a4f49bf73a13e85659d695c90f51 BASE_IMAGE_TAG=a8910fff6a9bd485fdeff12cfa6fd694e6ab61ba \
  FORGE_NAMESPACE=forge-rustielin FORGE_TEST_SUITE=compat \
  FORGE_NAMESPACE_KEEP=true FORGE_RUNNER_MODE=local ./testsuite/run_forge.sh
...
...
Compatibility test results for daab3b690cd4a4f49bf73a13e85659d695c90f51 ==> daab3b690cd4a4f49bf73a13e85659d695c90f51 (PR)
1. Check liveness of validators at old version: daab3b690cd4a4f49bf73a13e85659d695c90f51
compatibility::simple-validator-upgrade::liveness-check : 2577 TPS, 1087 ms latency, 1400 ms p99 latency,no expired txns
2. Upgrading first Validator to new version: daab3b690cd4a4f49bf73a13e85659d695c90f51
compatibility::simple-validator-upgrade::single-validator-upgrade : 2788 TPS, 1043 ms latency, 1050 ms p99 latency,no expired txns
3. Upgrading rest of first batch to new version: daab3b690cd4a4f49bf73a13e85659d695c90f51
compatibility::simple-validator-upgrade::half-validator-upgrade : 2785 TPS, 1218 ms latency, 3100 ms p99 latency,no expired txns
4. upgrading second batch to new version: daab3b690cd4a4f49bf73a13e85659d695c90f51
compatibility::simple-validator-upgrade::rest-validator-upgrade : 2836 TPS, 1037 ms latency, 1050 ms p99 latency,no expired txns
5. check swarm health
Compatibility test for daab3b690cd4a4f49bf73a13e85659d695c90f51 ==> daab3b690cd4a4f49bf73a13e85659d695c90f51 passed
```

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2772)
<!-- Reviewable:end -->
