### PR TITLE
Make FaucetClient async

### DIFF
--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -481,29 +481,15 @@ mod tests {
     async fn create_account_with_client() {
         let (faucet_client, _service) = get_client().await;
         let address = get_address();
-
-        let res = tokio::task::spawn_blocking(move || faucet_client.create_account(address))
-            .await
-            .unwrap();
-        res.unwrap();
+        faucet_client.create_account(address).await.unwrap();
     }
 
     #[tokio::test]
     async fn fund_account_with_client() {
         let (faucet_client, _service) = get_client().await;
         let address = get_address();
-
-        let (res1, res2) = tokio::task::spawn_blocking(move || {
-            (
-                faucet_client.create_account(address),
-                faucet_client.fund(address, 10),
-            )
-        })
-        .await
-        .unwrap();
-
-        res1.unwrap();
-        res2.unwrap();
+        faucet_client.create_account(address).await.unwrap();
+        faucet_client.fund(address, 10).await.unwrap();
     }
 
     async fn get_client() -> (FaucetClient, JoinHandle<()>) {


### PR DESCRIPTION
## Description
The regular client is async, so to use the faucet client we jump through all kinds of hoops with blocking calls and whatnot. This PR just makes it async to fix all those problems.

## Test Plan
CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2866)
<!-- Reviewable:end -->
