### PR TITLE
feat: serializes txn arguments with remote ABI info

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,18 +5,26 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
 ## Unreleased
+
 N/A
 
+## 1.3.7 (2022-08-17)
+
+- Add a transaction builder that is able to serialize transaction arguments with remote ABIs. Remote ABIs are fetchable through REST APIs. With the remote ABI transaction builder, developers can build BCS transactions by only providing the native JS values.
+
 ## 1.3.6 (2022-08-10)
+
 - Switch back to representing certain move types (MoveModuleId, MoveStructTag, ScriptFunctionId) as strings, for both requests and responses. This reverts the change made in 1.3.2. See [#2663](https://github.com/aptos-labs/aptos-core/pull/2663) for more.
 - Represent certain fields with slightly different snake casing, e.g. `ed25519_signature` now instead of `ed_25519_signature`.
 - Add generated types for healthcheck endpoint.
 - If the given URL is missing `/v1`, the `AptosClient` constructor will add it for you. You can opt out of this behavior by setting `doNotFixNodeUrl` to true when calling the constructor.
 
 ## 1.3.5 (2022-08-08)
+
 - Re-expose BCS and items from `transaction_builder/builder` from the root of the module.
 
 ## 1.3.4 (2022-08-07)
+
 - Downscaled default value for `max_gas`.
 
 ## 1.3.3 (2022-08-05)

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -60,5 +60,5 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   },
-  "version": "1.3.6"
+  "version": "1.3.7"
 }

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/abi.ts
@@ -80,6 +80,7 @@ export class TransactionScriptABI extends ScriptABI {
   }
 
   serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(0);
     serializer.serializeStr(this.name);
     serializer.serializeStr(this.doc);
     serializer.serializeBytes(this.code);
@@ -117,6 +118,7 @@ export class ScriptFunctionABI extends ScriptABI {
   }
 
   serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(1);
     serializer.serializeStr(this.name);
     this.module_name.serialize(serializer);
     serializer.serializeStr(this.doc);

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -3,6 +3,7 @@
 
 import * as SHA3 from "js-sha3";
 import { Buffer } from "buffer/";
+import { MemoizeExpiring } from "typescript-memoize";
 import {
   Ed25519PublicKey,
   Ed25519Signature,
@@ -23,11 +24,13 @@ import {
   TransactionArgument,
   TransactionPayloadScriptFunction,
   TransactionPayloadScript,
+  ModuleId,
 } from "./aptos_types";
 import { bcsToBytes, Bytes, Deserializer, Serializer, Uint64, Uint8 } from "./bcs";
-import { ScriptABI, ScriptFunctionABI, TransactionScriptABI } from "./aptos_types/abi";
-import { HexString } from "../hex_string";
+import { ArgumentABI, ScriptABI, ScriptFunctionABI, TransactionScriptABI, TypeArgumentABI } from "./aptos_types/abi";
+import { HexString, MaybeHexString } from "../hex_string";
 import { argToTransactionArgument, TypeTagParser, serializeArg } from "./builder_utils";
+import * as Gen from "../generated/index";
 
 const RAW_TRANSACTION_SALT = "APTOS::RawTransaction";
 const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";
@@ -137,7 +140,7 @@ export class TransactionBuilderMultiEd25519 extends TransactionBuilder<SigningFn
  * Config for creating raw transactions.
  */
 interface ABIBuilderConfig {
-  sender: HexString | AccountAddress;
+  sender: MaybeHexString | AccountAddress;
   sequenceNumber: Uint64 | string;
   gasUnitPrice?: Uint64 | string;
   maxGasAmount?: Uint64 | string;
@@ -183,8 +186,8 @@ export class TransactionBuilderABI {
 
     this.builderConfig = {
       gasUnitPrice: 1n,
-      maxGasAmount: 1000n,
-      expSecFromNow: 10,
+      maxGasAmount: 2000n,
+      expSecFromNow: 20,
       ...builderConfig,
     };
   }
@@ -273,7 +276,7 @@ export class TransactionBuilderABI {
   build(func: string, ty_tags: string[], args: any[]): RawTransaction {
     const { sender, sequenceNumber, gasUnitPrice, maxGasAmount, expSecFromNow, chainId } = this.builderConfig;
 
-    const senderAccount = sender instanceof HexString ? AccountAddress.fromHex(sender) : sender;
+    const senderAccount = sender instanceof AccountAddress ? sender : AccountAddress.fromHex(sender);
     const expTimestampSec = BigInt(Math.floor(Date.now() / 1000) + Number(expSecFromNow));
     const payload = this.buildTransactionPayload(func, ty_tags, args);
 
@@ -290,5 +293,115 @@ export class TransactionBuilderABI {
     }
 
     throw new Error("Invalid ABI.");
+  }
+}
+
+export type RemoteABIBuilderConfig = Partial<Omit<ABIBuilderConfig, "sender">> & {
+  sender: MaybeHexString | AccountAddress;
+};
+
+interface AptosClientInterface {
+  getAccountModules: (arg0: string) => Promise<Gen.MoveModuleBytecode[]>;
+  getAccount: (accountAddress: MaybeHexString) => Promise<Gen.AccountData>;
+  getChainId: () => Promise<number>;
+}
+
+/**
+ * This transaction builder downloads JSON ABIs from the fullnodes.
+ * It then translates the JSON ABIs to the format that is accepted by TransactionBuilderABI
+ */
+export class TransactionBuilderRemoteABI {
+  // We don't want the builder to depend on the actual AptosClient. There might be circular dependencies.
+  constructor(
+    private readonly aptosClient: AptosClientInterface,
+    private readonly builderConfig: RemoteABIBuilderConfig,
+  ) {}
+
+  // Cache for 10 minutes
+  @MemoizeExpiring(10 * 60 * 1000)
+  async fetchABI(addr: string) {
+    const modules = await this.aptosClient.getAccountModules(HexString.ensure(addr).hex());
+    const abis = modules
+      .map((module) => module.abi)
+      .flatMap((abi) =>
+        abi.exposed_functions
+          .filter((ef) => ef.is_entry)
+          .map(
+            (ef) =>
+              ({
+                fullName: `${abi.address}::${abi.name}::${ef.name}`,
+                ...ef,
+              } as Gen.MoveFunction & { fullName: string }),
+          ),
+      );
+
+    const abiMap = new Map<string, Gen.MoveFunction & { fullName: string }>();
+    abis.forEach((abi) => {
+      abiMap.set(abi.fullName, abi);
+    });
+
+    return abiMap;
+  }
+
+  /**
+   * Builds a raw transaction. Only support script function a.k.a entry function payloads
+   *
+   * @param func fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coins::transfer
+   * @param ty_tags
+   * @param args
+   * @returns RawTransaction
+   */
+  async build(func: Gen.ScriptFunctionId, ty_tags: Gen.MoveType[], args: any[]): Promise<RawTransaction> {
+    const funcNameParts = func.split("::");
+    if (funcNameParts.length !== 3) {
+      throw new Error(
+        // eslint-disable-next-line max-len
+        "'func' needs to be a fully qualified function name in format <address>::<module>::<function>, e.g. 0x1::coins::transfer",
+      );
+    }
+
+    const [addr, module] = func.split("::");
+
+    // Downloads the JSON abi
+    const abiMap = await this.fetchABI(addr);
+    if (!abiMap.has(func)) {
+      throw new Error(`${func} doesn't exist.`);
+    }
+
+    const funcAbi = abiMap.get(func);
+
+    // Remove all `signer` and `&signer` from arugment list because the Move VM injects those arugments. Clients do not
+    // need to care about those args. `signer` and `&signer` are required be in the front of the arugment list. But we
+    // just loop through all arguments and filter out `singer` and `&signer`.
+    const originalArgs = funcAbi.params.filter((param) => param !== "signer" && param !== "&signer");
+
+    // Convert string arugments to TypeArgumentABI
+    const typeArgABIs = originalArgs.map((arg, i) => new ArgumentABI(`var${i}`, new TypeTagParser(arg).parseTypeTag()));
+
+    const scriptFunctionABI = new ScriptFunctionABI(
+      funcAbi.name,
+      ModuleId.fromStr(`${addr}::${module}`),
+      "", // Doc string
+      funcAbi.generic_type_params.map((_, i) => new TypeArgumentABI(`${i}`)),
+      typeArgABIs,
+    );
+
+    const { sender, ...rest } = this.builderConfig;
+
+    const senderAddress = sender instanceof AccountAddress ? HexString.fromUint8Array(sender.address) : sender;
+
+    const [{ sequence_number: sequenceNumber }, chainId] = await Promise.all([
+      this.aptosClient.getAccount(senderAddress),
+      this.aptosClient.getChainId(),
+    ]);
+
+    const builderABI = new TransactionBuilderABI([bcsToBytes(scriptFunctionABI)], {
+      sender,
+      sequenceNumber,
+      chainId,
+      ...rest,
+    });
+
+    return builderABI.build(func, ty_tags, args);
   }
 }


### PR DESCRIPTION
### Description
Aptos REST APIs export JSON ABIs, which can be used to instruct BCS to serialize transaction arguments. The code in this PR fetches the JSON ABIs and converts the JSON ABIs to their binary format. The reason is that we want to reuse the code as much as possible since we have a builder that accepts binary ABIs already.

Note: Remote ABIs only support ScriptFunction aka Entry Function payloads. Script and other payloads are not supported.

### Test Plan
Jest test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3093)
<!-- Reviewable:end -->
