### PR TITLE
[community] Dedicated layout for user Sign in

### DIFF
--- a/ecosystem/platform/server/app/controllers/users/sessions_controller.rb
+++ b/ecosystem/platform/server/app/controllers/users/sessions_controller.rb
@@ -5,6 +5,5 @@
 
 module Users
   class SessionsController < Devise::SessionsController
-    layout 'it3', only: %i[new]
   end
 end

--- a/ecosystem/platform/server/app/views/devise/sessions/new.html.erb
+++ b/ecosystem/platform/server/app/views/devise/sessions/new.html.erb
@@ -1,17 +1,18 @@
-<div class="flex flex-col lg:flex-row gap-8 sm:gap-24 xl:gap-48 justify-between flex-[2]">
-  <div>
-    <div class="max-w-prose mb-12 font-light sm:text-lg">
+<div class="bg-neutral-900 h-full px-4 sm:px-6 md:px-8 py-12 sm:py-24">
+  <div class="flex justify-center items-center w-full h-full">
+    <div class="max-w-xl w-full ">
       <%= render 'layouts/flash' %>
-      <%= render 'shared/it3_intro' %>
-    </div>
-    <div class="flex-1 p-8 rounded-lg bg-neutral-800 max-w-xl">
-      <h3 class="font-mono uppercase text-2xl mb-2">Sign in with</h3>
-      <div class="mb-8"><%= render DividerComponent.new %></div>
-      <div class="flex flex-col gap-3">
-        <%= render LoginButtonComponent.new(provider: :discord, size: :large, class: 'w-full') %>
-        <%= render LoginButtonComponent.new(provider: :google, size: :large, class: 'w-full') %>
-        <%= render LoginButtonComponent.new(provider: :github, size: :large, class: 'w-full') %>
-      </div>
+      <%= render CardOutlineComponent.new(scheme: :filled) do %>
+        <h3 class="flex items-start gap-2 font-mono uppercase text-xl mb-2 text-neutral-300">
+          Sign in with
+        </h3>
+        <div class="mb-8"><%= render DividerComponent.new %></div>
+        <div class="flex flex-col gap-3">
+          <%= render LoginButtonComponent.new(provider: :discord, size: :large, class: 'w-full') %>
+          <%= render LoginButtonComponent.new(provider: :google, size: :large, class: 'w-full') %>
+          <%= render LoginButtonComponent.new(provider: :github, size: :large, class: 'w-full') %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Description
Initial template for a dedicated Sign in page no longer reliant on AIT layout

### Test Plan
Manually test "Sign in" links and verify the following layout: 

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/98909677/184996025-5ab2b6bc-8ca3-4510-84e8-1aa1e7dad98b.png">

<img width="1467" alt="image" src="https://user-images.githubusercontent.com/98909677/184996075-7d48fbe1-9934-41a3-893d-32a03cfe4317.png">

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/98909677/185003199-47cdc51c-d6af-4c09-a424-bb6c56474704.png">

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/98909677/185003169-c12cbac9-5bd0-4f7e-b3b1-5ab0e9527fc4.png">


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3026)
<!-- Reviewable:end -->
