### PR TITLE
chore: install yarn with dev_setup

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -624,6 +624,7 @@ function install_nodejs {
     fi
     install_pkg nodejs "$PACKAGE_MANAGER"
     install_pkg npm "$PACKAGE_MANAGER"
+    curl -fsSL https://yarnpkg.com/install.sh | bash
 }
 
 function install_python3 {


### PR DESCRIPTION
### Description
A lot of developers prefer to use `yarn`. Update the dev_setup script to be able to install yarn across Mac and Linux OS.

### Test Plan
Tested on a fresh Ubuntu.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2789)
<!-- Reviewable:end -->
