### PR TITLE
[move] Rename initialize_owner_only to initialize_stake_owner

### DIFF
--- a/api/goldens/aptos_api__tests__blocks_test__test_get_genesis_block_by_version.json
+++ b/api/goldens/aptos_api__tests__blocks_test__test_get_genesis_block_by_version.json
@@ -6523,7 +6523,7 @@
                   "return": []
                 },
                 {
-                  "name": "initialize_owner_only",
+                  "name": "initialize_stake_owner",
                   "visibility": "public",
                   "is_entry": true,
                   "generic_type_params": [],
@@ -17379,7 +17379,7 @@
                       "return": []
                     },
                     {
-                      "name": "initialize_owner_only",
+                      "name": "initialize_stake_owner",
                       "visibility": "public",
                       "is_entry": true,
                       "generic_type_params": [],

--- a/aptos-move/e2e-move-tests/src/stake.rs
+++ b/aptos-move/e2e-move-tests/src/stake.rs
@@ -32,7 +32,7 @@ pub fn initialize_staking(
 ) -> TransactionStatus {
     harness.run_transaction_payload(
         account,
-        aptos_stdlib::stake_initialize_owner_only(
+        aptos_stdlib::stake_initialize_stake_owner(
             initial_stake_amount,
             operator_address,
             voter_address,

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -144,7 +144,7 @@ module aptos_framework::genesis {
             aptos_coin::mint(aptos_framework, validator.owner_address, validator.stake_amount);
 
             // Initialize the stake pool and join the validator set.
-            stake::initialize_owner_only(
+            stake::initialize_stake_owner(
                 owner,
                 validator.stake_amount,
                 validator.operator_address,

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -367,7 +367,7 @@ module aptos_framework::stake {
     /// except it leaves the ValidatorConfig to be set by another entity.
     /// Note: this triggers setting the operator and owner, set it to the account's address
     /// to set later.
-    public entry fun initialize_owner_only(
+    public entry fun initialize_stake_owner(
         owner: &signer,
         initial_stake_amount: u64,
         operator: address,
@@ -2128,7 +2128,7 @@ module aptos_framework::stake {
         aptos_framework::coin::register_for_test<AptosCoin>(account);
         let address = signer::address_of(account);
         coin::deposit<AptosCoin>(address, coin::mint<AptosCoin>(1000, mint_cap));
-        initialize_owner_only(account, 0, address, address);
+        initialize_stake_owner(account, 0, address, address);
         add_stake(account, 100);
         assert_validator_state(signer::address_of(account), 100, 0, 0, 0, 0);
     }
@@ -2243,7 +2243,7 @@ module aptos_framework::stake {
         locked_until_secs: u64,
     ) acquires OwnerCapability, StakePool, ValidatorSet {
         let account_address = signer::address_of(account);
-        initialize_owner_only(account, 0, account_address, account_address);
+        initialize_stake_owner(account, 0, account_address, account_address);
         let stake_pool = borrow_global_mut<StakePool>(account_address);
         coin::merge(&mut stake_pool.active, active);
         coin::merge(&mut stake_pool.pending_inactive, pending_inactive);

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -164,7 +164,7 @@ pub enum EntryFunctionCall {
     /// except it leaves the ValidatorConfig to be set by another entity.
     /// Note: this triggers setting the operator and owner, set it to the account's address
     /// to set later.
-    StakeInitializeOwnerOnly {
+    StakeInitializeStakeOwner {
         initial_stake_amount: u64,
         operator: AccountAddress,
         voter: AccountAddress,
@@ -312,11 +312,11 @@ impl EntryFunctionCall {
             } => resource_account_create_resource_account(seed, optional_auth_key),
             StakeAddStake { amount } => stake_add_stake(amount),
             StakeIncreaseLockup {} => stake_increase_lockup(),
-            StakeInitializeOwnerOnly {
+            StakeInitializeStakeOwner {
                 initial_stake_amount,
                 operator,
                 voter,
-            } => stake_initialize_owner_only(initial_stake_amount, operator, voter),
+            } => stake_initialize_stake_owner(initial_stake_amount, operator, voter),
             StakeInitializeValidator {
                 consensus_pubkey,
                 proof_of_possession,
@@ -768,7 +768,7 @@ pub fn stake_increase_lockup() -> TransactionPayload {
 /// except it leaves the ValidatorConfig to be set by another entity.
 /// Note: this triggers setting the operator and owner, set it to the account's address
 /// to set later.
-pub fn stake_initialize_owner_only(
+pub fn stake_initialize_stake_owner(
     initial_stake_amount: u64,
     operator: AccountAddress,
     voter: AccountAddress,
@@ -781,7 +781,7 @@ pub fn stake_initialize_owner_only(
             ]),
             ident_str!("stake").to_owned(),
         ),
-        ident_str!("initialize_owner_only").to_owned(),
+        ident_str!("initialize_stake_owner").to_owned(),
         vec![],
         vec![
             bcs::to_bytes(&initial_stake_amount).unwrap(),
@@ -1231,9 +1231,9 @@ mod decoder {
         }
     }
 
-    pub fn stake_initialize_owner_only(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+    pub fn stake_initialize_stake_owner(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
-            Some(EntryFunctionCall::StakeInitializeOwnerOnly {
+            Some(EntryFunctionCall::StakeInitializeStakeOwner {
                 initial_stake_amount: bcs::from_bytes(script.args().get(0)?).ok()?,
                 operator: bcs::from_bytes(script.args().get(1)?).ok()?,
                 voter: bcs::from_bytes(script.args().get(2)?).ok()?,
@@ -1456,8 +1456,8 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
             Box::new(decoder::stake_increase_lockup),
         );
         map.insert(
-            "stake_initialize_owner_only".to_string(),
-            Box::new(decoder::stake_initialize_owner_only),
+            "stake_initialize_stake_owner".to_string(),
+            Box::new(decoder::stake_initialize_stake_owner),
         );
         map.insert(
             "stake_initialize_validator".to_string(),

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -172,7 +172,7 @@ impl CliCommand<Transaction> for InitializeStakeOwner {
     async fn execute(mut self) -> CliTypedResult<Transaction> {
         let owner_address = self.txn_options.sender_address()?;
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_initialize_owner_only(
+            .submit_transaction(aptos_stdlib::stake_initialize_stake_owner(
                 self.initial_stake_amount,
                 self.operator_address.unwrap_or(owner_address),
                 self.voter_address.unwrap_or(owner_address),


### PR DESCRIPTION
I've used this name in the CLI PR yesterday, but wanted to leave breaking change to move separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3015)
<!-- Reviewable:end -->
