### PR TITLE
[aptos-cli] Show Profiles

### DIFF
--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -14,7 +14,7 @@ use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, ValidCryptoMaterialSt
 use async_trait::async_trait;
 use clap::Parser;
 use reqwest::Url;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub const DEFAULT_REST_URL: &str = "https://fullnode.devnet.aptoslabs.com/v1";
 pub const DEFAULT_FAUCET_URL: &str = "https://faucet.devnet.aptoslabs.com";
@@ -181,7 +181,7 @@ impl CliCommand<()> for InitTool {
 
         // Ensure the loaded config has profiles setup for a possible empty file
         if config.profiles.is_none() {
-            config.profiles = Some(HashMap::new());
+            config.profiles = Some(BTreeMap::new());
         }
         config
             .profiles

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -45,7 +45,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::BTreeMap,
     fmt::{Debug, Display, Formatter},
     fs::OpenOptions,
     path::{Path, PathBuf},
@@ -170,7 +170,7 @@ impl From<bcs::Error> for CliError {
 pub struct CliConfig {
     /// Map of profile configs
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub profiles: Option<HashMap<String, ProfileConfig>>,
+    pub profiles: Option<BTreeMap<String, ProfileConfig>>,
 }
 
 const CONFIG_FILE: &str = "config.yaml";
@@ -197,10 +197,36 @@ pub struct ProfileConfig {
     pub faucet_url: Option<String>,
 }
 
+/// ProfileConfig but without the private parts
+#[derive(Debug, Serialize)]
+pub struct ProfileSummary {
+    pub has_private_key: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<Ed25519PublicKey>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account: Option<AccountAddress>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rest_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub faucet_url: Option<String>,
+}
+
+impl From<&ProfileConfig> for ProfileSummary {
+    fn from(config: &ProfileConfig) -> Self {
+        ProfileSummary {
+            has_private_key: config.private_key.is_some(),
+            public_key: config.public_key.clone(),
+            account: config.account,
+            rest_url: config.rest_url.clone(),
+            faucet_url: config.faucet_url.clone(),
+        }
+    }
+}
+
 impl Default for CliConfig {
     fn default() -> Self {
         CliConfig {
-            profiles: Some(HashMap::new()),
+            profiles: Some(BTreeMap::new()),
         }
     }
 }


### PR DESCRIPTION
### Description
A lot of the use cases I've seen about people copying their address
outside is hard when you can't show the available profiles.  This
will show the config without the private keys for ease of use.

Also uses a BTreeMap now for stability purposes

### Test Plan
```
 aptos config show-profiles
{
  "Result": {
    "greg": {
      "has_private_key": true,
      "public_key": "0xfe6276f3440264cc72af48ca5a160cd37c8b113ad17e0e860b59bfae9ec2baea",
      "account": "a1a52c66dcc30fa6536bf1490d9a9ed83437c3063d063fb5560ef4e1764b420e",
      "rest_url": "https://my-unknown-url.xyz/"
    },
    "operator": {
      "has_private_key": true,
      "public_key": "0x1e3c5982a7a4f2d7d93c2ad82e2f67406d587e8c6bcd41bff79933de59e41fb9",
      "account": "4c43820067724df9f5c97637d82d0643fd45511b28b60592d690b1b3498a9a69",
      "rest_url": "https://fullnode.devnet.aptoslabs.com/v1",
      "faucet_url": "https://faucet.devnet.aptoslabs.com/"
    },
    "owner": {
      "has_private_key": true,
      "public_key": "0x24c993adc39c78126465d1ac302bf59f48df34a4020fef28ef943bb1f1e4f755",
      "account": "5e77a3f857396148caebffe70eacc99dee012d9315866a16658bb3e3d158e5f7",
      "rest_url": "https://fullnode.devnet.aptoslabs.com/v1",
      "faucet_url": "https://faucet.devnet.aptoslabs.com/"
    }
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3064)
<!-- Reviewable:end -->
