### PR TITLE
[api] Add BCS as an alternative to JSON with similar but slightly different types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "aptos-transaction-builder",
  "aptos-types",
  "bcs",
+ "bytes 1.2.1",
  "hex",
  "move-deps",
  "poem-openapi",

--- a/api/goldens/aptos_api__tests__blocks_test__test_get_unknown_block_by_height.json
+++ b/api/goldens/aptos_api__tests__blocks_test__test_get_unknown_block_by_height.json
@@ -1,5 +1,5 @@
 {
-  "message": "Failed to retrieve block by height: NotFound(Json(AptosError { message: \"Failed to find block: Event 02000000000000000000000000000000000000000000000000000000000000000000000000000001 of seq num 1000. not found.\", error_code: None, aptos_ledger_version: None }))",
+  "message": "Failed to find block: Event 02000000000000000000000000000000000000000000000000000000000000000000000000000001 of seq num 1000. not found.",
   "error_code": null,
   "aptos_ledger_version": null
 }

--- a/api/goldens/aptos_api__tests__index_test__test_get_index.json
+++ b/api/goldens/aptos_api__tests__index_test__test_get_index.json
@@ -3,8 +3,8 @@
   "epoch": "0",
   "ledger_version": "0",
   "oldest_ledger_version": "0",
-  "block_height": "0",
-  "oldest_block_height": "0",
   "ledger_timestamp": "0",
-  "node_role": "validator"
+  "node_role": "validator",
+  "oldest_block_height": "0",
+  "block_height": "0"
 }

--- a/api/src/accept_type.rs
+++ b/api/src/accept_type.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::bcs_payload;
+use aptos_api_types::mime_types::BCS;
+use aptos_api_types::mime_types::BCS_OUTPUT_NEW;
 use poem::{web::Accept, FromRequest, Request, RequestBody, Result};
 
 #[derive(PartialEq)]
@@ -24,7 +25,7 @@ impl<'a> FromRequest<'a> for AcceptType {
 /// overriding explicit accept type, default to JSON.
 fn parse_accept(accept: &Accept) -> Result<AcceptType> {
     for mime in &accept.0 {
-        if bcs_payload::CONTENT_TYPE == mime.as_ref() {
+        if matches!(mime.as_ref(), BCS_OUTPUT_NEW | BCS) {
             return Ok(AcceptType::Bcs);
         }
     }

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -28,6 +28,7 @@ use move_deps::move_core_types::{
 };
 use poem_openapi::param::Query;
 use poem_openapi::{param::Path, OpenApi};
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -181,20 +182,34 @@ impl Account {
     pub fn resources(self, accept_type: &AcceptType) -> BasicResultWith404<Vec<MoveResource>> {
         let account_state = self.account_state()?;
         let resources = account_state.get_resources();
-        let move_resolver = self.context.move_resolver_poem()?;
-        let converted_resources = move_resolver
-            .as_converter(self.context.db.clone())
-            .try_into_resources(resources)
-            .context("Failed to build move resource response from data in DB")
-            .map_err(BasicErrorWith404::internal)
-            .map_err(|e| e.error_code(AptosErrorCode::InvalidBcsInStorageError))?;
 
-        BasicResponse::try_from_rust_value((
-            converted_resources,
-            &self.latest_ledger_info,
-            BasicResponseStatus::Ok,
-            accept_type,
-        ))
+        match accept_type {
+            AcceptType::Json => {
+                let move_resolver = self.context.move_resolver_poem()?;
+                let converted_resources = move_resolver
+                    .as_converter(self.context.db.clone())
+                    .try_into_resources(resources)
+                    .context("Failed to build move resource response from data in DB")
+                    .map_err(BasicErrorWith404::internal)
+                    .map_err(|e| e.error_code(AptosErrorCode::InvalidBcsInStorageError))?;
+
+                BasicResponse::try_from_json((
+                    converted_resources,
+                    &self.latest_ledger_info,
+                    BasicResponseStatus::Ok,
+                ))
+            }
+            AcceptType::Bcs => {
+                let resources: BTreeMap<StructTag, Vec<u8>> = resources
+                    .map(|(key, value)| (key, value.to_vec()))
+                    .collect();
+                BasicResponse::try_from_bcs((
+                    resources,
+                    &self.latest_ledger_info,
+                    BasicResponseStatus::Ok,
+                ))
+            }
+        }
     }
 
     pub fn modules(self, accept_type: &AcceptType) -> BasicResultWith404<Vec<MoveModuleBytecode>> {

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -164,12 +164,18 @@ impl Account {
             .map_err(BasicErrorWith404::internal)?;
         let account_data: AccountData = account_resource.into();
 
-        BasicResponse::try_from_rust_value((
-            account_data,
-            &self.latest_ledger_info,
-            BasicResponseStatus::Ok,
-            accept_type,
-        ))
+        match accept_type {
+            AcceptType::Json => BasicResponse::try_from_json((
+                account_data,
+                &self.latest_ledger_info,
+                BasicResponseStatus::Ok,
+            )),
+            AcceptType::Bcs => BasicResponse::try_from_encoded((
+                state_value,
+                &self.latest_ledger_info,
+                BasicResponseStatus::Ok,
+            )),
+        }
     }
 
     pub fn resources(self, accept_type: &AcceptType) -> BasicResultWith404<Vec<MoveResource>> {

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -102,7 +102,7 @@ impl AccountsApi {
         accept_type: AcceptType,
         address: Path<Address>,
         ledger_version: Query<Option<U64>>,
-    ) -> BasicResultWith404<BTreeMap<MoveModuleId, MoveModuleBytecode>> {
+    ) -> BasicResultWith404<Vec<MoveModuleBytecode>> {
         fail_point_poem("endpoint_get_account_modules")?;
         let account = Account::new(self.context.clone(), address.0, ledger_version.0)?;
         account.modules(&accept_type)
@@ -212,17 +212,13 @@ impl Account {
         }
     }
 
-    pub fn modules(
-        self,
-        accept_type: &AcceptType,
-    ) -> BasicResultWith404<BTreeMap<MoveModuleId, MoveModuleBytecode>> {
+    pub fn modules(self, accept_type: &AcceptType) -> BasicResultWith404<Vec<MoveModuleBytecode>> {
         let modules = self.account_state()?.into_modules();
         match accept_type {
             AcceptType::Json => {
-                let mut converted_modules = BTreeMap::new();
-                for (module_id, module) in modules {
-                    converted_modules.insert(
-                        module_id.into(),
+                let mut converted_modules = Vec::new();
+                for (_, module) in modules {
+                    converted_modules.push(
                         MoveModuleBytecode::new(module)
                             .try_parse_abi()
                             .context("Failed to parse move module ABI")

--- a/api/src/blocks.rs
+++ b/api/src/blocks.rs
@@ -4,11 +4,8 @@
 use crate::accept_type::AcceptType;
 use crate::context::Context;
 use crate::failpoint::fail_point_poem;
-use crate::response::{
-    BasicErrorWith404, BasicResponse, BasicResponseStatus, BasicResultWith404, InternalError,
-};
+use crate::response::BasicResultWith404;
 use crate::ApiTags;
-use anyhow::Context as AnyhowContext;
 use aptos_api_types::Block;
 use poem_openapi::param::{Path, Query};
 use poem_openapi::OpenApi;
@@ -77,19 +74,12 @@ impl BlocksApi {
         with_transactions: bool,
     ) -> BasicResultWith404<Block> {
         let latest_ledger_info = self.context.get_latest_ledger_info()?;
-        let latest_version = latest_ledger_info.version();
-        let block = self
-            .context
-            .get_block_by_height(block_height, latest_version, with_transactions)
-            .context("Failed to retrieve block by height")
-            .map_err(BasicErrorWith404::internal)?;
-
-        BasicResponse::try_from_rust_value((
-            block,
-            &latest_ledger_info,
-            BasicResponseStatus::Ok,
+        self.context.get_block_by_height(
             &accept_type,
-        ))
+            block_height,
+            latest_ledger_info,
+            with_transactions,
+        )
     }
 
     fn get_by_version(
@@ -99,18 +89,11 @@ impl BlocksApi {
         with_transactions: bool,
     ) -> BasicResultWith404<Block> {
         let latest_ledger_info = self.context.get_latest_ledger_info()?;
-        let latest_version = latest_ledger_info.version();
-        let block = self
-            .context
-            .get_block_by_version(version, latest_version, with_transactions)
-            .context("Failed to retrieve block by height")
-            .map_err(BasicErrorWith404::internal)?;
-
-        BasicResponse::try_from_rust_value((
-            block,
-            &latest_ledger_info,
-            BasicResponseStatus::Ok,
+        self.context.get_block_by_version(
             &accept_type,
-        ))
+            version,
+            latest_ledger_info,
+            with_transactions,
+        )
     }
 }

--- a/api/src/response.rs
+++ b/api/src/response.rs
@@ -295,6 +295,53 @@ macro_rules! generate_success_response {
                     ))),
                 }
             }
+
+           pub fn try_from_json<E: InternalError>(
+                (value, ledger_info, status): (
+                    T,
+                    &aptos_api_types::LedgerInfo,
+                    [<$enum_name Status>],
+                ),
+            ) -> Result<Self, E> {
+               Ok(Self::from((
+                    poem_openapi::payload::Json(value),
+                    ledger_info,
+                    status
+               )))
+            }
+
+            pub fn try_from_bcs<B: serde::Serialize, E: InternalError>(
+                (value, ledger_info, status): (
+                    B,
+                    &aptos_api_types::LedgerInfo,
+                    [<$enum_name Status>],
+                ),
+            ) -> Result<Self, E> {
+               Ok(Self::from((
+                    $crate::bcs_payload::Bcs(
+                        bcs::to_bytes(&value)
+                            .map_err(|e| E::internal(e.into()).error_code(aptos_api_types::AptosErrorCode::BcsSerializationError))?
+                    ),
+                    ledger_info,
+                    status
+               )))
+            }
+
+            pub fn try_from_encoded<E: InternalError>(
+                (value, ledger_info, status): (
+                    Vec<u8>,
+                    &aptos_api_types::LedgerInfo,
+                    [<$enum_name Status>],
+                ),
+            ) -> Result<Self, E> {
+               Ok(Self::from((
+                    $crate::bcs_payload::Bcs(
+                        value
+                    ),
+                    ledger_info,
+                    status
+               )))
+            }
         }
         }
     };

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -9,7 +9,7 @@ use crate::response::{
     BasicResultWith404, InternalError, NotFoundError,
 };
 use crate::ApiTags;
-use anyhow::Context as AnyhowContext;
+use anyhow::{anyhow, Context as AnyhowContext};
 use aptos_api_types::{
     Address, AsConverter, IdentifierWrapper, MoveModuleBytecode, MoveStructTag, MoveValue,
     TableItemRequest, TransactionId, U128, U64,
@@ -150,6 +150,12 @@ impl StateApi {
         resource_type: MoveStructTag,
         ledger_version: Option<U64>,
     ) -> BasicResultWith404<MoveResource> {
+        // TODO: Determine what is needed to deserialize the storage type
+        if accept_type == &AcceptType::Bcs {
+            return Err(anyhow!("BCS is not supported for get resource"))
+                .map_err(BasicErrorWith404::bad_request);
+        }
+
         let resource_type: StructTag = resource_type
             .try_into()
             .context("Failed to parse given resource type")
@@ -186,6 +192,11 @@ impl StateApi {
         name: IdentifierWrapper,
         ledger_version: Option<U64>,
     ) -> BasicResultWith404<MoveModuleBytecode> {
+        // TODO: Determine what is needed to deserialize the storage type
+        if accept_type == &AcceptType::Bcs {
+            return Err(anyhow!("BCS is not supported for get module"))
+                .map_err(BasicErrorWith404::bad_request);
+        }
         let module_id = ModuleId::new(address.into(), name.into());
         let access_path = AccessPath::code_access_path(module_id.clone());
         let state_key = StateKey::AccessPath(access_path);
@@ -216,6 +227,11 @@ impl StateApi {
         table_item_request: TableItemRequest,
         ledger_version: Option<U64>,
     ) -> BasicResultWith404<MoveValue> {
+        // TODO: Determine what is needed to deserialize the storage type
+        if accept_type == &AcceptType::Bcs {
+            return Err(anyhow!("BCS is not supported for get table item"))
+                .map_err(BasicErrorWith404::bad_request);
+        }
         let key_type = table_item_request
             .key_type
             .try_into()

--- a/api/src/tests/blocks_test.rs
+++ b/api/src/tests/blocks_test.rs
@@ -17,7 +17,7 @@ async fn test_get_unknown_block_by_height() {
     let mut context = new_test_context(current_function_name!());
 
     let resp = context
-        .expect_status_code(500)
+        .expect_status_code(404)
         .get(&blocks_by_height(1000))
         .await;
     context.check_golden_output(resp);

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -436,13 +436,16 @@ impl TransactionsApi {
             )
             .context("Failed to get account transactions for the given account")
             .map_err(BasicErrorWith404::internal)?;
-
-        BasicResponse::try_from_rust_value((
-            self.render_transactions(data)?,
-            &latest_ledger_info,
-            BasicResponseStatus::Ok,
-            accept_type,
-        ))
+        match accept_type {
+            AcceptType::Json => BasicResponse::try_from_json((
+                self.render_transactions(data)?,
+                &latest_ledger_info,
+                BasicResponseStatus::Ok,
+            )),
+            AcceptType::Bcs => {
+                BasicResponse::try_from_bcs((data, &latest_ledger_info, BasicResponseStatus::Ok))
+            }
+        }
     }
 
     fn get_signed_transaction(

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -275,12 +275,16 @@ impl TransactionsApi {
             .map_err(BasicErrorWith404::internal)
             .map_err(|e| e.error_code(AptosErrorCode::InvalidBcsInStorageError))?;
 
-        BasicResponse::try_from_rust_value((
-            self.render_transactions(data)?,
-            &latest_ledger_info,
-            BasicResponseStatus::Ok,
-            accept_type,
-        ))
+        match accept_type {
+            AcceptType::Json => BasicResponse::try_from_json((
+                self.render_transactions(data)?,
+                &latest_ledger_info,
+                BasicResponseStatus::Ok,
+            )),
+            AcceptType::Bcs => {
+                BasicResponse::try_from_bcs((data, &latest_ledger_info, BasicResponseStatus::Ok))
+            }
+        }
     }
 
     fn render_transactions<E: InternalError>(

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -18,7 +18,7 @@ use crate::response::{
 };
 use crate::ApiTags;
 use crate::{generate_error_response, generate_success_response};
-use anyhow::Context as AnyhowContext;
+use anyhow::{anyhow, Context as AnyhowContext};
 use aptos_api_types::{
     Address, AptosErrorCode, AsConverter, EncodeSubmissionRequest, HashValue, HexEncodedBytes,
     LedgerInfo, PendingTransaction, SubmitTransactionRequest, Transaction, TransactionData,
@@ -589,6 +589,11 @@ impl TransactionsApi {
         accept_type: &AcceptType,
         request: EncodeSubmissionRequest,
     ) -> BasicResult<HexEncodedBytes> {
+        if accept_type == &AcceptType::Bcs {
+            return Err(anyhow!("BCS is not supported for encode submission"))
+                .map_err(BasicError::bad_request);
+        }
+
         let resolver = self.context.move_resolver_poem()?;
         let raw_txn: RawTransaction = resolver
             .as_converter(self.context.db.clone())

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -88,7 +88,7 @@ impl TransactionsApi {
         start: Query<Option<U64>>,
         limit: Query<Option<u16>>,
     ) -> BasicResultWith404<Vec<Transaction>> {
-        fail_point_poem("endppoint_get_transactions")?;
+        fail_point_poem("endpoint_get_transactions")?;
         let page = Page::new(start.0.map(|v| v.0), limit.0);
         self.list(&accept_type, page)
     }

--- a/api/types/src/address.rs
+++ b/api/types/src/address.rs
@@ -6,7 +6,7 @@ use move_deps::move_core_types;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str::FromStr};
 
-#[derive(Clone, Debug, PartialEq, Copy)]
+#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Address(AccountAddress);
 
 impl Address {

--- a/api/types/src/block.rs
+++ b/api/types/src/block.rs
@@ -8,19 +8,19 @@ use serde::{Deserialize, Serialize};
 // TODO: Consider including this in the API.
 // If we do that, change these u64s to U64.
 
-/// A description of a block
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-pub struct BlockInfo {
-    pub block_height: u64,
+#[derive(Debug, Clone, Serialize, Deserialize, Object)]
+pub struct Block {
+    pub block_height: U64,
     pub block_hash: HashValue,
-    pub block_timestamp: u64,
-    pub start_version: u64,
-    pub end_version: u64,
-    pub num_transactions: u16,
+    pub block_timestamp: U64,
+    pub first_version: U64,
+    pub last_version: U64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transactions: Option<Vec<Transaction>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Object)]
-pub struct Block {
+pub struct BcsBlock {
     pub block_height: U64,
     pub block_hash: HashValue,
     pub block_timestamp: U64,

--- a/api/types/src/block.rs
+++ b/api/types/src/block.rs
@@ -1,12 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{HashValue, Transaction, U64};
+use crate::{HashValue, Transaction, TransactionOnChainData, U64};
 use poem_openapi::Object;
 use serde::{Deserialize, Serialize};
-
-// TODO: Consider including this in the API.
-// If we do that, change these u64s to U64.
 
 #[derive(Debug, Clone, Serialize, Deserialize, Object)]
 pub struct Block {
@@ -21,11 +18,11 @@ pub struct Block {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Object)]
 pub struct BcsBlock {
-    pub block_height: U64,
-    pub block_hash: HashValue,
-    pub block_timestamp: U64,
-    pub first_version: U64,
-    pub last_version: U64,
+    pub block_height: u64,
+    pub block_hash: aptos_crypto::HashValue,
+    pub block_timestamp: u64,
+    pub first_version: u64,
+    pub last_version: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transactions: Option<Vec<Transaction>>,
+    pub transactions: Option<Vec<TransactionOnChainData>>,
 }

--- a/api/types/src/block.rs
+++ b/api/types/src/block.rs
@@ -16,7 +16,7 @@ pub struct Block {
     pub transactions: Option<Vec<Transaction>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Object)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BcsBlock {
     pub block_height: u64,
     pub block_hash: aptos_crypto::HashValue,

--- a/api/types/src/index.rs
+++ b/api/types/src/index.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::LedgerInfo;
+use crate::{LedgerInfo, U64};
 use aptos_config::config::RoleType;
 use poem_openapi::Object as PoemObject;
 use serde::{Deserialize, Serialize};
@@ -13,16 +13,26 @@ use serde::{Deserialize, Serialize};
 /// index endpoint (i.e., GET "/").
 #[derive(Clone, Debug, Deserialize, PartialEq, PoemObject, Serialize)]
 pub struct IndexResponse {
-    #[oai(flatten)]
-    #[serde(flatten)]
-    pub ledger_info: LedgerInfo,
+    pub chain_id: u8,
+    pub epoch: U64,
+    pub ledger_version: U64,
+    pub oldest_ledger_version: U64,
+    pub ledger_timestamp: U64,
     pub node_role: RoleType,
+    pub oldest_block_height: U64,
+    pub block_height: U64,
 }
 
 impl IndexResponse {
     pub fn new(ledger_info: LedgerInfo, node_role: RoleType) -> IndexResponse {
         Self {
-            ledger_info,
+            chain_id: ledger_info.chain_id,
+            epoch: ledger_info.epoch,
+            ledger_version: ledger_info.ledger_version,
+            oldest_ledger_version: ledger_info.oldest_ledger_version,
+            ledger_timestamp: ledger_info.ledger_timestamp,
+            oldest_block_height: ledger_info.oldest_block_height,
+            block_height: ledger_info.block_height,
             node_role,
         }
     }

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -21,7 +21,7 @@ mod wrappers;
 
 pub use account::AccountData;
 pub use address::Address;
-pub use block::Block;
+pub use block::{BcsBlock, Block};
 pub use bytecode::Bytecode;
 pub use convert::{new_vm_utf8_string, AsConverter, MoveConverter};
 pub use error::{AptosError, AptosErrorCode};

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -22,7 +22,6 @@ mod wrappers;
 pub use account::AccountData;
 pub use address::Address;
 pub use block::Block;
-pub use block::BlockInfo;
 pub use bytecode::Bytecode;
 pub use convert::{new_vm_utf8_string, AsConverter, MoveConverter};
 pub use error::{AptosError, AptosErrorCode};

--- a/api/types/src/mime_types.rs
+++ b/api/types/src/mime_types.rs
@@ -4,3 +4,4 @@
 pub const BCS_SIGNED_TRANSACTION: &str = "application/x.aptos.signed_transaction+bcs";
 pub const JSON: &str = "application/json";
 pub const BCS: &str = "application/x.aptos.output+bcs";
+pub const BCS_OUTPUT_NEW: &str = "application/x-bcs";

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -656,7 +656,7 @@ impl From<CompiledModule> for MoveModule {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MoveModuleId {
     pub address: Address,
     pub name: IdentifierWrapper,

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -34,7 +34,7 @@ use std::{
 // TODO: Investigate the use of discriminator_name, see https://github.com/poem-web/poem/issues/329.
 // TODO: See https://github.com/poem-web/poem/issues/347 re mapping stuff. UPDATE: Wait for 2.0.7 to be released.
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum TransactionData {
     OnChain(TransactionOnChainData),
     Pending(Box<SignedTransaction>),

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -16,6 +16,7 @@ dpn = []
 [dependencies]
 anyhow = "1.0.57"
 bcs = "0.1.3"
+bytes = "1.2.1"
 hex = "0.4.3"
 poem-openapi = { git = "https://github.com/poem-web/poem", rev = "f39eba95cbfb52989e0eff516dad86719dc7dcba", features = ["url"] }
 reqwest = { version = "0.11.10", features = ["json", "cookies", "blocking"] }

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -603,6 +603,16 @@ impl Client {
         self.json(response).await
     }
 
+    pub async fn get_account_resource_bcs<T: DeserializeOwned>(
+        &self,
+        address: AccountAddress,
+        resource_type: &str,
+    ) -> Result<Response<T>> {
+        let url = self.build_path(&format!("accounts/{}/resource/{}", address, resource_type))?;
+        let response = self.get_bcs(url).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
+    }
+
     pub async fn get_account_resource_at_version(
         &self,
         address: AccountAddress,

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -28,6 +28,7 @@ use aptos_api_types::{
 };
 use aptos_crypto::HashValue;
 use aptos_types::account_config::AccountResource;
+use aptos_types::contract_event::EventWithVersion;
 use aptos_types::transaction::ExecutionStatus;
 use aptos_types::{
     account_address::AccountAddress,
@@ -690,6 +691,25 @@ impl Client {
 
         let response = request.send().await?;
         self.json(response).await
+    }
+
+    pub async fn get_account_events_bcs(
+        &self,
+        address: AccountAddress,
+        struct_tag: &str,
+        field_name: &str,
+        start: Option<u64>,
+        limit: Option<u16>,
+    ) -> Result<Response<Vec<EventWithVersion>>> {
+        let url = self.build_path(&format!(
+            "accounts/{}/events/{}/{}",
+            address.to_hex_literal(),
+            struct_tag,
+            field_name
+        ))?;
+
+        let response = self.get_bcs_with_page(url, start, limit).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
 
     pub async fn get_new_block_events(

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -23,7 +23,7 @@ use anyhow::{anyhow, Result};
 use aptos_api_types::mime_types::BCS_OUTPUT_NEW;
 use aptos_api_types::{
     mime_types::BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE, AptosError, Block, HexEncodedBytes,
-    VersionedEvent,
+    MoveModuleId, VersionedEvent,
 };
 use aptos_crypto::HashValue;
 use aptos_types::account_config::AccountResource;
@@ -394,11 +394,20 @@ impl Client {
     pub async fn get_account_modules(
         &self,
         address: AccountAddress,
-    ) -> Result<Response<Vec<MoveModuleBytecode>>> {
+    ) -> Result<Response<BTreeMap<MoveModuleId, MoveModuleBytecode>>> {
         let url = self.build_path(&format!("accounts/{}/modules", address))?;
 
         let response = self.inner.get(url).send().await?;
         self.json(response).await
+    }
+
+    pub async fn get_account_modules_bcs(
+        &self,
+        address: AccountAddress,
+    ) -> Result<Response<BTreeMap<MoveModuleId, Vec<u8>>>> {
+        let url = self.build_path(&format!("accounts/{}/modules", address))?;
+        let response = self.get_bcs(url).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
 
     pub async fn get_account_events(

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -632,7 +632,7 @@ impl Client {
     pub async fn get_account_modules(
         &self,
         address: AccountAddress,
-    ) -> Result<Response<BTreeMap<MoveModuleId, MoveModuleBytecode>>> {
+    ) -> Result<Response<Vec<MoveModuleBytecode>>> {
         let url = self.build_path(&format!("accounts/{}/modules", address))?;
 
         let response = self.inner.get(url).send().await?;

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -149,13 +149,13 @@ impl Client {
 
     pub async fn get_ledger_information(&self) -> Result<Response<State>> {
         let response = self.get_index().await?.map(|r| State {
-            chain_id: r.ledger_info.chain_id,
-            epoch: r.ledger_info.epoch.into(),
-            version: r.ledger_info.ledger_version.into(),
-            timestamp_usecs: r.ledger_info.ledger_timestamp.into(),
-            oldest_ledger_version: r.ledger_info.oldest_ledger_version.into(),
-            oldest_block_height: r.ledger_info.oldest_block_height.into(),
-            block_height: r.ledger_info.block_height.into(),
+            chain_id: r.chain_id,
+            epoch: r.epoch.into(),
+            version: r.ledger_version.into(),
+            timestamp_usecs: r.ledger_timestamp.into(),
+            oldest_ledger_version: r.oldest_ledger_version.into(),
+            oldest_block_height: r.oldest_block_height.into(),
+            block_height: r.block_height.into(),
         });
 
         Ok(response)

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 pub mod faucet;
 
 pub use faucet::FaucetClient;
+use std::collections::BTreeMap;
 pub mod response;
 pub use response::Response;
 pub mod state;
@@ -31,6 +32,7 @@ use aptos_types::{
     account_config::{NewBlockEvent, CORE_CODE_ADDRESS},
     transaction::SignedTransaction,
 };
+use move_deps::move_core_types::language_storage::StructTag;
 use poem_openapi::types::ParseFromJSON;
 use reqwest::header::ACCEPT;
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient, StatusCode};
@@ -317,6 +319,15 @@ impl Client {
         let response = self.inner.get(url).send().await?;
 
         self.json(response).await
+    }
+
+    pub async fn get_account_resources_bcs(
+        &self,
+        address: AccountAddress,
+    ) -> Result<Response<BTreeMap<StructTag, Vec<u8>>>> {
+        let url = self.build_path(&format!("accounts/{}/resources", address))?;
+        let response = self.get_bcs(url).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
 
     pub async fn get_account_resources_at_version(

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -647,6 +647,24 @@ impl Client {
         Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
 
+    pub async fn get_account_module(
+        &self,
+        address: AccountAddress,
+        module_name: &str,
+    ) -> Result<Response<MoveModuleBytecode>> {
+        let url = self.build_path(&format!("accounts/{}/module/{}", address, module_name))?;
+        self.get(url).await
+    }
+
+    pub async fn get_account_module_bcs(
+        &self,
+        address: AccountAddress,
+        module_name: &str,
+    ) -> Result<Response<bytes::Bytes>> {
+        let url = self.build_path(&format!("accounts/{}/module/{}", address, module_name))?;
+        self.get_bcs(url).await
+    }
+
     pub async fn get_account_events(
         &self,
         address: AccountAddress,

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -23,7 +23,7 @@ use anyhow::{anyhow, Result};
 use aptos_api_types::mime_types::BCS_OUTPUT_NEW;
 use aptos_api_types::{
     mime_types::BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE, AptosError, Block, HexEncodedBytes,
-    MoveModuleId, VersionedEvent,
+    MoveModuleId, TransactionOnChainData, VersionedEvent,
 };
 use aptos_crypto::HashValue;
 use aptos_types::account_config::AccountResource;
@@ -308,6 +308,17 @@ impl Client {
         let response = request.send().await?;
 
         self.json(response).await
+    }
+
+    pub async fn get_account_transactions_bcs(
+        &self,
+        address: AccountAddress,
+        start: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<Response<Vec<TransactionOnChainData>>> {
+        let url = self.build_path(&format!("accounts/{}/transactions", address))?;
+        let response = self.get_bcs_with_page(url, start, limit).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
 
     pub async fn get_account_resources(
@@ -614,6 +625,27 @@ impl Client {
             .header(ACCEPT, BCS_OUTPUT_NEW)
             .send()
             .await?;
+        let (response, state) = self.check_response(response).await?;
+        Ok(Response::new(response.bytes().await?, state))
+    }
+
+    async fn get_bcs_with_page(
+        &self,
+        url: Url,
+        start: Option<u64>,
+        limit: Option<u64>,
+    ) -> Result<Response<bytes::Bytes>> {
+        let mut request = self.inner.get(url).header(ACCEPT, BCS_OUTPUT_NEW);
+        if let Some(start) = start {
+            request = request.query(&[("start", start)])
+        }
+
+        if let Some(limit) = limit {
+            request = request.query(&[("limit", limit)])
+        }
+
+        let response = request.send().await?;
+
         let (response, state) = self.check_response(response).await?;
         Ok(Response::new(response.bytes().await?, state))
     }

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -19,17 +19,20 @@ pub use types::{Account, Resource};
 
 use crate::aptos::{AptosVersion, Balance};
 use anyhow::{anyhow, Result};
+use aptos_api_types::mime_types::BCS_OUTPUT_NEW;
 use aptos_api_types::{
     mime_types::BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE, AptosError, Block, HexEncodedBytes,
     VersionedEvent,
 };
 use aptos_crypto::HashValue;
+use aptos_types::account_config::AccountResource;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{NewBlockEvent, CORE_CODE_ADDRESS},
     transaction::SignedTransaction,
 };
 use poem_openapi::types::ParseFromJSON;
+use reqwest::header::ACCEPT;
 use reqwest::{header::CONTENT_TYPE, Client as ReqwestClient, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -513,6 +516,15 @@ impl Client {
         self.json(response).await
     }
 
+    pub async fn get_account_bcs(
+        &self,
+        address: AccountAddress,
+    ) -> Result<Response<AccountResource>> {
+        let url = self.build_path(&format!("accounts/{}", address))?;
+        let response = self.get_bcs(url).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
+    }
+
     pub async fn set_failpoint(&self, name: String, actions: String) -> Result<String> {
         let mut base = self.build_path("set_failpoint")?;
         let url = base
@@ -573,6 +585,17 @@ impl Client {
 
     async fn get<T: DeserializeOwned>(&self, url: Url) -> Result<Response<T>> {
         self.json(self.inner.get(url).send().await?).await
+    }
+
+    async fn get_bcs(&self, url: Url) -> Result<Response<bytes::Bytes>> {
+        let response = self
+            .inner
+            .get(url)
+            .header(ACCEPT, BCS_OUTPUT_NEW)
+            .send()
+            .await?;
+        let (response, state) = self.check_response(response).await?;
+        Ok(Response::new(response.bytes().await?, state))
     }
 }
 

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -327,6 +327,16 @@ impl Client {
         self.json(response).await
     }
 
+    pub async fn get_transactions_bcs(
+        &self,
+        start: Option<u64>,
+        limit: Option<u16>,
+    ) -> Result<Response<Vec<TransactionOnChainData>>> {
+        let url = self.build_path("transactions")?;
+        let response = self.get_bcs_with_page(url, start, limit).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
+    }
+
     pub async fn get_transaction_by_hash(&self, hash: HashValue) -> Result<Response<Transaction>> {
         self.json(self.get_transaction_by_hash_inner(hash).await?)
             .await
@@ -405,7 +415,7 @@ impl Client {
         &self,
         address: AccountAddress,
         start: Option<u64>,
-        limit: Option<u64>,
+        limit: Option<u16>,
     ) -> Result<Response<Vec<TransactionOnChainData>>> {
         let url = self.build_path(&format!("accounts/{}/transactions", address))?;
         let response = self.get_bcs_with_page(url, start, limit).await?;
@@ -723,7 +733,7 @@ impl Client {
         &self,
         url: Url,
         start: Option<u64>,
-        limit: Option<u64>,
+        limit: Option<u16>,
     ) -> Result<Response<bytes::Bytes>> {
         let mut request = self.inner.get(url).header(ACCEPT, BCS_OUTPUT_NEW);
         if let Some(start) = start {

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -23,10 +23,11 @@ use anyhow::{anyhow, Result};
 use aptos_api_types::mime_types::BCS_OUTPUT_NEW;
 use aptos_api_types::{
     mime_types::BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE, AptosError, Block, HexEncodedBytes,
-    MoveModuleId, TransactionOnChainData, VersionedEvent,
+    MoveModuleId, TransactionData, TransactionOnChainData, VersionedEvent,
 };
 use aptos_crypto::HashValue;
 use aptos_types::account_config::AccountResource;
+use aptos_types::transaction::ExecutionStatus;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{NewBlockEvent, CORE_CODE_ADDRESS},
@@ -247,6 +248,64 @@ impl Client {
         Err(anyhow!("timeout"))
     }
 
+    pub async fn wait_for_transaction_by_hash_bcs(
+        &self,
+        hash: HashValue,
+        expiration_timestamp_secs: u64,
+    ) -> Result<Response<TransactionOnChainData>, (Option<Response<TransactionData>>, anyhow::Error)>
+    {
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+        const DEFAULT_DELAY: Duration = Duration::from_millis(500);
+
+        let start = std::time::Instant::now();
+        while start.elapsed() < DEFAULT_TIMEOUT {
+            let resp = self
+                .get_transaction_by_hash_bcs_inner(hash)
+                .await
+                .map_err(|err| (None, err))?;
+
+            // If it's not found, keep waiting for it
+            if resp.status() != StatusCode::NOT_FOUND {
+                let resp = self
+                    .check_and_parse_bcs_response(resp)
+                    .await
+                    .map_err(|err| (None, err))?;
+                let resp = resp
+                    .and_then(|bytes| bcs::from_bytes(&bytes))
+                    .map_err(|err| (None, err.into()))?;
+                let (maybe_pending_txn, state) = resp.into_parts();
+
+                // If we have a committed transaction, determine if it failed or not
+                if let TransactionData::OnChain(txn) = maybe_pending_txn {
+                    let status = txn.info.status();
+
+                    // The user can handle the error
+                    return match status {
+                        ExecutionStatus::Success => Ok(Response::new(txn, state)),
+                        _ => Err((
+                            Some(Response::new(TransactionData::OnChain(txn), state)),
+                            anyhow!("Transaction failed"),
+                        )),
+                    };
+                }
+
+                // If it's expired lets give up
+                if Duration::from_secs(expiration_timestamp_secs)
+                    <= Duration::from_micros(state.timestamp_usecs)
+                {
+                    return Err((
+                        Some(Response::new(maybe_pending_txn, state)),
+                        anyhow!("Transaction expired"),
+                    ));
+                }
+            }
+
+            tokio::time::sleep(DEFAULT_DELAY).await;
+        }
+
+        return Err((None, anyhow!("Timed out waiting for transaction")));
+    }
+
     pub async fn get_transactions(
         &self,
         start: Option<u64>,
@@ -273,6 +332,29 @@ impl Client {
             .await
     }
 
+    pub async fn get_transaction_by_hash_bcs(
+        &self,
+        hash: HashValue,
+    ) -> Result<Response<TransactionData>> {
+        let response = self.get_transaction_by_hash_bcs_inner(hash).await?;
+        let response = self.check_and_parse_bcs_response(response).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
+    }
+
+    pub async fn get_transaction_by_hash_bcs_inner(
+        &self,
+        hash: HashValue,
+    ) -> Result<reqwest::Response> {
+        let url = self.build_path(&format!("transactions/by_hash/{}", hash.to_hex_literal()))?;
+        let response = self
+            .inner
+            .get(url)
+            .header(ACCEPT, BCS_OUTPUT_NEW)
+            .send()
+            .await?;
+        Ok(response)
+    }
+
     async fn get_transaction_by_hash_inner(&self, hash: HashValue) -> Result<reqwest::Response> {
         let url = self.build_path(&format!("transactions/by_hash/{}", hash.to_hex_literal()))?;
         Ok(self.inner.get(url).send().await?)
@@ -281,6 +363,15 @@ impl Client {
     pub async fn get_transaction_by_version(&self, version: u64) -> Result<Response<Transaction>> {
         self.json(self.get_transaction_by_version_inner(version).await?)
             .await
+    }
+
+    pub async fn get_transaction_by_version_bcs(
+        &self,
+        version: u64,
+    ) -> Result<Response<TransactionData>> {
+        let url = self.build_path(&format!("transactions/by_version/{}", version))?;
+        let response = self.get_bcs(url).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
     }
 
     async fn get_transaction_by_version_inner(&self, version: u64) -> Result<reqwest::Response> {
@@ -625,8 +716,7 @@ impl Client {
             .header(ACCEPT, BCS_OUTPUT_NEW)
             .send()
             .await?;
-        let (response, state) = self.check_response(response).await?;
-        Ok(Response::new(response.bytes().await?, state))
+        self.check_and_parse_bcs_response(response).await
     }
 
     async fn get_bcs_with_page(
@@ -645,7 +735,13 @@ impl Client {
         }
 
         let response = request.send().await?;
+        self.check_and_parse_bcs_response(response).await
+    }
 
+    async fn check_and_parse_bcs_response(
+        &self,
+        response: reqwest::Response,
+    ) -> Result<Response<bytes::Bytes>> {
         let (response, state) = self.check_response(response).await?;
         Ok(Response::new(response.bytes().await?, state))
     }

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -178,7 +178,7 @@ impl BlockCache {
     ) -> ApiResult<aptos_rest_client::aptos_api_types::Block> {
         let block = self
             .rest_client
-            .get_block(height, with_transactions)
+            .get_block_by_height(height, with_transactions)
             .await?
             .into_inner();
         let block_id = BlockInfo::from_block(&block);

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -106,12 +106,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
                 .map_err(map_err_func)?
                 .into_inner()
                 .into_iter()
-                .map(|(module_id, module)| (module_id, json!(module.try_parse_abi().unwrap())))
-                .map(|(module_id, module)| {
-                    let mut map = serde_json::Map::new();
-                    map.insert(module_id.to_string(), module);
-                    serde_json::Value::Object(map)
-                })
+                .map(|module| (json!(module.try_parse_abi().unwrap())))
                 .collect::<Vec<serde_json::Value>>(),
             ListQuery::Resources => client
                 .get_account_resources(account)

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -105,10 +105,13 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
                 .await
                 .map_err(map_err_func)?
                 .into_inner()
-                .iter()
-                .cloned()
-                .map(|module| module.try_parse_abi().unwrap())
-                .map(|module| json!(module))
+                .into_iter()
+                .map(|(module_id, module)| (module_id, json!(module.try_parse_abi().unwrap())))
+                .map(|(module_id, module)| {
+                    let mut map = serde_json::Map::new();
+                    map.insert(module_id.to_string(), module);
+                    serde_json::Value::Object(map)
+                })
                 .collect::<Vec<serde_json::Value>>(),
             ListQuery::Resources => client
                 .get_account_resources(account)

--- a/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
@@ -27,7 +27,7 @@ pub async fn get_node_identity(
         .await
         .map_err(|e| format_err!("Failed to get response from index (/) of API. Make sure your API port ({}) is open: {}", node_address.api_port, e))?;
     Ok((
-        ChainId::new(index_response.ledger_info.chain_id),
+        ChainId::new(index_response.chain_id),
         index_response.node_role,
     ))
 }

--- a/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
@@ -75,18 +75,10 @@ impl Evaluator for TransactionAvailabilityEvaluator {
     /// baseline produced after a delay. We confirm that the transactions are
     /// same by looking at the version.
     async fn evaluate(&self, input: &Self::Input) -> Result<Vec<EvaluationResult>, Self::Error> {
-        let oldest_baseline_version = input
-            .baseline_index_response
-            .ledger_info
-            .oldest_ledger_version
-            .0;
-        let oldest_target_version = input
-            .target_index_response
-            .ledger_info
-            .oldest_ledger_version
-            .0;
-        let latest_baseline_version = input.baseline_index_response.ledger_info.ledger_version.0;
-        let latest_target_version = input.target_index_response.ledger_info.ledger_version.0;
+        let oldest_baseline_version = input.baseline_index_response.oldest_ledger_version.0;
+        let oldest_target_version = input.target_index_response.oldest_ledger_version.0;
+        let latest_baseline_version = input.baseline_index_response.ledger_version.0;
+        let latest_target_version = input.target_index_response.ledger_version.0;
 
         // Get the oldest ledger version between the two nodes.
         let oldest_shared_version = max(oldest_baseline_version, oldest_target_version);

--- a/ecosystem/node-checker/src/evaluators/direct/types.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/types.rs
@@ -27,6 +27,6 @@ impl DirectEvaluatorInput {
     }
 
     pub fn get_target_chain_id(&self) -> ChainId {
-        ChainId::new(self.target_index_response.ledger_info.chain_id)
+        ChainId::new(self.target_index_response.chain_id)
     }
 }

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -112,11 +112,24 @@ async fn test_bcs() {
         .into_inner();
 
     assert_eq!(modules.len(), bcs_modules.len());
-    let (module_id, _) = modules.iter().next().unwrap();
+    let (module_id, module_bytecode) = modules.iter().next().unwrap();
     assert_eq!(
-        &modules.get(module_id).unwrap().bytecode.0,
+        &module_bytecode.bytecode.0,
         bcs_modules.get(module_id).unwrap()
     );
+
+    let json_module = client
+        .get_account_module(AccountAddress::ONE, module_id.name.as_str())
+        .await
+        .unwrap()
+        .into_inner();
+    let bcs_module = client
+        .get_account_module_bcs(AccountAddress::ONE, module_id.name.as_str())
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(json_module.bytecode.0, bcs_module);
+    assert_eq!(module_bytecode.bytecode.0, bcs_module);
 
     // Transfer money to make a transaction
     let pending_transaction = info

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -1,9 +1,13 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos::common::types::account_address_from_public_key;
+use aptos_crypto::PrivateKey;
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_config::CORE_CODE_ADDRESS;
+use aptos_types::transaction::authenticator::AuthenticationKey;
 use forge::Swarm;
+use std::convert::TryFrom;
 
 use crate::smoke_test_environment::new_local_swarm_with_aptos;
 
@@ -50,4 +54,35 @@ async fn test_basic_client() {
         .unwrap();
 
     info.client().get_transactions(None, None).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_bcs() {
+    // FIXME: Use swarm instead of local node
+    // let mut swarm = new_local_swarm_with_aptos(1).await;
+    //let mut info = swarm.aptos_public_info();
+    //let client = info.client();
+    let rest_api = reqwest::Url::parse("http://localhost:8080/v1").unwrap();
+    let client = aptos_rest_client::Client::new(rest_api.clone());
+    let faucet_client = aptos_rest_client::FaucetClient::new(
+        reqwest::Url::parse("http://localhost:8081").unwrap(),
+        rest_api,
+    );
+
+    // Create account
+    let mut keygen = aptos_keygen::KeyGen::from_seed([0u8; 32]);
+    let private_key = keygen.generate_ed25519_private_key();
+    let public_key = private_key.public_key();
+    let account = account_address_from_public_key(&public_key);
+
+    // Fund account
+    faucet_client.fund(account, 10000000).await.unwrap();
+
+    // Check get account
+    let account_resource = client.get_account_bcs(account).await.unwrap().into_inner();
+    let expected_auth_key = AuthenticationKey::ed25519(&public_key);
+    let onchain_auth_key =
+        AuthenticationKey::try_from(account_resource.authentication_key()).unwrap();
+    assert_eq!(expected_auth_key, onchain_auth_key);
+    assert_eq!(0, account_resource.sequence_number());
 }

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -92,6 +92,13 @@ async fn test_bcs() {
     let account_resource: AccountResource = bcs::from_bytes(bytes).unwrap();
     assert_eq!(0, account_resource.sequence_number());
 
+    let single_account_resource: AccountResource = client
+        .get_account_resource_bcs(account, "0x1::account::Account")
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(account_resource, single_account_resource);
+
     // Check Modules align
     let modules = client
         .get_account_modules(AccountAddress::ONE)

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -176,4 +176,29 @@ async fn test_bcs() {
             .unwrap()
             .into_inner()
     );
+
+    // Check that the first 5 transactions match
+    let json_txns = client
+        .get_transactions(Some(0), Some(5))
+        .await
+        .unwrap()
+        .into_inner();
+    let bcs_txns = client
+        .get_transactions_bcs(Some(0), Some(5))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(5, json_txns.len());
+    assert_eq!(json_txns.len(), bcs_txns.len());
+
+    // Ensure same hashes and versions for each transaction
+    for (i, json_txn) in json_txns.iter().enumerate() {
+        let bcs_txn = bcs_txns.get(i).unwrap();
+
+        assert_eq!(json_txn.version().unwrap(), bcs_txn.version);
+        assert_eq!(
+            aptos_crypto::HashValue::from(json_txn.transaction_info().unwrap().hash),
+            bcs_txn.info.transaction_hash()
+        );
+    }
 }

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -308,4 +308,31 @@ async fn test_bcs() {
         aptos_crypto::HashValue::from(json_block_by_height.block_hash),
         bcs_block_by_height.block_hash
     );
+
+    let json_events = client
+        .get_account_events(
+            AccountAddress::ONE,
+            "0x1::block::BlockResource",
+            "new_block_events",
+            Some(0),
+            Some(1),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    let bcs_events = client
+        .get_account_events_bcs(
+            AccountAddress::ONE,
+            "0x1::block::BlockResource",
+            "new_block_events",
+            Some(0),
+            Some(1),
+        )
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        json_events.first().unwrap().version.0,
+        bcs_events.first().unwrap().transaction_version
+    );
 }

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -5,6 +5,7 @@ use aptos::common::types::account_address_from_public_key;
 use aptos_crypto::PrivateKey;
 use aptos_sdk::move_types::language_storage::StructTag;
 use aptos_transaction_builder::aptos_stdlib;
+use aptos_types::account_address::AccountAddress;
 use aptos_types::account_config::{AccountResource, CORE_CODE_ADDRESS};
 use aptos_types::transaction::authenticator::AuthenticationKey;
 use forge::Swarm;
@@ -99,4 +100,23 @@ async fn test_bcs() {
         .unwrap();
     let account_resource: AccountResource = bcs::from_bytes(bytes).unwrap();
     assert_eq!(0, account_resource.sequence_number());
+
+    // Check Modules align
+    let modules = client
+        .get_account_modules(AccountAddress::ONE)
+        .await
+        .unwrap()
+        .into_inner();
+    let bcs_modules = client
+        .get_account_modules_bcs(AccountAddress::ONE)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(modules.len(), bcs_modules.len());
+    let (module_id, _) = modules.iter().next().unwrap();
+    assert_eq!(
+        &modules.get(module_id).unwrap().bytecode.0,
+        bcs_modules.get(module_id).unwrap()
+    );
 }

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -204,8 +204,8 @@ async fn test_bcs() {
     }
 
     // Test simulation of a transaction should be the same in BCS & JSON
-    let transaction_factory = info.transaction_factory();
-    let transfer_txn = transaction_factory
+    let transfer_txn = info
+        .transaction_factory()
         .transfer(other_local_account.address(), 500)
         .sender(local_account.address())
         .sequence_number(local_account.sequence_number())
@@ -224,4 +224,18 @@ async fn test_bcs() {
         aptos_crypto::HashValue::from(json_txn.info.hash),
         bcs_txn.info.transaction_hash()
     );
+
+    // Actually submit the transaction, and ensure it submits and succeeds
+    // TODO: check failure case?
+    let transfer_txn = local_account.sign_with_transaction_builder(
+        info.transaction_factory()
+            .transfer(other_local_account.address(), 500),
+    );
+
+    let txn = client
+        .submit_and_wait_bcs(&transfer_txn)
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(txn.transaction.as_signed_user_txn().unwrap(), &transfer_txn);
 }

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::ed25519::Ed25519Signature;
-use aptos_rest_client::aptos_api_types::TransactionData;
+use aptos_rest_client::aptos_api_types::{MoveModuleId, TransactionData};
 use aptos_sdk::move_types::language_storage::StructTag;
 use aptos_transaction_builder::aptos_stdlib;
 use aptos_types::account_address::AccountAddress;
@@ -112,10 +112,15 @@ async fn test_bcs() {
         .into_inner();
 
     assert_eq!(modules.len(), bcs_modules.len());
-    let (module_id, module_bytecode) = modules.iter().next().unwrap();
+    let module_bytecode = modules.get(0).unwrap().clone().try_parse_abi().unwrap();
+    let module_abi = module_bytecode.abi.as_ref().unwrap();
+    let module_id = MoveModuleId {
+        address: module_abi.address,
+        name: module_abi.name.clone(),
+    };
     assert_eq!(
         &module_bytecode.bytecode.0,
-        bcs_modules.get(module_id).unwrap()
+        bcs_modules.get(&module_id).unwrap()
     );
 
     let json_module = client

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -296,7 +296,7 @@ async fn test_block() {
         .await
         .expect("Should transfer coins");
     let final_block_to_check = rest_client
-        .get_block_info(summary.version)
+        .get_block_by_version(summary.version, false)
         .await
         .expect("Should be able to get block info for completed txns");
     let final_block_height = final_block_to_check.into_inner().block_height.0 + 2;
@@ -335,7 +335,7 @@ async fn test_block() {
             .expect("Should be able to get blocks that are already known");
         let block = response.block.expect("Every response should have a block");
         let actual_block = rest_client
-            .get_block(block_height, true)
+            .get_block_by_height(block_height, true)
             .await
             .expect("Should be able to get block for a known block")
             .into_inner();
@@ -744,7 +744,7 @@ async fn test_invalid_transaction_gas_charged() {
     let txn_version = actual_txn.info.version.0;
 
     let block_info = rest_client
-        .get_block_info(txn_version)
+        .get_block_by_version(txn_version, false)
         .await
         .unwrap()
         .into_inner();

--- a/types/src/account_config/resources/core_account.rs
+++ b/types/src/account_config/resources/core_account.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 /// A Rust representation of an Account resource.
 /// This is not how the Account is represented in the VM but it's a convenient representation.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct AccountResource {
     authentication_key: Vec<u8>,

--- a/types/src/account_state.rs
+++ b/types/src/account_state.rs
@@ -8,6 +8,7 @@ use crate::{
     state_store::{state_key::StateKey, state_value::StateValue},
 };
 use anyhow::{anyhow, Error, Result};
+use move_deps::move_core_types::language_storage::ModuleId;
 use move_deps::move_core_types::{
     account_address::AccountAddress, language_storage::StructTag, move_resource::MoveResource,
 };
@@ -60,10 +61,10 @@ impl AccountState {
     }
 
     /// Into an iterator over the module values stored under this account
-    pub fn into_modules(self) -> impl Iterator<Item = Vec<u8>> {
+    pub fn into_modules(self) -> impl Iterator<Item = (ModuleId, Vec<u8>)> {
         self.data.into_iter().filter_map(|(k, v)| {
             match Path::try_from(&k).expect("Invalid access path") {
-                Path::Code(_) => Some(v),
+                Path::Code(module) => Some((module, v)),
                 Path::Resource(_) => None,
             }
         })


### PR DESCRIPTION
### Description
For performance reasons, BCS is a lot faster.  If we don't convert the structs in the middle, then we save time, plus JSON is just generally slower.

APIs that are supported in this PR:
* get account
* get ledger info (was already supported)
* get block by height / version
* get account resources
* get account modules
* get account transactions
* get transactions
* simulate transaction
* submit transaction
* get transaction by hash
* get transaction by version

APIs that are not supported in this PR:
* get events by key
* get events by handle
* get account resource
* get account module
* get table item

### Test Plan
There is one E2E test that handles all of these, comparing them to the ones that already exist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3110)
<!-- Reviewable:end -->
