### PR TITLE
[framework] Adjust coin module types

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -215,7 +215,7 @@ module aptos_framework::account {
             txn_sequence_number == sender_account.sequence_number,
             error::invalid_argument(PROLOGUE_ESEQUENCE_NUMBER_TOO_NEW)
         );
-        let max_transaction_fee = txn_gas_price * txn_max_gas_units;
+        let max_transaction_fee = (txn_gas_price as u128) * (txn_max_gas_units as u128);
         assert!(
             coin::is_account_registered<AptosCoin>(transaction_sender),
             error::invalid_argument(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
@@ -317,11 +317,8 @@ module aptos_framework::account {
         assert!(txn_max_gas_units >= gas_units_remaining, error::invalid_argument(EGAS));
         let gas_used = txn_max_gas_units - gas_units_remaining;
 
-        assert!(
-            (txn_gas_price as u128) * (gas_used as u128) <= MAX_U64,
-            error::out_of_range(EGAS)
-        );
-        let transaction_fee_amount = txn_gas_price * gas_used;
+        let transaction_fee_amount = (txn_gas_price as u128) * (gas_used as u128);
+        assert!(transaction_fee_amount <= MAX_U64, error::out_of_range(EGAS));
         let addr = signer::address_of(&account);
         // it's important to maintain the error code consistent with vm
         // to do failed transaction cleanup.
@@ -375,7 +372,7 @@ module aptos_framework::account {
         (signer, signer_cap)
     }
 
-    public entry fun transfer(source: &signer, to: address, amount: u64) acquires Account {
+    public entry fun transfer(source: &signer, to: address, amount: u128) acquires Account {
         if(!exists<Account>(to)) {
             create_account(to)
         };

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -78,7 +78,7 @@ module aptos_framework::aptos_coin {
     public entry fun mint(
         account: &signer,
         dst_addr: address,
-        amount: u64,
+        amount: u128,
     ) acquires Capabilities {
         let account_addr = signer::address_of(account);
 

--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -47,7 +47,7 @@ module aptos_framework::aptos_governance {
     /// by this AptosGovernance module.
     struct GovernanceConfig has key {
         min_voting_threshold: u128,
-        required_proposer_stake: u64,
+        required_proposer_stake: u128,
         voting_duration_secs: u64,
     }
 
@@ -83,14 +83,14 @@ module aptos_framework::aptos_governance {
         proposal_id: u64,
         voter: address,
         stake_pool: address,
-        num_votes: u64,
+        num_votes: u128,
         should_pass: bool,
     }
 
     /// Event emitted when the governance configs are updated.
     struct UpdateConfigEvent has drop, store {
         min_voting_threshold: u128,
-        required_proposer_stake: u64,
+        required_proposer_stake: u128,
         voting_duration_secs: u64,
     }
 
@@ -117,7 +117,7 @@ module aptos_framework::aptos_governance {
     fun initialize(
         aptos_framework: &signer,
         min_voting_threshold: u128,
-        required_proposer_stake: u64,
+        required_proposer_stake: u128,
         voting_duration_secs: u64,
     ) {
         system_addresses::assert_aptos_framework(aptos_framework);
@@ -143,7 +143,7 @@ module aptos_framework::aptos_governance {
     public fun update_governance_config(
         _proposal: GovernanceProposal,
         min_voting_threshold: u128,
-        required_proposer_stake: u64,
+        required_proposer_stake: u128,
         voting_duration_secs: u64,
     ) acquires GovernanceConfig, GovernanceEvents {
         let governance_config = borrow_global_mut<GovernanceConfig>(@aptos_framework);

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -18,11 +18,11 @@ module aptos_framework::staking_config {
         // A validator needs to stake at least this amount to be able to join the validator set.
         // If after joining the validator set and at the start of any epoch, a validator's stake drops below this amount
         // they will be removed from the set.
-        minimum_stake: u64,
+        minimum_stake: u128,
         // A validator can only stake at most this amount. Any larger stake will be rejected.
         // If after joining the validator set and at the start of any epoch, a validator's stake exceeds this amount,
         // their voting power and rewards would only be issued for the max stake amount.
-        maximum_stake: u64,
+        maximum_stake: u128,
         recurring_lockup_duration_secs: u64,
         // Whether validators are allow to join/leave post genesis.
         allow_validator_set_change: bool,
@@ -35,8 +35,8 @@ module aptos_framework::staking_config {
     /// Only called during genesis.
     public(friend) fun initialize(
         aptos_framework: &signer,
-        minimum_stake: u64,
-        maximum_stake: u64,
+        minimum_stake: u128,
+        maximum_stake: u128,
         recurring_lockup_duration_secs: u64,
         allow_validator_set_change: bool,
         rewards_rate: u64,
@@ -72,7 +72,7 @@ module aptos_framework::staking_config {
     }
 
     /// Return the required min/max stake.
-    public fun get_required_stake(config: &StakingConfig): (u64, u64) {
+    public fun get_required_stake(config: &StakingConfig): (u128, u128) {
         (config.minimum_stake, config.maximum_stake)
     }
 
@@ -91,8 +91,8 @@ module aptos_framework::staking_config {
     /// Can only be called as part of the Aptos governance proposal process established by the AptosGovernance module.
     public fun update_required_stake(
         aptos_framework: &signer,
-        minimum_stake: u64,
-        maximum_stake: u64,
+        minimum_stake: u128,
+        maximum_stake: u128,
     ) acquires StakingConfig {
         system_addresses::assert_aptos_framework(aptos_framework);
         validate_required_stake(minimum_stake, maximum_stake);
@@ -133,7 +133,7 @@ module aptos_framework::staking_config {
         staking_config.rewards_rate_denominator = new_rewards_rate_denominator;
     }
 
-    fun validate_required_stake(minimum_stake: u64, maximum_stake: u64) {
+    fun validate_required_stake(minimum_stake: u128, maximum_stake: u128) {
         assert!(minimum_stake <= maximum_stake && maximum_stake > 0, error::invalid_argument(EINVALID_STAKE_RANGE));
     }
 
@@ -197,8 +197,8 @@ module aptos_framework::staking_config {
 
     public fun initialize_for_test(
         aptos_framework: &signer,
-        minimum_stake: u64,
-        maximum_stake: u64,
+        minimum_stake: u128,
+        maximum_stake: u128,
         recurring_lockup_duration_secs: u64,
         allow_validator_set_change: bool,
         rewards_rate: u64,

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -27,8 +27,8 @@ module aptos_framework::genesis {
         initial_version: u64,
         consensus_config: vector<u8>,
         epoch_interval: u64,
-        minimum_stake: u64,
-        maximum_stake: u64,
+        minimum_stake: u128,
+        maximum_stake: u128,
         recurring_lockup_duration_secs: u64,
         allow_validator_set_change: bool,
         rewards_rate: u64,
@@ -117,7 +117,7 @@ module aptos_framework::genesis {
         proof_of_possession: vector<vector<u8>>,
         validator_network_addresses: vector<vector<u8>>,
         full_node_network_addresses: vector<vector<u8>>,
-        staking_distribution: vector<u64>,
+        staking_distribution: vector<u128>,
     ) {
         let num_owners = vector::length(&owners);
         let num_validator_network_addresses = vector::length(&validator_network_addresses);

--- a/aptos-move/framework/aptos-framework/sources/managed_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/managed_coin.move
@@ -35,7 +35,7 @@ module aptos_framework::managed_coin {
     /// Withdraw an `amount` of coin `CoinType` from `account` and burn it.
     public entry fun burn<CoinType>(
         account: &signer,
-        amount: u64,
+        amount: u128,
     ) acquires Capabilities {
         let account_addr = signer::address_of(account);
 
@@ -56,7 +56,7 @@ module aptos_framework::managed_coin {
         account: &signer,
         name: vector<u8>,
         symbol: vector<u8>,
-        decimals: u64,
+        decimals: u8,
         monitor_supply: bool,
     ) {
         let (burn_cap, freeze_cap, mint_cap) = coin::initialize<CoinType>(
@@ -78,7 +78,7 @@ module aptos_framework::managed_coin {
     public entry fun mint<CoinType>(
         account: &signer,
         dst_addr: address,
-        amount: u64,
+        amount: u128,
     ) acquires Capabilities {
         let account_addr = signer::address_of(account);
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -11,7 +11,7 @@ module aptos_framework::transaction_fee {
     }
 
     /// Burn transaction fees in epilogue.
-    public(friend) fun burn_fee(account: address, fee: u64) acquires AptosCoinCapabilities {
+    public(friend) fun burn_fee(account: address, fee: u128) acquires AptosCoinCapabilities {
         coin::burn_from<AptosCoin>(
             account,
             fee,

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -111,7 +111,7 @@ module aptos_framework::voting {
 
     struct VoteEvent has drop, store {
         proposal_id: u64,
-        num_votes: u64,
+        num_votes: u128,
     }
 
     struct ResolveProposal has drop, store {
@@ -209,7 +209,7 @@ module aptos_framework::voting {
         _proof: &ProposalType,
         voting_forum_address: address,
         proposal_id: u64,
-        num_votes: u64,
+        num_votes: u128,
         should_pass: bool,
     ) acquires VotingForum {
         let voting_forum = borrow_global_mut<VotingForum<ProposalType>>(voting_forum_address);


### PR DESCRIPTION
### Description
Changes: 
1. Make decimals a u8. There are 20 digits in u64, and 39 in a u128: u64 is a bit much
2. The maximum supply is a u128, but a coin can only be a u64. This means there are situations where you can not get 
additional existing coin into your account as it would overflow. I have changed all types to u128 to allow for maximum 
coinage, and to prevent said situation from happening

### Test Plan
Existing tests
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2934)
<!-- Reviewable:end -->
