### PR TITLE
[api] Add get block by version

### DIFF
--- a/api/src/poem_backend/blocks.rs
+++ b/api/src/poem_backend/blocks.rs
@@ -43,6 +43,30 @@ impl BlocksApi {
             with_transactions.0.unwrap_or_default(),
         )
     }
+
+    /// Get blocks by version
+    ///
+    /// This endpoint allows you to get the transactions in a block
+    /// and the corresponding block information given a version in the block.
+    #[oai(
+        path = "/blocks/by_version/:version",
+        method = "get",
+        operation_id = "get_block_by_version",
+        tag = "ApiTags::Blocks"
+    )]
+    async fn get_block_by_version(
+        &self,
+        accept_type: AcceptType,
+        version: Path<u64>,
+        with_transactions: Query<Option<bool>>,
+    ) -> BasicResultWith404<Block> {
+        fail_point_poem("endpoint_get_block_by_version")?;
+        self.get_by_version(
+            accept_type,
+            version.0,
+            with_transactions.0.unwrap_or_default(),
+        )
+    }
 }
 
 impl BlocksApi {
@@ -57,6 +81,28 @@ impl BlocksApi {
         let block = self
             .context
             .get_block_by_height(block_height, latest_version, with_transactions)
+            .context("Failed to retrieve block by height")
+            .map_err(BasicErrorWith404::internal)?;
+
+        BasicResponse::try_from_rust_value((
+            block,
+            &latest_ledger_info,
+            BasicResponseStatus::Ok,
+            &accept_type,
+        ))
+    }
+
+    fn get_by_version(
+        &self,
+        accept_type: AcceptType,
+        version: u64,
+        with_transactions: bool,
+    ) -> BasicResultWith404<Block> {
+        let latest_ledger_info = self.context.get_latest_ledger_info_poem()?;
+        let latest_version = latest_ledger_info.version();
+        let block = self
+            .context
+            .get_block_by_version(version, latest_version, with_transactions)
             .context("Failed to retrieve block by height")
             .map_err(BasicErrorWith404::internal)?;
 

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1222,7 +1222,10 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_block_info(&self, version: Version) -> Result<(Version, Version, NewBlockEvent)> {
+    fn get_block_info_by_version(
+        &self,
+        version: Version,
+    ) -> Result<(Version, Version, NewBlockEvent)> {
         gauged_api("get_block_info", || {
             let latest_li = self.get_latest_ledger_info()?;
             let committed_version = latest_li.ledger_info().version();

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -218,7 +218,10 @@ pub trait DbReader: Send + Sync {
 
     /// Returns the start_version, end_version and NewBlockEvent of the block containing the input
     /// transaction version.
-    fn get_block_info(&self, version: Version) -> Result<(Version, Version, NewBlockEvent)> {
+    fn get_block_info_by_version(
+        &self,
+        version: Version,
+    ) -> Result<(Version, Version, NewBlockEvent)> {
         unimplemented!()
     }
 


### PR DESCRIPTION
### Description
To find the block corresponding to a transaction, this provides the API for it.

### Test Plan
```
$ curl localhost:8080/v1/blocks/by_version/1
{"block_height":"1","block_hash":"0x380029b65e0db2311f9aa9c3fdb92207ebc201873cfe141f9f50f4c66d6cabbd","block_timestamp":"1660247629760032","first_version":"1","last_version":"1","transactions":null}%
$ curl 'localhost:8080/v1/blocks/by_version/1?with_transactions=false' 
{"block_height":"1","block_hash":"0x380029b65e0db2311f9aa9c3fdb92207ebc201873cfe141f9f50f4c66d6cabbd","block_timestamp":"1660247629760032","first_version":"1","last_version":"1","transactions":null}%

$ curl 'localhost:8080/v1/blocks/by_version/1?with_transactions=true' 
{"block_height":"1","block_hash":"0x380029b65e0db2311f9aa9c3fdb92207ebc201873cfe141f9f50f4c66d6cabbd","block_timestamp":"1660247629760032","first_version":"1","last_version":"1","transactions":[{"version":"1",... [],"timestamp":"1660247629760032","type":"block_metadata_transaction"}]}%
```

```
curl localhost:8080/v1/blocks/by_version/0
{"block_height":"0","block_hash":"0x0000000000000000000000000000000000000000000000000000000000000000","block_timestamp":"0","first_version":"0","last_version":"0","transactions":null}%                                                                        
curl localhost:8080/v1/blocks/by_version/1
{"block_height":"1","block_hash":"0x380029b65e0db2311f9aa9c3fdb92207ebc201873cfe141f9f50f4c66d6cabbd","block_timestamp":"1660247629760032","first_version":"1","last_version":"1","transactions":null}% 
curl localhost:8080/v1/blocks/by_version/2
{"block_height":"2","block_hash":"0xcd63bfd84eb54090011fd6ed8e32fa1355d03fe61c235c0693c0e5476589df71","block_timestamp":"1660247630410024","first_version":"2","last_version":"5","transactions":null}%  
 curl localhost:8080/v1/blocks/by_version/3
{"block_height":"2","block_hash":"0xcd63bfd84eb54090011fd6ed8e32fa1355d03fe61c235c0693c0e5476589df71","block_timestamp":"1660247630410024","first_version":"2","last_version":"5","transactions":null}%
 curl localhost:8080/v1/blocks/by_version/4
{"block_height":"2","block_hash":"0xcd63bfd84eb54090011fd6ed8e32fa1355d03fe61c235c0693c0e5476589df71","block_timestamp":"1660247630410024","first_version":"2","last_version":"5","transactions":null}%
 curl localhost:8080/v1/blocks/by_version/5
{"block_height":"2","block_hash":"0xcd63bfd84eb54090011fd6ed8e32fa1355d03fe61c235c0693c0e5476589df71","block_timestamp":"1660247630410024","first_version":"2","last_version":"5","transactions":null}%
curl localhost:8080/v1/blocks/by_version/6
{"block_height":"3","block_hash":"0xf1d92b471ba17236b3d694e4c2b107d554e4a17d1301cc530275caebf1607ef5","block_timestamp":"1660247630420912","first_version":"6","last_version":"7","transactions":null}%   
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2826)
<!-- Reviewable:end -->
