### PR TITLE
[deps] Remove diesel patch warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,4 +179,4 @@ debug = true
 lz4 = { git = 'https://github.com/aptos-labs/lz4-rs' }
 rocksdb = { git = 'https://github.com/aptos-labs/rust-rocksdb' }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
-diesel = { git = "https://github.com/aptos-labs/diesel", branch = "1.4.x", features = ["chrono", "postgres", "r2d2", "numeric", "serde_json"] }
+diesel = { git = "https://github.com/aptos-labs/diesel", branch = "1.4.x" }


### PR DESCRIPTION
### Description
Remove warning because features can't be in the patches

### Test Plan
Before
```
cargo run -p aptos
warning: patch for `diesel` uses the features mechanism. default-features and features will not take effect because the patch dependency does not support this mechanism
Compiling aptos-types v0.0.3 (/opt/git/aptos-core/types)
```
After
```
cargo run -p aptos
Compiling aptos-types v0.0.3 (/opt/git/aptos-core/types)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2947)
<!-- Reviewable:end -->
