### PR TITLE
[lazy_db] fix of unsynced snapshot

### DIFF
--- a/storage/aptosdb/src/state_store/buffered_state.rs
+++ b/storage/aptosdb/src/state_store/buffered_state.rs
@@ -7,12 +7,13 @@ use crate::{
     state_merkle_db::StateMerkleDb, state_store::state_snapshot_committer::StateSnapshotCommitter,
 };
 use anyhow::{ensure, Result};
+use aptos_logger::info;
 use aptos_types::state_store::state_key::StateKey;
 use aptos_types::state_store::state_value::StateValue;
 use aptos_types::transaction::Version;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::mem::swap;
-use std::sync::mpsc::{Sender, SyncSender};
+use std::sync::mpsc::{Receiver, Sender, SyncSender};
 use std::sync::{mpsc, Arc};
 use std::thread::JoinHandle;
 use storage_interface::state_delta::StateDelta;
@@ -34,11 +35,16 @@ pub struct BufferedState {
     state_after_checkpoint: StateDelta,
     state_commit_sender: SyncSender<CommitMessage<Arc<StateDelta>>>,
     target_snapshot_size: usize,
+    snapshot_ready_receivers: VecDeque<Receiver<()>>,
     join_handle: Option<JoinHandle<()>>,
 }
 
 pub(crate) enum CommitMessage<T> {
-    Data(T),
+    Data {
+        data: T,
+        prev_snapshot_ready_receiver: Option<Receiver<()>>,
+        snapshot_ready_sender: Sender<()>,
+    },
     Sync(Sender<()>),
     Exit,
 }
@@ -52,6 +58,7 @@ impl BufferedState {
         let (state_commit_sender, state_commit_receiver) =
             mpsc::sync_channel(ASYNC_COMMIT_CHANNEL_BUFFER_SIZE as usize);
         let arc_state_merkle_db = Arc::clone(state_merkle_db);
+        let (initial_snapshot_ready_sender, initial_snapshot_ready_receiver) = mpsc::channel();
         let join_handle = std::thread::Builder::new()
             .name("state_snapshot_committer".to_string())
             .spawn(move || {
@@ -60,11 +67,14 @@ impl BufferedState {
                 committer.run();
             })
             .expect("Failed to spawn state committer thread.");
+        // The initial snapshot is always already persisted in db.
+        initial_snapshot_ready_sender.send(()).unwrap();
         Self {
             state_until_checkpoint: None,
             state_after_checkpoint,
             state_commit_sender,
             target_snapshot_size,
+            snapshot_ready_receivers: VecDeque::from([initial_snapshot_ready_receiver]),
             // The join handle of the async state commit thread for graceful drop.
             join_handle: Some(join_handle),
         }
@@ -78,13 +88,29 @@ impl BufferedState {
         self.state_after_checkpoint.base_version
     }
 
+    fn send_to_commit(&mut self, to_commit: Arc<StateDelta>) {
+        let prev_snapshot_ready_receiver = self
+            .snapshot_ready_receivers
+            .pop_front()
+            .expect("receivers should never be empty");
+        assert!(self.snapshot_ready_receivers.is_empty());
+        let (snapshot_ready_sender, snapshot_ready_receiver) = mpsc::channel();
+        self.snapshot_ready_receivers
+            .push_back(snapshot_ready_receiver);
+        self.state_commit_sender
+            .send(CommitMessage::Data {
+                data: to_commit,
+                prev_snapshot_ready_receiver: Some(prev_snapshot_ready_receiver),
+                snapshot_ready_sender,
+            })
+            .unwrap();
+    }
+
     fn maybe_commit(&mut self, sync_commit: bool) {
         if sync_commit {
             let (commit_sync_sender, commit_sync_receiver) = mpsc::channel();
             if let Some(to_commit) = self.state_until_checkpoint.take().map(Arc::from) {
-                self.state_commit_sender
-                    .send(CommitMessage::Data(to_commit))
-                    .unwrap();
+                self.send_to_commit(to_commit);
             }
             self.state_commit_sender
                 .send(CommitMessage::Sync(commit_sync_sender))
@@ -100,14 +126,17 @@ impl BufferedState {
                         >= TARGET_SNAPSHOT_INTERVAL_IN_VERSION
             };
             if take_out_to_commit {
-                let to_commit = self
+                let to_commit: Arc<StateDelta> = self
                     .state_until_checkpoint
                     .take()
                     .map(Arc::from)
                     .expect("Must exist");
-                self.state_commit_sender
-                    .send(CommitMessage::Data(to_commit))
-                    .unwrap();
+                info!(
+                    base_version = to_commit.base_version,
+                    version = to_commit.current_version,
+                    "Sent StateDelta to async commit thread."
+                );
+                self.send_to_commit(to_commit);
             }
         }
     }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -12,7 +12,7 @@ use aptos_infallible::Mutex;
 use aptos_jellyfish_merkle::{
     iterator::JellyfishMerkleIterator, restore::StateSnapshotRestore, StateValueWriter,
 };
-use aptos_logger::{debug, info};
+use aptos_logger::info;
 use aptos_state_view::StateViewId;
 #[cfg(test)]
 use aptos_types::nibble::nibble_path::NibblePath;
@@ -315,9 +315,11 @@ impl StateStore {
             )?;
         }
 
-        debug!(
-            latest_version = buffered_state.current_state().current_version,
-            root_hash = buffered_state.current_state().current.root_hash(),
+        info!(
+            latest_snapshot_version = buffered_state.current_state().base_version,
+            latest_snapshot_root_hash = buffered_state.current_state().base.root_hash(),
+            latest_in_memory_version = buffered_state.current_state().current_version,
+            latest_in_memory_root_hash = buffered_state.current_state().current.root_hash(),
             "StateStore initialization finished.",
         );
         Ok(buffered_state)


### PR DESCRIPTION
### Description
There is a bug caught by @grao1991 today that when async commit pipelined and the previous batch may be not committed yet, the current batch may start to merklize data and tries to read from the snapshot of the previous batch. We need another channel to sync this and make our code even more complicated :(

Added some logs in this PR too.

### Test Plan
ut...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2783)
<!-- Reviewable:end -->
