### PR TITLE
Revert "[Netowrking] Removing a redundant collect, using iter instead."

### DIFF
--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -413,8 +413,7 @@ where
     /// this function will close our connection to it.
     async fn close_stale_connections(&mut self) {
         let eligible = self.eligible.read().clone();
-
-        for p in self
+        let stale_connections: Vec<_> = self
             .connected
             .iter()
             .filter(|(peer_id, _)| !eligible.contains_key(peer_id))
@@ -430,7 +429,8 @@ where
                     Some(*peer_id)
                 }
             })
-        {
+            .collect();
+        for p in stale_connections.into_iter() {
             info!(
                 NetworkSchema::new(&self.network_context).remote_peer(&p),
                 "{} Closing stale connection to peer {}",


### PR DESCRIPTION


### Description
This causes discoverability to break

This reverts commit ff455ce9683a07930ffb462f8a0e1e8ff62d48ec.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
