### PR TITLE
[gas] fix bug in abstract value size calculation

### DIFF
--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -311,8 +311,8 @@ impl GasMeter for AptosGasMeter {
 
         let cost = instr_params.eq_base
             + per_unit
-                * (abs_val_params.abstract_value_size(lhs)
-                    + abs_val_params.abstract_value_size(rhs));
+                * (abs_val_params.abstract_value_size_dereferenced(lhs)
+                    + abs_val_params.abstract_value_size_dereferenced(rhs));
 
         self.charge(cost)
     }
@@ -325,8 +325,8 @@ impl GasMeter for AptosGasMeter {
 
         let cost = instr_params.neq_base
             + per_unit
-                * (abs_val_params.abstract_value_size(lhs)
-                    + abs_val_params.abstract_value_size(rhs));
+                * (abs_val_params.abstract_value_size_dereferenced(lhs)
+                    + abs_val_params.abstract_value_size_dereferenced(rhs));
 
         self.charge(cost)
     }

--- a/aptos-move/aptos-gas/src/misc.rs
+++ b/aptos-move/aptos-gas/src/misc.rs
@@ -41,92 +41,179 @@ crate::params::define_gas_parameters!(
     ]
 );
 
-impl AbstractMemorySizeGasParameters {
-    pub fn abstract_value_size(&self, val: impl ValueView) -> AbstractValueSize {
-        struct Visitor<'a> {
-            params: &'a AbstractMemorySizeGasParameters,
-            size: AbstractValueSize,
+struct DerefVisitor<V> {
+    inner: V,
+    offset: usize,
+}
+
+impl<V> DerefVisitor<V>
+where
+    V: ValueVisitor,
+{
+    pub fn new(visitor: V) -> Self {
+        Self {
+            inner: visitor,
+            offset: 0,
         }
+    }
 
-        impl<'a> ValueVisitor for Visitor<'a> {
-            #[inline]
-            fn visit_u8(&mut self, _depth: usize, _val: u8) {
-                self.size += self.params.u8;
-            }
-
-            #[inline]
-            fn visit_u64(&mut self, _depth: usize, _val: u64) {
-                self.size += self.params.u64;
-            }
-
-            #[inline]
-            fn visit_u128(&mut self, _depth: usize, _val: u128) {
-                self.size += self.params.u128;
-            }
-
-            #[inline]
-            fn visit_bool(&mut self, _depth: usize, _val: bool) {
-                self.size += self.params.bool;
-            }
-
-            #[inline]
-            fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
-                self.size += self.params.address;
-            }
-
-            #[inline]
-            fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
-                self.size += self.params.struct_;
-                true
-            }
-
-            #[inline]
-            fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
-                self.size += self.params.vector;
-                true
-            }
-
-            #[inline]
-            fn visit_vec_u8(&mut self, _depth: usize, vals: &[u8]) {
-                self.size += self.params.per_u8_packed * NumArgs::new(vals.len() as u64);
-            }
-
-            #[inline]
-            fn visit_vec_u64(&mut self, _depth: usize, vals: &[u64]) {
-                self.size += self.params.per_u64_packed * NumArgs::new(vals.len() as u64);
-            }
-
-            #[inline]
-            fn visit_vec_u128(&mut self, _depth: usize, vals: &[u128]) {
-                self.size += self.params.per_u128_packed * NumArgs::new(vals.len() as u64);
-            }
-
-            #[inline]
-            fn visit_vec_bool(&mut self, _depth: usize, vals: &[bool]) {
-                self.size += self.params.per_bool_packed * NumArgs::new(vals.len() as u64);
-            }
-
-            #[inline]
-            fn visit_vec_address(&mut self, _depth: usize, vals: &[AccountAddress]) {
-                self.size += self.params.per_address_packed * NumArgs::new(vals.len() as u64);
-            }
-
-            #[inline]
-            fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
-                self.size += self.params.reference;
-                false
-            }
-        }
-
-        let mut visitor = Visitor {
-            params: self,
-            size: 0.into(),
-        };
-        val.visit(&mut visitor);
-        visitor.size
+    pub fn into_inner(self) -> V {
+        self.inner
     }
 }
 
+macro_rules! deref_visitor_delegate_simple {
+    ($([$fn: ident, $ty: ty $(,)?]),+ $(,)?) => {
+        $(
+            #[inline]
+            fn $fn(&mut self, depth: usize, val: $ty) {
+                self.inner.$fn(depth - self.offset, val);
+            }
+        )*
+    };
+}
+
+impl<V> ValueVisitor for DerefVisitor<V>
+where
+    V: ValueVisitor,
+{
+    deref_visitor_delegate_simple!(
+        [visit_u8, u8],
+        [visit_u64, u64],
+        [visit_u128, u128],
+        [visit_bool, bool],
+        [visit_address, AccountAddress],
+        [visit_vec_u8, &[u8]],
+        [visit_vec_u64, &[u64]],
+        [visit_vec_u128, &[u128]],
+        [visit_vec_bool, &[bool]],
+        [visit_vec_address, &[AccountAddress]],
+    );
+
+    #[inline]
+    fn visit_struct(&mut self, depth: usize, len: usize) -> bool {
+        self.inner.visit_struct(depth - self.offset, len)
+    }
+
+    #[inline]
+    fn visit_vec(&mut self, depth: usize, len: usize) -> bool {
+        self.inner.visit_vec(depth - self.offset, len)
+    }
+
+    #[inline]
+    fn visit_ref(&mut self, depth: usize, _is_global: bool) -> bool {
+        assert_eq!(depth, 0, "There shouldn't be inner refs");
+        self.offset = 1;
+        true
+    }
+}
+
+struct AbstractValueSizeVisitor<'a> {
+    params: &'a AbstractMemorySizeGasParameters,
+    size: AbstractValueSize,
+}
+
+impl<'a> AbstractValueSizeVisitor<'a> {
+    fn new(params: &'a AbstractMemorySizeGasParameters) -> Self {
+        Self {
+            params,
+            size: 0.into(),
+        }
+    }
+
+    fn finish(self) -> AbstractValueSize {
+        self.size
+    }
+}
+
+impl<'a> ValueVisitor for AbstractValueSizeVisitor<'a> {
+    #[inline]
+    fn visit_u8(&mut self, _depth: usize, _val: u8) {
+        self.size += self.params.u8;
+    }
+
+    #[inline]
+    fn visit_u64(&mut self, _depth: usize, _val: u64) {
+        self.size += self.params.u64;
+    }
+
+    #[inline]
+    fn visit_u128(&mut self, _depth: usize, _val: u128) {
+        self.size += self.params.u128;
+    }
+
+    #[inline]
+    fn visit_bool(&mut self, _depth: usize, _val: bool) {
+        self.size += self.params.bool;
+    }
+
+    #[inline]
+    fn visit_address(&mut self, _depth: usize, _val: AccountAddress) {
+        self.size += self.params.address;
+    }
+
+    #[inline]
+    fn visit_struct(&mut self, _depth: usize, _len: usize) -> bool {
+        self.size += self.params.struct_;
+        true
+    }
+
+    #[inline]
+    fn visit_vec(&mut self, _depth: usize, _len: usize) -> bool {
+        self.size += self.params.vector;
+        true
+    }
+
+    #[inline]
+    fn visit_vec_u8(&mut self, _depth: usize, vals: &[u8]) {
+        self.size += self.params.per_u8_packed * NumArgs::new(vals.len() as u64);
+    }
+
+    #[inline]
+    fn visit_vec_u64(&mut self, _depth: usize, vals: &[u64]) {
+        self.size += self.params.per_u64_packed * NumArgs::new(vals.len() as u64);
+    }
+
+    #[inline]
+    fn visit_vec_u128(&mut self, _depth: usize, vals: &[u128]) {
+        self.size += self.params.per_u128_packed * NumArgs::new(vals.len() as u64);
+    }
+
+    #[inline]
+    fn visit_vec_bool(&mut self, _depth: usize, vals: &[bool]) {
+        self.size += self.params.per_bool_packed * NumArgs::new(vals.len() as u64);
+    }
+
+    #[inline]
+    fn visit_vec_address(&mut self, _depth: usize, vals: &[AccountAddress]) {
+        self.size += self.params.per_address_packed * NumArgs::new(vals.len() as u64);
+    }
+
+    #[inline]
+    fn visit_ref(&mut self, _depth: usize, _is_global: bool) -> bool {
+        self.size += self.params.reference;
+        false
+    }
+}
+
+impl AbstractMemorySizeGasParameters {
+    /// Calculates the abstract size of the given value.
+    pub fn abstract_value_size(&self, val: impl ValueView) -> AbstractValueSize {
+        let mut visitor = AbstractValueSizeVisitor::new(self);
+        val.visit(&mut visitor);
+        visitor.finish()
+    }
+
+    /// Calculates the abstract size of the given value.
+    /// If the value is a reference, then the size of the value behind it will be returned.
+    pub fn abstract_value_size_dereferenced(&self, val: impl ValueView) -> AbstractValueSize {
+        let mut visitor = DerefVisitor::new(AbstractValueSizeVisitor::new(self));
+        val.visit(&mut visitor);
+        visitor.into_inner().finish()
+    }
+}
+
+/// Miscellaneous gas parameters.
 #[derive(Debug, Clone)]
 pub struct MiscGasParameters {
     pub abs_val: AbstractMemorySizeGasParameters,


### PR DESCRIPTION
Previously when you calculate the abstract size of a reference, you would get a constant size. This was reasonable as it was the size of the reference itself being measured. However this is not suitable for the `eq` and `neq` instructions. This adds an alternative function that if given a reference value, will return the size of the value behind the reference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3245)
<!-- Reviewable:end -->
