### PR TITLE
[local swarm] Surface nodes account private keys

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -49,6 +49,7 @@ pub struct ValidatorNodeConfig {
     pub name: String,
     pub config: NodeConfig,
     pub dir: PathBuf,
+    pub account_private_key: Option<Ed25519PrivateKey>,
     pub genesis_stake_amount: u64,
 }
 
@@ -69,6 +70,7 @@ impl ValidatorNodeConfig {
             name,
             config,
             dir,
+            account_private_key: None,
             genesis_stake_amount,
         })
     }
@@ -76,7 +78,8 @@ impl ValidatorNodeConfig {
     /// Initializes keys and identities for a validator config
     /// TODO: Put this all in storage rather than files?
     fn init_keys(&mut self, seed: Option<[u8; 32]>) -> anyhow::Result<()> {
-        self.get_key_objects(seed)?;
+        let (validator_identity, _, _, _) = self.get_key_objects(seed)?;
+        self.account_private_key = validator_identity.account_private_key;
 
         // Init network identity
         let validator_network = self.config.validator_network.as_mut().unwrap();

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -5,7 +5,10 @@ use crate::{FullNode, HealthCheckError, LocalVersion, Node, NodeExt, Validator, 
 use anyhow::{anyhow, ensure, Context, Result};
 use aptos_config::config::NodeConfig;
 use aptos_logger::debug;
-use aptos_sdk::types::{account_address::AccountAddress, PeerId};
+use aptos_sdk::{
+    crypto::ed25519::Ed25519PrivateKey,
+    types::{account_address::AccountAddress, PeerId},
+};
 use std::{
     env,
     fs::{self, OpenOptions},
@@ -40,13 +43,19 @@ pub struct LocalNode {
     version: LocalVersion,
     process: Option<Process>,
     name: String,
+    account_private_key: Option<Ed25519PrivateKey>,
     peer_id: AccountAddress,
     directory: PathBuf,
     config: NodeConfig,
 }
 
 impl LocalNode {
-    pub fn new(version: LocalVersion, name: String, directory: PathBuf) -> Result<Self> {
+    pub fn new(
+        version: LocalVersion,
+        name: String,
+        directory: PathBuf,
+        account_private_key: Option<Ed25519PrivateKey>,
+    ) -> Result<Self> {
         let config_path = directory.join("node.yaml");
         let config = NodeConfig::load(&config_path)
             .with_context(|| format!("Failed to load NodeConfig from file: {:?}", config_path))?;
@@ -58,6 +67,7 @@ impl LocalNode {
             version,
             process: None,
             name,
+            account_private_key,
             peer_id,
             directory,
             config,
@@ -70,6 +80,10 @@ impl LocalNode {
 
     pub fn log_path(&self) -> PathBuf {
         self.directory.join("log")
+    }
+
+    pub fn account_private_key(&self) -> &Option<Ed25519PrivateKey> {
+        &self.account_private_key
     }
 
     pub fn peer_id(&self) -> PeerId {

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -161,7 +161,8 @@ impl LocalSwarm {
         let mut validators = validators
             .into_iter()
             .map(|v| {
-                let node = LocalNode::new(version.to_owned(), v.name, v.dir)?;
+                let node =
+                    LocalNode::new(version.to_owned(), v.name, v.dir, v.account_private_key)?;
                 Ok((node.peer_id(), node))
             })
             .collect::<Result<HashMap<_, _>>>()?;
@@ -322,6 +323,7 @@ impl LocalSwarm {
             version.to_owned(),
             fullnode_config.name,
             fullnode_config.dir,
+            None,
         )?;
 
         let peer_id = fullnode.peer_id();
@@ -349,6 +351,7 @@ impl LocalSwarm {
             version.to_owned(),
             fullnode_config.name,
             fullnode_config.dir,
+            None,
         )?;
 
         let peer_id = fullnode.peer_id();
@@ -376,11 +379,16 @@ impl LocalSwarm {
     }
 
     pub fn validators(&self) -> impl Iterator<Item = &LocalNode> {
-        self.validators.values()
+        // sort by id to keep the order stable:
+        let mut validators: Vec<&LocalNode> = self.validators.values().collect();
+        validators.sort_by_key(|v| v.name().parse::<i32>().unwrap());
+        validators.into_iter()
     }
 
     pub fn validators_mut(&mut self) -> impl Iterator<Item = &mut LocalNode> {
-        self.validators.values_mut()
+        let mut validators: Vec<&mut LocalNode> = self.validators.values_mut().collect();
+        validators.sort_by_key(|v| v.name().parse::<i32>().unwrap());
+        validators.into_iter()
     }
 
     pub fn fullnode(&self, peer_id: PeerId) -> Option<&LocalNode> {


### PR DESCRIPTION
### Description

For more comprehensive testing, having those keys allows us for those nodes to leave validator set/change their lockup/etc.

Also, made validators list be consistent (which matters as most tests fetch first validator for RestClient, and if we are changing reliability of nodes, we can get into odd cases.

### Test Plan
Stacked unit test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3065)
<!-- Reviewable:end -->
