### PR TITLE
[State Sync] Add tests to ensure that state sync can tolerate network frame limits

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -527,8 +527,8 @@ fn create_data_stream(
         .unwrap()],
     };
 
-    // Create a aptos data client mock and notification generator
-    let aptos_data_client = MockAptosDataClient::new(false);
+    // Create an aptos data client mock and notification generator
+    let aptos_data_client = MockAptosDataClient::new(false, false, false);
     let notification_generator = Arc::new(U64IdGenerator::new());
 
     // Return the data stream and listener pair


### PR DESCRIPTION
### Description
This PR adds new tests to ensure that state sync can tolerate network frame limits and non-contiguous data chunks from the prefetcher. How this works is: the driver will accept data from a stream as long as it is contiguous. When a gap in data is detected, the data chunk with the gap will be deemed invalid, dropped, and a new data stream will be started. In a future PR, I'll update the peer scoring logic to avoid penalizing the peer that sends the non-contiguous chunk. But, given this happens rarely, it should be okay.

### Test Plan
New tests!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3018)
<!-- Reviewable:end -->
