### PR TITLE
[CP] set default font-weight to 300

### DIFF
--- a/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
+++ b/ecosystem/platform/server/app/assets/stylesheets/application.tailwind.css
@@ -3,6 +3,9 @@
 @tailwind utilities;
 
 @layer base {
+  html {
+    font-weight:300;
+  }
   [type='checkbox']:checked {
       background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='black' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
   }
@@ -15,6 +18,7 @@ html {
 
 .font-mono {
   font-variant-ligatures: none;
+  font-weight: 400;
 }
 
 dialog::backdrop {

--- a/ecosystem/platform/server/tailwind.config.js
+++ b/ecosystem/platform/server/tailwind.config.js
@@ -36,6 +36,9 @@ module.exports = {
         mono: ["lft-etica-mono", ...defaultTheme.fontFamily.mono],
         display: ["apparat-semicond", ...defaultTheme.fontFamily.sans],
       },
+      fontWeight: {
+        normal: 300,
+      },
       screens: {
         'max-sm': {'max': '767px'},
       }


### PR DESCRIPTION
### Description
Set default font-weight to 300 to prevent need for `font-light` everywhere. This is due to a "mismatch" between Apparat's normal weight (300) v.s. browser / Tailwind default weight (400). 

### Test Plan
Check any text (or parent element) without adding `font-light` class to match Apparat's proper weight for _normal_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3046)
<!-- Reviewable:end -->
