### PR TITLE
[mempool] avoid excessive logging (snapshot, excluded txns) except at trace level

### DIFF
--- a/crates/aptos-logger/src/macros.rs
+++ b/crates/aptos-logger/src/macros.rs
@@ -25,6 +25,19 @@ macro_rules! log {
     }};
 }
 
+#[macro_export]
+macro_rules! enabled {
+    ($level:expr) => {{
+        const METADATA: $crate::Metadata = $crate::Metadata::new(
+            $level,
+            env!("CARGO_CRATE_NAME"),
+            module_path!(),
+            concat!(file!(), ':', line!()),
+        );
+        METADATA.enabled()
+    }};
+}
+
 /// Log at the `trace` level
 #[macro_export]
 macro_rules! trace {

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -236,17 +236,13 @@ impl Mempool {
         }
         let result_size = result.len();
         // convert transaction pointers to real values
-        let mut block_log = TxnsLog::new();
         let block: Vec<_> = result
             .into_iter()
-            .filter_map(|(address, tx_seq)| {
-                block_log.add(address, tx_seq);
-                self.transactions.get(&address, tx_seq)
-            })
+            .filter_map(|(address, tx_seq)| self.transactions.get(&address, tx_seq))
             .collect();
 
         debug!(
-            LogSchema::new(LogEntry::GetBlock).txns(block_log),
+            LogSchema::new(LogEntry::GetBlock),
             seen_consensus = seen_size,
             walked = txn_walked,
             seen_after = seen.len(),

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -357,6 +357,6 @@ pub(crate) async fn snapshot_job(mempool: Arc<Mutex<CoreMempool>>, snapshot_inte
     let mut interval = IntervalStream::new(interval(Duration::from_secs(snapshot_interval_secs)));
     while let Some(_interval) = interval.next().await {
         let snapshot = mempool.lock().gen_snapshot();
-        debug!(LogSchema::new(LogEntry::MempoolSnapshot).txns(snapshot));
+        trace!(LogSchema::new(LogEntry::MempoolSnapshot).txns(snapshot));
     }
 }

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -13,6 +13,7 @@ use crate::{
 use aptos_config::{config::NodeConfig, network_id::NetworkId};
 use aptos_infallible::{Mutex, RwLock};
 
+use aptos_logger::Level;
 use event_notifications::ReconfigNotificationListener;
 use futures::channel::mpsc::{self, Receiver, UnboundedSender};
 use mempool_notifications::MempoolNotificationListener;
@@ -78,10 +79,12 @@ pub(crate) fn start_shared_mempool<V>(
         config.mempool.system_transaction_gc_interval_ms,
     ));
 
-    executor.spawn(snapshot_job(
-        mempool,
-        config.mempool.mempool_snapshot_interval_secs,
-    ));
+    if aptos_logger::enabled!(Level::Debug) {
+        executor.spawn(snapshot_job(
+            mempool,
+            config.mempool.mempool_snapshot_interval_secs,
+        ));
+    }
 }
 
 pub fn bootstrap(

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -79,7 +79,7 @@ pub(crate) fn start_shared_mempool<V>(
         config.mempool.system_transaction_gc_interval_ms,
     ));
 
-    if aptos_logger::enabled!(Level::Debug) {
+    if aptos_logger::enabled!(Level::Trace) {
         executor.spawn(snapshot_job(
             mempool,
             config.mempool.mempool_snapshot_interval_secs,

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -27,7 +27,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt,
-    fmt::Write,
     pin::Pin,
     sync::Arc,
     task::Waker,
@@ -173,21 +172,17 @@ impl fmt::Display for QuorumStoreRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let payload = match self {
             QuorumStoreRequest::GetBatchRequest(batch_size, excluded_txns, _) => {
-                let mut txns_str = "".to_string();
-                for tx in excluded_txns.iter() {
-                    write!(txns_str, "{} ", tx)?;
-                }
                 format!(
-                    "GetBatchRequest [batch_size: {}, excluded_txns: {}]",
-                    batch_size, txns_str
+                    "GetBatchRequest [batch_size: {}, excluded_txns_length: {}]",
+                    batch_size,
+                    excluded_txns.len()
                 )
             }
             QuorumStoreRequest::RejectNotification(rejected_txns, _) => {
-                let mut txns_str = "".to_string();
-                for tx in rejected_txns.iter() {
-                    write!(txns_str, "{} ", tx)?;
-                }
-                format!("RejectNotification [rejected_txns: {}]", txns_str)
+                format!(
+                    "RejectNotification [rejected_txns_length: {}]",
+                    rejected_txns.len()
+                )
             }
         };
         write!(f, "{}", payload)


### PR DESCRIPTION
### Description

Removed where huge vectors of transaction (summaries) are logged.

For the snapshot, made a check to check log level while also downgrading to trace.

### Test Plan

Run existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2846)
<!-- Reviewable:end -->
