### PR TITLE
Change GiB to GB for node requirements

### DIFF
--- a/developer-docs-site/docs/nodes/ait/node-requirements.md
+++ b/developer-docs-site/docs/nodes/ait/node-requirements.md
@@ -5,19 +5,19 @@ slug: "node-requirements"
 
 # Node Requirements
 
-Follow the requirements specified in this document to make your AIT-2 Validator and FullNode deployment hassle-free. 
+Follow the requirements specified in this document to make your AIT-2 Validator and FullNode deployment hassle-free.
 
 ## Validator and FullNode
 
-- For the AIT-2, we require that you run the Validator. We recommend that optionally you run a FullNode also. However, a FullNode is not required. 
+- For the AIT-2, we require that you run the Validator. We recommend that optionally you run a FullNode also. However, a FullNode is not required.
 - If you run FullNode also, then we strongly recommend that you run the Validator and the FullNode on two separate and independent machines. Make sure that these machines are well-provisioned and isolated from each other. Guaranteeing the resource isolation between the Validator and the FullNode will help ensure smooth deployment of these nodes.
 - For best availability and stability, **we recommend that you deploy your node on the cloud**. We have provided Terraform support for deploying the node on three cloud providers: GCP, AWS and Azure. See [Validators](/nodes/validator-node/validators).
 - Make sure that you open the network ports prior to the date the AIT goes live. See [Networking configuration requirements](#networking-requirements).
 - Make sure that you close these ports after either being accepted or rejected for the AIT-2.
 
-## Validator node in test mode 
+## Validator node in test mode
 
-You must run a Validator node in the test mode to be eligible for AIT-2. This is a method Aptos Labs uses to verify that a node operator can successfully start a Validator node and configure it properly with the Aptos network identity. 
+You must run a Validator node in the test mode to be eligible for AIT-2. This is a method Aptos Labs uses to verify that a node operator can successfully start a Validator node and configure it properly with the Aptos network identity.
 
 In test mode, you will be running a local network with one single node, and it should be functioning like a normal blockchain.
 
@@ -26,10 +26,10 @@ In test mode, you will be running a local network with one single node, and it s
 For running an Aptos **Validator node** we recommend the following hardware resources:
 
   - **CPU**:
-      - 8 cores, 16 threads 
+      - 8 cores, 16 threads
       - 2.8GHz, or faster
       - Intel Xeon Skylake or newer
-  - **Memory**: 32GiB RAM.
+  - **Memory**: 32GB RAM.
 
 Example machine types on various clouds:
   - AWS
@@ -43,10 +43,10 @@ Example machine types on various clouds:
 For running an Aptos **Fullnode** we recommend the following hardware resources:
 
   - **CPU**:
-      - 4 cores, 8 threads 
+      - 4 cores, 8 threads
       - 2.8GHz, or faster
       - Intel Xeon Skylake or newer
-  - **Memory**: 16GiB RAM.
+  - **Memory**: 16GB RAM.
 
 Example machine types on various clouds:
   - AWS
@@ -71,11 +71,11 @@ Bandwidth requirement: 1 Gbps
 
 When you are running a validator node, you are required to open network ports on your node to allow other nodes to connect to you. For fullnodes this is optional.
 
-There are three types of Aptos networks. Your node can be configured so that each of these networks can connect to your node using a different port on your node. 
+There are three types of Aptos networks. Your node can be configured so that each of these networks can connect to your node using a different port on your node.
 
 1. The validator network: A validator node connects to this network.
-2. The public network. A public fullnode connects to this network. 
-3. The validator fullnode network (VFN network): A validator fullnode connects to this network. The VFN network allows the validator fullnode to connect to the specific validator. 
+2. The public network. A public fullnode connects to this network.
+3. The validator fullnode network (VFN network): A validator fullnode connects to this network. The VFN network allows the validator fullnode to connect to the specific validator.
 
 You can configure the port settings on your node using the configuration YAML file. See the [example configuration YAML here](https://github.com/aptos-labs/aptos-core/blob/4ce85456853c7b19b0a751fb645abd2971cc4c0c/docker/compose/aptos-node/fullnode.yaml#L10-L9). With this configuration YAML on your node, the public network connects to your node on port 6182 and the VFN network on 6181. Because these port settings are configurable, we don't explicitly say port X is for network Y.
 

--- a/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
+++ b/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
@@ -34,12 +34,12 @@ We recommend the following hardware resources:
 - For running a production grade FullNode:
 
   - **CPU**: 4 cores (Intel Xeon Skylake or newer).
-  - **Memory**: 8GiB RAM.
+  - **Memory**: 8GB RAM.
 
 - For running the FullNode for development or testing:
 
   - **CPU**: 2 cores.
-  - **Memory**: 4GiB RAM.
+  - **Memory**: 4GB RAM.
 
 ## Storage requirements
 
@@ -92,7 +92,7 @@ With your development environment ready, now you can start to setup your FullNod
 
 5. Checkout the `devnet` branch using `git checkout --track origin/devnet`.
 
-6. Make sure your current working directory is `aptos-core`. 
+6. Make sure your current working directory is `aptos-core`.
    Run `cp config/src/config/test_data/public_full_node.yaml fullnode.yaml` to create a copy of the fullnode config template. You will edit this file to ensure that your FullNode:
 
     - Contains the correct genesis blob that is published by the Aptos devnet.
@@ -153,7 +153,7 @@ This section describes how to configure and run your FullNode using Docker.
 
 :::caution Running Aptos-core via Docker is currently only suported on x86-64 CPUs and not on ARM64 CPUs (which includes M1/M2 Macs).
 
-We currently only publish docker images compatible with x86-64 CPUs. 
+We currently only publish docker images compatible with x86-64 CPUs.
 If you have an M1/M2 (ARM64) Mac, use the Aptos-core source approach.
 If M1/M2 support is important to you, please comment on and follow this issue: https://github.com/aptos-labs/aptos-core/issues/1412
 
@@ -161,7 +161,7 @@ If M1/M2 support is important to you, please comment on and follow this issue: h
 
 1. Install [Docker](https://docs.docker.com/get-docker/).
 2. Create a directory for your local public FullNode, and `cd` into it.
-   For example: 
+   For example:
    ```bash
    mkdir aptos-fullnode && cd aptos-fullnode
    ```
@@ -283,7 +283,7 @@ full_node_networks:
             addresses:
             - "/dns4/pfn2.node.devnet.aptoslabs.com/tcp/6182/noise-ik/f6b135a59591677afc98168791551a0a476222516fdc55869d2b649c614d965b/handshake/0"
             role: "Upstream"
-...            
+...
 ```
 [rest_spec]: https://github.com/aptos-labs/aptos-core/tree/main/api
 [devnet_genesis]: https://devnet.aptoslabs.com/genesis.blob


### PR DESCRIPTION
## Description
Discussed offline. tldr, if we say you need 32 GiB of RAM, people will get 32GB instances and then be confused when they're 2GiB short of the requirement.

(My editor also removed random whitespace).

## Test Plan
Eyes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3061)
<!-- Reviewable:end -->
