### PR TITLE
[governance upgrade] Proposal script generator for package upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,7 @@ dependencies = [
  "project-root",
  "proptest",
  "serde 1.0.143",
+ "tempfile",
  "vm-genesis",
 ]
 
@@ -3832,6 +3833,7 @@ dependencies = [
  "curve25519-dalek",
  "flate2",
  "include_dir 0.7.2",
+ "itertools",
  "libsecp256k1",
  "log",
  "move-deps",

--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_entry_function_payload.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_entry_function_payload.json
@@ -53,7 +53,7 @@
         "data": {
           "type": "0x1::state_storage::StateStorageUsage",
           "data": {
-            "bytes": "296380",
+            "bytes": "296867",
             "epoch": "1",
             "items": "100"
           }

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.10.0"
 project-root = "0.2.2"
 proptest = "1.0.0"
 serde = { version = "1.0.137", default-features = false }
+tempfile = "3.3.0"
 
 aptos = { path = "../../crates/aptos" }
 aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }

--- a/aptos-move/e2e-move-tests/src/lib.rs
+++ b/aptos-move/e2e-move-tests/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod harness;
+pub mod package_builder;
 pub mod stake;
 
 use anyhow::bail;

--- a/aptos-move/e2e-move-tests/src/package_builder.rs
+++ b/aptos-move/e2e-move-tests/src/package_builder.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use itertools::Itertools;
+use move_deps::move_command_line_common::files::MOVE_EXTENSION;
+use move_deps::move_package::compilation::package_layout::CompiledPackageLayout;
+use std::path::PathBuf;
+use tempfile::{tempdir, TempDir};
+
+/// A helper for building Move packages on-the-fly for testing.
+#[derive(Debug, Clone)]
+pub struct PackageBuilder {
+    name: String,
+    deps: Vec<String>,
+    aliases: Vec<(String, String)>,
+    sources: Vec<(String, String)>,
+}
+
+impl PackageBuilder {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            deps: vec![],
+            aliases: vec![],
+            sources: vec![],
+        }
+    }
+
+    pub fn add_dep(&mut self, dep: &str) {
+        self.deps.push(dep.to_string())
+    }
+
+    pub fn add_alias(&mut self, name: &str, addr: &str) {
+        self.aliases.push((name.to_string(), addr.to_string()))
+    }
+
+    pub fn add_source(&mut self, name: &str, src: &str) {
+        self.sources.push((name.to_string(), src.to_string()))
+    }
+
+    pub fn write_to_disk(self, path: PathBuf) -> anyhow::Result<()> {
+        let sources_path = path.join(CompiledPackageLayout::Sources.path());
+        std::fs::create_dir_all(&sources_path)?;
+        std::fs::write(
+            path.join("Move.toml"),
+            format!(
+                "\
+[package]
+name = \"{}\"
+version = \"0.0.0\"
+[addresses]
+{}
+[dependencies]
+{}",
+                self.name,
+                self.aliases
+                    .into_iter()
+                    .map(|(k, v)| format!("{} = \"{}\"", k, v))
+                    .join("\n"),
+                self.deps.into_iter().join("\n")
+            ),
+        )?;
+        for (name, src) in self.sources {
+            std::fs::write(sources_path.join(name).with_extension(MOVE_EXTENSION), src)?
+        }
+        Ok(())
+    }
+
+    pub fn write_to_temp(self) -> anyhow::Result<TempDir> {
+        let dir = tempdir()?;
+        self.write_to_disk(dir.path().to_path_buf())?;
+        Ok(dir)
+    }
+}

--- a/aptos-move/e2e-move-tests/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/tests/code_publishing.rs
@@ -29,7 +29,7 @@ fn code_publishing_basic() {
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_initial"),
+        &common::test_dir_path("code_publishing.data/pack_initial"),
     ));
 
     // Validate metadata as expected.
@@ -68,13 +68,13 @@ fn code_publishing_upgrade_success_no_compat() {
     // Install the initial version with no compat requirements
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_initial_arbitrary"),
+        &common::test_dir_path("code_publishing.data/pack_initial_arbitrary"),
     ));
 
     // We should be able to upgrade it with the incompatible version
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_upgrade_incompat_arbitrary"),
+        &common::test_dir_path("code_publishing.data/pack_upgrade_incompat_arbitrary"),
     ));
 }
 
@@ -86,13 +86,13 @@ fn code_publishing_upgrade_success_compat() {
     // Install the initial version with compat requirements
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_initial"),
+        &common::test_dir_path("code_publishing.data/pack_initial"),
     ));
 
     // We should be able to upgrade it with the compatible version
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_upgrade_compat"),
+        &common::test_dir_path("code_publishing.data/pack_upgrade_compat"),
     ));
 }
 
@@ -104,13 +104,13 @@ fn code_publishing_upgrade_fail_compat() {
     // Install the initial version with compat requirements
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_initial"),
+        &common::test_dir_path("code_publishing.data/pack_initial"),
     ));
 
     // We should not be able to upgrade it with the incompatible version
     let status = h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_upgrade_incompat"),
+        &common::test_dir_path("code_publishing.data/pack_upgrade_incompat"),
     );
     assert_vm_status!(status, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE)
 }
@@ -123,13 +123,13 @@ fn code_publishing_upgrade_fail_immutable() {
     // Install the initial version with immutable requirements
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_initial_immutable"),
+        &common::test_dir_path("code_publishing.data/pack_initial_immutable"),
     ));
 
     // We should not be able to upgrade it with the compatible version
     let status = h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_upgrade_compat"),
+        &common::test_dir_path("code_publishing.data/pack_upgrade_compat"),
     );
     assert_abort!(status, _);
 }
@@ -142,13 +142,13 @@ fn code_publishing_upgrade_fail_overlapping_module() {
     // Install the initial version
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_initial"),
+        &common::test_dir_path("code_publishing.data/pack_initial"),
     ));
 
     // Install a different package with the same module.
     let status = h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_other_name"),
+        &common::test_dir_path("code_publishing.data/pack_other_name"),
     );
     assert_abort!(status, _);
 }
@@ -169,19 +169,19 @@ fn code_publishing_upgrade_loader_cache_consistency() {
     let txns = vec![
         h.create_publish_package(
             &acc,
-            &common::package_path("code_publishing.data/pack_initial"),
+            &common::test_dir_path("code_publishing.data/pack_initial"),
         ),
         // Compatible with above package
         h.create_publish_package(
             &acc,
-            &common::package_path("code_publishing.data/pack_upgrade_compat"),
+            &common::test_dir_path("code_publishing.data/pack_upgrade_compat"),
         ),
         // Not compatible with above package, but with first one.
         // Correct behavior: should create backward_incompatible error
         // Bug behavior: succeeds because is compared with the first module
         h.create_publish_package(
             &acc,
-            &common::package_path("code_publishing.data/pack_compat_first_not_second"),
+            &common::test_dir_path("code_publishing.data/pack_compat_first_not_second"),
         ),
     ];
     let result = h.run_block(txns);
@@ -199,7 +199,7 @@ fn code_publishing_framework_upgrade() {
     // compatible changes. (We added a new function to string.move.)
     assert_success!(h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_stdlib"),
+        &common::test_dir_path("code_publishing.data/pack_stdlib"),
     ));
 }
 
@@ -212,7 +212,7 @@ fn code_publishing_framework_upgrade_fail() {
     // from the string module.
     let result = h.publish_package(
         &acc,
-        &common::package_path("code_publishing.data/pack_stdlib_incompat"),
+        &common::test_dir_path("code_publishing.data/pack_stdlib_incompat"),
     );
     assert_vm_status!(result, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE)
 }

--- a/aptos-move/e2e-move-tests/tests/common/mod.rs
+++ b/aptos-move/e2e-move-tests/tests/common/mod.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-pub fn package_path(s: &str) -> PathBuf {
+pub fn test_dir_path(s: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join(s)

--- a/aptos-move/e2e-move-tests/tests/error_map.rs
+++ b/aptos-move/e2e-move-tests/tests/error_map.rs
@@ -23,7 +23,7 @@ fn error_map() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::package_path("error_map.data/pack")));
+    assert_success!(h.publish_package(&acc, &common::test_dir_path("error_map.data/pack")));
 
     // Now send transactions which abort with one of two errors, depending on the boolean parameter.
     let result = h.run_entry_function(

--- a/aptos-move/e2e-move-tests/tests/generate_upgrade_script.rs
+++ b/aptos-move/e2e-move-tests/tests/generate_upgrade_script.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::test_dir_path;
+use aptos_types::account_address::AccountAddress;
+use e2e_move_tests::package_builder::PackageBuilder;
+use e2e_move_tests::MoveHarness;
+use framework::{BuildOptions, BuiltPackage, ReleasePackage};
+use move_deps::move_package::compilation::package_layout::CompiledPackageLayout;
+
+mod common;
+
+#[test]
+fn generate_upgrade_script() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    // Construct two packages: one for which a proposal is created, the other for
+    // holding the proposal script.
+
+    let mut upgrade = PackageBuilder::new("Pack");
+    upgrade.add_source(
+        "test",
+        &format!(
+            "\
+module 0x{}::test {{
+    public entry fun hi(_s: &signer){{
+    }}
+}}",
+            acc.address()
+        ),
+    );
+    let upgrade_dir = upgrade.write_to_temp().unwrap();
+
+    let mut proposal = PackageBuilder::new("Proposal");
+    proposal.add_dep(&format!(
+        "AptosFramework = {{ local = \"{}\" }}",
+        test_dir_path("../../framework/aptos-framework").display()
+    ));
+    let proposal_dir = proposal.write_to_temp().unwrap();
+
+    let upgrade_release = ReleasePackage::new(
+        BuiltPackage::build(upgrade_dir.path().to_path_buf(), BuildOptions::default()).unwrap(),
+    )
+    .unwrap();
+
+    // Generate the proposal and compile it.
+    upgrade_release
+        .generate_script_proposal(
+            AccountAddress::ONE,
+            proposal_dir
+                .path()
+                .to_path_buf()
+                .join(CompiledPackageLayout::Sources.path())
+                .join("proposal.move"),
+        )
+        .unwrap();
+    let _ =
+        BuiltPackage::build(proposal_dir.path().to_path_buf(), BuildOptions::default()).unwrap();
+
+    // TODO: maybe execute the proposal.
+}

--- a/aptos-move/e2e-move-tests/tests/init_module.rs
+++ b/aptos-move/e2e-move-tests/tests/init_module.rs
@@ -20,7 +20,7 @@ fn init_module() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::package_path("init_module.data/pack"),));
+    assert_success!(h.publish_package(&acc, &common::test_dir_path("init_module.data/pack"),));
 
     // Verify that init_module was called.
     let module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();

--- a/aptos-move/e2e-move-tests/tests/max_loop_depth.rs
+++ b/aptos-move/e2e-move-tests/tests/max_loop_depth.rs
@@ -19,9 +19,10 @@ fn module_loop_depth_at_limit() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
-    assert_success!(
-        h.publish_package(&acc, &common::package_path("max_loop_depth.data/pack-good"),)
-    );
+    assert_success!(h.publish_package(
+        &acc,
+        &common::test_dir_path("max_loop_depth.data/pack-good"),
+    ));
 }
 
 #[test]
@@ -31,7 +32,7 @@ fn module_loop_depth_just_above_limit() {
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xbeef").unwrap());
     assert_vm_status!(
-        h.publish_package(&acc, &common::package_path("max_loop_depth.data/pack-bad"),),
+        h.publish_package(&acc, &common::test_dir_path("max_loop_depth.data/pack-bad"),),
         StatusCode::LOOP_MAX_DEPTH_REACHED
     );
 }

--- a/aptos-move/e2e-move-tests/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/tests/string_args.rs
@@ -20,7 +20,7 @@ fn string_args() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::package_path("string_args.data/pack"),));
+    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack"),));
 
     let module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();
 

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -19,6 +19,7 @@ clap = "3.1.8"
 curve25519-dalek = { version = "3", default-features = false }
 flate2 = "1.0.24"
 include_dir = "0.7.2"
+itertools = "0.10.0"
 libsecp256k1 = "0.7.0"
 log = "0.4.17"
 once_cell = "1.10.0"

--- a/aptos-move/framework/aptos-framework/sources/code.move
+++ b/aptos-move/framework/aptos-framework/sources/code.move
@@ -143,9 +143,22 @@ module aptos_framework::code {
 
     /// Same as `publish_package` but as an entry function which can be called as a transaction. Because
     /// of current restrictions for txn parameters, the metadata needs to be passed in serialized form.
-    public entry fun publish_package_txn(owner: &signer, pack_serialized: vector<u8>, code: vector<vector<u8>>)
+    public entry fun publish_package_txn(owner: &signer, metadata_serialized: vector<u8>, code: vector<vector<u8>>)
     acquires PackageRegistry {
-        publish_package(owner, util::from_bytes<PackageMetadata>(pack_serialized), code)
+        publish_package(owner, util::from_bytes<PackageMetadata>(metadata_serialized), code)
+    }
+
+    /// Same as `publish_package_txn` but allows to split the metadata into multiple parts for working around
+    /// size constraints.
+    public entry fun publish_package_chunk3_txn(owner: &signer,
+                                                metadata_chunk1: vector<u8>,
+                                                metadata_chunk2: vector<u8>,
+                                                metadata_chunk3: vector<u8>,
+                                                code: vector<vector<u8>>)
+    acquires PackageRegistry {
+        vector::append(&mut metadata_chunk1, metadata_chunk2);
+        vector::append(&mut metadata_chunk1, metadata_chunk3);
+        publish_package(owner, util::from_bytes<PackageMetadata>(metadata_chunk1), code)
     }
 
     // Helpers

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::types::{
-    CliError, CliTypedResult, PoolAddressArgs, PromptOptions, TransactionOptions,
+    CliError, CliTypedResult, MovePackageDir, PoolAddressArgs, PromptOptions, TransactionOptions,
     TransactionSummary,
 };
 use crate::common::utils::prompt_yes_with_override;
-use crate::move_tool::{init_move_dir, ArgWithType, FunctionArgType};
+use crate::move_tool::{init_move_dir, ArgWithType, FunctionArgType, IncludedArtifacts};
 use crate::{CliCommand, CliResult};
 use aptos_crypto::HashValue;
 use aptos_logger::warn;
@@ -18,7 +18,7 @@ use aptos_types::{
 };
 use async_trait::async_trait;
 use clap::Parser;
-use framework::{BuildOptions, BuiltPackage};
+use framework::{BuildOptions, BuiltPackage, ReleasePackage};
 use move_deps::move_core_types::{
     language_storage::TypeTag, transaction_argument::TransactionArgument,
 };
@@ -45,6 +45,7 @@ pub enum GovernanceTool {
     Propose(SubmitProposal),
     Vote(SubmitVote),
     ExecuteProposal(ExecuteProposal),
+    GenerateUpgradeProposal(GenerateUpgradeProposal),
 }
 
 impl GovernanceTool {
@@ -54,6 +55,7 @@ impl GovernanceTool {
             Propose(tool) => tool.execute_serialized().await,
             Vote(tool) => tool.execute_serialized().await,
             ExecuteProposal(tool) => tool.execute_serialized().await,
+            GenerateUpgradeProposal(tool) => tool.execute_serialized().await,
         }
     }
 }
@@ -485,5 +487,52 @@ impl CompileProposalArgs {
 
         // Compile script
         compile_in_temp_dir(script_path, &self.framework_git_rev, self.prompt_options)
+    }
+}
+
+/// Generates a package upgrade proposal script.
+#[derive(Parser)]
+pub struct GenerateUpgradeProposal {
+    /// Address of the account which the proposal addresses.
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) account: AccountAddress,
+
+    /// Where to store the generated proposal
+    #[clap(long, parse(from_os_str), default_value = "proposal.move")]
+    pub(crate) output: PathBuf,
+
+    /// What artifacts to include in the package. This can be one of `none`, `sparse`, and
+    /// `all`. `none` is the most compact form and does not allow to reconstruct a source
+    /// package from chain; `sparse` is the minimal set of artifacts needed to reconstruct
+    /// a source package; `all` includes all available artifacts. The choice of included
+    /// artifacts heavily influences the size and therefore gas cost of publishing: `none`
+    /// is the size of bytecode alone; `sparse` is roughly 2 times as much; and `all` 3-4
+    /// as much.
+    #[clap(long, default_value_t = IncludedArtifacts::Sparse)]
+    pub(crate) included_artifacts: IncludedArtifacts,
+
+    #[clap(flatten)]
+    pub(crate) move_options: MovePackageDir,
+}
+
+#[async_trait]
+impl CliCommand<&'static str> for GenerateUpgradeProposal {
+    fn command_name(&self) -> &'static str {
+        "GenerateUpgradeProposal"
+    }
+
+    async fn execute(self) -> CliTypedResult<&'static str> {
+        let GenerateUpgradeProposal {
+            move_options,
+            account,
+            included_artifacts,
+            output,
+        } = self;
+        let package_path = move_options.get_package_path()?;
+        let options = included_artifacts.build_options(move_options.named_addresses());
+        let package = BuiltPackage::build(package_path, options)?;
+        let release = ReleasePackage::new(package)?;
+        release.generate_script_proposal(account, output)?;
+        Ok("success")
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -398,7 +398,10 @@ impl FromStr for IncludedArtifacts {
 }
 
 impl IncludedArtifacts {
-    fn build_options(self, named_addresses: BTreeMap<String, AccountAddress>) -> BuildOptions {
+    pub(crate) fn build_options(
+        self,
+        named_addresses: BTreeMap<String, AccountAddress>,
+    ) -> BuildOptions {
         use IncludedArtifacts::*;
         match self {
             None => BuildOptions {
@@ -544,7 +547,7 @@ impl CliCommand<&'static str> for DownloadPackage {
 /// Lists information about packages and modules on-chain
 #[derive(Parser)]
 pub struct ListPackage {
-    /// Address of the account onchain
+    /// Address of the account for which to list packages.
     #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
 


### PR DESCRIPTION
### Description

This adds a generator for proposal scripts as `aptos governance generate-upgrade-proposal <options>`. With some tweaking of the compilation scheme, the generated proposal for our largest package, aptos-framework, compiles fine.

Besides:
- Fixes a bug in the `--included-artifacts` flag; that one was simply ignored (also for publish ...)
- Adding a new test helper to e2e-move-tests to construct packages from the fly.

### Test Plan

Added e2e test. Manually tested with aptos-framework.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3248)
<!-- Reviewable:end -->
