### PR TITLE
[community] Fix error when sort param is malformed.

### DIFF
--- a/ecosystem/platform/server/app/helpers/application_helper.rb
+++ b/ecosystem/platform/server/app/helpers/application_helper.rb
@@ -5,9 +5,13 @@
 
 module ApplicationHelper
   SORT_ORDER = { '+' => 1, '-' => -1 }.freeze
+  EMPTY_SORT = [].freeze
 
   def parse_sort(params)
-    (params.fetch(:sort, nil).presence || '').split(',').map do |attr|
+    sort_param = params.fetch(:sort, nil)
+    return EMPTY_SORT unless sort_param.is_a? String
+
+    sort_param.split(',').map do |attr|
       sort_sign = attr =~ /\A[+-]/ ? attr.slice!(0) : '+'
       [attr, SORT_ORDER[sort_sign]]
     end

--- a/ecosystem/platform/server/test/controllers/leaderboard_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/leaderboard_controller_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+class LeaderboardControllerTest < ActionDispatch::IntegrationTest
+  test 'loads correctly' do
+    get it1_path
+    assert_response :success
+  end
+
+  test 'loads correctly with sort param' do
+    get it1_path(sort: '-participation,liveness')
+    assert_response :success
+  end
+
+  test 'loads correctly with malformed sort param' do
+    get it1_path(sort: { '$foo': 1 })
+    assert_response :success
+  end
+end


### PR DESCRIPTION
### Description

Fixes this error:

```
NoMethodError
undefined method `split' for #<ActionController::Parameters {"$foo"=>"1"} permitted: false>

    (params.fetch(:sort, nil).presence || '').split(',').map do |attr|
                                             ^^^^^^
```

### Test Plan
I wrote automated tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2808)
<!-- Reviewable:end -->
