### PR TITLE
[Netowrking] Removing a redundant collect, using iter instead.

### DIFF
--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -413,7 +413,8 @@ where
     /// this function will close our connection to it.
     async fn close_stale_connections(&mut self) {
         let eligible = self.eligible.read().clone();
-        let stale_connections: Vec<_> = self
+
+        for p in self
             .connected
             .iter()
             .filter(|(peer_id, _)| !eligible.contains_key(peer_id))
@@ -429,8 +430,7 @@ where
                     Some(*peer_id)
                 }
             })
-            .collect();
-        for p in stale_connections.into_iter() {
+        {
             info!(
                 NetworkSchema::new(&self.network_context).remote_peer(&p),
                 "{} Closing stale connection to peer {}",


### PR DESCRIPTION
### Description

Removing a redundant collect inside the connectivity manager.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3132)
<!-- Reviewable:end -->
