### PR TITLE
[Aptos Framework][Genesis] Update genesis to only initialize core resources account for tests/testnets

### DIFF
--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -17,7 +17,7 @@ use aptos_mempool::mocks::MockSharedMempool;
 use aptos_sdk::{
     transaction_builder::TransactionFactory,
     types::{
-        account_config::aptos_root_address, transaction::SignedTransaction, AccountKey,
+        account_config::aptos_test_root_address, transaction::SignedTransaction, AccountKey,
         LocalAccount,
     },
 };
@@ -238,7 +238,7 @@ impl TestContext {
     }
 
     pub fn root_account(&self) -> LocalAccount {
-        LocalAccount::new(aptos_root_address(), self.root_key.private_key(), 0)
+        LocalAccount::new(aptos_test_root_address(), self.root_key.private_key(), 0)
     }
 
     pub fn latest_state_view(&self) -> DbStateView {

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -12,7 +12,7 @@ use aptos_gas::{InitialGasSchedule, TransactionGasParameters};
 use aptos_state_view::StateView;
 use aptos_types::{
     access_path::AccessPath,
-    account_config::{aptos_root_address, AccountResource, CoinStoreResource},
+    account_config::{aptos_test_root_address, AccountResource, CoinStoreResource},
     block_metadata::BlockMetadata,
     chain_id::ChainId,
     contract_event::ContractEvent,
@@ -492,11 +492,11 @@ impl<'a> AptosTestAdapter<'a> {
 
     fn create_and_fund_account(&mut self, account_addr: AccountAddress, amount: u64) {
         let parameters = self
-            .fetch_transaction_parameters(&aptos_root_address(), None, None, None, None)
+            .fetch_transaction_parameters(&aptos_test_root_address(), None, None, None, None)
             .unwrap();
 
         let txn = RawTransaction::new(
-            aptos_root_address(),
+            aptos_test_root_address(),
             parameters.sequence_number,
             aptos_transaction_builder::aptos_stdlib::account_create_account(account_addr),
             parameters.max_gas_amount,
@@ -512,7 +512,7 @@ impl<'a> AptosTestAdapter<'a> {
             .expect("Failed to create an account. This should not happen.");
 
         let txn = RawTransaction::new(
-            aptos_root_address(),
+            aptos_test_root_address(),
             parameters.sequence_number + 1,
             aptos_transaction_builder::aptos_stdlib::aptos_coin_mint(account_addr, amount),
             parameters.max_gas_amount,

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__drop_txn_after_reconfiguration_version_4.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__drop_txn_after_reconfiguration_version_4.exp
@@ -84,7 +84,7 @@ Ok(
                 ContractEvent { key: EventKey { creation_number: 8, account_address: D1126CE48BD65FB72190DBD9A6EAA65BA973F1E1664AC0CFBA4DB1D071FD0C36 }, index: 0, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("stake"), name: Identifier("DistributeRewardsEvent"), type_params: [] }), event_data: "d1126ce48bd65fb72190dbd9a6eaa65ba973f1e1664ac0cfba4db1d071fd0c360000000000000000" },
                 ContractEvent { key: EventKey { creation_number: 1, account_address: 0000000000000000000000000000000000000000000000000000000000000001 }, index: 1, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("reconfiguration"), name: Identifier("NewEpochEvent"), type_params: [] }), event_data: "0200000000000000" },
             ],
-            gas_used: 23,
+            gas_used: 22,
             status: Keep(
                 Success,
             ),

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__initial_aptos_version_version_4.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__on_chain_configs__initial_aptos_version_version_4.exp
@@ -84,7 +84,7 @@ Ok(
                 ContractEvent { key: EventKey { creation_number: 8, account_address: D1126CE48BD65FB72190DBD9A6EAA65BA973F1E1664AC0CFBA4DB1D071FD0C36 }, index: 0, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("stake"), name: Identifier("DistributeRewardsEvent"), type_params: [] }), event_data: "d1126ce48bd65fb72190dbd9a6eaa65ba973f1e1664ac0cfba4db1d071fd0c360000000000000000" },
                 ContractEvent { key: EventKey { creation_number: 1, account_address: 0000000000000000000000000000000000000000000000000000000000000001 }, index: 1, type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("reconfiguration"), name: Identifier("NewEpochEvent"), type_params: [] }), event_data: "0200000000000000" },
             ],
-            gas_used: 23,
+            gas_used: 22,
             status: Keep(
                 Success,
             ),

--- a/aptos-move/e2e-tests/src/account.rs
+++ b/aptos-move/e2e-tests/src/account.rs
@@ -107,10 +107,10 @@ impl Account {
 
     /// Creates a new account representing the aptos root account in memory.
     ///
-    /// The address will be [`aptos_root_address`][account_config::aptos_root_address], and
+    /// The address will be [`aptos_test_root_address`][account_config::aptos_test_root_address], and
     /// the account will use [`GENESIS_KEYPAIR`][struct@GENESIS_KEYPAIR] as its keypair.
     pub fn new_aptos_root() -> Self {
-        Self::new_genesis_account(account_config::aptos_root_address())
+        Self::new_genesis_account(account_config::aptos_test_root_address())
     }
 
     /// Returns the address of the account. This is a hash of the public key the account was created

--- a/aptos-move/e2e-tests/src/on_chain_configs.rs
+++ b/aptos-move/e2e-tests/src/on_chain_configs.rs
@@ -3,11 +3,11 @@
 
 use crate::{account::Account, executor::FakeExecutor};
 use aptos_transaction_builder::aptos_stdlib;
-use aptos_types::{account_config::aptos_root_address, on_chain_config::Version};
+use aptos_types::{account_config::aptos_test_root_address, on_chain_config::Version};
 use aptos_vm::AptosVM;
 
 pub fn set_aptos_version(executor: &mut FakeExecutor, version: Version) {
-    let account = Account::new_genesis_account(aptos_root_address());
+    let account = Account::new_genesis_account(aptos_test_root_address());
     let txn = account
         .transaction()
         .payload(aptos_stdlib::version_set_version(version.major))

--- a/aptos-move/e2e-testsuite/src/tests/genesis_initializations.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis_initializations.rs
@@ -3,6 +3,7 @@
 
 use aptos_types::account_config::CORE_CODE_ADDRESS;
 use language_e2e_tests::executor::FakeExecutor;
+use move_deps::move_core_types::vm_status::StatusCode;
 use move_deps::move_core_types::{
     account_address::AccountAddress,
     value::{serialize_values, MoveValue},
@@ -36,7 +37,7 @@ fn test_timestamp_time_has_started() {
         serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]),
     );
 
-    assert_eq!(output.unwrap_err().move_abort_code(), Some(196608));
+    assert_eq!(output.unwrap_err().move_abort_code(), Some(196609));
 }
 
 #[test]
@@ -45,23 +46,26 @@ fn test_block_double_init() {
 
     executor.exec(
         "block",
-        "initialize_block_metadata",
+        "initialize",
         vec![],
         serialize_values(&vec![
             MoveValue::Signer(CORE_CODE_ADDRESS),
-            MoveValue::U64(0),
+            MoveValue::U64(1),
         ]),
     );
 
     let output = executor.try_exec(
         "block",
-        "initialize_block_metadata",
+        "initialize",
         vec![],
         serialize_values(&vec![
             MoveValue::Signer(CORE_CODE_ADDRESS),
-            MoveValue::U64(0),
+            MoveValue::U64(1),
         ]),
     );
 
-    assert_eq!(output.unwrap_err().move_abort_code(), Some(524288));
+    assert_eq!(
+        output.unwrap_err().status_code(),
+        StatusCode::RESOURCE_ALREADY_EXISTS
+    );
 }

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -86,7 +86,7 @@ module aptos_framework::account {
     native fun create_address(bytes: vector<u8>): address;
     native fun create_signer(addr: address): signer;
 
-    public fun initialize(account: &signer,
+    public(friend) fun initialize(account: &signer,
         module_addr: address,
         module_name: vector<u8>,
         script_prologue_name: vector<u8>,
@@ -380,7 +380,7 @@ module aptos_framework::account {
     }
 
     /// Create the account for @aptos_framework to help module upgrades on testnet.
-    public(friend) fun create_core_framework_account(): (signer, SignerCapability) {
+    public(friend) fun create_aptos_framework_account(): (signer, SignerCapability) {
         timestamp::assert_genesis();
         let signer = create_account_unchecked(@aptos_framework);
         let signer_cap = SignerCapability { account: @aptos_framework };
@@ -482,14 +482,14 @@ module aptos_framework::account {
     // Test account helpers
     ///////////////////////////////////////////////////////////////////////////
 
-    #[test(alice = @0xa11ce, mint = @0xA550C18, core = @0x1)]
-    public fun test_transfer(alice: signer, mint: signer, core: signer) acquires Account {
+    #[test(alice = @0xa11ce, core = @0x1)]
+    public fun test_transfer(alice: signer, core: signer) acquires Account {
         let bob = create_address(x"0000000000000000000000000000000000000000000000000000000000000b0b");
         let carol = create_address(x"00000000000000000000000000000000000000000000000000000000000ca501");
 
-        let (mint_cap, burn_cap) = aptos_framework::aptos_coin::initialize(&core, &mint);
+        let (mint_cap, burn_cap) = aptos_framework::aptos_coin::initialize_for_test(&core);
         create_account(signer::address_of(&alice));
-        aptos_framework::aptos_coin::mint(&mint, signer::address_of(&alice), 10000);
+        coin::deposit(signer::address_of(&alice), coin::mint(10000, &mint_cap));
         transfer(&alice, bob, 500);
         assert!(coin::balance<AptosCoin>(bob) == 500, 0);
         transfer(&alice, carol, 500);

--- a/aptos-move/framework/aptos-framework/sources/chain_id.move
+++ b/aptos-move/framework/aptos-framework/sources/chain_id.move
@@ -4,21 +4,18 @@
 module aptos_framework::chain_id {
     use aptos_framework::system_addresses;
     use aptos_framework::timestamp;
-    use std::error;
-    use std::signer;
+
+    friend aptos_framework::genesis;
 
     struct ChainId has key {
         id: u8
     }
 
-    /// The `ChainId` resource was not in the required state
-    const ECHAIN_ID: u64 = 0;
-
+    /// Only called during genesis.
     /// Publish the chain ID `id` of this instance under the SystemAddresses address
-    public fun initialize(account: &signer, id: u8) {
+    public(friend) fun initialize(account: &signer, id: u8) {
         timestamp::assert_genesis();
         system_addresses::assert_aptos_framework(account);
-        assert!(!exists<ChainId>(signer::address_of(account)), error::already_exists(ECHAIN_ID));
         move_to(account, ChainId { id })
     }
 

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
@@ -1,29 +1,22 @@
 /// Maintains the consensus config for the blockchain. The config is stored in a
 /// Reconfiguration, and may be updated by root.
 module aptos_framework::consensus_config {
-    use std::error;
-    use std::vector;
     use aptos_framework::reconfiguration;
     use aptos_framework::timestamp;
     use aptos_framework::system_addresses;
 
-    /// Error with config
-    const ECONFIG: u64 = 1;
+    friend aptos_framework::genesis;
 
     struct ConsensusConfig has key {
         config: vector<u8>,
     }
 
     /// Publishes the ConsensusConfig config.
-    public fun initialize(account: &signer) {
+    public(friend) fun initialize(account: &signer, config: vector<u8>) {
         timestamp::assert_genesis();
         system_addresses::assert_aptos_framework(account);
 
-        assert!(
-            !exists<ConsensusConfig>(@aptos_framework),
-            error::already_exists(ECONFIG)
-        );
-        move_to(account, ConsensusConfig { config: vector::empty() });
+        move_to(account, ConsensusConfig { config });
     }
 
     /// Update the config.

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -1,7 +1,10 @@
 /// Provides the configuration for staking and rewards
 module aptos_framework::staking_config {
     use std::error;
+
     use aptos_framework::system_addresses;
+
+    friend aptos_framework::genesis;
 
     /// Invalid required stake lockup value.
     const EINVALID_LOCKUP_VALUE: u64 = 1;
@@ -29,7 +32,8 @@ module aptos_framework::staking_config {
         rewards_rate_denominator: u64,
     }
 
-    public fun initialize(
+    /// Only called during genesis.
+    public(friend) fun initialize(
         aptos_framework: &signer,
         minimum_stake: u64,
         maximum_stake: u64,
@@ -189,5 +193,25 @@ module aptos_framework::staking_config {
     #[expected_failure(abort_code = 0x10002)]
     public entry fun test_update_rewards_invalid_denominator_should_fail(aptos_framework: signer) acquires StakingConfig {
         update_rewards_rate(&aptos_framework, 1, 0);
+    }
+
+    public fun initialize_for_test(
+        aptos_framework: &signer,
+        minimum_stake: u64,
+        maximum_stake: u64,
+        recurring_lockup_duration_secs: u64,
+        allow_validator_set_change: bool,
+        rewards_rate: u64,
+        rewards_rate_denominator: u64,
+    ) {
+        initialize(
+            aptos_framework,
+            minimum_stake,
+            maximum_stake,
+            recurring_lockup_duration_secs,
+            allow_validator_set_change,
+            rewards_rate,
+            rewards_rate_denominator,
+        );
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -5,24 +5,20 @@ module aptos_framework::version {
     use aptos_framework::timestamp;
     use aptos_framework::system_addresses;
 
+    friend aptos_framework::genesis;
+
     struct Version has key, copy, drop, store {
         major: u64,
     }
 
-    /// Error with config
-    const ECONFIG: u64 = 0;
     /// Tried to set an invalid major version for the VM. Major versions must be strictly increasing
     const EINVALID_MAJOR_VERSION_NUMBER: u64 = 1;
 
+    /// Only called during genesis.
     /// Publishes the Version config.
-    public fun initialize(account: &signer, initial_version: u64) {
+    public(friend) fun initialize(account: &signer, initial_version: u64) {
         timestamp::assert_genesis();
         system_addresses::assert_aptos_framework(account);
-
-        assert!(
-            !exists<Version>(@aptos_framework),
-            error::already_exists(ECONFIG)
-        );
 
         move_to(
             account,
@@ -34,7 +30,6 @@ module aptos_framework::version {
     /// This is only used in test environments and outside of them, the core resources account shouldn't exist.
     public entry fun set_version(account: signer, major: u64) acquires Version {
         system_addresses::assert_core_resource(&account);
-        assert!(exists<Version>(@aptos_framework), error::not_found(ECONFIG));
         let old_major = *&borrow_global<Version>(@aptos_framework).major;
 
         assert!(

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -13,6 +13,7 @@ module aptos_framework::reconfiguration {
     friend aptos_framework::block;
     // TODO: migrate all to callback in block prologue
     friend aptos_framework::consensus_config;
+    friend aptos_framework::genesis;
     friend aptos_framework::version;
     friend aptos_framework::gas_schedule;
 
@@ -37,26 +38,24 @@ module aptos_framework::reconfiguration {
     struct DisableReconfiguration has key {}
 
     /// The `Configuration` resource is in an invalid state
-    const ECONFIGURATION: u64 = 0;
+    const ECONFIGURATION: u64 = 1;
     /// A `Reconfiguration` resource is in an invalid state
-    const ECONFIG: u64 = 1;
+    const ECONFIG: u64 = 2;
     /// A `ModifyConfigCapability` is in a different state than was expected
-    const EMODIFY_CAPABILITY: u64 = 2;
+    const EMODIFY_CAPABILITY: u64 = 3;
     /// An invalid block time was encountered.
-    const EINVALID_BLOCK_TIME: u64 = 3;
+    const EINVALID_BLOCK_TIME: u64 = 4;
     /// An invalid block time was encountered.
-    const EINVALID_GUID_FOR_EVENT: u64 = 4;
-    /// The largest possible u64 value
-    const MAX_U64: u64 = 18446744073709551615;
+    const EINVALID_GUID_FOR_EVENT: u64 = 5;
 
+    /// Only called during genesis.
     /// Publishes `Configuration` resource. Can only be invoked by aptos framework account, and only a single time in Genesis.
-    public fun initialize(
+    public(friend) fun initialize(
         account: &signer,
     ) {
         timestamp::assert_genesis();
         system_addresses::assert_aptos_framework(account);
 
-        assert!(!exists<Configuration>(@aptos_framework), error::already_exists(ECONFIGURATION));
         // assert it matches `new_epoch_event_key()`, otherwise the event can't be recognized
         assert!(guid::get_next_creation_num(signer::address_of(account)) == 1, error::invalid_state(EINVALID_GUID_FOR_EVENT));
         move_to<Configuration>(
@@ -106,12 +105,12 @@ module aptos_framework::reconfiguration {
         borrow_global<Configuration>(@aptos_framework).last_reconfiguration_time
     }
 
-    /// Private function to do reconfiguration.  Updates reconfiguration status resource
+    /// Private function to do reconfiguration. Updates reconfiguration status resource
     /// `Configuration` and emits a `NewEpochEvent`
     fun reconfigure_() acquires Configuration {
         // Do not do anything if genesis has not finished.
         if (timestamp::is_genesis() || timestamp::now_microseconds() == 0 || !reconfiguration_enabled()) {
-            return ()
+            return
         };
 
         let config_ref = borrow_global_mut<Configuration>(@aptos_framework);
@@ -148,7 +147,6 @@ module aptos_framework::reconfiguration {
     /// Emit a `NewEpochEvent` event. This function will be invoked by genesis directly to generate the very first
     /// reconfiguration event.
     fun emit_genesis_reconfiguration_event() acquires Configuration {
-        assert!(exists<Configuration>(@aptos_framework), error::not_found(ECONFIGURATION));
         let config_ref = borrow_global_mut<Configuration>(@aptos_framework);
         assert!(config_ref.epoch == 0 && config_ref.last_reconfiguration_time == 0, error::invalid_state(ECONFIGURATION));
         config_ref.epoch = 1;

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -327,7 +327,7 @@ module aptos_framework::stake {
     }
 
     /// Initialize validator set to the core resource account.
-    public fun initialize(aptos_framework: &signer) {
+    public(friend) fun initialize(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         move_to(aptos_framework, ValidatorSet {
@@ -344,7 +344,7 @@ module aptos_framework::stake {
 
     /// This is only called during Genesis, which is where MintCapability<AptosCoin> can be created.
     /// Beyond genesis, no one can create AptosCoin mint/burn capabilities.
-    public fun store_aptos_coin_mint_cap(account: &signer, mint_cap: MintCapability<AptosCoin>) {
+    public(friend) fun store_aptos_coin_mint_cap(account: &signer, mint_cap: MintCapability<AptosCoin>) {
         system_addresses::assert_aptos_framework(account);
         move_to(account, AptosCoinCapabilities { mint_cap })
     }
@@ -1029,18 +1029,17 @@ module aptos_framework::stake {
     public entry fun test_setup(aptos_framework: &signer) {
         timestamp::set_time_has_started_for_testing(aptos_framework);
         initialize(aptos_framework);
-        staking_config::initialize(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
+        staking_config::initialize_for_test(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10009)]
     public entry fun test_inactive_validator_cannot_add_stake_if_exceeding_max_allowed(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, ValidatorConfig, ValidatorSet {
         test_setup(&aptos_framework);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         let validator_address = signer::address_of(&validator);
         coin::deposit(validator_address, coin::mint(9901, &mint_cap));
@@ -1051,15 +1050,14 @@ module aptos_framework::stake {
         add_stake(&validator, 9901);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10009)]
     public entry fun test_pending_active_validator_cannot_add_stake_if_exceeding_max_allowed(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, ValidatorConfig, ValidatorSet {
         test_setup(&aptos_framework);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         let validator_address = signer::address_of(&validator);
         coin::deposit(validator_address, coin::mint(9901, &mint_cap));
@@ -1073,15 +1071,14 @@ module aptos_framework::stake {
         add_stake(&validator, 9901);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10009)]
     public entry fun test_active_validator_cannot_add_stake_if_exceeding_max_allowed(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         let validator_address = signer::address_of(&validator);
         coin::deposit(validator_address, coin::mint(9901, &mint_cap));
@@ -1096,15 +1093,14 @@ module aptos_framework::stake {
         add_stake(&validator, 9901);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10009)]
     public entry fun test_active_validator_with_pending_inactive_stake_cannot_add_stake_if_exceeding_max_allowed(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         let validator_address = signer::address_of(&validator);
         coin::deposit(validator_address, coin::mint(9901, &mint_cap));
@@ -1123,16 +1119,15 @@ module aptos_framework::stake {
         add_stake(&validator, 9901);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123, other_validator = @0x234)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, other_validator = @0x234)]
     #[expected_failure(abort_code = 0x10009)]
     public entry fun test_pending_inactivecannot_add_stake_if_exceeding_max_allowed(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
         other_validator: signer,
     ) acquires AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         register_mint_stake(&other_validator, &mint_cap);
         let validator_address = signer::address_of(&validator);
@@ -1153,15 +1148,14 @@ module aptos_framework::stake {
         add_stake(&validator, 9901);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_end_to_end(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
         let validator_address = signer::address_of(&validator);
-        join_test_staking(&aptos_framework, &core_resources, &validator, true);
+        join_test_staking(&aptos_framework, &validator, true);
 
         // Validator has a lockup now that they've joined the validator set.
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
@@ -1209,15 +1203,14 @@ module aptos_framework::stake {
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 9);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_inactive_validator_with_existing_lockup_join_validator_set(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
 
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);
@@ -1238,14 +1231,13 @@ module aptos_framework::stake {
         assert_validator_state(validator_address, 100, 0, 0, 0, 0);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_pending_active_validator_can_add_more_stake(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        join_test_staking(&aptos_framework, &core_resources, &validator, false);
+        join_test_staking(&aptos_framework, &validator, false);
 
         // Add more stake while still pending_active.
         let validator_address = signer::address_of(&validator);
@@ -1259,17 +1251,16 @@ module aptos_framework::stake {
         assert_validator_state(validator_address, 200, 0, 0, 0, 0);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_unlock_partial_stake(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         initialize(&aptos_framework);
         // Reward rate = 10%.
-        staking_config::initialize(&aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10);
-        join_test_staking(&aptos_framework, &core_resources, &validator, true);
+        staking_config::initialize_for_test(&aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 10);
+        join_test_staking(&aptos_framework, &validator, true);
 
         // Unlock half of the coins.
         let validator_address = signer::address_of(&validator);
@@ -1287,14 +1278,13 @@ module aptos_framework::stake {
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 3);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_can_withdraw_all_stake_and_rewards_at_once(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        join_test_staking(&aptos_framework, &core_resources, &validator, true);
+        join_test_staking(&aptos_framework, &validator, true);
         let validator_address = signer::address_of(&validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
 
@@ -1324,28 +1314,26 @@ module aptos_framework::stake {
         assert!(get_validator_state(validator_address) == VALIDATOR_STATUS_INACTIVE, 4);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x10005)]
     public entry fun test_active_validator_unlocking_more_than_available_stake_should_error_out(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        join_test_staking(&aptos_framework, &core_resources, &validator, true);
+        join_test_staking(&aptos_framework, &validator, true);
 
         // Validator unlocks more stake than they have active. This should error out.
         unlock(&validator, 200);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_withdraw_should_cap_by_inactive_stake(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        join_test_staking(&aptos_framework, &core_resources, &validator, true);
+        join_test_staking(&aptos_framework, &validator, true);
 
         // Validator unlocks stake.
         unlock(&validator, 100);
@@ -1360,14 +1348,13 @@ module aptos_framework::stake {
         assert_validator_state(validator_address, 0, 0, 0, 0, 0);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_active_validator_having_insufficient_remaining_stake_after_withdrawal_gets_kicked(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        join_test_staking(&aptos_framework, &core_resources, &validator, true);
+        join_test_staking(&aptos_framework, &validator, true);
 
         // Unlock enough coins that the remaining is not enough to meet the min required.
         let validator_address = signer::address_of(&validator);
@@ -1387,15 +1374,14 @@ module aptos_framework::stake {
         assert!(get_remaining_lockup_secs(validator_address) == 0, 3);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123, validator_2 = @0x234)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, validator_2 = @0x234)]
     public entry fun test_active_validator_leaves_staking_but_still_has_a_lockup(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
         validator_2: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         register_mint_stake(&validator_2, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
@@ -1437,15 +1423,14 @@ module aptos_framework::stake {
         assert_validator_state(validator_address, 51, 0, 0, 0, 1);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123, validator_2 = @0x234)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123, validator_2 = @0x234)]
     public entry fun test_active_validator_leaves_staking_and_rejoins_with_expired_lockup_should_be_renewed(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
         validator_2: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         register_mint_stake(&validator_2, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
@@ -1474,10 +1459,9 @@ module aptos_framework::stake {
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 2);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator_1 = @0x123, validator_2 = @0x234, validator_3 = @0x345)]
+    #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234, validator_3 = @0x345)]
     public entry fun test_multiple_validators_join_and_leave(
         aptos_framework: signer,
-        core_resources: signer,
         validator_1: signer,
         validator_2: signer,
         validator_3: signer
@@ -1488,9 +1472,9 @@ module aptos_framework::stake {
         let validator_3_address = signer::address_of(&validator_3);
 
         initialize(&aptos_framework);
-        staking_config::initialize(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
+        staking_config::initialize_for_test(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
 
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator_1, &mint_cap);
         register_mint_stake(&validator_2, &mint_cap);
         register_mint_stake(&validator_3, &mint_cap);
@@ -1546,18 +1530,17 @@ module aptos_framework::stake {
         assert!(get_validator_state(validator_1_address) == VALIDATOR_STATUS_INACTIVE, 11);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_delegated_staking_with_owner_cap(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
 
         initialize(&aptos_framework);
-        staking_config::initialize(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
+        staking_config::initialize_for_test(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
 
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         let stake = coin::mint<AptosCoin>(100, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
 
@@ -1602,33 +1585,31 @@ module aptos_framework::stake {
         coin::destroy_burn_cap<AptosCoin>(burn_cap);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000E)]
     public entry fun test_validator_cannot_join_post_genesis(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         initialize(&aptos_framework);
-        staking_config::initialize(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, false, 1, 100);
+        staking_config::initialize_for_test(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, false, 1, 100);
 
         // Joining the validator set should fail as post genesis validator set change is not allowed.
-        join_test_staking(&aptos_framework, &core_resources, &validator, true);
+        join_test_staking(&aptos_framework, &validator, true);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000E)]
     public entry fun test_validator_cannot_leave_post_genesis(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         initialize(&aptos_framework);
-        staking_config::initialize(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, false, 1, 100);
+        staking_config::initialize_for_test(&aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, false, 1, 100);
 
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);
@@ -1643,9 +1624,8 @@ module aptos_framework::stake {
     }
 
     #[test(
-        aptos_framework = @0x1,
-        core_resources = @core_resources,
-        validator_1 = @0x1,
+        aptos_framework = @aptos_framework,
+        validator_1 = @aptos_framework,
         validator_2 = @0x2,
         validator_3 = @0x3,
         validator_4 = @0x4,
@@ -1653,7 +1633,6 @@ module aptos_framework::stake {
     )]
     public entry fun test_staking_validator_index(
         aptos_framework: signer,
-        core_resources: signer,
         validator_1: signer,
         validator_2: signer,
         validator_3: signer,
@@ -1668,7 +1647,7 @@ module aptos_framework::stake {
 
         test_setup(&aptos_framework);
 
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator_1, &mint_cap);
         register_mint_stake(&validator_2, &mint_cap);
         register_mint_stake(&validator_3, &mint_cap);
@@ -1715,10 +1694,9 @@ module aptos_framework::stake {
         assert!(validator_index(v2_addr) == 2, 17);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator_1 = @0x123, validator_2 = @0x234)]
+    #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
     public entry fun test_validator_rewards_are_performance_based(
         aptos_framework: signer,
-        core_resources: signer,
         validator_1: signer,
         validator_2: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
@@ -1726,7 +1704,7 @@ module aptos_framework::stake {
 
         let validator_1_address = signer::address_of(&validator_1);
         let validator_2_address = signer::address_of(&validator_2);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator_1, &mint_cap);
         register_mint_stake(&validator_2, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
@@ -1769,16 +1747,15 @@ module aptos_framework::stake {
         assert_validator_state(validator_2_address, 0, 100, 0, 0, 0);
     }
 
-    #[test(aptos_framework = @0x1, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_update_performance_statistics_should_not_fail_due_to_out_of_bounds(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         test_setup(&aptos_framework);
 
         let validator_address = signer::address_of(&validator);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_mint_stake(&validator, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);
@@ -1805,18 +1782,17 @@ module aptos_framework::stake {
         end_epoch();
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     #[expected_failure(abort_code = 0x1000F)]
     public entry fun test_invalid_config(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, ValidatorConfig, ValidatorSet {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         initialize(&aptos_framework);
-        staking_config::initialize(&aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
+        staking_config::initialize_for_test(&aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
 
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_owner_only(&validator, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);
@@ -1826,17 +1802,16 @@ module aptos_framework::stake {
         join_validator_set(&validator, validator_address);
     }
 
-    #[test(aptos_framework = @aptos_framework, core_resources = @core_resources, validator = @0x123)]
+    #[test(aptos_framework = @aptos_framework, validator = @0x123)]
     public entry fun test_valid_config(
         aptos_framework: signer,
-        core_resources: signer,
         validator: signer,
     ) acquires OwnerCapability, StakePool, ValidatorConfig, ValidatorSet {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         initialize(&aptos_framework);
-        staking_config::initialize(&aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
+        staking_config::initialize_for_test(&aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100);
 
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&aptos_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&aptos_framework);
         register_owner_only(&validator, &mint_cap);
         store_aptos_coin_mint_cap(&aptos_framework, mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);
@@ -1916,11 +1891,10 @@ module aptos_framework::stake {
     #[test_only]
     public entry fun join_test_staking(
         aptos_framework: &signer,
-        core_resources: &signer,
         validator: &signer,
         change_epoch: bool,
     ) acquires AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
-        let (mint_cap, burn_cap) = aptos_coin::initialize(aptos_framework, core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(aptos_framework);
         register_mint_stake(validator, &mint_cap);
         store_aptos_coin_mint_cap(aptos_framework, mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);

--- a/aptos-move/framework/aptos-framework/sources/timestamp.move
+++ b/aptos-move/framework/aptos-framework/sources/timestamp.move
@@ -24,11 +24,11 @@ module aptos_framework::timestamp {
     const MICRO_CONVERSION_FACTOR: u64 = 1000000;
 
     /// The blockchain is not in the genesis state anymore
-    const ENOT_GENESIS: u64 = 0;
+    const ENOT_GENESIS: u64 = 1;
     /// The blockchain is not in an operating state yet
-    const ENOT_OPERATING: u64 = 1;
+    const ENOT_OPERATING: u64 = 2;
     /// An invalid timestamp was provided
-    const ETIMESTAMP: u64 = 2;
+    const ETIMESTAMP: u64 = 3;
 
     /// Marks that time has started and genesis has finished. This can only be called from genesis and with the root
     /// account.

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -4,6 +4,7 @@ module aptos_framework::transaction_fee {
     use aptos_framework::system_addresses;
 
     friend aptos_framework::account;
+    friend aptos_framework::genesis;
 
     struct AptosCoinCapabilities has key {
         burn_cap: BurnCapability<AptosCoin>,
@@ -18,7 +19,8 @@ module aptos_framework::transaction_fee {
         );
     }
 
-    public fun store_aptos_coin_burn_cap(account: &signer, burn_cap: BurnCapability<AptosCoin>) {
+    /// Only called during genesis.
+    public(friend) fun store_aptos_coin_burn_cap(account: &signer, burn_cap: BurnCapability<AptosCoin>) {
         system_addresses::assert_aptos_framework(account);
         move_to(account, AptosCoinCapabilities { burn_cap })
     }

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -48,15 +48,18 @@ pub enum ScriptFunctionCall {
         amount: u64,
     },
 
+    /// Only callable in tests and testnets where the core resources account exists.
     /// Claim the delegated mint capability and destroy the delegated token.
     AptosCoinClaimMintCapability {},
 
+    /// Only callable in tests and testnets where the core resources account exists.
     /// Create delegated token for the address so the account could claim MintCapability later.
     AptosCoinDelegateMintCapability {
         to: AccountAddress,
     },
 
-    /// Create new test coins and deposit them into dst_addr's account.
+    /// Only callable in tests and testnets where the core resources account exists.
+    /// Create new coins and deposit them into dst_addr's account.
     AptosCoinMint {
         dst_addr: AccountAddress,
         amount: u64,
@@ -396,6 +399,7 @@ pub fn account_transfer(to: AccountAddress, amount: u64) -> TransactionPayload {
     ))
 }
 
+/// Only callable in tests and testnets where the core resources account exists.
 /// Claim the delegated mint capability and destroy the delegated token.
 pub fn aptos_coin_claim_mint_capability() -> TransactionPayload {
     TransactionPayload::ScriptFunction(ScriptFunction::new(
@@ -412,6 +416,7 @@ pub fn aptos_coin_claim_mint_capability() -> TransactionPayload {
     ))
 }
 
+/// Only callable in tests and testnets where the core resources account exists.
 /// Create delegated token for the address so the account could claim MintCapability later.
 pub fn aptos_coin_delegate_mint_capability(to: AccountAddress) -> TransactionPayload {
     TransactionPayload::ScriptFunction(ScriptFunction::new(
@@ -428,7 +433,8 @@ pub fn aptos_coin_delegate_mint_capability(to: AccountAddress) -> TransactionPay
     ))
 }
 
-/// Create new test coins and deposit them into dst_addr's account.
+/// Only callable in tests and testnets where the core resources account exists.
+/// Create new coins and deposit them into dst_addr's account.
 pub fn aptos_coin_mint(dst_addr: AccountAddress, amount: u64) -> TransactionPayload {
     TransactionPayload::ScriptFunction(ScriptFunction::new(
         ModuleId::new(

--- a/aptos-move/move-examples/shared_account/sources/shared_account.move
+++ b/aptos-move/move-examples/shared_account/sources/shared_account.move
@@ -107,18 +107,18 @@ module shared_account::SharedAccount {
         *&borrow_global<SharedAccountEvent>(user_addr).resource_addr
     }
 
-    #[test(user = @0x1111, test_user1 = @0x1112, test_user2 = @0x1113, core_resources = @core_resources, core_framework = @aptos_framework)]
-    public entry fun test_disperse(user: signer, test_user1: signer, test_user2: signer, core_resources: signer, core_framework: signer) acquires SharedAccount, SharedAccountEvent {
+    #[test(user = @0x1111, test_user1 = @0x1112, test_user2 = @0x1113, core_framework = @aptos_framework)]
+    public entry fun test_disperse(user: signer, test_user1: signer, test_user2: signer, core_framework: signer) acquires SharedAccount, SharedAccountEvent {
         use aptos_framework::aptos_coin::{Self, AptosCoin};
         let user_addr1 = signer::address_of(&test_user1);
         let user_addr2 = signer::address_of(&test_user2);
         let resource_addr = set_up(user, test_user1, test_user2);
-        let (mint_cap, burn_cap) = aptos_coin::initialize(&core_framework, &core_resources);
+        let (mint_cap, burn_cap) = aptos_coin::initialize_for_test(&core_framework);
 
         let shared_account = borrow_global<SharedAccount>(resource_addr);
         let resource_signer = account::create_signer_with_capability(&shared_account.signer_capability);
         coin::register_for_test<AptosCoin>(&resource_signer);
-        aptos_coin::mint(&core_framework, resource_addr, 1000);
+        coin::deposit(resource_addr, coin::mint(1000, &mint_cap));
         disperse<AptosCoin>(resource_addr);
         coin::destroy_mint_cap<AptosCoin>(mint_cap);
         coin::destroy_burn_cap<AptosCoin>(burn_cap);

--- a/aptos-move/transaction-replay/src/lib.rs
+++ b/aptos-move/transaction-replay/src/lib.rs
@@ -8,7 +8,7 @@ use aptos_types::{
     access_path,
     access_path::AccessPath,
     account_address::AccountAddress,
-    account_config::aptos_root_address,
+    account_config::aptos_test_root_address,
     account_state::AccountState,
     account_view::AccountView,
     contract_event::{ContractEvent, EventWithVersion},
@@ -139,7 +139,7 @@ impl AptosDebugger {
         let cache = aptos_vm::data_cache::StateViewCache::new(&state_view);
         let sequence_number = match self
             .debugger
-            .get_account_state_by_version(aptos_root_address(), base_version)?
+            .get_account_state_by_version(aptos_test_root_address(), base_version)?
         {
             Some(account) => account
                 .get_account_resource()?
@@ -149,7 +149,7 @@ impl AptosDebugger {
         };
         let txn_data = aptos_vm::transaction_metadata::TransactionMetadata {
             sequence_number,
-            sender: aptos_root_address(),
+            sender: aptos_test_root_address(),
             ..Default::default()
         };
 
@@ -370,7 +370,7 @@ impl AptosDebugger {
                 session.execute_script(
                     predicate.clone(),
                     vec![],
-                    vec![aptos_root_address().to_vec(), sender.to_vec()],
+                    vec![aptos_test_root_address().to_vec(), sender.to_vec()],
                     &mut UnmeteredGasMeter,
                 )
             })

--- a/aptos-move/writeset-transaction-generator/src/admin_script_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/admin_script_builder.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::aptos_root_address,
+    account_config::aptos_test_root_address,
     transaction::{Script, WriteSetPayload},
 };
 use handlebars::Handlebars;
@@ -70,7 +70,7 @@ pub fn remove_validators_payload(validators: Vec<AccountAddress>) -> WriteSetPay
 
     WriteSetPayload::Script {
         script,
-        execute_as: aptos_root_address(),
+        execute_as: aptos_test_root_address(),
     }
 }
 
@@ -93,7 +93,7 @@ pub fn custom_script<T: Serialize>(
 
     WriteSetPayload::Script {
         script,
-        execute_as: execute_as.unwrap_or_else(aptos_root_address),
+        execute_as: execute_as.unwrap_or_else(aptos_test_root_address),
     }
 }
 
@@ -107,6 +107,6 @@ pub fn halt_network_payload() -> WriteSetPayload {
             vec![],
             vec![],
         ),
-        execute_as: aptos_root_address(),
+        execute_as: aptos_test_root_address(),
     }
 }

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -7,7 +7,7 @@ use aptos_gas::NativeGasParameters;
 use aptos_state_view::StateView;
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::{self, aptos_root_address},
+    account_config::{self, aptos_test_root_address},
     transaction::{ChangeSet, Script, Version},
 };
 use aptos_vm::{
@@ -78,7 +78,7 @@ impl<'r, 'l, S: MoveResolverExt> GenesisSession<'r, 'l, S> {
             "Reconfiguration",
             "disable_reconfiguration",
             vec![],
-            serialize_values(&vec![MoveValue::Signer(aptos_root_address())]),
+            serialize_values(&vec![MoveValue::Signer(aptos_test_root_address())]),
         )
     }
 
@@ -87,7 +87,7 @@ impl<'r, 'l, S: MoveResolverExt> GenesisSession<'r, 'l, S> {
             "Reconfiguration",
             "enable_reconfiguration",
             vec![],
-            serialize_values(&vec![MoveValue::Signer(aptos_root_address())]),
+            serialize_values(&vec![MoveValue::Signer(aptos_test_root_address())]),
         )
     }
     pub fn set_aptos_version(&mut self, version: Version) {
@@ -96,7 +96,7 @@ impl<'r, 'l, S: MoveResolverExt> GenesisSession<'r, 'l, S> {
             "set_version",
             vec![],
             serialize_values(&vec![
-                MoveValue::Signer(aptos_root_address()),
+                MoveValue::Signer(aptos_test_root_address()),
                 MoveValue::U64(version),
             ]),
         )

--- a/crates/aptos-faucet-cli/src/main.rs
+++ b/crates/aptos-faucet-cli/src/main.rs
@@ -6,7 +6,7 @@ use aptos_config::keys::ConfigKey;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_faucet::{mint, mint::MintParams, Service};
 use aptos_sdk::types::{
-    account_address::AccountAddress, account_config::aptos_root_address, chain_id::ChainId,
+    account_address::AccountAddress, account_config::aptos_test_root_address, chain_id::ChainId,
     LocalAccount,
 };
 use clap::Parser;
@@ -59,7 +59,9 @@ pub struct FaucetCliArgs {
 
 impl FaucetCliArgs {
     async fn execute(self) {
-        let mint_account_address = self.mint_account_address.unwrap_or_else(aptos_root_address);
+        let mint_account_address = self
+            .mint_account_address
+            .unwrap_or_else(aptos_test_root_address);
         let mint_key = if let Some(ref key) = self.mint_key {
             key.private_key()
         } else {

--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -27,8 +27,8 @@ use aptos_rest_client::Client;
 use aptos_sdk::{
     transaction_builder::{aptos_stdlib, TransactionFactory},
     types::{
-        account_address::AccountAddress, account_config::aptos_root_address, chain_id::ChainId,
-        LocalAccount,
+        account_address::AccountAddress, account_config::aptos_test_root_address,
+        chain_id::ChainId, LocalAccount,
     },
 };
 use clap::Parser;
@@ -108,8 +108,9 @@ impl FaucetArgs {
             .expect("Failed to deserialize mint key file")
         };
 
-        let faucet_address: AccountAddress =
-            self.mint_account_address.unwrap_or_else(aptos_root_address);
+        let faucet_address: AccountAddress = self
+            .mint_account_address
+            .unwrap_or_else(aptos_test_root_address);
         let faucet_account = LocalAccount::new(faucet_address, key, 0);
 
         // Do not use maximum amount on delegation, this allows the new delegated faucet to

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -361,6 +361,7 @@ const ONE_DAY: u64 = 86400;
 pub struct GenesisConfiguration {
     pub allow_new_validators: bool,
     pub epoch_duration_secs: u64,
+    pub is_test: bool,
     pub min_stake: u64,
     pub max_stake: u64,
     pub min_voting_threshold: u128,
@@ -549,6 +550,7 @@ impl Builder {
         let mut genesis_config = GenesisConfiguration {
             allow_new_validators: false,
             epoch_duration_secs: ONE_DAY,
+            is_test: true,
             min_stake: 0,
             min_voting_threshold: 0,
             max_stake: u64::MAX,
@@ -567,15 +569,7 @@ impl Builder {
             root_key,
             configs,
             self.move_modules.clone(),
-            genesis_config.allow_new_validators,
-            genesis_config.epoch_duration_secs,
-            genesis_config.min_stake,
-            genesis_config.min_voting_threshold,
-            genesis_config.max_stake,
-            genesis_config.recurring_lockup_duration_secs,
-            genesis_config.required_proposer_stake,
-            genesis_config.rewards_apy_percentage,
-            genesis_config.voting_duration_secs,
+            &genesis_config,
         )?;
         let waypoint = genesis_info.generate_waypoint()?;
         let genesis = genesis_info.get_genesis();

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -36,6 +36,7 @@ pub struct Layout {
     pub allow_new_validators: bool,
     /// Duration of an epoch
     pub epoch_duration_secs: u64,
+    pub is_test: bool,
     /// Minimum stake to be in the validator set
     pub min_stake: u64,
     /// Minimum number of votes to consider a proposal valid.

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -10,6 +10,7 @@ pub mod keys;
 #[cfg(any(test, feature = "testing"))]
 pub mod test_utils;
 
+use crate::builder::GenesisConfiguration;
 use crate::config::ValidatorConfiguration;
 use aptos_config::config::{RocksdbConfigs, NO_OP_STORAGE_PRUNER_CONFIG, TARGET_SNAPSHOT_SIZE};
 use aptos_crypto::ed25519::Ed25519PublicKey;
@@ -39,6 +40,7 @@ pub struct GenesisInfo {
     pub allow_new_validators: bool,
     /// Duration of an epoch
     pub epoch_duration_secs: u64,
+    pub is_test: bool,
     /// Minimum stake to be in the validator set
     pub min_stake: u64,
     /// Minimum number of votes to consider a proposal valid.
@@ -61,15 +63,7 @@ impl GenesisInfo {
         root_key: Ed25519PublicKey,
         configs: Vec<ValidatorConfiguration>,
         modules: Vec<Vec<u8>>,
-        allow_new_validators: bool,
-        epoch_duration_secs: u64,
-        min_stake: u64,
-        min_voting_threshold: u128,
-        max_stake: u64,
-        recurring_lockup_duration_secs: u64,
-        required_proposer_stake: u64,
-        rewards_apy_percentage: u64,
-        voting_duration_secs: u64,
+        genesis_config: &GenesisConfiguration,
     ) -> anyhow::Result<GenesisInfo> {
         let mut validators = Vec::new();
 
@@ -83,15 +77,16 @@ impl GenesisInfo {
             validators,
             modules,
             genesis: None,
-            allow_new_validators,
-            epoch_duration_secs,
-            min_stake,
-            min_voting_threshold,
-            max_stake,
-            recurring_lockup_duration_secs,
-            required_proposer_stake,
-            rewards_apy_percentage,
-            voting_duration_secs,
+            allow_new_validators: genesis_config.allow_new_validators,
+            epoch_duration_secs: genesis_config.epoch_duration_secs,
+            is_test: genesis_config.is_test,
+            min_stake: genesis_config.min_stake,
+            min_voting_threshold: genesis_config.min_voting_threshold,
+            max_stake: genesis_config.max_stake,
+            recurring_lockup_duration_secs: genesis_config.recurring_lockup_duration_secs,
+            required_proposer_stake: genesis_config.required_proposer_stake,
+            rewards_apy_percentage: genesis_config.rewards_apy_percentage,
+            voting_duration_secs: genesis_config.voting_duration_secs,
         })
     }
 
@@ -113,6 +108,7 @@ impl GenesisInfo {
             vm_genesis::GenesisConfiguration {
                 allow_new_validators: self.allow_new_validators,
                 epoch_duration_secs: self.epoch_duration_secs,
+                is_test: true,
                 min_stake: self.min_stake,
                 min_voting_threshold: self.min_voting_threshold,
                 max_stake: self.max_stake,

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     CliCommand, CliResult,
 };
 use aptos_crypto::{bls12381, ed25519::Ed25519PublicKey, x25519, ValidCryptoMaterialStringExt};
+use aptos_genesis::builder::GenesisConfiguration;
 use aptos_genesis::{
     config::{HostAndPort, Layout, ValidatorConfiguration},
     GenesisInfo,
@@ -134,15 +135,18 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
         layout.root_key,
         validators,
         modules,
-        layout.allow_new_validators,
-        layout.epoch_duration_secs,
-        layout.min_stake,
-        layout.min_voting_threshold,
-        layout.max_stake,
-        layout.recurring_lockup_duration_secs,
-        layout.required_proposer_stake,
-        layout.rewards_apy_percentage,
-        layout.voting_duration_secs,
+        &GenesisConfiguration {
+            allow_new_validators: layout.allow_new_validators,
+            epoch_duration_secs: layout.epoch_duration_secs,
+            is_test: layout.is_test,
+            min_stake: layout.min_stake,
+            min_voting_threshold: layout.min_voting_threshold,
+            max_stake: layout.max_stake,
+            recurring_lockup_duration_secs: layout.recurring_lockup_duration_secs,
+            required_proposer_stake: layout.required_proposer_stake,
+            rewards_apy_percentage: layout.rewards_apy_percentage,
+            voting_duration_secs: layout.voting_duration_secs,
+        },
     )?)
 }
 

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -136,6 +136,7 @@ fn create_layout_file(
         chain_id,
         allow_new_validators: false,
         epoch_duration_secs: 86400,
+        is_test: true,
         min_stake: 0,
         min_voting_threshold: 0,
         max_stake: u64::MAX,

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -12,7 +12,7 @@ use aptos_logger::{info, warn};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
-    types::{account_config::aptos_root_address, chain_id::ChainId, AccountKey, LocalAccount},
+    types::{account_config::aptos_test_root_address, chain_id::ChainId, AccountKey, LocalAccount},
 };
 use rand::seq::SliceRandom;
 use std::convert::TryFrom;
@@ -142,12 +142,12 @@ impl Cluster {
     }
 
     pub async fn load_aptos_root_account(&self, client: &RestClient) -> Result<LocalAccount> {
-        self.load_account_with_mint_key(client, aptos_root_address())
+        self.load_account_with_mint_key(client, aptos_test_root_address())
             .await
     }
 
     pub async fn load_faucet_account(&self, client: &RestClient) -> Result<LocalAccount> {
-        self.load_account_with_mint_key(client, aptos_root_address())
+        self.load_account_with_mint_key(client, aptos_test_root_address())
             .await
     }
 

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -7,7 +7,7 @@ use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_types::{
     account_address::AccountAddress,
-    account_config::aptos_root_address,
+    account_config::aptos_test_root_address,
     account_view::AccountView,
     chain_id::ChainId,
     transaction::{Transaction, Version},
@@ -97,7 +97,7 @@ impl TransactionGenerator {
     pub fn new(genesis_key: Ed25519PrivateKey) -> Self {
         Self {
             seed_accounts_cache: None,
-            root_account: LocalAccount::new(aptos_root_address(), genesis_key, 0),
+            root_account: LocalAccount::new(aptos_test_root_address(), genesis_key, 0),
             accounts_cache: None,
             num_existing_accounts: 0,
             version: 0,
@@ -170,9 +170,9 @@ impl TransactionGenerator {
         Self {
             seed_accounts_cache: None,
             root_account: LocalAccount::new(
-                aptos_root_address(),
+                aptos_test_root_address(),
                 genesis_key,
-                get_sequence_number(aptos_root_address(), db.reader),
+                get_sequence_number(aptos_test_root_address(), db.reader),
             ),
             accounts_cache,
             num_existing_accounts,

--- a/execution/executor-test-helpers/src/integration_test_impl.rs
+++ b/execution/executor-test-helpers/src/integration_test_impl.rs
@@ -10,7 +10,7 @@ use aptos_sdk::{
 use aptos_state_view::account_with_state_view::{AccountWithStateView, AsAccountWithStateView};
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::{
-    account_config::aptos_root_address,
+    account_config::aptos_test_root_address,
     account_view::AccountView,
     block_metadata::BlockMetadata,
     chain_id::ChainId,
@@ -38,7 +38,7 @@ pub fn test_execution_with_storage_impl() -> Arc<AptosDB> {
     let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
 
     let mut genesis_account: LocalAccount = LocalAccount::new(
-        aptos_root_address(),
+        aptos_test_root_address(),
         AccountKey::from_private_key(vm_genesis::GENESIS_KEYPAIR.0.clone()),
         0,
     );

--- a/execution/executor/tests/db_bootstrapper_test.rs
+++ b/execution/executor/tests/db_bootstrapper_test.rs
@@ -11,7 +11,7 @@ use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
     account_config::{
-        aptos_root_address, new_block_event_key, CoinStoreResource, NewBlockEvent,
+        aptos_test_root_address, new_block_event_key, CoinStoreResource, NewBlockEvent,
         CORE_CODE_ADDRESS,
     },
     account_view::AccountView,
@@ -125,7 +125,7 @@ fn get_aptos_coin_mint_transaction(
     amount: u64,
 ) -> Transaction {
     get_test_signed_transaction(
-        aptos_root_address(),
+        aptos_test_root_address(),
         /* sequence_number = */ aptos_root_seq_num,
         aptos_root_key.clone(),
         aptos_root_key.public_key(),
@@ -140,7 +140,7 @@ fn get_account_transaction(
     _account_key: &Ed25519PrivateKey,
 ) -> Transaction {
     get_test_signed_transaction(
-        aptos_root_address(),
+        aptos_test_root_address(),
         /* sequence_number = */ aptos_root_seq_num,
         aptos_root_key.clone(),
         aptos_root_key.public_key(),

--- a/execution/executor/tests/storage_integration_test.rs
+++ b/execution/executor/tests/storage_integration_test.rs
@@ -6,7 +6,7 @@ use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::{
     access_path::AccessPath,
-    account_config::{aptos_root_address, AccountResource, CORE_CODE_ADDRESS},
+    account_config::{aptos_test_root_address, AccountResource, CORE_CODE_ADDRESS},
     account_view::AccountView,
     block_metadata::BlockMetadata,
     state_store::state_key::StateKey,
@@ -108,7 +108,7 @@ fn test_reconfiguration() {
 
     // txn1 = give the validator some money so they can send a tx
     let txn1 = get_test_signed_transaction(
-        aptos_root_address(),
+        aptos_test_root_address(),
         /* sequence_number = */ 0,
         genesis_key.clone(),
         genesis_key.public_key(),
@@ -128,7 +128,7 @@ fn test_reconfiguration() {
 
     // txn3 = set the aptos version
     let txn3 = get_test_signed_transaction(
-        aptos_root_address(),
+        aptos_test_root_address(),
         /* sequence_number = */ 1,
         genesis_key.clone(),
         genesis_key.public_key(),
@@ -156,7 +156,7 @@ fn test_reconfiguration() {
 
     let t3 = db
         .reader
-        .get_account_transaction(aptos_root_address(), 1, true, current_version)
+        .get_account_transaction(aptos_test_root_address(), 1, true, current_version)
         .unwrap();
     verify_committed_txn_status(t3.as_ref(), &txn_block[2]).unwrap();
 

--- a/sf-stream/src/tests/proto_converter_tests.rs
+++ b/sf-stream/src/tests/proto_converter_tests.rs
@@ -14,7 +14,7 @@ use aptos_protos::extractor::v1::{
     Transaction as TransactionPB,
 };
 
-use aptos_sdk::types::{account_config::aptos_root_address, LocalAccount};
+use aptos_sdk::types::{account_config::aptos_test_root_address, LocalAccount};
 use move_deps::{
     move_core_types::{account_address::AccountAddress, value::MoveValue},
     move_package::BuildConfig,
@@ -38,7 +38,7 @@ async fn test_genesis_works() {
     if let TxnData::Genesis(txn) = txn.txn_data.unwrap() {
         assert_eq!(
             txn.events[0].key.clone().unwrap().account_address,
-            aptos_root_address().to_string()
+            aptos_test_root_address().to_string()
         );
     }
 }

--- a/sf-stream/src/tests/test_context.rs
+++ b/sf-stream/src/tests/test_context.rs
@@ -7,7 +7,9 @@ use aptos_mempool::mocks::MockSharedMempool;
 use aptos_protos::extractor::v1::Transaction as TransactionPB;
 use aptos_sdk::{
     transaction_builder::TransactionFactory,
-    types::{account_config::aptos_root_address, transaction::SignedTransaction, LocalAccount},
+    types::{
+        account_config::aptos_test_root_address, transaction::SignedTransaction, LocalAccount,
+    },
 };
 use aptos_temppath::TempPath;
 use aptos_types::{
@@ -135,7 +137,7 @@ impl TestContext {
     }
 
     pub fn root_account(&self) -> LocalAccount {
-        LocalAccount::new(aptos_root_address(), self.root_key.private_key(), 0)
+        LocalAccount::new(aptos_test_root_address(), self.root_key.private_key(), 0)
     }
 
     pub fn gen_account(&mut self) -> LocalAccount {

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -15,6 +15,7 @@ data:
     chain_id: {{ .Values.chain.chain_id | int }}
     allow_new_validators: {{ .Values.chain.allow_new_validators }}
     epoch_duration_secs: {{ .Values.chain.epoch_duration_secs | int }}
+    is_test: {{ .Values.chain.is_test }}
     min_price_per_gas_unit: {{ .Values.chain.min_price_per_gas_unit }}
     min_stake: {{ .Values.chain.min_stake | int }}
     min_voting_threshold: {{ .Values.chain.min_voting_threshold | int }}

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -11,6 +11,7 @@ chain:
   allow_new_validators: false
   # -- Length of each epoch in seconds. Defaults to 2 hours
   epoch_duration_secs: 7200
+  is_test: true
   # -- Minimum price per gas unit
   min_price_per_gas_unit: 1
   # -- Minimum stake. Defaults to 1M APTOS coins with 8 decimals

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -61,7 +61,7 @@ impl K8sSwarm {
         let client = validators.values().next().unwrap().rest_client();
         let key = load_root_key(root_key);
         let account_key = AccountKey::from_private_key(key);
-        let address = aptos_sdk::types::account_config::aptos_root_address();
+        let address = aptos_sdk::types::account_config::aptos_test_root_address();
         let sequence_number = query_sequence_numbers(&client, &[address])
             .await
             .map_err(|e| {

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -194,7 +194,7 @@ impl LocalSwarm {
             .collect::<Result<HashMap<_, _>>>()?;
         let root_key = ConfigKey::new(root_key);
         let root_account = LocalAccount::new(
-            aptos_sdk::types::account_config::aptos_root_address(),
+            aptos_sdk::types::account_config::aptos_test_root_address(),
             AccountKey::from_private_key(root_key.private_key()),
             0,
         );

--- a/testsuite/smoke-test/src/aptos/error_report.rs
+++ b/testsuite/smoke-test/src/aptos/error_report.rs
@@ -4,7 +4,7 @@
 use aptos_sdk::{transaction_builder::TransactionBuilder, types::LocalAccount};
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::{
-    account_address::AccountAddress, account_config::aptos_root_address, chain_id::ChainId,
+    account_address::AccountAddress, account_config::aptos_test_root_address, chain_id::ChainId,
 };
 use forge::{AptosPublicInfo, Swarm};
 
@@ -75,7 +75,7 @@ async fn test_error_report() {
     submit_and_check_err(
         &local_account,
         &mut info,
-        |t| t.sender(aptos_root_address()),
+        |t| t.sender(aptos_test_root_address()),
         "SEQUENCE_NUMBER_TOO_OLD",
     )
     .await;
@@ -84,7 +84,7 @@ async fn test_error_report() {
         &local_account,
         &mut info,
         |t| {
-            t.sender(aptos_root_address())
+            t.sender(aptos_test_root_address())
                 .sequence_number(root_account_sequence_number)
         },
         "INVALID_AUTH_KEY",

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -7,7 +7,7 @@ use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_faucet::FaucetArgs;
 use aptos_genesis::builder::{InitConfigFn, InitGenesisConfigFn};
 use aptos_logger::info;
-use aptos_types::{account_config::aptos_root_address, chain_id::ChainId};
+use aptos_types::{account_config::aptos_test_root_address, chain_id::ChainId};
 use forge::Node;
 use forge::{Factory, LocalFactory, LocalSwarm};
 use once_cell::sync::Lazy;
@@ -150,7 +150,7 @@ pub fn launch_faucet(
         server_url: endpoint,
         mint_key_file_path: PathBuf::new(),
         mint_key: Some(ConfigKey::new(mint_key)),
-        mint_account_address: Some(aptos_root_address()),
+        mint_account_address: Some(aptos_test_root_address()),
         chain_id,
         maximum_amount: None,
         do_not_delegate: true,

--- a/types/src/account_config/constants/addresses.rs
+++ b/types/src/account_config/constants/addresses.rs
@@ -5,8 +5,7 @@ use crate::account_address::AccountAddress;
 
 pub use move_deps::move_core_types::language_storage::CORE_CODE_ADDRESS;
 
-// TODO: Rename to aptos_test_address to be clear this is only used in tests.
-pub fn aptos_root_address() -> AccountAddress {
+pub fn aptos_test_root_address() -> AccountAddress {
     AccountAddress::from_hex_literal("0xA550C18")
         .expect("Parsing valid hex literal should always succeed")
 }

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -79,7 +79,7 @@ impl std::ops::Deref for TestValidator {
 fn test_validate_transaction() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let program = aptos_stdlib::aptos_coin_mint(address, 100);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
@@ -100,7 +100,7 @@ fn test_validate_invalid_signature() {
     let other_private_key = Ed25519PrivateKey::generate(&mut rng);
     // Submit with an account using an different private/public keypair
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let program = aptos_stdlib::aptos_coin_transfer(address, 100);
     let transaction = transaction_test_helpers::get_test_unchecked_txn(
         address,
@@ -117,7 +117,7 @@ fn test_validate_invalid_signature() {
 fn test_validate_known_script_too_large_args() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
         1,
@@ -147,7 +147,7 @@ fn test_validate_known_script_too_large_args() {
 fn test_validate_max_gas_units_above_max() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
         1,
@@ -169,7 +169,7 @@ fn test_validate_max_gas_units_above_max() {
 fn test_validate_max_gas_units_below_min() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     // Calculate a size for the transaction script that will ensure
     // that the minimum transaction gas is at least 1 after scaling to the
     // external gas units.
@@ -200,7 +200,7 @@ fn test_validate_max_gas_units_below_min() {
 #[test]
 fn test_get_account_sequence_number() {
     let vm_validator = TestValidator::new();
-    let root_address = account_config::aptos_root_address();
+    let root_address = account_config::aptos_test_root_address();
     let state_view = vm_validator
         .vm_validator
         .db_reader
@@ -227,7 +227,7 @@ fn test_get_account_sequence_number() {
 fn test_validate_max_gas_price_above_bounds() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
         1,
@@ -252,7 +252,7 @@ fn test_validate_max_gas_price_above_bounds() {
 fn test_validate_max_gas_price_below_bounds() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let program = aptos_stdlib::aptos_coin_transfer(address, 100);
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
@@ -278,7 +278,7 @@ fn test_validate_max_gas_price_below_bounds() {
 fn test_validate_module_publishing() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_test_signed_module_publishing_transaction(
         address,
         1,
@@ -294,7 +294,7 @@ fn test_validate_module_publishing() {
 fn test_validate_module_publishing_non_association() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_test_signed_module_publishing_transaction(
         address,
         1,
@@ -315,7 +315,7 @@ fn test_validate_invalid_auth_key() {
     let other_private_key = Ed25519PrivateKey::generate(&mut rng);
     // Submit with an account using an different private/public keypair
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let program = aptos_stdlib::aptos_coin_transfer(address, 100);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
@@ -332,7 +332,7 @@ fn test_validate_invalid_auth_key() {
 fn test_validate_account_doesnt_exist() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let random_account_addr = account_address::AccountAddress::random();
     let program = aptos_stdlib::aptos_coin_transfer(address, 100);
     let transaction = transaction_test_helpers::get_test_signed_transaction(
@@ -356,7 +356,7 @@ fn test_validate_account_doesnt_exist() {
 fn test_validate_sequence_number_too_new() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let program = aptos_stdlib::aptos_coin_transfer(address, 100);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
@@ -373,7 +373,7 @@ fn test_validate_sequence_number_too_new() {
 fn test_validate_invalid_arguments() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let program = aptos_stdlib::aptos_coin_transfer(address, 100);
     let transaction = transaction_test_helpers::get_test_signed_txn(
         address,
@@ -392,7 +392,7 @@ fn test_validate_non_genesis_write_set() {
     let vm_validator = TestValidator::new();
 
     // Confirm that a correct transaction is validated successfully.
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_write_set_txn(
         address,
         1,
@@ -406,7 +406,7 @@ fn test_validate_non_genesis_write_set() {
 
     // A WriteSet txn is only valid when sent from the root account.
     let bad_transaction = transaction_test_helpers::get_write_set_txn(
-        account_config::aptos_root_address(),
+        account_config::aptos_test_root_address(),
         1,
         &vm_genesis::GENESIS_KEYPAIR.0,
         vm_genesis::GENESIS_KEYPAIR.1.clone(),
@@ -421,7 +421,7 @@ fn test_validate_non_genesis_write_set() {
 fn test_validate_expiration_time() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_test_signed_transaction(
         address,
         1, /* sequence_number */
@@ -440,7 +440,7 @@ fn test_validate_expiration_time() {
 fn test_validate_chain_id() {
     let vm_validator = TestValidator::new();
 
-    let address = account_config::aptos_root_address();
+    let address = account_config::aptos_test_root_address();
     let transaction = transaction_test_helpers::get_test_txn_with_chain_id(
         address,
         0, /* sequence_number */


### PR DESCRIPTION
### Description

Refactor genesis and make sure the core resources account is only initialized in tests and testnets.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2842)
<!-- Reviewable:end -->
