### PR TITLE
[Aptos Data Client] Make optimistic fetch take into account peer state.

### DIFF
--- a/state-sync/aptos-data-client/src/aptosnet/state.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/state.rs
@@ -18,7 +18,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use storage_service_types::requests::{DataRequest, StorageServiceRequest};
+use storage_service_types::requests::StorageServiceRequest;
 use storage_service_types::responses::StorageServerSummary;
 
 /// Scores for peer rankings based on preferences and behavior.
@@ -141,11 +141,8 @@ impl PeerStates {
         // Storage services can always respond to data advertisement requests.
         // We need this outer check, since we need to be able to send data summary
         // requests to new peers (who don't have a peer state yet).
-        // Likewise, we can always send subscription requests to any peers and
-        // all peers should support versioning.
-        if request.data_request.is_get_storage_server_summary()
-            || request.data_request.is_data_subscription_request()
-            || matches!(request.data_request, DataRequest::GetServerProtocolVersion)
+        if request.data_request.is_storage_summary_request()
+            || request.data_request.is_protocol_version_request()
         {
             return true;
         }

--- a/state-sync/aptos-data-client/src/aptosnet/tests.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/tests.rs
@@ -36,7 +36,7 @@ use storage_service_types::requests::{
 };
 use storage_service_types::responses::{
     CompleteDataRange, DataResponse, DataSummary, ProtocolMetadata, StorageServerSummary,
-    StorageServiceResponse,
+    StorageServiceResponse, OPTIMISTIC_FETCH_VERSION_DELTA,
 };
 use storage_service_types::{StorageServiceError, StorageServiceMessage};
 
@@ -652,24 +652,10 @@ async fn prioritized_peer_request_selection() {
     ::aptos_logger::Logger::init_for_testing();
     let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
 
-    // Ensure the properties hold for storage summary and data subscription requests
+    // Ensure the properties hold for storage summary and version requests
     let storage_summary_request = DataRequest::GetStorageServerSummary;
-    let new_transactions_request =
-        DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
-            known_version: 1023,
-            known_epoch: 23,
-            include_events: false,
-        });
-    let new_outputs_request =
-        DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
-            known_version: 4504,
-            known_epoch: 3,
-        });
-    for data_request in [
-        storage_summary_request,
-        new_transactions_request,
-        new_outputs_request,
-    ] {
+    let get_version_request = DataRequest::GetServerProtocolVersion;
+    for data_request in [storage_summary_request, get_version_request] {
         let storage_request = StorageServiceRequest::new(data_request, true);
 
         // Ensure no peers can service the request (we have no connections)
@@ -715,6 +701,103 @@ async fn prioritized_peer_request_selection() {
 
         // Disconnect the regular peer so that we no longer have any connections
         mock_network.disconnect_peer(regular_peer_1);
+    }
+}
+
+#[tokio::test]
+async fn prioritized_peer_subscription_selection() {
+    ::aptos_logger::Logger::init_for_testing();
+    let (mut mock_network, _, client, _) = MockNetwork::new(None, None, None);
+
+    // Create test data
+    let known_version = 10000000;
+    let known_epoch = 10;
+
+    // Ensure the properties hold for both subscription requests
+    let new_transactions_request =
+        DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+            known_version,
+            known_epoch,
+            include_events: false,
+        });
+    let new_outputs_request =
+        DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
+            known_version,
+            known_epoch,
+        });
+    for data_request in [new_transactions_request, new_outputs_request] {
+        let storage_request = StorageServiceRequest::new(data_request, true);
+
+        // Ensure no peers can service the request (we have no connections)
+        assert_matches!(
+            client.choose_peer_for_request(&storage_request),
+            Err(Error::DataIsUnavailable(_))
+        );
+
+        // Add a regular peer and verify the peer cannot support the request
+        let regular_peer_1 = mock_network.add_peer(false);
+        assert_matches!(
+            client.choose_peer_for_request(&storage_request),
+            Err(Error::DataIsUnavailable(_))
+        );
+
+        // Advertise the data for the regular peer and verify it is now selected
+        client.update_summary(regular_peer_1, mock_storage_summary(known_version));
+        assert_eq!(
+            client.choose_peer_for_request(&storage_request),
+            Ok(regular_peer_1)
+        );
+
+        // Add a priority peer and verify the regular peer is selected
+        let priority_peer_1 = mock_network.add_peer(true);
+        assert_eq!(
+            client.choose_peer_for_request(&storage_request),
+            Ok(regular_peer_1)
+        );
+
+        // Advertise the data for the priority peer and verify it is now selected
+        client.update_summary(priority_peer_1, mock_storage_summary(known_version));
+        assert_eq!(
+            client.choose_peer_for_request(&storage_request),
+            Ok(priority_peer_1)
+        );
+
+        // Update the priority peer to be too far behind and verify it is not selected
+        client.update_summary(
+            priority_peer_1,
+            mock_storage_summary(known_version - OPTIMISTIC_FETCH_VERSION_DELTA),
+        );
+        assert_eq!(
+            client.choose_peer_for_request(&storage_request),
+            Ok(regular_peer_1)
+        );
+
+        // Update the regular peer to be too far behind and verify neither is selected
+        client.update_summary(
+            regular_peer_1,
+            mock_storage_summary(known_version - (OPTIMISTIC_FETCH_VERSION_DELTA * 2)),
+        );
+        assert_matches!(
+            client.choose_peer_for_request(&storage_request),
+            Err(Error::DataIsUnavailable(_))
+        );
+
+        // Disconnect the regular peer and verify neither is selected
+        mock_network.disconnect_peer(regular_peer_1);
+        assert_matches!(
+            client.choose_peer_for_request(&storage_request),
+            Err(Error::DataIsUnavailable(_))
+        );
+
+        // Advertise the data for the priority peer and verify it is now selected again
+        client.update_summary(priority_peer_1, mock_storage_summary(known_version + 1000));
+        assert_eq!(
+            client.choose_peer_for_request(&storage_request),
+            Ok(priority_peer_1)
+        );
+
+        // Disconnect the priority peer so that we no longer have any connections
+        mock_network.disconnect_peer(priority_peer_1);
     }
 }
 

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -60,13 +60,17 @@ impl DataRequest {
         }
     }
 
-    pub fn is_get_storage_server_summary(&self) -> bool {
+    pub fn is_storage_summary_request(&self) -> bool {
         matches!(self, &Self::GetStorageServerSummary)
     }
 
     pub fn is_data_subscription_request(&self) -> bool {
         matches!(self, &Self::GetNewTransactionOutputsWithProof(_))
             || matches!(self, &Self::GetNewTransactionsWithProof(_))
+    }
+
+    pub fn is_protocol_version_request(&self) -> bool {
+        matches!(self, &Self::GetServerProtocolVersion)
     }
 }
 


### PR DESCRIPTION
### Description
This PR updates the Aptos Data Client to only consider peers eligible for an optimistic data fetch (i.e., single subscription request) if the peer is within some delta of the synced version of the client. This prevents the case where a node sends one of these requests to a peer that has fallen behind, and thus will wait for the request to timeout (5 seconds) before checking if there's new data available in the rest of the network. 

Note: we saw this behaviour in `devnet`, where a validator got stuck, and its VFN would get up-to-date via fallback peers and then send the subscription request to the validator (because it is considered a priority peer). But, because the validator was behind the VFN, the VFN would wait for 5 seconds before being to request data from the fallback peers.

### Test Plan
Added a new unit test to ensure that peer selection for optimistic data fetches works as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2881)
<!-- Reviewable:end -->
