### PR TITLE
Replace CircleCI badge with Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Aptos Rust Crate Documentation (main)](https://img.shields.io/badge/docs-main-59f)](https://aptos-labs.github.io/aptos-core/)
 [![License](https://img.shields.io/badge/license-Apache-green.svg)](LICENSE)
-[![CircleCI](https://circleci.com/gh/aptos-labs/aptos-core/tree/main.svg?style=shield&circle-token=d248cf1c0580eb69a507a71c0d238e1eaf193767)](https://circleci.com/gh/aptos-labs/aptos-core/tree/main)
+[![Lint+Test](https://github.com/aptos-labs/aptos-core/actions/workflows/lint-test.yaml/badge.svg)](https://github.com/aptos-labs/aptos-core/actions/workflows/lint-test.yaml)
 [![grcov](https://img.shields.io/badge/Coverage-grcov-green)](https://ci-artifacts.aptoslabs.com/coverage/unit-coverage/latest/index.html)
 [![test history](https://img.shields.io/badge/Test-History-green)](https://ci-artifacts.aptoslabs.com/testhistory/aptos/aptos/auto/ci-test.yml/index.html)
 [![Automated Issues](https://img.shields.io/github/issues-search?color=orange&label=Automated%20Issues&query=repo%3Aaptos%2Faptos%20is%3Aopen%20author%3Aapp%2Fgithub-actions)](https://github.com/aptos-labs/aptos-core/issues/created_by/app/github-actions)


### PR DESCRIPTION
### Description
CircleCI was removed in https://github.com/aptos-labs/aptos-core/commit/be3936ea1a5aec5f9e67f327416c09a695d15497

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2830)
<!-- Reviewable:end -->
