### PR TITLE
Switch from `BigInt` to `BigInt | number` for TS SDK parameters

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
 ## Unreleased
-N/A
+- Make all functions that accept `BigInt` parameters accept `BigInt | number` instead.
 
 ## 1.3.6 (2022-08-10)
 - Switch back to representing certain move types (MoveModuleId, MoveStructTag, ScriptFunctionId) as strings, for both requests and responses. This reverts the change made in 1.3.2. See [#2663](https://github.com/aptos-labs/aptos-core/pull/2663) for more.

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -64,7 +64,7 @@ export class AptosClient {
    */
   async getAccountTransactions(
     accountAddress: MaybeHexString,
-    query?: { start?: BigInt; limit?: number },
+    query?: { start?: BigInt | number; limit?: number },
   ): Promise<Gen.Transaction[]> {
     return this.client.transactions.getAccountTransactions(
       HexString.ensure(accountAddress).hex(),
@@ -83,7 +83,7 @@ export class AptosClient {
    */
   async getAccountModules(
     accountAddress: MaybeHexString,
-    query?: { ledgerVersion?: BigInt },
+    query?: { ledgerVersion?: BigInt | number },
   ): Promise<Gen.MoveModuleBytecode[]> {
     return this.client.accounts.getAccountModules(
       HexString.ensure(accountAddress).hex(),
@@ -103,7 +103,7 @@ export class AptosClient {
   async getAccountModule(
     accountAddress: MaybeHexString,
     moduleName: string,
-    query?: { ledgerVersion?: BigInt },
+    query?: { ledgerVersion?: BigInt | number },
   ): Promise<Gen.MoveModuleBytecode> {
     return this.client.accounts.getAccountModule(
       HexString.ensure(accountAddress).hex(),
@@ -127,7 +127,7 @@ export class AptosClient {
    */
   async getAccountResources(
     accountAddress: MaybeHexString,
-    query?: { ledgerVersion?: BigInt },
+    query?: { ledgerVersion?: BigInt | number },
   ): Promise<Gen.MoveResource[]> {
     return this.client.accounts.getAccountResources(
       HexString.ensure(accountAddress).hex(),
@@ -152,7 +152,7 @@ export class AptosClient {
   async getAccountResource(
     accountAddress: MaybeHexString,
     resourceType: Gen.MoveStructTag,
-    query?: { ledgerVersion?: BigInt },
+    query?: { ledgerVersion?: BigInt | number },
   ): Promise<Gen.MoveResource> {
     return this.client.accounts.getAccountResource(
       HexString.ensure(accountAddress).hex(),
@@ -288,7 +288,7 @@ export class AptosClient {
     address: MaybeHexString,
     eventHandleStruct: Gen.MoveStructTag,
     fieldName: string,
-    query?: { start?: BigInt; limit?: number },
+    query?: { start?: BigInt | number; limit?: number },
   ): Promise<Gen.Event[]> {
     return this.client.events.getEventsByEventHandle(
       HexString.ensure(address).hex(),
@@ -361,7 +361,7 @@ export class AptosClient {
    * @param query?.limit The max number of transactions should be returned for the page. Default is 25
    * @returns Array of on-chain transactions
    */
-  async getTransactions(query?: { start?: BigInt; limit?: number }): Promise<Gen.Transaction[]> {
+  async getTransactions(query?: { start?: BigInt | number; limit?: number }): Promise<Gen.Transaction[]> {
     return this.client.transactions.getTransactions(query?.start?.toString(), query?.limit);
   }
 
@@ -379,7 +379,7 @@ export class AptosClient {
    * Transaction version is an uint64 number.
    * @returns Transaction from mempool or on-chain transaction
    */
-  async getTransactionByVersion(txnVersion: BigInt): Promise<Gen.Transaction> {
+  async getTransactionByVersion(txnVersion: BigInt | number): Promise<Gen.Transaction> {
     return this.client.transactions.getTransactionByVersion(txnVersion.toString());
   }
 
@@ -514,7 +514,11 @@ export class AptosClient {
    * @param params Request params
    * @returns Table item value rendered in JSON
    */
-  async getTableItem(handle: string, data: Gen.TableItemRequest, query?: { ledgerVersion?: BigInt }): Promise<any> {
+  async getTableItem(
+    handle: string,
+    data: Gen.TableItemRequest,
+    query?: { ledgerVersion?: BigInt | number },
+  ): Promise<any> {
     const tableItem = await this.client.tables.getTableItem(handle, data, query?.ledgerVersion?.toString());
     return tableItem;
   }


### PR DESCRIPTION
## Description
Turns out BigInt doesn't play nice with regular numbers. This PR gives users the option to use just numbers instead of BigInts, since in most cases right now a regular number is sufficient.

## Test Plan
```
yarn test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3011)
<!-- Reviewable:end -->
