### PR TITLE
[aptos-cli] CLI build information and bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "0.2.4"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "aptos-bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +183,7 @@ dependencies = [
  "serde 1.0.141",
  "serde_json",
  "serde_yaml 0.8.26",
+ "shadow-rs",
  "short-hex-str",
  "storage-interface",
  "tempfile",
@@ -2584,6 +2594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
+
+[[package]]
 name = "const_format"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,6 +3417,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,6 +4041,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
+name = "git2"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2994bee4a3a6a51eb90c218523be382fd7ea09b16380b9312e9dbe955ff7c7d1"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4474,6 +4524,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5528d9c2817db4e10cc78f8d4c8228906e5854f389ff6b076cee3572a09d35"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4639,6 +4702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,6 +4721,12 @@ name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
+
+[[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
 
 [[package]]
 name = "isahc"
@@ -4981,6 +5056,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.14.0+1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a00859c70c8a4f7218e6d1cc32875c4b55f6799445b842b0d8ed5e4c3d959b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5091,6 +5178,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
@@ -7974,6 +8067,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.35.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d2b64e76b8da597d38473a277e87b91c3747d0cf9922be989e68fc1c046adf9"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustls"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8484,6 +8591,19 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug",
+]
+
+[[package]]
+name = "shadow-rs"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0ea0c68418544f725eba5401a5b965a2263254c92458d04aeae74e9d88ff4e"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time 0.3.12",
+ "tzdb",
 ]
 
 [[package]]
@@ -9804,6 +9924,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a87d58ddb21cda9e2236e99f1f27e7094334aae4cd580dd8f5ffa137580de61a"
+dependencies = [
+ "iana-time-zone",
+ "phf",
+ "phf_shared 0.11.0",
+ "tz-rs",
+ "utcnow",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9981,6 +10123,22 @@ dependencies = [
  "matches",
  "percent-encoding",
  "serde 1.0.141",
+]
+
+[[package]]
+name = "utcnow"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9835442f055fab72d40eb8e5164f2b98e70ebadedbf4506aac23ca7d623053"
+dependencies = [
+ "const_fn",
+ "errno",
+ "js-sys",
+ "libc",
+ "rustix",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.2.4"
+version = "0.2.6"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -27,6 +27,7 @@ reqwest = { version = "0.11.10", features = ["blocking", "json"] }
 serde = "1.0.137"
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
+shadow-rs = "0.16.2"
 tempfile = "3.3.0"
 termcolor = "1.1.3"
 thiserror = "1.0.31"
@@ -68,3 +69,6 @@ vm-genesis = { path = "../../aptos-move/vm-genesis" }
 [features]
 default = []
 fuzzing = []
+
+[build-dependencies]
+shadow-rs = "0.16.2"

--- a/crates/aptos/build.rs
+++ b/crates/aptos/build.rs
@@ -1,0 +1,6 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() -> shadow_rs::SdResult<()> {
+    shadow_rs::new()
+}

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -77,6 +77,41 @@ pub async fn to_common_result<T: Serialize>(
     }
 }
 
+pub fn cli_build_information() -> BTreeMap<String, String> {
+    shadow_rs::shadow!(build);
+
+    let mut build_information = collect_build_information!();
+    build_information.insert(
+        aptos_telemetry::build_information::BUILD_BRANCH.into(),
+        build::BRANCH.into(),
+    );
+    build_information.insert(
+        aptos_telemetry::build_information::BUILD_CARGO_VERSION.into(),
+        build::CARGO_VERSION.into(),
+    );
+    build_information.insert(
+        aptos_telemetry::build_information::BUILD_COMMIT_HASH.into(),
+        build::COMMIT_HASH.into(),
+    );
+    build_information.insert(
+        aptos_telemetry::build_information::BUILD_OS.into(),
+        build::BUILD_OS.into(),
+    );
+    build_information.insert(
+        aptos_telemetry::build_information::BUILD_PKG_VERSION.into(),
+        build::PKG_VERSION.into(),
+    );
+    build_information.insert(
+        aptos_telemetry::build_information::BUILD_RUST_CHANNEL.into(),
+        build::RUST_CHANNEL.into(),
+    );
+    build_information.insert(
+        aptos_telemetry::build_information::BUILD_RUST_VERSION.into(),
+        build::RUST_VERSION.into(),
+    );
+    build_information
+}
+
 /// Sends a telemetry event about the CLI build, command and result
 async fn send_telemetry_event(
     command: &str,
@@ -85,7 +120,7 @@ async fn send_telemetry_event(
     error: Option<String>,
 ) {
     // Collect the build information
-    let build_information = collect_build_information!();
+    let build_information = cli_build_information();
 
     // Send the event
     aptos_telemetry::cli_metrics::send_cli_telemetry_event(

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -16,7 +16,7 @@ pub mod stake;
 pub mod test;
 
 use crate::common::types::{CliCommand, CliResult, CliTypedResult};
-use aptos_telemetry::collect_build_information;
+use crate::common::utils::cli_build_information;
 use async_trait::async_trait;
 use clap::Parser;
 use std::collections::BTreeMap;
@@ -77,8 +77,6 @@ impl CliCommand<BTreeMap<String, String>> for InfoTool {
     }
 
     async fn execute(self) -> CliTypedResult<BTreeMap<String, String>> {
-        let build_information = collect_build_information!();
-
-        Ok(build_information)
+        Ok(cli_build_information())
     }
 }


### PR DESCRIPTION
### Description
It's been too hard to investigate issue people have with the CLI, so I am reintroducing the build information.

I won't push this until right before the branch cut
 
When there is less churn, I will move all the inner files to a different crate so that telemetry is only built for the executable (just main) and none of the dependent crates.

### Test Plan
```
 aptos info
{
  "Result": {
    "build_branch": "cli-metrics",
    "build_cargo_version": "cargo 1.62.1 (a748cf5a3 2022-06-08)",
    "build_commit_hash": "215b8fff0340dfe56ca3718c435e5fe9dd3b0678",
    "build_os": "macos-aarch64",
    "build_pkg_version": "0.2.6",
    "build_rust_channel": "1.62.1-aarch64-apple-darwin",
    "build_rust_version": "rustc 1.62.1 (e092d0b6b 2022-07-16)"
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3068)
<!-- Reviewable:end -->
