### PR TITLE
[Storage] Make state snapshot finalization atomic.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -655,24 +655,13 @@ fn spawn_state_snapshot_receiver<
                                     "Failed to finish the state value synchronization! Error: {:?}",
                                     error
                                 ))
-                            } else if let Err(error) = storage
-                                .writer
-                                .finalize_state_snapshot(version, target_output_with_proof)
-                            {
+                            } else if let Err(error) = storage.writer.finalize_state_snapshot(
+                                version,
+                                target_output_with_proof,
+                                &epoch_change_proofs,
+                            ) {
                                 Err(format!(
                                     "Failed to finalize the state snapshot! Error: {:?}",
-                                    error
-                                ))
-                            } else if let Err(error) =
-                                storage.writer.save_ledger_infos(&epoch_change_proofs)
-                            {
-                                Err(format!(
-                                    "Failed to save all epoch ending ledger infos! Error: {:?}",
-                                    error
-                                ))
-                            } else if let Err(error) = storage.writer.delete_genesis() {
-                                Err(format!(
-                                    "Failed to delete the genesis transaction! Error: {:?}",
                                     error
                                 ))
                             } else if let Err(error) = metadata_storage

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -306,9 +306,8 @@ mock! {
             &self,
             version: Version,
             output_with_proof: TransactionOutputListWithProof,
+            ledger_infos: &[LedgerInfoWithSignatures],
         ) -> Result<()>;
-
-        fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()>;
 
         fn save_transactions<'a>(
             &self,
@@ -319,8 +318,6 @@ mock! {
             sync_commit: bool,
             in_memory_state: StateDelta,
         ) -> Result<()>;
-
-        fn delete_genesis(&self) -> Result<()>;
     }
 }
 

--- a/storage/aptosdb/src/backup/restore_handler.rs
+++ b/storage/aptosdb/src/backup/restore_handler.rs
@@ -71,6 +71,7 @@ impl RestoreHandler {
             self.ledger_db.clone(),
             self.ledger_store.clone(),
             ledger_infos,
+            None,
         )
     }
 
@@ -83,6 +84,7 @@ impl RestoreHandler {
             self.ledger_db.clone(),
             num_leaves,
             frozen_subtrees,
+            None,
         )
     }
 
@@ -102,6 +104,7 @@ impl RestoreHandler {
             txns,
             txn_infos,
             events,
+            None,
         )
     }
 

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use anyhow::{ensure, Result};
 use aptos_crypto::HashValue;
+use aptos_types::proof::position::Position;
 use aptos_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
@@ -20,39 +21,53 @@ use aptos_types::{
 use schemadb::DB;
 use std::sync::Arc;
 
+/// Saves the given ledger infos to the ledger store. If a change set is provided,
+/// a batch of db alterations will be added to the change set without writing them to the db.
 pub fn save_ledger_infos(
     db: Arc<DB>,
     ledger_store: Arc<LedgerStore>,
     ledger_infos: &[LedgerInfoWithSignatures],
+    existing_change_set: Option<&mut ChangeSet>,
 ) -> Result<()> {
     ensure!(!ledger_infos.is_empty(), "No LedgerInfos to save.");
 
-    let mut cs = ChangeSet::new();
-    ledger_infos
-        .iter()
-        .map(|li| ledger_store.put_ledger_info(li, &mut cs))
-        .collect::<Result<Vec<_>>>()?;
-    db.write_schemas(cs.batch)?;
+    if let Some(existing_change_set) = existing_change_set {
+        save_ledger_infos_impl(ledger_store, ledger_infos, existing_change_set)?;
+    } else {
+        let mut change_set = ChangeSet::new();
+        save_ledger_infos_impl(ledger_store.clone(), ledger_infos, &mut change_set)?;
+        db.write_schemas(change_set.batch)?;
+        update_latest_ledger_info(ledger_store, ledger_infos)?;
+    }
 
+    Ok(())
+}
+
+/// Updates the latest ledger info iff a ledger info with a higher epoch is found
+pub fn update_latest_ledger_info(
+    ledger_store: Arc<LedgerStore>,
+    ledger_infos: &[LedgerInfoWithSignatures],
+) -> Result<()> {
     if let Some(li) = ledger_store.get_latest_ledger_info_option() {
         if li.ledger_info().epoch() > ledger_infos.last().unwrap().ledger_info().epoch() {
             // No need to update latest ledger info.
             return Ok(());
         }
     }
-
     ledger_store.set_latest_ledger_info(ledger_infos.last().unwrap().clone());
+
     Ok(())
 }
 
+/// Confirms or saves the frozen subtrees. If a change set is provided, a batch
+/// of db alterations will be added to the change set without writing them to the db.
 pub fn confirm_or_save_frozen_subtrees(
     db: Arc<DB>,
     num_leaves: LeafCount,
     frozen_subtrees: &[HashValue],
+    existing_change_set: Option<&mut ChangeSet>,
 ) -> Result<()> {
-    let cs = ChangeSet::new();
     let positions: Vec<_> = FrozenSubTreeIterator::new(num_leaves).collect();
-
     ensure!(
         positions.len() == frozen_subtrees.len(),
         "Number of frozen subtree roots not expected. Expected: {}, actual: {}",
@@ -60,6 +75,149 @@ pub fn confirm_or_save_frozen_subtrees(
         frozen_subtrees.len(),
     );
 
+    if let Some(existing_change_set) = existing_change_set {
+        confirm_or_save_frozen_subtrees_impl(db, frozen_subtrees, positions, existing_change_set)?;
+    } else {
+        let mut change_set = ChangeSet::new();
+        confirm_or_save_frozen_subtrees_impl(
+            db.clone(),
+            frozen_subtrees,
+            positions,
+            &mut change_set,
+        )?;
+        db.write_schemas(change_set.batch)?;
+    }
+
+    Ok(())
+}
+
+/// Saves the given transactions to the db. If a change set is provided, a batch
+/// of db alterations will be added to the change set without writing them to the db.
+pub fn save_transactions(
+    db: Arc<DB>,
+    ledger_store: Arc<LedgerStore>,
+    transaction_store: Arc<TransactionStore>,
+    event_store: Arc<EventStore>,
+    first_version: Version,
+    txns: &[Transaction],
+    txn_infos: &[TransactionInfo],
+    events: &[Vec<ContractEvent>],
+    existing_change_set: Option<&mut ChangeSet>,
+) -> Result<()> {
+    if let Some(existing_change_set) = existing_change_set {
+        save_transactions_impl(
+            ledger_store,
+            transaction_store,
+            event_store,
+            first_version,
+            txns,
+            txn_infos,
+            events,
+            existing_change_set,
+        )?;
+    } else {
+        let mut change_set = ChangeSet::new();
+        save_transactions_impl(
+            ledger_store,
+            transaction_store,
+            event_store,
+            first_version,
+            txns,
+            txn_infos,
+            events,
+            &mut change_set,
+        )?;
+        db.write_schemas(change_set.batch)?;
+    }
+
+    Ok(())
+}
+
+/// Saves the given transaction outputs to the db. If a change set is provided, a batch
+/// of db alterations will be added to the change set without writing them to the db.
+pub fn save_transaction_outputs(
+    db: Arc<DB>,
+    transaction_store: Arc<TransactionStore>,
+    first_version: Version,
+    transaction_outputs: Vec<TransactionOutput>,
+    existing_change_set: Option<&mut ChangeSet>,
+) -> Result<()> {
+    if let Some(existing_change_set) = existing_change_set {
+        save_transaction_outputs_impl(
+            transaction_store,
+            first_version,
+            transaction_outputs,
+            existing_change_set,
+        )?;
+    } else {
+        let mut change_set = ChangeSet::new();
+        save_transaction_outputs_impl(
+            transaction_store,
+            first_version,
+            transaction_outputs,
+            &mut change_set,
+        )?;
+        db.write_schemas(change_set.batch)?;
+    }
+
+    Ok(())
+}
+
+/// A helper function that saves the ledger infos to the given change set
+fn save_ledger_infos_impl(
+    ledger_store: Arc<LedgerStore>,
+    ledger_infos: &[LedgerInfoWithSignatures],
+    change_set: &mut ChangeSet,
+) -> Result<()> {
+    ledger_infos
+        .iter()
+        .map(|li| ledger_store.put_ledger_info(li, change_set))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(())
+}
+
+/// A helper function that saves the transactions to the given change set
+pub fn save_transactions_impl(
+    ledger_store: Arc<LedgerStore>,
+    transaction_store: Arc<TransactionStore>,
+    event_store: Arc<EventStore>,
+    first_version: Version,
+    txns: &[Transaction],
+    txn_infos: &[TransactionInfo],
+    events: &[Vec<ContractEvent>],
+    change_set: &mut ChangeSet,
+) -> Result<()> {
+    for (idx, txn) in txns.iter().enumerate() {
+        transaction_store.put_transaction(first_version + idx as Version, txn, change_set)?;
+    }
+    ledger_store.put_transaction_infos(first_version, txn_infos, change_set)?;
+    event_store.put_events_multiple_versions(first_version, events, change_set)?;
+
+    Ok(())
+}
+
+/// A helper function that saves the transaction outputs to the given change set
+pub fn save_transaction_outputs_impl(
+    transaction_store: Arc<TransactionStore>,
+    first_version: Version,
+    transaction_outputs: Vec<TransactionOutput>,
+    change_set: &mut ChangeSet,
+) -> Result<()> {
+    for output in transaction_outputs {
+        transaction_store.put_write_set(first_version, output.write_set(), change_set)?;
+    }
+
+    Ok(())
+}
+
+/// A helper function that confirms or saves the frozen subtrees to the given change set
+fn confirm_or_save_frozen_subtrees_impl(
+    db: Arc<DB>,
+    frozen_subtrees: &[HashValue],
+    positions: Vec<Position>,
+    change_set: &mut ChangeSet,
+) -> Result<()> {
     positions
         .iter()
         .zip(frozen_subtrees.iter().rev())
@@ -72,43 +230,11 @@ pub fn confirm_or_save_frozen_subtrees(
                         _h,
                     );
             } else {
-                cs.batch.put::<TransactionAccumulatorSchema>(p, h)?;
+                change_set.batch.put::<TransactionAccumulatorSchema>(p, h)?;
             }
             Ok(())
         })
         .collect::<Result<Vec<_>>>()?;
-    db.write_schemas(cs.batch)
-}
 
-pub fn save_transactions(
-    db: Arc<DB>,
-    ledger_store: Arc<LedgerStore>,
-    transaction_store: Arc<TransactionStore>,
-    event_store: Arc<EventStore>,
-    first_version: Version,
-    txns: &[Transaction],
-    txn_infos: &[TransactionInfo],
-    events: &[Vec<ContractEvent>],
-) -> Result<()> {
-    let mut cs = ChangeSet::new();
-    for (idx, txn) in txns.iter().enumerate() {
-        transaction_store.put_transaction(first_version + idx as Version, txn, &mut cs)?;
-    }
-    ledger_store.put_transaction_infos(first_version, txn_infos, &mut cs)?;
-    event_store.put_events_multiple_versions(first_version, events, &mut cs)?;
-
-    db.write_schemas(cs.batch)
-}
-
-pub fn save_transaction_outputs(
-    db: Arc<DB>,
-    transaction_store: Arc<TransactionStore>,
-    first_version: Version,
-    transaction_outputs: Vec<TransactionOutput>,
-) -> Result<()> {
-    let mut cs = ChangeSet::new();
-    for output in transaction_outputs {
-        transaction_store.put_write_set(first_version, output.write_set(), &mut cs)?;
-    }
-    db.write_schemas(cs.batch)
+    Ok(())
 }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -49,7 +49,7 @@ use crate::{
         API_LATENCY_SECONDS, COMMITTED_TXNS, LATEST_TXN_VERSION, LEDGER_VERSION, NEXT_BLOCK_EPOCH,
         OTHER_TIMERS_SECONDS, ROCKSDB_PROPERTIES,
     },
-    pruner::{db_pruner::DBPruner, pruner_manager::PrunerManager, utils},
+    pruner::{pruner_manager::PrunerManager, utils},
     schema::*,
     state_store::StateStore,
     system_store::SystemStore,
@@ -1378,16 +1378,6 @@ impl DbReader for AptosDB {
 }
 
 impl DbWriter for AptosDB {
-    fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()> {
-        gauged_api("save_ledger_infos", || {
-            restore_utils::save_ledger_infos(
-                self.ledger_db.clone(),
-                self.ledger_store.clone(),
-                ledger_infos,
-            )
-        })
-    }
-
     /// `first_version` is the version of the first transaction in `txns_to_commit`.
     /// When `ledger_info_with_sigs` is provided, verify that the transaction accumulator root hash
     /// it carries is generated after the `txns_to_commit` are applied.
@@ -1553,6 +1543,7 @@ impl DbWriter for AptosDB {
         &self,
         version: Version,
         output_with_proof: TransactionOutputListWithProof,
+        ledger_infos: &[LedgerInfoWithSignatures],
     ) -> Result<()> {
         gauged_api("finalize_state_snapshot", || {
             // Ensure the output with proof only contains a single transaction output and info
@@ -1569,6 +1560,9 @@ impl DbWriter for AptosDB {
                 num_transaction_infos
             );
 
+            // TODO(joshlind): include confirm_or_save_frozen_subtrees in the change set
+            // bundle below.
+
             // Update the merkle accumulator using the given proof
             let frozen_subtrees = output_with_proof
                 .proof
@@ -1578,9 +1572,13 @@ impl DbWriter for AptosDB {
                 self.ledger_db.clone(),
                 version,
                 frozen_subtrees,
+                None,
             )?;
 
-            // Insert the target transactions, outputs, infos and events into the database
+            // Create a single change set for all further write operations
+            let mut change_set = ChangeSet::new();
+
+            // Save the target transactions, outputs, infos and events
             let (transactions, outputs): (Vec<Transaction>, Vec<TransactionOutput>) =
                 output_with_proof
                     .transactions_and_outputs
@@ -1601,38 +1599,33 @@ impl DbWriter for AptosDB {
                 &transactions,
                 &transaction_infos,
                 &events,
+                Some(&mut change_set),
             )?;
             restore_utils::save_transaction_outputs(
                 self.ledger_db.clone(),
                 self.transaction_store.clone(),
                 version,
                 outputs,
+                Some(&mut change_set),
             )?;
+
+            // Save the epoch ending ledger infos
+            restore_utils::save_ledger_infos(
+                self.ledger_db.clone(),
+                self.ledger_store.clone(),
+                ledger_infos,
+                Some(&mut change_set),
+            )?;
+
+            // Delete the genesis transaction
+            StateStorePruner::prune_genesis(self.state_merkle_db.clone(), &mut change_set)?;
+            LedgerPruner::prune_genesis(self.ledger_db.clone(), &mut change_set)?;
+
+            // Apply the change set writes to the database (atomically) and update in-memory state
+            self.ledger_db.clone().write_schemas(change_set.batch)?;
+            restore_utils::update_latest_ledger_info(self.ledger_store.clone(), ledger_infos)?;
             self.state_store.reset();
-            Ok(())
-        })
-    }
 
-    fn delete_genesis(&self) -> Result<()> {
-        gauged_api("delete_genesis", || {
-            // Execute each pruner to clean up the genesis state
-            let target_version = 1; // The genesis version is 0. Delete [0,1) (exclusive).
-            let max_version = 1; // We should only really be pruning at a single version.
-
-            // Create all the db pruners
-            let state_pruner = StateStorePruner::new(Arc::clone(&self.state_merkle_db));
-            let ledger_pruner = LedgerPruner::new(
-                Arc::clone(&self.ledger_db),
-                Arc::new(TransactionStore::new(Arc::clone(&self.ledger_db))),
-                Arc::new(EventStore::new(Arc::clone(&self.ledger_db))),
-                Arc::new(LedgerStore::new(Arc::clone(&self.ledger_db))),
-            );
-
-            state_pruner.set_target_version(target_version);
-            state_pruner.prune(max_version)?;
-
-            ledger_pruner.set_target_version(target_version);
-            ledger_pruner.prune(max_version)?;
             Ok(())
         })
     }

--- a/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_store/ledger_store_pruner.rs
@@ -12,7 +12,7 @@ use crate::{
         },
     },
     transaction::TransactionSchema,
-    EventStore, LedgerStore, TransactionStore,
+    utils, ChangeSet, EventStore, LedgerStore, TransactionStore,
 };
 use aptos_types::transaction::{AtomicVersion, Version};
 use schemadb::{ReadOptions, SchemaBatch, DB};
@@ -42,30 +42,10 @@ impl DBPruner for LedgerPruner {
         if !self.is_pruning_pending() {
             return Ok(self.min_readable_version());
         }
+
+        // Collect the schema batch writes
         let mut db_batch = SchemaBatch::new();
-        let min_readable_version = self.min_readable_version();
-        // Current target version might be less than the target version to ensure we don't prune
-        // more than max_version in one go.
-        let current_target_version = self.get_currrent_batch_target(max_versions as Version);
-
-        self.transaction_store_pruner.prune(
-            &mut db_batch,
-            min_readable_version,
-            current_target_version,
-        )?;
-        self.write_set_pruner
-            .prune(&mut db_batch, min_readable_version, current_target_version)?;
-        self.ledger_counter_pruner.prune(
-            &mut db_batch,
-            min_readable_version,
-            current_target_version,
-        )?;
-
-        self.event_store_pruner.prune(
-            &mut db_batch,
-            min_readable_version,
-            current_target_version,
-        )?;
+        let current_target_version = self.prune_inner(max_versions, &mut db_batch)?;
 
         // Commit all the changes to DB atomically
         self.db.write_schemas(db_batch)?;
@@ -130,5 +110,43 @@ impl LedgerPruner {
         };
         pruner.initialize();
         pruner
+    }
+
+    /// Prunes the genesis transaction and saves the db alterations to the given change set
+    pub fn prune_genesis(ledger_db: Arc<DB>, change_set: &mut ChangeSet) -> anyhow::Result<()> {
+        let target_version = 1; // The genesis version is 0. Delete [0,1) (exclusive)
+        let max_version = 1; // We should only be pruning a single version
+
+        let ledger_pruner = utils::create_ledger_pruner(ledger_db);
+        ledger_pruner.set_target_version(target_version);
+        ledger_pruner.prune_inner(max_version, &mut change_set.batch)?;
+
+        Ok(())
+    }
+
+    fn prune_inner(
+        &self,
+        max_versions: usize,
+        db_batch: &mut SchemaBatch,
+    ) -> anyhow::Result<Version> {
+        let min_readable_version = self.min_readable_version();
+
+        // Current target version might be less than the target version to ensure we don't prune
+        // more than max_version in one go.
+        let current_target_version = self.get_currrent_batch_target(max_versions as Version);
+
+        self.transaction_store_pruner.prune(
+            db_batch,
+            min_readable_version,
+            current_target_version,
+        )?;
+        self.write_set_pruner
+            .prune(db_batch, min_readable_version, current_target_version)?;
+        self.ledger_counter_pruner
+            .prune(db_batch, min_readable_version, current_target_version)?;
+        self.event_store_pruner
+            .prune(db_batch, min_readable_version, current_target_version)?;
+
+        Ok(current_target_version)
     }
 }

--- a/storage/aptosdb/src/pruner/utils.rs
+++ b/storage/aptosdb/src/pruner/utils.rs
@@ -11,11 +11,12 @@ use crate::{
 use schemadb::DB;
 use std::sync::Arc;
 
-/// Utility functions to instantiate pruners.
+/// A utility function to instantiate the state pruner
 pub fn create_state_pruner(state_merkle_db: Arc<DB>) -> Arc<StateStorePruner> {
     Arc::new(StateStorePruner::new(Arc::clone(&state_merkle_db)))
 }
 
+/// A utility function to instantiate the ledger pruner
 pub fn create_ledger_pruner(ledger_db: Arc<DB>) -> Arc<LedgerPruner> {
     Arc::new(LedgerPruner::new(
         Arc::clone(&ledger_db),

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -49,7 +49,12 @@ fn prune_stale_indices(
     limit: usize,
 ) -> Version {
     state_pruner
-        .prune_state_store(min_readable_version, target_min_readable_version, limit)
+        .prune_state_store(
+            min_readable_version,
+            target_min_readable_version,
+            limit,
+            None,
+        )
         .unwrap()
 }
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -564,8 +564,8 @@ pub trait DbWriter: Send + Sync {
     }
 
     /// Finalizes a state snapshot that has already been restored to the database through
-    /// a state snapshot receiver. This is required to bootstrap the transaction accumulator
-    /// and populate transaction and event information.
+    /// a state snapshot receiver. This is required to bootstrap the transaction accumulator,
+    /// populate transaction information, save the epoch ending ledger infos and delete genesis.
     ///
     /// Note: this assumes that the output with proof has already been verified and that the
     /// state snapshot was restored at the same version.
@@ -573,14 +573,8 @@ pub trait DbWriter: Send + Sync {
         &self,
         version: Version,
         output_with_proof: TransactionOutputListWithProof,
+        ledger_infos: &[LedgerInfoWithSignatures],
     ) -> Result<()> {
-        unimplemented!()
-    }
-
-    /// Persists the specified ledger infos.
-    ///
-    /// Note: this assumes that the ledger infos have already been verified.
-    fn save_ledger_infos(&self, ledger_infos: &[LedgerInfoWithSignatures]) -> Result<()> {
         unimplemented!()
     }
 
@@ -598,14 +592,6 @@ pub trait DbWriter: Send + Sync {
         sync_commit: bool,
         latest_in_memory_state: StateDelta,
     ) -> Result<()> {
-        unimplemented!()
-    }
-
-    /// Deletes transaction data associated with the genesis transaction. This is useful for
-    /// cleaning up the database after a node has bootstrapped all accounts through state sync.
-    ///
-    /// TODO(joshlind): find a cleaner (long term) solution to avoid us having to expose this...
-    fn delete_genesis(&self) -> Result<()> {
         unimplemented!()
     }
 }

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -47,7 +47,12 @@ async fn test_full_node_bootstrap_state_snapshot() {
         .unwrap();
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
+
+    // Verify that the vfn no longer has the genesis transaction
+    let vfn_client = swarm.fullnode_mut(vfn_peer_id).unwrap().rest_client();
+    let ledger_information = vfn_client.get_ledger_information().await.unwrap();
+    assert_ne!(ledger_information.inner().oldest_ledger_version, 0);
 }
 
 #[tokio::test]
@@ -69,7 +74,7 @@ async fn test_full_node_bootstrap_outputs() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
 }
 
 #[tokio::test]
@@ -91,7 +96,7 @@ async fn test_full_node_bootstrap_outputs_no_compression() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
 }
 
 #[tokio::test]
@@ -113,7 +118,7 @@ async fn test_full_node_bootstrap_transactions() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, swarm, true).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, true).await;
 }
 
 #[tokio::test]
@@ -132,7 +137,7 @@ async fn test_full_node_continuous_sync_outputs() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, swarm, false).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, false).await;
 }
 
 #[tokio::test]
@@ -151,7 +156,7 @@ async fn test_full_node_continuous_sync_transactions() {
     let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_peer_id, swarm, false).await;
+    test_full_node_sync(vfn_peer_id, &mut swarm, false).await;
 }
 
 /// Creates a new full node using the given config and swarm
@@ -175,16 +180,16 @@ async fn create_full_node(full_node_config: NodeConfig, swarm: &mut LocalSwarm) 
 
 /// A helper method that tests that a full node can sync from a validator after
 /// a failure and continue to stay up-to-date.
-async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_changes: bool) {
+async fn test_full_node_sync(vfn_peer_id: PeerId, swarm: &mut LocalSwarm, epoch_changes: bool) {
     // Stop the fullnode
     swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
 
     // Execute a number of transactions on the validator
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
     let validator_client = swarm.validator(validator_peer_id).unwrap().rest_client();
-    let (mut account_0, mut account_1) = create_test_accounts(&mut swarm).await;
+    let (mut account_0, mut account_1) = create_test_accounts(swarm).await;
     execute_transactions(
-        &mut swarm,
+        swarm,
         &validator_client,
         &mut account_0,
         &account_1,
@@ -199,11 +204,11 @@ async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_c
         .restart()
         .await
         .unwrap();
-    wait_for_all_nodes(&mut swarm).await;
+    wait_for_all_nodes(swarm).await;
 
     // Execute more transactions on the validator and verify the fullnode catches up
     execute_transactions_and_wait(
-        &mut swarm,
+        swarm,
         &validator_client,
         &mut account_1,
         &account_0,
@@ -215,7 +220,7 @@ async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_c
 #[tokio::test]
 async fn test_validator_bootstrap_outputs() {
     // Create a swarm of 4 validators with state sync v2 enabled (output syncing)
-    let swarm = SwarmBuilder::new_local(4)
+    let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
@@ -227,13 +232,37 @@ async fn test_validator_bootstrap_outputs() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(swarm).await;
+    test_validator_sync(&mut swarm, 1).await;
+}
+
+#[tokio::test]
+async fn test_validator_bootstrap_state_snapshot() {
+    // Create a swarm of 4 validators with state sync v2 enabled (snapshot syncing, chunk size = 1)
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::DownloadLatestStates;
+            config.state_sync.storage_service.max_state_chunk_size = 1;
+        }))
+        .build()
+        .await;
+
+    // Test the ability of the validators to sync
+    let validator_index_to_test = 1;
+    test_validator_sync(&mut swarm, validator_index_to_test).await;
+
+    // Verify that the bootstrapped validator no longer has the genesis transaction
+    let bootstrapped_validator = swarm.validators().collect::<Vec<_>>()[validator_index_to_test];
+    let validator_client = bootstrapped_validator.rest_client();
+    let ledger_information = validator_client.get_ledger_information().await.unwrap();
+    assert_ne!(ledger_information.inner().oldest_ledger_version, 0);
 }
 
 #[tokio::test]
 async fn test_validator_bootstrap_transactions() {
     // Create a swarm of 4 validators with state sync v2 enabled (transaction syncing)
-    let swarm = SwarmBuilder::new_local(4)
+    let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
@@ -245,13 +274,13 @@ async fn test_validator_bootstrap_transactions() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(swarm).await;
+    test_validator_sync(&mut swarm, 1).await;
 }
 
 #[tokio::test]
 async fn test_validator_bootstrap_transactions_no_compression() {
     // Create a swarm of 4 validators with state sync v2 enabled (transaction syncing, no compression)
-    let swarm = SwarmBuilder::new_local(4)
+    let mut swarm = SwarmBuilder::new_local(4)
         .with_aptos()
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
@@ -264,55 +293,36 @@ async fn test_validator_bootstrap_transactions_no_compression() {
         .await;
 
     // Test the ability of the validators to sync
-    test_validator_sync(swarm).await;
+    test_validator_sync(&mut swarm, 1).await;
 }
 
 /// A helper method that tests that a validator can sync after a failure and
 /// continue to stay up-to-date.
-async fn test_validator_sync(mut swarm: LocalSwarm) {
+async fn test_validator_sync(swarm: &mut LocalSwarm, validator_index_to_test: usize) {
     // Execute multiple transactions through validator 0
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let validator_client_0 = swarm
         .validator(validator_peer_ids[0])
         .unwrap()
         .rest_client();
-    let (mut account_0, mut account_1) = create_test_accounts(&mut swarm).await;
-    execute_transactions_and_wait(
-        &mut swarm,
-        &validator_client_0,
-        &mut account_0,
-        &account_1,
-        true,
-    )
-    .await;
+    let (mut account_0, mut account_1) = create_test_accounts(swarm).await;
+    execute_transactions_and_wait(swarm, &validator_client_0, &mut account_0, &account_1, true)
+        .await;
 
-    // Stop validator 1 and delete the storage
-    let validator_1 = validator_peer_ids[1];
-    stop_validator_and_delete_storage(&mut swarm, validator_1);
+    // Stop the validator and delete the storage
+    let validator = validator_peer_ids[validator_index_to_test];
+    stop_validator_and_delete_storage(swarm, validator);
 
     // Execute more transactions
-    execute_transactions(
-        &mut swarm,
-        &validator_client_0,
-        &mut account_1,
-        &account_0,
-        true,
-    )
-    .await;
+    execute_transactions(swarm, &validator_client_0, &mut account_1, &account_0, true).await;
 
-    // Restart validator 1 and wait for all nodes to catchup
-    swarm.validator_mut(validator_1).unwrap().start().unwrap();
-    wait_for_all_nodes(&mut swarm).await;
+    // Restart the validator and wait for all nodes to catchup
+    swarm.validator_mut(validator).unwrap().start().unwrap();
+    wait_for_all_nodes(swarm).await;
 
-    // Execute multiple transactions and verify validator 1 can sync
-    execute_transactions_and_wait(
-        &mut swarm,
-        &validator_client_0,
-        &mut account_0,
-        &account_1,
-        true,
-    )
-    .await;
+    // Execute multiple transactions and verify the validator can sync
+    execute_transactions_and_wait(swarm, &validator_client_0, &mut account_0, &account_1, true)
+        .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Description
During the fast sync process, we need to perform three tasks once all state keys/values have been restored to storage: (i) finalize the sync by writing the transaction information to storage; (ii) save the newly verified epoch ending ledger infos to storage; and (iii) delete the genesis transaction. This PR updates the three operations to occur atomically. This prevents crashes from causing storage to end up in an invalid state (e.g., if the node crashes between step (i) and (ii)). With this, fast sync should be mostly* crash fault tolerant.

Notes:
- To achieve this, I've had to refactor a bunch of code so that we can pass in an existing change set to various functions (so that all storage alterations can be committed atomically), including updating the pruners.

*I say mostly, because there's still a small edge case where `confirm_or_save_frozen_subtrees` should be atomic as well. But, this is not currently possible without some major changes on the storage side, so I've added a TODO to the code. We're willing to accept the risk for now, given that it would take a very rare crash to expose this, and in the worst case, we'd just restart the sync.

### Test Plan
In addition to the existing smoke tests that verify the fast sync functionality, I've also updated the smoke tests to ensure that the genesis transaction is pruned after a snapshot is restored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2874)
<!-- Reviewable:end -->
