### PR TITLE
[doc] fix broken link

### DIFF
--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/index.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/index.md
@@ -10,6 +10,6 @@ slug: "aptos-cli-index"
 
 :::tip Using CLI to run a local testnet
 
-If you want to use CLI to start and run a local testnet, see [Using CLI to Run a Local Testnet](/nodes/using-cli-to-run-a-local-testnet).
+If you want to use CLI to start and run a local testnet, see [Using CLI to Run a Local Testnet](/nodes/local-testnet/using-cli-to-run-a-local-testnet).
 :::
 


### PR DESCRIPTION
### Description
Changed link to reflect `using-cli-to-run-a-local-testnet`'s move to `/nodes/local-testnet/`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3146)
<!-- Reviewable:end -->
