### PR TITLE
[Token] fixed calc error when token royalty denomintor is zero

### DIFF
--- a/aptos-move/framework/aptos-token/sources/token_coin_swap.move
+++ b/aptos-move/framework/aptos-token/sources/token_coin_swap.move
@@ -95,7 +95,12 @@ module aptos_token::token_coin_swap {
         let royalty = token::get_royalty(token_id);
 
         let total_cost = token_swap.min_price_per_token * token_amount;
-        let royalty_fee = total_cost * token::get_royalty_numerator(&royalty) / token::get_royalty_denominator(&royalty);
+        let royalty_denominator = token::get_royalty_denominator(&royalty);
+        let royalty_fee = if (royalty_denominator == 0) {
+            0
+        } else {
+            total_cost * token::get_royalty_numerator(&royalty) / token::get_royalty_denominator(&royalty)
+        };
         let remaining = total_cost - royalty_fee;
 
         //deposite to the original creators


### PR DESCRIPTION
### Description
When exchange token with coin, there has a error when token royalty denominator is 0

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2782)
<!-- Reviewable:end -->
