### PR TITLE
[API] Log per-endpoint metrics based on operation_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6900,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "poem"
 version = "1.3.37"
-source = "git+https://github.com/poem-web/poem?rev=5c6134800756d40256d49b274ce3215da8fa3839#5c6134800756d40256d49b274ce3215da8fa3839"
+source = "git+https://github.com/poem-web/poem?rev=f39eba95cbfb52989e0eff516dad86719dc7dcba#f39eba95cbfb52989e0eff516dad86719dc7dcba"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6938,7 +6938,7 @@ dependencies = [
 [[package]]
 name = "poem-derive"
 version = "1.3.37"
-source = "git+https://github.com/poem-web/poem?rev=5c6134800756d40256d49b274ce3215da8fa3839#5c6134800756d40256d49b274ce3215da8fa3839"
+source = "git+https://github.com/poem-web/poem?rev=f39eba95cbfb52989e0eff516dad86719dc7dcba#f39eba95cbfb52989e0eff516dad86719dc7dcba"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.42",
@@ -6949,7 +6949,7 @@ dependencies = [
 [[package]]
 name = "poem-openapi"
 version = "2.0.7"
-source = "git+https://github.com/poem-web/poem?rev=5c6134800756d40256d49b274ce3215da8fa3839#5c6134800756d40256d49b274ce3215da8fa3839"
+source = "git+https://github.com/poem-web/poem?rev=f39eba95cbfb52989e0eff516dad86719dc7dcba#f39eba95cbfb52989e0eff516dad86719dc7dcba"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.2.1",
@@ -6972,7 +6972,7 @@ dependencies = [
 [[package]]
 name = "poem-openapi-derive"
 version = "2.0.7"
-source = "git+https://github.com/poem-web/poem?rev=5c6134800756d40256d49b274ce3215da8fa3839#5c6134800756d40256d49b274ce3215da8fa3839"
+source = "git+https://github.com/poem-web/poem?rev=f39eba95cbfb52989e0eff516dad86719dc7dcba#f39eba95cbfb52989e0eff516dad86719dc7dcba"
 dependencies = [
  "darling",
  "http",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -22,8 +22,8 @@ mime = "0.3.16"
 once_cell = "1.10.0"
 paste = "1.0.7"
 percent-encoding = "2.1.0"
-poem = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839", features = ["anyhow", "rustls"] }
-poem-openapi = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839", features = ["url"] }
+poem = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba", features = ["anyhow", "rustls"] }
+poem-openapi = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba", features = ["url"] }
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.81", features = ["preserve_order"] }
 thiserror = "1.0.31"

--- a/api/src/poem_backend/log.rs
+++ b/api/src/poem_backend/log.rs
@@ -11,6 +11,7 @@ use aptos_logger::{
     Schema,
 };
 use poem::{http::header, Endpoint, Request, Response, Result};
+use poem_openapi::OperationId;
 
 /// Logs information about the request and response if the response status code
 /// is >= 500, to help us debug since this will be an error on our side.
@@ -60,9 +61,10 @@ pub async fn middleware_log<E: Endpoint>(next: E, request: Request) -> Result<Re
     HISTOGRAM
         .with_label_values(&[
             log.method.as_str(),
-            // TODO: Log based on operation_id instead.
-            // https://github.com/poem-web/poem/issues/351
-            log.path.as_str(),
+            response
+                .data::<OperationId>()
+                .map(|operation_id| operation_id.0)
+                .unwrap_or("operation_id_not_set"),
             log.status.to_string().as_str(),
         ])
         .observe(elapsed.as_secs_f64());

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -16,8 +16,8 @@ bcs = "0.1.3"
 hex = "0.4.3"
 indoc = "1.0.6"
 mime = "0.3.16"
-poem = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839" }
-poem-openapi = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839" }
+poem = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba" }
+poem-openapi = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba" }
 serde = { version = "1.0.137", default-features = false }
 serde_json = "1.0.81"
 warp = { version = "0.3.2", features = ["default"] }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 get_if_addrs = { version = "0.5.3", default-features = false }
 mirai-annotations = "1.12.0"
-poem-openapi = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839", features = ["url"] }
+poem-openapi = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba", features = ["url"] }
 rand = "0.7.3"
 serde = { version = "1.0.137", features = ["rc"], default-features = false }
 serde_yaml = "0.8.24"

--- a/crates/aptos-openapi/Cargo.toml
+++ b/crates/aptos-openapi/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 async-trait = "0.1.53"
 mime = "0.3.16"
 percent-encoding = "2.1.0"
-poem = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839" }
-poem-openapi = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839" }
+poem = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba" }
+poem-openapi = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba" }
 serde = { version = "1.0.137", default-features = false }
 serde_json = "1.0.81"

--- a/ecosystem/node-checker/Cargo.toml
+++ b/ecosystem/node-checker/Cargo.toml
@@ -18,8 +18,8 @@ env_logger = "0.8.4"
 futures = "0.3.21"
 log = "0.4"
 once_cell = "1.10.0"
-poem = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839", features = ["anyhow"] }
-poem-openapi = { git = "https://github.com/poem-web/poem", rev = "5c6134800756d40256d49b274ce3215da8fa3839", features = ["swagger-ui", "url"] }
+poem = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba", features = ["anyhow"] }
+poem-openapi = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba", features = ["swagger-ui", "url"] }
 prometheus-parse = "0.2.2"
 reqwest = "0.11.10"
 serde = { version = "1.0.137", features = ["derive"] }


### PR DESCRIPTION
## Description
An awesome change was just landed in Poem that gives access to the operation ID, so we don't have to log by path anymore (which wasn't working): https://github.com/poem-web/poem/issues/351. This PR makes our code use this new feature.

## Test Plan
TBA, I need to chat with Brian to figure out how to make sure this is working properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2781)
<!-- Reviewable:end -->
