### PR TITLE
[TS][SDK] Add /v1 if missing automatically

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -11,6 +11,7 @@ N/A
 - Switch back to representing certain move types (MoveModuleId, MoveStructTag, ScriptFunctionId) as strings, for both requests and responses. This reverts the change made in 1.3.2. See [#2663](https://github.com/aptos-labs/aptos-core/pull/2663) for more.
 - Represent certain fields with slightly different snake casing, e.g. `ed25519_signature` now instead of `ed_25519_signature`.
 - Add generated types for healthcheck endpoint.
+- If the given URL is missing `/v1`, the `AptosClient` constructor will add it for you. You can opt out of this behavior by setting `doNotFixNodeUrl` to true when calling the constructor.
 
 ## 1.3.5 (2022-08-08)
 - Re-expose BCS and items from `transaction_builder/builder` from the root of the module.

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -1,6 +1,6 @@
 import { Memoize } from "typescript-memoize";
 import { HexString, MaybeHexString } from "./hex_string";
-import { sleep } from "./util";
+import { fixNodeUrl, sleep } from "./util";
 import { AptosAccount } from "./aptos_account";
 import * as Gen from "./generated/index";
 import { TxnBuilderTypes, TransactionBuilderEd25519, BCS } from "./transaction_builder";
@@ -14,12 +14,21 @@ export class AptosClient {
 
   /**
    * Build a client configured to connect to an Aptos node at the given URL.
+   *
+   * Note: If you forget to append `/v1` to the URL, the client constructor
+   * will automatically append it. If you don't want this URL processing to
+   * take place, set doNotFixNodeUrl to true.
+   *
    * @param nodeUrl URL of the Aptos Node API endpoint.
    * @param config Additional configuration options for the generated Axios client.
    */
-  constructor(nodeUrl: string, config?: Partial<Gen.OpenAPIConfig>) {
+  constructor(nodeUrl: string, config?: Partial<Gen.OpenAPIConfig>, doNotFixNodeUrl: boolean = false) {
     const conf = config === undefined || config === null ? {} : { ...config };
-    conf.BASE = nodeUrl;
+    if (doNotFixNodeUrl) {
+      conf.BASE = nodeUrl;
+    } else {
+      conf.BASE = fixNodeUrl(nodeUrl);
+    }
     this.client = new Gen.AptosGeneratedClient(conf);
   }
 

--- a/ecosystem/typescript/sdk/src/util.test.ts
+++ b/ecosystem/typescript/sdk/src/util.test.ts
@@ -1,3 +1,5 @@
+import { AptosClient } from "./aptos_client";
+
 export const NODE_URL = process.env.APTOS_NODE_URL || "https://fullnode.devnet.aptoslabs.com/v1";
 export const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptoslabs.com";
 
@@ -6,4 +8,12 @@ test("noop", () => {
   // Adding this empty test allows us to:
   // 1. Guarantee that this test library won't get compiled
   // 2. Prevent jest from exploding when it finds a file with no tests in it
+});
+
+test("test fixNodeUrl", () => {
+  expect(new AptosClient("https://test.com").client.request.config.BASE).toBe("https://test.com/v1");
+  expect(new AptosClient("https://test.com/").client.request.config.BASE).toBe("https://test.com/v1");
+  expect(new AptosClient("https://test.com/v1").client.request.config.BASE).toBe("https://test.com/v1");
+  expect(new AptosClient("https://test.com/v1/").client.request.config.BASE).toBe("https://test.com/v1");
+  expect(new AptosClient("https://test.com", {}, true).client.request.config.BASE).toBe("https://test.com");
 });

--- a/ecosystem/typescript/sdk/src/util.ts
+++ b/ecosystem/typescript/sdk/src/util.ts
@@ -7,3 +7,16 @@ export async function sleep(timeMs: number): Promise<null> {
     setTimeout(resolve, timeMs);
   });
 }
+
+export const DEFAULT_VERSION_PATH_BASE = "/v1";
+
+export function fixNodeUrl(nodeUrl: string): string {
+  let out = `${nodeUrl}`;
+  if (out.endsWith("/")) {
+    out = out.substring(0, out.length - 1);
+  }
+  if (!out.endsWith(DEFAULT_VERSION_PATH_BASE)) {
+    out = `${out}${DEFAULT_VERSION_PATH_BASE}`;
+  }
+  return out;
+}


### PR DESCRIPTION
## Description
It'll be annoying for users to update the URLs for nodes, this PR makes it that we add the `v1` if you don't have it. This makes it easier for new API versions in the future too.

## Test Plan
I removed `/v1` from the configured node URL for the testing and saw that the tests all passed:
```
yarn test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2837)
<!-- Reviewable:end -->
