### PR TITLE
[forge] run compat in continuous

### DIFF
--- a/.github/workflows/continuous-e2e-tests.yaml
+++ b/.github/workflows/continuous-e2e-tests.yaml
@@ -58,6 +58,20 @@ jobs:
       # Pre release has chaos applied
       FORGE_TEST_SUITE: chaos
       POST_TO_SLACK: true
+  # Run a faster chaos forge to quickly surface correctness failures
+  run-forge-compat:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-compat
+      FORGE_CLUSTER_NAME: aptos-forge-2
+      # Run for 5 minutes
+      FORGE_RUNNER_DURATION_SECS: 300
+      # We expect slightly lower tps on longer timeline
+      FORGE_RUNNER_TPS_THRESHOLD: 5000
+      # This will upgrade from devnet to the latest main
+      FORGE_TEST_SUITE: compat
+      POST_TO_SLACK: true
   # Example new forge nightly test, simply add this block below to schedule your own forge job
   # run-forge-example:
   #   uses: ./.github/workflows/run-forge.yaml

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -138,6 +138,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           append: true
+          recreate: true
           path: ${{ env.FORGE_COMMENT }}
       - name: Post to a Slack channel
         # Post a Slack comment if the run has not been cancelled and the envs are set
@@ -148,7 +149,7 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "${{ github.job }}(suite: ${{ inputs.FORGE_TEST_SUITE }}, namespace: ${{ inputs.FORGE_NAMESPACE }}) ${{ job.status }}: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+              "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} ${{ github.job }}(suite: `${{ inputs.FORGE_TEST_SUITE }}`, namespace: `${{ inputs.FORGE_NAMESPACE }}`): <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -5,13 +5,13 @@ metadata:
   labels:
     app.kubernetes.io/name: forge
     forge-namespace: {FORGE_NAMESPACE}
-    forge-image-tag: {IMAGE_TAG}
+    forge-image-tag: {FORGE_IMAGE_TAG}
 spec:
   restartPolicy: Never
   serviceAccountName: forge
   containers:
   - name: main
-    image: {AWS_ACCOUNT_NUM}.dkr.ecr.{AWS_REGION}.amazonaws.com/aptos/forge:{IMAGE_TAG}
+    image: {AWS_ACCOUNT_NUM}.dkr.ecr.{AWS_REGION}.amazonaws.com/aptos/forge:{FORGE_IMAGE_TAG}
     imagePullPolicy: Always
     command:
     - /bin/bash

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -162,6 +162,9 @@ impl Swarm for K8sSwarm {
             .get(version)
             .cloned()
             .ok_or_else(|| anyhow!("Invalid version: {:?}", version))?;
+        // stop the validator first so there is no race on the upgrade
+        validator.stop().await?;
+        // set the image tag of the StatefulSet spec while there are 0 replicas
         set_stateful_set_image_tag(
             validator.stateful_set_name().to_string(),
             // the container name for the validator in its StatefulSet is "validator"


### PR DESCRIPTION
### Description

Run a new job in the GHA continuous testing workflow that runs Forge `compat` test suite on `forge-2`. This test will upgrade from `devnet` to the latest build on `main`.

Bonus:
* Improve the slack comment
* Always run the Forge test runner with the latest image tag, even if we're spinning up the network at an older version. The change is in `run_forge.sh` and we can port it into the python wrapper as that lands

### Test Plan
Trigger on `push`: https://github.com/aptos-labs/aptos-core/runs/7886586797?check_suite_focus=true. 

For now, the test fails likely because of a race on the kube StatefulSet state in the remote environment -- upgrading the image tag doesn't necessarily spin down the pod immediately. To fix that, when upgrading the image tag of a running node, we first spin it down, upgrade the spec, and then spin it back up. After this lands, subsequent continuous testing will pick it up. Compat tests in continuous will fail until then though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3071)
<!-- Reviewable:end -->
