### PR TITLE
[helm][aptos-node] bump down cpu and mem requirements

### DIFF
--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -29,8 +29,8 @@ validator:
       cpu: 15.5
       memory: 30Gi
     requests:
-      cpu: 15.5
-      memory: 30Gi
+      cpu: 15
+      memory: 26Gi
   storage:
     # -- Kubernetes storage class to use for validator persistent storage
     class:


### PR DESCRIPTION
### Description

To get them allocatable. Other required pods on the machines take up a few gb mem by themselves

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3199)
<!-- Reviewable:end -->
