### PR TITLE
Make sdk-release work on high-perf-docker

### DIFF
--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -52,12 +52,16 @@ jobs:
           node-version-file: .node-version
           registry-url: 'https://registry.npmjs.org'
 
+      # Self hosted runners don't have yarn preinstalled.
+      # https://github.com/actions/setup-node/issues/182
+      - run: npm install -g yarn
+
       # When using high-perf-docker, the CI is actually run with two containers
       # in a k8s pod, one for docker commands run in the CI steps (docker), and
       # one for everything else (runner). These containers share some volume
-      # mounts, /runner is one of them. Writing the specs here ensures the docker
-      # run step writes to a same place that the runner can read from.
-      - run: mkdir -p /runner/specs
+      # mounts, ${{ runner.temp }} is one of them. Writing the specs here ensures
+      # the docker run step writes to a same place that the runner can read from.
+      - run: mkdir -p ${{ runner.temp }}/specs
 
       # Build the API specs.
       - uses: nick-fields/retry@v2
@@ -65,20 +69,20 @@ jobs:
         with:
           max_attempts: 3
           timeout_minutes: 20
-          command: docker run --rm --mount=type=bind,source=/runner/specs,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f yaml -o /specs/spec.yaml
+          command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f yaml -o /specs/spec.yaml
       - uses: nick-fields/retry@v2
         name: generate-json-spec
         with:
           max_attempts: 3
           timeout_minutes: 20
-          command: docker run --rm --mount=type=bind,source=/tmp,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f json -o /specs/spec.json
+          command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f json -o /specs/spec.json
 
       # Confirm that the specs we built here are the same as those checked in.
       - run: echo "If this step fails, run the following commands locally to fix it:"
       - run: echo "cargo run -p aptos-openapi-spec-generator -- -f yaml -o api/doc/v1/spec.yaml"
       - run: echo "cargo run -p aptos-openapi-spec-generator -- -f json -o api/doc/v1/spec.json"
-      - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines /runner/specs/spec.yaml api/doc/v1/spec.yaml
-      - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines /runner/specs/spec.json api/doc/v1/spec.json
+      - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines ${{ runner.temp }}/specs/spec.yaml api/doc/v1/spec.yaml
+      - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines ${{ runner.temp }}/specs/spec.json api/doc/v1/spec.json
 
       # Set up dotenv file for tests (jest doesn't read env vars properly).
       - run: echo 'APTOS_NODE_URL="http://127.0.0.1:8080/v1"' >> ./ecosystem/typescript/sdk/.env


### PR DESCRIPTION
## Description
https://github.com/aptos-labs/aptos-core/pull/2955 worked in the PR but not on main. I'm investigating why and fixing it in this PR.

## Test Plan
Same as in https://github.com/aptos-labs/aptos-core/pull/2955.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2957)
<!-- Reviewable:end -->
