### PR TITLE
[aptos-rest-client/smoke-test] Fix aptos rest client to use correct version & add rosetta test

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -102,8 +102,8 @@ impl Client {
         .await
     }
 
-    pub async fn get_block_info(&self, version: u64) -> Result<Response<BlockInfo>> {
-        self.get(self.build_path(&format!("blocks/{}", version))?)
+    pub async fn get_block_info(&self, version: u64) -> Result<Response<Block>> {
+        self.get(self.build_path(&format!("blocks/by_version/{}", version))?)
             .await
     }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -383,8 +383,6 @@ async fn test_block() {
     assert!(newer_block.timestamp >= latest_block.timestamp);
 }
 
-// TODO: Unignore this when we have get_block_info for the v1 API.
-#[ignore]
 #[tokio::test]
 async fn test_block_transactions() {
     let (swarm, cli, _faucet, rosetta_client) = setup_test(1, 2).await;
@@ -506,8 +504,6 @@ async fn test_block_transactions() {
     }
 }
 
-// TODO: Unignore this when we have get_block_info for the v1 API.
-#[ignore]
 #[tokio::test]
 async fn test_invalid_transaction_gas_charged() {
     let (swarm, cli, _faucet, rosetta_client) = setup_test(1, 1).await;


### PR DESCRIPTION
### Description
I spent a bunch of time trying to figure out why Rosetta wasn't working.  But I finally got it working after I realized `version` != `ledger_version`.  This will need to be cleaned up tomorrow, but for now, we have a test that actually tests full functionality of Rosetta (similar to the Rosetta CLI), but with the constraints that we actually know how long it will run for.

### Test Plan
This adds the test that checks all of it in Rosetta.

1. Makes a bunch of valid & invalid transfers
2. Tracks creation of accounts & transfers
3. Checks balances afterwards to see if they're correct
4. Validates blocks, transactions, and operations correctness.
5. Has almost excessive expect & assert messages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2948)
<!-- Reviewable:end -->
