### PR TITLE
[Aptos Framework] Move aggregator to framework

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aggregator/aggregator.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/aggregator.move
@@ -60,7 +60,7 @@
 /// ====================
 /// Users are encouraged to use "cheap" operations (e.g. additions) to exploit the
 /// parallelism in execution.
-module aptos_std::aggregator {
+module aptos_framework::aggregator {
 
     /// When the value of aggregator (actual or accumulated) overflows (raised
     /// by native code).

--- a/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/aggregator_factory.move
@@ -26,7 +26,7 @@
 /// When something whants to use an aggregator, the factory is queried and an
 /// aggregator instance is created. Once aggregator is no longer in use, it
 /// should be destroyed by the user.
-module aptos_std::aggregator_factory {
+module aptos_framework::aggregator_factory {
     use std::error;
     use std::signer;
 
@@ -34,10 +34,10 @@ module aptos_std::aggregator_factory {
     use aptos_std::table::{Self, Table};
 
     #[test_only]
-    friend aptos_std::aggregator_tests;
+    friend aptos_framework::aggregator_tests;
 
     // TODO: only certain modules are allowed to create a aggregator.
-    friend aptos_std::optional_aggregator;
+    friend aptos_framework::optional_aggregator;
 
     /// When aggregator factory has already been published.
     const EAGGREGATOR_FACTORY_EXISTS: u64 = 1;

--- a/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
+++ b/aptos-move/framework/aptos-framework/sources/aggregator/optional_aggregator.move
@@ -1,11 +1,11 @@
 /// This module provides an interface to aggregate integers either via
 /// aggregator (parallelizable) or via normal integers.
-module aptos_std::optional_aggregator {
+module aptos_framework::optional_aggregator {
     use std::error;
     use std::option::{Self, Option};
 
-    use aptos_std::aggregator_factory;
-    use aptos_std::aggregator::{Self, Aggregator};
+    use aptos_framework::aggregator_factory;
+    use aptos_framework::aggregator::{Self, Aggregator};
 
     // These error codes are produced by `Aggregator` and used by `Integer` for
     // consistency.

--- a/aptos-move/framework/aptos-framework/tests/aggregator_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/aggregator_tests.move
@@ -1,8 +1,8 @@
 #[test_only]
-module aptos_std::aggregator_tests {
+module aptos_framework::aggregator_tests {
 
-    use aptos_std::aggregator;
-    use aptos_std::aggregator_factory;
+    use aptos_framework::aggregator;
+    use aptos_framework::aggregator_factory;
 
     #[test(account = @aptos_framework)]
     fun test_can_add_and_sub_and_read(account: signer) {


### PR DESCRIPTION
### Description

**Second PR in supporting aggregatable total supply in Move, should land after #3048**

All aggregator code moved to `framework`. Reasons: 1) it makes many assumptions based on framework (we want to have aggregator during genesis, use system accounts, etc.); 2) this way we can friend some modules in framework.

Note: base branch is not main, when #3048 merges it will be rebased to main automatically.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3050)
<!-- Reviewable:end -->
