### PR TITLE
[mempool] add support to limit maximum bytes for a batch

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -8,7 +8,8 @@ use std::path::PathBuf;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ConsensusConfig {
-    pub max_block_size: u64,
+    pub max_block_txns: u64,
+    pub max_block_bytes: u64,
     pub max_pruned_blocks_in_mem: usize,
     // Timeout for consensus to get an ack from mempool for executed transactions (in milliseconds)
     pub mempool_executed_txn_timeout_ms: u64,
@@ -32,7 +33,8 @@ pub struct ConsensusConfig {
 impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
-            max_block_size: 6000,
+            max_block_txns: 6000,
+            max_block_bytes: 10 * 1024 * 1024, // 10MB
             max_pruned_blocks_in_mem: 100,
             mempool_executed_txn_timeout_ms: 1000,
             mempool_txn_pull_timeout_ms: 1000,

--- a/consensus/consensus-types/src/request_response.rs
+++ b/consensus/consensus-types/src/request_response.rs
@@ -12,6 +12,8 @@ pub enum ConsensusRequest {
     GetBlockRequest(
         // max block size
         u64,
+        // max byte size
+        u64,
         // block payloads to exclude from the requested block
         PayloadFilter,
         // callback to respond to
@@ -31,11 +33,11 @@ pub enum ConsensusRequest {
 impl fmt::Display for ConsensusRequest {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            ConsensusRequest::GetBlockRequest(block_size, excluded, _) => {
+            ConsensusRequest::GetBlockRequest(max_txns, max_bytes, excluded, _) => {
                 write!(
                     f,
-                    "GetBlockRequest [block_size: {}, excluded: {}]",
-                    block_size, excluded
+                    "GetBlockRequest [max_txns: {}, max_bytes: {} excluded: {}]",
+                    max_txns, max_bytes, excluded
                 )
             }
             ConsensusRequest::CleanRequest(epoch, round, _) => {

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -576,7 +576,8 @@ impl EpochManager {
             block_store.clone(),
             Arc::new(payload_manager),
             self.time_service.clone(),
-            self.config.max_block_size,
+            self.config.max_block_txns,
+            self.config.max_block_bytes,
             onchain_config.max_failed_authors_to_store(),
         );
 

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -12,7 +12,6 @@ use consensus_types::{
     quorum_cert::QuorumCert,
 };
 
-use aptos_infallible::Mutex;
 use consensus_types::common::{Payload, PayloadFilter};
 use futures::future::BoxFuture;
 use std::sync::Arc;
@@ -46,11 +45,13 @@ pub struct ProposalGenerator {
     // Time service to generate block timestamps
     time_service: Arc<dyn TimeService>,
     // Max number of transactions to be added to a proposed block.
-    max_block_size: u64,
+    max_block_txns: u64,
+    // Max number of bytes to be added to a proposed block.
+    max_block_bytes: u64,
     // Max number of failed authors to be added to a proposed block.
     max_failed_authors_to_store: usize,
     // Last round that a proposal was generated
-    last_round_generated: Mutex<Round>,
+    last_round_generated: Round,
 }
 
 impl ProposalGenerator {
@@ -59,7 +60,8 @@ impl ProposalGenerator {
         block_store: Arc<dyn BlockReader + Send + Sync>,
         payload_manager: Arc<dyn PayloadManager>,
         time_service: Arc<dyn TimeService>,
-        max_block_size: u64,
+        max_block_txns: u64,
+        max_block_bytes: u64,
         max_failed_authors_to_store: usize,
     ) -> Self {
         Self {
@@ -67,9 +69,10 @@ impl ProposalGenerator {
             block_store,
             payload_manager,
             time_service,
-            max_block_size,
+            max_block_txns,
+            max_block_bytes,
             max_failed_authors_to_store,
-            last_round_generated: Mutex::new(0),
+            last_round_generated: 0,
         }
     }
 
@@ -110,13 +113,10 @@ impl ProposalGenerator {
         proposer_election: &mut UnequivocalProposerElection,
         wait_callback: BoxFuture<'static, ()>,
     ) -> anyhow::Result<BlockData> {
-        {
-            let mut last_round_generated = self.last_round_generated.lock();
-            if *last_round_generated < round {
-                *last_round_generated = round;
-            } else {
-                bail!("Already proposed in the round {}", round);
-            }
+        if self.last_round_generated < round {
+            self.last_round_generated = round;
+        } else {
+            bail!("Already proposed in the round {}", round);
         }
 
         let hqc = self.ensure_highest_quorum_cert(round)?;
@@ -159,7 +159,8 @@ impl ProposalGenerator {
             let payload = self
                 .payload_manager
                 .pull_payload(
-                    self.max_block_size,
+                    self.max_block_txns,
+                    self.max_block_bytes,
                     payload_filter,
                     wait_callback,
                     pending_ordering,

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -33,6 +33,7 @@ async fn test_proposal_generation_empty_tree() {
         Arc::new(SimulatedTimeService::new()),
         1,
         10,
+        10,
     );
     let mut proposer_election =
         UnequivocalProposerElection::new(Box::new(RotatingProposer::new(vec![signer.author()], 1)));
@@ -67,6 +68,7 @@ async fn test_proposal_generation_parent() {
         Arc::new(MockPayloadManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
+        1000,
         10,
     );
     let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
@@ -134,6 +136,7 @@ async fn test_old_proposal_generation() {
         Arc::new(MockPayloadManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
+        1000,
         10,
     );
     let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(
@@ -166,6 +169,7 @@ async fn test_correct_failed_authors() {
         Arc::new(MockPayloadManager::new(None)),
         Arc::new(SimulatedTimeService::new()),
         1,
+        1000,
         10,
     );
     let mut proposer_election = UnequivocalProposerElection::new(Box::new(RotatingProposer::new(

--- a/consensus/src/quorum_store/direct_mempool_quorum_store.rs
+++ b/consensus/src/quorum_store/direct_mempool_quorum_store.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::monitor;
-use crate::quorum_store::counters;
+use crate::{monitor, quorum_store::counters};
 use anyhow::Result;
 use aptos_logger::prelude::*;
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
@@ -42,11 +41,12 @@ impl DirectMempoolQuorumStore {
 
     async fn pull_internal(
         &self,
-        max_size: u64,
+        max_items: u64,
+        max_bytes: u64,
         exclude_txns: Vec<TransactionSummary>,
     ) -> Result<Vec<SignedTransaction>, anyhow::Error> {
         let (callback, callback_rcv) = oneshot::channel();
-        let msg = QuorumStoreRequest::GetBatchRequest(max_size, exclude_txns, callback);
+        let msg = QuorumStoreRequest::GetBatchRequest(max_items, max_bytes, exclude_txns, callback);
         self.mempool_sender
             .clone()
             .try_send(msg)
@@ -74,14 +74,15 @@ impl DirectMempoolQuorumStore {
 
     async fn handle_block_request(
         &self,
-        max_size: u64,
+        max_txns: u64,
+        max_bytes: u64,
         payload_filter: PayloadFilter,
         callback: oneshot::Sender<Result<ConsensusResponse>>,
     ) {
         let get_batch_start_time = Instant::now();
         let (txns, result) = match payload_filter {
             PayloadFilter::DirectMempool(exclude_txns) => {
-                match self.pull_internal(max_size, exclude_txns).await {
+                match self.pull_internal(max_txns, max_bytes, exclude_txns).await {
                     Err(_) => {
                         error!("GetBatch failed");
                         (vec![], counters::REQUEST_FAIL_LABEL)
@@ -127,8 +128,8 @@ impl DirectMempoolQuorumStore {
 
     async fn handle_consensus_request(&self, req: ConsensusRequest) {
         match req {
-            ConsensusRequest::GetBlockRequest(max_size, payload_filter, callback) => {
-                self.handle_block_request(max_size, payload_filter, callback)
+            ConsensusRequest::GetBlockRequest(max_txns, max_bytes, payload_filter, callback) => {
+                self.handle_block_request(max_txns, max_bytes, payload_filter, callback)
                     .await;
             }
             ConsensusRequest::CleanRequest(_, _, callback) => {

--- a/consensus/src/quorum_store/tests/direct_mempool_quorum_store_test.rs
+++ b/consensus/src/quorum_store/tests/direct_mempool_quorum_store_test.rs
@@ -31,12 +31,18 @@ async fn test_block_request_no_txns() {
     consensus_to_quorum_store_sender
         .try_send(ConsensusRequest::GetBlockRequest(
             100,
+            1000,
             PayloadFilter::DirectMempool(vec![]),
             consensus_callback,
         ))
         .unwrap();
 
-    if let QuorumStoreRequest::GetBatchRequest(_max_batch_size, _exclude_txns, callback) = timeout(
+    if let QuorumStoreRequest::GetBatchRequest(
+        _max_batch_size,
+        _max_bytes,
+        _exclude_txns,
+        callback,
+    ) = timeout(
         Duration::from_millis(1_000),
         quorum_store_to_mempool_receiver.select_next_some(),
     )

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -146,6 +146,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         Arc::new(MockPayloadManager::new(None)),
         time_service,
         1,
+        1024,
         10,
     );
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -205,6 +205,7 @@ impl NodeSetup {
             Arc::new(MockPayloadManager::new(None)),
             time_service.clone(),
             1,
+            1000,
             10,
         );
 

--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -21,7 +21,8 @@ pub type StateComputerCommitCallBackType =
 pub trait PayloadManager: Send + Sync {
     async fn pull_payload(
         &self,
-        max_size: u64,
+        max_items: u64,
+        max_bytes: u64,
         exclude: PayloadFilter,
         wait_callback: BoxFuture<'static, ()>,
         pending_ordering: bool,

--- a/consensus/src/test_utils/mock_payload_manager.rs
+++ b/consensus/src/test_utils/mock_payload_manager.rs
@@ -52,6 +52,7 @@ impl PayloadManager for MockPayloadManager {
     async fn pull_payload(
         &self,
         _max_size: u64,
+        _max_bytes: u64,
         _exclude: PayloadFilter,
         _wait_callback: BoxFuture<'static, ()>,
         _pending_ordering: bool,

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -182,7 +182,8 @@ impl Mempool {
     #[allow(clippy::explicit_counter_loop)]
     pub(crate) fn get_batch(
         &self,
-        batch_size: u64,
+        max_txns: u64,
+        max_bytes: u64,
         mut seen: HashSet<TxnPointer>,
     ) -> Vec<SignedTransaction> {
         let mut result = vec![];
@@ -193,6 +194,7 @@ impl Mempool {
         // but can't be executed before first txn. Once observed, such txn will be saved in
         // `skipped` DS and rechecked once it's ancestor becomes available
         let mut skipped = HashSet::new();
+        let mut total_bytes = 0;
         let seen_size = seen.len();
         let mut txn_walked = 0usize;
         // iterate over the queue of transactions based on gas price
@@ -215,7 +217,7 @@ impl Mempool {
                 let ptr = TxnPointer::from(txn);
                 seen.insert(ptr);
                 result.push(ptr);
-                if (result.len() as u64) == batch_size {
+                if (result.len() as u64) == max_txns {
                     break;
                 }
 
@@ -225,7 +227,7 @@ impl Mempool {
                 while skipped.contains(&skipped_txn) {
                     seen.insert(skipped_txn);
                     result.push(skipped_txn);
-                    if (result.len() as u64) == batch_size {
+                    if (result.len() as u64) == max_txns {
                         break 'main;
                     }
                     skipped_txn = (txn.address, skipped_txn.1 + 1);
@@ -235,11 +237,17 @@ impl Mempool {
             }
         }
         let result_size = result.len();
-        // convert transaction pointers to real values
-        let block: Vec<_> = result
-            .into_iter()
-            .filter_map(|(address, tx_seq)| self.transactions.get(&address, tx_seq))
-            .collect();
+        let mut block = Vec::with_capacity(result_size);
+        for (address, seq) in result {
+            if let Some(txn) = self.transactions.get(&address, seq) {
+                let txn_size = txn.raw_txn_bytes_len();
+                if total_bytes + txn_size > max_bytes as usize {
+                    break;
+                }
+                total_bytes += txn_size;
+                block.push(txn);
+            }
+        }
 
         debug!(
             LogSchema::new(LogEntry::GetBlock),
@@ -247,7 +255,8 @@ impl Mempool {
             walked = txn_walked,
             seen_after = seen.len(),
             result_size = result_size,
-            block_size = block.len()
+            block_size = block.len(),
+            byte_size = total_bytes,
         );
         for transaction in &block {
             self.log_latency(

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Tasks that are executed by coordinators (short-lived compared to coordinators)
-use crate::shared_mempool::types::BatchId;
-use crate::thread_pool::IO_POOL;
 use crate::{
     core_mempool::{CoreMempool, TimelineState, TxnPointer},
     counters,
     logging::{LogEntry, LogEvent, LogSchema},
     network::{BroadcastError, MempoolSyncMsg},
     shared_mempool::types::{
-        notify_subscribers, ScheduledBroadcast, SharedMempool, SharedMempoolNotification,
+        notify_subscribers, BatchId, ScheduledBroadcast, SharedMempool, SharedMempoolNotification,
         SubmissionStatusBundle,
     },
+    thread_pool::IO_POOL,
     QuorumStoreRequest, QuorumStoreResponse, SubmissionStatus,
 };
 use anyhow::Result;
@@ -390,7 +389,7 @@ pub(crate) fn process_quorum_store_request<V: TransactionValidation>(
     debug!(LogSchema::event_log(LogEntry::QuorumStore, LogEvent::Received).quorum_store_msg(&req));
 
     let (resp, callback, counter_label) = match req {
-        QuorumStoreRequest::GetBatchRequest(max_batch_size, transactions, callback) => {
+        QuorumStoreRequest::GetBatchRequest(max_txns, max_bytes, transactions, callback) => {
             let exclude_transactions: HashSet<TxnPointer> = transactions
                 .iter()
                 .map(|txn| (txn.sender, txn.sequence_number))
@@ -402,8 +401,8 @@ pub(crate) fn process_quorum_store_request<V: TransactionValidation>(
                 // Note: this gc operation relies on the fact that consensus uses the system time to determine block timestamp
                 let curr_time = aptos_infallible::duration_since_epoch();
                 mempool.gc_by_expiration_time(curr_time);
-                let batch_size = cmp::max(max_batch_size, 1);
-                txns = mempool.get_batch(batch_size, exclude_transactions);
+                let max_txns = cmp::max(max_txns, 1);
+                txns = mempool.get_batch(max_txns, max_bytes, exclude_transactions);
             }
             counters::mempool_service_transactions(counters::GET_BLOCK_LABEL, txns.len());
 

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -154,6 +154,8 @@ pub enum QuorumStoreRequest {
     GetBatchRequest(
         // max batch size
         u64,
+        // max byte size
+        u64,
         // transactions to exclude from the requested batch
         Vec<TransactionSummary>,
         // callback to respond to
@@ -171,10 +173,11 @@ pub enum QuorumStoreRequest {
 impl fmt::Display for QuorumStoreRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let payload = match self {
-            QuorumStoreRequest::GetBatchRequest(batch_size, excluded_txns, _) => {
+            QuorumStoreRequest::GetBatchRequest(max_txns, max_bytes, excluded_txns, _) => {
                 format!(
-                    "GetBatchRequest [batch_size: {}, excluded_txns_length: {}]",
-                    batch_size,
+                    "GetBatchRequest [max_txns: {}, max_bytes: {}, excluded_txns_length: {}]",
+                    max_txns,
+                    max_bytes,
                     excluded_txns.len()
                 )
             }

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -73,11 +73,11 @@ impl TestTransaction {
         &self,
         max_gas_amount: u64,
     ) -> SignedTransaction {
-        self.make_signed_transaction_impl(max_gas_amount, u64::max_value())
+        self.make_signed_transaction_impl(max_gas_amount, u64::MAX)
     }
 
     pub(crate) fn make_signed_transaction(&self) -> SignedTransaction {
-        self.make_signed_transaction_impl(100, u64::max_value())
+        self.make_signed_transaction_impl(100, u64::MAX)
     }
 
     fn make_signed_transaction_impl(
@@ -169,9 +169,10 @@ impl ConsensusMock {
     pub(crate) fn get_block(
         &mut self,
         mempool: &mut CoreMempool,
-        block_size: u64,
+        max_txns: u64,
+        max_bytes: u64,
     ) -> Vec<SignedTransaction> {
-        let block = mempool.get_batch(block_size, self.0.clone());
+        let block = mempool.get_batch(max_txns, max_bytes, self.0.clone());
         self.0 = self
             .0
             .union(

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -163,7 +163,8 @@ impl MockSharedMempool {
 
     pub fn get_txns(&self, size: u64) -> Vec<SignedTransaction> {
         let pool = self.mempool.lock();
-        pool.get_batch(size, HashSet::new())
+        // assume txn size is less than 100kb
+        pool.get_batch(size, size * 102400, HashSet::new())
     }
 
     pub fn remove_txn(&self, txn: &SignedTransaction) {

--- a/mempool/src/tests/multi_node_test.rs
+++ b/mempool/src/tests/multi_node_test.rs
@@ -383,10 +383,11 @@ impl TestHarness {
 
                         // Verify transaction was inserted into Mempool
                         if check_txns_in_mempool {
-                            let block = self
-                                .node(sender_id)
-                                .mempool()
-                                .get_batch(100, HashSet::new());
+                            let block = self.node(sender_id).mempool().get_batch(
+                                100,
+                                102400,
+                                HashSet::new(),
+                            );
                             for txn in transactions.iter() {
                                 assert!(block.contains(txn));
                             }

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -151,7 +151,7 @@ impl MempoolNode {
     /// Asynchronously waits for up to 1 second for txns to appear in mempool
     pub async fn wait_on_txns_in_mempool(&self, txns: &[TestTransaction]) {
         for _ in 0..10 {
-            let block = self.mempool.lock().get_batch(100, HashSet::new());
+            let block = self.mempool.lock().get_batch(100, 102400, HashSet::new());
 
             if block_contains_all_transactions(&block, txns) {
                 break;
@@ -201,7 +201,7 @@ impl MempoolNode {
         txns: &[TestTransaction],
         condition: Condition,
     ) -> Result<(), (Vec<(AccountAddress, u64)>, Vec<(AccountAddress, u64)>)> {
-        let block = self.mempool.lock().get_batch(100, HashSet::new());
+        let block = self.mempool.lock().get_batch(100, 102400, HashSet::new());
         if !condition(&block, txns) {
             let actual: Vec<_> = block
                 .iter()


### PR DESCRIPTION
There's a bump for single transaction size limit to 6MB https://github.com/aptos-labs/aptos-core/pull/2829, there's no way we can support 6mb  * 6000 blocks, this commit adds the limit on bytes level

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2844)
<!-- Reviewable:end -->
