### PR TITLE
[forge] write TestResult to report text

### DIFF
--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -3,6 +3,7 @@
 
 use crate::*;
 use rand::{Rng, SeedableRng};
+use std::fmt::{Display, Formatter};
 use std::time::Duration;
 use std::{
     io::{self, Write},
@@ -304,6 +305,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     &mut report,
                 );
                 let result = run_test(|| runtime.block_on(test.run(&mut aptos_ctx)));
+                report.report_text(result.to_string());
                 summary.handle_result(test.name().to_owned(), result)?;
             }
 
@@ -315,6 +317,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     &mut report,
                 );
                 let result = run_test(|| test.run(&mut admin_ctx));
+                report.report_text(result.to_string());
                 summary.handle_result(test.name().to_owned(), result)?;
             }
 
@@ -327,6 +330,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     self.success_criteria.clone(),
                 );
                 let result = run_test(|| test.run(&mut network_ctx));
+                report.report_text(result.to_string());
                 summary.handle_result(test.name().to_owned(), result)?;
             }
 
@@ -381,6 +385,16 @@ enum TestResult {
     Ok,
     Failed,
     FailedWithMsg(String),
+}
+
+impl Display for TestResult {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            TestResult::Ok => write!(f, "Test Ok"),
+            TestResult::Failed => write!(f, "Test Failed"),
+            TestResult::FailedWithMsg(msg) => write!(f, "Test Failed: {}", msg),
+        }
+    }
 }
 
 fn run_test<F: FnOnce() -> Result<()>>(f: F) -> TestResult {


### PR DESCRIPTION
### Description

So we can have more signal in the test report text that gets printed as a Github comment, in the event of test failure. Previously, we were failing tests due to some "success criteria" such as no validators/fullnodes restarted, TPS, latency, etc, but often you wouldn't know unless you looked at the actual test runner logs.

### Test Plan

Canary in CI: https://github.com/aptos-labs/aptos-core/pull/3247#issuecomment-1221432979
Output looks like:

```
performance benchmark with full nodes : 6938 TPS, 4324 ms latency, 6000 ms p99 latency,no expired txns
Test Failed: TPS requirement failed. Average TPS 6938, minimum TPS requirement 100000000
```
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3246)
<!-- Reviewable:end -->
