### PR TITLE
[aptos-cli] Make input args consistent and commented

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -14,11 +14,12 @@ pub const DEFAULT_FUNDED_COINS: u64 = 10_000;
 ///
 #[derive(Debug, Parser)]
 pub struct CreateAccount {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
     /// Address of the new account
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -20,9 +20,6 @@ use std::str::FromStr;
 /// 2. Use a faucet to create the account
 #[derive(Debug, Parser)]
 pub struct CreateResourceAccount {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
-
     /// Resource account seed
     ///
     /// Seed used in generation of the AccountId of the resource account
@@ -33,6 +30,9 @@ pub struct CreateResourceAccount {
     /// Optional Resource Account authentication key.
     #[clap(long, parse(try_from_str = AuthenticationKey::from_str))]
     pub(crate) authentication_key: Option<AuthenticationKey>,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 /// A shortened create resource account output

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -16,6 +16,7 @@ use clap::Parser;
 
 /// Command to fund an account with tokens from a faucet
 ///
+/// If the account doesn't exist, it will create it when funding it from the faucet
 #[derive(Debug, Parser)]
 pub struct FundWithFaucet {
     /// Address to fund

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -24,7 +24,7 @@ pub struct FundWithFaucet {
 
     /// Coins to fund when using the faucet
     #[clap(long, default_value_t = DEFAULT_FUNDED_COINS)]
-    pub(crate) num_coins: u64,
+    pub(crate) amount: u64,
 
     #[clap(flatten)]
     pub(crate) faucet_options: FaucetOptions,
@@ -44,7 +44,7 @@ impl CliCommand<String> for FundWithFaucet {
         let hashes = fund_account(
             self.faucet_options
                 .faucet_url(&self.profile_options.profile)?,
-            self.num_coins,
+            self.amount,
             self.account,
         )
         .await?;
@@ -59,7 +59,7 @@ impl CliCommand<String> for FundWithFaucet {
         }
         return Ok(format!(
             "Added {} coins to account {}",
-            self.num_coins, self.account
+            self.amount, self.account
         ));
     }
 }

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -18,18 +18,20 @@ use clap::Parser;
 ///
 #[derive(Debug, Parser)]
 pub struct FundWithFaucet {
-    #[clap(flatten)]
-    pub(crate) profile_options: ProfileOptions,
     /// Address to fund
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
-    #[clap(flatten)]
-    pub(crate) faucet_options: FaucetOptions,
+
     /// Coins to fund when using the faucet
     #[clap(long, default_value_t = DEFAULT_FUNDED_COINS)]
     pub(crate) num_coins: u64,
+
+    #[clap(flatten)]
+    pub(crate) faucet_options: FaucetOptions,
     #[clap(flatten)]
     pub(crate) rest_options: RestOptions,
+    #[clap(flatten)]
+    pub(crate) profile_options: ProfileOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -48,12 +48,6 @@ impl FromStr for ListQuery {
 ///
 #[derive(Debug, Parser)]
 pub struct ListAccount {
-    #[clap(flatten)]
-    pub(crate) rest_options: RestOptions,
-
-    #[clap(flatten)]
-    pub(crate) profile_options: ProfileOptions,
-
     /// Address of the account you want to list resources/modules for
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: Option<AccountAddress>,
@@ -61,6 +55,11 @@ pub struct ListAccount {
     /// Type of items to list: [balance, resources, modules]
     #[clap(long, default_value_t = ListQuery::Resources)]
     pub(crate) query: ListQuery,
+
+    #[clap(flatten)]
+    pub(crate) rest_options: RestOptions,
+    #[clap(flatten)]
+    pub(crate) profile_options: ProfileOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -18,9 +18,6 @@ use std::collections::BTreeMap;
 ///
 #[derive(Debug, Parser)]
 pub struct TransferCoins {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
-
     /// Address of account you want to send coins to
     #[clap(long, parse(try_from_str = crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
@@ -28,6 +25,9 @@ pub struct TransferCoins {
     /// Amount of coins to transfer
     #[clap(long)]
     pub(crate) amount: u64,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -44,10 +44,7 @@ impl CliCommand<TransferSummary> for TransferCoins {
     }
 }
 
-const SUPPORTED_COINS: [&str; 2] = [
-    "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
-    "0x1::coin::CoinStore<0x1::aptoscoin::AptosCoin>",
-];
+const SUPPORTED_COINS: [&str; 1] = ["0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>"];
 
 /// A shortened transaction output
 #[derive(Clone, Debug, Serialize)]

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -28,12 +28,15 @@ pub struct InitTool {
     /// URL to a fullnode on the network
     #[clap(long)]
     pub rest_url: Option<Url>,
+
     /// URL for the Faucet endpoint
     #[clap(long)]
     pub faucet_url: Option<Url>,
+
     /// Whether to skip the faucet for a non-faucet endpoint
     #[clap(long)]
     pub skip_faucet: bool,
+
     #[clap(flatten)]
     pub rng_args: RngArgs,
     #[clap(flatten)]

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -687,7 +687,7 @@ pub struct RestOptions {
     /// URL to a fullnode on the network
     ///
     /// Defaults to <https://fullnode.devnet.aptoslabs.com/v1>
-    #[clap(long, parse(try_from_str))]
+    #[clap(long)]
     url: Option<reqwest::Url>,
 }
 
@@ -1119,25 +1119,13 @@ impl TransactionOptions {
 #[derive(Parser)]
 pub struct OptionalPoolAddressArgs {
     /// Address of the Staking pool
-    #[clap(long)]
-    pub(crate) pool_address: Option<AccountAddressWrapper>,
-}
-
-impl OptionalPoolAddressArgs {
-    pub fn pool_address(&self) -> Option<AccountAddress> {
-        self.pool_address.map(|inner| inner.account_address)
-    }
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) pool_address: Option<AccountAddress>,
 }
 
 #[derive(Parser)]
 pub struct PoolAddressArgs {
     /// Address of the Staking pool
-    #[clap(long)]
-    pub(crate) pool_address: AccountAddressWrapper,
-}
-
-impl PoolAddressArgs {
-    pub fn pool_address(&self) -> AccountAddress {
-        self.pool_address.account_address
-    }
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) pool_address: AccountAddress,
 }

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -52,6 +52,7 @@ pub struct GenerateShellCompletions {
     /// Shell to generate completions for one of [bash, elvish, powershell, zsh]
     #[clap(long)]
     shell: Shell,
+
     /// File to output shell completions to
     #[clap(long, parse(from_os_str))]
     output_file: PathBuf,

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -82,12 +82,15 @@ pub struct GitOptions {
     /// Github repository e.g. 'aptos-labs/aptos-core'
     #[clap(long)]
     pub(crate) github_repository: Option<GithubRepo>,
+
     /// Github repository branch e.g. main
     #[clap(long, default_value = "main")]
     pub(crate) github_branch: String,
+
     /// Path to Github API token.  Token must have repo:* permissions
     #[clap(long, parse(from_os_str))]
     pub(crate) github_token_file: Option<PathBuf>,
+
     /// Path to local git repository
     #[clap(long, parse(from_os_str))]
     pub(crate) local_repository_dir: Option<PathBuf>,

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -33,6 +33,7 @@ pub const FRAMEWORK_NAME: &str = "framework.mrb";
 pub struct SetupGit {
     #[clap(flatten)]
     pub(crate) git_options: GitOptions,
+
     /// Path to the `Layout` file which defines where all the files are
     #[clap(long, parse(from_os_str))]
     pub(crate) layout_file: PathBuf,

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -62,7 +62,7 @@ impl CliCommand<Vec<PathBuf>> for GenerateKeys {
             generate_key_objects(&mut key_generator)?;
 
         // Allow for the owner to be different than the operator
-        if let Some(pool_address) = self.pool_address_args.pool_address() {
+        if let Some(pool_address) = self.pool_address_args.pool_address {
             validator_blob.account_address = Some(pool_address);
             vfn_blob.account_address = Some(pool_address);
         }

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -101,26 +101,33 @@ pub struct SetValidatorConfiguration {
     /// Name of validator
     #[clap(long)]
     pub(crate) username: String,
-    #[clap(flatten)]
-    pub(crate) git_options: GitOptions,
+
     /// Host and port pair for the validator e.g. 127.0.0.1:6180 or aptoslabs.com:6180
     #[clap(long)]
     pub(crate) validator_host: HostAndPort,
+
     /// Host and port pair for the fullnode e.g. 127.0.0.1:6180 or aptoslabs.com:6180
     #[clap(long)]
     pub(crate) full_node_host: Option<HostAndPort>,
+
     /// Stake amount for stake distribution
     #[clap(long, default_value_t = 1)]
     pub(crate) stake_amount: u64,
+
     /// Path to private identity generated from GenerateKeys
     #[clap(long, parse(from_os_str))]
     pub(crate) owner_public_identity_file: Option<PathBuf>,
+
     /// Path to operator public identity, defaults to owner identity
     #[clap(long, parse(from_os_str))]
     pub(crate) operator_public_identity_file: Option<PathBuf>,
+
     /// Path to voter public identity, defaults to owner identity
     #[clap(long, parse(from_os_str))]
     pub(crate) voter_public_identity_file: Option<PathBuf>,
+
+    #[clap(flatten)]
+    pub(crate) git_options: GitOptions,
 }
 
 #[async_trait]
@@ -242,6 +249,7 @@ pub struct GenerateLayoutTemplate {
     /// Path of the output layout template
     #[clap(long, parse(from_os_str), default_value = LAYOUT_FILE)]
     pub(crate) output_file: PathBuf,
+
     #[clap(flatten)]
     pub(crate) prompt_options: PromptOptions,
 }

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -27,15 +27,16 @@ const VFN_FILE: &str = "validator-full-node-identity.yaml";
 /// Generate account key, consensus key, and network key for a validator
 #[derive(Parser)]
 pub struct GenerateKeys {
+    /// Output directory for the key files
+    #[clap(long, parse(from_os_str))]
+    pub(crate) output_dir: Option<PathBuf>,
+
     #[clap(flatten)]
     pub(crate) pool_address_args: OptionalPoolAddressArgs,
     #[clap(flatten)]
     pub(crate) prompt_options: PromptOptions,
     #[clap(flatten)]
     pub rng_args: RngArgs,
-    /// Output directory for the key files
-    #[clap(long, parse(from_os_str))]
-    pub(crate) output_dir: Option<PathBuf>,
 }
 
 #[async_trait]

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -60,13 +60,14 @@ impl GenesisTool {
 /// Generate genesis from a git repository
 #[derive(Parser)]
 pub struct GenerateGenesis {
+    /// Output directory for Genesis file and waypoint
+    #[clap(long, parse(from_os_str))]
+    output_dir: Option<PathBuf>,
+
     #[clap(flatten)]
     prompt_options: PromptOptions,
     #[clap(flatten)]
     git_options: GitOptions,
-    /// Output directory for Genesis file and waypoint
-    #[clap(long, parse(from_os_str))]
-    output_dir: Option<PathBuf>,
 }
 
 #[async_trait]

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -126,7 +126,7 @@ impl CliCommand<Transaction> for SubmitProposal {
                 "create_proposal",
                 vec![],
                 vec![
-                    bcs::to_bytes(&self.pool_address_args.pool_address())?,
+                    bcs::to_bytes(&self.pool_address_args.pool_address)?,
                     bcs::to_bytes(&self.execution_hash)?,
                     bcs::to_bytes(&self.metadata_url.to_string())?,
                     bcs::to_bytes(&metadata_hash)?,
@@ -180,7 +180,7 @@ impl CliCommand<Transaction> for SubmitVote {
                 "vote",
                 vec![],
                 vec![
-                    bcs::to_bytes(&self.pool_address_args.pool_address())?,
+                    bcs::to_bytes(&self.pool_address_args.pool_address)?,
                     bcs::to_bytes(&self.proposal_id)?,
                     bcs::to_bytes(&self.should_pass)?,
                 ],

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -60,19 +60,20 @@ impl GovernanceTool {
 /// Submit proposal to other validators to be proposed on
 #[derive(Parser)]
 pub struct SubmitProposal {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
-    #[clap(flatten)]
-    pub(crate) pool_address_args: PoolAddressArgs,
     /// Execution hash of the script to be voted on
     #[clap(long, parse(try_from_str = read_hex_hash))]
     pub(crate) execution_hash: HashValue,
+
     /// Code location of the script to be voted on
     #[clap(long)]
     pub(crate) metadata_url: Url,
 
     #[clap(flatten)]
     pub(crate) prompt_options: PromptOptions,
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(flatten)]
+    pub(crate) pool_address_args: PoolAddressArgs,
 }
 
 #[async_trait]
@@ -142,18 +143,20 @@ fn read_hex_hash(str: &str) -> CliTypedResult<HashValue> {
 
 #[derive(Parser)]
 pub struct SubmitVote {
+    /// Id of proposal to vote on
+    #[clap(long)]
+    pub(crate) proposal_id: u64,
+
+    /// Vote choice. True for yes. False for no.
+    #[clap(long)]
+    pub(crate) should_pass: bool,
+
+    #[clap(flatten)]
+    pub(crate) prompt_options: PromptOptions,
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
     #[clap(flatten)]
     pub(crate) pool_address_args: PoolAddressArgs,
-    /// Id of proposal to vote on
-    #[clap(long)]
-    pub(crate) proposal_id: u64,
-    /// Vote choice. True for yes. False for no.
-    #[clap(long)]
-    pub(crate) should_pass: bool,
-    #[clap(flatten)]
-    pub(crate) prompt_options: PromptOptions,
 }
 
 #[async_trait]
@@ -270,9 +273,6 @@ impl CliCommand<ScriptHash> for PrepareProposal {
 
 #[derive(Parser)]
 pub struct ExecuteProposal {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
-
     /// Path to the compiled script file
     #[clap(long, parse(from_os_str))]
     pub path: PathBuf,
@@ -282,11 +282,15 @@ pub struct ExecuteProposal {
     /// Example: `0x01 0x02 0x03`
     #[clap(long, multiple_values = true)]
     pub(crate) args: Vec<ArgWithType>,
+
     /// TypeTag arguments separated by spaces.
     ///
     /// Example: `u8 u64 u128 bool address vector true false signer`
     #[clap(long, multiple_values = true)]
     pub(crate) type_args: Vec<MoveType>,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 impl TryFrom<&ArgWithType> for TransactionArgument {

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -219,7 +219,6 @@ impl ValidatorNetworkAddressesArgs {
 pub struct InitializeValidator {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
-
     #[clap(flatten)]
     pub(crate) validator_config_file_args: ValidatorConfigFileArgs,
     #[clap(flatten)]
@@ -599,10 +598,8 @@ impl CliCommand<()> for RunLocalTestnet {
 pub struct UpdateConsensusKey {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
-
     #[clap(flatten)]
     pub(crate) operator_args: OperatorArgs,
-
     #[clap(flatten)]
     pub(crate) validator_config_file_args: ValidatorConfigFileArgs,
     #[clap(flatten)]
@@ -642,10 +639,8 @@ impl CliCommand<Transaction> for UpdateConsensusKey {
 pub struct UpdateValidatorNetworkAddresses {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
-
     #[clap(flatten)]
     pub(crate) operator_args: OperatorArgs,
-
     #[clap(flatten)]
     pub(crate) validator_config_file_args: ValidatorConfigFileArgs,
     #[clap(flatten)]
@@ -697,18 +692,25 @@ impl CliCommand<Transaction> for UpdateValidatorNetworkAddresses {
     }
 }
 
+/// Tool to analyze the performance of an individual validator
 #[derive(Parser)]
 pub struct AnalyzeValidatorPerformance {
+    /// First epoch to analyze
     #[clap(long)]
     pub start_epoch: Option<u64>,
+
+    /// Last epoch to analyze
     #[clap(long)]
     pub end_epoch: Option<u64>,
+
+    /// Analyze mode for the validator: [All, DetailedEpochTable, ValidatorHealthOverTime, NetworkHealthOverTime]
+    #[clap(arg_enum, long)]
+    pub(crate) analyze_mode: AnalyzeMode,
+
     #[clap(flatten)]
     pub(crate) rest_options: RestOptions,
     #[clap(flatten)]
     pub(crate) profile_options: ProfileOptions,
-    #[clap(arg_enum, long)]
-    pub(crate) analyze_mode: AnalyzeMode,
 }
 
 #[derive(PartialEq, clap::ArgEnum, Clone)]

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -77,7 +77,7 @@ impl NodeTool {
 #[derive(Parser)]
 pub struct ValidatorConfigFileArgs {
     /// Validator Configuration file, created from the `genesis set-validator-configuration` command
-    #[clap(long)]
+    #[clap(long, parse(from_os_str))]
     pub(crate) validator_config_file: Option<PathBuf>,
 }
 
@@ -291,7 +291,7 @@ impl OperatorArgs {
         &self,
         profile_options: &ProfileOptions,
     ) -> CliTypedResult<AccountAddress> {
-        if let Some(address) = self.pool_address_args.pool_address() {
+        if let Some(address) = self.pool_address_args.pool_address {
             Ok(address)
         } else {
             profile_options.account_address()
@@ -302,7 +302,7 @@ impl OperatorArgs {
         &self,
         transaction_options: &TransactionOptions,
     ) -> CliTypedResult<AccountAddress> {
-        if let Some(address) = self.pool_address_args.pool_address() {
+        if let Some(address) = self.pool_address_args.pool_address {
             Ok(address)
         } else {
             transaction_options.sender_address()

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -97,6 +97,7 @@ pub struct ValidatorConsensusKeyArgs {
     /// Hex encoded Consensus public key
     #[clap(long, parse(try_from_str = bls12381::PublicKey::from_encoded_string))]
     pub(crate) consensus_public_key: Option<bls12381::PublicKey>,
+
     /// Hex encoded Consensus proof of possession
     #[clap(long, parse(try_from_str = bls12381::ProofOfPossession::from_encoded_string))]
     pub(crate) proof_of_possession: Option<bls12381::ProofOfPossession>,
@@ -142,12 +143,15 @@ pub struct ValidatorNetworkAddressesArgs {
     /// Host and port pair for the validator e.g. 127.0.0.1:6180
     #[clap(long)]
     pub(crate) validator_host: Option<HostAndPort>,
+
     /// Validator x25519 public network key
     #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
     pub(crate) validator_network_public_key: Option<x25519::PublicKey>,
+
     /// Host and port pair for the fullnode e.g. 127.0.0.1:6180.  Optional
     #[clap(long)]
     pub(crate) full_node_host: Option<HostAndPort>,
+
     /// Full node x25519 public network key
     #[clap(long, parse(try_from_str = x25519::PublicKey::from_encoded_string))]
     pub(crate) full_node_network_public_key: Option<x25519::PublicKey>,
@@ -453,23 +457,29 @@ pub struct RunLocalTestnet {
     /// An overridable config template for the test node
     #[clap(long, parse(from_os_str))]
     config_path: Option<PathBuf>,
+
     /// The directory to save all files for the node
     #[clap(long, parse(from_os_str))]
     test_dir: Option<PathBuf>,
+
     /// Random seed for key generation in test mode
     #[clap(long, parse(try_from_str = FromHex::from_hex))]
     seed: Option<[u8; 32]>,
+
     /// Clean the state and start with a new chain at genesis
     #[clap(long)]
     force_restart: bool,
-    #[clap(flatten)]
-    prompt_options: PromptOptions,
+
     /// Run a faucet alongside the node
     #[clap(long)]
     with_faucet: bool,
+
     /// Port to run the faucet on
     #[clap(long, default_value = "8081")]
     faucet_port: u16,
+
+    #[clap(flatten)]
+    prompt_options: PromptOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -105,6 +105,7 @@ pub struct GenerateKey {
     /// Key type to generate. Must be one of [x25519, ed25519]
     #[clap(long, default_value_t = KeyType::Ed25519)]
     pub(crate) key_type: KeyType,
+
     #[clap(flatten)]
     pub rng_args: RngArgs,
     #[clap(flatten)]

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -39,11 +39,12 @@ impl StakeTool {
 /// Stake coins for an account to the stake pool
 #[derive(Parser)]
 pub struct AddStake {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
     /// Amount of coins to add to stake
     #[clap(long)]
     pub amount: u64,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -150,13 +150,13 @@ pub struct InitializeStakeOwner {
     /// Account Address of delegated operator
     ///
     /// If not specified, it will be the same as the owner
-    #[clap(long)]
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub operator_address: Option<AccountAddress>,
 
     /// Account address of delegated voter
     ///
     /// If not specified, it will be the same as the owner
-    #[clap(long)]
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub voter_address: Option<AccountAddress>,
 
     #[clap(flatten)]
@@ -187,7 +187,7 @@ pub struct SetOperator {
     /// Account Address of delegated operator
     ///
     /// If not specified, it will be the same as the owner
-    #[clap(long)]
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub operator_address: AccountAddress,
 
     #[clap(flatten)]
@@ -213,7 +213,7 @@ pub struct SetDelegatedVoter {
     /// Account Address of delegated voter
     ///
     /// If not specified, it will be the same as the owner
-    #[clap(long)]
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub voter_address: AccountAddress,
 
     #[clap(flatten)]

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -36,7 +36,9 @@ impl StakeTool {
     }
 }
 
-/// Stake coins for an account to the stake pool
+/// Stake coins to the stake pool
+///
+/// This command allows stake pool owners to add coins to their stake.
 #[derive(Parser)]
 pub struct AddStake {
     /// Amount of coins to add to stake
@@ -65,11 +67,12 @@ impl CliCommand<Transaction> for AddStake {
 /// Coins can only be unlocked if they no longer have an applied lockup period
 #[derive(Parser)]
 pub struct UnlockStake {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
     /// Amount of coins to unlock
     #[clap(long)]
     pub amount: u64,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 #[async_trait]
@@ -85,16 +88,18 @@ impl CliCommand<Transaction> for UnlockStake {
     }
 }
 
-/// Withdraw all unlocked staked coins
+/// Withdraw unlocked staked coins
 ///
+/// This allows users to withdraw stake back into their CoinStore.
 /// Before calling `WithdrawStake`, `UnlockStake` must be called first.
 #[derive(Parser)]
 pub struct WithdrawStake {
-    #[clap(flatten)]
-    pub(crate) node_op_options: TransactionOptions,
     /// Amount of coins to withdraw
     #[clap(long)]
     pub amount: u64,
+
+    #[clap(flatten)]
+    pub(crate) node_op_options: TransactionOptions,
 }
 
 #[async_trait]
@@ -110,7 +115,9 @@ impl CliCommand<Transaction> for WithdrawStake {
     }
 }
 
-/// Increase lockup of all staked coins in an account
+/// Increase lockup of all staked coins in the stake pool
+///
+/// Lockup may need to be increased in order to vote on a proposal.
 #[derive(Parser)]
 pub struct IncreaseLockup {
     #[clap(flatten)]
@@ -130,18 +137,30 @@ impl CliCommand<Transaction> for IncreaseLockup {
     }
 }
 
-/// Register stake owner, to gain capability to delegate
-/// operator or voting capability to a different account.
+/// Initialize stake owner
+///
+/// Initializing stake owner adds the capability to delegate the
+/// stake pool to an operator, or delegate voting to a different account.
 #[derive(Parser)]
 pub struct InitializeStakeOwner {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
+    /// Initial amount of coins to be staked
     #[clap(long)]
     pub initial_stake_amount: u64,
+
+    /// Account Address of delegated operator
+    ///
+    /// If not specified, it will be the same as the owner
     #[clap(long)]
     pub operator_address: Option<AccountAddress>,
+
+    /// Account address of delegated voter
+    ///
+    /// If not specified, it will be the same as the owner
     #[clap(long)]
     pub voter_address: Option<AccountAddress>,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 #[async_trait]
@@ -162,14 +181,17 @@ impl CliCommand<Transaction> for InitializeStakeOwner {
     }
 }
 
-/// Delegate operator (running validator node) capability from the stake owner
-/// to the given voter address
+/// Delegate operator capability from the stake owner to another account
 #[derive(Parser)]
 pub struct SetOperator {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
+    /// Account Address of delegated operator
+    ///
+    /// If not specified, it will be the same as the owner
     #[clap(long)]
     pub operator_address: AccountAddress,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 #[async_trait]
@@ -185,13 +207,17 @@ impl CliCommand<Transaction> for SetOperator {
     }
 }
 
-/// Delegate voting capability from the stake owner to the given voter address
+/// Delegate voting capability from the stake owner to another account
 #[derive(Parser)]
 pub struct SetDelegatedVoter {
-    #[clap(flatten)]
-    pub(crate) txn_options: TransactionOptions,
+    /// Account Address of delegated voter
+    ///
+    /// If not specified, it will be the same as the owner
     #[clap(long)]
     pub voter_address: AccountAddress,
+
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -169,7 +169,7 @@ impl CliTestFramework {
             profile_options: Default::default(),
             account: self.account_id(index),
             faucet_options: self.faucet_options(),
-            num_coins: amount.unwrap_or(DEFAULT_FUNDED_COINS),
+            amount: amount.unwrap_or(DEFAULT_FUNDED_COINS),
             rest_options: self.rest_options(),
         }
         .execute()
@@ -769,9 +769,7 @@ impl CliTestFramework {
     fn operator_args(&self, pool_index: Option<usize>) -> OperatorArgs {
         OperatorArgs {
             pool_address_args: OptionalPoolAddressArgs {
-                pool_address: pool_index.map(|idx| AccountAddressWrapper {
-                    account_address: self.account_id(idx),
-                }),
+                pool_address: pool_index.map(|idx| self.account_id(idx)),
             },
         }
     }


### PR DESCRIPTION
### Description
* fixes up readability, moving flattens to the bottom (no particular order)
* Adds documentation for undocumented commands and arguments
* Ensures profiles can be used anywhere that takes an AcccountAddress
* Ensures inputs are consistently read across the board 

Note:
I did not touch the Move CLI commands so that they don't have merge conflicts.  Will do later.

### Test Plan
Current tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3049)
<!-- Reviewable:end -->
