### PR TITLE
[forge] Dont schedule forge on main push take 2

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -141,7 +141,7 @@ jobs:
     needs: rust-images
     if: |
       !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
-        github.event_name == 'push' ||
+        (github.event_name == 'push' && github.ref_name != "main") ||
         github.event_name == 'workflow_dispatch' ||
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
         github.event.pull_request.auto_merge != null ||


### PR DESCRIPTION
Last time this accidentally disable whole build workflow!

This time just dont schedule forge on main if the branch name is main

Test Plan: this feels fairly not testable

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2971)
<!-- Reviewable:end -->
