### PR TITLE
[aptos-cli] Use current directory for workspace .aptos if it doesn't exist

### DIFF
--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -193,13 +193,9 @@ fn find_workspace_config(
                 let cand = current_path.join(CONFIG_FOLDER);
                 if cand.is_dir() {
                     break Ok(cand);
-                }
-                if !current_path.pop() {
-                    return Err(CliError::ConfigNotFoundError(format!(
-                        "Unable to find {} in {} or any parent directory",
-                        CONFIG_FOLDER,
-                        starting_path.display()
-                    )));
+                } else if !current_path.pop() {
+                    // If we aren't able to find the folder, we'll create a new one right here
+                    break Ok(starting_path.join(CONFIG_FOLDER));
                 }
             }
         }


### PR DESCRIPTION
### Test Plan
```
cargo run -p aptos -- node run-local-testnet --with-faucet
warning: patch for `diesel` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
   Compiling aptos v0.2.4 (/opt/git/aptos-core/crates/aptos)
    Finished dev [unoptimized + debuginfo] target(s) in 26.22s
     Running `target/debug/aptos node run-local-testnet --with-faucet`
Building genesis with 1 validators. Directory of output: "/opt/git/aptos-core/.aptos/testnet"
Completed generating configuration:
        Log file: "/opt/git/aptos-core/.aptos/testnet/validator.log"
        Test dir: "/opt/git/aptos-core/.aptos/testnet"
        Aptos root key path: "/opt/git/aptos-core/.aptos/testnet/mint.key"
        Waypoint: 0:baf2610e2c80c28204b22f116f15341a952b82cdd2556b685c772b4867bf2c38
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit

Faucet is running.  Faucet endpoint: 0.0.0.0:8081
^C
(venv)  ✘ greg@jiggy  /opt/git/aptos-core   fix-cli-path  rm .aptos 
rm: .aptos: is a directory
(venv)  ✘ greg@jiggy  /opt/git/aptos-core   fix-cli-path  rm -r .aptos
(venv)  greg@jiggy  /opt/git/aptos-core   fix-cli-path  cargo run -p aptos -- node run-local-testnet --with-faucet
warning: patch for `diesel` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
    Finished dev [unoptimized + debuginfo] target(s) in 0.76s
     Running `target/debug/aptos node run-local-testnet --with-faucet`
Building genesis with 1 validators. Directory of output: "/opt/git/aptos-core/.aptos/testnet"
Completed generating configuration:
        Log file: "/opt/git/aptos-core/.aptos/testnet/validator.log"
        Test dir: "/opt/git/aptos-core/.aptos/testnet"
        Aptos root key path: "/opt/git/aptos-core/.aptos/testnet/mint.key"
        Waypoint: 0:1cb4fd88e241a53038f5cbd25fa1a08a386e11eea965ba0093f0852e86888fdb
        ChainId: TESTING
        REST API endpoint: 0.0.0.0:8080
        FullNode network: /ip4/0.0.0.0/tcp/6181

Aptos is running, press ctrl-c to exit

^C
(venv)  ✘ greg@jiggy  /opt/git/aptos-core   fix-cli-path  ls .aptos 
testnet

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2845)
<!-- Reviewable:end -->
