### PR TITLE
[Configs] Remove unused config.

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -48,10 +48,6 @@ use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519};
 use aptos_types::account_address::AccountAddress;
 use poem_openapi::Enum as PoemEnum;
 
-/// Represents a deprecated config that provides no field verification.
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-pub struct DeprecatedConfig {}
-
 /// Config pulls in configuration information from the config file.
 /// This is used to set up the nodes and configure various parameters.
 /// The config file is broken up into sections for each module
@@ -73,8 +69,6 @@ pub struct NodeConfig {
     pub logger: LoggerConfig,
     #[serde(default)]
     pub mempool: MempoolConfig,
-    #[serde(default)]
-    pub metrics: DeprecatedConfig,
     #[serde(default)]
     pub peer_monitoring_service: PeerMonitoringServiceConfig,
     #[serde(default)]


### PR DESCRIPTION
### Description

This PR removes the unused (and deprecated) `metric` config. No idea what it was doing or why 😄 

### Test Plan
Existing test infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2887)
<!-- Reviewable:end -->
