### PR TITLE
[community] Add the ability to send notifications from admin.

### DIFF
--- a/ecosystem/platform/server/Gemfile.lock
+++ b/ecosystem/platform/server/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
-    minitest (5.16.2)
+    minitest (5.16.3)
     mocha (1.14.0)
     msgpack (1.5.4)
     multi_json (1.15.0)

--- a/ecosystem/platform/server/app/admin/network_operations.rb
+++ b/ecosystem/platform/server/app/admin/network_operations.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+ActiveAdmin.register NetworkOperation do
+  permit_params :title, :content
+
+  form do |f|
+    f.semantic_errors
+    f.inputs :title, :content
+    f.actions
+  end
+
+  show do
+    h3 network_operation.title
+    div do
+      sanitize network_operation.content
+    end
+  end
+
+  sidebar :notifications, only: [:show] do
+    ul do
+      li do
+        link_to 'Send governance proposal notification',
+                notify_admin_network_operation_path(network_operation,
+                                                    notification_type: :governance_proposal_notification)
+      end
+      li do
+        link_to 'Send node upgrade notification',
+                notify_admin_network_operation_path(network_operation, notification_type: :node_upgrade_notification)
+      end
+    end
+  end
+
+  member_action :notify, method: %i[get post] do
+    notification_types = {
+      governance_proposal_notification: GovernanceProposalNotification,
+      node_upgrade_notification: NodeUpgradeNotification
+    }.freeze
+
+    @network_operation = resource
+    unless @network_operation.notified_at.nil?
+      return redirect_to admin_network_operation_path(@network_operation),
+                         notice: "Notifications were already sent at #{@network_operation.notified_at.to_fs}."
+    end
+
+    @notification_type = params.require(:notification_type).to_sym
+    unless notification_types.include?(@notification_type)
+      return redirect_to admin_network_operation_path(@network_operation),
+                         notice: "#{@notification_type} is not a valid notification type."
+    end
+
+    @users = User
+             .left_outer_joins(:notification_preferences)
+             .where(users: { notification_preferences: { delivery_method: :email,
+                                                         @notification_type => true } })
+             .or(User.where(users: { notification_preferences: { id: nil } }))
+
+    if request.post?
+      notification = notification_types[@notification_type].with(network_operation: @network_operation)
+      notification.deliver_later(@users)
+      @network_operation.touch(:notified_at)
+      return redirect_to admin_network_operation_path(@network_operation),
+                         notice: 'Notifications queued for delivery.'
+    end
+  end
+end

--- a/ecosystem/platform/server/app/admin/network_operations.rb
+++ b/ecosystem/platform/server/app/admin/network_operations.rb
@@ -52,10 +52,8 @@ ActiveAdmin.register NetworkOperation do
     end
 
     @users = User
-             .left_outer_joins(:notification_preferences)
-             .where(users: { notification_preferences: { delivery_method: :email,
-                                                         @notification_type => true } })
-             .or(User.where(users: { notification_preferences: { id: nil } }))
+             .joins(:notification_preferences)
+             .where(users: { notification_preferences: { @notification_type => true } })
 
     if request.post?
       notification = notification_types[@notification_type].with(network_operation: @network_operation)

--- a/ecosystem/platform/server/app/notifications/base_notification.rb
+++ b/ecosystem/platform/server/app/notifications/base_notification.rb
@@ -11,7 +11,7 @@ class BaseNotification < Noticed::Base
     unless respond_to?(guard_method_name)
       define_method guard_method_name do
         prefs = recipient.notification_preferences.where(delivery_method:).first
-        return true if prefs.nil?
+        return false if prefs.nil?
 
         prefs[notification_name]
       end

--- a/ecosystem/platform/server/app/views/admin/network_operations/notify.html.erb
+++ b/ecosystem/platform/server/app/views/admin/network_operations/notify.html.erb
@@ -1,0 +1,13 @@
+<h3>
+  Sending
+  <% if @notification_type == :governance_proposal_notification %>
+    Governance Proposal
+  <% elsif @notification_type == :node_upgrade_notification %>
+    Node Upgrade
+  <% else %>
+    UNKNOWN - ERROR!
+  <% end %>
+  Notifications
+</h3>
+<p>This is expected to generate <%= @users.count %> notifications.</p>
+<%= button_to 'Send Notifications', notify_admin_network_operation_path(@network_operation, notification_type: @notification_type), method: :post %>

--- a/ecosystem/platform/server/db/migrate/20220819161242_add_notified_at_to_network_operation.rb
+++ b/ecosystem/platform/server/db/migrate/20220819161242_add_notified_at_to_network_operation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class AddNotifiedAtToNetworkOperation < ActiveRecord::Migration[7.0]
+  def change
+    add_column :network_operations, :notified_at, :datetime,
+               comment: 'The time at which a notification was sent for this network operation.'
+  end
+end

--- a/ecosystem/platform/server/db/migrate/20220823183316_change_notification_preferences_default_to_false.rb
+++ b/ecosystem/platform/server/db/migrate/20220823183316_change_notification_preferences_default_to_false.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class ChangeNotificationPreferencesDefaultToFalse < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :notification_preferences, :governance_proposal_notification, from: true, to: false
+    change_column_default :notification_preferences, :node_upgrade_notification, from: true, to: false
+  end
+end

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_19_233543) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_23_183316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -317,8 +317,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_233543) do
   create_table "notification_preferences", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "delivery_method", default: 0, null: false
-    t.boolean "node_upgrade_notification", default: true, null: false
-    t.boolean "governance_proposal_notification", default: true, null: false
+    t.boolean "node_upgrade_notification", default: false, null: false
+    t.boolean "governance_proposal_notification", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id", "delivery_method"], name: "index_notification_preferences_on_user_id_and_delivery_method", unique: true

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -292,6 +292,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_19_233543) do
     t.text "content", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "notified_at", comment: "The time at which a notification was sent for this network operation."
   end
 
   create_table "nft_offers", force: :cascade do |t|

--- a/ecosystem/platform/server/test/notifications/governance_proposal_notification_test.rb
+++ b/ecosystem/platform/server/test/notifications/governance_proposal_notification_test.rb
@@ -8,13 +8,13 @@ require 'test_helper'
 class GovernanceProposalNotificationTest < ActiveSupport::TestCase
   include ActionMailer::TestHelper
 
-  test 'is delivered if preferences don\'t exist' do
+  test 'is not delivered if preferences don\'t exist' do
     user = FactoryBot.create(:user)
     network_operation = NetworkOperation.create(title: 'foo', content: 'bar')
     notification = GovernanceProposalNotification.with(network_operation:)
 
-    assert_difference('Notification.count') do
-      assert_emails 1 do
+    assert_no_difference('Notification.count') do
+      assert_emails 0 do
         notification.deliver(user)
       end
     end
@@ -22,8 +22,8 @@ class GovernanceProposalNotificationTest < ActiveSupport::TestCase
 
   test 'is delivered if preference is true' do
     user = FactoryBot.create(:user)
-    NotificationPreference.create(user:, delivery_method: :database)
-    NotificationPreference.create(user:, delivery_method: :email)
+    NotificationPreference.create(user:, delivery_method: :database, governance_proposal_notification: true)
+    NotificationPreference.create(user:, delivery_method: :email, governance_proposal_notification: true)
     network_operation = NetworkOperation.create(title: 'foo', content: 'bar')
     notification = GovernanceProposalNotification.with(network_operation:)
 


### PR DESCRIPTION
### Description

Adds the ability to send network operation notifications from admin.

cc @sherry-x 

![image](https://user-images.githubusercontent.com/310773/185674796-d5bf7657-d73b-4ea0-93d6-2424124cc41e.png)

![image](https://user-images.githubusercontent.com/310773/185674834-ab50cc5a-ce67-4937-8036-550b95548645.png)

![image](https://user-images.githubusercontent.com/310773/185675033-4cb6989d-e610-4cb1-abce-21ba7d706c2b.png)

![image](https://user-images.githubusercontent.com/310773/185675060-7ef56162-01b3-429e-a858-c6ba7f7c0645.png)

![image](https://user-images.githubusercontent.com/310773/185674623-b2209724-faa7-47d4-ab47-ce9568b14b69.png)


### Test Plan
Tested manually.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3187)
<!-- Reviewable:end -->
