### PR TITLE
[forge] fix cleanup timestamp parse

### DIFF
--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -831,14 +831,16 @@ fn check_namespace_for_cleanup(
     } else {
         // TODO(rustielin): come up with some sane values for namespaces
         let cleanup_time_since_epoch: u64 = data.get("cleanup").unwrap().parse().unwrap();
-        info!(
-            "Namespace {} has remaining {} seconds before cleanup",
-            namespace,
-            cleanup_time_since_epoch - time_since_the_epoch
-        );
 
         if cleanup_time_since_epoch <= time_since_the_epoch {
+            info!("Namespace {} will be cleaned up", namespace,);
             return true;
+        } else {
+            info!(
+                "Namespace {} has remaining {} seconds before cleanup",
+                namespace,
+                cleanup_time_since_epoch - time_since_the_epoch
+            );
         }
     }
     false


### PR DESCRIPTION
### Description

Prevent overflow on the log, when `cleanup_time_since_epoch` < `time_since_the_epoch`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3130)
<!-- Reviewable:end -->
