### PR TITLE
add type_address in type_info

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -19,6 +19,11 @@ module aptos_std::type_info {
         type_info.struct_name
     }
 
+    public fun type_address<T>(): address {
+        let type_info = type_of<T>();
+        account_address(&type_info)
+    }
+
     public native fun type_of<T>(): TypeInfo;
     public native fun type_name<T>(): string::String;
 
@@ -32,6 +37,7 @@ module aptos_std::type_info {
         assert!(account_address(&type_info) == @aptos_std, 0);
         assert!(module_name(&type_info) == b"type_info", 1);
         assert!(struct_name(&type_info) == b"TypeInfo", 2);
+        assert!(type_address<TypeInfo>() == account_address(&type_info), 3);
     }
 
     #[test]


### PR DESCRIPTION
### Description
developers often need to assert type_address<T>, like the initialize function in coin.move.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2949)
<!-- Reviewable:end -->
