### PR TITLE
Fix "moudle" typo

### DIFF
--- a/developer-docs-site/static/examples/typescript/hello_blockchain.ts
+++ b/developer-docs-site/static/examples/typescript/hello_blockchain.ts
@@ -17,7 +17,7 @@ const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
 
 /** Publish a new module to the blockchain within the specified account */
 export async function publishModule(accountFrom: AptosAccount, moduleHex: string): Promise<string> {
-  const moudleBundlePayload = new TxnBuilderTypes.TransactionPayloadModuleBundle(
+  const moduleBundlePayload = new TxnBuilderTypes.TransactionPayloadModuleBundle(
     new TxnBuilderTypes.ModuleBundle([new TxnBuilderTypes.Module(new HexString(moduleHex).toUint8Array())]),
   );
 
@@ -29,7 +29,7 @@ export async function publishModule(accountFrom: AptosAccount, moduleHex: string
   const rawTxn = new TxnBuilderTypes.RawTransaction(
     TxnBuilderTypes.AccountAddress.fromHex(accountFrom.address()),
     BigInt(sequenceNumber),
-    moudleBundlePayload,
+    moduleBundlePayload,
     1000n,
     1n,
     BigInt(Math.floor(Date.now() / 1000) + 10),


### PR DESCRIPTION
### Description
Word `module` was incorrectly written as `moudle`. This PR fixes it :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2927)
<!-- Reviewable:end -->
