### PR TITLE
Make AptosErrorCode compatible with serde deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,7 @@ dependencies = [
  "bcs",
  "hex",
  "move-deps",
+ "poem-openapi",
  "reqwest 0.11.11",
  "serde 1.0.141",
  "serde_json",

--- a/api/types/src/error.rs
+++ b/api/types/src/error.rs
@@ -47,6 +47,7 @@ impl From<anyhow::Error> for AptosError {
 // Make sure the integer codes increment one by one.
 #[derive(Debug, Deserialize, Enum)]
 #[oai(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum AptosErrorCode {
     /// The API failed to read from storage for this request, not because of a
     /// bad request, but because of some internal error.

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -17,6 +17,7 @@ dpn = []
 anyhow = "1.0.57"
 bcs = "0.1.3"
 hex = "0.4.3"
+poem-openapi = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba", features = ["url"] }
 reqwest = { version = "0.11.10", features = ["json", "cookies", "blocking"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -28,6 +28,7 @@ use aptos_types::{
     account_config::{NewBlockEvent, CORE_CODE_ADDRESS},
     transaction::SignedTransaction,
 };
+use poem_openapi::types::ParseFromJSON;
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -510,7 +511,7 @@ impl Client {
         let response = self.inner.get(url.clone()).send().await?;
 
         if !response.status().is_success() {
-            let error_response = response.json::<AptosError>().await?;
+            let error_response = AptosError::parse_from_json(Some(response.json().await?));
             return Err(anyhow::anyhow!("Request failed: {:?}", error_response));
         }
 
@@ -525,7 +526,7 @@ impl Client {
         response: reqwest::Response,
     ) -> Result<(reqwest::Response, State)> {
         if !response.status().is_success() {
-            let error_response = response.json::<AptosError>().await?;
+            let error_response = AptosError::parse_from_json(Some(response.json().await?));
             return Err(anyhow::anyhow!("Request failed: {:?}", error_response));
         }
         let state = State::from_headers(response.headers())?;


### PR DESCRIPTION
## Description
With the `oai` annotation it was serializing this data with snake case, but the REST client was using serde to deserialize it, which did not have the snake case annotation. This PR fixes it in two ways:
- Make the REST client use the correct deserialization function (the counterpart to how it was serialized), as provided by the derive from Poem.
- Make it possible to deserialize it with serde by adding the snake case annotation (so it works elsewhere if it is being used).

See this issue for more on this problem: https://github.com/aptos-labs/aptos-core/issues/3014.

### Test Plan
```
cargo run -p aptos --release -- node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
```
```
cargo run -- --pg-uri "postgresql://localhost/postgres" --node-url "http://localhost:8080" --emit-every 25 --batch-size 10
```
Previously you would get this error:
```
Caused by:
    invalid type: string "invalid_start_param", expected internally tagged enum AptosErrorCode at line 1 column 134
```

Now you get this:
```
2022-08-16T17:08:44.176943Z [tokio-runtime-worker] ERROR ecosystem/indexer/src/indexer/fetcher.rs:81 Could not fetch 500 transactions starting at 225826, will retry in 5000ms. Err: Request failed: Ok(AptosError { message: "Given start value (225826) is higher than the current ledger version, it must be < 706", error_code: Some(InvalidStartParam), aptos_ledger_version: None })
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3013)
<!-- Reviewable:end -->
