### PR TITLE
[move] add gas metering for SipHash

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/bucket_table.move
+++ b/aptos-move/framework/aptos-framework/sources/bucket_table.move
@@ -5,7 +5,7 @@
 module aptos_framework::bucket_table {
     use std::error;
     use std::vector;
-    use std::hash::sip_hash;
+    use aptos_std::aptos_hash::sip_hash_from_value;
     use aptos_std::table_with_length::{Self, TableWithLength};
 
     const TARGET_LOAD_PER_BUCKET: u64 = 10;
@@ -68,7 +68,7 @@ module aptos_framework::bucket_table {
     /// Note it may not split the actual overflowed bucket.
     /// Abort if `key` already exists.
     public fun add<K, V>(map: &mut BucketTable<K, V>, key: K, value: V) {
-        let hash = sip_hash(&key);
+        let hash = sip_hash_from_value(&key);
         let index = bucket_index(map.level, map.num_buckets, hash);
         let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
         let i = 0;
@@ -145,7 +145,7 @@ module aptos_framework::bucket_table {
     /// The requirement of &mut BucketTable is to bypass the borrow checker issue described in https://github.com/move-language/move/issues/95
     /// Once Table supports borrow by K, we can remove the &mut
     public fun borrow<K: copy + drop, V>(map: &mut BucketTable<K, V>, key: K): &V {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash(&key));
+        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
         let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
@@ -162,7 +162,7 @@ module aptos_framework::bucket_table {
     /// Acquire a mutable reference to the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun borrow_mut<K: copy + drop, V>(map: &mut BucketTable<K, V>, key: K): &mut V {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash(&key));
+        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(&key));
         let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
@@ -178,7 +178,7 @@ module aptos_framework::bucket_table {
 
     /// Returns true iff `table` contains an entry for `key`.
     public fun contains<K, V>(map: &BucketTable<K, V>, key: &K): bool {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash(key));
+        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(key));
         let bucket = table_with_length::borrow(&map.buckets, index);
         let i = 0;
         let len = vector::length(bucket);
@@ -195,7 +195,7 @@ module aptos_framework::bucket_table {
     /// Remove from `table` and return the value which `key` maps to.
     /// Aborts if there is no entry for `key`.
     public fun remove<K: drop, V>(map: &mut BucketTable<K,V>, key: &K): V {
-        let index = bucket_index(map.level, map.num_buckets, sip_hash(key));
+        let index = bucket_index(map.level, map.num_buckets, sip_hash_from_value(key));
         let bucket = table_with_length::borrow_mut(&mut map.buckets, index);
         let i = 0;
         let len = vector::length(bucket);

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -1,0 +1,17 @@
+/// Non-cryptographic hashes
+module aptos_std::aptos_hash {
+    use std::bcs;
+
+    native public fun sip_hash(bytes: vector<u8>): u64;
+
+    public fun sip_hash_from_value<MoveValue>(v: &MoveValue): u64 {
+        let bytes = bcs::to_bytes(v);
+
+        sip_hash(bytes)
+    }
+
+    spec sip_hash_from_value {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+}

--- a/aptos-move/framework/move-stdlib/sources/hash.move
+++ b/aptos-move/framework/move-stdlib/sources/hash.move
@@ -3,12 +3,6 @@
 /// The functions in this module are natively declared both in the Move runtime
 /// as in the Move prover's prelude.
 module std::hash {
-    // TODO: move sip_hash into aptos_framework
-    native public fun sip_hash<MoveValue>(v: &MoveValue): u64;
     native public fun sha2_256(data: vector<u8>): vector<u8>;
     native public fun sha3_256(data: vector<u8>): vector<u8>;
-
-    spec sip_hash { // TODO: temporary mockup.
-        pragma opaque;
-    }
 }

--- a/aptos-move/framework/src/natives/hash.rs
+++ b/aptos-move/framework/src/natives/hash.rs
@@ -3,13 +3,9 @@
 
 use move_deps::{
     move_binary_format::errors::PartialVMResult,
-    move_core_types::vm_status::sub_status::NFE_BCS_SERIALIZATION_FAILURE,
     move_vm_runtime::native_functions::{NativeContext, NativeFunction},
     move_vm_types::{
-        loaded_data::runtime_types::Type,
-        natives::function::NativeResult,
-        pop_arg,
-        values::{values_impl::Reference, Value},
+        loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
     },
 };
 use smallvec::smallvec;
@@ -27,40 +23,27 @@ pub struct SipHashGasParameters {
     pub unit_cost: u64,
 }
 
-/// Serialize the MoveValue with BCS and then feed the bytes into SipHasher. This is not
-/// cryptographically secure.
+/// Feed thes bytes into SipHasher. This is not cryptographically secure.
 fn native_sip_hash(
-    _gas_params: &SipHashGasParameters,
-    context: &mut NativeContext,
-    mut ty_args: Vec<Type>,
+    gas_params: &SipHashGasParameters,
+    _context: &mut NativeContext,
+    mut _ty_args: Vec<Type>,
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
-    debug_assert!(ty_args.len() == 1);
+    debug_assert!(_ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    // TODO(Gas): proper gas metering
+    let mut cost = gas_params.base_cost;
 
-    let ref_to_val = pop_arg!(args, Reference);
-    let arg_type = ty_args.pop().unwrap();
-
-    // delegate to the BCS serialization for `Value`
-    let serialized_value_opt = match context.type_to_type_layout(&arg_type)? {
-        None => None,
-        Some(layout) => ref_to_val.read_ref()?.simple_serialize(&layout),
-    };
-    let serialized_value = match serialized_value_opt {
-        None => {
-            return Ok(NativeResult::err(0, NFE_BCS_SERIALIZATION_FAILURE));
-        }
-        Some(serialized_value) => serialized_value,
-    };
+    let bytes = pop_arg!(args, Vec<u8>);
 
     // SipHash of the serialized bytes
+    cost += gas_params.unit_cost;
     let mut hasher = siphasher::sip::SipHasher::new();
-    hasher.write(&serialized_value);
+    hasher.write(&bytes);
     let hash = hasher.finish();
 
-    Ok(NativeResult::ok(0, smallvec![Value::u64(hash)]))
+    Ok(NativeResult::ok(cost, smallvec![Value::u64(hash)]))
 }
 
 pub fn make_native_sip_hash(gas_params: SipHashGasParameters) -> NativeFunction {

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -122,7 +122,7 @@ pub fn all_natives(
 
     add_natives_from_module!("account", account::make_all(gas_params.account));
     add_natives_from_module!("signature", signature::make_all(gas_params.signature));
-    add_natives_from_module!("hash", hash::make_all(gas_params.hash));
+    add_natives_from_module!("aptos_hash", hash::make_all(gas_params.hash));
     add_natives_from_module!("type_info", type_info::make_all(gas_params.type_info));
     add_natives_from_module!("util", util::make_all(gas_params.util));
     add_natives_from_module!(


### PR DESCRIPTION
### Description

@vgao1996 requested to fix the missing gas metering.

Also, there are some potential gas metering problems in the native Rust code AFAICT due to the use of the ? operator. @zekun000 and @vgao1996 please take a look at the `TODO`'s in the changes.

Oh, and I tried moving `sip_hash` into `aptos-stdlib` (as per the TODO) but had a naming conflict because both `std` and `aptos_std` are at 0x01, I think.

After fixing that by renaming `aptos_std::hash` to `aptos_std::hashing`, I still had a problem with the `test_genesis_e2e_flow` test, which AFAICT publishes Move modules in the genesis block (I think). So I couldn't move it.

If you tell me how to fix that I can move it to `aptos-stdlib`, which maybe we should move to a new address, to avoid future naming conflicts?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2801)
<!-- Reviewable:end -->
