### PR TITLE
[forge] Add back python install action

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -75,6 +75,9 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         with:
           python-version: '3.9'
+      - name: Install python deps
+        if: ${{ env.FORGE_ENABLED == 'true' && env.WRAPPER_KILLSWITCH == 'false' }}
+        run: pip3 install -r testsuite/requirements.txt
       - name: Set kubectl context
         if: env.FORGE_ENABLED == 'true'
         run: aws eks update-kubeconfig --name $FORGE_CLUSTER_NAME


### PR DESCRIPTION
So here is a fun one...

Because we use pull request target instead of pull request... workflows all use
the yaml definition from main. Now what does this mean?

It means that if you modify a workflow in a way that might not be backwards
compatible with repo like say in https://github.com/aptos-labs/aptos-core/pull/2992
then your land time check will succeed, however when it lands all other PR will
start using the non backwards compatible changes in workflow, and if they dont
have your commit in their ancestor their workflow will break.

The only silver lining is that because of this you can also quickly fix forward
everyone broken workflow.

Unless there is a very good reason we should get rid of pull_request_target

Test plan:

push to branch and make sure that branch job doesnt run step since killswitch is
on

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3111)
<!-- Reviewable:end -->
