### PR TITLE
[docs] make download AptosFramework step more clear

### DIFF
--- a/developer-docs-site/docs/nodes/validator-node/using-aws.md
+++ b/developer-docs-site/docs/nodes/validator-node/using-aws.md
@@ -184,7 +184,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 13. Download the AptosFramework Move package into the `~/$WORKSPACE` directory as `framework.mrb`
 
     ```
-    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb
+    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb -P ~/$WORKSPACE
     ```
 
 14. Compile the genesis blob and waypoint.

--- a/developer-docs-site/docs/nodes/validator-node/using-azure.md
+++ b/developer-docs-site/docs/nodes/validator-node/using-azure.md
@@ -167,7 +167,7 @@ This will download all the terraform dependencies for you, in the `.terraform` f
 13. Download the AptosFramework Move package into the `~/$WORKSPACE` directory as `framework.mrb`
 
     ```
-    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb
+    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb -P ~/$WORKSPACE
     ```
 
 14. Compile the genesis blob and waypoint.

--- a/developer-docs-site/docs/nodes/validator-node/using-docker.md
+++ b/developer-docs-site/docs/nodes/validator-node/using-docker.md
@@ -117,7 +117,7 @@ Docker has only been tested on Linux, Windows, and Intel macOS. If you are on M1
 7. Download the AptosFramework Move package into the `~/$WORKSPACE` directory as `framework.mrb`
 
     ```
-    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb
+    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb -P ~/$WORKSPACE
     ```
 
 8. Compile genesis blob and waypoint

--- a/developer-docs-site/docs/nodes/validator-node/using-gcp.md
+++ b/developer-docs-site/docs/nodes/validator-node/using-gcp.md
@@ -176,7 +176,7 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
 13. Download the AptosFramework Move package into the `~/$WORKSPACE` directory as `framework.mrb`
 
     ```
-    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb
+    wget https://github.com/aptos-labs/aptos-core/releases/download/aptos-framework-v0.3.0/framework.mrb -P ~/$WORKSPACE
     ```
 
 14. Compile the genesis blob and waypoint.


### PR DESCRIPTION
### Description

This needs to be in `~/$WORKSPACE` to work. Make the command do what the instructions say. `-P` in `wget` lets us download to a directory prefix

### Test Plan

Running through registration

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3209)
<!-- Reviewable:end -->
