### PR TITLE
[community] Add consensus_pop to it3 profiles.

### DIFF
--- a/ecosystem/platform/server/app/controllers/it3_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it3_profiles_controller.rb
@@ -164,9 +164,10 @@ class It3ProfilesController < ApplicationController
   # Only allow a list of trusted parameters through.
   def it3_profile_params
     params.fetch(:it3_profile, {}).permit(:owner_key,
-                                          :consensus_key, :account_key, :network_key, :validator_address,
-                                          :validator_port, :validator_api_port, :validator_metrics_port,
-                                          :fullnode_address, :fullnode_port, :fullnode_network_key, :terms_accepted)
+                                          :consensus_key, :consensus_pop, :account_key, :network_key,
+                                          :validator_address, :validator_port, :validator_api_port,
+                                          :validator_metrics_port, :fullnode_address, :fullnode_port,
+                                          :fullnode_network_key, :terms_accepted)
   end
 
   def ensure_registration_enabled!

--- a/ecosystem/platform/server/app/models/it3_profile.rb
+++ b/ecosystem/platform/server/app/models/it3_profile.rb
@@ -13,7 +13,8 @@ class It3Profile < ApplicationRecord
   has_one :location, as: :item
 
   validates :owner_key, presence: true, uniqueness: true, format: { with: /\A0x[a-f0-9]{64}\z/i }
-  validates :consensus_key, presence: true, uniqueness: true, format: { with: /\A0x[a-f0-9]{64}\z/i }
+  validates :consensus_key, presence: true, uniqueness: true, format: { with: /\A0x[a-f0-9]{96}\z/i }
+  validates :consensus_pop, presence: true, uniqueness: true, format: { with: /\A0x[a-f0-9]{192}\z/i }
   validates :account_key, presence: true, uniqueness: true, format: { with: /\A0x[a-f0-9]{64}\z/i }
   validates :network_key, presence: true, uniqueness: true, format: { with: /\A0x[a-f0-9]{64}\z/i }
 

--- a/ecosystem/platform/server/app/views/it3_profiles/_form.html.erb
+++ b/ecosystem/platform/server/app/views/it3_profiles/_form.html.erb
@@ -26,7 +26,11 @@
           </div>
           <div class="mb-6">
             <%= f.label :consensus_key, class: 'font-mono uppercase block mb-2' %>
-            <%= f.text_field :consensus_key, autofocus: true, required: true, pattern: '0x[a-f0-9]{64}', spellcheck: false %>
+            <%= f.text_field :consensus_key, autofocus: true, required: true, pattern: '0x[a-f0-9]{96}', spellcheck: false %>
+          </div>
+          <div class="mb-6">
+            <%= f.label :consensus_pop, 'Consensus PoP', class: 'font-mono uppercase block mb-2' %>
+            <%= f.text_field :consensus_pop, required: true, pattern: '0x[a-f0-9]{192}', spellcheck: false %>
           </div>
           <div class="mb-6">
             <%= f.label :account_key, class: 'font-mono uppercase block mb-2' %>

--- a/ecosystem/platform/server/db/migrate/20220819233543_add_consensus_pop_to_it3_profiles.rb
+++ b/ecosystem/platform/server/db/migrate/20220819233543_add_consensus_pop_to_it3_profiles.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class AddConsensusPopToIt3Profiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :it3_profiles, :consensus_pop, :string
+  end
+end

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_17_185306) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_19_233543) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -214,6 +214,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_185306) do
     t.string "account_address", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "consensus_pop"
     t.index ["account_address"], name: "index_it3_profiles_on_account_address", unique: true
     t.index ["account_key"], name: "index_it3_profiles_on_account_key", unique: true
     t.index ["consensus_key"], name: "index_it3_profiles_on_consensus_key", unique: true

--- a/ecosystem/platform/server/spec/factories/it3_profiles.rb
+++ b/ecosystem/platform/server/spec/factories/it3_profiles.rb
@@ -7,7 +7,8 @@ FactoryBot.define do
   factory :it3_profile do
     user { nil }
     owner_key { "0x#{Faker::Crypto.sha256}" }
-    consensus_key { "0x#{Faker::Crypto.sha256}" }
+    consensus_key { "0x#{Faker::Crypto.sha256}#{Faker::Crypto.sha256}"[0...98] }
+    consensus_pop { "0x#{Faker::Crypto.sha256}#{Faker::Crypto.sha256}#{Faker::Crypto.sha256}"[0...194] }
     account_key { "0x#{Faker::Crypto.sha256}" }
     network_key { "0x#{Faker::Crypto.sha256}" }
     validator_address { "0x#{Faker::Crypto.sha256}" }

--- a/ecosystem/platform/server/test/controllers/it3_profiles_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/it3_profiles_controller_test.rb
@@ -26,7 +26,8 @@ class It3ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_nil @user.it3_profile
     post it3_profiles_path, params: { it3_profile: {
       owner_key: '0xecaa0d44b821a745bc29767713cd78dbc88da73679e3ccdf5c145a2b4f7b17ac',
-      consensus_key: '0xbcaa0d44b821a745bc29767713cd78dbc88da73679e3ccdf5c145a2b4f7b17ac',
+      consensus_key: "0x#{Faker::Crypto.sha256}#{Faker::Crypto.sha256}"[0...98],
+      consensus_pop: "0x#{Faker::Crypto.sha256}#{Faker::Crypto.sha256}#{Faker::Crypto.sha256}"[0...194],
       account_key: '0x7964a378e4c6d387d900c6e02430b7ee8263a977ace368484fc72c3b8469f520',
       network_key: '0x2b0ebca9776bd79dcd3c0551e784965e87e8a1551d52c4a48758e1df2122064b',
       validator_address: '127.0.0.1',


### PR DESCRIPTION
### Description

We changed the format for consensus keys, including a new field for consensus proof of possession.

![image](https://user-images.githubusercontent.com/310773/185720381-e46c3b1a-645e-4938-b2e8-60e92873b028.png)


### Test Plan
I wrote automated tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3217)
<!-- Reviewable:end -->
