### PR TITLE
[tf][aws] increase root volume size

### DIFF
--- a/terraform/aptos-node/aws/cluster.tf
+++ b/terraform/aptos-node/aws/cluster.tf
@@ -65,6 +65,16 @@ resource "aws_launch_template" "nodes" {
     })
   )
 
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      delete_on_termination = true
+      volume_size           = 100
+      volume_type           = "gp3"
+    }
+  }
+
   tag_specifications {
     resource_type = "instance"
     tags = merge(local.default_tags, {

--- a/terraform/modules/eks/cluster.tf
+++ b/terraform/modules/eks/cluster.tf
@@ -55,11 +55,21 @@ resource "aws_launch_template" "nodes" {
   for_each      = local.pools
   name          = "aptos-${local.workspace_name}/${each.key}"
   instance_type = each.value.instance_type
-  user_data     = base64encode(
+  user_data = base64encode(
     templatefile("${path.module}/templates/eks_user_data.sh", {
       taints = each.value.taint ? "aptos/nodepool=${each.key}:NoExecute" : ""
     })
   )
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+
+    ebs {
+      delete_on_termination = true
+      volume_size           = 100
+      volume_type           = "gp3"
+    }
+  }
 
   tag_specifications {
     resource_type = "instance"


### PR DESCRIPTION
### Description

Increase the default EKS worker node root volume size. We are running out of space when pulling large docker images

### Test Plan

Apply to a test cluster and inspect the volume size: 
<img width="906" alt="image" src="https://user-images.githubusercontent.com/12578616/184041783-705dc419-18ca-4e2a-a3ed-6d1f122e51da.png">


<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2776)
<!-- Reviewable:end -->
