### PR TITLE
[aptos-cli] Allow owner to be different when generating validator keys

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1115,3 +1115,29 @@ impl TransactionOptions {
         Ok(response.into_inner())
     }
 }
+
+#[derive(Parser)]
+pub struct OptionalPoolAddressArgs {
+    /// Address of the Staking pool
+    #[clap(long)]
+    pub(crate) pool_address: Option<AccountAddressWrapper>,
+}
+
+impl OptionalPoolAddressArgs {
+    pub fn pool_address(&self) -> Option<AccountAddress> {
+        self.pool_address.map(|inner| inner.account_address)
+    }
+}
+
+#[derive(Parser)]
+pub struct PoolAddressArgs {
+    /// Address of the Staking pool
+    #[clap(long)]
+    pub(crate) pool_address: AccountAddressWrapper,
+}
+
+impl PoolAddressArgs {
+    pub fn pool_address(&self) -> AccountAddress {
+        self.pool_address.account_address
+    }
+}

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::types::OptionalPoolAddressArgs;
 use crate::common::utils::{create_dir_if_not_exist, dir_default_to_current};
 use crate::genesis::git::LAYOUT_FILE;
 use crate::{
@@ -29,6 +30,8 @@ const VFN_FILE: &str = "validator-full-node-identity.yaml";
 #[derive(Parser)]
 pub struct GenerateKeys {
     #[clap(flatten)]
+    pub(crate) pool_address_args: OptionalPoolAddressArgs,
+    #[clap(flatten)]
     pub(crate) prompt_options: PromptOptions,
     #[clap(flatten)]
     pub rng_args: RngArgs,
@@ -54,8 +57,14 @@ impl CliCommand<Vec<PathBuf>> for GenerateKeys {
         check_if_file_exists(vfn_file.as_path(), self.prompt_options)?;
 
         let mut key_generator = self.rng_args.key_generator()?;
-        let (validator_blob, vfn_blob, private_identity) =
+        let (mut validator_blob, mut vfn_blob, private_identity) =
             generate_key_objects(&mut key_generator)?;
+
+        // Allow for the owner to be different than the operator
+        if let Some(pool_address) = self.pool_address_args.pool_address() {
+            validator_blob.account_address = Some(pool_address);
+            vfn_blob.account_address = Some(pool_address);
+        }
 
         // Create the directory if it doesn't exist
         create_dir_if_not_exist(output_dir.as_path())?;

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::types::OptionalPoolAddressArgs;
 use crate::common::utils::read_from_file;
 use crate::genesis::git::from_yaml;
 use crate::genesis::keys::GenerateLayoutTemplate;
@@ -165,6 +166,7 @@ async fn create_layout_file(
 async fn generate_keys(dir: &Path, index: u8) -> PathBuf {
     let output_dir = dir.join(index.to_string());
     let command = GenerateKeys {
+        pool_address_args: OptionalPoolAddressArgs { pool_address: None },
         rng_args: RngArgs::from_seed([index; 32]),
         prompt_options: PromptOptions::yes(),
         output_dir: Some(output_dir.clone()),

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -3,7 +3,7 @@
 
 pub mod analyze;
 
-use crate::common::types::{ConfigSearchMode, PromptOptions};
+use crate::common::types::{ConfigSearchMode, OptionalPoolAddressArgs, PromptOptions};
 use crate::common::utils::prompt_yes_with_override;
 use crate::config::GlobalConfig;
 use crate::node::analyze::analyze_validators::AnalyzeValidators;
@@ -279,9 +279,8 @@ impl CliCommand<Transaction> for InitializeValidator {
 /// Arguments used for operator of the staking pool
 #[derive(Parser)]
 pub struct OperatorArgs {
-    /// Address of the Staking pool
-    #[clap(long)]
-    pub(crate) pool_address: Option<AccountAddress>,
+    #[clap(flatten)]
+    pub(crate) pool_address_args: OptionalPoolAddressArgs,
 }
 
 impl OperatorArgs {
@@ -289,7 +288,7 @@ impl OperatorArgs {
         &self,
         profile_options: &ProfileOptions,
     ) -> CliTypedResult<AccountAddress> {
-        if let Some(address) = self.pool_address {
+        if let Some(address) = self.pool_address_args.pool_address() {
             Ok(address)
         } else {
             profile_options.account_address()
@@ -300,7 +299,7 @@ impl OperatorArgs {
         &self,
         transaction_options: &TransactionOptions,
     ) -> CliTypedResult<AccountAddress> {
-        if let Some(address) = self.pool_address {
+        if let Some(address) = self.pool_address_args.pool_address() {
             Ok(address)
         } else {
             transaction_options.sender_address()

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -11,8 +11,8 @@ use crate::common::init::InitTool;
 use crate::common::types::{
     account_address_from_public_key, AccountAddressWrapper, CliError, CliTypedResult,
     EncodingOptions, FaucetOptions, GasOptions, KeyType, MoveManifestAccountWrapper,
-    MovePackageDir, PrivateKeyInputOptions, PromptOptions, RestOptions, RngArgs, SaveFile,
-    TransactionOptions, TransactionSummary,
+    MovePackageDir, OptionalPoolAddressArgs, PrivateKeyInputOptions, PromptOptions, RestOptions,
+    RngArgs, SaveFile, TransactionOptions, TransactionSummary,
 };
 use crate::common::utils::write_to_file;
 use crate::move_tool::{
@@ -768,7 +768,11 @@ impl CliTestFramework {
 
     fn operator_args(&self, pool_index: Option<usize>) -> OperatorArgs {
         OperatorArgs {
-            pool_address: pool_index.map(|idx| self.account_id(idx)),
+            pool_address_args: OptionalPoolAddressArgs {
+                pool_address: pool_index.map(|idx| AccountAddressWrapper {
+                    account_address: self.account_id(idx),
+                }),
+            },
         }
     }
 


### PR DESCRIPTION
### Description
This allows for operators to be different than owners, but
still use the files that exist today.

### Test Plan
```
$ ./target/debug/aptos genesis generate-keys --owner-address 0xDEADBEEF
{
  "Result": [
    "/opt/git/aptos-core/private-keys.yaml",
    "/opt/git/aptos-core/validator-identity.yaml",
    "/opt/git/aptos-core/validator-full-node-identity.yaml"
  ]
}

$ cat /opt/git/aptos-core/validator-identity.yaml 
---
account_address: 00000000000000000000000000000000000000000000000000000000deadbeef
account_private_key: "***"
consensus_private_key: "***"
network_private_key: "***"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2981)
<!-- Reviewable:end -->
