### PR TITLE
[cli][delegation] Add owner-relatd CLI functions and AIT3 flow e2e test

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -1,10 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::{
-    types::{CliCommand, CliTypedResult, FaucetOptions, TransactionOptions},
-    utils::fund_account,
-};
+use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions};
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
@@ -22,14 +19,6 @@ pub struct CreateAccount {
     /// Address of the new account
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
-    /// If set, the faucet will be used to create the new account
-    #[clap(long)]
-    pub(crate) use_faucet: bool,
-    #[clap(flatten)]
-    pub(crate) faucet_options: FaucetOptions,
-    /// Number of initial coins to fund when using the faucet
-    #[clap(long, default_value_t = DEFAULT_FUNDED_COINS)]
-    pub(crate) initial_coins: u64,
 }
 
 #[async_trait]
@@ -40,27 +29,9 @@ impl CliCommand<String> for CreateAccount {
 
     async fn execute(self) -> CliTypedResult<String> {
         let address = self.account;
-        if self.use_faucet {
-            fund_account(
-                self.faucet_options
-                    .faucet_url(&self.txn_options.profile_options.profile)?,
-                self.initial_coins,
-                self.account,
-            )
-            .await
-            .map(|_| ())
-        } else {
-            self.create_account_with_key(address).await
-        }
-        .map(|_| format!("Account Created at {}", address))
-    }
-}
-
-impl CreateAccount {
-    async fn create_account_with_key(self, address: AccountAddress) -> CliTypedResult<()> {
         self.txn_options
             .submit_transaction(aptos_stdlib::account_create_account(address))
-            .await?;
-        Ok(())
+            .await
+            .map(|_| format!("Account Created at {}", address))
     }
 }

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -17,7 +17,7 @@ use clap::Parser;
 /// Command to fund an account with tokens from a faucet
 ///
 #[derive(Debug, Parser)]
-pub struct FundAccount {
+pub struct FundWithFaucet {
     #[clap(flatten)]
     pub(crate) profile_options: ProfileOptions,
     /// Address to fund
@@ -33,9 +33,9 @@ pub struct FundAccount {
 }
 
 #[async_trait]
-impl CliCommand<String> for FundAccount {
+impl CliCommand<String> for FundWithFaucet {
     fn command_name(&self) -> &'static str {
-        "FundAccount"
+        "FundWithFaucet"
     }
 
     async fn execute(self) -> CliTypedResult<String> {

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -18,7 +18,7 @@ pub mod transfer;
 pub enum AccountTool {
     Create(create::CreateAccount),
     CreateResourceAccount(create_resource_account::CreateResourceAccount),
-    Fund(fund::FundAccount),
+    FundWithFaucet(fund::FundWithFaucet),
     List(list::ListAccount),
     Transfer(transfer::TransferCoins),
 }
@@ -28,7 +28,7 @@ impl AccountTool {
         match self {
             AccountTool::Create(tool) => tool.execute_serialized().await,
             AccountTool::CreateResourceAccount(tool) => tool.execute_serialized().await,
-            AccountTool::Fund(tool) => tool.execute_serialized().await,
+            AccountTool::FundWithFaucet(tool) => tool.execute_serialized().await,
             AccountTool::List(tool) => tool.execute_serialized().await,
             AccountTool::Transfer(tool) => tool.execute_serialized().await,
         }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1063,6 +1063,11 @@ impl TransactionOptions {
         self.rest_options.client(&self.profile_options.profile)
     }
 
+    pub fn sender_address(&self) -> CliTypedResult<AccountAddress> {
+        let sender_key = self.private_key()?;
+        Ok(account_address_from_public_key(&sender_key.public_key()))
+    }
+
     /// Submits a script function based on module name and function inputs
     pub async fn submit_script_function(
         &self,
@@ -1090,8 +1095,7 @@ impl TransactionOptions {
         let client = self.rest_client()?;
 
         // Get sender address
-        let sender_address = AuthenticationKey::ed25519(&sender_key.public_key()).derived_address();
-        let sender_address = AccountAddress::new(*sender_address);
+        let sender_address = self.sender_address()?;
 
         // Get sequence number for account
         let sequence_number = get_sequence_number(&client, sender_address).await?;

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -11,6 +11,7 @@ pub mod governance;
 pub mod move_tool;
 pub mod node;
 pub mod op;
+pub mod stake;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod test;
 
@@ -40,6 +41,8 @@ pub enum Tool {
     Move(move_tool::MoveTool),
     #[clap(subcommand)]
     Node(node::NodeTool),
+    #[clap(subcommand)]
+    Stake(stake::StakeTool),
 }
 
 impl Tool {
@@ -56,6 +59,7 @@ impl Tool {
             Key(tool) => tool.execute().await,
             Move(tool) => tool.execute().await,
             Node(tool) => tool.execute().await,
+            Stake(tool) => tool.execute().await,
         }
     }
 }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -44,17 +44,14 @@ use tokio::time::Instant;
 /// identify issues with nodes, and show related information.
 #[derive(Parser)]
 pub enum NodeTool {
-    AddStake(AddStake),
-    UnlockStake(UnlockStake),
-    WithdrawStake(WithdrawStake),
-    IncreaseLockup(IncreaseLockup),
-    RegisterValidatorCandidate(RegisterValidatorCandidate),
+    InitializeValidator(InitializeValidator),
     JoinValidatorSet(JoinValidatorSet),
     LeaveValidatorSet(LeaveValidatorSet),
     ShowValidatorConfig(ShowValidatorConfig),
     ShowValidatorSet(ShowValidatorSet),
     ShowValidatorStake(ShowValidatorStake),
     RunLocalTestnet(RunLocalTestnet),
+    UpdateConsensusKey(UpdateConsensusKey),
     UpdateValidatorNetworkAddresses(UpdateValidatorNetworkAddresses),
     AnalyzeValidatorPerformance(AnalyzeValidatorPerformance),
 }
@@ -63,143 +60,49 @@ impl NodeTool {
     pub async fn execute(self) -> CliResult {
         use NodeTool::*;
         match self {
-            AddStake(tool) => tool.execute_serialized().await,
-            UnlockStake(tool) => tool.execute_serialized().await,
-            WithdrawStake(tool) => tool.execute_serialized().await,
-            IncreaseLockup(tool) => tool.execute_serialized().await,
-            RegisterValidatorCandidate(tool) => tool.execute_serialized().await,
+            InitializeValidator(tool) => tool.execute_serialized().await,
             JoinValidatorSet(tool) => tool.execute_serialized().await,
             LeaveValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorSet(tool) => tool.execute_serialized().await,
             ShowValidatorStake(tool) => tool.execute_serialized().await,
             ShowValidatorConfig(tool) => tool.execute_serialized().await,
             RunLocalTestnet(tool) => tool.execute_serialized_without_logger().await,
+            UpdateConsensusKey(tool) => tool.execute_serialized().await,
             UpdateValidatorNetworkAddresses(tool) => tool.execute_serialized().await,
             AnalyzeValidatorPerformance(tool) => tool.execute_serialized().await,
         }
     }
 }
 
-/// Stake coins for an account to the stake pool
 #[derive(Parser)]
-pub struct AddStake {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
-    /// Amount of coins to add to stake
-    #[clap(long)]
-    pub amount: u64,
-}
-
-#[async_trait]
-impl CliCommand<Transaction> for AddStake {
-    fn command_name(&self) -> &'static str {
-        "AddStake"
-    }
-
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
-        self.txn_options
-            .submit_transaction(aptos_stdlib::stake_add_stake(self.amount))
-            .await
-    }
-}
-
-/// Unlock staked coins
-///
-/// Coins can only be unlocked if they no longer have an applied lockup period
-#[derive(Parser)]
-pub struct UnlockStake {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
-    /// Amount of coins to unlock
-    #[clap(long)]
-    pub amount: u64,
-}
-
-#[async_trait]
-impl CliCommand<Transaction> for UnlockStake {
-    fn command_name(&self) -> &'static str {
-        "UnlockStake"
-    }
-
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
-        self.txn_options
-            .submit_transaction(aptos_stdlib::stake_unlock(self.amount))
-            .await
-    }
-}
-
-/// Withdraw all unlocked staked coins
-///
-/// Before calling `WithdrawStake`, `UnlockStake` must be called first.
-#[derive(Parser)]
-pub struct WithdrawStake {
-    #[clap(flatten)]
-    pub(crate) node_op_options: TransactionOptions,
-    /// Amount of coins to withdraw
-    #[clap(long)]
-    pub amount: u64,
-}
-
-#[async_trait]
-impl CliCommand<Transaction> for WithdrawStake {
-    fn command_name(&self) -> &'static str {
-        "WithdrawStake"
-    }
-
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
-        self.node_op_options
-            .submit_transaction(aptos_stdlib::stake_withdraw(self.amount))
-            .await
-    }
-}
-
-/// Increase lockup of all staked coins in an account
-#[derive(Parser)]
-pub struct IncreaseLockup {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
-}
-
-#[async_trait]
-impl CliCommand<Transaction> for IncreaseLockup {
-    fn command_name(&self) -> &'static str {
-        "IncreaseLockup"
-    }
-
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
-        self.txn_options
-            .submit_transaction(aptos_stdlib::stake_increase_lockup())
-            .await
-    }
-}
-
-#[derive(Parser)]
-pub struct ValidatorConfigArgs {
+pub struct ValidatorConfigFileArgs {
     /// Validator Configuration file, created from the `genesis set-validator-configuration` command
     #[clap(long)]
     pub(crate) validator_config_file: Option<PathBuf>,
+}
+
+impl ValidatorConfigFileArgs {
+    fn read_validator_config(&self) -> CliTypedResult<Option<ValidatorConfiguration>> {
+        if let Some(ref file) = self.validator_config_file {
+            Ok(from_yaml(
+                &String::from_utf8(read_from_file(file)?).map_err(CliError::from)?,
+            )?)
+        } else {
+            Ok(None)
+        }
+    }
+}
+#[derive(Parser)]
+pub struct ValidatorConsensusKeyArgs {
     /// Hex encoded Consensus public key
     #[clap(long, parse(try_from_str = bls12381::PublicKey::from_encoded_string))]
     pub(crate) consensus_public_key: Option<bls12381::PublicKey>,
     /// Hex encoded Consensus proof of possession
     #[clap(long, parse(try_from_str = bls12381::ProofOfPossession::from_encoded_string))]
     pub(crate) proof_of_possession: Option<bls12381::ProofOfPossession>,
-
-    /// Host and port pair for the validator e.g. 127.0.0.1:6180
-    #[clap(long)]
-    pub(crate) validator_host: Option<HostAndPort>,
-    /// Validator x25519 public network key
-    #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
-    pub(crate) validator_network_public_key: Option<x25519::PublicKey>,
-    /// Host and port pair for the fullnode e.g. 127.0.0.1:6180.  Optional
-    #[clap(long)]
-    pub(crate) full_node_host: Option<HostAndPort>,
-    /// Full node x25519 public network key
-    #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
-    pub(crate) full_node_network_public_key: Option<x25519::PublicKey>,
 }
 
-impl ValidatorConfigArgs {
+impl ValidatorConsensusKeyArgs {
     fn get_consensus_public_key(
         &self,
         validator_config: &Option<ValidatorConfiguration>,
@@ -232,7 +135,25 @@ impl ValidatorConfigArgs {
         };
         Ok(proof_of_possession)
     }
+}
 
+#[derive(Parser)]
+pub struct ValidatorNetworkAddressesArgs {
+    /// Host and port pair for the validator e.g. 127.0.0.1:6180
+    #[clap(long)]
+    pub(crate) validator_host: Option<HostAndPort>,
+    /// Validator x25519 public network key
+    #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
+    pub(crate) validator_network_public_key: Option<x25519::PublicKey>,
+    /// Host and port pair for the fullnode e.g. 127.0.0.1:6180.  Optional
+    #[clap(long)]
+    pub(crate) full_node_host: Option<HostAndPort>,
+    /// Full node x25519 public network key
+    #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
+    pub(crate) full_node_network_public_key: Option<x25519::PublicKey>,
+}
+
+impl ValidatorNetworkAddressesArgs {
     fn get_network_configs(
         &self,
         validator_config: &Option<ValidatorConfiguration>,
@@ -288,41 +209,38 @@ impl ValidatorConfigArgs {
             full_node_host,
         ))
     }
-
-    fn read_validator_config(&self) -> CliTypedResult<Option<ValidatorConfiguration>> {
-        if let Some(ref file) = self.validator_config_file {
-            Ok(from_yaml(
-                &String::from_utf8(read_from_file(file)?).map_err(CliError::from)?,
-            )?)
-        } else {
-            Ok(None)
-        }
-    }
 }
 
+/// Register the current account as a validator node operator of it's own owned stake.
+///
+/// Use InitializeStakeOwner whenever stake owner
+/// and validator operator are different accounts.
 #[derive(Parser)]
-/// Register the current account as a Validator candidate
-pub struct RegisterValidatorCandidate {
+pub struct InitializeValidator {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
 
     #[clap(flatten)]
-    pub(crate) validator_config_args: ValidatorConfigArgs,
+    pub(crate) validator_config_file_args: ValidatorConfigFileArgs,
+    #[clap(flatten)]
+    pub(crate) validator_consensus_key_args: ValidatorConsensusKeyArgs,
+    #[clap(flatten)]
+    pub(crate) validator_network_addresses_args: ValidatorNetworkAddressesArgs,
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for RegisterValidatorCandidate {
+impl CliCommand<Transaction> for InitializeValidator {
     fn command_name(&self) -> &'static str {
-        "RegisterValidatorCandidate"
+        "InitializeValidator"
     }
 
     async fn execute(mut self) -> CliTypedResult<Transaction> {
-        let validator_config = self.validator_config_args.read_validator_config()?;
+        let validator_config = self.validator_config_file_args.read_validator_config()?;
         let consensus_public_key = self
-            .validator_config_args
+            .validator_consensus_key_args
             .get_consensus_public_key(&validator_config)?;
         let consensus_proof_of_possession = self
-            .validator_config_args
+            .validator_consensus_key_args
             .get_consensus_proof_of_possession(&validator_config)?;
         let (
             validator_network_public_key,
@@ -330,7 +248,7 @@ impl CliCommand<Transaction> for RegisterValidatorCandidate {
             validator_host,
             full_node_host,
         ) = self
-            .validator_config_args
+            .validator_network_addresses_args
             .get_network_configs(&validator_config)?;
         let validator_network_addresses =
             vec![validator_host.as_network_address(validator_network_public_key)?];
@@ -367,11 +285,25 @@ pub struct OperatorArgs {
 }
 
 impl OperatorArgs {
-    fn address(&self, profile_options: &ProfileOptions) -> CliTypedResult<AccountAddress> {
+    fn address_fallback_to_profile(
+        &self,
+        profile_options: &ProfileOptions,
+    ) -> CliTypedResult<AccountAddress> {
         if let Some(address) = self.pool_address {
             Ok(address)
         } else {
             profile_options.account_address()
+        }
+    }
+
+    fn address_fallback_to_txn(
+        &self,
+        transaction_options: &TransactionOptions,
+    ) -> CliTypedResult<AccountAddress> {
+        if let Some(address) = self.pool_address {
+            Ok(address)
+        } else {
+            transaction_options.sender_address()
         }
     }
 }
@@ -394,7 +326,7 @@ impl CliCommand<Transaction> for JoinValidatorSet {
     async fn execute(mut self) -> CliTypedResult<Transaction> {
         let address = self
             .operator_args
-            .address(&self.txn_options.profile_options)?;
+            .address_fallback_to_txn(&self.txn_options)?;
 
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_join_validator_set(address))
@@ -420,7 +352,7 @@ impl CliCommand<Transaction> for LeaveValidatorSet {
     async fn execute(mut self) -> CliTypedResult<Transaction> {
         let address = self
             .operator_args
-            .address(&self.txn_options.profile_options)?;
+            .address_fallback_to_txn(&self.txn_options)?;
 
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_leave_validator_set(address))
@@ -447,7 +379,9 @@ impl CliCommand<serde_json::Value> for ShowValidatorStake {
 
     async fn execute(mut self) -> CliTypedResult<serde_json::Value> {
         let client = self.rest_options.client(&self.profile_options.profile)?;
-        let address = self.operator_args.address(&self.profile_options)?;
+        let address = self
+            .operator_args
+            .address_fallback_to_profile(&self.profile_options)?;
         let response = client
             .get_resource(address, "0x1::stake::StakePool")
             .await?;
@@ -474,7 +408,9 @@ impl CliCommand<serde_json::Value> for ShowValidatorConfig {
 
     async fn execute(mut self) -> CliTypedResult<serde_json::Value> {
         let client = self.rest_options.client(&self.profile_options.profile)?;
-        let address = self.operator_args.address(&self.profile_options)?;
+        let address = self
+            .operator_args
+            .address_fallback_to_profile(&self.profile_options)?;
         let response = client
             .get_resource(address, "0x1::stake::ValidatorConfig")
             .await?;
@@ -659,6 +595,49 @@ impl CliCommand<()> for RunLocalTestnet {
     }
 }
 
+/// Update consensus key for the validator node.
+#[derive(Parser)]
+pub struct UpdateConsensusKey {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+
+    #[clap(flatten)]
+    pub(crate) operator_args: OperatorArgs,
+
+    #[clap(flatten)]
+    pub(crate) validator_config_file_args: ValidatorConfigFileArgs,
+    #[clap(flatten)]
+    pub(crate) validator_consensus_key_args: ValidatorConsensusKeyArgs,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for UpdateConsensusKey {
+    fn command_name(&self) -> &'static str {
+        "UpdateConsensusKey"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        let address = self
+            .operator_args
+            .address_fallback_to_txn(&self.txn_options)?;
+
+        let validator_config = self.validator_config_file_args.read_validator_config()?;
+        let consensus_public_key = self
+            .validator_consensus_key_args
+            .get_consensus_public_key(&validator_config)?;
+        let consensus_proof_of_possession = self
+            .validator_consensus_key_args
+            .get_consensus_proof_of_possession(&validator_config)?;
+        self.txn_options
+            .submit_transaction(aptos_stdlib::stake_rotate_consensus_key(
+                address,
+                consensus_public_key.to_bytes().to_vec(),
+                consensus_proof_of_possession.to_bytes().to_vec(),
+            ))
+            .await
+    }
+}
+
 /// Update the current validator's network and fullnode addresses
 #[derive(Parser)]
 pub struct UpdateValidatorNetworkAddresses {
@@ -669,7 +648,9 @@ pub struct UpdateValidatorNetworkAddresses {
     pub(crate) operator_args: OperatorArgs,
 
     #[clap(flatten)]
-    pub(crate) validator_config_args: ValidatorConfigArgs,
+    pub(crate) validator_config_file_args: ValidatorConfigFileArgs,
+    #[clap(flatten)]
+    pub(crate) validator_network_addresses_args: ValidatorNetworkAddressesArgs,
 }
 
 #[async_trait]
@@ -681,16 +662,16 @@ impl CliCommand<Transaction> for UpdateValidatorNetworkAddresses {
     async fn execute(mut self) -> CliTypedResult<Transaction> {
         let address = self
             .operator_args
-            .address(&self.txn_options.profile_options)?;
+            .address_fallback_to_txn(&self.txn_options)?;
 
-        let validator_config = self.validator_config_args.read_validator_config()?;
+        let validator_config = self.validator_config_file_args.read_validator_config()?;
         let (
             validator_network_public_key,
             full_node_network_public_key,
             validator_host,
             full_node_host,
         ) = self
-            .validator_config_args
+            .validator_network_addresses_args
             .get_network_configs(&validator_config)?;
         let validator_network_addresses =
             vec![validator_host.as_network_address(validator_network_public_key)?];

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -1,0 +1,207 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::{CliCommand, CliResult, CliTypedResult, TransactionOptions};
+use aptos_rest_client::Transaction;
+use aptos_transaction_builder::aptos_stdlib;
+use aptos_types::account_address::AccountAddress;
+use async_trait::async_trait;
+use clap::Parser;
+
+/// Tool for manipulating stake
+///
+#[derive(Parser)]
+pub enum StakeTool {
+    AddStake(AddStake),
+    UnlockStake(UnlockStake),
+    WithdrawStake(WithdrawStake),
+    IncreaseLockup(IncreaseLockup),
+    InitializeStakeOwner(InitializeStakeOwner),
+    SetOperator(SetOperator),
+    SetDelegatedVoter(SetDelegatedVoter),
+}
+
+impl StakeTool {
+    pub async fn execute(self) -> CliResult {
+        use StakeTool::*;
+        match self {
+            AddStake(tool) => tool.execute_serialized().await,
+            UnlockStake(tool) => tool.execute_serialized().await,
+            WithdrawStake(tool) => tool.execute_serialized().await,
+            IncreaseLockup(tool) => tool.execute_serialized().await,
+            InitializeStakeOwner(tool) => tool.execute_serialized().await,
+            SetOperator(tool) => tool.execute_serialized().await,
+            SetDelegatedVoter(tool) => tool.execute_serialized().await,
+        }
+    }
+}
+
+/// Stake coins for an account to the stake pool
+#[derive(Parser)]
+pub struct AddStake {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    /// Amount of coins to add to stake
+    #[clap(long)]
+    pub amount: u64,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for AddStake {
+    fn command_name(&self) -> &'static str {
+        "AddStake"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::stake_add_stake(self.amount))
+            .await
+    }
+}
+
+/// Unlock staked coins
+///
+/// Coins can only be unlocked if they no longer have an applied lockup period
+#[derive(Parser)]
+pub struct UnlockStake {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    /// Amount of coins to unlock
+    #[clap(long)]
+    pub amount: u64,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for UnlockStake {
+    fn command_name(&self) -> &'static str {
+        "UnlockStake"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::stake_unlock(self.amount))
+            .await
+    }
+}
+
+/// Withdraw all unlocked staked coins
+///
+/// Before calling `WithdrawStake`, `UnlockStake` must be called first.
+#[derive(Parser)]
+pub struct WithdrawStake {
+    #[clap(flatten)]
+    pub(crate) node_op_options: TransactionOptions,
+    /// Amount of coins to withdraw
+    #[clap(long)]
+    pub amount: u64,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for WithdrawStake {
+    fn command_name(&self) -> &'static str {
+        "WithdrawStake"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.node_op_options
+            .submit_transaction(aptos_stdlib::stake_withdraw(self.amount))
+            .await
+    }
+}
+
+/// Increase lockup of all staked coins in an account
+#[derive(Parser)]
+pub struct IncreaseLockup {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for IncreaseLockup {
+    fn command_name(&self) -> &'static str {
+        "IncreaseLockup"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::stake_increase_lockup())
+            .await
+    }
+}
+
+/// Register stake owner, to gain capability to delegate
+/// operator or voting capability to a different account.
+#[derive(Parser)]
+pub struct InitializeStakeOwner {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(long)]
+    pub initial_stake_amount: u64,
+    #[clap(long)]
+    pub operator_address: Option<AccountAddress>,
+    #[clap(long)]
+    pub voter_address: Option<AccountAddress>,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for InitializeStakeOwner {
+    fn command_name(&self) -> &'static str {
+        "InitializeStakeOwner"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        let owner_address = self.txn_options.sender_address()?;
+        self.txn_options
+            .submit_transaction(aptos_stdlib::stake_initialize_owner_only(
+                self.initial_stake_amount,
+                self.operator_address.unwrap_or(owner_address),
+                self.voter_address.unwrap_or(owner_address),
+            ))
+            .await
+    }
+}
+
+/// Delegate operator (running validator node) capability from the stake owner
+/// to the given voter address
+#[derive(Parser)]
+pub struct SetOperator {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(long)]
+    pub operator_address: AccountAddress,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for SetOperator {
+    fn command_name(&self) -> &'static str {
+        "SetOperator"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::stake_set_operator(self.operator_address))
+            .await
+    }
+}
+
+/// Delegate voting capability from the stake owner to the given voter address
+#[derive(Parser)]
+pub struct SetDelegatedVoter {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(long)]
+    pub voter_address: AccountAddress,
+}
+
+#[async_trait]
+impl CliCommand<Transaction> for SetDelegatedVoter {
+    fn command_name(&self) -> &'static str {
+        "SetDelegatedVoter"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<Transaction> {
+        self.txn_options
+            .submit_transaction(aptos_stdlib::stake_set_delegated_voter(self.voter_address))
+            .await
+    }
+}

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::account::{
     create::{CreateAccount, DEFAULT_FUNDED_COINS},
-    fund::FundAccount,
+    fund::FundWithFaucet,
     list::{ListAccount, ListQuery},
     transfer::{TransferCoins, TransferSummary},
 };
@@ -19,12 +19,16 @@ use crate::move_tool::{
     ArgWithType, CompilePackage, InitPackage, MemberId, PublishPackage, RunFunction, TestPackage,
 };
 use crate::node::{
-    AddStake, AnalyzeMode, AnalyzeValidatorPerformance, IncreaseLockup, JoinValidatorSet,
-    LeaveValidatorSet, OperatorArgs, RegisterValidatorCandidate, ShowValidatorConfig,
-    ShowValidatorSet, ShowValidatorStake, UnlockStake, UpdateValidatorNetworkAddresses,
-    ValidatorConfigArgs, WithdrawStake,
+    AnalyzeMode, AnalyzeValidatorPerformance, InitializeValidator, JoinValidatorSet,
+    LeaveValidatorSet, OperatorArgs, ShowValidatorConfig, ShowValidatorSet, ShowValidatorStake,
+    UpdateConsensusKey, UpdateValidatorNetworkAddresses, ValidatorConfigFileArgs,
+    ValidatorConsensusKeyArgs, ValidatorNetworkAddressesArgs,
 };
 use crate::op::key::{ExtractPeer, GenerateKey, SaveKey};
+use crate::stake::{
+    AddStake, IncreaseLockup, InitializeStakeOwner, SetDelegatedVoter, SetOperator, UnlockStake,
+    WithdrawStake,
+};
 use crate::CliCommand;
 use aptos_config::config::Peer;
 use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519, PrivateKey};
@@ -102,7 +106,7 @@ impl CliTestFramework {
 
         for _ in 0..num_accounts {
             framework
-                .add_cli_account(keygen.generate_ed25519_private_key())
+                .create_cli_account_from_faucet(keygen.generate_ed25519_private_key(), None)
                 .await
                 .unwrap();
         }
@@ -110,66 +114,58 @@ impl CliTestFramework {
         framework
     }
 
-    pub async fn add_cli_account(
-        &mut self,
-        private_key: Ed25519PrivateKey,
-    ) -> CliTypedResult<usize> {
-        let index = self.add_private_key(private_key);
-
+    async fn check_account_exists(&self, index: usize) -> bool {
         // Create account if it doesn't exist (and there's a faucet)
         let client = aptos_rest_client::Client::new(self.endpoint.clone());
         let address = self.account_id(index);
-        if client.get_account(address).await.is_err() {
-            self.fund_account(index, None).await?;
-            warn!("Funded account {:?}", address);
-        } else {
-            warn!("Account {:?} already exists", address);
-        }
-
-        Ok(index)
+        return client.get_account(address).await.is_ok();
     }
 
-    pub fn add_private_key(&mut self, private_key: Ed25519PrivateKey) -> usize {
+    pub fn add_account_to_cli(&mut self, private_key: Ed25519PrivateKey) -> usize {
         self.account_keys.push(private_key);
         self.account_keys.len() - 1
     }
 
-    pub async fn create_account(
-        &self,
-        index: usize,
-        mint_key: &Ed25519PrivateKey,
-    ) -> CliTypedResult<String> {
+    pub async fn create_cli_account(
+        &mut self,
+        private_key: Ed25519PrivateKey,
+        sender_index: usize,
+    ) -> CliTypedResult<usize> {
+        let index = self.add_account_to_cli(private_key);
+        if self.check_account_exists(index).await {
+            return Err(CliError::UnexpectedError(
+                "Account already exists".to_string(),
+            ));
+        }
         CreateAccount {
-            txn_options: TransactionOptions {
-                private_key_options: PrivateKeyInputOptions::from_private_key(mint_key)?,
-                encoding_options: Default::default(),
-                profile_options: Default::default(),
-                rest_options: self.rest_options(),
-                gas_options: Default::default(),
-            },
+            txn_options: self.transaction_options(sender_index, None),
             account: self.account_id(index),
-            use_faucet: false,
-            faucet_options: Default::default(),
-            initial_coins: DEFAULT_FUNDED_COINS,
         }
         .execute()
-        .await
+        .await?;
+
+        Ok(index)
     }
 
-    pub async fn create_account_with_faucet(&self, index: usize) -> CliTypedResult<String> {
-        CreateAccount {
-            txn_options: Default::default(),
-            account: self.account_id(index),
-            use_faucet: true,
-            faucet_options: self.faucet_options(),
-            initial_coins: 0,
+    pub async fn create_cli_account_from_faucet(
+        &mut self,
+        private_key: Ed25519PrivateKey,
+        amount: Option<u64>,
+    ) -> CliTypedResult<usize> {
+        let index = self.add_account_to_cli(private_key);
+        if self.check_account_exists(index).await {
+            return Err(CliError::UnexpectedError(
+                "Account already exists".to_string(),
+            ));
         }
-        .execute()
-        .await
+
+        self.fund_account(index, amount).await?;
+        warn!("Funded account {:?}", self.account_id(index));
+        Ok(index)
     }
 
     pub async fn fund_account(&self, index: usize, amount: Option<u64>) -> CliTypedResult<String> {
-        FundAccount {
+        FundWithFaucet {
             profile_options: Default::default(),
             account: self.account_id(index),
             faucet_options: self.faucet_options(),
@@ -222,11 +218,14 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn show_validator_config(&self, index: usize) -> CliTypedResult<ValidatorConfig> {
+    pub async fn show_validator_config(
+        &self,
+        pool_index: usize,
+    ) -> CliTypedResult<ValidatorConfig> {
         ShowValidatorConfig {
             rest_options: self.rest_options(),
             profile_options: Default::default(),
-            operator_args: self.operator_args(index),
+            operator_args: self.operator_args(Some(pool_index)),
         }
         .execute()
         .await
@@ -243,17 +242,17 @@ impl CliTestFramework {
         .map(|v| to_validator_set(&v))
     }
 
-    pub async fn show_validator_stake(&self, index: usize) -> CliTypedResult<Value> {
+    pub async fn show_validator_stake(&self, pool_index: usize) -> CliTypedResult<Value> {
         ShowValidatorStake {
             rest_options: self.rest_options(),
             profile_options: Default::default(),
-            operator_args: self.operator_args(index),
+            operator_args: self.operator_args(Some(pool_index)),
         }
         .execute()
         .await
     }
 
-    pub async fn register_validator_candidate(
+    pub async fn initialize_validator(
         &self,
         index: usize,
         consensus_public_key: bls12381::PublicKey,
@@ -261,12 +260,16 @@ impl CliTestFramework {
         validator_host: HostAndPort,
         validator_network_public_key: x25519::PublicKey,
     ) -> CliTypedResult<Transaction> {
-        RegisterValidatorCandidate {
+        InitializeValidator {
             txn_options: self.transaction_options(index, None),
-            validator_config_args: ValidatorConfigArgs {
+            validator_config_file_args: ValidatorConfigFileArgs {
                 validator_config_file: None,
+            },
+            validator_consensus_key_args: ValidatorConsensusKeyArgs {
                 consensus_public_key: Some(consensus_public_key),
                 proof_of_possession: Some(proof_of_possession),
+            },
+            validator_network_addresses_args: ValidatorNetworkAddressesArgs {
                 validator_host: Some(validator_host),
                 validator_network_public_key: Some(validator_network_public_key),
                 full_node_host: None,
@@ -312,19 +315,27 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn join_validator_set(&self, index: usize) -> CliTypedResult<Transaction> {
+    pub async fn join_validator_set(
+        &self,
+        operator_index: usize,
+        pool_index: Option<usize>,
+    ) -> CliTypedResult<Transaction> {
         JoinValidatorSet {
-            txn_options: self.transaction_options(index, None),
-            operator_args: self.operator_args(index),
+            txn_options: self.transaction_options(operator_index, None),
+            operator_args: self.operator_args(pool_index),
         }
         .execute()
         .await
     }
 
-    pub async fn leave_validator_set(&self, index: usize) -> CliTypedResult<Transaction> {
+    pub async fn leave_validator_set(
+        &self,
+        operator_index: usize,
+        pool_index: Option<usize>,
+    ) -> CliTypedResult<Transaction> {
         LeaveValidatorSet {
-            txn_options: self.transaction_options(index, None),
-            operator_args: self.operator_args(index),
+            txn_options: self.transaction_options(operator_index, None),
+            operator_args: self.operator_args(pool_index),
         }
         .execute()
         .await
@@ -332,17 +343,18 @@ impl CliTestFramework {
 
     pub async fn update_validator_network_addresses(
         &self,
-        index: usize,
+        operator_index: usize,
+        pool_index: Option<usize>,
         validator_host: HostAndPort,
         validator_network_public_key: x25519::PublicKey,
     ) -> CliTypedResult<Transaction> {
         UpdateValidatorNetworkAddresses {
-            txn_options: self.transaction_options(index, None),
-            operator_args: self.operator_args(index),
-            validator_config_args: ValidatorConfigArgs {
+            txn_options: self.transaction_options(operator_index, None),
+            operator_args: self.operator_args(pool_index),
+            validator_config_file_args: ValidatorConfigFileArgs {
                 validator_config_file: None,
-                consensus_public_key: None,
-                proof_of_possession: None,
+            },
+            validator_network_addresses_args: ValidatorNetworkAddressesArgs {
                 validator_host: Some(validator_host),
                 validator_network_public_key: Some(validator_network_public_key),
                 full_node_host: None,
@@ -369,6 +381,28 @@ impl CliTestFramework {
         .await
     }
 
+    pub async fn update_consensus_key(
+        &self,
+        operator_index: usize,
+        pool_index: Option<usize>,
+        consensus_public_key: bls12381::PublicKey,
+        proof_of_possession: bls12381::ProofOfPossession,
+    ) -> CliTypedResult<Transaction> {
+        UpdateConsensusKey {
+            txn_options: self.transaction_options(operator_index, None),
+            operator_args: self.operator_args(pool_index),
+            validator_config_file_args: ValidatorConfigFileArgs {
+                validator_config_file: None,
+            },
+            validator_consensus_key_args: ValidatorConsensusKeyArgs {
+                consensus_public_key: Some(consensus_public_key),
+                proof_of_possession: Some(proof_of_possession),
+            },
+        }
+        .execute()
+        .await
+    }
+
     pub async fn init(&self, private_key: &Ed25519PrivateKey) -> CliTypedResult<()> {
         InitTool {
             rest_url: Some(self.endpoint.clone()),
@@ -379,6 +413,49 @@ impl CliTestFramework {
             prompt_options: PromptOptions::yes(),
             encoding_options: EncodingOptions::default(),
             skip_faucet: false,
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn initialize_stake_owner(
+        &self,
+        owner_index: usize,
+        initial_stake_amount: u64,
+        voter_index: Option<usize>,
+        operator_index: Option<usize>,
+    ) -> CliTypedResult<Transaction> {
+        InitializeStakeOwner {
+            txn_options: self.transaction_options(owner_index, None),
+            initial_stake_amount,
+            operator_address: operator_index.map(|idx| self.account_id(idx)),
+            voter_address: voter_index.map(|idx| self.account_id(idx)),
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn set_operator(
+        &self,
+        owner_index: usize,
+        operator_index: usize,
+    ) -> CliTypedResult<Transaction> {
+        SetOperator {
+            txn_options: self.transaction_options(owner_index, None),
+            operator_address: self.account_id(operator_index),
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn set_delegated_voter(
+        &self,
+        owner_index: usize,
+        voter_index: usize,
+    ) -> CliTypedResult<Transaction> {
+        SetDelegatedVoter {
+            txn_options: self.transaction_options(owner_index, None),
+            voter_address: self.account_id(voter_index),
         }
         .execute()
         .await
@@ -689,9 +766,9 @@ impl CliTestFramework {
         }
     }
 
-    fn operator_args(&self, index: usize) -> OperatorArgs {
+    fn operator_args(&self, pool_index: Option<usize>) -> OperatorArgs {
         OperatorArgs {
-            pool_address: Some(self.account_id(index)),
+            pool_address: pool_index.map(|idx| self.account_id(idx)),
         }
     }
 

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -48,7 +48,7 @@ async fn test_account_flow() {
         .await;
 
     // Create another cli account:
-    cli.add_cli_account(KeyGen::from_os_rng().generate_ed25519_private_key())
+    cli.create_cli_account_from_faucet(KeyGen::from_os_rng().generate_ed25519_private_key(), None)
         .await
         .unwrap();
     cli.assert_account_balance_now(2, DEFAULT_FUNDED_COINS)

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -79,7 +79,7 @@ async fn test_register_and_update_validator() {
     let rest_client = swarm.validators().next().unwrap().rest_client();
 
     let mut keygen = KeyGen::from_os_rng();
-    let (validator_cli_index, keys) = init_validator_account(&mut cli, &mut keygen).await;
+    let (validator_cli_index, keys) = init_validator_account(&mut cli, &mut keygen, None).await;
     // faucet can make our root LocalAccount sequence number get out of sync.
     swarm
         .chain_info()
@@ -93,7 +93,7 @@ async fn test_register_and_update_validator() {
         .is_err()); // validator not registered yet
 
     let port = 1234;
-    cli.register_validator_candidate(
+    cli.initialize_validator(
         validator_cli_index,
         keys.consensus_public_key(),
         keys.consensus_proof_of_possession(),
@@ -120,6 +120,7 @@ async fn test_register_and_update_validator() {
 
     cli.update_validator_network_addresses(
         validator_cli_index,
+        None,
         HostAndPort {
             host: dns_name("0.0.0.0"),
             port: new_port,
@@ -183,7 +184,7 @@ async fn test_join_and_leave_validator() {
     let rest_client = swarm.validators().next().unwrap().rest_client();
 
     let mut keygen = KeyGen::from_os_rng();
-    let (validator_cli_index, keys) = init_validator_account(&mut cli, &mut keygen).await;
+    let (validator_cli_index, keys) = init_validator_account(&mut cli, &mut keygen, None).await;
     let mut gas_used = 0;
 
     // faucet can make our root LocalAccount sequence number get out of sync.
@@ -195,7 +196,7 @@ async fn test_join_and_leave_validator() {
 
     let port = 1234;
     gas_used += get_gas(
-        cli.register_validator_candidate(
+        cli.initialize_validator(
             validator_cli_index,
             keys.consensus_public_key(),
             keys.consensus_proof_of_possession(),
@@ -245,7 +246,11 @@ async fn test_join_and_leave_validator() {
 
     assert_validator_set_sizes(&cli, 1, 0, 0).await;
 
-    gas_used += get_gas(cli.join_validator_set(validator_cli_index).await.unwrap());
+    gas_used += get_gas(
+        cli.join_validator_set(validator_cli_index, None)
+            .await
+            .unwrap(),
+    );
 
     assert_validator_set_sizes(&cli, 1, 1, 0).await;
 
@@ -265,7 +270,11 @@ async fn test_join_and_leave_validator() {
     )
     .await;
 
-    gas_used += get_gas(cli.leave_validator_set(validator_cli_index).await.unwrap());
+    gas_used += get_gas(
+        cli.leave_validator_set(validator_cli_index, None)
+            .await
+            .unwrap(),
+    );
 
     assert_validator_set_sizes(&cli, 1, 0, 1).await;
 
@@ -310,6 +319,213 @@ async fn test_join_and_leave_validator() {
     .await;
 }
 
+#[tokio::test]
+async fn test_owner_create_and_delegate_flow() {
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_i, conf, genesis_stake_amount| {
+            // reduce timeout, as we will have dead node during rounds
+            conf.consensus.round_initial_timeout_ms = 200;
+            conf.consensus.quorum_store_poll_count = 4;
+            // enough for quorum
+            *genesis_stake_amount = 5000000;
+        }))
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            genesis_config.allow_new_validators = true;
+            genesis_config.epoch_duration_secs = 5;
+            genesis_config.recurring_lockup_duration_secs = 10;
+            genesis_config.voting_duration_secs = 5;
+            genesis_config.min_stake = 500000
+        }))
+        .build_with_cli(0)
+        .await;
+
+    let transaction_factory = swarm.chain_info().transaction_factory();
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+
+    let mut keygen = KeyGen::from_os_rng();
+
+    let owner_initial_coins = 1100000;
+    let voter_initial_coins = 10000;
+    let operator_initial_coins = 10000;
+
+    // Owner of the coins receives coins
+    let owner_cli_index = cli
+        .create_cli_account_from_faucet(
+            keygen.generate_ed25519_private_key(),
+            Some(owner_initial_coins),
+        )
+        .await
+        .unwrap();
+
+    cli.assert_account_balance_now(owner_cli_index, owner_initial_coins)
+        .await;
+
+    // faucet can make our root LocalAccount sequence number get out of sync.
+    swarm
+        .chain_info()
+        .resync_root_account_seq_num(&rest_client)
+        .await
+        .unwrap();
+
+    let operator_keys = ValidatorNodeKeys::new(&mut keygen);
+    let voter_cli_index = cli
+        .create_cli_account(keygen.generate_ed25519_private_key(), owner_cli_index)
+        .await
+        .unwrap();
+    let operator_cli_index = cli
+        .create_cli_account(operator_keys.account_private_key.clone(), owner_cli_index)
+        .await
+        .unwrap();
+
+    // Fetch amount of gas used for the above account creations
+    let mut owner_gas =
+        owner_initial_coins - cli.account_balance_now(owner_cli_index).await.unwrap();
+
+    // Voter and operator start with no coins
+    // Owner needs to send small amount of coins to operator and voter, to create their accounts and so they have enough for gas fees.
+    owner_gas += cli
+        .transfer_coins(owner_cli_index, voter_cli_index, voter_initial_coins, None)
+        .await
+        .unwrap()
+        .gas_used;
+    owner_gas += cli
+        .transfer_coins(
+            owner_cli_index,
+            operator_cli_index,
+            operator_initial_coins,
+            None,
+        )
+        .await
+        .unwrap()
+        .gas_used;
+
+    cli.assert_account_balance_now(
+        owner_cli_index,
+        owner_initial_coins - voter_initial_coins - operator_initial_coins - owner_gas,
+    )
+    .await;
+    cli.assert_account_balance_now(voter_cli_index, voter_initial_coins)
+        .await;
+    cli.assert_account_balance_now(operator_cli_index, operator_initial_coins)
+        .await;
+
+    let stake_amount = 1000000;
+    let mut operator_gas = 0;
+    owner_gas += get_gas(
+        cli.initialize_stake_owner(
+            owner_cli_index,
+            stake_amount,
+            Some(voter_cli_index),
+            Some(operator_cli_index),
+        )
+        .await
+        .unwrap(),
+    );
+
+    cli.assert_account_balance_now(
+        owner_cli_index,
+        owner_initial_coins
+            - voter_initial_coins
+            - operator_initial_coins
+            - stake_amount
+            - owner_gas,
+    )
+    .await;
+
+    assert_validator_set_sizes(&cli, 1, 0, 0).await;
+    assert_validator_state(&cli, owner_cli_index, ValidatorState::NONE).await;
+
+    let port = 6543;
+
+    operator_gas += get_gas(
+        cli.update_consensus_key(
+            operator_cli_index,
+            Some(owner_cli_index),
+            operator_keys.consensus_public_key(),
+            operator_keys.consensus_proof_of_possession(),
+        )
+        .await
+        .unwrap(),
+    );
+
+    operator_gas += get_gas(
+        cli.update_validator_network_addresses(
+            operator_cli_index,
+            Some(owner_cli_index),
+            HostAndPort {
+                host: dns_name("0.0.0.0"),
+                port,
+            },
+            operator_keys.network_public_key(),
+        )
+        .await
+        .unwrap(),
+    );
+
+    cli.assert_account_balance_now(operator_cli_index, operator_initial_coins - operator_gas)
+        .await;
+
+    cli.join_validator_set(operator_cli_index, Some(owner_cli_index))
+        .await
+        .unwrap();
+
+    assert_validator_state(&cli, owner_cli_index, ValidatorState::JOINING).await;
+
+    reconfig(
+        &rest_client,
+        &transaction_factory,
+        swarm.chain_info().root_account(),
+    )
+    .await;
+
+    assert_validator_state(&cli, owner_cli_index, ValidatorState::ACTIVE).await;
+
+    let new_operator_keys = ValidatorNodeKeys::new(&mut keygen);
+    let new_voter_cli_index = cli.add_account_to_cli(keygen.generate_ed25519_private_key());
+    let new_operator_cli_index = cli
+        .create_cli_account(
+            new_operator_keys.account_private_key.clone(),
+            owner_cli_index,
+        )
+        .await
+        .unwrap();
+
+    cli.set_delegated_voter(owner_cli_index, new_voter_cli_index)
+        .await
+        .unwrap();
+    cli.set_operator(owner_cli_index, new_operator_cli_index)
+        .await
+        .unwrap();
+
+    cli.transfer_coins(
+        owner_cli_index,
+        new_operator_cli_index,
+        operator_initial_coins,
+        None,
+    )
+    .await
+    .unwrap();
+
+    cli.leave_validator_set(new_operator_cli_index, Some(owner_cli_index))
+        .await
+        .unwrap();
+    assert_validator_state(&cli, owner_cli_index, ValidatorState::LEAVING).await;
+
+    reconfig(
+        &rest_client,
+        &transaction_factory,
+        swarm.chain_info().root_account(),
+    )
+    .await;
+
+    assert_validator_state(&cli, owner_cli_index, ValidatorState::NONE).await;
+    cli.join_validator_set(operator_cli_index, Some(owner_cli_index))
+        .await
+        .unwrap_err();
+    assert_validator_state(&cli, owner_cli_index, ValidatorState::NONE).await;
+}
+
 fn dns_name(addr: &str) -> DnsName {
     DnsName::try_from(addr.to_string()).unwrap()
 }
@@ -321,6 +537,14 @@ struct ValidatorNodeKeys {
 }
 
 impl ValidatorNodeKeys {
+    pub fn new(keygen: &mut KeyGen) -> Self {
+        Self {
+            account_private_key: keygen.generate_ed25519_private_key(),
+            network_private_key: keygen.generate_x25519_private_key().unwrap(),
+            consensus_private_key: keygen.generate_bls12381_private_key(),
+        }
+    }
+
     pub fn network_public_key(&self) -> x25519::PublicKey {
         self.network_private_key.public_key()
     }
@@ -337,18 +561,15 @@ impl ValidatorNodeKeys {
 async fn init_validator_account(
     cli: &mut CliTestFramework,
     keygen: &mut KeyGen,
+    amount: Option<u64>,
 ) -> (usize, ValidatorNodeKeys) {
-    let validator_node_keys = ValidatorNodeKeys {
-        account_private_key: keygen.generate_ed25519_private_key(),
-        network_private_key: keygen.generate_x25519_private_key().unwrap(),
-        consensus_private_key: keygen.generate_bls12381_private_key(),
-    };
+    let validator_node_keys = ValidatorNodeKeys::new(keygen);
     let validator_cli_index = cli
-        .add_cli_account(validator_node_keys.account_private_key.clone())
+        .create_cli_account_from_faucet(validator_node_keys.account_private_key.clone(), amount)
         .await
         .unwrap();
 
-    cli.assert_account_balance_now(validator_cli_index, DEFAULT_FUNDED_COINS)
+    cli.assert_account_balance_now(validator_cli_index, amount.unwrap_or(DEFAULT_FUNDED_COINS))
         .await;
     (validator_cli_index, validator_node_keys)
 }
@@ -378,6 +599,48 @@ async fn assert_validator_set_sizes(
         "{:?}",
         validator_set
     );
+}
+
+#[derive(Debug)]
+enum ValidatorState {
+    ACTIVE,
+    JOINING,
+    LEAVING,
+    NONE,
+}
+
+async fn assert_validator_state(cli: &CliTestFramework, pool_index: usize, state: ValidatorState) {
+    let validator_set = cli.show_validator_set().await.unwrap();
+    let pool_address = cli.account_id(pool_index);
+
+    if let ValidatorState::NONE = state {
+        for list in [
+            &validator_set.active_validators,
+            &validator_set.pending_active,
+            &validator_set.pending_inactive,
+        ] {
+            assert!(
+                !list.iter().any(|info| info.account_address == pool_address),
+                "{} shouldn't be in any for {:?}",
+                pool_address,
+                validator_set
+            );
+        }
+    } else {
+        let list = match state {
+            ValidatorState::ACTIVE => &validator_set.active_validators,
+            ValidatorState::JOINING => &validator_set.pending_active,
+            ValidatorState::LEAVING => &validator_set.pending_inactive,
+            ValidatorState::NONE => panic!(),
+        };
+        assert!(
+            list.iter().any(|info| info.account_address == pool_address),
+            "{} not in {:?} of {:?}",
+            pool_address,
+            state,
+            validator_set
+        );
+    }
 }
 
 fn get_gas(transaction: Transaction) -> u64 {


### PR DESCRIPTION
### Description

- Added owner-related CLI functions 
- Added AIT3 e2e flow for creating owner/validator/voter accounts and delegating everything appropriately
- separated out "stake owner" related commands into "stake" subcommand, leaving "node" subcommand for validator node operations
- change transfer CLI to use account_transfer (so that account gets created if not present already)
- deduped CreateAccount +faucet and FundAccount into FundWithFaucet, and made explicit testing APIs which use faucet, so that we can create more end-to-end flows be realistic - i.e. without faucet.
- updated register_validator_candidate into initialize_validator. 
- named initialize_stake_owner the CLI call (instead of initialize_owner_only) to be clearer, I would recommend updating move accordingly

### Test Plan
Added e2e test

Will sync up with @rajkaramchedu async, and leaving docs changes for a separate PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2867)
<!-- Reviewable:end -->
