### PR TITLE
[smoke-test] Improve reconfig test utils

### DIFF
--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -3,7 +3,8 @@
 
 use super::Test;
 use crate::{CoreContext, Result, TestReport};
-use aptos_rest_client::{Client as RestClient, PendingTransaction};
+use aptos_logger::info;
+use aptos_rest_client::{Client as RestClient, PendingTransaction, State, Transaction};
 use aptos_sdk::{
     crypto::ed25519::Ed25519PublicKey,
     move_types::identifier::Identifier,
@@ -215,4 +216,77 @@ impl<'t> AptosPublicInfo<'t> {
         self.mint(account.address(), amount).await?;
         Ok(account)
     }
+
+    pub async fn reconfig(&mut self) -> State {
+        // dedupe with smoke-test::test_utils::reconfig
+        reconfig(
+            &self.rest_client,
+            &self.transaction_factory(),
+            self.root_account,
+        )
+        .await
+    }
+}
+
+pub async fn reconfig(
+    client: &RestClient,
+    transaction_factory: &TransactionFactory,
+    root_account: &mut LocalAccount,
+) -> State {
+    let aptos_version = client.get_aptos_version().await.unwrap();
+    let (current, state) = aptos_version.into_parts();
+    let current_version = *current.major.inner();
+    let txn = root_account.sign_with_transaction_builder(
+        transaction_factory.payload(aptos_stdlib::version_set_version(current_version + 1)),
+    );
+    let result = client.submit_and_wait(&txn).await;
+    if let Err(e) = result {
+        let last_transactions = client
+            .get_account_transactions(root_account.address(), None, None)
+            .await
+            .map(|result| {
+                result
+                    .into_inner()
+                    .iter()
+                    .map(|t| {
+                        if let Transaction::UserTransaction(ut) = t {
+                            format!(
+                                "user seq={}, payload={:?}",
+                                ut.request.sequence_number, ut.request.payload
+                            )
+                        } else {
+                            t.type_str().to_string()
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            });
+
+        panic!(
+            "Couldn't execute {:?}, for account {:?}, error {:?}, last account transactions: {:?}",
+            txn,
+            root_account,
+            e,
+            last_transactions.unwrap_or_default()
+        )
+    }
+
+    let transaction = result.unwrap();
+    // Next transaction after reconfig should be a new epoch.
+    let new_state = client
+        .wait_for_version(transaction.inner().version().unwrap() + 1)
+        .await
+        .unwrap();
+
+    info!(
+        "Changed aptos version from {} (epoch={}, ledger_v={}), to {}, (epoch={}, ledger_v={})",
+        current_version,
+        state.epoch,
+        state.version,
+        current_version + 1,
+        new_state.epoch,
+        new_state.version
+    );
+    assert_ne!(state.epoch, new_state.epoch);
+
+    new_state
 }

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::smoke_test_environment::SwarmBuilder;
-use crate::test_utils::reconfig;
 use aptos::common::types::TransactionSummary;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
@@ -10,7 +9,7 @@ use aptos_crypto::{bls12381, x25519};
 use aptos_genesis::config::HostAndPort;
 use aptos_keygen::KeyGen;
 use aptos_types::network_address::DnsName;
-use forge::{NodeExt, Swarm};
+use forge::{reconfig, NodeExt, Swarm};
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::Duration;

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::test_utils::reconfig;
 use crate::{
     smoke_test_environment::new_local_swarm_with_aptos,
     test_utils::{
@@ -15,7 +14,7 @@ use anyhow::{bail, Result};
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Version, waypoint::Waypoint};
 use backup_cli::metadata::view::BackupStorageState;
-use forge::{NodeExt, Swarm, SwarmExt};
+use forge::{reconfig, NodeExt, Swarm, SwarmExt};
 use std::{
     fs,
     path::Path,

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -7,7 +7,7 @@ use aptos_sdk::{
     types::{transaction::SignedTransaction, LocalAccount},
 };
 use cached_packages::aptos_stdlib;
-use forge::{LocalSwarm, NodeExt, Swarm};
+use forge::{reconfig, LocalSwarm, NodeExt, Swarm};
 use rand::random;
 
 pub async fn create_and_fund_account(swarm: &'_ mut dyn Swarm, amount: u64) -> LocalAccount {
@@ -49,30 +49,6 @@ pub async fn transfer_coins(
     client.wait_for_signed_transaction(&txn).await.unwrap();
 
     txn
-}
-
-pub async fn reconfig(
-    client: &RestClient,
-    transaction_factory: &TransactionFactory,
-    root_account: &mut LocalAccount,
-) {
-    let aptos_version = client.get_aptos_version().await.unwrap();
-    let current_version = *aptos_version.into_inner().major.inner();
-    let txn = root_account.sign_with_transaction_builder(
-        transaction_factory.payload(aptos_stdlib::version_set_version(current_version + 1)),
-    );
-    client
-        .submit_and_wait(&txn)
-        .await
-        .map_err(|e| {
-            panic!(
-                "Couldn't execute {:?}, for account {:?}, error {:?}",
-                txn, root_account, e
-            )
-        })
-        .unwrap();
-
-    println!("Changing aptos version to {}", current_version + 1,);
 }
 
 pub async fn transfer_and_reconfig(


### PR DESCRIPTION
### Description

Previously, after reconfig, it wasn't guaranteed that new epoch has started, making it easy to have race condition in the tests.

### Test Plan
current, and rewards and consensus tests stacked on top

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3138)
<!-- Reviewable:end -->
