### PR TITLE
[cli] Allow users to bypass minting delegation

### DIFF
--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -481,6 +481,10 @@ pub struct RunLocalTestnet {
 
     #[clap(flatten)]
     prompt_options: PromptOptions,
+
+    /// Disable the delegation of minting to a dedicated account
+    #[clap(long)]
+    do_not_delegate: bool,
 }
 
 #[async_trait]
@@ -586,7 +590,7 @@ impl CliCommand<()> for RunLocalTestnet {
                 mint_account_address: None,
                 chain_id: ChainId::test(),
                 maximum_amount: None,
-                do_not_delegate: false,
+                do_not_delegate: self.do_not_delegate,
             }
             .run()
             .await;


### PR DESCRIPTION
### Description
Delegating the minting work to another account is going to delay the booting time of the faucet for at least 10 seconds. Users should be able to bypass the minting delegation by passing in a CLI flag. Doing so, minting will be handled by the Aptos root test account. 

### Test Plan
`yes | cargo run -p aptos -- node run-local-testnet --force-restart  --with-faucet --do-not-delegate` boots almost instantly 
 `yes | cargo run -p aptos -- node run-local-testnet --force-restart  --with-faucet` took at least 10 seconds on M1 Mac

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3207)
<!-- Reviewable:end -->
