### PR TITLE
[gas] bump max_transaction_size_in_bytes to 6 MB

### DIFF
--- a/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -591,7 +591,7 @@
         },
         {
           "key": "txn.max_transaction_size_in_bytes",
-          "val": "8192"
+          "val": "6291456"
         },
         {
           "key": "txn.gas_unit_scaling_factor",

--- a/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -591,7 +591,7 @@
         },
         {
           "key": "txn.max_transaction_size_in_bytes",
-          "val": "8192"
+          "val": "6291456"
         },
         {
           "key": "txn.gas_unit_scaling_factor",

--- a/aptos-move/aptos-gas/src/transaction.rs
+++ b/aptos-move/aptos-gas/src/transaction.rs
@@ -83,7 +83,7 @@ define_gas_parameters_for_transaction!(
     [
         max_transaction_size_in_bytes,
         "max_transaction_size_in_bytes",
-        8192
+        6 * 1024 * 1024
     ],
     [gas_unit_scaling_factor, "gas_unit_scaling_factor", 1000],
 );

--- a/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
+++ b/aptos-move/e2e-testsuite/src/tests/verify_txn.rs
@@ -27,7 +27,7 @@ use move_deps::{
     move_ir_compiler::Compiler,
 };
 
-pub const MAX_TRANSACTION_SIZE_IN_BYTES: u64 = 262144;
+pub const MAX_TRANSACTION_SIZE_IN_BYTES: u64 = 6 * 1024 * 1024;
 
 #[test]
 fn verify_signature() {

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -24,7 +24,7 @@ pub struct ApiConfig {
 
 pub const DEFAULT_ADDRESS: &str = "127.0.0.1";
 pub const DEFAULT_PORT: u16 = 8080;
-pub const DEFAULT_REQUEST_CONTENT_LENGTH_LIMIT: u64 = 4 * 1024 * 1024; // 4mb
+pub const DEFAULT_REQUEST_CONTENT_LENGTH_LIMIT: u64 = 8 * 1024 * 1024; // 8 MB
 
 fn default_enabled() -> bool {
     true

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -19,7 +19,7 @@ use rand::SeedableRng;
 use storage_interface::state_view::LatestDbStateCheckpointView;
 use storage_interface::DbReaderWriter;
 
-const MAX_TRANSACTION_SIZE_IN_BYTES: u64 = 262144;
+const MAX_TRANSACTION_SIZE_IN_BYTES: u64 = 6 * 1024 * 1024;
 
 struct TestValidator {
     vm_validator: VMValidator,


### PR DESCRIPTION
This `bumps max_transaction_size_in_bytes` up to 6 MB to allow larger transactions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2829)
<!-- Reviewable:end -->
