### PR TITLE
[api] Fix RestClient version => ledger_version change

### DIFF
--- a/api/goldens/aptos_api__tests__state_test__test_get_account_resource_with_version.json
+++ b/api/goldens/aptos_api__tests__state_test__test_get_account_resource_with_version.json
@@ -1,0 +1,6 @@
+{
+  "type": "0x1::guid::Generator",
+  "data": {
+    "counter": "3"
+  }
+}

--- a/api/goldens/aptos_api__tests__state_test__test_get_account_resource_with_version_too_large.json
+++ b/api/goldens/aptos_api__tests__state_test__test_get_account_resource_with_version_too_large.json
@@ -1,0 +1,5 @@
+{
+  "message": "ledger not found by version(100000000)",
+  "error_code": null,
+  "aptos_ledger_version": "0"
+}

--- a/api/src/tests/state_test.rs
+++ b/api/src/tests/state_test.rs
@@ -65,6 +65,35 @@ async fn test_get_account_resource_struct_tag_not_found() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_get_account_resource_with_version() {
+    let mut context = new_test_context(current_function_name!());
+    let ledger_version = context.get_latest_ledger_info().version();
+    let resp = context
+        .get(&get_account_resource_with_version(
+            "0xA550C18",
+            "0x1::guid::Generator",
+            ledger_version,
+        ))
+        .await;
+
+    context.check_golden_output(resp);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_get_account_resource_with_version_too_large() {
+    let mut context = new_test_context(current_function_name!());
+    let resp = context
+        .expect_status_code(404)
+        .get(&get_account_resource_with_version(
+            "0xA550C18",
+            "0x1::guid::Generator",
+            100000000,
+        ))
+        .await;
+    context.check_golden_output(resp);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_get_account_module() {
     let mut context = new_test_context(current_function_name!());
     let resp = context.get(&get_account_module("0x1", "guid")).await;
@@ -175,6 +204,13 @@ async fn test_get_table_item() {
 
 fn get_account_resource(address: &str, struct_tag: &str) -> String {
     format!("/accounts/{}/resource/{}", address, struct_tag)
+}
+
+fn get_account_resource_with_version(address: &str, struct_tag: &str, version: u64) -> String {
+    format!(
+        "/accounts/{}/resource/{}?ledger_version={}",
+        address, struct_tag, version
+    )
 }
 
 fn get_account_module(address: &str, name: &str) -> String {

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -368,7 +368,7 @@ impl Client {
         version: u64,
     ) -> Result<Response<Option<Resource>>> {
         let url = self.build_path(&format!(
-            "accounts/{}/resource/{}?version={}",
+            "accounts/{}/resource/{}?ledger_version={}",
             address, resource_type, version
         ))?;
 


### PR DESCRIPTION
Unfortunately, REST API doesn't reject invalid arguments, and so
a change from version => ledger_version silently started returning
wrong data

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3155)
<!-- Reviewable:end -->
