### PR TITLE
[telemetry] client side of log ingest via telemetry service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "chrono",
  "console-subscriber",
  "erased-serde",
+ "futures",
  "hostname",
  "once_cell",
  "pretty_assertions",

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -37,7 +37,7 @@ use data_streaming_service::{
 use event_notifications::EventSubscriptionService;
 use executor::{chunk_executor::ChunkExecutor, db_bootstrapper::maybe_bootstrap};
 use framework::ReleaseBundle;
-use futures::channel::mpsc::channel;
+use futures::channel::mpsc;
 use hex::FromHex;
 use mempool_notifications::MempoolNotificationSender;
 use network::application::storage::PeerMetadataStorage;
@@ -69,6 +69,7 @@ use tokio::runtime::{Builder, Runtime};
 const AC_SMP_CHANNEL_BUFFER_SIZE: usize = 1_024;
 const INTRA_NODE_CHANNEL_BUFFER_SIZE: usize = 1;
 const MEMPOOL_NETWORK_CHANNEL_BUFFER_SIZE: usize = 1_024;
+const TELEMETRY_LOG_INGEST_BUFFER_SIZE: usize = 128;
 
 /// Runs an aptos fullnode or validator
 #[derive(Clone, Debug, Parser)]
@@ -168,6 +169,7 @@ pub fn start(config: NodeConfig, log_file: Option<PathBuf>) -> anyhow::Result<()
         .channel_size(config.logger.chan_size)
         .is_async(config.logger.is_async)
         .level(config.logger.level)
+        .telemetry_level(config.logger.telemetry_level)
         .console_port(config.logger.console_port)
         .read_env();
     if config.logger.enable_backtrace {
@@ -176,7 +178,13 @@ pub fn start(config: NodeConfig, log_file: Option<PathBuf>) -> anyhow::Result<()
     if let Some(log_file) = log_file {
         logger.printer(Box::new(FileWriter::new(log_file)));
     }
-    let _logger = Some(logger.build());
+    let mut remote_log_rx = None;
+    if config.logger.enable_telemetry_remote_log {
+        let (tx, rx) = mpsc::channel(TELEMETRY_LOG_INGEST_BUFFER_SIZE);
+        logger.remote_log_tx(tx);
+        remote_log_rx = Some(rx);
+    }
+    let _logger = logger.build();
 
     // Let's now log some important information, since the logger is set up
     info!(config = config, "Loaded AptosNode config");
@@ -192,7 +200,8 @@ pub fn start(config: NodeConfig, log_file: Option<PathBuf>) -> anyhow::Result<()
         warn!("failpoints is set in config, but the binary doesn't compile with this feature");
     }
 
-    let _node_handle = setup_environment(config)?;
+    let _node_handle = setup_environment(config, remote_log_rx)?;
+
     let term = Arc::new(AtomicBool::new(false));
 
     while !term.load(Ordering::Acquire) {
@@ -470,7 +479,10 @@ fn setup_state_sync_storage_service(
     Ok(storage_service_runtime)
 }
 
-pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle> {
+pub fn setup_environment(
+    node_config: NodeConfig,
+    remote_log_rx: Option<mpsc::Receiver<String>>,
+) -> anyhow::Result<AptosHandle> {
     // Start the node inspection service
     let node_config_clone = node_config.clone();
     thread::spawn(move || {
@@ -658,7 +670,7 @@ pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle>
         db_rw.clone(),
     )?;
 
-    let (mp_client_sender, mp_client_events) = channel(AC_SMP_CHANNEL_BUFFER_SIZE);
+    let (mp_client_sender, mp_client_events) = mpsc::channel(AC_SMP_CHANNEL_BUFFER_SIZE);
 
     let api_runtime = bootstrap_api(
         &node_config,
@@ -673,7 +685,7 @@ pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle>
 
     let mut consensus_runtime = None;
     let (consensus_to_mempool_sender, consensus_to_mempool_receiver) =
-        channel(INTRA_NODE_CHANNEL_BUFFER_SIZE);
+        mpsc::channel(INTRA_NODE_CHANNEL_BUFFER_SIZE);
 
     instant = Instant::now();
     let mempool = aptos_mempool::bootstrap(
@@ -732,6 +744,7 @@ pub fn setup_environment(node_config: NodeConfig) -> anyhow::Result<AptosHandle>
         node_config.clone(),
         chain_id,
         build_info,
+        remote_log_rx,
     );
 
     Ok(AptosHandle {

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -18,6 +18,8 @@ pub struct LoggerConfig {
     pub level: Level,
     // tokio-console port
     pub console_port: Option<u16>,
+    pub enable_telemetry_remote_log: bool,
+    pub telemetry_level: Level,
 }
 
 impl Default for LoggerConfig {
@@ -28,6 +30,8 @@ impl Default for LoggerConfig {
             is_async: true,
             level: Level::Info,
             console_port: Some(6669),
+            enable_telemetry_remote_log: false,
+            telemetry_level: Level::Error,
         }
     }
 }

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -16,6 +16,7 @@ backtrace = { version = "0.3.58", features = ["serde"] }
 chrono = "0.4.19"
 console-subscriber = { version = "0.1.6", optional = true }
 erased-serde = "0.3.13"
+futures = "0.3.21"
 hostname = "0.3.1"
 once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }

--- a/crates/aptos-logger/src/counters.rs
+++ b/crates/aptos-logger/src/counters.rs
@@ -79,3 +79,21 @@ pub static STRUCT_LOG_PARSE_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Counter for failed log ingest writes (see also: aptos-telemetry for sender metrics)
+pub static APTOS_LOG_INGEST_WRITER_FULL: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_log_ingest_writer_full",
+        "Number of log ingest writes that failed due to channel full"
+    )
+    .unwrap()
+});
+
+/// Counter for failed log ingest writes (see also: aptos-telemetry for sender metrics)
+pub static APTOS_LOG_INGEST_WRITER_DISCONNECTED: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_log_ingest_writer_disconnected",
+        "Number of log ingest writes that failed due to channel disconnected"
+    )
+    .unwrap()
+});

--- a/crates/aptos-logger/src/lib.rs
+++ b/crates/aptos-logger/src/lib.rs
@@ -151,6 +151,7 @@ mod logger;
 mod macros;
 mod metadata;
 pub mod sample;
+mod telemetry_log_writer;
 pub mod tracing_adapter;
 
 mod security;

--- a/crates/aptos-logger/src/telemetry_log_writer.rs
+++ b/crates/aptos-logger/src/telemetry_log_writer.rs
@@ -1,0 +1,41 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::counters::{APTOS_LOG_INGEST_WRITER_DISCONNECTED, APTOS_LOG_INGEST_WRITER_FULL};
+use futures::channel::mpsc;
+use std::io::{Error, ErrorKind};
+
+#[derive(Debug)]
+pub(crate) struct TelemetryLogWriter {
+    tx: mpsc::Sender<String>,
+}
+
+impl TelemetryLogWriter {
+    pub fn new(tx: mpsc::Sender<String>) -> Self {
+        Self { tx }
+    }
+}
+
+impl TelemetryLogWriter {
+    pub fn write(&mut self, log: String) -> std::io::Result<usize> {
+        let len = log.len();
+        match self.tx.try_send(log) {
+            Ok(_) => Ok(len),
+            Err(err) => {
+                if err.is_full() {
+                    APTOS_LOG_INGEST_WRITER_FULL.inc_by(len as u64);
+                    Err(Error::new(ErrorKind::WouldBlock, "Channel full"))
+                } else {
+                    APTOS_LOG_INGEST_WRITER_DISCONNECTED.inc_by(len as u64);
+                    Err(Error::new(ErrorKind::ConnectionRefused, "Disconnected"))
+                }
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    // TODO: hook up flush when it is implemented in LoggerService
+    pub fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -11,4 +11,5 @@ mod network_metrics;
 mod sender;
 pub mod service;
 pub mod system_information;
+mod telemetry_log_sender;
 pub mod utils;

--- a/crates/aptos-telemetry/src/metrics.rs
+++ b/crates/aptos-telemetry/src/metrics.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_metrics_core::{register_int_counter_vec, IntCounterVec};
+use aptos_metrics_core::{
+    register_int_counter, register_int_counter_vec, IntCounter, IntCounterVec,
+};
 use once_cell::sync::Lazy;
 
 /// Counter for successful telemetry events sent from Telemetry Sender to Telemetry Service
@@ -72,4 +74,46 @@ pub(crate) fn increment_telemetry_service_failures(event_name: &str) {
     APTOS_TELEMETRY_SERVICE_FAILURE
         .with_label_values(&[event_name])
         .inc();
+}
+
+/// Counter for successful log ingest events sent to Telemetry Service
+pub(crate) static APTOS_LOG_INGEST_SUCCESS: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_log_ingest_success",
+        "Number of log ingest events successfully sent"
+    )
+    .unwrap()
+});
+
+/// Counter for successful log ingest events sent to Telemetry Service
+pub(crate) static APTOS_LOG_INGEST_TOO_LARGE: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_log_ingest_too_large",
+        "Number of log ingest events that were too large"
+    )
+    .unwrap()
+});
+
+/// Counter for failed log ingest events sent to Telemetry Service
+pub(crate) static APTOS_LOG_INGEST_FAILURE: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_log_ingest_failure",
+        "Number of log ingest events that failed to send"
+    )
+    .unwrap()
+});
+
+/// Increments the number of successful log ingest events sent to Telemetry Service
+pub(crate) fn increment_log_ingest_successes_by(v: u64) {
+    APTOS_LOG_INGEST_SUCCESS.inc_by(v);
+}
+
+/// Increments the number of ignored log ingest events because too large
+pub(crate) fn increment_log_ingest_too_large_by(v: u64) {
+    APTOS_LOG_INGEST_TOO_LARGE.inc_by(v);
+}
+
+/// Increments the number of failed log ingest events
+pub(crate) fn increment_log_ingest_failures_by(v: u64) {
+    APTOS_LOG_INGEST_FAILURE.inc_by(v);
 }

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics;
+use crate::metrics::{increment_log_ingest_failures_by, increment_log_ingest_successes_by};
 use anyhow::{anyhow, Error};
 use aptos_config::config::{NodeConfig, RoleType};
 use aptos_crypto::{
@@ -131,6 +132,67 @@ impl TelemetrySender {
             |e| error!("Failed to push Prometheus Metrics: {}", e),
             |_| debug!("Prometheus Metrics pushed successfully."),
         );
+    }
+
+    pub async fn send_logs(&self, batch: Vec<String>) {
+        if let Ok(json) = serde_json::to_string(&batch) {
+            let len = json.len();
+
+            let retry_strategy = ExponentialBackoff::from_millis(10)
+                .map(jitter) // add jitter to delays
+                .take(4); // limit to 4 retries
+
+            let result = Retry::spawn(retry_strategy, || async {
+                self.post_logs(json.as_bytes()).await
+            })
+            .await;
+            match result {
+                Ok(_) => {
+                    increment_log_ingest_successes_by(batch.len() as u64);
+                    debug!("Sent log of length: {}", len);
+                }
+                Err(error) => {
+                    increment_log_ingest_failures_by(batch.len() as u64);
+                    error!("Failed send log of length: {} with error: {}", len, error);
+                }
+            }
+        } else {
+            error!("Failed json serde of batch: {:?}", batch);
+        }
+    }
+
+    async fn post_logs(&self, json: &[u8]) -> Result<(), anyhow::Error> {
+        let token = self.get_auth_token().await?;
+
+        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::default());
+        gzip_encoder.write_all(json)?;
+        let compressed_bytes = gzip_encoder.finish()?;
+
+        // Send the request and wait for a response
+        let send_result = self
+            .client
+            .post(format!("{}/log_ingest", self.base_url))
+            .header("Content-Encoding", "gzip")
+            .bearer_auth(token)
+            .body(compressed_bytes)
+            .send()
+            .await;
+
+        // Process the result
+        match send_result {
+            Ok(response) => {
+                let status_code = response.status();
+                if status_code.is_success() {
+                    Ok(())
+                } else if status_code == StatusCode::UNAUTHORIZED {
+                    self.reset_token();
+                    Err(anyhow!("Unauthorized"))
+                } else {
+                    Err(anyhow!("Error status received: {}", status_code))
+                }
+            }
+            Err(error) => Err(anyhow!("Error sending log. Err: {}", error)),
+        }
     }
 
     pub async fn send_metrics(&self, event_name: String, telemetry_dump: TelemetryDump) {
@@ -472,6 +534,36 @@ mod tests {
 
         mock.assert();
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_post_logs() {
+        let batch = vec!["log1".to_string(), "log2".to_string()];
+        let json = serde_json::to_string(&batch);
+        assert!(json.is_ok());
+
+        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::default());
+        gzip_encoder.write_all(json.unwrap().as_bytes()).unwrap();
+        let expected_compressed_bytes = gzip_encoder.finish().unwrap();
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method("POST")
+                .header("Authorization", "Bearer SECRET_JWT_TOKEN")
+                .path("/log_ingest")
+                .body(String::from_utf8_lossy(&expected_compressed_bytes));
+            then.status(200);
+        });
+
+        let node_config = NodeConfig::default();
+        let client = TelemetrySender::new(server.base_url(), ChainId::default(), &node_config);
+        {
+            *client.auth_context.token.write() = Some("SECRET_JWT_TOKEN".into());
+        }
+
+        client.send_logs(batch).await;
+
+        mock.assert();
     }
 }
 

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -3,6 +3,11 @@
 
 #![forbid(unsafe_code)]
 
+use aptos_config::config::NodeConfig;
+use aptos_logger::prelude::*;
+use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
+use aptos_types::chain_id::ChainId;
+use futures::channel::mpsc;
 use futures::future;
 use once_cell::sync::Lazy;
 use rand::Rng;
@@ -22,11 +27,6 @@ use tokio::{
 };
 use uuid::Uuid;
 
-use aptos_config::config::NodeConfig;
-use aptos_logger::prelude::*;
-use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
-use aptos_types::chain_id::ChainId;
-
 use crate::constants::{
     ENV_APTOS_DISABLE_EXPERIMENTAL_PUSH_METRICS, ENV_TELEMETRY_SERVICE_URL,
     PROMETHEUS_PUSH_METRICS_FREQ_SECS,
@@ -44,6 +44,7 @@ use crate::{
     network_metrics::create_network_metric_telemetry_event,
     sender::TelemetrySender,
     system_information::create_system_info_telemetry_event,
+    telemetry_log_sender::TelemetryLogSender,
 };
 
 const IP_ADDRESS_KEY: &str = "IP_ADDRESS";
@@ -77,6 +78,7 @@ pub fn start_telemetry_service(
     node_config: NodeConfig,
     chain_id: ChainId,
     build_info: BTreeMap<String, String>,
+    remote_log_rx: Option<mpsc::Receiver<String>>,
 ) -> Option<Runtime> {
     // Don't start the service if telemetry has been disabled
     if telemetry_is_disabled() {
@@ -91,9 +93,20 @@ pub fn start_telemetry_service(
         .build()
         .expect("Failed to create the Aptos Telemetry runtime!");
 
+    let telemetry_svc_url =
+        env::var(ENV_TELEMETRY_SERVICE_URL).unwrap_or_else(|_| TELEMETRY_SERVICE_URL.into());
+
+    let telemetry_sender = TelemetrySender::new(telemetry_svc_url, chain_id, &node_config);
+
+    if let Some(rx) = remote_log_rx {
+        let telemetry_log_sender = TelemetryLogSender::new(telemetry_sender.clone());
+        telemetry_runtime.spawn(telemetry_log_sender.start(rx));
+    }
+
     // Spawn the telemetry service
     let peer_id = fetch_peer_id(&node_config);
     telemetry_runtime.handle().spawn(spawn_telemetry_service(
+        telemetry_sender,
         peer_id,
         chain_id,
         node_config,
@@ -125,16 +138,12 @@ where
 
 /// Spawns the dedicated telemetry service that operates periodically
 async fn spawn_telemetry_service(
+    telemetry_sender: TelemetrySender,
     peer_id: String,
     chain_id: ChainId,
     node_config: NodeConfig,
     build_info: BTreeMap<String, String>,
 ) {
-    let telemetry_svc_url =
-        env::var(ENV_TELEMETRY_SERVICE_URL).unwrap_or_else(|_| TELEMETRY_SERVICE_URL.into());
-
-    let telemetry_sender = TelemetrySender::new(telemetry_svc_url, chain_id, &node_config);
-
     // Send build information once (only on startup)
     send_build_information(
         peer_id.clone(),

--- a/crates/aptos-telemetry/src/telemetry_log_sender.rs
+++ b/crates/aptos-telemetry/src/telemetry_log_sender.rs
@@ -1,0 +1,136 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::metrics::increment_log_ingest_too_large_by;
+use crate::sender::TelemetrySender;
+use aptos_logger::prelude::*;
+use futures::channel::mpsc;
+use futures::StreamExt;
+use std::time::Duration;
+use tokio::time::interval;
+use tokio_stream::wrappers::IntervalStream;
+
+const MAX_BYTES: usize = 128 * 1024;
+const MAX_BATCH_TIME: Duration = Duration::from_secs(5);
+
+/// Buffered
+pub(crate) struct TelemetryLogSender {
+    sender: TelemetrySender,
+    batch: Vec<String>,
+    max_bytes: usize,
+    current_bytes: usize,
+}
+
+impl TelemetryLogSender {
+    pub fn new(sender: TelemetrySender) -> Self {
+        Self {
+            // TODO: use an existing sender?
+            sender,
+            batch: Vec::new(),
+            max_bytes: MAX_BYTES,
+            current_bytes: 0,
+        }
+    }
+
+    fn drain_batch(&mut self) -> Vec<String> {
+        let batch: Vec<_> = self.batch.drain(..).collect();
+        self.current_bytes = 0;
+        batch
+    }
+
+    pub(crate) fn add_to_batch(&mut self, log: String) -> Option<Vec<String>> {
+        if log.len() > self.max_bytes {
+            warn!("Log ignored, size: {}", log.len());
+            increment_log_ingest_too_large_by(1);
+            return None;
+        }
+
+        self.current_bytes += log.len();
+        self.batch.push(log);
+
+        if self.current_bytes > self.max_bytes {
+            return Some(self.drain_batch());
+        }
+        None
+    }
+
+    pub async fn handle_next_log(&mut self, log: String) {
+        if let Some(batch) = self.add_to_batch(log) {
+            self.sender.send_logs(batch).await;
+        }
+    }
+
+    pub async fn flush_batch(&mut self) {
+        if !self.batch.is_empty() {
+            let drained = self.drain_batch();
+            self.sender.send_logs(drained).await;
+        }
+    }
+
+    pub async fn start(mut self, mut rx: mpsc::Receiver<String>) {
+        let mut interval = IntervalStream::new(interval(MAX_BATCH_TIME)).fuse();
+
+        loop {
+            tokio::select! {
+                Some(log) = rx.next() => {
+                    self.handle_next_log(log).await;
+                }
+                _ = interval.select_next_some() => {
+                    self.flush_batch().await;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sender::TelemetrySender;
+    use crate::telemetry_log_sender::{TelemetryLogSender, MAX_BYTES};
+    use aptos_config::config::NodeConfig;
+    use aptos_types::chain_id::ChainId;
+
+    #[tokio::test]
+    async fn test_add_to_batch() {
+        let telemetry_sender =
+            TelemetrySender::new("test".to_string(), ChainId::test(), &NodeConfig::default());
+        let mut sender = TelemetryLogSender::new(telemetry_sender);
+
+        for _i in 0..2 {
+            // Large batch should not be allowed
+            let batch = sender.add_to_batch("a".repeat(MAX_BYTES + 1));
+            assert!(batch.is_none());
+
+            // Batch is flushed before reaching size
+            let to_send = vec!["test"];
+            let batch = sender.add_to_batch(to_send[0].to_string());
+            assert!(batch.is_none());
+            let batch = sender.drain_batch();
+            assert_eq!(batch.len(), 1);
+            assert_eq!(batch, to_send);
+
+            // Create batch that reaches max bytes
+            let bytes_per_string = 11;
+            let num_strings = (MAX_BYTES + 1) / bytes_per_string
+                + if (MAX_BYTES + 1) % bytes_per_string == 0 {
+                    0
+                } else {
+                    1
+                };
+            let to_send: Vec<_> = (0..num_strings).map(|i| format!("{:11}", i)).collect();
+            to_send.iter().enumerate().for_each(|(i, s)| {
+                // Large batch should not be allowed
+                let batch = sender.add_to_batch("a".repeat(MAX_BYTES + 1));
+                assert!(batch.is_none());
+
+                let batch = sender.add_to_batch(s.clone());
+                if i == (num_strings - 1) {
+                    assert!(batch.is_some());
+                    assert_eq!(batch.unwrap(), to_send);
+                } else {
+                    assert!(batch.is_none());
+                }
+            })
+        }
+    }
+}


### PR DESCRIPTION
### Description

Add log ingest via telemetry service on the client side. (#3254 added the endpoint.)
Logs are sent to telemetry service asynchronously in batches. Batches are sent every 5 seconds, or earlier if the batch size is reached. Other than the time to add to channel, there should be no slowdown for the main threads.

### Test Plan

```
RUST_LOG_TELEMETRY=warn cargo run -p aptos-node -- --test
cargo run -p aptos-telemetry-service -- -f telemetry-service.yaml
```
(with local `telemetry-service.yaml` and `bq-sa.json`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3151)
<!-- Reviewable:end -->
