### PR TITLE
[Logger] Add a new line after each log.

### DIFF
--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -583,7 +583,7 @@ impl Writer for StdoutWriter {
     }
     fn write_buferred(&mut self, log: String) {
         self.buffer
-            .write_fmt(format_args!("{}", log))
+            .write_fmt(format_args!("{}\n", log))
             .unwrap_or_default();
     }
 }

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -17,6 +17,8 @@ use std::{
     time::{Duration, Instant},
 };
 
+const MAX_WAIT_SECS: u64 = 60;
+
 #[tokio::test]
 async fn test_full_node_basic_flow() {
     let mut swarm = new_local_swarm_with_aptos(1).await;
@@ -35,7 +37,7 @@ async fn test_full_node_basic_flow() {
         .unwrap();
     for fullnode in swarm.full_nodes_mut() {
         fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
             .await
             .unwrap();
     }
@@ -50,7 +52,7 @@ async fn test_full_node_basic_flow() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(10))
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 
@@ -131,11 +133,11 @@ async fn test_vfn_failover() {
     }
     for fullnode in swarm.full_nodes_mut() {
         fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
             .await
             .unwrap();
         fullnode
-            .wait_for_connectivity(Instant::now() + Duration::from_secs(60))
+            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
             .await
             .unwrap();
     }
@@ -145,7 +147,7 @@ async fn test_vfn_failover() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(10))
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 
@@ -238,7 +240,7 @@ async fn test_private_full_node() {
     let user = swarm.add_full_node(&version, user_config).unwrap();
 
     swarm
-        .wait_for_connectivity(Instant::now() + Duration::from_secs(60))
+        .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 
@@ -264,7 +266,7 @@ async fn test_private_full_node() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(60))
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 


### PR DESCRIPTION
### Description
This PR adds a newline after each log to ensure logs are printed to separate lines. This was introduced by: https://github.com/aptos-labs/aptos-core/pull/2962/files.


### Test Plan
I tested this by running a local validator swarm with and without this change. Without the change, logs were on the same line. With the change, logs are back to their own lines. 😄

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3092)
<!-- Reviewable:end -->
