### PR TITLE
[forge] Rename workflow, try out chaos suite, new cluster

### DIFF
--- a/.github/workflows/continuous-e2e-tests.yaml
+++ b/.github/workflows/continuous-e2e-tests.yaml
@@ -9,9 +9,10 @@ on:
   push:
     branches:
       - pre-release-continuous-test
+      - devnet
   schedule:
     # Run every hour - TODO: Decrease the frequency once things stabilizes
-    - cron: "0 */1 * * *"
+    - cron: "0 */3 * * *"
 
 jobs:
   ### Please remember to use different namespace for different tests
@@ -22,8 +23,8 @@ jobs:
     with:
       FORGE_NAMESPACE: forge-performance
       FORGE_CLUSTER_NAME: aptos-forge-1
-      # Run for 30 minutes
-      FORGE_RUNNER_DURATION_SECS: 1800
+      # Run for 2 hours
+      FORGE_RUNNER_DURATION_SECS: 7200
       # We expect slightly lower tps on longer timeline
       FORGE_RUNNER_TPS_THRESHOLD: 5000
       # Land blocking is performance test
@@ -40,20 +41,20 @@ jobs:
       # We expect slightly lower tps on longer timeline
       FORGE_RUNNER_TPS_THRESHOLD: 1000
       # Pre release has chaos applied
-      FORGE_TEST_SUITE: pre_release
+      FORGE_TEST_SUITE: chaos
   # Run a faster chaos forge to quickly surface correctness failures
   run-forge-fast-chaos:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-fast-chaos
-      FORGE_CLUSTER_NAME: aptos-forge-1
-      # Run for 30 minutes
+      FORGE_NAMESPACE: forge-fast-chaos-new-cluster
+      FORGE_CLUSTER_NAME: aptos-forge-2
+      # Run for 5 minutes
       FORGE_RUNNER_DURATION_SECS: 300
       # We expect slightly lower tps on longer timeline
       FORGE_RUNNER_TPS_THRESHOLD: 1000
       # Pre release has chaos applied
-      FORGE_TEST_SUITE: pre_release
+      FORGE_TEST_SUITE: chaos
   # Example new forge nightly test, simply add this block below to schedule your own forge job
   # run-forge-example:
   #   uses: ./.github/workflows/run-forge.yaml


### PR DESCRIPTION
Make the workflow name a little more clear
Try out the new chaos testing suite (including network loss)
Try out the new cluster as well running k8s v 1.23 fresh off the presses

Test plan:

push branch and dispatch a workflow, however it cannot be dispatched until it lands :upside_down_smile:

Worst case it breaks continuous job, but that is easy to fix because after its in main i can test it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2879)
<!-- Reviewable:end -->
