### PR TITLE
[community] Don't cover anchors with sticky header.

### DIFF
--- a/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
+++ b/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
@@ -8,6 +8,11 @@
   }
 }
 
+html {
+  /* So the sticky header doesn't cover things that are scrolled into view. */
+  scroll-padding-top: 120px;
+}
+
 .font-mono {
   font-variant-ligatures: none;
 }


### PR DESCRIPTION
### Description

This adds some scroll padding to compensate for the sticky header, so that when the browser scrolls to an element (e.g. when a form input is invalid on submit) it's not covered beneath the header.

### Test Plan
Tested manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2960)
<!-- Reviewable:end -->
