### PR TITLE
[Parallel Executor] make V convertible to u8 in MVHashMap

### DIFF
--- a/aptos-move/parallel-executor/src/executor.rs
+++ b/aptos-move/parallel-executor/src/executor.rs
@@ -35,7 +35,7 @@ pub struct MVHashMapView<'a, K, V> {
     captured_reads: Mutex<Vec<ReadDescriptor<K>>>,
 }
 
-impl<'a, K: ModulePath + PartialOrd + Send + Clone + Hash + Eq, V: Send + Sync>
+impl<'a, K: ModulePath + PartialOrd + Send + Clone + Hash + Eq, V: Into<Vec<u8>> + Send + Sync>
     MVHashMapView<'a, K, V>
 {
     /// Drains the captured reads.

--- a/aptos-move/parallel-executor/src/proptest_types/bencher.rs
+++ b/aptos-move/parallel-executor/src/proptest_types/bencher.rs
@@ -36,6 +36,7 @@ impl<K, V> Bencher<K, V>
 where
     K: Hash + Clone + Debug + Eq + Send + Sync + PartialOrd + Ord + Arbitrary + 'static,
     V: Clone + Eq + Send + Sync + Arbitrary + 'static,
+    Vec<u8>: From<V>,
 {
     pub fn new(transaction_size: usize, universe_size: usize) -> Self {
         Self {
@@ -67,6 +68,7 @@ impl<K, V> BencherState<K, V>
 where
     K: Hash + Clone + Debug + Eq + Send + Sync + PartialOrd + Ord + 'static,
     V: Clone + Eq + Send + Sync + Arbitrary + 'static,
+    Vec<u8>: From<V>,
 {
     /// Creates a new benchmark state with the given account universe strategy and number of
     /// transactions.

--- a/aptos-move/parallel-executor/src/proptest_types/tests.rs
+++ b/aptos-move/parallel-executor/src/proptest_types/tests.rs
@@ -30,6 +30,7 @@ fn run_transactions<K, V>(
 where
     K: Hash + Clone + Debug + Eq + Send + Sync + PartialOrd + Ord + 'static,
     V: Clone + Eq + Send + Sync + Arbitrary + 'static,
+    Vec<u8>: From<V>,
 {
     let mut transactions: Vec<_> = transaction_gens
         .into_iter()

--- a/aptos-move/parallel-executor/src/proptest_types/types.rs
+++ b/aptos-move/parallel-executor/src/proptest_types/types.rs
@@ -74,7 +74,7 @@ pub struct TransactionGenParams {
 
 #[derive(Arbitrary, Debug, Clone)]
 #[proptest(params = "TransactionGenParams")]
-pub struct TransactionGen<V: Arbitrary + Debug + 'static + Clone> {
+pub struct TransactionGen<V: Into<Vec<u8>> + Arbitrary + Debug + 'static + Clone> {
     /// Generate keys and values for possible write-sets based on above transaction gen parameters.
     #[proptest(
         strategy = "vec(vec((any::<Index>(), any::<V>()), 1..params.write_size), 1..params.read_write_alternatives)"
@@ -131,7 +131,7 @@ impl Default for TransactionGenParams {
     }
 }
 
-impl<V: Arbitrary + Debug + Clone> TransactionGen<V> {
+impl<V: Into<Vec<u8>> + Arbitrary + Debug + Clone> TransactionGen<V> {
     fn writes_from_gen<K: Clone + Hash + Debug + Eq + Ord>(
         universe: &[K],
         gen: Vec<Vec<(Index, V)>>,
@@ -216,6 +216,7 @@ impl<K, V> TransactionType for Transaction<K, V>
 where
     K: PartialOrd + Send + Sync + Clone + Hash + Eq + ModulePath + 'static,
     V: Send + Sync + Debug + Clone + 'static,
+    Vec<u8>: From<V>,
 {
     type Key = K;
     type Value = V;
@@ -237,6 +238,7 @@ impl<K, V> ExecutorTask for Task<K, V>
 where
     K: PartialOrd + Send + Sync + Clone + Hash + Eq + ModulePath + 'static,
     V: Send + Sync + Debug + Clone + 'static,
+    Vec<u8>: From<V>,
 {
     type T = Transaction<K, V>;
     type Output = Output<K, V>;
@@ -286,6 +288,7 @@ impl<K, V> TransactionOutput for Output<K, V>
 where
     K: PartialOrd + Send + Sync + Clone + Hash + Eq + ModulePath + 'static,
     V: Send + Sync + Debug + Clone + 'static,
+    Vec<u8>: From<V>,
 {
     type T = Transaction<K, V>;
 

--- a/aptos-move/parallel-executor/src/task.rs
+++ b/aptos-move/parallel-executor/src/task.rs
@@ -37,7 +37,7 @@ impl ModulePath for StateKey {
 /// transaction will write to a key value storage as their side effect.
 pub trait Transaction: Sync + Send + 'static {
     type Key: PartialOrd + Send + Sync + Clone + Hash + Eq + ModulePath;
-    type Value: Send + Sync;
+    type Value: Into<Vec<u8>> + Send + Sync;
 }
 
 /// Inference result of a transaction.

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -25,6 +25,15 @@ impl WriteOp {
     }
 }
 
+impl From<WriteOp> for Vec<u8> {
+    fn from(w: WriteOp) -> Vec<u8> {
+        match w {
+            WriteOp::Value(v) => v,
+            WriteOp::Deletion => vec![],
+        }
+    }
+}
+
 impl std::fmt::Debug for WriteOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
Aggregators require knowing values to aggregate, MVHashMap is generic, reconcile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3053)
<!-- Reviewable:end -->
