### PR TITLE
[storage][pruner] Add index to avoid seek_to_first on pruner startup

### DIFF
--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -29,6 +29,7 @@ pub(super) fn ledger_db_column_families() -> Vec<ColumnFamilyName> {
         TRANSACTION_INFO_CF_NAME,
         VERSION_DATA_CF_NAME,
         WRITE_SET_CF_NAME,
+        DB_METADATA_CF_NAME,
     ]
 }
 
@@ -37,6 +38,7 @@ pub(super) fn state_merkle_db_column_families() -> Vec<ColumnFamilyName> {
         /* empty cf */ DEFAULT_COLUMN_FAMILY_NAME,
         JELLYFISH_MERKLE_NODE_CF_NAME,
         STALE_NODE_INDEX_CF_NAME,
+        DB_METADATA_CF_NAME,
     ]
 }
 

--- a/storage/aptosdb/src/pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod event_store;
 pub(crate) mod ledger_pruner_worker;
 pub(crate) mod ledger_store;
 pub(crate) mod pruner_manager;
+pub(crate) mod pruner_metadata;
 pub(crate) mod state_pruner_worker;
 pub(crate) mod state_store;
 pub(crate) mod transaction_store;

--- a/storage/aptosdb/src/pruner/pruner_metadata.rs
+++ b/storage/aptosdb/src/pruner/pruner_metadata.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_types::transaction::Version;
+use num_derive::FromPrimitive;
+use num_derive::ToPrimitive;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+pub(crate) enum PrunerMetadata {
+    LatestVersion(Version),
+}
+
+#[derive(Clone, Debug, Deserialize, FromPrimitive, PartialEq, ToPrimitive, Serialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
+#[repr(u8)]
+pub(crate) enum PrunerTag {
+    StateMerklePruner = 0,
+    LedgerPruner = 1,
+}

--- a/storage/aptosdb/src/pruner/state_store/mod.rs
+++ b/storage/aptosdb/src/pruner/state_store/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::pruner::pruner_metadata::{PrunerMetadata, PrunerTag};
+use crate::pruner_metadata::PrunerMetadataSchema;
 use crate::{
     jellyfish_merkle_node::JellyfishMerkleNodeSchema, metrics::PRUNER_LEAST_READABLE_VERSION,
     pruner::db_pruner::DBPruner, stale_node_index::StaleNodeIndexSchema, utils, ChangeSet,
@@ -24,7 +26,8 @@ pub const STATE_MERKLE_PRUNER_NAME: &str = "state_merkle_pruner";
 #[derive(Debug)]
 /// Responsible for pruning the state tree.
 pub struct StateMerklePruner {
-    db: Arc<DB>,
+    /// State DB.
+    state_merkle_db: Arc<DB>,
     /// Keeps track of the target version that the pruner needs to achieve.
     target_version: AtomicVersion,
     min_readable_version: AtomicVersion,
@@ -60,16 +63,12 @@ impl DBPruner for StateMerklePruner {
     }
 
     fn initialize_min_readable_version(&self) -> Result<Version> {
-        let mut iter = self
-            .db
-            .iter::<StaleNodeIndexSchema>(ReadOptions::default())?;
-        iter.seek_to_first();
-        Ok(iter.next().transpose()?.map_or(0, |(index, _)| {
-            index
-                .stale_since_version
-                .checked_sub(1)
-                .expect("Nothing is stale since version 0.")
-        }))
+        Ok(self
+            .state_merkle_db
+            .get::<PrunerMetadataSchema>(&PrunerTag::StateMerklePruner)?
+            .map_or(0, |pruned_until_version| match pruned_until_version {
+                PrunerMetadata::LatestVersion(version) => version,
+            }))
     }
 
     fn min_readable_version(&self) -> Version {
@@ -106,9 +105,9 @@ impl DBPruner for StateMerklePruner {
 }
 
 impl StateMerklePruner {
-    pub fn new(db: Arc<DB>) -> Self {
+    pub fn new(state_merkle_db: Arc<DB>) -> Self {
         let pruner = StateMerklePruner {
-            db,
+            state_merkle_db,
             target_version: AtomicVersion::new(0),
             min_readable_version: AtomicVersion::new(0),
             pruned_to_the_end_of_target_version: AtomicBool::new(false),
@@ -137,6 +136,9 @@ impl StateMerklePruner {
         Ok(())
     }
 
+    // If the existing schema batch is not none, this function only adds items need to be
+    // deleted to the schema batch and the caller is responsible for committing the schema batches
+    // to the DB.
     pub fn prune_state_store(
         &self,
         min_readable_version: Version,
@@ -172,8 +174,13 @@ impl StateMerklePruner {
                     batch.delete::<StaleNodeIndexSchema>(&index)
                 })?;
 
-                // Delete the stale node indices.
-                self.db.write_schemas(batch)?;
+                batch.put::<PrunerMetadataSchema>(
+                    &PrunerTag::StateMerklePruner,
+                    &PrunerMetadata::LatestVersion(new_min_readable_version),
+                )?;
+
+                // Commit to DB.
+                self.state_merkle_db.write_schemas(batch)?;
             }
 
             // TODO(zcc): recording progress after writing schemas might provide wrong answers to
@@ -194,7 +201,7 @@ impl StateMerklePruner {
     ) -> Result<(Vec<StaleNodeIndex>, bool)> {
         let mut indices = Vec::new();
         let mut iter = self
-            .db
+            .state_merkle_db
             .iter::<StaleNodeIndexSchema>(ReadOptions::default())?;
         iter.seek(&start_version)?;
 

--- a/storage/aptosdb/src/schema/mod.rs
+++ b/storage/aptosdb/src/schema/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod event_by_version;
 pub(crate) mod jellyfish_merkle_node;
 pub(crate) mod ledger_counters;
 pub(crate) mod ledger_info;
+pub(crate) mod pruner_metadata;
 pub(crate) mod stale_node_index;
 pub(crate) mod stale_state_value_index;
 pub(crate) mod state_value;
@@ -48,6 +49,7 @@ pub const TRANSACTION_BY_HASH_CF_NAME: ColumnFamilyName = "transaction_by_hash";
 pub const TRANSACTION_INFO_CF_NAME: ColumnFamilyName = "transaction_info";
 pub const VERSION_DATA_CF_NAME: ColumnFamilyName = "version_data";
 pub const WRITE_SET_CF_NAME: ColumnFamilyName = "write_set";
+pub const DB_METADATA_CF_NAME: ColumnFamilyName = "db_metadata";
 
 fn ensure_slice_len_eq(data: &[u8], len: usize) -> Result<()> {
     ensure!(
@@ -102,6 +104,7 @@ pub mod fuzzing {
             assert_no_panic_decoding::<super::transaction_info::TransactionInfoSchema>(data);
             assert_no_panic_decoding::<super::version_data::VersionDataSchema>(data);
             assert_no_panic_decoding::<super::write_set::WriteSetSchema>(data);
+            assert_no_panic_decoding::<super::pruner_metadata::PrunerMetadataSchema>(data);
         }
     }
 }

--- a/storage/aptosdb/src/schema/pruner_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/pruner_metadata/mod.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+//! This module defines the physical storage schema for indexes of min_readable_version of pruners.
+//! For the state pruner, the metadata represents the key of the StaleNodeIndexSchema and for the
+//! ledger pruner, the metadata represents the key of the TransactionSchema.
+//!
+//! ```text
+//! |<------key---->|<------ value ----->|
+//! | pruner tag    | pruned until values|
+//! ```
+//!
+
+use crate::pruner::pruner_metadata::{PrunerMetadata, PrunerTag};
+use crate::schema::DB_METADATA_CF_NAME;
+use anyhow::{anyhow, Result};
+use byteorder::ReadBytesExt;
+use num_traits::{FromPrimitive, ToPrimitive};
+use schemadb::{
+    define_schema,
+    schema::{KeyCodec, ValueCodec},
+};
+
+define_schema!(
+    PrunerMetadataSchema,
+    PrunerTag,
+    PrunerMetadata,
+    DB_METADATA_CF_NAME
+);
+
+impl KeyCodec<PrunerMetadataSchema> for PrunerTag {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        Ok(vec![self.to_u8().unwrap()])
+    }
+
+    fn decode_key(mut data: &[u8]) -> Result<Self> {
+        Self::from_u8(data.read_u8()?).ok_or_else(|| anyhow!("Failed to parse PrunerTag."))
+    }
+}
+
+impl ValueCodec<PrunerMetadataSchema> for PrunerMetadata {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(bcs::to_bytes(self)?)
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        Ok(bcs::from_bytes(data)?)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/storage/aptosdb/src/schema/pruner_metadata/test.rs
+++ b/storage/aptosdb/src/schema/pruner_metadata/test.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use proptest::prelude::*;
+use schemadb::{schema::fuzzing::assert_encode_decode, test_no_panic_decoding};
+
+proptest! {
+    #[test]
+    fn test_encode_decode(
+        tag in any::<PrunerTag>(),
+        version in any::<PrunerMetadata>(),
+    ) {
+        assert_encode_decode::<PrunerMetadataSchema>(&tag, &version);
+    }
+}
+
+test_no_panic_decoding!(PrunerMetadataSchema);

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -254,7 +254,6 @@ fn test_stale_node_index() {
     let tmp_dir = TempPath::new();
     let db = AptosDB::new_for_test(&tmp_dir);
     let store = &db.state_store;
-    let pruner = StateMerklePruner::new(Arc::clone(&db.state_merkle_db));
 
     // Update.
     // ```text
@@ -299,6 +298,7 @@ fn test_stale_node_index() {
     // Prune with limit = 2 and target_min_readable_version = 2, two entries with
     // stale_since_version = 1 will be pruned. min_readable_version will be promoted to 1.
     {
+        let pruner = StateMerklePruner::new(Arc::clone(&db.state_merkle_db));
         assert_eq!(
             prune_stale_indices(
                 &pruner, 0, /* min_readable_version */
@@ -319,6 +319,7 @@ fn test_stale_node_index() {
     // stale_since_version = 2 will be pruned. Min readable version will change even though there
     // is one more entry with stale_since_version = 2 remaining.
     {
+        let pruner = StateMerklePruner::new(Arc::clone(&db.state_merkle_db));
         assert_eq!(
             prune_stale_indices(
                 &pruner, 1, /* min_readable_version */
@@ -340,6 +341,7 @@ fn test_stale_node_index() {
     // stale_since_version = 2 will be pruned. Min_readable_version will change since there is
     // one more entry with stale_since_version = 2 remaining.
     {
+        let pruner = StateMerklePruner::new(Arc::clone(&db.state_merkle_db));
         assert_eq!(
             prune_stale_indices(
                 &pruner, 1, /* min_readable_version */
@@ -374,7 +376,6 @@ fn test_stale_node_index_with_target_version() {
     let tmp_dir = TempPath::new();
     let db = AptosDB::new_for_test(&tmp_dir);
     let store = &db.state_store;
-    let pruner = StateMerklePruner::new(Arc::clone(&db.state_merkle_db));
 
     // Update.
     // ```text
@@ -417,8 +418,10 @@ fn test_stale_node_index_with_target_version() {
 
     // Verify.
     // Prune with limit = 2 and target_min_readable_version = 1, two entries with
-    // stale_since_version = 1 will be pruned. min_readable_version will be promoted to 1.
+    // stale_since_version = 1 will be pruned. min_readable_version will be promoted to 1. Create a
+    // new pruner everytime to test the min_readable_version initialization logic.
     {
+        let pruner = StateMerklePruner::new(Arc::clone(&db.state_merkle_db));
         assert_eq!(
             prune_stale_indices(
                 &pruner, 0, /* min_readable_version */
@@ -444,8 +447,10 @@ fn test_stale_node_index_with_target_version() {
         verify_value_and_proof(store, key3.clone(), Some(&value3), 1, root1);
     }
     // Prune with limit = 1 and target_min_readable_version = 1, entries with
-    // stale_since_version = 2 will not be pruned.
+    // stale_since_version = 2 will not be pruned. Create a new pruner everytime to test the
+    // min_readable_version initialization logic.
     {
+        let pruner = StateMerklePruner::new(Arc::clone(&db.state_merkle_db));
         assert_eq!(
             prune_stale_indices(
                 &pruner, 1, /* min_readable_version */


### PR DESCRIPTION
### Description
- When initializing min_readable_version in pruner, avoid using seek_to_first due to https://github.com/facebook/rocksdb/issues/5265.
- Create a DB index to memorize the min_readable_version pruned to every time and store it in the ledger db for ledger pruner and state db for state pruner. On machine restart, read the min_readable_version from the directly instead of using seek_to_first

### Test Plan
In the existing UTs, create a pruner before every pruning operation instead of keep using the same pruner to touch the min_readable_version initialization code path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3032)
<!-- Reviewable:end -->
