### PR TITLE
[State Sync] Add custom configs for state value streams.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -116,8 +116,8 @@ impl Default for StorageServiceConfig {
             max_lru_cache_size: 100,
             max_network_channel_size: 4000,
             max_network_chunk_bytes: (MAX_APPLICATION_FRAME_SIZE - MESSAGE_PADDING_SIZE) as u64,
-            max_state_chunk_size: 1000,
-            max_subscription_period_ms: 10000,
+            max_state_chunk_size: 2000,
+            max_subscription_period_ms: 5000,
             max_transaction_chunk_size: 1000,
             max_transaction_output_chunk_size: 1000,
             storage_summary_refresh_interval_ms: 50,
@@ -133,6 +133,9 @@ pub struct DataStreamingServiceConfig {
 
     // Maximum number of concurrent data client requests (per stream).
     pub max_concurrent_requests: u64,
+
+    // Maximum number of concurrent data client requests (per stream) for state keys/values.
+    pub max_concurrent_state_requests: u64,
 
     // Maximum channel sizes for each data stream listener. If messages are not
     // consumed, they will be dropped (oldest messages first). The remaining
@@ -156,6 +159,7 @@ impl Default for DataStreamingServiceConfig {
         Self {
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: 2,
+            max_concurrent_state_requests: 4,
             max_data_stream_channel_sizes: 1000,
             max_request_retry: 3,
             max_notification_id_mappings: 2000,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -25,8 +25,10 @@ use aptos_data_client::{
 };
 use aptos_id_generator::U64IdGenerator;
 use aptos_infallible::Mutex;
+use aptos_types::proof::SparseMerkleRangeProof;
+use aptos_types::state_store::state_value::StateValueChunkWithProof;
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
-use claim::{assert_err, assert_ge, assert_none, assert_ok};
+use claim::{assert_err, assert_ge, assert_matches, assert_none, assert_ok};
 use futures::{FutureExt, StreamExt};
 use std::{sync::Arc, time::Duration};
 use storage_service_types::responses::CompleteDataRange;
@@ -240,11 +242,12 @@ async fn test_stream_invalid_response() {
 }
 
 #[tokio::test]
-async fn test_stream_out_of_order_responses() {
+async fn test_epoch_stream_out_of_order_responses() {
     // Create an epoch ending data stream
     let max_concurrent_requests = 3;
     let streaming_service_config = DataStreamingServiceConfig {
         max_concurrent_requests,
+        max_concurrent_state_requests: 1,
         ..Default::default()
     };
     let (mut data_stream, mut stream_listener) =
@@ -309,6 +312,91 @@ async fn test_stream_out_of_order_responses() {
             create_ledger_info(0, MIN_ADVERTISED_EPOCH_END, true),
         )
         .await;
+    }
+    assert_none!(stream_listener.select_next_some().now_or_never());
+}
+
+#[tokio::test]
+async fn test_state_stream_out_of_order_responses() {
+    // Create a state value data stream
+    let max_concurrent_state_requests = 6;
+    let streaming_service_config = DataStreamingServiceConfig {
+        max_concurrent_requests: 1,
+        max_concurrent_state_requests,
+        ..Default::default()
+    };
+    let (mut data_stream, mut stream_listener) =
+        create_state_value_stream(streaming_service_config, MIN_ADVERTISED_STATES);
+
+    // Initialize the data stream
+    let global_data_summary = create_global_data_summary(1);
+    data_stream
+        .initialize_data_requests(global_data_summary.clone())
+        .unwrap();
+
+    // Verify a single request is made (to fetch the number of state values)
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    assert_eq!(sent_requests.as_ref().unwrap().len(), 1);
+
+    // Set a response for the number of state values
+    set_num_state_values_response_in_queue(&mut data_stream, 0);
+    data_stream
+        .process_data_responses(global_data_summary.clone())
+        .unwrap();
+
+    // Verify at least six requests have been made
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    assert_ge!(
+        sent_requests.as_ref().unwrap().len(),
+        max_concurrent_state_requests as usize
+    );
+
+    // Set a response for the second request and verify no notifications
+    set_state_value_response_in_queue(&mut data_stream, 1);
+    data_stream
+        .process_data_responses(global_data_summary.clone())
+        .unwrap();
+    assert_none!(stream_listener.select_next_some().now_or_never());
+
+    // Set a response for the first request and verify two notifications
+    set_state_value_response_in_queue(&mut data_stream, 0);
+    data_stream
+        .process_data_responses(global_data_summary.clone())
+        .unwrap();
+    for _ in 0..2 {
+        let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
+        assert_matches!(
+            data_notification.data_payload,
+            DataPayload::StateValuesWithProof(_)
+        );
+    }
+    assert_none!(stream_listener.select_next_some().now_or_never());
+
+    // Set the response for the first and third request and verify one notification sent
+    set_state_value_response_in_queue(&mut data_stream, 0);
+    set_state_value_response_in_queue(&mut data_stream, 2);
+    data_stream
+        .process_data_responses(global_data_summary.clone())
+        .unwrap();
+    let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
+    assert_matches!(
+        data_notification.data_payload,
+        DataPayload::StateValuesWithProof(_)
+    );
+    assert_none!(stream_listener.select_next_some().now_or_never());
+
+    // Set the response for the first and third request and verify three notifications sent
+    set_state_value_response_in_queue(&mut data_stream, 0);
+    set_state_value_response_in_queue(&mut data_stream, 2);
+    data_stream
+        .process_data_responses(global_data_summary.clone())
+        .unwrap();
+    for _ in 0..3 {
+        let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
+        assert_matches!(
+            data_notification.data_payload,
+            DataPayload::StateValuesWithProof(_)
+        );
     }
     assert_none!(stream_listener.select_next_some().now_or_never());
 }
@@ -485,6 +573,42 @@ fn set_epoch_ending_response_in_queue(
             MIN_ADVERTISED_EPOCH_END,
             true,
         )]),
+    )));
+    pending_response.lock().client_response = client_response;
+}
+
+/// Sets the client response at the index in the pending queue to contain a
+/// number of state values response.
+fn set_num_state_values_response_in_queue(
+    data_stream: &mut DataStream<MockAptosDataClient>,
+    index: usize,
+) {
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    let pending_response = sent_requests.as_mut().unwrap().get_mut(index).unwrap();
+    let client_response = Some(Ok(create_data_client_response(
+        ResponsePayload::NumberOfStates(1000000),
+    )));
+    pending_response.lock().client_response = client_response;
+}
+
+/// Sets the client response at the index in the pending queue to contain an
+/// state value data response.
+fn set_state_value_response_in_queue(
+    data_stream: &mut DataStream<MockAptosDataClient>,
+    index: usize,
+) {
+    let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
+    let pending_response = sent_requests.as_mut().unwrap().get_mut(index).unwrap();
+    let client_response = Some(Ok(create_data_client_response(
+        ResponsePayload::StateValuesWithProof(StateValueChunkWithProof {
+            first_index: 0,
+            last_index: 0,
+            first_key: Default::default(),
+            last_key: Default::default(),
+            raw_values: vec![],
+            proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: Default::default(),
+        }),
     )));
     pending_response.lock().client_response = client_response;
 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
@@ -1090,6 +1090,7 @@ fn create_streaming_client_with_mocks(
     // Create the data streaming service config
     let data_streaming_service_config = DataStreamingServiceConfig {
         max_concurrent_requests: 3,
+        max_concurrent_state_requests: 6,
         ..Default::default()
     };
 


### PR DESCRIPTION
### Description
This PR adds a new config for specifying the max number of concurrent requests allowed for state value streams. This is separate to the existing config which only applies to other stream types. This is useful because state value syncing is bottlenecked by the network, while other streams are not. So, we need to be slightly more aggressive with state value prefetching.

### Test Plan
Added a new unit test for this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3090)
<!-- Reviewable:end -->
