### PR TITLE
[gha] forge comment append and send to slack

### DIFF
--- a/.github/workflows/continuous-e2e-tests.yaml
+++ b/.github/workflows/continuous-e2e-tests.yaml
@@ -10,6 +10,8 @@ on:
     branches:
       - pre-release-continuous-test
       - devnet
+      # remove this after testing
+      - rustielin/forge-comment-again
   schedule:
     # Run every hour - TODO: Decrease the frequency once things stabilizes
     - cron: "0 */3 * * *"
@@ -21,40 +23,43 @@ jobs:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-performance
+      FORGE_NAMESPACE: forge-performance-rustie
       FORGE_CLUSTER_NAME: aptos-forge-1
       # Run for 2 hours
-      FORGE_RUNNER_DURATION_SECS: 7200
+      FORGE_RUNNER_DURATION_SECS: 30
       # We expect slightly lower tps on longer timeline
       FORGE_RUNNER_TPS_THRESHOLD: 5000
       # Land blocking is performance test
       FORGE_TEST_SUITE: land_blocking
+      POST_TO_SLACK: true
   # Test under sub optimal circumstances (network delay / loss)
   run-forge-chaos:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-chaos
+      FORGE_NAMESPACE: forge-chaos-rustie
       FORGE_CLUSTER_NAME: aptos-forge-1
       # Run for 30 minutes
-      FORGE_RUNNER_DURATION_SECS: 1800
+      FORGE_RUNNER_DURATION_SECS: 30
       # We expect slightly lower tps on longer timeline
       FORGE_RUNNER_TPS_THRESHOLD: 100
       # Pre release has chaos applied
       FORGE_TEST_SUITE: chaos
+      POST_TO_SLACK: true
   # Run a faster chaos forge to quickly surface correctness failures
   run-forge-fast-chaos:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-fast-chaos-new-cluster
+      FORGE_NAMESPACE: forge-fast-chaos-new-cluster-rustie
       FORGE_CLUSTER_NAME: aptos-forge-2
       # Run for 5 minutes
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 30
       # We expect slightly lower tps on longer timeline
       FORGE_RUNNER_TPS_THRESHOLD: 100
       # Pre release has chaos applied
       FORGE_TEST_SUITE: chaos
+      POST_TO_SLACK: true
   # Example new forge nightly test, simply add this block below to schedule your own forge job
   # run-forge-example:
   #   uses: ./.github/workflows/run-forge.yaml

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -78,21 +78,18 @@ jobs:
 
           source testsuite/run_forge.sh
 
-          # export env vars for next step
-          echo "FORGE_PRE_COMMENT=$FORGE_PRE_COMMENT" >> $GITHUB_ENV
-
           # append some GHA-specific content to the comment
           cat << EOF >> $FORGE_PRE_COMMENT
           * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           * Pending test run ${{ github.run_attempt }} ${{ env.FORGE_BLOCKING == 'true' && 'is land-blocking' || 'is not land-blocking' }}
+          * Triggered by ${{ github.event_name || github.event.pull_request.auto_merge != null && 'automerge' }}
           EOF
 
       - name: Post pre-Forge comment
         if: env.FORGE_ENABLED == 'true' && github.event.number != null
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          recreate: true
-          header: forge-comment-${{ github.run_attempt }}
+          append: true
           path: ${{ env.FORGE_PRE_COMMENT }}
 
       - name: Run Forge
@@ -112,6 +109,7 @@ jobs:
           cat << EOF >> $FORGE_COMMENT
           * [Test runner output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           * Test run ${{ github.run_attempt }} ${{ env.FORGE_BLOCKING == 'true' && 'is land-blocking' || 'is not land-blocking' }}
+          * Triggered by ${{ github.event_name || github.event.pull_request.auto_merge != null && 'automerge' }}
           EOF
 
           # add github step summary as described here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
@@ -125,6 +123,5 @@ jobs:
         if: env.FORGE_ENABLED == 'true' && github.event.number != null && !cancelled()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          recreate: true
+          append: true
           path: ${{ env.FORGE_COMMENT }}
-          header: forge-comment-${{ github.run_attempt }}

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -32,7 +32,11 @@ on:
         type: string
         default: land_blocking
         description: Test suite to run
-
+      POST_TO_SLACK:
+        required: false
+        type: boolean
+        default: false
+        description: Whether to post the test results comment to Slack
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -51,6 +55,7 @@ env:
   FORGE_RUNNER_TPS_THRESHOLD: ${{ inputs.FORGE_RUNNER_TPS_THRESHOLD }}
   FORGE_NAMESPACE: ${{ inputs.FORGE_NAMESPACE }}
   FORGE_TEST_SUITE: ${{ inputs.FORGE_TEST_SUITE }}
+  POST_TO_SLACK: ${{ inputs.POST_TO_SLACK }}
 
 jobs:
   forge:
@@ -115,13 +120,30 @@ jobs:
           # add github step summary as described here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
           cat $FORGE_COMMENT >> $GITHUB_STEP_SUMMARY
 
+          # get the Forge comment into text
+          echo "FORGE_COMMENT_TEXT=$(cat $FORGE_COMMENT | jq -Rsa)" >> $GITHUB_ENV
+
           if [ "$FORGE_BLOCKING" = "true" ]; then
             exit $FORGE_EXIT_CODE
           fi
 
       - name: Post forge result comment
+        # Post a Github comment if the run has not been cancelled and if we're running on a PR
         if: env.FORGE_ENABLED == 'true' && github.event.number != null && !cancelled()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           append: true
           path: ${{ env.FORGE_COMMENT }}
+      - name: Post to a Slack channel
+        # Post a Slack comment if the run has not been cancelled and the envs are set
+        if: env.FORGE_ENABLED == 'true' && env.POST_TO_SLACK == 'true' && !cancelled()
+        id: slack
+        uses: slackapi/slack-github-action@v1.21.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": "${{ github.job }}(${{ inputs.FORGE_TEST_SUITE }}) ${{ job.status }}: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
### Description

Two changes to Forge reporting behavior after each test run:
* Forge will now append to its initial comment, rather than replacing it
* Forge will now send the same comment to Slack as shows in Github

### Test Plan

Trigger on push to this branch.

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2974)
<!-- Reviewable:end -->
