### PR TITLE
Fix multiagent txn test in TS SDK

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -285,7 +285,7 @@ test(
   30 * 1000,
 );
 
-test.skip(
+test(
   "submits multiagent transaction",
   async () => {
     const client = new AptosClient(NODE_URL);
@@ -331,13 +331,14 @@ test.skip(
       ),
     );
 
+    const propertyVersion = 0;
     const tokenId = {
       token_data_id: {
         creator: alice.address().hex(),
         collection: collectionName,
         name: tokenName,
       },
-      property_version: "0",
+      property_version: `${propertyVersion}`,
     };
 
     // Transfer Token from Alice's Account to Bob's Account
@@ -354,8 +355,8 @@ test.skip(
           BCS.bcsToBytes(TxnBuilderTypes.AccountAddress.fromHex(alice.address())),
           BCS.bcsSerializeStr(collectionName),
           BCS.bcsSerializeStr(tokenName),
+          BCS.bcsSerializeUint64(propertyVersion),
           BCS.bcsSerializeUint64(1),
-          BCS.bcsSerializeUint64(0),
         ],
       ),
     );


### PR DESCRIPTION
## Description
Fixing this broken test. I previously disabled it bc it was broken. Positional arguments of the same type were in the wrong order, classic.

## Test Plan
```
yarn test -t 'submits multiagent transaction'
```
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2880)
<!-- Reviewable:end -->
