### PR TITLE
Rotation Capability

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -65,6 +65,11 @@ module aptos_framework::account {
         new_public_key: vector<u8>,
     }
 
+    struct RotationCapabilityOfferProofChallenge has drop {
+        sequence_number: u64,
+        recipient_address: address,
+    }
+
     const MAX_U64: u128 = 18446744073709551615;
 
     /// Account already exists
@@ -87,6 +92,8 @@ module aptos_framework::account {
     const EINVALID_PROOF_OF_KNOWLEDGE: u64 = 9;
     /// The caller does not have a digital-signature-based capability to call this function
     const ENO_CAPABILITY: u64 = 10;
+    // The caller does not have a valid rotation capability offer from the other account
+    const EINVALID_ACCEPT_ROTATION_CAPABILITY: u64 = 11;
 
     /// Prologue errors. These are separated out from the other errors in this
     /// module since they are mapped separately to major VM statuses, and are
@@ -209,6 +216,15 @@ module aptos_framework::account {
         account_resource.authentication_key = new_auth_key;
     }
 
+    // Check account_public_key_bytes matches current_auth_key:
+    //  1. First, append the Ed25519 scheme identifier '0x00' to `account_public_key_bytes`
+    //  2. Second, hash this using SHA3-256
+    fun verify_authentication_key_matches_ed25519_public_key(account_auth_key: vector<u8>, account_public_key_bytes: vector<u8>) : bool {
+        vector::push_back(&mut account_public_key_bytes, 0);
+        let expected_account_auth_key = hash::sha3_256(account_public_key_bytes);
+        expected_account_auth_key == account_auth_key
+    }
+
     /// Rotates the authentication key and records a mapping on chain from the new authentication key to the originating
     /// address of the account. To authorize the rotation, a signature under the old public key on a `RotationProofChallenge`
     /// is given in `current_sig`. To ensure the account owner knows the secret key corresponding to the new public key
@@ -229,17 +245,11 @@ module aptos_framework::account {
         let new_sig = ed25519::new_signature_from_bytes(new_sig_bytes);
         let curr_sig = ed25519::new_signature_from_bytes(curr_sig_bytes);
 
-        // Get the current authentication key of the account
+        // Get the current authentication key of the account and verify that it matches with `curr_pk_bytes`
         let account_resource = borrow_global_mut<Account>(addr);
+        assert!(verify_authentication_key_matches_ed25519_public_key(account_resource.authentication_key, curr_pk_bytes), std::error::unauthenticated(EWRONG_CURRENT_PUBLIC_KEY));
+
         let curr_auth_key = create_address(account_resource.authentication_key);
-
-        // Check current_pk matches current_auth_key:
-        //  1. First, append the Ed25519 scheme identifier '0x00' to the PK
-        //  2. Second, hash this using SHA3-256
-        vector::push_back(&mut curr_pk_bytes, 0);
-        let expected_current_auth_key = hash::sha3_256(curr_pk_bytes);
-        assert!(create_address(expected_current_auth_key) == curr_auth_key, std::error::unauthenticated(EWRONG_CURRENT_PUBLIC_KEY));
-
         // Construct a RotationProofChallenge struct
         let challenge = RotationProofChallenge {
             sequence_number: account_resource.sequence_number,
@@ -270,6 +280,53 @@ module aptos_framework::account {
 
         // Update the account with the new authentication key
         account_resource.authentication_key = new_auth_key;
+    }
+
+    /// Offer rotation capability of this account to another address
+    /// To authorize the rotation capability offer, a signature under the current public key on a `RotationCapabilityOfferProofChallenge`
+    /// is given in `rotation_capability_sig_bytes`. The current public key is passed into `account_public_key_bytes` to verify proof-of-knowledge.
+    /// The recipient address refers to the address that the account owner wants to give the rotation capability to.
+    public entry fun offer_rotation_capability_ed25519(account: &signer, rotation_capability_sig_bytes: vector<u8>, account_public_key_bytes: vector<u8>, recipient_address: address) acquires Account {
+        let addr = signer::address_of(account);
+        assert!(exists_at(addr) && exists_at(recipient_address), error::not_found(EACCOUNT_DOES_NOT_EXIST));
+
+        let pubkey = ed25519::new_unvalidated_public_key_from_bytes(account_public_key_bytes);
+        let rotation_capability_sig = ed25519::new_signature_from_bytes(rotation_capability_sig_bytes);
+
+        // Get the current authentication key of the account and verify that it matches with `account_public_key_bytes`
+        let account_resource = borrow_global_mut<Account>(addr);
+        assert!(verify_authentication_key_matches_ed25519_public_key(account_resource.authentication_key, account_public_key_bytes), EWRONG_CURRENT_PUBLIC_KEY);
+
+        //  Construct a RotationCapabilityOfferProofChallenge struct
+        let rotation_capability_offer_proof_challenge = RotationCapabilityOfferProofChallenge {
+            sequence_number: account_resource.sequence_number,
+            recipient_address,
+        };
+
+        // Verify a digital-signature-based capability that assures us this rotation capability offer was intended by the account owner
+        assert!(ed25519::signature_verify_strict_t(&rotation_capability_sig, &pubkey, rotation_capability_offer_proof_challenge), EINVALID_PROOF_OF_KNOWLEDGE);
+
+        // Add the recipient's address in account owner's rotation capability offer once we verify that this action is intended by the account owner
+        option::fill(&mut account_resource.rotation_capability_offer.for, recipient_address);
+    }
+
+    // Accept rotation capability from `offerer_address` if there's an existing rotation capability offer to the account owner in the offerer's account
+    public fun accept_rotation_capability_ed25519(account: &signer, offerer_address: address) : RotationCapability acquires Account {
+        assert!(exists_at(offerer_address), error::not_found(EACCOUNT_DOES_NOT_EXIST));
+
+        // Check if there's an existing rotation capability offer from the offerer
+        let account_resource = borrow_global_mut<Account>(offerer_address);
+        let addr = signer::address_of(account);
+        assert!(option::contains(&account_resource.rotation_capability_offer.for, &addr), EINVALID_ACCEPT_ROTATION_CAPABILITY);
+
+        // If there's an existing rotation capability offer for this account in the offerer's account,
+        // we create a RotationCapability of offerer and return the RotationCapability
+        let rotation_capability = RotationCapability {
+            account: offerer_address,
+        };
+        option::extract(&mut account_resource.rotation_capability_offer.for);
+
+        rotation_capability
     }
 
     fun prologue_common(
@@ -604,5 +661,58 @@ module aptos_framework::account {
         let test_signature  = vector::empty<u8>();
         let pk = x"0000000000000000000000000000000000000000000000000000000000000000";
         rotate_authentication_key_ed25519(&alice, test_signature, test_signature, pk, pk);
+    }
+
+    #[test(bob = @0x345)]
+    #[expected_failure(abort_code = 9)]
+    public entry fun test_invalid_offer_rotation_capability(bob: signer) acquires Account {
+        let pk_with_scheme = x"f66bf0ce5ceb582b93d6780820c2025b9967aedaa259bdbb9f3d0297eced0e18";
+        vector::push_back(&mut pk_with_scheme, 0);
+        let alice_address = create_address(hash::sha3_256(pk_with_scheme));
+        let alice = create_account_unchecked(alice_address);
+        create_account(signer::address_of(&bob));
+
+        let pk = x"f66bf0ce5ceb582b93d6780820c2025b9967aedaa259bdbb9f3d0297eced0e18";
+        let invalid_signature = x"78f7d09ef7a9d8d7450d600b10231e6512610f919a63bd71bea1c907f7e101ed333bff360eeda97a8637a53fd622d597c03a0d6fd1315c6fa23719983ff7de0c";
+        offer_rotation_capability_ed25519(&alice, invalid_signature, pk, signer::address_of(&bob));
+    }
+
+    #[test(bob = @0x345)]
+    public entry fun test_valid_accept_rotation_capability(bob: signer) acquires Account {
+        let pk_with_scheme = x"f66bf0ce5ceb582b93d6780820c2025b9967aedaa259bdbb9f3d0297eced0e18";
+        vector::push_back(&mut pk_with_scheme, 0);
+        let alice_address = create_address(hash::sha3_256(pk_with_scheme));
+        let alice = create_account_unchecked(alice_address);
+        create_account(signer::address_of(&bob));
+
+        let pk = x"f66bf0ce5ceb582b93d6780820c2025b9967aedaa259bdbb9f3d0297eced0e18";
+        let valid_signature = x"68f7d09ef7a9d8d7450d600b10231e6512610f919a63bd71bea1c907f7e101ed333bff360eeda97a8637a53fd622d597c03a0d6fd1315c6fa23719983ff7de0c";
+        offer_rotation_capability_ed25519(&alice, valid_signature, pk, signer::address_of(&bob));
+
+        let alice_account_resource = borrow_global_mut<Account>(signer::address_of(&alice));
+        assert!(option::contains(&alice_account_resource.rotation_capability_offer.for, &signer::address_of(&bob)), 0);
+
+        let rotation_cap = accept_rotation_capability_ed25519(&bob, signer::address_of(&alice));
+        assert!(rotation_cap.account == signer::address_of(&alice), 0);
+    }
+
+    #[test(bob = @0x345, charlie=@0x567)]
+    #[expected_failure(abort_code = 11)]
+    public entry fun test_invalid_accept_rotation_capability(bob: signer, charlie: signer) acquires Account {
+        let pk_with_scheme = x"f66bf0ce5ceb582b93d6780820c2025b9967aedaa259bdbb9f3d0297eced0e18";
+        vector::push_back(&mut pk_with_scheme, 0);
+        let alice_address = create_address(hash::sha3_256(pk_with_scheme));
+        let alice = create_account_unchecked(alice_address);
+        create_account(signer::address_of(&bob));
+        create_account(signer::address_of(&charlie));
+
+        let pk = x"f66bf0ce5ceb582b93d6780820c2025b9967aedaa259bdbb9f3d0297eced0e18";
+        let valid_signature = x"68f7d09ef7a9d8d7450d600b10231e6512610f919a63bd71bea1c907f7e101ed333bff360eeda97a8637a53fd622d597c03a0d6fd1315c6fa23719983ff7de0c";
+        offer_rotation_capability_ed25519(&alice, valid_signature, pk, signer::address_of(&bob));
+
+        let alice_account_resource = borrow_global_mut<Account>(signer::address_of(&alice));
+        assert!(option::contains(&alice_account_resource.rotation_capability_offer.for, &signer::address_of(&bob)), 0);
+
+        accept_rotation_capability_ed25519(&bob, signer::address_of(&charlie));
     }
 }

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -39,6 +39,16 @@ pub enum EntryFunctionCall {
         auth_key: AccountAddress,
     },
 
+    /// Offer rotation capability of this account to another address
+    /// To authorize the rotation capability offer, a signature under the current public key on a `RotationCapabilityOfferProofChallenge`
+    /// is given in `rotation_capability_sig_bytes`. The current public key is passed into `account_public_key_bytes` to verify proof-of-knowledge.
+    /// The recipient address refers to the address that the account owner wants to give the rotation capability to.
+    AccountOfferRotationCapabilityEd25519 {
+        rotation_capability_sig_bytes: Vec<u8>,
+        account_public_key_bytes: Vec<u8>,
+        recipient_address: AccountAddress,
+    },
+
     AccountRotateAuthenticationKey {
         new_auth_key: Vec<u8>,
     },
@@ -265,6 +275,15 @@ impl EntryFunctionCall {
         use EntryFunctionCall::*;
         match self {
             AccountCreateAccount { auth_key } => account_create_account(auth_key),
+            AccountOfferRotationCapabilityEd25519 {
+                rotation_capability_sig_bytes,
+                account_public_key_bytes,
+                recipient_address,
+            } => account_offer_rotation_capability_ed25519(
+                rotation_capability_sig_bytes,
+                account_public_key_bytes,
+                recipient_address,
+            ),
             AccountRotateAuthenticationKey { new_auth_key } => {
                 account_rotate_authentication_key(new_auth_key)
             }
@@ -419,6 +438,33 @@ pub fn account_create_account(auth_key: AccountAddress) -> TransactionPayload {
         ident_str!("create_account").to_owned(),
         vec![],
         vec![bcs::to_bytes(&auth_key).unwrap()],
+    ))
+}
+
+/// Offer rotation capability of this account to another address
+/// To authorize the rotation capability offer, a signature under the current public key on a `RotationCapabilityOfferProofChallenge`
+/// is given in `rotation_capability_sig_bytes`. The current public key is passed into `account_public_key_bytes` to verify proof-of-knowledge.
+/// The recipient address refers to the address that the account owner wants to give the rotation capability to.
+pub fn account_offer_rotation_capability_ed25519(
+    rotation_capability_sig_bytes: Vec<u8>,
+    account_public_key_bytes: Vec<u8>,
+    recipient_address: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("account").to_owned(),
+        ),
+        ident_str!("offer_rotation_capability_ed25519").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&rotation_capability_sig_bytes).unwrap(),
+            bcs::to_bytes(&account_public_key_bytes).unwrap(),
+            bcs::to_bytes(&recipient_address).unwrap(),
+        ],
     ))
 }
 
@@ -1091,6 +1137,20 @@ mod decoder {
         }
     }
 
+    pub fn account_offer_rotation_capability_ed25519(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::AccountOfferRotationCapabilityEd25519 {
+                rotation_capability_sig_bytes: bcs::from_bytes(script.args().get(0)?).ok()?,
+                account_public_key_bytes: bcs::from_bytes(script.args().get(1)?).ok()?,
+                recipient_address: bcs::from_bytes(script.args().get(2)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
     pub fn account_rotate_authentication_key(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
@@ -1484,6 +1544,10 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "account_create_account".to_string(),
             Box::new(decoder::account_create_account),
+        );
+        map.insert(
+            "account_offer_rotation_capability_ed25519".to_string(),
+            Box::new(decoder::account_offer_rotation_capability_ed25519),
         );
         map.insert(
             "account_rotate_authentication_key".to_string(),


### PR DESCRIPTION
### Description
added rotation capability functions to allow a user to offer their rotation capability to another account, and allow another account to accept a rotation capability.

### Test Plan
unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3091)
<!-- Reviewable:end -->
