### PR TITLE
[aptos-rosetta] Add gas fee operation to rosetta

### DIFF
--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -83,6 +83,7 @@ pub enum OperationType {
     CreateAccount,
     Deposit,
     Withdraw,
+    Fee,
     SetOperator,
 }
 
@@ -90,6 +91,7 @@ impl OperationType {
     const CREATE_ACCOUNT: &'static str = "create_account";
     const DEPOSIT: &'static str = "deposit";
     const WITHDRAW: &'static str = "withdraw";
+    const FEE: &'static str = "fee";
     const SET_OPERATOR: &'static str = "set_operator";
 
     pub fn all() -> Vec<OperationType> {
@@ -97,6 +99,7 @@ impl OperationType {
             OperationType::CreateAccount,
             OperationType::Deposit,
             OperationType::Withdraw,
+            OperationType::Fee,
             OperationType::SetOperator,
         ]
     }
@@ -110,6 +113,7 @@ impl FromStr for OperationType {
             Self::CREATE_ACCOUNT => Ok(OperationType::CreateAccount),
             Self::DEPOSIT => Ok(OperationType::Deposit),
             Self::WITHDRAW => Ok(OperationType::Withdraw),
+            Self::FEE => Ok(OperationType::Fee),
             Self::SET_OPERATOR => Ok(OperationType::SetOperator),
             _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
@@ -126,6 +130,7 @@ impl Display for OperationType {
             OperationType::Deposit => Self::DEPOSIT,
             OperationType::Withdraw => Self::WITHDRAW,
             OperationType::SetOperator => Self::SET_OPERATOR,
+            OperationType::Fee => Self::FEE,
         })
     }
 }


### PR DESCRIPTION
### Description
Split gas fee into a different operation

### Test Plan
E2E test handles it accordingly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3039)
<!-- Reviewable:end -->
