### PR TITLE
[Docs] Fixing nav bar link in the docs and window title for the spec.

### DIFF
--- a/api/doc/v1/spec.html
+++ b/api/doc/v1/spec.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="cache-control" content="no-cache">
-    <title>Elements in HTML</title>
+    <title>Aptos REST API</title>
     <!-- Embed elements Elements via Web Component -->
     <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">

--- a/developer-docs-site/docusaurus.config.js
+++ b/developer-docs-site/docusaurus.config.js
@@ -150,7 +150,7 @@ const config = {
           },
           {
             position: "left",
-            href: "https://fullnode.devnet.aptoslabs.com/spec.html#/",
+            href: "https://fullnode.devnet.aptoslabs.com/v1/spec#/",
             label: "REST API",
           },
         ],


### PR DESCRIPTION
Minor fixes. Next time when the API spec gets into the binary, it will have the correct title, I think. 

@banool The published doc version says "v0.1.0" still, even though the spec.yaml has the correct version. Do you know what might be going on?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2817)
<!-- Reviewable:end -->
