### PR TITLE
[aptos-cli] Use current directory for workspace .aptos if it doesn't exist (#2845)

### DIFF
--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -193,13 +193,9 @@ fn find_workspace_config(
                 let cand = current_path.join(CONFIG_FOLDER);
                 if cand.is_dir() {
                     break Ok(cand);
-                }
-                if !current_path.pop() {
-                    return Err(CliError::ConfigNotFoundError(format!(
-                        "Unable to find {} in {} or any parent directory",
-                        CONFIG_FOLDER,
-                        starting_path.display()
-                    )));
+                } else if !current_path.pop() {
+                    // If we aren't able to find the folder, we'll create a new one right here
+                    break Ok(starting_path.join(CONFIG_FOLDER));
                 }
             }
         }


### PR DESCRIPTION
Cherry pick of (#2845)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2847)
<!-- Reviewable:end -->
