### PR TITLE
[storage] Use default values for pruner when not provided

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -98,7 +98,7 @@ pub const NO_OP_STORAGE_PRUNER_CONFIG: StoragePrunerConfig = StoragePrunerConfig
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct StoragePrunerConfig {
     /// Boolean to enable/disable the state store pruner. The state pruner is responsible for
     /// pruning state tree nodes.
@@ -123,6 +123,22 @@ pub struct StoragePrunerConfig {
     pub user_pruning_window_offset: u64,
 }
 
+impl Default for StoragePrunerConfig {
+    fn default() -> Self {
+        StoragePrunerConfig {
+            enable_state_store_pruner: true,
+            enable_ledger_pruner: true,
+            state_store_prune_window: 1_000_000,
+            ledger_prune_window: 10_000_000,
+            ledger_pruning_batch_size: 500,
+            // A 10k transaction block (touching 60k state values, in the case of the account
+            // creation benchmark) on a 4B items DB (or 1.33B accounts) yields 300k JMT nodes
+            state_store_pruning_batch_size: 1_000,
+            user_pruning_window_offset: 200_000,
+        }
+    }
+}
+
 impl Default for StorageConfig {
     fn default() -> StorageConfig {
         StorageConfig {
@@ -136,17 +152,7 @@ impl Default for StorageConfig {
             // of the DB might require, 10k (TPS)  * 100 (seconds)  =  1 Million might be a
             // conservatively safe minimal prune window. It'll take a few Gigabytes of disk space
             // depending on the size of an average account blob.
-            storage_pruner_config: StoragePrunerConfig {
-                enable_state_store_pruner: true,
-                enable_ledger_pruner: true,
-                state_store_prune_window: 1_000_000,
-                ledger_prune_window: 10_000_000,
-                ledger_pruning_batch_size: 500,
-                // A 10k transaction block (touching 60k state values, in the case of the account
-                // creation benchmark) on a 4B items DB (or 1.33B accounts) yields 300k JMT nodes
-                state_store_pruning_batch_size: 1_000,
-                user_pruning_window_offset: 200_000,
-            },
+            storage_pruner_config: StoragePrunerConfig::default(),
             data_dir: PathBuf::from("/opt/aptos/data"),
             // Default read/write/connection timeout, in milliseconds
             timeout_ms: 30_000,


### PR DESCRIPTION
### Description
https://serde.rs/container-attrs.html#default

### Test Plan
This seems to work?
```
cat config/src/config/test_data/public_full_node.yaml 
base:
    # Update this value to the location you want the node to store its database
    data_dir: "/opt/aptos/data"
    role: "full_node"
    waypoint:
        # Update this value to that which the blockchain publicly provides. Please regard the directions
        # below on how to safely manage your genesis_file_location with respect to the waypoint.
        from_file: "./waypoint.txt"

execution:
    # Update this to the location to where the genesis.blob is stored, prefer fullpaths
    # Note, this must be paired with a waypoint. If you update your waypoint without a
    # corresponding genesis, the file location should be an empty path.
    genesis_file_location: "./genesis.blob"

full_node_networks:
    - discovery_method: "onchain"
      # The network must have a listen address to specify protocols. This runs it locally to
      # prevent remote, incoming connections.
      listen_address: "/ip4/127.0.0.1/tcp/6180"
      network_id: "public"
      # Define the upstream peers to connect to
      seeds:
        {}

storage:
  storage_pruner_config:
    enable_state_store_pruner: false

api:
    enabled: true
    address: 127.0.0.1:8080
(venv)  greg@jiggy  /opt/git/aptos-core   fix-config ±  cargo run -p apto
s -- node run-local-testnet --config-path /opt/git/aptos-core/config/src/config/test_data/public_full_node.yaml
warning: patch for `diesel` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
    Finished dev [unoptimized + debuginfo] target(s) in 0.82s
     Running `target/debug/aptos node run-local-testnet --config-path /opt/git/aptos-core/config/src/config/test_data/public_full_node.yaml`
Completed generating configuration:
        Log file: "/Users/greg/.aptos/testnet/validator.log"
        Test dir: "/Users/greg/.aptos/testnet"
        Aptos root key path: "/Users/greg/.aptos/testnet/mint.key"
        Waypoint: 0:61f39436edda0bc55cc8d7b35ad66d593b80666da6548443884d53613a2ef85b
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2793)
<!-- Reviewable:end -->
