### PR TITLE
[helm][aptos-node] config for user_pruning_window_offset

### DIFF
--- a/terraform/helm/aptos-node/files/configs/fullnode.yaml
+++ b/terraform/helm/aptos-node/files/configs/fullnode.yaml
@@ -15,6 +15,7 @@ storage:
     state_store_prune_window: {{ int $.Values.validator.config.state_store_prune_window }}
     ledger_pruning_batch_size: {{ int $.Values.validator.config.ledger_pruning_batch_size }}
     state_store_pruning_batch_size: {{ int $.Values.validator.config.state_store_pruning_batch_size }}
+    user_pruning_window_offset: {{ int $.Values.validator.config.user_pruning_window_offset }}
 
 full_node_networks:
 - network_id:

--- a/terraform/helm/aptos-node/files/configs/validator.yaml
+++ b/terraform/helm/aptos-node/files/configs/validator.yaml
@@ -35,6 +35,7 @@ storage:
     state_store_prune_window: {{ int $.Values.validator.config.state_store_prune_window }}
     ledger_pruning_batch_size: {{ int $.Values.validator.config.ledger_pruning_batch_size }}
     state_store_pruning_batch_size: {{ int $.Values.validator.config.state_store_pruning_batch_size }}
+    user_pruning_window_offset: {{ int $.Values.validator.config.user_pruning_window_offset }}
 
 execution:
   genesis_file_location: /opt/aptos/genesis/genesis.blob

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -43,6 +43,7 @@ validator:
     state_store_prune_window: 1000000
     ledger_pruning_batch_size: 10000
     state_store_pruning_batch_size: 10000
+    user_pruning_window_offset: 200000
   enableNetworkPolicy: true
 
 fullnode:


### PR DESCRIPTION
### Description

Config for `user_pruning_window_offset` to be set in the `aptos-node` helm chart. Follow up for https://github.com/aptos-labs/aptos-core/pull/2768, which introduced the config

### Test Plan

Forge runs, meaning that validators are able to start up with this config

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2792)
<!-- Reviewable:end -->
