### PR TITLE
[aptos-genesis] Allow voters and operators to be split from owner in genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,27 +1290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aptos-transaction-replay"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "aptos-gas",
- "aptos-resource-viewer",
- "aptos-state-view",
- "aptos-types",
- "aptos-validator-interface",
- "aptos-vm",
- "aptosdb",
- "bcs",
- "difference",
- "framework",
- "hex",
- "move-deps",
- "structopt 0.3.26",
- "vm-genesis",
-]
-
-[[package]]
 name = "aptos-transactional-test-harness"
 version = "0.1.0"
 dependencies = [

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -99,7 +99,7 @@ pub fn new_test_context(test_name: String, use_db_with_indexer: bool) -> TestCon
     .with_randomize_first_validator_ports(false);
 
     let (root_key, genesis, genesis_waypoint, validators) = builder.build(&mut rng).unwrap();
-    let (validator_identity, _, _) = validators[0].get_key_objects(None).unwrap();
+    let (validator_identity, _, _, _) = validators[0].get_key_objects(None).unwrap();
     let validator_owner = validator_identity.account_address.unwrap();
 
     let (db, db_rw) = if use_db_with_indexer {

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -179,12 +179,16 @@ impl TryFrom<&ValidatorNodeConfig> for ValidatorConfiguration {
                 .try_into()?,
         );
         Ok(ValidatorConfiguration {
-            account_address: private_identity.account_address,
+            owner_account_address: private_identity.account_address,
+            owner_account_public_key: private_identity.account_private_key.public_key(),
+            operator_account_address: private_identity.account_address,
+            operator_account_public_key: private_identity.account_private_key.public_key(),
+            voter_account_address: private_identity.account_address,
+            voter_account_public_key: private_identity.account_private_key.public_key(),
             consensus_public_key: private_identity.consensus_private_key.public_key(),
             proof_of_possession: bls12381::ProofOfPossession::create(
                 &private_identity.consensus_private_key,
             ),
-            account_public_key: private_identity.account_private_key.public_key(),
             validator_network_public_key: private_identity
                 .validator_network_private_key
                 .public_key(),

--- a/crates/aptos-genesis/src/keys.rs
+++ b/crates/aptos-genesis/src/keys.rs
@@ -3,6 +3,7 @@
 
 use crate::config::{HostAndPort, ValidatorConfiguration};
 use aptos_config::{config::IdentityBlob, keys::ConfigKey};
+use aptos_crypto::ed25519::Ed25519PublicKey;
 use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519, PrivateKey};
 use aptos_keygen::KeyGen;
 use aptos_types::{account_address::AccountAddress, transaction::authenticator::AuthenticationKey};
@@ -16,6 +17,16 @@ pub struct PrivateIdentity {
     pub consensus_private_key: bls12381::PrivateKey,
     pub full_node_network_private_key: x25519::PrivateKey,
     pub validator_network_private_key: x25519::PrivateKey,
+}
+
+/// Type for serializing public keys file
+#[derive(Deserialize, Serialize)]
+pub struct PublicIdentity {
+    pub account_address: AccountAddress,
+    pub account_public_key: Ed25519PublicKey,
+    pub consensus_public_key: Option<bls12381::PublicKey>,
+    pub full_node_network_public_key: Option<x25519::PublicKey>,
+    pub validator_network_public_key: Option<x25519::PublicKey>,
 }
 
 /// Builds validator configuration from private identity
@@ -54,7 +65,7 @@ pub fn build_validator_configuration(
 /// Generates objects used for a user in genesis
 pub fn generate_key_objects(
     keygen: &mut KeyGen,
-) -> anyhow::Result<(IdentityBlob, IdentityBlob, PrivateIdentity)> {
+) -> anyhow::Result<(IdentityBlob, IdentityBlob, PrivateIdentity, PublicIdentity)> {
     let account_key = ConfigKey::new(keygen.generate_ed25519_private_key());
     let consensus_key = ConfigKey::new(keygen.generate_bls12381_private_key());
     let validator_network_key = ConfigKey::new(keygen.generate_x25519_private_key()?);
@@ -84,5 +95,13 @@ pub fn generate_key_objects(
         validator_network_private_key: validator_network_key.private_key(),
     };
 
-    Ok((validator_blob, vfn_blob, private_identity))
+    let public_identity = PublicIdentity {
+        account_address,
+        account_public_key: account_key.public_key(),
+        consensus_public_key: Some(consensus_key.public_key()),
+        full_node_network_public_key: Some(full_node_network_key.public_key()),
+        validator_network_public_key: Some(validator_network_key.public_key()),
+    };
+
+    Ok((validator_blob, vfn_blob, private_identity, public_identity))
 }

--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -23,6 +23,7 @@ pub fn test_config() -> (NodeConfig, Ed25519PrivateKey) {
         },
         _,
         _,
+        _,
     ) = validators[0].get_key_objects(None).unwrap();
     let mut configs = validators.into_iter().map(|v| v.config).collect::<Vec<_>>();
 

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -165,9 +165,17 @@ impl Client {
     pub fn put<T: Serialize + ?Sized>(&self, name: &Path, input: &T) -> CliTypedResult<()> {
         match self {
             Client::Local(local_repository_path) => {
-                self.create_dir(local_repository_path.as_path())?;
-
                 let path = local_repository_path.join(name);
+
+                // Create repository path and any sub-directories
+                if let Some(dir) = path.parent() {
+                    self.create_dir(dir)?;
+                } else {
+                    return Err(CliError::UnexpectedError(format!(
+                        "Path should always have a parent {}",
+                        path.display()
+                    )));
+                }
                 write_to_file(
                     path.as_path(),
                     &path.display().to_string(),

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -23,6 +23,7 @@ use clap::Parser;
 use std::path::PathBuf;
 
 const PRIVATE_KEYS_FILE: &str = "private-keys.yaml";
+const PUBLIC_KEYS_FILE: &str = "public-keys.yaml";
 const VALIDATOR_FILE: &str = "validator-identity.yaml";
 const VFN_FILE: &str = "validator-full-node-identity.yaml";
 
@@ -49,15 +50,17 @@ impl CliCommand<Vec<PathBuf>> for GenerateKeys {
     async fn execute(self) -> CliTypedResult<Vec<PathBuf>> {
         let output_dir = dir_default_to_current(self.output_dir.clone())?;
 
-        let keys_file = output_dir.join(PRIVATE_KEYS_FILE);
+        let private_keys_file = output_dir.join(PRIVATE_KEYS_FILE);
+        let public_keys_file = output_dir.join(PUBLIC_KEYS_FILE);
         let validator_file = output_dir.join(VALIDATOR_FILE);
         let vfn_file = output_dir.join(VFN_FILE);
-        check_if_file_exists(keys_file.as_path(), self.prompt_options)?;
+        check_if_file_exists(private_keys_file.as_path(), self.prompt_options)?;
+        check_if_file_exists(public_keys_file.as_path(), self.prompt_options)?;
         check_if_file_exists(validator_file.as_path(), self.prompt_options)?;
         check_if_file_exists(vfn_file.as_path(), self.prompt_options)?;
 
         let mut key_generator = self.rng_args.key_generator()?;
-        let (mut validator_blob, mut vfn_blob, private_identity) =
+        let (mut validator_blob, mut vfn_blob, private_identity, public_identity) =
             generate_key_objects(&mut key_generator)?;
 
         // Allow for the owner to be different than the operator
@@ -70,9 +73,14 @@ impl CliCommand<Vec<PathBuf>> for GenerateKeys {
         create_dir_if_not_exist(output_dir.as_path())?;
 
         write_to_user_only_file(
-            keys_file.as_path(),
+            private_keys_file.as_path(),
             PRIVATE_KEYS_FILE,
             to_yaml(&private_identity)?.as_bytes(),
+        )?;
+        write_to_user_only_file(
+            public_keys_file.as_path(),
+            PUBLIC_KEYS_FILE,
+            to_yaml(&public_identity)?.as_bytes(),
         )?;
         write_to_user_only_file(
             validator_file.as_path(),
@@ -80,7 +88,12 @@ impl CliCommand<Vec<PathBuf>> for GenerateKeys {
             to_yaml(&validator_blob)?.as_bytes(),
         )?;
         write_to_user_only_file(vfn_file.as_path(), VFN_FILE, to_yaml(&vfn_blob)?.as_bytes())?;
-        Ok(vec![keys_file, validator_file, vfn_file])
+        Ok(vec![
+            public_keys_file,
+            private_keys_file,
+            validator_file,
+            vfn_file,
+        ])
     }
 }
 

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -7,6 +7,7 @@ pub mod keys;
 mod tests;
 
 use crate::common::utils::dir_default_to_current;
+use crate::genesis::git::{OPERATOR_FILE, OWNER_FILE};
 use crate::{
     common::{
         types::{CliError, CliTypedResult, PromptOptions},
@@ -17,14 +18,14 @@ use crate::{
 };
 use aptos_crypto::{bls12381, ed25519::Ed25519PublicKey, x25519, ValidCryptoMaterialStringExt};
 use aptos_genesis::builder::GenesisConfiguration;
+use aptos_genesis::config::{StringOperatorConfiguration, StringOwnerConfiguration};
 use aptos_genesis::{
-    config::{HostAndPort, Layout, ValidatorConfiguration},
+    config::{Layout, ValidatorConfiguration},
     GenesisInfo,
 };
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
 use clap::Parser;
-use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::{path::PathBuf, str::FromStr};
 
@@ -167,67 +168,183 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
 
 /// Do proper parsing so more information is known about failures
 fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfiguration> {
-    let file = PathBuf::from(format!("{}.yaml", user));
-    let config = client.get::<StringValidatorConfiguration>(file.as_path())?;
+    // Load a user's configuration files
+    let dir = PathBuf::from(user);
+    let owner_file = dir.join(OWNER_FILE);
+    let owner_file = owner_file.as_path();
+    let owner_config = client.get::<StringOwnerConfiguration>(owner_file)?;
 
-    // Convert each individually
-    let account_address = AccountAddress::from_str(&config.account_address)
-        .map_err(|_| CliError::UnexpectedError("account_address invalid".to_string()))?;
-    let account_key = Ed25519PublicKey::from_encoded_string(&config.account_public_key)
-        .map_err(|_| CliError::UnexpectedError("account_key invalid".to_string()))?;
-    let consensus_key = bls12381::PublicKey::from_encoded_string(&config.consensus_public_key)
-        .map_err(|_| CliError::UnexpectedError("consensus_key invalid".to_string()))?;
-    let proof_of_possession =
-        bls12381::ProofOfPossession::from_encoded_string(&config.proof_of_possession)
-            .map_err(|_| CliError::UnexpectedError("proof_of_possession invalid".to_string()))?;
-    let validator_network_key =
-        x25519::PublicKey::from_encoded_string(&config.validator_network_public_key)
-            .map_err(|_| CliError::UnexpectedError("validator_network_key invalid".to_string()))?;
-    let validator_host = config.validator_host.clone();
-    let full_node_network_key =
-        if let Some(ref full_node_network_key) = config.full_node_network_public_key {
-            Some(
-                x25519::PublicKey::from_encoded_string(full_node_network_key).map_err(|_| {
-                    CliError::UnexpectedError("full_node_network_key invalid".to_string())
-                })?,
-            )
-        } else {
-            None
-        };
-    let full_node_host = config.full_node_host;
+    let operator_file = dir.join(OPERATOR_FILE);
+    let operator_file = operator_file.as_path();
+    let operator_config = client.get::<StringOperatorConfiguration>(operator_file)?;
 
+    // Check and convert fields in owner file
+    let owner_account_address = parse_required_option(
+        &owner_config.owner_account_address,
+        owner_file,
+        "owner_account_address",
+        AccountAddress::from_str,
+    )?;
+    let owner_account_public_key = parse_required_option(
+        &owner_config.owner_account_public_key,
+        owner_file,
+        "owner_account_public_key",
+        Ed25519PublicKey::from_encoded_string,
+    )?;
+
+    let operator_account_address = parse_required_option(
+        &owner_config.operator_account_address,
+        owner_file,
+        "operator_account_address",
+        AccountAddress::from_str,
+    )?;
+    let operator_account_public_key = parse_required_option(
+        &owner_config.operator_account_public_key,
+        owner_file,
+        "operator_account_public_key",
+        Ed25519PublicKey::from_encoded_string,
+    )?;
+
+    let voter_account_address = parse_required_option(
+        &owner_config.voter_account_address,
+        owner_file,
+        "voter_account_address",
+        AccountAddress::from_str,
+    )?;
+    let voter_account_public_key = parse_required_option(
+        &owner_config.voter_account_public_key,
+        owner_file,
+        "voter_account_public_key",
+        Ed25519PublicKey::from_encoded_string,
+    )?;
+
+    let stake_amount = parse_required_option(
+        &owner_config.stake_amount,
+        owner_file,
+        "stake_amount",
+        u64::from_str,
+    )?;
+
+    // Check and convert fields in operator file
+    let operator_account_address_from_file = parse_required_option(
+        &operator_config.operator_account_address,
+        operator_file,
+        "operator_account_address",
+        AccountAddress::from_str,
+    )?;
+    let operator_account_public_key_from_file = parse_required_option(
+        &operator_config.operator_account_public_key,
+        operator_file,
+        "operator_account_public_key",
+        Ed25519PublicKey::from_encoded_string,
+    )?;
+    let consensus_public_key = parse_required_option(
+        &operator_config.consensus_public_key,
+        operator_file,
+        "consensus_public_key",
+        bls12381::PublicKey::from_encoded_string,
+    )?;
+    let consensus_proof_of_possession = parse_required_option(
+        &operator_config.consensus_proof_of_possession,
+        operator_file,
+        "consensus_proof_of_possesion",
+        bls12381::ProofOfPossession::from_encoded_string,
+    )?;
+    let validator_network_public_key = parse_required_option(
+        &operator_config.validator_network_public_key,
+        operator_file,
+        "validator_network_public_key",
+        x25519::PublicKey::from_encoded_string,
+    )?;
+    let full_node_network_public_key = parse_optional_option(
+        &operator_config.full_node_network_public_key,
+        operator_file,
+        "full_node_network_public_key",
+        x25519::PublicKey::from_encoded_string,
+    )?;
+
+    // Verify owner & operator agree on operator
+    if operator_account_address != operator_account_address_from_file {
+        return Err(
+            CliError::CommandArgumentError(
+                format!("Operator account {} in owner file {} does not match operator account {} in operator file {}",
+                        operator_account_address,
+                        owner_file.display(),
+                        operator_account_address_from_file,
+                        operator_file.display()
+                )));
+    }
+    if operator_account_public_key != operator_account_public_key_from_file {
+        return Err(
+            CliError::CommandArgumentError(
+                format!("Operator public key {} in owner file {} does not match operator public key {} in operator file {}",
+                        operator_account_public_key,
+                        owner_file.display(),
+                        operator_account_public_key_from_file,
+                        operator_file.display()
+                )));
+    }
+
+    // Build Validator configuration
     Ok(ValidatorConfiguration {
-        account_address,
-        consensus_public_key: consensus_key,
-        proof_of_possession,
-        account_public_key: account_key,
-        validator_network_public_key: validator_network_key,
-        validator_host,
-        full_node_network_public_key: full_node_network_key,
-        full_node_host,
-        stake_amount: config.stake_amount,
+        owner_account_address,
+        owner_account_public_key,
+        operator_account_address,
+        operator_account_public_key,
+        voter_account_address,
+        voter_account_public_key,
+        consensus_public_key,
+        proof_of_possession: consensus_proof_of_possession,
+        validator_network_public_key,
+        validator_host: operator_config.validator_host.clone(),
+        full_node_network_public_key,
+        full_node_host: operator_config.full_node_host,
+        stake_amount,
     })
 }
 
-/// For better parsing error messages
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct StringValidatorConfiguration {
-    /// Account address
-    pub account_address: String,
-    /// Key used for signing in consensus
-    pub consensus_public_key: String,
-    /// Proof of possession of the consensus key
-    pub proof_of_possession: String,
-    /// Key used for signing transactions with the account
-    pub account_public_key: String,
-    /// Public key used for validator network identity (same as account address)
-    pub validator_network_public_key: String,
-    /// Host for validator which can be an IP or a DNS name
-    pub validator_host: HostAndPort,
-    /// Public key used for full node network identity (same as account address)
-    pub full_node_network_public_key: Option<String>,
-    /// Host for full node which can be an IP or a DNS name and is optional
-    pub full_node_host: Option<HostAndPort>,
-    /// Stake amount for consensus
-    pub stake_amount: u64,
+fn parse_required_option<F: Fn(&str) -> Result<T, E>, T, E: std::fmt::Display>(
+    option: &Option<String>,
+    file: &Path,
+    field_name: &'static str,
+    parse: F,
+) -> Result<T, CliError> {
+    if let Some(ref field) = option {
+        parse(field).map_err(|err| {
+            CliError::CommandArgumentError(format!(
+                "Field {} is invalid in file {}.  Err: {}",
+                field_name,
+                file.display(),
+                err
+            ))
+        })
+    } else {
+        Err(CliError::CommandArgumentError(format!(
+            "File {} is missing {}",
+            file.display(),
+            field_name
+        )))
+    }
+}
+
+fn parse_optional_option<F: Fn(&str) -> Result<T, E>, T, E: std::fmt::Display>(
+    option: &Option<String>,
+    file: &Path,
+    field_name: &'static str,
+    parse: F,
+) -> Result<Option<T>, CliError> {
+    if let Some(ref field) = option {
+        parse(field)
+            .map_err(|err| {
+                CliError::CommandArgumentError(format!(
+                    "Field {} is invalid in file {}.  Err: {}",
+                    field_name,
+                    file.display(),
+                    err
+                ))
+            })
+            .map(Some)
+    } else {
+        Ok(None)
+    }
 }

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -5,7 +5,7 @@ use crate::common::types::OptionalPoolAddressArgs;
 use crate::common::utils::read_from_file;
 use crate::genesis::git::from_yaml;
 use crate::genesis::git::FRAMEWORK_NAME;
-use crate::genesis::keys::GenerateLayoutTemplate;
+use crate::genesis::keys::{GenerateLayoutTemplate, PUBLIC_KEYS_FILE};
 use crate::{
     common::{
         types::{PromptOptions, RngArgs},
@@ -178,10 +178,12 @@ async fn add_public_keys(username: String, git_options: GitOptions, keys_dir: &P
     let command = SetValidatorConfiguration {
         username,
         git_options,
-        keys_dir: Some(PathBuf::from(keys_dir)),
+        owner_public_identity_file: Some(PathBuf::from(keys_dir).join(PUBLIC_KEYS_FILE)),
         validator_host: HostAndPort::from_str("localhost:6180").unwrap(),
-        full_node_host: None,
         stake_amount: 100_000_000_000_000,
+        full_node_host: None,
+        operator_public_identity_file: None,
+        voter_public_identity_file: None,
     };
 
     command.execute().await.unwrap()

--- a/terraform/helm/genesis/files/genesis.sh
+++ b/terraform/helm/genesis/files/genesis.sh
@@ -58,7 +58,7 @@ fi
 
 
 aptos genesis generate-keys --output-dir $user_dir
-aptos genesis set-validator-configuration --keys-dir $user_dir --local-repository-dir $WORKSPACE \
+aptos genesis set-validator-configuration --owner-public-identity-file $user_dir/public-keys.yaml --local-repository-dir $WORKSPACE \
     --username $username \
     --validator-host $validator_host \
     --full-node-host $fullnode_host \


### PR DESCRIPTION
### Description
Now you can have voters and operators in genesis.  Owner is the validator's address, and operator and voter is used for the other addresses.

### Test Plan
There's an E2E test for this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3023)
<!-- Reviewable:end -->
