### PR TITLE
[aptos] expose prover error

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -81,8 +81,8 @@ pub enum CliError {
     MoveCompilationError(String),
     #[error("Move unit tests failed")]
     MoveTestError,
-    #[error("Move Prover failed")]
-    MoveProverError,
+    #[error("Move Prover failed: {0}")]
+    MoveProverError(String),
     #[error("Unable to parse '{0}': error: {1}")]
     UnableToParse(&'static str, String),
     #[error("Unable to read file '{0}', error: {1}")]
@@ -103,7 +103,7 @@ impl CliError {
             CliError::IO(_, _) => "IO",
             CliError::MoveCompilationError(_) => "MoveCompilationError",
             CliError::MoveTestError => "MoveTestError",
-            CliError::MoveProverError => "MoveProverError",
+            CliError::MoveProverError(_) => "MoveProverError",
             CliError::UnableToParse(_, _) => "UnableToParse",
             CliError::UnableToReadFile(_, _) => "UnableToReadFile",
             CliError::UnexpectedError(_) => "UnexpectedError",

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -304,7 +304,7 @@ impl CliCommand<&'static str> for ProvePackage {
 
         match result {
             Ok(_) => Ok("Success"),
-            Err(_) => Err(CliError::MoveProverError),
+            Err(err) => Err(CliError::MoveProverError(err.to_string())),
         }
     }
 }


### PR DESCRIPTION
FAILURE proving 1 modules from package `debug-move-example` in 0.369s
{
  "Error": "Move Prover failed: No boogie executable set.  Please set BOOGIE_EXE"
}

address #2898

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2904)
<!-- Reviewable:end -->
