### PR TITLE
[forge] Lower continuous chaos thresholds

### DIFF
--- a/.github/workflows/continuous-e2e-tests.yaml
+++ b/.github/workflows/continuous-e2e-tests.yaml
@@ -39,7 +39,7 @@ jobs:
       # Run for 30 minutes
       FORGE_RUNNER_DURATION_SECS: 1800
       # We expect slightly lower tps on longer timeline
-      FORGE_RUNNER_TPS_THRESHOLD: 1000
+      FORGE_RUNNER_TPS_THRESHOLD: 100
       # Pre release has chaos applied
       FORGE_TEST_SUITE: chaos
   # Run a faster chaos forge to quickly surface correctness failures
@@ -52,7 +52,7 @@ jobs:
       # Run for 5 minutes
       FORGE_RUNNER_DURATION_SECS: 300
       # We expect slightly lower tps on longer timeline
-      FORGE_RUNNER_TPS_THRESHOLD: 1000
+      FORGE_RUNNER_TPS_THRESHOLD: 100
       # Pre release has chaos applied
       FORGE_TEST_SUITE: chaos
   # Example new forge nightly test, simply add this block below to schedule your own forge job


### PR DESCRIPTION
Lower the thresholds to where they currently are for test duration

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2973)
<!-- Reviewable:end -->
