### PR TITLE
[aptos-telemetry] Authenticate Validator Full Nodes

### DIFF
--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -6,7 +6,7 @@ use crate::error::ServiceError;
 use crate::jwt_auth::{authorize_jwt, create_jwt_token, jwt_from_header};
 use crate::types::auth::{AuthRequest, AuthResponse, Claims};
 use anyhow::{anyhow, Result};
-use aptos_config::config::PeerRole;
+use aptos_config::config::{PeerRole, RoleType};
 use aptos_crypto::{noise, x25519};
 use aptos_logger::{debug, error, warn};
 use aptos_types::PeerId;
@@ -28,6 +28,8 @@ pub fn auth(context: Context) -> BoxedFilter<(impl Reply,)> {
 }
 
 pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Reply, Rejection> {
+    debug!("received auth request: {:?}", body);
+
     let client_init_message = &body.handshake_msg;
 
     // Check whether the client (validator) is using the correct server's public key, which the
@@ -59,7 +61,13 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
             ))
         })?;
 
-    let (epoch, peer_role) = match context.validator_cache().read().get(&body.chain_id) {
+    let cache = if body.role_type == RoleType::Validator {
+        context.validator_cache()
+    } else {
+        context.vfn_cache()
+    };
+
+    let (epoch, peer_role) = match cache.read().get(&body.chain_id) {
         Some((epoch, peer_set)) => {
             match peer_set.get(&body.peer_id) {
                 Some(peer) => {

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -3,9 +3,10 @@
 
 use std::{convert::Infallible, sync::Arc};
 
+use crate::validator_cache::PeerSetCache;
 use crate::{
-    clients::humio, clients::victoria_metrics_api::Client as MetricsClient,
-    validator_cache::ValidatorSetCache, GCPBigQueryConfig, TelemetryServiceConfig,
+    clients::humio, clients::victoria_metrics_api::Client as MetricsClient, GCPBigQueryConfig,
+    TelemetryServiceConfig,
 };
 use aptos_crypto::noise;
 use gcp_bigquery_client::Client as BQClient;
@@ -15,7 +16,8 @@ use warp::Filter;
 #[derive(Clone)]
 pub struct Context {
     noise_config: Arc<noise::NoiseConfig>,
-    validator_cache: ValidatorSetCache,
+    validator_cache: PeerSetCache,
+    vfn_cache: PeerSetCache,
 
     pub gcp_bq_client: Option<BQClient>,
     pub gcp_bq_config: GCPBigQueryConfig,
@@ -31,7 +33,8 @@ pub struct Context {
 impl Context {
     pub fn new(
         config: &TelemetryServiceConfig,
-        validator_cache: ValidatorSetCache,
+        validator_cache: PeerSetCache,
+        vfn_cache: PeerSetCache,
         gcp_bigquery_client: Option<BQClient>,
         victoria_metrics_client: Option<MetricsClient>,
         humio_client: humio::IngestClient,
@@ -40,6 +43,7 @@ impl Context {
         Self {
             noise_config: Arc::new(noise::NoiseConfig::new(private_key)),
             validator_cache,
+            vfn_cache,
 
             gcp_bq_client: gcp_bigquery_client,
             gcp_bq_config: config.gcp_bq_config.clone(),
@@ -57,8 +61,12 @@ impl Context {
         warp::any().map(move || self.clone())
     }
 
-    pub fn validator_cache(&self) -> ValidatorSetCache {
+    pub fn validator_cache(&self) -> PeerSetCache {
         self.validator_cache.clone()
+    }
+
+    pub fn vfn_cache(&self) -> PeerSetCache {
+        self.vfn_cache.clone()
     }
 
     pub fn noise_config(&self) -> Arc<noise::NoiseConfig> {

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -26,7 +26,11 @@ pub fn custom_event(context: Context) -> BoxedFilter<(impl Reply,)> {
         .and(context.clone().filter())
         .and(with_auth(
             context,
-            vec![PeerRole::Validator, PeerRole::Unknown],
+            vec![
+                PeerRole::Validator,
+                PeerRole::ValidatorFullNode,
+                PeerRole::Unknown,
+            ],
         ))
         .and(warp::body::json())
         .and_then(handle_custom_event)

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -21,7 +21,7 @@ use crate::{
     clients::victoria_metrics_api::Client as MetricsClient,
     context::Context,
     index::routes,
-    validator_cache::{ValidatorSetCache, ValidatorSetCacheUpdater},
+    validator_cache::{PeerSetCache, PeerSetCacheUpdater},
 };
 
 mod auth;
@@ -58,8 +58,6 @@ impl AptosTelemetryServiceArgs {
             });
         info!("Using config {:?}", &config);
 
-        let cache = ValidatorSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
-
         let gcp_bigquery_client = Client::from_service_account_key_file(
             env::var("GOOGLE_APPLICATION_CREDENTIALS")
                 .expect("environment variable GOOGLE_APPLICATION_CREDENTIALS must be set")
@@ -77,16 +75,19 @@ impl AptosTelemetryServiceArgs {
             Url::parse(&config.humio_url).unwrap(),
             config.humio_auth_token.clone(),
         );
+        let validators_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
+        let vfns_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
 
         let context = Context::new(
             &config,
-            cache.clone(),
+            validators_cache.clone(),
+            vfns_cache.clone(),
             Some(gcp_bigquery_client),
             Some(victoria_metrics_client),
             humio_client,
         );
 
-        ValidatorSetCacheUpdater::new(cache, &config).run();
+        PeerSetCacheUpdater::new(validators_cache, vfns_cache, &config).run();
 
         Self::serve(&config, routes(context)).await;
     }

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 
 use crate::clients::humio;
 use crate::GCPBigQueryConfig;
-use crate::{context::Context, index, validator_cache::ValidatorSetCache, TelemetryServiceConfig};
+use crate::{context::Context, index, validator_cache::PeerSetCache, TelemetryServiceConfig};
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::{x25519, Uniform};
 use aptos_rest_client::aptos_api_types::mime_types;
@@ -38,12 +38,21 @@ pub async fn new_test_context() -> TestContext {
         humio_url: "".into(),
         humio_auth_token: "".into(),
     };
-    let cache = ValidatorSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
     let humio_client = humio::IngestClient::new(
         Url::parse("http://localhost/").unwrap(),
         config.humio_auth_token.clone(),
     );
-    TestContext::new(Context::new(config, cache, None, None, humio_client))
+    let validator_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
+    let vfn_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
+
+    TestContext::new(Context::new(
+        config,
+        validator_cache,
+        vfn_cache,
+        None,
+        None,
+        humio_client,
+    ))
 }
 
 #[derive(Clone)]

--- a/crates/aptos-telemetry-service/src/types/auth.rs
+++ b/crates/aptos-telemetry-service/src/types/auth.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_config::config::PeerRole;
+use aptos_config::config::{PeerRole, RoleType};
 use aptos_crypto::x25519;
 use aptos_types::{chain_id::ChainId, PeerId};
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct AuthRequest {
     pub chain_id: ChainId,
     pub peer_id: PeerId,
+    pub role_type: RoleType,
     pub server_public_key: x25519::PublicKey,
     pub handshake_msg: Vec<u8>,
 }

--- a/crates/aptos-telemetry-service/src/types/validator_set.rs
+++ b/crates/aptos-telemetry-service/src/types/validator_set.rs
@@ -23,6 +23,9 @@ impl ValidatorConfig {
     pub fn validator_network_addresses(&self) -> Result<Vec<NetworkAddress>, bcs::Error> {
         bcs::from_bytes(&self.network_addresses)
     }
+    pub fn fullnode_network_addresses(&self) -> Result<Vec<NetworkAddress>, bcs::Error> {
+        bcs::from_bytes(&self.fullnode_addresses)
+    }
 }
 
 /// Consensus information per validator, stored in ValidatorSet.

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -12,20 +12,26 @@ use url::Url;
 use crate::{clients::aptos_api::RestClient, TelemetryServiceConfig};
 
 pub type EpochNum = u64;
-pub type ValidatorSetCache = Arc<RwLock<HashMap<ChainId, (EpochNum, PeerSet)>>>;
+pub type PeerSetCache = Arc<RwLock<HashMap<ChainId, (EpochNum, PeerSet)>>>;
 
 #[derive(Clone)]
-pub struct ValidatorSetCacheUpdater {
-    cache: ValidatorSetCache,
+pub struct PeerSetCacheUpdater {
+    validators: PeerSetCache,
+    validator_fullnodes: PeerSetCache,
 
     query_addresses: Arc<HashMap<ChainId, String>>,
     update_interval: time::Duration,
 }
 
-impl ValidatorSetCacheUpdater {
-    pub fn new(cache: ValidatorSetCache, config: &TelemetryServiceConfig) -> Self {
+impl PeerSetCacheUpdater {
+    pub fn new(
+        validators: PeerSetCache,
+        validator_fullnodes: PeerSetCache,
+        config: &TelemetryServiceConfig,
+    ) -> Self {
         Self {
-            cache,
+            validators,
+            validator_fullnodes,
             query_addresses: Arc::new(config.trusted_full_node_addresses.clone()),
             update_interval: Duration::from_secs(config.update_interval),
         }
@@ -45,33 +51,54 @@ impl ValidatorSetCacheUpdater {
     pub async fn update(&self) {
         for (chain_id, url) in self.query_addresses.iter() {
             let client = RestClient::new(Url::parse(url).unwrap());
-            let validators = client.validator_set_validator_addresses().await;
-            match validators {
-                Ok((validators, state)) => {
+            let result = client.validator_set_all_addresses().await;
+            match result {
+                Ok((peer_addrs, state)) => {
                     let received_chain_id = ChainId::new(state.chain_id);
                     if received_chain_id != *chain_id {
                         error!("Chain Id mismatch: Received in headers: {}. Provided in configuration: {} for {}", received_chain_id, chain_id, url);
                         continue;
                     }
 
-                    let mut store = self.cache.write();
+                    let mut validator_cache = self.validators.write();
+                    let mut vfn_cache = self.validator_fullnodes.write();
 
-                    let peer_set = validators
+                    let validator_peers = peer_addrs
                         .iter()
-                        .map(|(peer_id, addrs)| {
+                        .map(|(peer_id, validator_addrs, _)| {
                             (
                                 *peer_id,
-                                Peer::from_addrs(PeerRole::Validator, addrs.to_vec()),
+                                Peer::from_addrs(PeerRole::Validator, validator_addrs.to_vec()),
                             )
                         })
                         .collect();
 
                     debug!(
-                        "Validator set for chain id {} at epoch {}: {:?}",
-                        chain_id, state.epoch, peer_set
+                        "Validator peers for chain id {} at epoch {}: {:?}",
+                        chain_id, state.epoch, validator_peers
                     );
 
-                    store.insert(*chain_id, (state.epoch, peer_set));
+                    validator_cache.insert(*chain_id, (state.epoch, validator_peers));
+
+                    let vfn_peers = peer_addrs
+                        .iter()
+                        .map(|(peer_id, _, network_address)| {
+                            (
+                                *peer_id,
+                                Peer::from_addrs(
+                                    PeerRole::ValidatorFullNode,
+                                    network_address.to_vec(),
+                                ),
+                            )
+                        })
+                        .collect();
+
+                    debug!(
+                        "Validator fullnode peers for chain id {} at epoch {}: {:?}",
+                        chain_id, state.epoch, vfn_peers
+                    );
+
+                    vfn_cache.insert(*chain_id, (state.epoch, vfn_peers));
                 }
                 Err(err) => {
                     error!(

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -21,7 +21,8 @@ pub(crate) const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
 // See: https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#transport
 pub(crate) const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
 pub(crate) const HTTPBIN_URL: &str = "https://httpbin.org/ip";
-pub(crate) const TELEMETRY_SERVICE_URL: &str = "https://telemetry.aptoslabs.com";
+// pub(crate) const TELEMETRY_SERVICE_URL: &str = "https://telemetry.aptoslabs.com";
+pub(crate) const TELEMETRY_SERVICE_URL: &str = "http://localhost:8000";
 
 // Frequencies for the various metrics and pushes
 pub(crate) const NODE_CORE_METRICS_FREQ_SECS: u64 = 30; // 30 seconds

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -21,8 +21,7 @@ pub(crate) const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
 // See: https://developers.google.com/analytics/devguides/collection/protocol/v1/reference#transport
 pub(crate) const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
 pub(crate) const HTTPBIN_URL: &str = "https://httpbin.org/ip";
-// pub(crate) const TELEMETRY_SERVICE_URL: &str = "https://telemetry.aptoslabs.com";
-pub(crate) const TELEMETRY_SERVICE_URL: &str = "http://localhost:8000";
+pub(crate) const TELEMETRY_SERVICE_URL: &str = "https://telemetry.aptoslabs.com";
 
 // Frequencies for the various metrics and pushes
 pub(crate) const NODE_CORE_METRICS_FREQ_SECS: u64 = 30; // 30 seconds

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -180,7 +180,11 @@ impl TelemetrySender {
                     self.reset_token();
                     Err(anyhow!("Unauthorized"))
                 } else {
-                    Err(anyhow!("Error status received: {}", status_code))
+                    Err(anyhow!(
+                        "Error status received {}: {}",
+                        status_code,
+                        response.text().await?,
+                    ))
                 }
             }
             Err(error) => Err(anyhow!("Error sending metrics. Err: {}", error)),

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -3,7 +3,7 @@
 
 use crate::metrics;
 use anyhow::{anyhow, Error};
-use aptos_config::config::NodeConfig;
+use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::{
     noise::{self, NoiseConfig},
     x25519,
@@ -44,6 +44,7 @@ pub(crate) struct TelemetrySender {
     base_url: String,
     chain_id: ChainId,
     peer_id: PeerId,
+    role_type: RoleType,
     client: reqwest::Client,
     auth_context: Arc<AuthContext>,
 }
@@ -54,6 +55,7 @@ impl TelemetrySender {
             base_url,
             chain_id,
             peer_id: node_config.peer_id().unwrap_or(PeerId::ZERO),
+            role_type: node_config.base.role,
             client: reqwest::Client::new(),
             auth_context: Arc::new(AuthContext::new(node_config)),
         }
@@ -201,7 +203,7 @@ impl TelemetrySender {
     async fn get_public_key_from_server(&self) -> Result<x25519::PublicKey, anyhow::Error> {
         let response = self.client.get(self.base_url.to_string()).send().await?;
 
-        match response.error_for_status() {
+        match error_for_status_with_body(response).await {
             Ok(response) => {
                 let public_key = response.json::<x25519::PublicKey>().await?;
                 Ok(public_key)
@@ -262,6 +264,7 @@ impl TelemetrySender {
         let auth_request = AuthRequest {
             chain_id: self.chain_id,
             peer_id: self.peer_id,
+            role_type: self.role_type,
             server_public_key,
             handshake_msg: client_noise_msg,
         };
@@ -273,12 +276,12 @@ impl TelemetrySender {
             .send()
             .await?;
 
-        let resp = match response.error_for_status() {
+        let resp = match error_for_status_with_body(response).await {
             Ok(response) => Ok(response.json::<AuthResponse>().await?),
             Err(err) => {
                 error!(
                     "[telemetry-client] Error sending authentication request: {}",
-                    err
+                    err,
                 );
                 Err(anyhow!("error {}", err))
             }
@@ -465,5 +468,18 @@ mod tests {
 
         mock.assert();
         assert!(result.is_ok());
+    }
+}
+
+async fn error_for_status_with_body(response: Response) -> Result<Response, anyhow::Error> {
+    if response.status().is_client_error() || response.status().is_server_error() {
+        Err(anyhow!(
+            "HTTP status error ({}) for url ({}): {}",
+            response.status(),
+            response.url().clone(),
+            response.text().await?,
+        ))
+    } else {
+        Ok(response)
     }
 }


### PR DESCRIPTION
### Description

This PR adds support for authenticating validator full nodes using the `fullnode_network_addresses` in the onchain config.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

I ran a local validator and a validator full node and was able to check that the service could authenticate Validators and VFNs accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3145)
<!-- Reviewable:end -->
