### PR TITLE
[forge] Stop running forge on main, rely on continuous

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -27,8 +27,6 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
-      - auto
-      - canary
       - devnet
       - testnet
 

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -27,7 +27,6 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
-      - main
       - auto
       - canary
       - devnet


### PR DESCRIPTION
Main is failing a lot due to preemption, lets rely on continuous instead

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2965)
<!-- Reviewable:end -->
