### PR TITLE
[SDK] Replace []byte with Bytes so golang sdk is buildable

### DIFF
--- a/aptos-move/aptos-sdk-builder/src/golang.rs
+++ b/aptos-move/aptos-sdk-builder/src/golang.rs
@@ -728,7 +728,7 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
                 format!("[]{}", Self::quote_type(type_tag))
             }
             Struct(struct_tag) => match struct_tag {
-                tag if tag == Lazy::force(&str_tag) => "[]byte".into(),
+                tag if tag == Lazy::force(&str_tag) => "Bytes".into(),
                 _ => common::type_not_allowed(type_tag),
             },
             Signer => common::type_not_allowed(type_tag),
@@ -774,12 +774,12 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
             U128 => Some("U128"),
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
-                U8 => Some("[]byte"),
+                U8 => Some("Bytes"),
                 type_tag => Self::bcs_primitive_type_name(type_tag).and(None),
                 // _ => common::type_not_allowed(type_tag),
             },
             Struct(struct_tag) => match struct_tag {
-                tag if tag == Lazy::force(&str_tag) => Some("[]byte"),
+                tag if tag == Lazy::force(&str_tag) => Some("Bytes"),
                 _ => common::type_not_allowed(type_tag),
             },
             Signer => common::type_not_allowed(type_tag),


### PR DESCRIPTION
### Description

* Replaces []byte with Bytes so sdk is buildable.
* Currently in main, the SDK contains functions defined as `Deserialize[]byte()` which fail to compile.
* Any suggestion would be helpful!

### Test Plan

Tested locally
1. Generated a framework release on `d45d355a2414791d48e879cfe4d14bd3b5630d41`
2. Generated using the go sdk builder
3. Go build succeeds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3038)
<!-- Reviewable:end -->
