### PR TITLE
[api] reduce api log rate to 1 per second

### DIFF
--- a/api/src/log.rs
+++ b/api/src/log.rs
@@ -49,7 +49,7 @@ pub async fn middleware_log<E: Endpoint>(next: E, request: Request) -> Result<Re
     if log.status >= 500 {
         sample!(SampleRate::Duration(Duration::from_secs(1)), error!(log));
     } else {
-        debug!(log);
+        sample!(SampleRate::Duration(Duration::from_secs(1)), debug!(log));
     }
 
     // Log response statuses generally.


### PR DESCRIPTION
### Description

This single line was contributing to the vast majority of log lines.

### Test Plan

Rely on land-blocking forge test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3034)
<!-- Reviewable:end -->
