### PR TITLE
[testing][move][swarm] Add flag to execute block prologue natively (for tests)

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -499,6 +499,11 @@ pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle>
         info!("Genesis txn not provided, it's fine if you don't expect to apply it otherwise please double check config");
     }
     AptosVM::set_concurrency_level_once(node_config.execution.concurrency_level as usize);
+    AptosVM::set_use_native_block_prologue_without_stake_performance(
+        node_config
+            .execution
+            .use_native_block_prologue_without_stake_performance,
+    );
     AptosVM::set_num_proof_reading_threads_once(
         node_config.execution.num_proof_reading_threads as usize,
     );

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -21,6 +21,7 @@ pub struct ExecutionConfig {
     pub network_timeout_ms: u64,
     pub concurrency_level: u16,
     pub num_proof_reading_threads: u16,
+    pub use_native_block_prologue_without_stake_performance: bool,
 }
 
 impl std::fmt::Debug for ExecutionConfig {
@@ -49,6 +50,7 @@ impl Default for ExecutionConfig {
             // Sequential execution by default.
             concurrency_level: 1,
             num_proof_reading_threads: 32,
+            use_native_block_prologue_without_stake_performance: false,
         }
     }
 }

--- a/execution/executor/src/components/chunk_output.rs
+++ b/execution/executor/src/components/chunk_output.rs
@@ -5,13 +5,13 @@
 
 use crate::components::apply_chunk_output::ApplyChunkOutput;
 use anyhow::Result;
-use aptos_logger::trace;
+use aptos_logger::{debug, trace};
 use aptos_state_view::StateView;
 use aptos_types::transaction::{Transaction, TransactionOutput};
 use aptos_vm::VMExecutor;
 use executor_types::ExecutedChunk;
 use fail::fail_point;
-use std::collections::HashSet;
+use std::{collections::HashSet, time::Instant};
 use storage_interface::{
     cached_state_view::{CachedStateView, StateCache},
     ExecutedTrees,
@@ -33,8 +33,13 @@ impl ChunkOutput {
         transactions: Vec<Transaction>,
         state_view: CachedStateView,
     ) -> Result<Self> {
+        let start = Instant::now();
         let transaction_outputs = V::execute_block(transactions.clone(), &state_view)?;
-
+        debug!(
+            "Chunk execution for {} transactions lasted: {}",
+            transactions.len(),
+            start.elapsed().as_secs_f32()
+        );
         Ok(Self {
             transactions,
             transaction_outputs,

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -105,19 +105,6 @@ impl LocalFactory {
         Self::with_revision_and_workspace(&merge_base)
     }
 
-    pub async fn new_swarm<R>(
-        &self,
-        rng: R,
-        number_of_validators: NonZeroUsize,
-    ) -> Result<LocalSwarm>
-    where
-        R: ::rand::RngCore + ::rand::CryptoRng,
-    {
-        let version = self.versions.keys().max().unwrap();
-        self.new_swarm_with_version(rng, number_of_validators, version, None, None, None)
-            .await
-    }
-
     pub async fn new_swarm_with_version<R>(
         &self,
         rng: R,
@@ -126,6 +113,7 @@ impl LocalFactory {
         genesis_modules: Option<Vec<Vec<u8>>>,
         init_config: Option<InitConfigFn>,
         init_genesis_config: Option<InitGenesisConfigFn>,
+        optimize_without_validator_performance_and_rewards: bool,
     ) -> Result<LocalSwarm>
     where
         R: ::rand::RngCore + ::rand::CryptoRng,
@@ -140,6 +128,7 @@ impl LocalFactory {
             init_genesis_config,
             None,
             genesis_modules,
+            optimize_without_validator_performance_and_rewards,
         )?;
 
         swarm
@@ -178,7 +167,15 @@ impl Factory for LocalFactory {
             None => None,
         };
         let swarm = self
-            .new_swarm_with_version(rng, num_validators, version, genesis_modules, None, None)
+            .new_swarm_with_version(
+                rng,
+                num_validators,
+                version,
+                genesis_modules,
+                None,
+                None,
+                false,
+            )
             .await?;
 
         Ok(Box::new(swarm))

--- a/testsuite/smoke-test/src/aptos/account_creation.rs
+++ b/testsuite/smoke-test/src/aptos/account_creation.rs
@@ -4,11 +4,13 @@
 use aptos_transaction_builder::aptos_stdlib;
 use forge::Swarm;
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 
 #[tokio::test]
 async fn test_account_creation() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     // created by root account

--- a/testsuite/smoke-test/src/aptos/error_report.rs
+++ b/testsuite/smoke-test/src/aptos/error_report.rs
@@ -8,7 +8,7 @@ use aptos_types::{
 };
 use forge::{AptosPublicInfo, Swarm};
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 
 async fn submit_and_check_err<F: Fn(TransactionBuilder) -> TransactionBuilder>(
     local_account: &LocalAccount,
@@ -35,7 +35,9 @@ async fn submit_and_check_err<F: Fn(TransactionBuilder) -> TransactionBuilder>(
 
 #[tokio::test]
 async fn test_error_report() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     let local_account = info.random_account();

--- a/testsuite/smoke-test/src/aptos/gas_check.rs
+++ b/testsuite/smoke-test/src/aptos/gas_check.rs
@@ -6,11 +6,13 @@ use aptos_transaction_builder::aptos_stdlib;
 use forge::Swarm;
 use std::time::Duration;
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 
 #[tokio::test]
 async fn test_gas_check() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     let mut account1 = info.random_account();

--- a/testsuite/smoke-test/src/aptos/mint_transfer.rs
+++ b/testsuite/smoke-test/src/aptos/mint_transfer.rs
@@ -1,13 +1,15 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 use aptos_transaction_builder::aptos_stdlib;
 use forge::Swarm;
 
 #[tokio::test]
 async fn test_mint_transfer() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     let mut account1 = info.random_account();

--- a/testsuite/smoke-test/src/aptos/package_publish.rs
+++ b/testsuite/smoke-test/src/aptos/package_publish.rs
@@ -1,14 +1,15 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::aptos::move_test_helpers;
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::{aptos::move_test_helpers, smoke_test_environment::SwarmBuilder};
 use forge::Swarm;
 use framework::natives::code::UpgradePolicy;
 
 #[tokio::test]
 async fn test_package_publish() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     let base_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));

--- a/testsuite/smoke-test/src/aptos/staking.rs
+++ b/testsuite/smoke-test/src/aptos/staking.rs
@@ -1,16 +1,19 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::{account_address::AccountAddress, account_config::CORE_CODE_ADDRESS};
 use forge::{AptosPublicInfo, Swarm};
+
+use crate::smoke_test_environment::SwarmBuilder;
 
 // re-enable after delegation is enabled
 #[ignore]
 #[tokio::test]
 async fn test_staking() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     // created by root account

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -8,8 +8,7 @@ use aptos_keygen::KeyGen;
 
 #[tokio::test]
 async fn test_account_flow() {
-    let (_swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let (_swarm, mut cli, _faucet) = SwarmBuilder::new_local_optimized_without_rewards(1)
         .build_with_cli(2)
         .await;
 

--- a/testsuite/smoke-test/src/aptos_cli/move.rs
+++ b/testsuite/smoke-test/src/aptos_cli/move.rs
@@ -77,8 +77,7 @@ async fn test_move_compile_flow() {
 
 #[tokio::test]
 async fn test_move_publish_flow() {
-    let (_swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let (_swarm, mut cli, _faucet) = SwarmBuilder::new_local_optimized_without_rewards(1)
         .build_with_cli(2)
         .await;
 

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -17,8 +17,7 @@ use std::time::Duration;
 
 #[tokio::test]
 async fn test_analyze_validators() {
-    let (mut swarm, cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let (mut swarm, cli, _faucet) = SwarmBuilder::new_local_optimized_without_rewards(1)
         .with_init_config(Arc::new(|_i, _conf, genesis_stake_amount| {
             *genesis_stake_amount = 100000;
         }))
@@ -50,8 +49,7 @@ async fn test_analyze_validators() {
 
 #[tokio::test]
 async fn test_show_validator_set() {
-    let (swarm, cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let (swarm, cli, _faucet) = SwarmBuilder::new_local_optimized_without_rewards(1)
         .build_with_cli(1)
         .await;
     let validator_set = cli.show_validator_set().await.unwrap();
@@ -71,8 +69,7 @@ async fn test_show_validator_set() {
 
 #[tokio::test]
 async fn test_register_and_update_validator() {
-    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local_optimized_without_rewards(1)
         .build_with_cli(0)
         .await;
     let transaction_factory = swarm.chain_info().transaction_factory();
@@ -163,8 +160,7 @@ async fn test_register_and_update_validator() {
 
 #[tokio::test]
 async fn test_join_and_leave_validator() {
-    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local_optimized_without_rewards(1)
         .with_init_config(Arc::new(|_i, conf, genesis_stake_amount| {
             // reduce timeout, as we will have dead node during rounds
             conf.consensus.round_initial_timeout_ms = 200;
@@ -321,8 +317,7 @@ async fn test_join_and_leave_validator() {
 
 #[tokio::test]
 async fn test_owner_create_and_delegate_flow() {
-    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local_optimized_without_rewards(1)
         .with_init_config(Arc::new(|_i, conf, genesis_stake_amount| {
             // reduce timeout, as we will have dead node during rounds
             conf.consensus.round_initial_timeout_ms = 200;

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    smoke_test_environment::new_local_swarm_with_aptos,
+    smoke_test_environment::SwarmBuilder,
     test_utils::{
         assert_balance, check_create_mint_transfer, create_and_fund_account, transfer_coins,
     },
@@ -13,7 +13,9 @@ use std::time::{Duration, Instant};
 
 #[tokio::test]
 async fn test_create_mint_transfer_block_metadata() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // This script does 4 transactions
     check_create_mint_transfer(&mut swarm).await;
@@ -37,14 +39,18 @@ async fn test_create_mint_transfer_block_metadata() {
 #[tokio::test]
 async fn test_basic_fault_tolerance() {
     // A configuration with 4 validators should tolerate single node failure.
-    let mut swarm = new_local_swarm_with_aptos(4).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
+        .build()
+        .await;
     swarm.validators_mut().nth(3).unwrap().stop();
     check_create_mint_transfer(&mut swarm).await;
 }
 
 #[tokio::test]
 async fn test_basic_restartability() {
-    let mut swarm = new_local_swarm_with_aptos(4).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
+        .build()
+        .await;
     let client = swarm.validators().next().unwrap().rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
@@ -86,7 +92,9 @@ async fn test_basic_restartability() {
 
 #[tokio::test]
 async fn test_concurrent_transfers_single_node() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let client = swarm.validators().next().unwrap().rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
@@ -109,7 +117,9 @@ async fn test_concurrent_transfers_single_node() {
 
 #[tokio::test]
 async fn test_latest_events_and_transactions() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let client = swarm.validators().next().unwrap().rest_client();
     let start_events = client
         .get_new_block_events(None, Some(2))

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    smoke_test_environment::new_local_swarm_with_aptos,
+    smoke_test_environment::SwarmBuilder,
     test_utils::{assert_balance, create_and_fund_account, transfer_coins},
 };
 use aptos_config::{
@@ -19,7 +19,9 @@ use std::{
 
 #[tokio::test]
 async fn test_full_node_basic_flow() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     let version = swarm.versions().max().unwrap();
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
@@ -114,7 +116,9 @@ async fn test_full_node_basic_flow() {
 
 #[tokio::test]
 async fn test_vfn_failover() {
-    let mut swarm = new_local_swarm_with_aptos(4).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
+        .build()
+        .await;
     let transaction_factory = swarm.chain_info().transaction_factory();
 
     let mut vfns = Vec::new();
@@ -184,7 +188,9 @@ async fn test_vfn_failover() {
 
 #[tokio::test]
 async fn test_private_full_node() {
-    let mut swarm = new_local_swarm_with_aptos(4).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
+        .build()
+        .await;
     let transaction_factory = swarm.chain_info().transaction_factory();
     let version = swarm.versions().max().unwrap();
 

--- a/testsuite/smoke-test/src/fullnode.rs
+++ b/testsuite/smoke-test/src/fullnode.rs
@@ -12,11 +12,13 @@ use forge::NodeExt;
 use forge::Result;
 use forge::Swarm;
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 
 #[tokio::test]
 async fn test_indexer() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     let version = swarm.versions().max().unwrap();
     let fullnode_peer_id = swarm

--- a/testsuite/smoke-test/src/indexer.rs
+++ b/testsuite/smoke-test/src/indexer.rs
@@ -14,7 +14,7 @@ use diesel::connection::Connection;
 use forge::{AptosPublicInfo, Result, Swarm};
 use std::sync::Arc;
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 
 pub fn wipe_database(conn: &PgPoolConnection) {
     for table in [
@@ -114,7 +114,9 @@ pub async fn execute_nft_txns<'t>(
 
 #[tokio::test]
 async fn test_indexer() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     if aptos_indexer::should_skip_pg_tests() {

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder};
+use crate::smoke_test_environment::SwarmBuilder;
 use aptos::common::types::EncodingType;
 use aptos::test::CliTestFramework;
 use aptos_config::config::Peer;
@@ -24,7 +24,9 @@ use std::{
 #[ignore]
 #[tokio::test]
 async fn test_connection_limiting() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let version = swarm.versions().max().unwrap();
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
 
@@ -137,8 +139,7 @@ async fn test_file_discovery() {
     let (_, peer_set) = generate_private_key_and_peer(&cli, [0u8; 32]).await;
     let discovery_file = Arc::new(create_discovery_file(peer_set));
     let discovery_file_for_closure = discovery_file.clone();
-    let swarm = SwarmBuilder::new_local(1)
-        .with_aptos()
+    let swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
         .with_init_config(Arc::new(move |_, config, _| {
             let discovery_file_for_closure2 = discovery_file_for_closure.clone();
             modify_network_config(config, &NetworkId::Validator, move |network| {

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -5,11 +5,13 @@ use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_config::CORE_CODE_ADDRESS;
 use forge::Swarm;
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 
 #[tokio::test]
 async fn test_get_index() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let info = swarm.aptos_public_info();
 
     let resp = reqwest::get(info.url().to_owned()).await.unwrap();
@@ -18,7 +20,9 @@ async fn test_get_index() {
 
 #[tokio::test]
 async fn test_basic_client() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     info.client().get_ledger_information().await.unwrap();

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -40,8 +40,7 @@ pub async fn setup_test(
     num_nodes: usize,
     num_accounts: usize,
 ) -> (LocalSwarm, CliTestFramework, JoinHandle<()>, RosettaClient) {
-    let (swarm, cli, faucet) = SwarmBuilder::new_local(num_nodes)
-        .with_aptos()
+    let (swarm, cli, faucet) = SwarmBuilder::new_local_optimized_without_rewards(num_nodes)
         .build_with_cli(num_accounts)
         .await;
     let validator = swarm.validators().next().unwrap();

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder},
+    smoke_test_environment::SwarmBuilder,
     test_utils::{create_and_fund_account, transfer_and_reconfig, transfer_coins},
 };
 use aptos_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
@@ -24,7 +24,9 @@ const MAX_CATCH_UP_SECS: u64 = 120; // The max time we'll wait for nodes to catc
 #[tokio::test]
 async fn test_full_node_bootstrap_state_snapshot() {
     // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // Create a fullnode config that uses snapshot syncing
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -58,7 +60,9 @@ async fn test_full_node_bootstrap_state_snapshot() {
 #[tokio::test]
 async fn test_full_node_bootstrap_outputs() {
     // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // Create a fullnode config that uses transaction outputs to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -80,7 +84,9 @@ async fn test_full_node_bootstrap_outputs() {
 #[tokio::test]
 async fn test_full_node_bootstrap_outputs_no_compression() {
     // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // Create a fullnode config that uses transaction outputs to sync (without compression)
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -102,7 +108,9 @@ async fn test_full_node_bootstrap_outputs_no_compression() {
 #[tokio::test]
 async fn test_full_node_bootstrap_transactions() {
     // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // Create a fullnode config that uses transactions to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -124,7 +132,9 @@ async fn test_full_node_bootstrap_transactions() {
 #[tokio::test]
 async fn test_full_node_continuous_sync_outputs() {
     // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // Create a fullnode config that uses transaction outputs to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -143,7 +153,9 @@ async fn test_full_node_continuous_sync_outputs() {
 #[tokio::test]
 async fn test_full_node_continuous_sync_transactions() {
     // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // Create a fullnode config that uses transactions to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -220,8 +232,7 @@ async fn test_full_node_sync(vfn_peer_id: PeerId, swarm: &mut LocalSwarm, epoch_
 #[tokio::test]
 async fn test_validator_bootstrap_outputs() {
     // Create a swarm of 4 validators with state sync v2 enabled (output syncing)
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ApplyTransactionOutputsFromGenesis;
@@ -238,8 +249,7 @@ async fn test_validator_bootstrap_outputs() {
 #[tokio::test]
 async fn test_validator_bootstrap_state_snapshot() {
     // Create a swarm of 4 validators with state sync v2 enabled (snapshot syncing, chunk size = 1)
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
@@ -262,8 +272,7 @@ async fn test_validator_bootstrap_state_snapshot() {
 #[tokio::test]
 async fn test_validator_bootstrap_transactions() {
     // Create a swarm of 4 validators with state sync v2 enabled (transaction syncing)
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
@@ -280,8 +289,7 @@ async fn test_validator_bootstrap_transactions() {
 #[tokio::test]
 async fn test_validator_bootstrap_transactions_no_compression() {
     // Create a swarm of 4 validators with state sync v2 enabled (transaction syncing, no compression)
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::ExecuteTransactionsFromGenesis;
@@ -329,8 +337,7 @@ async fn test_validator_sync(swarm: &mut LocalSwarm, validator_index_to_test: us
 async fn test_validator_failure_bootstrap_outputs() {
     // Create a swarm of 4 validators with state sync v2 enabled (snapshot
     // bootstrapping and transaction output application).
-    let swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
+    let swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
@@ -348,8 +355,7 @@ async fn test_validator_failure_bootstrap_outputs() {
 async fn test_validator_failure_bootstrap_execution() {
     // Create a swarm of 4 validators with state sync v2 enabled (snapshot
     // bootstrapping and transaction execution).
-    let swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
+    let swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
         .with_init_config(Arc::new(|_, config, _| {
             config.state_sync.state_sync_driver.bootstrapping_mode =
                 BootstrappingMode::DownloadLatestStates;
@@ -423,7 +429,9 @@ async fn test_all_validator_failures(mut swarm: LocalSwarm) {
 #[ignore]
 async fn test_single_validator_failure() {
     // Create a swarm of 1 validator
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
 
     // Execute multiple transactions
     let validator = swarm.validators_mut().next().unwrap();

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::smoke_test_environment::SwarmBuilder;
 use crate::test_utils::reconfig;
 use crate::{
-    smoke_test_environment::new_local_swarm_with_aptos,
     test_utils::{
         assert_balance, create_and_fund_account, swarm_utils::insert_waypoint,
         transfer_and_reconfig, transfer_coins,
@@ -30,7 +30,9 @@ async fn test_db_restore() {
     workspace_builder::get_bin("db-restore");
     workspace_builder::get_bin("db-backup-verify");
 
-    let mut swarm = new_local_swarm_with_aptos(4).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
+        .build()
+        .await;
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let client_1 = swarm
         .validator(validator_peer_ids[1])

--- a/testsuite/smoke-test/src/transaction.rs
+++ b/testsuite/smoke-test/src/transaction.rs
@@ -13,11 +13,13 @@ use aptos_sdk::{
 use aptos_transaction_builder::aptos_stdlib;
 use forge::Swarm;
 
-use crate::smoke_test_environment::new_local_swarm_with_aptos;
+use crate::smoke_test_environment::SwarmBuilder;
 
 #[tokio::test]
 async fn test_external_transaction_signer() {
-    let mut swarm = new_local_swarm_with_aptos(1).await;
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(1)
+        .build()
+        .await;
     let mut info = swarm.aptos_public_info();
 
     // generate key pair

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -12,8 +12,7 @@ use std::time::{Duration, Instant};
 /// This behavior should be true with both mempool and quorum store.
 #[tokio::test]
 async fn test_txn_broadcast() {
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
+    let mut swarm = SwarmBuilder::new_local_optimized_without_rewards(4)
         .with_init_config(Arc::new(|_, conf, _| {
             conf.api.failpoints_enabled = true;
         }))

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -103,7 +103,7 @@ pub static NEW_BLOCK_EVENT_PATH: Lazy<Vec<u8>> = Lazy::new(|| {
 });
 
 /// Should be kept in-sync with BlockResource move struct in block.move.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct BlockResource {
     height: u64,
     epoch_interval: u64,
@@ -111,12 +111,24 @@ pub struct BlockResource {
 }
 
 impl BlockResource {
+    pub fn new(height: u64, epoch_interval: u64, count: u64) -> Self {
+        Self {
+            height,
+            epoch_interval,
+            new_block_events: EventHandle::new(new_block_event_key(), count),
+        }
+    }
+
     pub fn new_block_events(&self) -> &EventHandle {
         &self.new_block_events
     }
 
     pub fn height(&self) -> u64 {
         self.height
+    }
+
+    pub fn epoch_interval(&self) -> u64 {
+        self.epoch_interval
     }
 }
 


### PR DESCRIPTION
### Description

80% of CPU in local swarm (run in debug mode) is consumed by loading modules.

On empty blocks, only block prologue is executed, and it is simple, except for validator statistics for rewards, and for epoch change. 

So creating a flag that enables block prologue to be executed in rust code only, (used for testing, as it is incompatible difference - as validator statistics are not updated), except for the epoch change.

On my machine, reduces empty block execution from 160ms to 2ms.
This allows me to have 50-100 blocks per second, instead of 5 - enabling much better and faster consensus tests.
On top of that it reduces CPU usage for all smoke tests, making them significantly faster and less flaky.

Because this is so big of a difference, that it should be used always, except when rewards are being tested, but makes logic different from prod - I made it an explicitly clear what is being used with:
SwarmBuilder::new_local_optimized_without_rewards
SwarmBuilder::new_local_with_rewards

It would probably be useful to have lazy loading in move, but only on access - as block.move links all the code, but uses most of it only on epoch change.

### Test Plan
all smoke tests

I'll add separately some rewards e2e swarm tests, and those will not be using above flag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/2999)
<!-- Reviewable:end -->
