### PR TITLE
[framework] Adjust coin module decimal type

### DIFF
--- a/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v0/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -2,7 +2,7 @@
   {
     "type": "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
     "data": {
-      "decimals": "8",
+      "decimals": 8,
       "name": "Aptos Coin",
       "supply": {
         "vec": []

--- a/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
+++ b/api/goldens/v1/aptos_api__tests__accounts_test__test_get_account_resources_returns_empty_array_for_account_has_no_resources.json
@@ -2,7 +2,7 @@
   {
     "type": "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
     "data": {
-      "decimals": "8",
+      "decimals": 8,
       "name": "Aptos Coin",
       "supply": {
         "vec": []

--- a/api/goldens/v1/aptos_api__tests__blocks_test__test_get_genesis_block_by_version.json
+++ b/api/goldens/v1/aptos_api__tests__blocks_test__test_get_genesis_block_by_version.json
@@ -186,7 +186,7 @@
           "data": {
             "type": "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
             "data": {
-              "decimals": "8",
+              "decimals": 8,
               "name": "Aptos Coin",
               "supply": {
                 "vec": []
@@ -11042,7 +11042,7 @@
               "data": {
                 "type": "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
                 "data": {
-                  "decimals": "8",
+                  "decimals": 8,
                   "name": "Aptos Coin",
                   "supply": {
                     "vec": []

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -73,7 +73,7 @@ module aptos_framework::coin {
         /// Number of decimals used to get its user representation.
         /// For example, if `decimals` equals `2`, a balance of `505` coins should
         /// be displayed to a user as `5.05` (`505 / 10 ** 2`).
-        decimals: u64,
+        decimals: u8,
         /// Amount of this coin type in existence.
         supply: Option<u128>,
     }
@@ -139,7 +139,7 @@ module aptos_framework::coin {
     /// Returns the number of decimals used to get its user representation.
     /// For example, if `decimals` equals `2`, a balance of `505` coins should
     /// be displayed to a user as `5.05` (`505 / 10 ** 2`).
-    public fun decimals<CoinType>(): u64 acquires CoinInfo {
+    public fun decimals<CoinType>(): u8 acquires CoinInfo {
         let type_info = type_info::type_of<CoinType>();
         let coin_address = type_info::account_address(&type_info);
         borrow_global<CoinInfo<CoinType>>(coin_address).decimals
@@ -249,7 +249,7 @@ module aptos_framework::coin {
         account: &signer,
         name: string::String,
         symbol: string::String,
-        decimals: u64,
+        decimals: u8,
         monitor_supply: bool,
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
         let account_addr = signer::address_of(account);

--- a/aptos-move/framework/aptos-framework/sources/managed_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/managed_coin.move
@@ -56,7 +56,7 @@ module aptos_framework::managed_coin {
         account: &signer,
         name: vector<u8>,
         symbol: vector<u8>,
-        decimals: u64,
+        decimals: u8,
         monitor_supply: bool,
     ) {
         let (burn_cap, freeze_cap, mint_cap) = coin::initialize<CoinType>(


### PR DESCRIPTION
### Description
Make decimals a u8. There are 20 digits in u64, and 39 in a u128: u64 is a bit much

### Test Plan
Existing tests
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2935)
<!-- Reviewable:end -->
