### PR TITLE
[api] Use block hash from new block event

### DIFF
--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -7,6 +7,7 @@ use crate::{
     event::{EventHandle, EventKey},
 };
 use anyhow::Result;
+use aptos_crypto::HashValue;
 use move_deps::move_core_types::{
     ident_str,
     identifier::IdentStr,
@@ -30,6 +31,10 @@ pub struct NewBlockEvent {
 }
 
 impl NewBlockEvent {
+    pub fn hash(&self) -> Result<HashValue> {
+        Ok(HashValue::from_slice(self.hash.to_vec())?)
+    }
+
     pub fn epoch(&self) -> u64 {
         self.epoch
     }


### PR DESCRIPTION
### Description
This cuts out an extra query for get block without transactions

### Test Plan
Current tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3228)
<!-- Reviewable:end -->
