### PR TITLE
[aptos-cli] Cleanup genesis layout

### DIFF
--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -26,7 +26,7 @@ use vm_genesis::Validator;
 pub struct Layout {
     /// Root key for the blockchain
     /// TODO: In the future, we won't need a root key
-    pub root_key: Ed25519PublicKey,
+    pub root_key: Option<Ed25519PublicKey>,
     /// List of usernames or identifiers
     pub users: Vec<String>,
     /// ChainId for the target network
@@ -67,6 +67,27 @@ impl Layout {
         })?;
 
         Ok(serde_yaml::from_str(&contents)?)
+    }
+}
+
+impl Default for Layout {
+    fn default() -> Self {
+        Layout {
+            root_key: None,
+            users: vec![],
+            chain_id: ChainId::test(),
+            allow_new_validators: false,
+            epoch_duration_secs: 7_200,
+            is_test: true,
+            min_stake: 100_000_000_000_000,
+            min_voting_threshold: 100_000_000_000_000,
+            max_stake: 100_000_000_000_000_000,
+            recurring_lockup_duration_secs: 86_400,
+            required_proposer_stake: 100_000_000_000_000,
+            rewards_apy_percentage: 10,
+            voting_duration_secs: 43_200,
+            voting_power_increase_limit: 20,
+        }
     }
 }
 

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -132,8 +132,9 @@ impl CliCommand<()> for SetValidatorConfiguration {
             stake_amount: self.stake_amount,
         };
 
+        let file = PathBuf::from(format!("{}.yaml", self.username));
         self.git_options
             .get_client()?
-            .put(&self.username, &credentials)
+            .put(file.as_path(), &credentials)
     }
 }


### PR DESCRIPTION
### Description
1. Add path support for git client, so we can have folders with multiple files in them easily
2. Add a `generate-layout-template` command so that users stop being confused about what fields they need to fill out with a template of the fields.

The only question is if I add these defaults will people remember to change them.

### Test Plan
```
$ aptos genesis generate-layout-template
"layout.yaml" already exists, are you sure you want to overwrite it? [yes/no] >
yes
{
  "Result": "Success"
}
$ cat layout.yaml 
---
root_key: ~
users: []
chain_id: 4
allow_new_validators: false
epoch_duration_secs: 86400
is_test: true
min_stake: 0
min_voting_threshold: 0
max_stake: 18446744073709551615
recurring_lockup_duration_secs: 86400
required_proposer_stake: 0
rewards_apy_percentage: 1
voting_duration_secs: 1
voting_power_increase_limit: 50
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2940)
<!-- Reviewable:end -->
