### PR TITLE
[move] add standard math library

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/math.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math.move
@@ -1,0 +1,75 @@
+/// Standard math utilities missing in the Move Language.
+module aptos_std::math {
+
+    /// Return the largest of two numbers.
+    public fun max(a: u64, b: u64): u64 {
+        if (a >= b) a else b
+    }
+
+    /// Return the smallest of two numbers.
+    public fun min(a: u64, b: u64): u64 {
+        if (a < b) a else b
+    }
+
+    /// Return the average of two.
+    public fun average(a: u64, b: u64): u64 {
+        (a & b) + (a ^ b) / 2
+    }
+
+    /// Return the value of n raised to power e
+    public fun pow(n: u64, e: u64): u64 {
+        if (e == 0) {
+            1
+        } else if (e == 1) {
+            n
+        } else {
+            let p = pow(n, e / 2);
+            p = p * p;
+            if (e % 2 == 1) {
+                p = p * n;
+                p
+            } else {
+                p
+            }
+        }
+    }
+
+    #[test]
+    public entry fun test_max() {
+        let result = max(3, 6);
+        assert!(result == 6, 0);
+
+        let result = max(15, 12);
+        assert!(result == 15, 1);
+    }
+
+    #[test]
+    public entry fun test_min() {
+        let result = min(3, 6);
+        assert!(result == 3, 0);
+
+        let result = min(15, 12);
+        assert!(result == 12, 1);
+    }
+
+    #[test]
+    public entry fun test_average() {
+        let result = average(3, 6);
+        assert!(result == 4, 0);
+
+        let result = average(15, 12);
+        assert!(result == 13, 0);
+    }
+
+    #[test]
+    public entry fun test_pow() {
+        let result = pow(10, 18);
+        assert!(result == 1000000000000000000, 0);
+
+        let result = pow(10, 1);
+        assert!(result == 10, 0);
+
+        let result = pow(10, 0);
+        assert!(result == 1, 0);
+    }
+}

--- a/aptos-move/framework/aptos-stdlib/sources/math128.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.move
@@ -1,0 +1,75 @@
+/// Standard math utilities missing in the Move Language.
+module aptos_std::math128 {
+
+    /// Return the largest of two numbers.
+    public fun max(a: u128, b: u128): u128 {
+        if (a >= b) a else b
+    }
+
+    /// Return the smallest of two numbers.
+    public fun min(a: u128, b: u128): u128 {
+        if (a < b) a else b
+    }
+
+    /// Return the average of two.
+    public fun average(a: u128, b: u128): u128 {
+        (a + b) / 2
+    }
+
+    /// Return the value of n raised to power e
+    public fun pow(n: u128, e: u128): u128 {
+        if (e == 0) {
+            1
+        } else if (e == 1) {
+            n
+        } else {
+            let p = pow(n, e / 2);
+            p = p * p;
+            if (e % 2 == 1) {
+                p = p * n;
+                p
+            } else {
+                p
+            }
+        }
+    }
+
+    #[test]
+    public entry fun test_max() {
+        let result = max(3u128, 6u128);
+        assert!(result == 6, 0);
+
+        let result = max(15u128, 12u128);
+        assert!(result == 15, 1);
+    }
+
+    #[test]
+    public entry fun test_min() {
+        let result = min(3u128, 6u128);
+        assert!(result == 3, 0);
+
+        let result = min(15u128, 12u128);
+        assert!(result == 12, 1);
+    }
+
+    #[test]
+    public entry fun test_average() {
+        let result = average(3u128, 6u128);
+        assert!(result == 4, 0);
+
+        let result = average(15u128, 12u128);
+        assert!(result == 13, 0);
+    }
+
+    #[test]
+    public entry fun test_pow() {
+        let result = pow(10u128, 18u128);
+        assert!(result == 1000000000000000000, 0);
+
+        let result = pow(10u128, 1u128);
+        assert!(result == 10, 0);
+
+        let result = pow(10u128, 0u128);
+        assert!(result == 1, 0);
+    }
+}

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -1,5 +1,5 @@
 /// Standard math utilities missing in the Move Language.
-module aptos_std::math {
+module aptos_std::math64 {
 
     /// Return the largest of two numbers.
     public fun max(a: u64, b: u64): u64 {
@@ -13,7 +13,7 @@ module aptos_std::math {
 
     /// Return the average of two.
     public fun average(a: u64, b: u64): u64 {
-        (a & b) + (a ^ b) / 2
+        (a + b) / 2
     }
 
     /// Return the value of n raised to power e
@@ -35,41 +35,41 @@ module aptos_std::math {
     }
 
     #[test]
-    public entry fun test_max() {
-        let result = max(3, 6);
+    public entry fun test_max_64() {
+        let result = max(3u64, 6u64);
         assert!(result == 6, 0);
 
-        let result = max(15, 12);
+        let result = max(15u64, 12u64);
         assert!(result == 15, 1);
     }
 
     #[test]
     public entry fun test_min() {
-        let result = min(3, 6);
+        let result = min(3u64, 6u64);
         assert!(result == 3, 0);
 
-        let result = min(15, 12);
+        let result = min(15u64, 12u64);
         assert!(result == 12, 1);
     }
 
     #[test]
     public entry fun test_average() {
-        let result = average(3, 6);
+        let result = average(3u64, 6u64);
         assert!(result == 4, 0);
 
-        let result = average(15, 12);
+        let result = average(15u64, 12u64);
         assert!(result == 13, 0);
     }
 
     #[test]
     public entry fun test_pow() {
-        let result = pow(10, 18);
+        let result = pow(10u64, 18u64);
         assert!(result == 1000000000000000000, 0);
 
-        let result = pow(10, 1);
+        let result = pow(10u64, 1u64);
         assert!(result == 10, 0);
 
-        let result = pow(10, 0);
+        let result = pow(10u64, 0u64);
         assert!(result == 1, 0);
     }
 }


### PR DESCRIPTION
### Description
Adds a math standard library. There are currently four functions; max, min, average, and pow. These will be helpful, especially for DeFi builders on Aptos Network to calculate something.

### Test Plan
In the file `math.move`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3172)
<!-- Reviewable:end -->
