### PR TITLE
[Framework][API] Remove the deprecated gas_currency_code field

### DIFF
--- a/api/doc/v0/openapi.yaml
+++ b/api/doc/v0/openapi.yaml
@@ -1072,9 +1072,6 @@ components:
           $ref: '#/components/schemas/Uint64'
         gas_unit_price:
           $ref: '#/components/schemas/Uint64'
-        gas_currency_code:
-          type: string
-          example: "XDX"
         expiration_timestamp_secs:
           $ref: '#/components/schemas/TimestampSec'
         payload:

--- a/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_payload_data_type.json
+++ b/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_payload_data_type.json
@@ -1,4 +1,4 @@
 {
   "code": 400,
-  "message": "Request body deserialize error: invalid type: integer `1234`, expected internally tagged enum TransactionPayload at line 1 column 172"
+  "message": "Request body deserialize error: invalid type: integer `1234`, expected internally tagged enum TransactionPayload at line 1 column 146"
 }

--- a/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_payload_type.json
+++ b/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_payload_type.json
@@ -1,4 +1,4 @@
 {
   "code": 400,
-  "message": "Request body deserialize error: unknown variant `invalid`, expected one of `script_function_payload`, `script_payload`, `module_bundle_payload`, `write_set_payload` at line 1 column 299"
+  "message": "Request body deserialize error: unknown variant `invalid`, expected one of `script_function_payload`, `script_payload`, `module_bundle_payload`, `write_set_payload` at line 1 column 273"
 }

--- a/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_script_function_function_id.json
+++ b/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_script_function_function_id.json
@@ -1,4 +1,4 @@
 {
   "code": 400,
-  "message": "Request body deserialize error: invalid script function id \"invalid\" at line 1 column 294"
+  "message": "Request body deserialize error: invalid script function id \"invalid\" at line 1 column 268"
 }

--- a/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_type_argument_data_type.json
+++ b/api/goldens/v0/aptos_api__tests__invalid_post_request_test__test_invalid_type_argument_data_type.json
@@ -1,4 +1,4 @@
 {
   "code": 400,
-  "message": "Request body deserialize error: deserialize Move type failed, invalid type: boolean `true`, expected a string at line 1 column 319"
+  "message": "Request body deserialize error: deserialize Move type failed, invalid type: boolean `true`, expected a string at line 1 column 293"
 }

--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -419,7 +419,6 @@ impl TestContext {
             "sequence_number": account.sequence_number().to_string(),
             "gas_unit_price": "0",
             "max_gas_amount": "1000000",
-            "gas_currency_code": "XUS",
             "expiration_timestamp_secs": "16373698888888",
             "payload": payload,
         });

--- a/api/src/tests/v0/invalid_post_request_test.rs
+++ b/api/src/tests/v0/invalid_post_request_test.rs
@@ -128,7 +128,6 @@ fn signing_message_request() -> Value {
         "sequence_number": "0",
         "gas_unit_price": "0",
         "max_gas_amount": "1000000",
-        "gas_currency_code": "XUS",
         "expiration_timestamp_secs": "9991638487317",
         "payload": {
             "type": "script_function_payload",

--- a/api/src/tests/v1/invalid_post_request_test.rs
+++ b/api/src/tests/v1/invalid_post_request_test.rs
@@ -128,7 +128,6 @@ fn signing_message_request() -> Value {
         "sequence_number": "0",
         "gas_unit_price": "0",
         "max_gas_amount": "1000000",
-        "gas_currency_code": "XUS",
         "expiration_timestamp_secs": "9991638487317",
         "payload": {
             "type": "script_function_payload",

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -238,7 +238,6 @@ impl AptosVMImpl {
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
         let chain_specific_info = self.chain_info();
-        let gas_currency = vec![];
         let txn_sequence_number = txn_data.sequence_number();
         let txn_public_key = txn_data.authentication_key_preimage().to_vec();
         let txn_gas_price = txn_data.gas_unit_price().get();
@@ -285,7 +284,8 @@ impl AptosVMImpl {
             .execute_function_bypass_visibility(
                 &chain_specific_info.module_id(),
                 prologue_function_name,
-                gas_currency,
+                // TODO: Deprecate this once we remove gas currency on the Move side.
+                vec![],
                 serialize_values(&args),
                 &mut gas_meter,
             )
@@ -303,7 +303,7 @@ impl AptosVMImpl {
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
         let chain_specific_info = self.chain_info();
-        let gas_currency = vec![];
+
         let txn_sequence_number = txn_data.sequence_number();
         let txn_public_key = txn_data.authentication_key_preimage().to_vec();
         let txn_gas_price = txn_data.gas_unit_price().get();
@@ -315,7 +315,8 @@ impl AptosVMImpl {
             .execute_function_bypass_visibility(
                 &chain_specific_info.module_id(),
                 &chain_specific_info.module_prologue_name,
-                gas_currency,
+                // TODO: Deprecate this once we remove gas currency on the Move side.
+                vec![],
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),
                     MoveValue::U64(txn_sequence_number),
@@ -347,7 +348,6 @@ impl AptosVMImpl {
             ))
         });
 
-        let gas_currency = vec![];
         let chain_specific_info = self.chain_info();
         let txn_sequence_number = txn_data.sequence_number();
         let txn_gas_price = txn_data.gas_unit_price().get();
@@ -356,7 +356,8 @@ impl AptosVMImpl {
             .execute_function_bypass_visibility(
                 &chain_specific_info.module_id(),
                 &chain_specific_info.user_epilogue_name,
-                gas_currency,
+                // TODO: Deprecate this once we remove gas currency on the Move side.
+                vec![],
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),
                     MoveValue::U64(txn_sequence_number),
@@ -380,7 +381,6 @@ impl AptosVMImpl {
         txn_data: &TransactionMetadata,
         log_context: &AdapterLogSchema,
     ) -> Result<(), VMStatus> {
-        let gas_currency = vec![];
         let chain_specific_info = self.chain_info();
         let txn_sequence_number = txn_data.sequence_number();
         let txn_gas_price = txn_data.gas_unit_price().get();
@@ -389,7 +389,8 @@ impl AptosVMImpl {
             .execute_function_bypass_visibility(
                 &chain_specific_info.module_id(),
                 &chain_specific_info.user_epilogue_name,
-                gas_currency,
+                // TODO: Deprecate this once we remove gas currency on the Move side.
+                vec![],
                 serialize_values(&vec![
                     MoveValue::Signer(txn_data.sender),
                     MoveValue::U64(txn_sequence_number),

--- a/aptos-move/aptos-vm/src/errors.rs
+++ b/aptos-move/aptos-vm/src/errors.rs
@@ -26,7 +26,10 @@ pub const ESCRIPT_NOT_ALLOWED: u64 = 1008;
 pub const EMODULE_NOT_ALLOWED: u64 = 1009;
 pub const EINVALID_WRITESET_SENDER: u64 = 1010; // invalid sender (not aptos root) for write set
 pub const ESEQUENCE_NUMBER_TOO_BIG: u64 = 1011;
-pub const EBAD_TRANSACTION_FEE_CURRENCY: u64 = 1012;
+// This error code has been deprecated and just left here sp future error codes would not
+// accidentally reuse.
+#[allow(dead_code)]
+pub const RESERVED_UNUSED: u64 = 1012;
 pub const ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH: u64 = 1013;
 pub const ESEQ_NONCE_NONCE_INVALID: u64 = 1014;
 
@@ -87,10 +90,6 @@ pub fn convert_prologue_error(
                 (INVALID_ARGUMENT, EINVALID_WRITESET_SENDER) => StatusCode::REJECTED_WRITE_SET,
                 // Sequence number will overflow
                 (LIMIT_EXCEEDED, ESEQUENCE_NUMBER_TOO_BIG) => StatusCode::SEQUENCE_NUMBER_TOO_BIG,
-                // The gas currency is not registered as a TransactionFee currency
-                (INVALID_ARGUMENT, EBAD_TRANSACTION_FEE_CURRENCY) => {
-                    StatusCode::BAD_TRANSACTION_FEE_CURRENCY
-                }
                 (INVALID_ARGUMENT, ESECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH) => {
                     StatusCode::SECONDARY_KEYS_ADDRESSES_COUNT_MISMATCH
                 }

--- a/developer-docs-site/docs/concepts/basics-txns-states.md
+++ b/developer-docs-site/docs/concepts/basics-txns-states.md
@@ -22,9 +22,8 @@ A [signed transaction](/reference/glossary#transaction) on the blockchain contai
   - A Move module and function name or a move bytecode transaction script.
   - An optional list of inputs to the script. For a peer-to-peer transaction, these inputs contain the recipient's information and the amount transferred to them.
   - An optional list of Move bytecode modules to publish.
-- **Gas price** (in specified currency/gas units): This is the amount the sender is willing to pay per unit of [gas](/reference/glossary#gas) to execute the transaction. [Gas](basics-gas-txn-fee.md) is a way to pay for computation and storage. A gas unit is an abstract measurement of computation with no inherent real-world value.
+- **Gas price** (in specified gas units): This is the amount the sender is willing to pay per unit of [gas](/reference/glossary#gas) to execute the transaction. [Gas](basics-gas-txn-fee.md) is a way to pay for computation and storage. A gas unit is an abstract measurement of computation with no inherent real-world value.
 - **Maximum gas amount**: The [maximum gas amount](/reference/glossary#maximum-gas-amount) is the maximum gas units the transaction is allowed to consume.
-- **Gas currency code**: The currency code used to pay for gas.
 - **Sequence number**: This is an unsigned integer that must be equal to the sender's account [sequence number](/reference/glossary#sequence-number) at the time of execution.
 - **Expiration time**: A timestamp after which the transaction ceases to be valid (i.e., expires).
 

--- a/developer-docs-site/static/examples/python/first_transaction.py
+++ b/developer-docs-site/static/examples/python/first_transaction.py
@@ -77,7 +77,6 @@ class RestClient:
             "sequence_number": str(seq_num),
             "max_gas_amount": "2000",
             "gas_unit_price": "1",
-            "gas_currency_code": "XUS",
             "expiration_timestamp_secs": str(int(time.time()) + 600),
             "payload": payload,
         }

--- a/developer-docs-site/static/examples/rust/first_transaction/src/lib.rs
+++ b/developer-docs-site/static/examples/rust/first_transaction/src/lib.rs
@@ -146,7 +146,6 @@ impl RestClient {
             "sequence_number": seq_num.to_string(),
             "max_gas_amount": "1000",
             "gas_unit_price": "1",
-            "gas_currency_code": "XUS",
             "expiration_timestamp_secs": expiration_time_secs.to_string(),
             "payload": payload,
         })

--- a/documentation/specifications/move_adapter/README.md
+++ b/documentation/specifications/move_adapter/README.md
@@ -109,10 +109,6 @@ pub struct RawTransaction {
     /// Price to be paid per gas unit.
     gas_unit_price: u64,
 
-    /// The currency code, e.g., "XDX", used to pay for gas. The `max_gas_amount`
-    /// and `gas_unit_price` values refer to units of this currency.
-    gas_currency_code: String,
-
     /// Expiration timestamp for this transaction, represented
     /// as seconds from the Unix Epoch. If the current blockchain timestamp
     /// is greater than or equal to this time, then the transaction is
@@ -248,20 +244,6 @@ successful, this value is returned as the `governance_role` field of the
 `VMValidatorResult` so that the client can choose to prioritize governance
 transactions.
 
-* Check that the `gas_currency_code` in the `RawTransaction` is a name composed
-of uppercase ASCII alphanumeric characters where the first character is a letter. If
-not, validation will fail with an `INVALID_GAS_SPECIFIER` status code. Note
-that this check does not ensure that the name corresponds to a currency
-recognized by the Aptos Framework.
-
-* Normalize the `gas_unit_price` from the `RawTransaction` to the Aptos (XDX)
-currency. If the validation is successful, the normalized gas price is
-returned as the `score` field of the `VMValidatorResult` for use in
-prioritizing the transaction. The normalization is calculated using the
-`to_xdx_exchange_rate` field of the on-chain `CurrencyInfo` for the specified
-gas currency. This can fail with a status code of
-`CURRENCY_INFO_DOES_NOT_EXIST` if the exchange rate cannot be retrieved.
-
 * If the transaction payload is a `ScriptFunction`, check if the on-chain
 Aptos Version number is 2 or later. For version 1, validation will fail with
 a `FEATURE_UNDER_GATING` status code.
@@ -363,11 +345,8 @@ account. If not, validation fails with an `INVALID_AUTH_KEY` status code.
 
 * The transaction sender must be able to pay the maximum transaction fee. The
 maximum fee is the product of the transaction's `max_gas_amount` and
-`gas_unit_price` fields. If the maximum fee is non-zero, the coin specified
-by the transaction's `gas_currency_code` must have been registered as a valid
-gas currency (via the `TransactionFee` module), or else validation will fail
-with a `BAD_TRANSACTION_FEE_CURRENCY` status. If the sender's account balance
-for the gas currency is less than the maximum fee, validation fails with an
+`gas_unit_price` fields. If the sender's account balance
+for the Aptos coin is less than the maximum fee, validation fails with an
 `INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE` status code. For `WriteSet`
 transactions, the maximum fee is treated as zero, regardless of the gas
 parameters specified in the transaction.

--- a/ecosystem/indexer-server/doc/openapi.yaml
+++ b/ecosystem/indexer-server/doc/openapi.yaml
@@ -726,7 +726,7 @@ components:
         Note:
           1. Empty chars should be ignored when comparing 2 struct tag ids.
           2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
-      example: "0x1::XUS::XUS"
+      example: "0x1::aptos_coin::AptosCoin"
     MoveTypeId:
       title: Move Type ID
       type: string
@@ -793,7 +793,7 @@ components:
         Note:
           1. Empty chars should be ignored when comparing 2 struct tag ids.
           2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
-      example: "0x1::AptosAccount::Balance<0x1::XUS::XUS>"
+      example: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>"
     MoveStructTagId:
       title: Move Struct Tag ID
       type: string
@@ -816,7 +816,7 @@ components:
           2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
 
         See [doc](https://diem.github.io/move/structs-and-resources.html) for more details.
-      example: "0x1::AptosAccount::Balance<0x1::XUS::XUS>"
+      example: "0x1::AptosAccount::Balance<0x1::aptos_coin::AptosCoin>"
     MoveModule:
       title: Move Module
       type: object
@@ -1003,7 +1003,6 @@ components:
         - sequence_number
         - max_gas_amount
         - gas_unit_price
-        - gas_currency_code
         - expiration_timestamp_secs
         - payload
       properties:
@@ -1015,9 +1014,6 @@ components:
           $ref: '#/components/schemas/Uint64'
         gas_unit_price:
           $ref: '#/components/schemas/Uint64'
-        gas_currency_code:
-          type: string
-          example: "XDX"
         expiration_timestamp_secs:
           $ref: '#/components/schemas/TimestampSec'
         payload:

--- a/ecosystem/indexer-server/typescript/src/openapi-schema.ts
+++ b/ecosystem/indexer-server/typescript/src/openapi-schema.ts
@@ -447,8 +447,6 @@ export interface components {
       sequence_number: components["schemas"]["Uint64"];
       max_gas_amount: components["schemas"]["Uint64"];
       gas_unit_price: components["schemas"]["Uint64"];
-      /** @example XDX */
-      gas_currency_code: string;
       expiration_timestamp_secs: components["schemas"]["TimestampSec"];
       payload: components["schemas"]["TransactionPayload"];
     };

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -190,7 +190,6 @@ export class AptosClient {
    *     sequence_number: account.sequence_number,
    *     max_gas_amount: "1000",
    *     gas_unit_price: "1",
-   *     gas_currency_code: "XUS",
    *     // Unix timestamp, in seconds + 10 seconds
    *     expiration_timestamp_secs: (Math.floor(Date.now() / 1000) + 10).toString(),
    *   }


### PR DESCRIPTION
### Description
This is an artifact from Diem time and no longer relevant - Aptos only has one gas currency (APT).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2902)
<!-- Reviewable:end -->
