### PR TITLE
[consensus] fallback to state sync if commit root falls behind too much

### DIFF
--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -335,7 +335,7 @@ impl Block {
         ))
         .chain(
             self.payload()
-                .unwrap_or(&Payload::new_empty())
+                .unwrap_or(&Payload::empty())
                 .clone()
                 .into_iter()
                 .map(Transaction::UserTransaction),

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -8,10 +8,10 @@ use crate::{
 };
 use aptos_crypto::hash::HashValue;
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
-use aptos_types::multi_signature::MultiSignature;
 use aptos_types::{
     block_info::BlockInfo,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    multi_signature::MultiSignature,
 };
 use mirai_annotations::*;
 use serde::{Deserialize, Serialize};
@@ -263,7 +263,7 @@ fn test_reconfiguration_suffix() {
         ),
     );
     let reconfig_suffix_block = BlockData::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         AccountAddress::random(),
         Vec::new(),
         2,

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -71,7 +71,7 @@ fn test_nil_block() {
         nil_block_qc.certified_block().id()
     );
     let nil_block_child = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         2,
         aptos_infallible::duration_since_epoch().as_micros() as u64,
         nil_block_qc,
@@ -89,7 +89,7 @@ fn test_block_relation() {
     // Test genesis and the next block
     let genesis_block = Block::make_genesis_block();
     let quorum_cert = certificate_for_genesis();
-    let payload = Payload::new_empty();
+    let payload = Payload::empty();
     let next_block = Block::new_proposal(
         payload.clone(),
         1,
@@ -118,7 +118,7 @@ fn test_same_qc_different_authors() {
     let signer = signers.get(0).unwrap();
     let genesis_qc = certificate_for_genesis();
     let round = 1;
-    let payload = Payload::new_empty();
+    let payload = Payload::empty();
     let current_timestamp = aptos_infallible::duration_since_epoch().as_micros() as u64;
     let block_round_1 = Block::new_proposal(
         payload.clone(),
@@ -177,7 +177,7 @@ fn test_block_metadata_bitvec() {
         &ledger_info,
         Block::make_genesis_block_from_ledger_info(&ledger_info).id(),
     );
-    let payload = Payload::new_empty();
+    let payload = Payload::empty();
     let start_round = 1;
     let start_timestamp = aptos_infallible::duration_since_epoch().as_micros() as u64;
 
@@ -247,7 +247,7 @@ fn test_failed_authors_well_formed() {
     let other = Author::random();
     // Test genesis and the next block
     let quorum_cert = certificate_for_genesis();
-    let payload = Payload::new_empty();
+    let payload = Payload::empty();
 
     let create_block = |round: Round, failed_authors: Vec<(Round, Author)>| {
         Block::new_proposal(

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -15,11 +15,10 @@ use aptos_crypto::{
     hash::{CryptoHash, HashValue},
     PrivateKey, Uniform,
 };
-use aptos_types::ledger_info::generate_ledger_info_with_sig;
 use aptos_types::{
     account_address::AccountAddress,
     block_info::BlockInfo,
-    ledger_info::LedgerInfo,
+    ledger_info::{generate_ledger_info_with_sig, LedgerInfo},
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     validator_signer::{proptests, ValidatorSigner},
 };
@@ -43,7 +42,7 @@ prop_compose! {
         parent_qc in Just(parent_qc)
     ) -> Block {
         Block::new_proposal(
-            Payload::new_empty(),
+            Payload::empty(),
             round,
             aptos_infallible::duration_since_epoch().as_micros() as u64,
             parent_qc,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -3,8 +3,7 @@
 
 use aptos_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use serde::{Deserialize, Serialize};
-use std::fmt;
-use std::fmt::Write;
+use std::{fmt, fmt::Write};
 
 /// The round of a block is a consensus-internal counter, which starts with 0 and increases
 /// monotonically. It is used for the protocol safety and liveness (please see the detailed
@@ -33,7 +32,7 @@ pub enum Payload {
 }
 
 impl Payload {
-    pub fn new_empty() -> Self {
+    pub fn empty() -> Self {
         Payload::DirectMempool(Vec::new())
     }
 

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -102,7 +102,7 @@ impl SafetyRules {
         let two_chain = qc.parent_block().round();
         if one_chain > safety_data.one_chain_round {
             safety_data.one_chain_round = one_chain;
-            info!(
+            trace!(
                 SafetyLogSchema::new(LogEntry::OneChainRound, LogEvent::Update)
                     .preferred_round(safety_data.one_chain_round)
             );
@@ -110,7 +110,7 @@ impl SafetyRules {
         }
         if two_chain > safety_data.preferred_round {
             safety_data.preferred_round = two_chain;
-            info!(
+            trace!(
                 SafetyLogSchema::new(LogEntry::PreferredRound, LogEvent::Update)
                     .preferred_round(safety_data.preferred_round)
             );
@@ -173,7 +173,7 @@ impl SafetyRules {
         }
 
         safety_data.last_voted_round = round;
-        info!(
+        trace!(
             SafetyLogSchema::new(LogEntry::LastVotedRound, LogEvent::Update)
                 .last_voted_round(safety_data.last_voted_round)
         );
@@ -196,7 +196,7 @@ impl SafetyRules {
         let waypoint = self.persistent_storage.waypoint()?;
         let safety_data = self.persistent_storage.safety_data()?;
 
-        info!(SafetyLogSchema::new(LogEntry::State, LogEvent::Update)
+        trace!(SafetyLogSchema::new(LogEntry::State, LogEvent::Update)
             .author(self.persistent_storage.author()?)
             .epoch(safety_data.epoch)
             .last_voted_round(safety_data.last_voted_round)
@@ -263,7 +263,7 @@ impl SafetyRules {
             Some(expected_key) => {
                 let current_key = self.signer().ok().map(|s| s.public_key());
                 if current_key == Some(expected_key.clone()) {
-                    debug!(
+                    info!(
                         SafetyLogSchema::new(LogEntry::KeyReconciliation, LogEvent::Success),
                         "in set",
                     );
@@ -419,11 +419,11 @@ where
     L: for<'a> Fn(SafetyLogSchema<'a>) -> SafetyLogSchema<'a>,
 {
     let _timer = counters::start_timer("internal", log_entry.as_str());
-    debug!(log_cb(SafetyLogSchema::new(log_entry, LogEvent::Request)));
+    trace!(log_cb(SafetyLogSchema::new(log_entry, LogEvent::Request)));
     counters::increment_query(log_entry.as_str(), "request");
     callback()
         .map(|v| {
-            info!(log_cb(SafetyLogSchema::new(log_entry, LogEvent::Success)));
+            trace!(log_cb(SafetyLogSchema::new(log_entry, LogEvent::Success)));
             counters::increment_query(log_entry.as_str(), "success");
             v
         })

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -75,13 +75,7 @@ pub fn make_proposal_with_qc(
     qc: QuorumCert,
     validator_signer: &ValidatorSigner,
 ) -> VoteProposal {
-    make_proposal_with_qc_and_proof(
-        Payload::new_empty(),
-        round,
-        empty_proof(),
-        qc,
-        validator_signer,
-    )
+    make_proposal_with_qc_and_proof(Payload::empty(), round, empty_proof(), qc, validator_signer)
 }
 
 pub fn make_proposal_with_parent_and_overrides(

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -3,11 +3,11 @@
 
 use crate::{test_utils, test_utils::make_timeout_cert, Error, TSafetyRules};
 use aptos_crypto::hash::{HashValue, ACCUMULATOR_PLACEHOLDER_HASH};
-use aptos_types::multi_signature::MultiSignature;
 use aptos_types::{
     block_info::BlockInfo,
     epoch_state::EpochState,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    multi_signature::MultiSignature,
     validator_signer::ValidatorSigner,
     validator_verifier::ValidatorVerifier,
 };
@@ -27,7 +27,7 @@ fn make_proposal_with_qc_and_proof(
     qc: QuorumCert,
     signer: &ValidatorSigner,
 ) -> VoteProposal {
-    test_utils::make_proposal_with_qc_and_proof(Payload::new_empty(), round, proof, qc, signer)
+    test_utils::make_proposal_with_qc_and_proof(Payload::empty(), round, proof, qc, signer)
 }
 
 fn make_proposal_with_parent(
@@ -36,7 +36,7 @@ fn make_proposal_with_parent(
     committed: Option<&VoteProposal>,
     signer: &ValidatorSigner,
 ) -> VoteProposal {
-    test_utils::make_proposal_with_parent(Payload::new_empty(), round, parent, committed, signer)
+    test_utils::make_proposal_with_parent(Payload::empty(), round, parent, committed, signer)
 }
 
 pub type Callback = Box<dyn Fn() -> (Box<dyn TSafetyRules + Send + Sync>, ValidatorSigner)>;
@@ -184,7 +184,7 @@ fn test_voting_bad_epoch(safety_rules: &Callback) {
 
     let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc, &signer);
     let a2 = test_utils::make_proposal_with_parent_and_overrides(
-        Payload::new_empty(),
+        Payload::empty(),
         round + 3,
         &a1,
         None,
@@ -352,7 +352,7 @@ fn test_validator_not_in_set(safety_rules: &Callback) {
     next_epoch_state.verifier =
         ValidatorVerifier::new_single(rand_signer.author(), rand_signer.public_key());
     let a2 = test_utils::make_proposal_with_parent_and_overrides(
-        Payload::new_empty(),
+        Payload::empty(),
         round + 2,
         &a1,
         Some(&a1),
@@ -390,7 +390,7 @@ fn test_key_not_in_store(safety_rules: &Callback) {
     next_epoch_state.verifier =
         ValidatorVerifier::new_single(signer.author(), rand_signer.public_key());
     let a2 = test_utils::make_proposal_with_parent_and_overrides(
-        Payload::new_empty(),
+        Payload::empty(),
         round + 2,
         &a1,
         Some(&a1),

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -554,6 +554,9 @@ impl BlockStore {
     /// Helper function to insert the block with the qc together
     pub async fn insert_block_with_qc(&self, block: Block) -> anyhow::Result<Arc<ExecutedBlock>> {
         self.insert_single_quorum_cert(block.quorum_cert().clone())?;
+        if self.ordered_root().round() < block.quorum_cert().commit_info().round() {
+            self.commit(block.quorum_cert().clone()).await?;
+        }
         self.execute_and_insert_block(block).await
     }
 }

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -15,7 +15,7 @@ use aptos_types::{
 use consensus_types::{
     block::{
         block_test_utils::{
-            self, certificate_for_genesis, placeholder_certificate_for_block,
+            self, certificate_for_genesis, gen_test_certificate, placeholder_certificate_for_block,
             placeholder_ledger_info,
         },
         Block,
@@ -347,7 +347,7 @@ async fn test_illegal_timestamp() {
     let block_store = build_empty_tree();
     let genesis = block_store.ordered_root();
     let block_with_illegal_timestamp = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         0,
         // This timestamp is illegal, it is the same as genesis
         genesis.timestamp_usecs(),
@@ -425,4 +425,55 @@ async fn test_need_fetch_for_qc() {
         block_store.need_fetch_for_quorum_cert(duplicate_qc.as_ref()),
         NeedFetchResult::QCAlreadyExist,
     );
+}
+
+#[tokio::test]
+async fn test_need_sync_for_ledger_info() {
+    let mut inserter = TreeInserter::default();
+    let block_store = inserter.block_store();
+
+    let mut prev = block_store.ordered_root();
+    for i in 1..=30 {
+        prev = inserter.insert_block(&prev, i, None).await;
+    }
+    inserter
+        .insert_block(
+            &prev,
+            31,
+            Some(prev.block().gen_block_info(HashValue::zero(), 1, None)),
+        )
+        .await;
+    assert_eq!(block_store.ordered_root().round(), 30);
+    assert_eq!(block_store.commit_root().round(), 0);
+
+    let create_ledger_info = |round: u64| {
+        let future_block = inserter.create_block_with_qc(
+            certificate_for_genesis(),
+            1,
+            round,
+            Payload::empty(),
+            vec![],
+        );
+        gen_test_certificate(
+            &[inserter.signer().clone()],
+            future_block.gen_block_info(HashValue::zero(), 0, None),
+            future_block.quorum_cert().parent_block().clone(),
+            Some(future_block.gen_block_info(HashValue::zero(), 0, None)),
+        )
+        .ledger_info()
+        .clone()
+    };
+    let ordered_round_too_far =
+        block_store.ordered_root().round() + block_store.back_pressure_limit + 1;
+    let ordered_too_far = create_ledger_info(ordered_round_too_far);
+    assert!(block_store.need_sync_for_ledger_info(&ordered_too_far));
+
+    let committed_round_too_far =
+        block_store.commit_root().round() + block_store.back_pressure_limit * 2 + 1;
+    let committed_too_far = create_ledger_info(committed_round_too_far);
+    assert!(block_store.need_sync_for_ledger_info(&committed_too_far));
+
+    let round_not_too_far = block_store.commit_root().round() + block_store.back_pressure_limit + 1;
+    let not_too_far = create_ledger_info(round_not_too_far);
+    assert!(!block_store.need_sync_for_ledger_info(&not_too_far));
 }

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -43,6 +43,7 @@ impl BlockStore {
     /// This ensures that the block referred by the ledger info is not in buffer manager.
     pub fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
         self.ordered_root().round() + self.back_pressure_limit < li.commit_info().round()
+            || self.commit_root().round() + 2 * self.back_pressure_limit < li.commit_info().round()
     }
 
     /// Checks if quorum certificate can be inserted in block store without RPC

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::liveness::leader_reputation::extract_epoch_to_proposers;
-use crate::monitor;
 use crate::{
     block_storage::BlockStore,
     commit_notifier::CommitNotifier,
@@ -16,7 +14,8 @@ use crate::{
     liveness::{
         cached_proposer_election::CachedProposerElection,
         leader_reputation::{
-            AptosDBBackend, LeaderReputation, ProposerAndVoterHeuristic, ReputationHeuristic,
+            extract_epoch_to_proposers, AptosDBBackend, LeaderReputation,
+            ProposerAndVoterHeuristic, ReputationHeuristic,
         },
         proposal_generator::ProposalGenerator,
         proposer_election::ProposerElection,
@@ -26,6 +25,7 @@ use crate::{
     },
     logging::{LogEvent, LogSchema},
     metrics_safety_rules::MetricsSafetyRules,
+    monitor,
     network::{IncomingBlockRetrievalRequest, NetworkReceivers, NetworkSender},
     network_interface::{ConsensusMsg, ConsensusNetworkSender},
     payload_manager::QuorumStoreClient,
@@ -68,9 +68,9 @@ use futures::{
 use itertools::Itertools;
 use network::protocols::network::{ApplicationNetworkSender, Event};
 use safety_rules::SafetyRulesManager;
-use std::collections::HashMap;
 use std::{
     cmp::Ordering,
+    collections::HashMap,
     mem::{discriminant, Discriminant},
     sync::Arc,
     time::Duration,
@@ -384,7 +384,7 @@ impl EpochManager {
         let ledger_info = proof
             .verify(self.epoch_state())
             .context("[EpochManager] Invalid EpochChangeProof")?;
-        debug!(
+        info!(
             LogSchema::new(LogEvent::NewEpoch).epoch(ledger_info.ledger_info().next_block_epoch()),
             "Received verified epoch change",
         );

--- a/consensus/src/experimental/buffer.rs
+++ b/consensus/src/experimental/buffer.rs
@@ -34,6 +34,10 @@ impl<T: Hashable> Buffer<T> {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
     pub fn head_cursor(&self) -> &Cursor {
         &self.head
     }

--- a/consensus/src/experimental/buffer_manager.rs
+++ b/consensus/src/experimental/buffer_manager.rs
@@ -170,13 +170,13 @@ impl BufferManager {
             callback,
         } = ordered_blocks;
 
-        let item = BufferItem::new_ordered(ordered_blocks, ordered_proof, callback);
-        self.buffer.push_back(item);
         info!(
             "Receive ordered block {}, the queue size is {}",
             ordered_proof.commit_info(),
-            self.buffer.len()
+            self.buffer.len() + 1,
         );
+        let item = BufferItem::new_ordered(ordered_blocks, ordered_proof, callback);
+        self.buffer.push_back(item);
     }
 
     /// Set the execution root to the first not executed item (Ordered) and send execution request

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -34,14 +34,7 @@ fn add_execution_phase_test_cases(
 ) {
     let genesis_qc = certificate_for_genesis();
     let (signers, _validators) = random_validator_verifier(1, None, false);
-    let block = Block::new_proposal(
-        Payload::new_empty(),
-        1,
-        1,
-        genesis_qc,
-        &signers[0],
-        Vec::new(),
-    );
+    let block = Block::new_proposal(Payload::empty(), 1, 1, genesis_qc, &signers[0], Vec::new());
 
     // happy path
     phase_tester.add_test_case(
@@ -69,8 +62,7 @@ fn add_execution_phase_test_cases(
         &LedgerInfo::mock_genesis(None),
         random_hash_value,
     );
-    let bad_block =
-        Block::new_proposal(Payload::new_empty(), 1, 1, bad_qc, &signers[0], Vec::new());
+    let bad_block = Block::new_proposal(Payload::empty(), 1, 1, bad_qc, &signers[0], Vec::new());
     phase_tester.add_test_case(
         ExecutionRequest {
             ordered_blocks: vec![ExecutedBlock::new(

--- a/consensus/src/experimental/tests/test_utils.rs
+++ b/consensus/src/experimental/tests/test_utils.rs
@@ -5,9 +5,8 @@ use crate::{metrics_safety_rules::MetricsSafetyRules, test_utils::MockStorage};
 use aptos_crypto::{hash::ACCUMULATOR_PLACEHOLDER_HASH, HashValue};
 use aptos_infallible::Mutex;
 use aptos_secure_storage::Storage;
-use aptos_types::ledger_info::generate_ledger_info_with_sig;
 use aptos_types::{
-    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    ledger_info::{generate_ledger_info_with_sig, LedgerInfo, LedgerInfoWithSignatures},
     validator_signer::ValidatorSigner,
     validator_verifier::random_validator_verifier,
     waypoint::Waypoint,
@@ -70,7 +69,7 @@ pub fn prepare_executed_blocks_with_ledger_info(
     assert!(num_blocks > 0);
 
     let p1 = if let Some(parent) = some_parent {
-        make_proposal_with_parent(Payload::new_empty(), init_round, &parent, None, signer)
+        make_proposal_with_parent(Payload::empty(), init_round, &parent, None, signer)
     } else {
         make_proposal_with_qc(init_round, init_qc.unwrap(), signer)
     };
@@ -81,7 +80,7 @@ pub fn prepare_executed_blocks_with_ledger_info(
         println!("Generating {}", i);
         let parent = proposals.last().unwrap();
         let proposal =
-            make_proposal_with_parent(Payload::new_empty(), init_round + i, parent, None, signer);
+            make_proposal_with_parent(Payload::empty(), init_round + i, parent, None, signer);
         proposals.push(proposal);
     }
 

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -124,10 +124,7 @@ impl ProposalGenerator {
         let (payload, timestamp) = if hqc.certified_block().has_reconfiguration() {
             // Reconfiguration rule - we propose empty blocks with parents' timestamp
             // after reconfiguration until it's committed
-            (
-                Payload::new_empty(),
-                hqc.certified_block().timestamp_usecs(),
-            )
+            (Payload::empty(), hqc.certified_block().timestamp_usecs())
         } else {
             // One needs to hold the blocks with the references to the payloads while get_block is
             // being executed: pending blocks vector keeps all the pending ancestors of the extended branch.

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -252,7 +252,7 @@ impl RoundState {
                 reason: new_round_reason,
                 timeout,
             };
-            debug!(round = new_round, "Starting new round: {}", new_round_event);
+            info!(round = new_round, "Starting new round: {}", new_round_event);
             return Some(new_round_event);
         }
         None

--- a/consensus/src/liveness/unequivocal_proposer_election_test.rs
+++ b/consensus/src/liveness/unequivocal_proposer_election_test.rs
@@ -40,7 +40,7 @@ fn test_is_valid_proposal() {
     let quorum_cert = certificate_for_genesis();
 
     let good_proposal = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         quorum_cert.clone(),
@@ -48,7 +48,7 @@ fn test_is_valid_proposal() {
         Vec::new(),
     );
     let bad_author_proposal = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         quorum_cert.clone(),
@@ -56,7 +56,7 @@ fn test_is_valid_proposal() {
         Vec::new(),
     );
     let bad_duplicate_proposal = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         2,
         quorum_cert.clone(),
@@ -64,7 +64,7 @@ fn test_is_valid_proposal() {
         Vec::new(),
     );
     let next_good_proposal = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         2,
         3,
         quorum_cert.clone(),
@@ -72,7 +72,7 @@ fn test_is_valid_proposal() {
         Vec::new(),
     );
     let next_bad_duplicate_proposal = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         2,
         4,
         quorum_cert,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -617,7 +617,7 @@ mod tests {
         let previous_qc = certificate_for_genesis();
         let proposal = ProposalMsg::new(
             Block::new_proposal(
-                Payload::new_empty(),
+                Payload::empty(),
                 1,
                 1,
                 previous_qc.clone(),

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -327,7 +327,7 @@ fn vote_on_successful_proposal() {
         node.next_proposal().await;
 
         let proposal = Block::new_proposal(
-            Payload::new_empty(),
+            Payload::empty(),
             1,
             1,
             genesis_qc.clone(),
@@ -359,7 +359,7 @@ fn no_vote_on_old_proposal() {
     let node = &mut nodes[0];
     let genesis_qc = certificate_for_genesis();
     let new_block = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         genesis_qc.clone(),
@@ -367,14 +367,8 @@ fn no_vote_on_old_proposal() {
         Vec::new(),
     );
     let new_block_id = new_block.id();
-    let old_block = Block::new_proposal(
-        Payload::new_empty(),
-        1,
-        2,
-        genesis_qc,
-        &node.signer,
-        Vec::new(),
-    );
+    let old_block =
+        Block::new_proposal(Payload::empty(), 1, 2, genesis_qc, &node.signer, Vec::new());
     timed_block_on(&mut runtime, async {
         // clear the message queue
         node.next_proposal().await;
@@ -407,7 +401,7 @@ fn no_vote_on_mismatch_round() {
         .unwrap();
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         genesis_qc.clone(),
@@ -415,7 +409,7 @@ fn no_vote_on_mismatch_round() {
         Vec::new(),
     );
     let block_skip_round = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         2,
         2,
         genesis_qc.clone(),
@@ -509,7 +503,7 @@ fn no_vote_on_invalid_proposer() {
     let mut node = nodes.pop().unwrap();
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         genesis_qc.clone(),
@@ -517,7 +511,7 @@ fn no_vote_on_invalid_proposer() {
         Vec::new(),
     );
     let block_incorrect_proposer = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         genesis_qc.clone(),
@@ -558,7 +552,7 @@ fn new_round_on_timeout_certificate() {
         .unwrap();
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         genesis_qc.clone(),
@@ -566,7 +560,7 @@ fn new_round_on_timeout_certificate() {
         Vec::new(),
     );
     let block_skip_round = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         2,
         2,
         genesis_qc.clone(),
@@ -622,7 +616,7 @@ fn reject_invalid_failed_authors() {
 
     let create_proposal = |round: Round, failed_authors: Vec<(Round, Author)>| {
         let block = Block::new_proposal(
-            Payload::new_empty(),
+            Payload::empty(),
             round,
             2,
             genesis_qc.clone(),
@@ -694,7 +688,7 @@ fn response_on_block_retrieval() {
 
     let genesis_qc = certificate_for_genesis();
     let block = Block::new_proposal(
-        Payload::new_empty(),
+        Payload::empty(),
         1,
         1,
         genesis_qc.clone(),
@@ -805,7 +799,7 @@ fn recover_on_restart() {
             genesis_qc.clone(),
             i,
             i,
-            Payload::new_empty(),
+            Payload::empty(),
             (std::cmp::max(1, i.saturating_sub(10))..i)
                 .map(|i| (i, inserter.signer().author()))
                 .collect(),

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -50,7 +50,7 @@ impl StateComputer for MockStateComputer {
     ) -> Result<StateComputeResult, Error> {
         self.block_cache.lock().insert(
             block.id(),
-            block.payload().unwrap_or(&Payload::new_empty()).clone(),
+            block.payload().unwrap_or(&Payload::empty()).clone(),
         );
         let result = StateComputeResult::new_dummy();
         Ok(result)

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -135,7 +135,7 @@ impl TreeInserter {
                 parent_qc,
                 parent.timestamp_usecs() + 1,
                 round,
-                Payload::new_empty(),
+                Payload::empty(),
                 vec![],
             ))
             .await


### PR DESCRIPTION
We only fallback to state sync when ordered root falls behind, and we'll hit the problem of ordering phase
can catch up but keep queueing more transactions in the buffer manager, this commit ensures that we also fallback to state sync.

Also update a few log levels to reduce noise as well as increase visibility

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2894)
<!-- Reviewable:end -->
