### PR TITLE
[CP] Create initial layout for Onboarding, remove default OATH username

### DIFF
--- a/ecosystem/platform/server/app/controllers/onboarding_controller.rb
+++ b/ecosystem/platform/server/app/controllers/onboarding_controller.rb
@@ -11,8 +11,6 @@ class OnboardingController < ApplicationController
   before_action :set_oauth_data, except: %i[kyc_callback]
   protect_from_forgery except: :kyc_callback
 
-  layout 'it3'
-
   def email
     redirect_to it2_path if current_user.registration_completed?
   end

--- a/ecosystem/platform/server/app/views/onboarding/email.html.erb
+++ b/ecosystem/platform/server/app/views/onboarding/email.html.erb
@@ -1,62 +1,72 @@
-<div class="flex-[2]">
-  <h2 class="text-4xl text-teal-400 font-mono mb-16 mt-8">Welcome, <%= @oauth_username || @oauth_email %>!</h2>
+<div class="bg-neutral-900 text-white h-full">
+  <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 md:px-8 py-12 sm:py-24">
+    <h3 class="text-base uppercase text-teal-400 mb-2 font-mono">Community</h3>
+    <h2 class="text-6xl mb-4 font-display font-light">Create Account</h2>
+    <div class="mb-16">
+      <%= render DividerComponent.new(scheme: :primary) %>
+    </div>
+    <div class="flex flex-col md:flex-row gap-14 md:gap-18 2xl:gap-36 justify-between">
+      <div class="flex-[2]">
+        <h2 class="text-4xl text-teal-400 font-mono mb-16 mt-8">Welcome, <%= @oauth_username || @oauth_email %>!</h2>
 
-  <%= render 'layouts/flash' %>
+        <%= render 'layouts/flash' %>
 
-  <% if current_user.errors.any? %>
-    <div id="error_explanation" class="flex p-4 mb-4 bg-red-100 rounded-lg" role="alert">
-      <div class="ml-3 text-sm font-medium text-red-700">
-        <h2><%= pluralize(current_user.errors.count, 'error') %> prohibited this user from being saved:</h2>
+        <% if current_user.errors.any? %>
+          <div id="error_explanation" class="flex p-4 mb-4 bg-red-100 rounded-lg" role="alert">
+            <div class="ml-3 text-sm font-medium text-red-700">
+              <h2><%= pluralize(current_user.errors.count, 'error') %> prohibited this user from being saved:</h2>
+              <ul>
+                <% current_user.errors.each do |error| %>
+                  <li><%= error.full_message %></li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+        <% end %>
 
-        <ul>
-          <% current_user.errors.each do |error| %>
-            <li><%= error.full_message %></li>
+        <%= form_with(model: current_user, url: onboarding_email_path, method: :post, data: { turbo: !@show_recaptcha_v2, controller: 'recaptcha', action: 'recaptcha#validate' }, builder: AptosFormBuilder) do |f| %>
+          <% if !current_user.email_confirmed? %>
+            <div class="mb-6">
+              <%= f.label :email, class: 'font-mono uppercase block mb-2' %>
+              <%= f.email_field :email, placeholder: 'Enter email address', autofocus: true, autocomplete: 'email', spellcheck: false, required: true, value: current_user.unconfirmed_email || @oauth_email, class: 'md:w-96' %>
+            </div>
           <% end %>
-        </ul>
+
+          <div class="mb-6">
+            <%= f.label :username, class: 'font-mono uppercase block mb-2' %>
+            <%= f.text_field :username, placeholder: 'Create username', autofocus: true, spellcheck: false, pattern: User::USERNAME_REGEX_JS, minlength: 3, maxlength: 20, value: current_user.username, class: 'md:w-96' %>
+            <ul class="list-disc list-inside text-neutral-400 text-xs font-light mt-4 block">
+              <li>Allowed Characters: a-z, A-Z, 0-9, _, -</li>
+              <li>Must begin and end alphanumerically</li>
+              <li>May not have two consecutive _ or -</li>
+            </ul>
+          </div>
+
+          <div class="mb-8">
+            <% if @show_recaptcha_v2 %>
+              <%= recaptcha_tags theme: :dark %>
+            <% else %>
+              <%= recaptcha_v3(action: 'onboarding/email', site_key: ENV.fetch('RECAPTCHA_V3_SITE_KEY', nil), turbolinks: true) %>
+            <% end %>
+          </div>
+
+          <div class="mb-12">
+            <%= f.submit 'Continue', class: 'w-72' %>
+          </div>
+
+          <div class="text-sm mb-4">
+            <label class="flex mb-4 gap-2 items-center cursor-pointer">
+              <%= f.check_box :terms_accepted, required: true %>
+              <span>I agree to the Aptos <%= link_to 'Terms of Use', terms_path, class: 'font-bold text-teal-400' %> and <%= link_to 'Privacy Policy', privacy_path, class: 'font-bold text-teal-400' %>.</span>
+            </label>
+          </div>
+          <div class="text-xs text-neutral-500">
+            This site is protected by reCAPTCHA and the Google
+            <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+            <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+          </div>
+        <% end %>
       </div>
     </div>
-  <% end %>
-
-  <%= form_with(model: current_user, url: onboarding_email_path, method: :post, data: { turbo: !@show_recaptcha_v2, controller: 'recaptcha', action: 'recaptcha#validate' }, builder: AptosFormBuilder) do |f| %>
-    <% if !current_user.email_confirmed? %>
-      <div class="mb-6">
-        <%= f.label :email, class: 'font-mono uppercase block mb-2' %>
-        <%= f.email_field :email, placeholder: 'ENTER YOUR EMAIL ADDRESS', autofocus: true, autocomplete: 'email', spellcheck: false, required: true, value: current_user.unconfirmed_email || @oauth_email, class: 'md:w-96' %>
-      </div>
-    <% end %>
-
-    <div class="mb-6">
-      <%= f.label :username, class: 'font-mono uppercase block mb-2' %>
-      <ul class="font-mono text-xs mb-2">
-        <li>Allowed Characters: a-z, A-Z, 0-9, _, -</li>
-        <li>Must begin and end alphanumerically</li>
-        <li>May not have two consecutive _ or -</li>
-      </ul>
-      <%= f.text_field :username, placeholder: 'CREATE YOUR USERNAME', autofocus: true, spellcheck: false, pattern: User::USERNAME_REGEX_JS, minlength: 3, maxlength: 20, value: current_user.username || @oauth_username, class: 'md:w-96' %>
-    </div>
-
-    <div class="mb-8">
-      <% if @show_recaptcha_v2 %>
-        <%= recaptcha_tags theme: :dark %>
-      <% else %>
-        <%= recaptcha_v3(action: 'onboarding/email', site_key: ENV.fetch('RECAPTCHA_V3_SITE_KEY', nil), turbolinks: true) %>
-      <% end %>
-    </div>
-
-    <div class="mb-12">
-      <%= f.submit 'Continue', class: 'w-72' %>
-    </div>
-
-    <div class="text-sm mb-4">
-      <label class="flex mb-4 gap-2 items-center cursor-pointer">
-        <%= f.check_box :terms_accepted, required: true %>
-        <span>I agree to the Aptos <%= link_to 'Terms of Use', terms_path, class: 'font-bold text-teal-400' %> and <%= link_to 'Privacy Policy', privacy_path, class: 'font-bold text-teal-400' %>.</span>
-      </label>
-    </div>
-    <div class="text-xs text-neutral-500">
-      This site is protected by reCAPTCHA and the Google
-      <a href="https://policies.google.com/privacy">Privacy Policy</a> and
-      <a href="https://policies.google.com/terms">Terms of Service</a> apply.
-    </div>
-  <% end %>
+  </div>
 </div>

--- a/ecosystem/platform/server/app/views/onboarding/email_success.html.erb
+++ b/ecosystem/platform/server/app/views/onboarding/email_success.html.erb
@@ -1,13 +1,23 @@
-<div class="flex-[2]">
-  <h2 class="text-4xl text-teal-400 font-mono mb-16 mt-8">Welcome, <%= @oauth_username || @oauth_email %>!</h2>
-
-  <p class="mb-4 font-light">
-  A verification email has been sent to <strong class="text-teal-400"><%= current_user.unconfirmed_email %></strong>.
-  </p>
-  <p class="mb-4 font-light">
-  Please verify your email by clicking the link sent to your inbox.
-  </p>
-  <p class="mb-4 font-light">
-  If you have not received this email, please check your spam folder, or <%= render(LinkComponent.new(href: onboarding_email_path)) { 'click here' } %> to send a new email.
-  </p>
+<div class="bg-neutral-900 text-white h-full">
+  <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 md:px-8 py-12 sm:py-24">
+    <h3 class="text-base uppercase text-teal-400 mb-2 font-mono">Community</h3>
+    <h2 class="text-6xl mb-4 font-display font-light">Create Account</h2>
+    <div class="mb-16">
+      <%= render DividerComponent.new(scheme: :primary) %>
+    </div>
+    <div class="flex flex-col md:flex-row gap-14 md:gap-18 2xl:gap-36 justify-between">
+      <div class="flex-[2]">
+        <h2 class="text-4xl text-teal-400 font-mono mb-16 mt-8">Welcome, <%= @oauth_username || @oauth_email %>!</h2>
+        <p class="mb-4 font-light">
+        A verification email has been sent to <strong class="text-teal-400"><%= current_user.unconfirmed_email %></strong>.
+        </p>
+        <p class="mb-4 font-light">
+        Please verify your email by clicking the link sent to your inbox.
+        </p>
+        <p class="mb-4 font-light">
+        If you have not received this email, please check your spam folder, or <%= render(LinkComponent.new(href: onboarding_email_path)) { 'click here' } %> to send a new email.
+        </p>
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
### Description
Setup initial template for Onboarding to deviate general onboarding from AIT flow.

- Sets onboarding templates specific to "Create Account"
- Move username helper text below field and match styling to Profile settings
- Remove default value of username field `@oauth_username` as this does not pass validation if left untouched

### Test Plan
<img width="1971" alt="image" src="https://user-images.githubusercontent.com/98909677/185251007-cbb86b68-235e-49ff-be55-d1f18ac8c804.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3086)
<!-- Reviewable:end -->
