### PR TITLE
[local swarm] [try2] Surface nodes account private keys

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -162,7 +162,8 @@ impl LocalSwarm {
         let mut validators = validators
             .into_iter()
             .map(|v| {
-                let node = LocalNode::new(version.to_owned(), v.name, v.dir)?;
+                let node =
+                    LocalNode::new(version.to_owned(), v.name, v.dir, v.account_private_key)?;
                 Ok((node.peer_id(), node))
             })
             .collect::<Result<HashMap<_, _>>>()?;
@@ -323,6 +324,7 @@ impl LocalSwarm {
             version.to_owned(),
             fullnode_config.name,
             fullnode_config.dir,
+            None,
         )?;
 
         let peer_id = fullnode.peer_id();
@@ -350,6 +352,7 @@ impl LocalSwarm {
             version.to_owned(),
             fullnode_config.name,
             fullnode_config.dir,
+            None,
         )?;
 
         let peer_id = fullnode.peer_id();
@@ -377,11 +380,17 @@ impl LocalSwarm {
     }
 
     pub fn validators(&self) -> impl Iterator<Item = &LocalNode> {
-        self.validators.values()
+        // sort by id to keep the order consistent:
+        let mut validators: Vec<&LocalNode> = self.validators.values().collect();
+        validators.sort_by_key(|v| v.name().parse::<i32>().unwrap());
+        validators.into_iter()
     }
 
     pub fn validators_mut(&mut self) -> impl Iterator<Item = &mut LocalNode> {
-        self.validators.values_mut()
+        // sort by id to keep the order consistent:
+        let mut validators: Vec<&mut LocalNode> = self.validators.values_mut().collect();
+        validators.sort_by_key(|v| v.name().parse::<i32>().unwrap());
+        validators.into_iter()
     }
 
     pub fn fullnode(&self, peer_id: PeerId) -> Option<&LocalNode> {


### PR DESCRIPTION
### Description

retrying #3065  with ConfigKey, to not break the build.
`cargo build -p aptos-node `works now

For more comprehensive testing, having those keys allows us for those nodes to leave validator set/change their lockup/etc.

Also, made validators list be consistent (which matters as most tests fetch first validator for RestClient, and if we are changing reliability of nodes, we can get into odd cases.

### Test Plan
Stacked unit test
`cargo build -p aptos-node`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3214)
<!-- Reviewable:end -->
