### PR TITLE
Expose a greater set of necessary components from aptos-core in the Rust SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ name = "aptos-sdk"
 version = "0.0.3"
 dependencies = [
  "aptos-crypto",
+ "aptos-rest-client",
  "aptos-types",
  "bcs",
  "cached-packages",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -10,12 +10,11 @@ publish = false
 edition = "2018"
 
 [dependencies]
+aptos-crypto = { path = "../crates/aptos-crypto" }
+aptos-rest-client = { path = "../crates/aptos-rest-client" }
+aptos-types = { path = "../types" }
 bcs = "0.1.3"
+cached-packages = { path = "../aptos-move/framework/cached-packages" }
+move-deps = { path = "../aptos-move/move-deps", features = ["address32"] }
 rand_core = "0.5.1"
 serde = { version = "1.0.137", features = ["derive"] }
-
-aptos-crypto = { path = "../crates/aptos-crypto" }
-aptos-types = { path = "../types" }
-cached-packages = { path = "../aptos-move/framework/cached-packages" }
-
-move-deps = { path = "../aptos-move/move-deps", features = ["address32"] }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -8,6 +8,8 @@
 //! This SDK provides all the necessary components for building on top of the Aptos Blockchain. Some of the important modules are:
 //!
 //! * `crypto` - Types used for signing and verifying
+//! * `move_types` - Includes types used when interacting with the Move VM
+//! * `rest_client` - The Aptos API Client, used for sending requests to the Aptos Blockchain.
 //! * `transaction_builder` - Includes helpers for constructing transactions
 //! * `types` - Includes types for Aptos on-chain data structures
 //!
@@ -17,14 +19,20 @@
 //! todo(davidiw) bring back example using rest
 //!
 
+pub use bcs;
+
 pub mod crypto {
     pub use aptos_crypto::*;
+}
+
+pub mod move_types {
+    pub use move_deps::move_core_types::*;
+}
+
+pub mod rest_client {
+    pub use aptos_rest_client::*;
 }
 
 pub mod transaction_builder;
 
 pub mod types;
-
-pub mod move_types {
-    pub use move_deps::move_core_types::*;
-}

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -26,6 +26,22 @@ pub struct TransactionBuilder {
 }
 
 impl TransactionBuilder {
+    pub fn new(
+        payload: TransactionPayload,
+        expiration_timestamp_secs: u64,
+        chain_id: ChainId,
+    ) -> Self {
+        Self {
+            payload,
+            chain_id,
+            expiration_timestamp_secs,
+            max_gas_amount: 4000,
+            gas_unit_price: 1,
+            sender: None,
+            sequence_number: None,
+        }
+    }
+
     pub fn sender(mut self, sender: AccountAddress) -> Self {
         self.sender = Some(sender);
         self

--- a/sdk/src/types.rs
+++ b/sdk/src/types.rs
@@ -16,6 +16,10 @@ use crate::{
 use aptos_types::event::EventKey;
 pub use aptos_types::*;
 
+/// LocalAccount represents an account on the Aptos blockchain. Internally it
+/// holds the private / public key pair and the address of the account. You can
+/// use this struct to help transact with the blockchain, e.g. by generating a
+/// new account and signing transactions.
 #[derive(Debug)]
 pub struct LocalAccount {
     /// Address of the account.
@@ -27,6 +31,9 @@ pub struct LocalAccount {
 }
 
 impl LocalAccount {
+    /// Create a new representation of an account locally. Note: This function
+    /// does not actually create an account on the Aptos blockchain, just a
+    /// local representation.
     pub fn new<T: Into<AccountKey>>(address: AccountAddress, key: T, sequence_number: u64) -> Self {
         Self {
             address,
@@ -35,6 +42,9 @@ impl LocalAccount {
         }
     }
 
+    /// Generate a new account locally. Note: This function does not actually
+    /// create an account on the Aptos blockchain, it just generates a new
+    /// account locally.
     pub fn generate<R>(rng: &mut R) -> Self
     where
         R: ::rand_core::RngCore + ::rand_core::CryptoRng,


### PR DESCRIPTION
## Description
These changes were inspired by making the docs site examples use the Rust SDK. I found myself wanting things that weren't exposed. Now they are. The philosophy is users shouldn't need to import any aptos crate besides aptos-sdk. Requiring them to import other opinionated crates is fine and desirable (e.g. anyhow, tokio, etc).

## Test Plan
CI. These changes are backwards compatible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2869)
<!-- Reviewable:end -->
