### PR TITLE
[jmt] support empty tree

### DIFF
--- a/storage/jellyfish-merkle/src/iterator/mod.rs
+++ b/storage/jellyfish-merkle/src/iterator/mod.rs
@@ -177,6 +177,9 @@ where
                     }
                 }
             }
+            Node::Null => {
+                done = true;
+            }
         }
 
         Ok(Self {
@@ -243,6 +246,7 @@ where
                     ));
                     current_node_key = next_node_key;
                 }
+                Node::Null => unreachable!("Null node has leaf count 0 so here is unreachable"),
             };
             current_node = reader.get_node(&current_node_key)?;
         }
@@ -300,6 +304,9 @@ where
                     // iterated past the last key.
                     return None;
                 }
+                Ok(Node::Null) => {
+                    unreachable!("When tree is empty, done should be already set to true")
+                }
                 Err(err) => return Some(Err(err)),
             }
         }
@@ -328,6 +335,9 @@ where
                     let ret = (leaf_node.account_key(), leaf_node.value_index().clone());
                     Self::cleanup_stack(&mut self.parent_stack);
                     return Some(Ok(ret));
+                }
+                Ok(Node::Null) => {
+                    unreachable!("When tree is empty, done should be already set to true")
                 }
                 Err(err) => return Some(Err(err)),
             }

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -258,6 +258,7 @@ where
                             leaf_count: Some(internal_node.leaf_count()),
                         },
                         Node::Leaf(leaf_node) => ChildInfo::Leaf(leaf_node),
+                        Node::Null => unreachable!("Child cannot be Null"),
                     };
                     internal_info.set_child(i, child_info);
                 }


### PR DESCRIPTION
### Description
We support empty tree at any version in storage.
### Test Plan
ut

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3095)
<!-- Reviewable:end -->
