### PR TITLE
[types] Remove private usage of anyhow

### DIFF
--- a/types/src/network_address/mod.rs
+++ b/types/src/network_address/mod.rs
@@ -484,7 +484,7 @@ impl TryFrom<Vec<Protocol>> for NetworkAddress {
 
     fn try_from(value: Vec<Protocol>) -> Result<Self, Self::Error> {
         if value.is_empty() {
-            anyhow::private::Err(ParseError::EmptyProtocolString)
+            Err(ParseError::EmptyProtocolString)
         } else {
             NetworkAddress::from_protocols(value)
         }


### PR DESCRIPTION
This was blocking cargo install for some reason

### Description
When running `cargo install aptos`
```
   Compiling move-deps v0.0.1 (/Users/greg/.cargo/git/checkouts/aptos-core-8f3268fcf79e1f38/157a3f6/aptos-move/move-deps)
   Compiling aptos-types v0.0.3 (/Users/greg/.cargo/git/checkouts/aptos-core-8f3268fcf79e1f38/157a3f6/types)
error[E0433]: failed to resolve: could not find `private` in `anyhow`
   --> types/src/network_address/mod.rs:487:21
    |
487 |             anyhow::private::Err(ParseError::EmptyProtocolString)
    |                     ^^^^^^^ could not find `private` in `anyhow`

For more information about this error, try `rustc --explain E0433`.
```

### Test Plan
TBD once this is in main

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3031)
<!-- Reviewable:end -->
