### PR TITLE
[smoke tests] extends startup timeout 10 -> 30s

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -244,7 +244,7 @@ impl LocalSwarm {
     }
 
     async fn wait_for_startup(&mut self) -> Result<()> {
-        let num_attempts = 10;
+        let num_attempts = 30;
         let mut done = vec![false; self.validators.len()];
         for i in 0..num_attempts {
             info!("Wait for startup attempt: {} of {}", i, num_attempts);


### PR DESCRIPTION
### Description

Another mitigation for flaky tests

### Test Plan

Smoke tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3083)
<!-- Reviewable:end -->
