### PR TITLE
[cli] Governance subcommands for preparing and exeucting scripts

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -313,7 +313,10 @@ impl CliCommand<&'static str> for ProvePackage {
 }
 
 /// Compiles a Move package dir, and returns the compiled modules.
-fn compile_move(build_config: BuildConfig, package_dir: &Path) -> CliTypedResult<CompiledPackage> {
+pub(crate) fn compile_move(
+    build_config: BuildConfig,
+    package_dir: &Path,
+) -> CliTypedResult<CompiledPackage> {
     // TODO: Add caching
     build_config
         .compile_package(package_dir, &mut Vec::new())
@@ -552,7 +555,7 @@ impl CliCommand<TransactionSummary> for RunFunction {
 }
 
 #[derive(Clone, Debug)]
-enum FunctionArgType {
+pub(crate) enum FunctionArgType {
     Address,
     Bool,
     Hex,
@@ -611,8 +614,8 @@ impl FromStr for FunctionArgType {
 
 /// A parseable arg with a type separated by a colon
 pub struct ArgWithType {
-    _ty: FunctionArgType,
-    arg: Vec<u8>,
+    pub(crate) _ty: FunctionArgType,
+    pub(crate) arg: Vec<u8>,
 }
 
 impl FromStr for ArgWithType {


### PR DESCRIPTION
### Description
Added two CLI sub-commands for governance.
`prepare-script` takes in a script package path, compiles the script, and prints out the script hash
`run-script` can submit a compiled script to the blockchain.

### Test Plan
Tested with a modified version of moon_coin package. 
For `prepare-script`:
![Screen Shot 2022-08-16 at 9 11 39 AM](https://user-images.githubusercontent.com/962285/184927762-e3e1b6a3-6bfc-4a90-9b6e-bd172d254b22.png)

For `run-script`:
![Screen Shot 2022-08-16 at 9 12 42 AM](https://user-images.githubusercontent.com/962285/184927991-161e1d95-4bca-4929-9ac8-b264297b21d4.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3009)
<!-- Reviewable:end -->
