### PR TITLE
[aptos-cli] Improve documentation consistency

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -19,15 +19,15 @@ pub const DEFAULT_FUNDED_COINS: u64 = 10_000;
 pub struct CreateAccount {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
-    /// Address to create account for
+    /// Address of the new account
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
-    /// Flag for using faucet to create the account
+    /// If set, the faucet will be used to create the new account
     #[clap(long)]
     pub(crate) use_faucet: bool,
     #[clap(flatten)]
     pub(crate) faucet_options: FaucetOptions,
-    /// Initial coins to fund when using the faucet
+    /// Number of initial coins to fund when using the faucet
     #[clap(long, default_value_t = DEFAULT_FUNDED_COINS)]
     pub(crate) initial_coins: u64,
 }

--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -13,8 +13,11 @@ use clap::Parser;
 use serde::Serialize;
 use std::str::FromStr;
 
-/// Command to create a resource account
+/// Command to create a resource account on-chain
 ///
+/// To create an account there are two options:
+/// 1. Submit a create account transaction with an account that has coins
+/// 2. Use a faucet to create the account
 #[derive(Debug, Parser)]
 pub struct CreateResourceAccount {
     #[clap(flatten)]

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 pub struct FundAccount {
     #[clap(flatten)]
     pub(crate) profile_options: ProfileOptions,
-    /// Address to create account for
+    /// Address to fund
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
     #[clap(flatten)]
@@ -28,7 +28,6 @@ pub struct FundAccount {
     /// Coins to fund when using the faucet
     #[clap(long, default_value_t = DEFAULT_FUNDED_COINS)]
     pub(crate) num_coins: u64,
-    /// if passed, rest endpoint to wait for transaction to complete
     #[clap(flatten)]
     pub(crate) rest_options: RestOptions,
 }

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -44,7 +44,7 @@ impl FromStr for ListQuery {
     }
 }
 
-/// Command to list items owned by an address
+/// Command to list resources, modules, or other items owned by an address
 ///
 #[derive(Debug, Parser)]
 pub struct ListAccount {
@@ -54,12 +54,11 @@ pub struct ListAccount {
     #[clap(flatten)]
     pub(crate) profile_options: ProfileOptions,
 
-    /// Address of account you want to list resources/modules for
+    /// Address of the account you want to list resources/modules for
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: Option<AccountAddress>,
 
-    /// Type of items to list: resources, modules. (Defaults to 'resources').
-    /// TODO: add options like --tokens --nfts etc
+    /// Type of items to list: [balance, resources, modules]
     #[clap(long, default_value_t = ListQuery::Resources)]
     pub(crate) query: ListQuery,
 }

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -10,8 +10,10 @@ pub mod fund;
 pub mod list;
 pub mod transfer;
 
-/// CLI tool for interacting with accounts
+/// Tool for interacting with accounts
 ///
+/// This tool is used to create accounts, get information about the
+/// account's resources, and transfer resources between accounts.
 #[derive(Debug, Subcommand)]
 pub enum AccountTool {
     Create(create::CreateAccount),

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -20,8 +20,10 @@ use std::fmt::Formatter;
 use std::path::PathBuf;
 use std::str::FromStr;
 
-/// Tool for configuration of the CLI tool
+/// Tool for interacting with configuration of the Aptos CLI tool
 ///
+/// This tool handles the global configuration of the CLI tool for
+/// default configuration, and user specific settings.
 #[derive(Parser)]
 pub enum ConfigTool {
     Init(crate::common::init::InitTool),

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -19,13 +19,16 @@ use std::{fmt::Debug, io::Read, path::PathBuf, str::FromStr};
 
 pub const LAYOUT_NAME: &str = "layout";
 
-/// Setup a shared Github repository for Genesis
+/// Setup a shared Git repository for Genesis
 ///
+/// This will setup a folder or an online Github repository to be used
+/// for Genesis.  If it's the local, it will create the folders but not
+/// set up a Git repository.
 #[derive(Parser)]
 pub struct SetupGit {
     #[clap(flatten)]
     pub(crate) git_options: GitOptions,
-    /// Path to `Layout` which defines where all the files are
+    /// Path to the `Layout` file which defines where all the files are
     #[clap(long, parse(from_os_str))]
     pub(crate) layout_file: PathBuf,
 }

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -30,7 +30,7 @@ pub struct GenerateKeys {
     pub(crate) prompt_options: PromptOptions,
     #[clap(flatten)]
     pub rng_args: RngArgs,
-    /// Output path for the three keys
+    /// Output directory for the key files
     #[clap(long, parse(from_os_str))]
     pub(crate) output_dir: Option<PathBuf>,
 }
@@ -73,21 +73,21 @@ impl CliCommand<Vec<PathBuf>> for GenerateKeys {
     }
 }
 
-/// Set ValidatorConfiguration for a single validator in the git repository
+/// Set validator configuration for a single validator in the git repository
 #[derive(Parser)]
 pub struct SetValidatorConfiguration {
-    /// Username
+    /// Name of validator
     #[clap(long)]
     pub(crate) username: String,
     #[clap(flatten)]
     pub(crate) git_options: GitOptions,
-    /// Path to folder with account.key, consensus.key, and network.key
+    /// Path to directory used in GenerateKeys
     #[clap(long, parse(from_os_str))]
     pub(crate) keys_dir: Option<PathBuf>,
-    /// Host and port pair for the validator e.g. 127.0.0.1:6180
+    /// Host and port pair for the validator e.g. 127.0.0.1:6180 or aptoslabs.com:6180
     #[clap(long)]
     pub(crate) validator_host: HostAndPort,
-    /// Host and port pair for the fullnode e.g. 127.0.0.1:6180
+    /// Host and port pair for the fullnode e.g. 127.0.0.1:6180 or aptoslabs.com:6180
     #[clap(long)]
     pub(crate) full_node_host: Option<HostAndPort>,
     /// Stake amount for stake distribution

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -60,6 +60,7 @@ pub struct GenerateGenesis {
     prompt_options: PromptOptions,
     #[clap(flatten)]
     git_options: GitOptions,
+    /// Output directory for Genesis file and waypoint
     #[clap(long, parse(from_os_str))]
     output_dir: Option<PathBuf>,
 }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -30,8 +30,10 @@ use std::{path::PathBuf, str::FromStr};
 const WAYPOINT_FILE: &str = "waypoint.txt";
 const GENESIS_FILE: &str = "genesis.blob";
 
-/// Tool for setting up and building the Genesis transaction
+/// Tool for setting up an Aptos chain Genesis transaction
 ///
+/// This tool sets up a space for multiple initial "validator"
+/// accounts to build a genesis transaction for a new chain.
 #[derive(Parser)]
 pub enum GenesisTool {
     GenerateGenesis(GenerateGenesis),

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -18,6 +18,9 @@ use std::fmt::Formatter;
 
 /// Tool for on-chain governance
 ///
+/// This tool allows voters that have stake to vote the ability to
+/// propose changes to the chain, as well as vote and execute these
+/// proposals.
 #[derive(Parser)]
 pub enum GovernanceTool {
     Propose(SubmitProposal),

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -20,8 +20,7 @@ use async_trait::async_trait;
 use clap::Parser;
 use std::collections::BTreeMap;
 
-/// CLI tool for interacting with the Aptos blockchain and nodes
-///
+/// Command Line Interface (CLI) for developing and interacting with the Aptos blockchain
 #[derive(Parser)]
 #[clap(name = "aptos", author, version, propagate_version = true)]
 pub enum Tool {
@@ -61,7 +60,7 @@ impl Tool {
     }
 }
 
-/// Show information about the build of the CLI
+/// Show build information about the CLI
 ///
 /// This is useful for debugging as well as determining what versions are compatible with the CLI
 #[derive(Parser)]

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -60,8 +60,11 @@ use std::{
 use tokio::task;
 use transactional_tests_runner::TransactionalTestOpts;
 
-/// CLI tool for performing Move tasks
+/// Tool for Move related operations
 ///
+/// This tool lets you compile, test, and publish Move code, in addition
+/// to run any other tools that help run, verify, or provide information
+/// about this code.
 #[derive(Subcommand)]
 pub enum MoveTool {
     Compile(CompilePackage),

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -38,8 +38,10 @@ use std::sync::Arc;
 use std::{path::PathBuf, thread, time::Duration};
 use tokio::time::Instant;
 
-/// Tool for manipulating nodes
+/// Tool for operations related to nodes
 ///
+/// This tool allows you to run a local test node for testing,
+/// identify issues with nodes, and show related information.
 #[derive(Parser)]
 pub enum NodeTool {
     AddStake(AddStake),

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -102,7 +102,7 @@ impl CliCommand<HashMap<AccountAddress, Peer>> for ExtractPeer {
 /// key encoded with the `encoding`.
 #[derive(Debug, Parser)]
 pub struct GenerateKey {
-    /// Key type: `x25519` or `ed25519`
+    /// Key type to generate. Must be one of [x25519, ed25519]
     #[clap(long, default_value_t = KeyType::Ed25519)]
     key_type: KeyType,
     #[clap(flatten)]

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -23,7 +23,10 @@ use std::{
 
 pub const PUBLIC_KEY_EXTENSION: &str = "pub";
 
-/// CLI tool for generating, inspecting, and interacting with keys.
+/// Tool for generating, inspecting, and interacting with keys
+///
+/// This tool allows users to generate and extract related information
+/// with all key types used on the Aptos blockchain.
 #[derive(Debug, Subcommand)]
 pub enum KeyTool {
     Generate(GenerateKey),


### PR DESCRIPTION
### Description
CLI information is now much more consistent

### Test Plan
Manual testing, it's all docs

Example:
```
 ./target/debug/aptos --help
aptos 0.2.4
Aptos Labs <opensource@aptoslabs.com>
Command Line Interface (CLI) for developing and interacting with the Aptos blockchain

USAGE:
    aptos <SUBCOMMAND>

OPTIONS:
    -h, --help       Print help information
    -V, --version    Print version information

SUBCOMMANDS:
    account       Tool for interacting with accounts
    config        Tool for interacting with configuration of the Aptos CLI tool
    genesis       Tool for setting up an Aptos chain Genesis transaction
    governance    Tool for on-chain governance
    help          Print this message or the help of the given subcommand(s)
    info          Show build information about the CLI
    init          Tool to initialize current directory for the aptos tool
    key           Tool for generating, inspecting, and interacting with keys
    move          Tool for Move related operations
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2911)
<!-- Reviewable:end -->
