### PR TITLE
[forge] Add pip install until requirements.txt exists everywhere

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -77,7 +77,7 @@ jobs:
           python-version: '3.9'
       - name: Install python deps
         if: ${{ env.FORGE_ENABLED == 'true' && env.WRAPPER_KILLSWITCH == 'false' }}
-        run: pip3 install -r testsuite/requirements.txt
+        run: pip3 install click==8.1.3 psutil==5.9.1
       - name: Set kubectl context
         if: env.FORGE_ENABLED == 'true'
         run: aws eks update-kubeconfig --name $FORGE_CLUSTER_NAME


### PR DESCRIPTION
So again an issue of pull_request_target action...

Because the workflow and pip requirements are out of sync for now it makes
sense to keep the dependencies minimal and just install them directly from the
command line.

Otherwise if you are running on an older commit, you will not find the
requirements file and fail :|

This on the other hand is guaranteed to just work (tm)

Test plan:

push to branch chaotic with killswitch off and make sure it installs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3117)
<!-- Reviewable:end -->
