### PR TITLE
[Networking HC] Reseting HC failure count on ingress HC request

### DIFF
--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -311,6 +311,20 @@ impl HealthChecker {
             peer_id.short_str(),
             ping.0,
         );
+        // Record Ingress HC here and reset failures.
+        let _ = self.network_interface.app_data().write(peer_id, |entry| {
+            match entry {
+                Entry::Vacant(..) => {
+                    // Don't do anything if there isn't an entry
+                }
+                Entry::Occupied(inner) => {
+                    let data = inner.get_mut();
+                    data.failures = 0;
+                }
+            };
+            Ok(())
+        });
+
         let _ = res_tx.send(Ok(message.into()));
     }
 


### PR DESCRIPTION
### Description

Resetting HC failure count on ingress HC request

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
1. *For testing only*, don't reply to incoming HC Pings.
2. Check logs to make sure there are no discinnects

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2910)
<!-- Reviewable:end -->
