### PR TITLE
[aptos-cli] Cleanup general CLI output and make it more consistent

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions};
+use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions, TransactionSummary};
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
@@ -23,16 +23,16 @@ pub struct CreateAccount {
 }
 
 #[async_trait]
-impl CliCommand<String> for CreateAccount {
+impl CliCommand<TransactionSummary> for CreateAccount {
     fn command_name(&self) -> &'static str {
         "CreateAccount"
     }
 
-    async fn execute(self) -> CliTypedResult<String> {
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
         let address = self.account;
         self.txn_options
             .submit_transaction(aptos_stdlib::account_create_account(address))
             .await
-            .map(|_| format!("Account Created at {}", address))
+            .map(TransactionSummary::from)
     }
 }

--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions};
+use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions, TransactionSummary};
 use aptos_rest_client::{
     aptos_api_types::{WriteResource, WriteSetChange},
     Transaction,
@@ -36,31 +36,23 @@ pub struct CreateResourceAccount {
 }
 
 /// A shortened create resource account output
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CreateResourceAccountSummary {
-    pub gas_used: Option<u64>,
-    pub sender: Option<AccountAddress>,
     pub resource_account: Option<AccountAddress>,
-    pub hash: Option<String>,
-    pub success: bool,
-    pub version: Option<u64>,
-    pub vm_status: String,
+    #[serde(flatten)]
+    pub transaction_summary: TransactionSummary,
 }
 
 impl From<Transaction> for CreateResourceAccountSummary {
     fn from(transaction: Transaction) -> Self {
+        let transaction_summary = TransactionSummary::from(&transaction);
+
         let mut summary = CreateResourceAccountSummary {
-            success: transaction.success(),
-            version: transaction.version(),
-            vm_status: transaction.vm_status(),
-            ..Default::default()
+            transaction_summary,
+            resource_account: None,
         };
 
         if let Transaction::UserTransaction(txn) = transaction {
-            summary.sender = Some(*txn.request.sender.inner());
-            summary.gas_used = Some(txn.info.gas_used.0);
-            summary.version = Some(txn.info.version.0);
-            summary.hash = Some(txn.info.hash.to_string());
             summary.resource_account = txn.info.changes.iter().find_map(|change| match change {
                 WriteSetChange::WriteResource(WriteResource { address, data, .. }) => {
                     if data.typ.name.as_str() == "Account"

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -894,16 +894,16 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
 /// A shortened transaction output
 #[derive(Clone, Debug, Serialize)]
 pub struct TransactionSummary {
-    transaction_hash: HashValue,
-    gas_used: Option<u64>,
-    gas_unit_price: Option<u64>,
-    pending: Option<bool>,
-    sender: Option<AccountAddress>,
-    sequence_number: Option<u64>,
-    success: Option<bool>,
-    timestamp_us: Option<u64>,
-    version: Option<u64>,
-    vm_status: Option<String>,
+    pub transaction_hash: HashValue,
+    pub gas_used: Option<u64>,
+    pub gas_unit_price: Option<u64>,
+    pub pending: Option<bool>,
+    pub sender: Option<AccountAddress>,
+    pub sequence_number: Option<u64>,
+    pub success: Option<bool>,
+    pub timestamp_us: Option<u64>,
+    pub version: Option<u64>,
+    pub vm_status: Option<String>,
 }
 
 impl From<Transaction> for TransactionSummary {

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -19,13 +19,8 @@ use aptos_crypto::{
     x25519, PrivateKey, ValidCryptoMaterial, ValidCryptoMaterialStringExt,
 };
 use aptos_keygen::KeyGen;
-use aptos_rest_client::{
-    aptos_api_types::{
-        DeleteModule, DeleteResource, DeleteTableItem, WriteModule, WriteResource, WriteSetChange,
-        WriteTableItem,
-    },
-    Client, Transaction,
-};
+use aptos_rest_client::aptos_api_types::HashValue;
+use aptos_rest_client::{Client, Transaction};
 use aptos_sdk::{
     move_types::{
         ident_str,
@@ -897,79 +892,89 @@ pub trait CliCommand<T: Serialize + Send>: Sized + Send {
 }
 
 /// A shortened transaction output
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct TransactionSummary {
-    changes: Vec<ChangeSummary>,
+    transaction_hash: HashValue,
     gas_used: Option<u64>,
-    success: bool,
+    gas_unit_price: Option<u64>,
+    pending: Option<bool>,
+    sender: Option<AccountAddress>,
+    sequence_number: Option<u64>,
+    success: Option<bool>,
+    timestamp_us: Option<u64>,
     version: Option<u64>,
-    vm_status: String,
+    vm_status: Option<String>,
 }
 
 impl From<Transaction> for TransactionSummary {
     fn from(transaction: Transaction) -> Self {
-        let mut summary = TransactionSummary {
-            success: transaction.success(),
-            version: transaction.version(),
-            vm_status: transaction.vm_status(),
-            ..Default::default()
-        };
-
-        if let Ok(info) = transaction.transaction_info() {
-            summary.gas_used = Some(info.gas_used.0);
-            summary.changes = info
-                .changes
-                .iter()
-                .map(|change| match change {
-                    WriteSetChange::DeleteModule(DeleteModule { module, .. }) => ChangeSummary {
-                        event: change.type_str(),
-                        module: Some(module.to_string()),
-                        ..Default::default()
-                    },
-                    WriteSetChange::DeleteResource(DeleteResource {
-                        address, resource, ..
-                    }) => ChangeSummary {
-                        event: change.type_str(),
-                        address: Some(*address.inner()),
-                        resource: Some(resource.to_string()),
-                        ..Default::default()
-                    },
-                    WriteSetChange::DeleteTableItem(DeleteTableItem { handle, key, .. }) => {
-                        ChangeSummary {
-                            event: change.type_str(),
-                            handle: Some(handle.to_string()),
-                            key: Some(key.to_string()),
-                            ..Default::default()
-                        }
-                    }
-                    WriteSetChange::WriteModule(WriteModule { address, .. }) => ChangeSummary {
-                        event: change.type_str(),
-                        address: Some(*address.inner()),
-                        ..Default::default()
-                    },
-                    WriteSetChange::WriteResource(WriteResource { address, data, .. }) => {
-                        ChangeSummary {
-                            event: change.type_str(),
-                            address: Some(*address.inner()),
-                            resource: Some(data.typ.to_string()),
-                            data: Some(serde_json::to_value(&data.data).unwrap_or_default()),
-                            ..Default::default()
-                        }
-                    }
-                    WriteSetChange::WriteTableItem(WriteTableItem {
-                        handle, key, value, ..
-                    }) => ChangeSummary {
-                        event: change.type_str(),
-                        handle: Some(handle.to_string()),
-                        key: Some(key.to_string()),
-                        value: Some(value.to_string()),
-                        ..Default::default()
-                    },
-                })
-                .collect();
+        transaction.into()
+    }
+}
+impl From<&Transaction> for TransactionSummary {
+    fn from(transaction: &Transaction) -> Self {
+        match transaction {
+            Transaction::PendingTransaction(txn) => TransactionSummary {
+                transaction_hash: txn.hash,
+                pending: Some(true),
+                sender: Some(*txn.request.sender.inner()),
+                sequence_number: Some(txn.request.sequence_number.0),
+                gas_used: None,
+                gas_unit_price: None,
+                success: None,
+                version: None,
+                vm_status: None,
+                timestamp_us: None,
+            },
+            Transaction::UserTransaction(txn) => TransactionSummary {
+                transaction_hash: txn.info.hash,
+                sender: Some(*txn.request.sender.inner()),
+                gas_used: Some(txn.info.gas_used.0),
+                gas_unit_price: Some(txn.request.gas_unit_price.0),
+                success: Some(txn.info.success),
+                version: Some(txn.info.version.0),
+                vm_status: Some(txn.info.vm_status.clone()),
+                sequence_number: Some(txn.request.sequence_number.0),
+                timestamp_us: Some(txn.timestamp.0),
+                pending: None,
+            },
+            Transaction::GenesisTransaction(txn) => TransactionSummary {
+                transaction_hash: txn.info.hash,
+                success: Some(txn.info.success),
+                version: Some(txn.info.version.0),
+                vm_status: Some(txn.info.vm_status.clone()),
+                sender: None,
+                gas_used: None,
+                gas_unit_price: None,
+                pending: None,
+                sequence_number: None,
+                timestamp_us: None,
+            },
+            Transaction::BlockMetadataTransaction(txn) => TransactionSummary {
+                transaction_hash: txn.info.hash,
+                success: Some(txn.info.success),
+                version: Some(txn.info.version.0),
+                vm_status: Some(txn.info.vm_status.clone()),
+                timestamp_us: Some(txn.timestamp.0),
+                sender: None,
+                gas_used: None,
+                gas_unit_price: None,
+                pending: None,
+                sequence_number: None,
+            },
+            Transaction::StateCheckpointTransaction(txn) => TransactionSummary {
+                transaction_hash: txn.info.hash,
+                success: Some(txn.info.success),
+                version: Some(txn.info.version.0),
+                vm_status: Some(txn.info.vm_status.clone()),
+                timestamp_us: Some(txn.timestamp.0),
+                sender: None,
+                gas_used: None,
+                gas_unit_price: None,
+                pending: None,
+                sequence_number: None,
+            },
         }
-
-        summary
     }
 }
 

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -107,7 +107,7 @@ pub struct InitPackage {
 
     /// Named addresses for the move binary
     ///
-    /// Example: alice=0x1234, bob=0x5678
+    /// Example: alice=0x1234,bob=0x5678
     ///
     /// Note: This will fail if there are duplicates in the Move.toml file remove those first.
     #[clap(long, parse(try_from_str = crate::common::utils::parse_map), default_value = "")]
@@ -223,7 +223,10 @@ impl CliCommand<Vec<String>> for CompilePackage {
     }
 }
 
-/// Run Move unit tests against a package path
+/// Runs Move unit tests for a package
+///
+/// This will run Move unit tests against a package with debug mode
+/// turned on.  Note, that move code warnings currently block tests from running.
 #[derive(Parser)]
 pub struct TestPackage {
     /// A filter string to determine which unit tests to run
@@ -261,7 +264,6 @@ impl CliCommand<&'static str> for TestPackage {
         )
         .map_err(|err| CliError::UnexpectedError(err.to_string()))?;
 
-        // TODO: commit back up to the move repo
         match result {
             UnitTestResult::Success => Ok("Success"),
             UnitTestResult::Failure => Err(CliError::MoveTestError),
@@ -289,7 +291,10 @@ impl CliCommand<()> for TransactionalTestOpts {
     }
 }
 
-/// Prove the Move package at the package path
+/// Proves the Move package
+///
+/// This is a tool for formal verification of a Move package using
+/// the Move prover
 #[derive(Parser)]
 pub struct ProvePackage {
     /// A filter string to determine which files to verify
@@ -343,7 +348,7 @@ pub(crate) fn compile_move(
         .map_err(|err| CliError::MoveCompilationError(format!("{:#}", err)))
 }
 
-/// Publishes the modules in a Move package
+/// Publishes the modules in a Move package to the Aptos blockchain
 #[derive(Parser)]
 pub struct PublishPackage {
     /// Whether to use the legacy publishing flow. This will be soon removed.
@@ -484,20 +489,23 @@ impl CliCommand<TransactionSummary> for PublishPackage {
     }
 }
 
-/// Downloads a package and stores it in a directory named after the package.
+/// Downloads a package and stores it in a directory named after the package
+///
+/// This lets you retrieve packages directly from the blockchain for inspection
+/// and use as a local dependency in testing.
 #[derive(Parser)]
 pub struct DownloadPackage {
-    /// Address of the account.
+    /// Address of the account containing the package
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
 
-    /// Name of the package.
+    /// Name of the package
     #[clap(long)]
     package: String,
 
-    /// Where to store the downloaded packages. Defaults to the current directory.
-    #[clap(long)]
-    target: Option<String>,
+    /// Directory to store downloaded package. Defaults to the current directory.
+    #[clap(long, parse(from_os_str))]
+    output_dir: Option<PathBuf>,
 
     #[clap(flatten)]
     rest_options: RestOptions,
@@ -514,35 +522,33 @@ impl CliCommand<&'static str> for DownloadPackage {
     async fn execute(self) -> CliTypedResult<&'static str> {
         let url = self.rest_options.url(&self.profile_options.profile)?;
         let registry = CachedPackageRegistry::create(url, self.account).await?;
-        let path = if let Some(p) = self.target {
-            PathBuf::from(p)
-        } else {
-            PathBuf::from(".")
-        };
+        let output_dir = dir_default_to_current(self.output_dir)?;
+
         let package = registry
             .get_package(self.package)
             .await
             .map_err(|s| CliError::CommandArgumentError(s.to_string()))?;
-        let package_path = path.join(package.name());
+        let package_path = output_dir.join(package.name());
         package
             .save_package_to_disk(package_path.clone(), true)
-            .map_err(|e| CliError::UnexpectedError(format!("cannot save package: {}", e)))?;
+            .map_err(|e| CliError::UnexpectedError(format!("Failed to save package: {}", e)))?;
         println!(
-            "saved package with {} module(s) to `{}`",
+            "Saved package with {} module(s) to `{}`",
             package.module_names().len(),
             package_path.display()
         );
-        Ok("download succeeded")
+        Ok("Download succeeded")
     }
 }
 
-/// Lists information about packages and modules.
+/// Lists information about packages and modules on-chain
 #[derive(Parser)]
 pub struct ListPackage {
-    /// Address of the account.
+    /// Address of the account onchain
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
 
+    /// Type of resources to query
     #[clap(long, default_value_t = ListQuery::Packages)]
     query: ListQuery,
 
@@ -559,10 +565,9 @@ pub enum ListQuery {
 
 impl Display for ListQuery {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let str = match self {
+        f.write_str(match self {
             ListQuery::Packages => "packages",
-        };
-        write!(f, "{}", str)
+        })
     }
 }
 

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -3,7 +3,9 @@
 
 pub mod analyze;
 
-use crate::common::types::{ConfigSearchMode, OptionalPoolAddressArgs, PromptOptions};
+use crate::common::types::{
+    ConfigSearchMode, OptionalPoolAddressArgs, PromptOptions, TransactionSummary,
+};
 use crate::common::utils::prompt_yes_with_override;
 use crate::config::GlobalConfig;
 use crate::node::analyze::analyze_validators::AnalyzeValidators;
@@ -22,7 +24,6 @@ use aptos_config::config::NodeConfig;
 use aptos_crypto::{bls12381, x25519, ValidCryptoMaterialStringExt};
 use aptos_faucet::FaucetArgs;
 use aptos_genesis::config::{HostAndPort, OperatorConfiguration};
-use aptos_rest_client::Transaction;
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::chain_id::ChainId;
 use aptos_types::{account_address::AccountAddress, account_config::CORE_CODE_ADDRESS};
@@ -233,12 +234,12 @@ pub struct InitializeValidator {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for InitializeValidator {
+impl CliCommand<TransactionSummary> for InitializeValidator {
     fn command_name(&self) -> &'static str {
         "InitializeValidator"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         let operator_config = self.operator_config_file_args.load()?;
         let consensus_public_key = self
             .validator_consensus_key_args
@@ -277,6 +278,7 @@ impl CliCommand<Transaction> for InitializeValidator {
                 bcs::to_bytes(&full_node_network_addresses)?,
             ))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -321,12 +323,12 @@ pub struct JoinValidatorSet {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for JoinValidatorSet {
+impl CliCommand<TransactionSummary> for JoinValidatorSet {
     fn command_name(&self) -> &'static str {
         "JoinValidatorSet"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         let address = self
             .operator_args
             .address_fallback_to_txn(&self.txn_options)?;
@@ -334,6 +336,7 @@ impl CliCommand<Transaction> for JoinValidatorSet {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_join_validator_set(address))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -347,12 +350,12 @@ pub struct LeaveValidatorSet {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for LeaveValidatorSet {
+impl CliCommand<TransactionSummary> for LeaveValidatorSet {
     fn command_name(&self) -> &'static str {
         "LeaveValidatorSet"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         let address = self
             .operator_args
             .address_fallback_to_txn(&self.txn_options)?;
@@ -360,6 +363,7 @@ impl CliCommand<Transaction> for LeaveValidatorSet {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_leave_validator_set(address))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -618,12 +622,12 @@ pub struct UpdateConsensusKey {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for UpdateConsensusKey {
+impl CliCommand<TransactionSummary> for UpdateConsensusKey {
     fn command_name(&self) -> &'static str {
         "UpdateConsensusKey"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         let address = self
             .operator_args
             .address_fallback_to_txn(&self.txn_options)?;
@@ -642,6 +646,7 @@ impl CliCommand<Transaction> for UpdateConsensusKey {
                 consensus_proof_of_possession.to_bytes().to_vec(),
             ))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -659,12 +664,12 @@ pub struct UpdateValidatorNetworkAddresses {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for UpdateValidatorNetworkAddresses {
+impl CliCommand<TransactionSummary> for UpdateValidatorNetworkAddresses {
     fn command_name(&self) -> &'static str {
         "UpdateValidatorNetworkAddresses"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         let address = self
             .operator_args
             .address_fallback_to_txn(&self.txn_options)?;
@@ -700,6 +705,7 @@ impl CliCommand<Transaction> for UpdateValidatorNetworkAddresses {
                 bcs::to_bytes(&full_node_network_addresses)?,
             ))
             .await
+            .map(|inner| inner.into())
     }
 }
 

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::{CliCommand, CliResult, CliTypedResult, TransactionOptions};
-use aptos_rest_client::Transaction;
+use crate::common::types::{
+    CliCommand, CliResult, CliTypedResult, TransactionOptions, TransactionSummary,
+};
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
@@ -50,15 +51,16 @@ pub struct AddStake {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for AddStake {
+impl CliCommand<TransactionSummary> for AddStake {
     fn command_name(&self) -> &'static str {
         "AddStake"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_add_stake(self.amount))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -76,15 +78,16 @@ pub struct UnlockStake {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for UnlockStake {
+impl CliCommand<TransactionSummary> for UnlockStake {
     fn command_name(&self) -> &'static str {
         "UnlockStake"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_unlock(self.amount))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -103,15 +106,16 @@ pub struct WithdrawStake {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for WithdrawStake {
+impl CliCommand<TransactionSummary> for WithdrawStake {
     fn command_name(&self) -> &'static str {
         "WithdrawStake"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.node_op_options
             .submit_transaction(aptos_stdlib::stake_withdraw(self.amount))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -125,15 +129,16 @@ pub struct IncreaseLockup {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for IncreaseLockup {
+impl CliCommand<TransactionSummary> for IncreaseLockup {
     fn command_name(&self) -> &'static str {
         "IncreaseLockup"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_increase_lockup())
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -164,12 +169,12 @@ pub struct InitializeStakeOwner {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for InitializeStakeOwner {
+impl CliCommand<TransactionSummary> for InitializeStakeOwner {
     fn command_name(&self) -> &'static str {
         "InitializeStakeOwner"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         let owner_address = self.txn_options.sender_address()?;
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_initialize_owner_only(
@@ -178,6 +183,7 @@ impl CliCommand<Transaction> for InitializeStakeOwner {
                 self.voter_address.unwrap_or(owner_address),
             ))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -195,15 +201,16 @@ pub struct SetOperator {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for SetOperator {
+impl CliCommand<TransactionSummary> for SetOperator {
     fn command_name(&self) -> &'static str {
         "SetOperator"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_set_operator(self.operator_address))
             .await
+            .map(|inner| inner.into())
     }
 }
 
@@ -221,14 +228,15 @@ pub struct SetDelegatedVoter {
 }
 
 #[async_trait]
-impl CliCommand<Transaction> for SetDelegatedVoter {
+impl CliCommand<TransactionSummary> for SetDelegatedVoter {
     fn command_name(&self) -> &'static str {
         "SetDelegatedVoter"
     }
 
-    async fn execute(mut self) -> CliTypedResult<Transaction> {
+    async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
             .submit_transaction(aptos_stdlib::stake_set_delegated_voter(self.voter_address))
             .await
+            .map(|inner| inner.into())
     }
 }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -259,7 +259,7 @@ impl CliTestFramework {
         proof_of_possession: bls12381::ProofOfPossession,
         validator_host: HostAndPort,
         validator_network_public_key: x25519::PublicKey,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         InitializeValidator {
             txn_options: self.transaction_options(index, None),
             operator_config_file_args: OperatorConfigFileArgs {
@@ -280,7 +280,7 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn add_stake(&self, index: usize, amount: u64) -> CliTypedResult<Transaction> {
+    pub async fn add_stake(&self, index: usize, amount: u64) -> CliTypedResult<TransactionSummary> {
         AddStake {
             txn_options: self.transaction_options(index, None),
             amount,
@@ -289,7 +289,11 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn unlock_stake(&self, index: usize, amount: u64) -> CliTypedResult<Transaction> {
+    pub async fn unlock_stake(
+        &self,
+        index: usize,
+        amount: u64,
+    ) -> CliTypedResult<TransactionSummary> {
         UnlockStake {
             txn_options: self.transaction_options(index, None),
             amount,
@@ -298,7 +302,11 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn withdraw_stake(&self, index: usize, amount: u64) -> CliTypedResult<Transaction> {
+    pub async fn withdraw_stake(
+        &self,
+        index: usize,
+        amount: u64,
+    ) -> CliTypedResult<TransactionSummary> {
         WithdrawStake {
             node_op_options: self.transaction_options(index, None),
             amount,
@@ -307,7 +315,7 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn increase_lockup(&self, index: usize) -> CliTypedResult<Transaction> {
+    pub async fn increase_lockup(&self, index: usize) -> CliTypedResult<TransactionSummary> {
         IncreaseLockup {
             txn_options: self.transaction_options(index, None),
         }
@@ -319,7 +327,7 @@ impl CliTestFramework {
         &self,
         operator_index: usize,
         pool_index: Option<usize>,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         JoinValidatorSet {
             txn_options: self.transaction_options(operator_index, None),
             operator_args: self.operator_args(pool_index),
@@ -332,7 +340,7 @@ impl CliTestFramework {
         &self,
         operator_index: usize,
         pool_index: Option<usize>,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         LeaveValidatorSet {
             txn_options: self.transaction_options(operator_index, None),
             operator_args: self.operator_args(pool_index),
@@ -347,7 +355,7 @@ impl CliTestFramework {
         pool_index: Option<usize>,
         validator_host: HostAndPort,
         validator_network_public_key: x25519::PublicKey,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         UpdateValidatorNetworkAddresses {
             txn_options: self.transaction_options(operator_index, None),
             operator_args: self.operator_args(pool_index),
@@ -387,7 +395,7 @@ impl CliTestFramework {
         pool_index: Option<usize>,
         consensus_public_key: bls12381::PublicKey,
         proof_of_possession: bls12381::ProofOfPossession,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         UpdateConsensusKey {
             txn_options: self.transaction_options(operator_index, None),
             operator_args: self.operator_args(pool_index),
@@ -424,7 +432,7 @@ impl CliTestFramework {
         initial_stake_amount: u64,
         voter_index: Option<usize>,
         operator_index: Option<usize>,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         InitializeStakeOwner {
             txn_options: self.transaction_options(owner_index, None),
             initial_stake_amount,
@@ -439,7 +447,7 @@ impl CliTestFramework {
         &self,
         owner_index: usize,
         operator_index: usize,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         SetOperator {
             txn_options: self.transaction_options(owner_index, None),
             operator_address: self.account_id(operator_index),
@@ -452,7 +460,7 @@ impl CliTestFramework {
         &self,
         owner_index: usize,
         voter_index: usize,
-    ) -> CliTypedResult<Transaction> {
+    ) -> CliTypedResult<TransactionSummary> {
         SetDelegatedVoter {
             txn_options: self.transaction_options(owner_index, None),
             voter_address: self.account_id(voter_index),

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -3,12 +3,12 @@
 
 use crate::smoke_test_environment::SwarmBuilder;
 use crate::test_utils::reconfig;
+use aptos::common::types::TransactionSummary;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_crypto::{bls12381, x25519};
 use aptos_genesis::config::HostAndPort;
 use aptos_keygen::KeyGen;
-use aptos_rest_client::Transaction;
 use aptos_types::network_address::DnsName;
 use forge::{NodeExt, Swarm};
 use std::convert::TryFrom;
@@ -645,6 +645,6 @@ async fn get_validator_state(cli: &CliTestFramework, pool_index: usize) -> Valid
     ValidatorState::NONE
 }
 
-fn get_gas(transaction: Transaction) -> u64 {
-    *transaction.transaction_info().unwrap().gas_used.inner()
+fn get_gas(transaction: TransactionSummary) -> u64 {
+    transaction.gas_used.unwrap() * transaction.gas_unit_price.unwrap()
 }


### PR DESCRIPTION
### Description
Now that there are less move tool changes going through, I'm cleaning up the inputs into the APIs and the associated docs.

Additionally, now TransactionSummary is nice and simple.  If users want the large number of changes, they can look it up on the explorer.

### Test Plan
Let's see how CI goes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3098)
<!-- Reviewable:end -->
