### PR TITLE
[telemetry-service] Log Ingest Endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "bcs",
  "chrono",
  "clap 3.2.17",
+ "flate2",
  "gcp-bigquery-client",
  "hex",
  "jsonwebtoken",
@@ -3890,9 +3891,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3905,9 +3906,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3915,15 +3916,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3932,9 +3933,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
 
 [[package]]
 name = "futures-lite"
@@ -3953,9 +3954,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -3964,21 +3965,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -259,7 +259,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_path_to_error",
  "storage-interface",
@@ -317,7 +317,7 @@ dependencies = [
  "rand 0.7.3",
  "regex",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_path_to_error",
  "storage-interface",
@@ -348,7 +348,7 @@ dependencies = [
  "move-deps",
  "poem",
  "poem-openapi",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "storage-interface",
 ]
@@ -360,7 +360,7 @@ dependencies = [
  "bcs",
  "proptest",
  "proptest-derive",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "serde_json",
 ]
@@ -376,7 +376,7 @@ dependencies = [
  "bcs",
  "lz4",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -397,7 +397,7 @@ dependencies = [
  "mirai-annotations",
  "poem-openapi",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_yaml 0.8.26",
  "short-hex-str",
  "thiserror",
@@ -427,7 +427,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "ring",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde-name",
  "serde_bytes",
  "serde_json",
@@ -472,7 +472,7 @@ dependencies = [
  "netcore",
  "network",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "short-hex-str",
  "storage-service-client",
  "storage-service-server",
@@ -501,7 +501,7 @@ dependencies = [
  "hex",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "tempfile",
  "tokio",
@@ -529,7 +529,7 @@ dependencies = [
  "hex",
  "rand 0.7.3",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -578,7 +578,7 @@ dependencies = [
  "prost 0.10.4",
  "rand 0.7.3",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "storage-interface",
  "tokio",
@@ -666,7 +666,7 @@ dependencies = [
  "executor",
  "framework",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_yaml 0.8.26",
  "storage-interface",
  "structopt 0.3.26",
@@ -680,7 +680,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "proxy",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thiserror",
  "ureq",
@@ -714,7 +714,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "tokio",
  "url",
@@ -747,7 +747,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "thiserror",
 ]
@@ -785,7 +785,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions",
  "prometheus",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "strum",
  "strum_macros",
@@ -826,7 +826,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "rayon",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "short-hex-str",
  "storage-interface",
@@ -923,7 +923,7 @@ dependencies = [
  "poem-openapi",
  "prometheus-parse",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_yaml 0.8.26",
  "thiserror",
@@ -941,7 +941,7 @@ dependencies = [
  "percent-encoding",
  "poem",
  "poem-openapi",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
 ]
 
@@ -996,7 +996,7 @@ dependencies = [
  "bytes 1.2.1",
  "pbjson",
  "prost 0.10.4",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -1045,7 +1045,7 @@ dependencies = [
  "move-deps",
  "poem-openapi",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1093,7 +1093,7 @@ dependencies = [
  "move-deps",
  "percent-encoding",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thiserror",
  "tokio",
@@ -1114,7 +1114,7 @@ dependencies = [
  "aptos-types",
  "clap 3.2.17",
  "hex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "tokio",
  "url",
@@ -1130,7 +1130,7 @@ dependencies = [
  "cached-packages",
  "move-deps",
  "rand_core 0.5.1",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -1163,7 +1163,7 @@ dependencies = [
  "aptos-logger",
  "aptos-metrics-core",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -1186,7 +1186,7 @@ dependencies = [
  "enum_dispatch",
  "rand 0.7.3",
  "schemadb",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thiserror",
 ]
@@ -1200,7 +1200,7 @@ dependencies = [
  "aptos-types",
  "bcs",
  "move-deps",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "serde_json",
 ]
@@ -1231,7 +1231,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "state-sync-driver",
  "sysinfo",
@@ -1263,7 +1263,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_repr",
  "serde_with",
@@ -1332,7 +1332,7 @@ dependencies = [
  "language-e2e-tests",
  "move-deps",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "storage-interface",
  "vm-genesis",
@@ -1359,7 +1359,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -1392,7 +1392,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "proptest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thiserror",
  "ureq",
@@ -1424,7 +1424,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "rayon",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "smallvec",
  "tracing",
@@ -1440,7 +1440,7 @@ dependencies = [
  "aptos-logger",
  "bcs",
  "hyper",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "warp",
 ]
@@ -1461,7 +1461,7 @@ dependencies = [
  "framework",
  "handlebars",
  "move-deps",
- "serde 1.0.143",
+ "serde 1.0.144",
  "tempfile",
 ]
 
@@ -1502,7 +1502,7 @@ dependencies = [
  "rayon",
  "schemadb",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "thiserror",
 ]
@@ -1537,7 +1537,7 @@ dependencies = [
  "rand 0.7.3",
  "schemadb",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
 ]
 
@@ -1607,7 +1607,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
 ]
 
@@ -1704,11 +1704,12 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
+checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
 dependencies = [
  "async-io",
+ "autocfg",
  "blocking",
  "cfg-if 1.0.0",
  "event-listener",
@@ -1827,7 +1828,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "serde 1.0.143",
+ "serde 1.0.144",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -1863,7 +1864,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -1899,7 +1900,7 @@ dependencies = [
  "regex",
  "reqwest",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "storage-interface",
  "structopt 0.3.26",
@@ -1927,7 +1928,7 @@ dependencies = [
  "hyper",
  "once_cell",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "tokio",
  "warp",
@@ -1962,7 +1963,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "510fd83e3eaf7263b06182f3550b4c0af2af42cb36ab8024969ff5ea7fcb2833"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -1995,7 +1996,7 @@ dependencies = [
  "num-bigint 0.2.6",
  "num-integer",
  "num-traits 0.2.15",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -2004,7 +2005,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -2148,7 +2149,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "memchr",
  "regex-automata",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -2197,7 +2198,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -2308,7 +2309,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits 0.2.15",
- "serde 1.0.143",
+ "serde 1.0.144",
  "time 0.1.44",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -2450,7 +2451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3362992a0d9f1dd7c3d0e89e0ab2bb540b7a95fea8cd798090e758fda2899b5e"
 dependencies = [
  "codespan-reporting",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -2459,7 +2460,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
  "termcolor",
  "unicode-width",
 ]
@@ -2503,7 +2504,7 @@ dependencies = [
  "lazy_static 1.4.0",
  "nom 5.1.2",
  "rust-ini",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde-hjson",
  "serde_json",
  "toml",
@@ -2554,7 +2555,7 @@ dependencies = [
  "rand 0.7.3",
  "safety-rules",
  "schemadb",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "short-hex-str",
  "storage-interface",
@@ -2575,7 +2576,7 @@ dependencies = [
  "claim",
  "futures",
  "move-deps",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
  "tokio",
 ]
@@ -2596,7 +2597,7 @@ dependencies = [
  "itertools",
  "mirai-annotations",
  "proptest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "short-hex-str",
 ]
@@ -2640,7 +2641,7 @@ dependencies = [
  "hdrhistogram",
  "humantime 2.1.0",
  "prost-types",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thread_local",
  "tokio",
@@ -2717,7 +2718,7 @@ dependencies = [
  "idna",
  "log",
  "publicsuffix",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "time 0.3.13",
  "url",
@@ -2741,9 +2742,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1079fb8528d9f9c888b1e8aa651e6e079ade467323d58f75faf1d30b1808f540"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -2754,7 +2755,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-logger",
  "backtrace",
- "serde 1.0.143",
+ "serde 1.0.144",
  "toml",
 ]
 
@@ -2785,7 +2786,7 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_cbor",
  "serde_derive",
  "serde_json",
@@ -2978,7 +2979,7 @@ dependencies = [
  "csv-core",
  "itoa 0.4.8",
  "ryu",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -3133,7 +3134,7 @@ dependencies = [
  "network",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "short-hex-str",
  "storage-service-types",
  "thiserror",
@@ -3354,7 +3355,7 @@ dependencies = [
  "move-deps",
  "project-root",
  "proptest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "tempfile",
  "vm-genesis",
 ]
@@ -3365,7 +3366,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
  "signature",
 ]
 
@@ -3378,7 +3379,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -3393,7 +3394,7 @@ dependencies = [
  "curve25519-dalek-fiat",
  "ed25519",
  "rand 0.8.5",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "sha2 0.9.9",
  "zeroize",
@@ -3473,7 +3474,7 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "003000e712ad0f95857bd4d2ef8d1890069e06554101697d12050668b2f6f020"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -3528,7 +3529,7 @@ dependencies = [
  "executor-test-helpers",
  "futures",
  "move-deps",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "thiserror",
  "vm-genesis",
@@ -3564,7 +3565,7 @@ dependencies = [
  "rand 0.7.3",
  "rayon",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "vm-genesis",
 ]
@@ -3598,7 +3599,7 @@ dependencies = [
  "rayon",
  "schemadb",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "structopt 0.3.26",
  "toml",
@@ -3641,7 +3642,7 @@ dependencies = [
  "itertools",
  "once_cell",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "thiserror",
 ]
@@ -3791,7 +3792,7 @@ dependencies = [
  "rayon",
  "regex",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "structopt 0.3.26",
  "tempfile",
@@ -3866,7 +3867,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rayon",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
@@ -3891,9 +3892,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3906,9 +3907,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3922,9 +3923,9 @@ checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -3954,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -3977,9 +3978,9 @@ checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4017,7 +4018,7 @@ dependencies = [
  "hyper-rustls",
  "log",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thiserror",
  "time 0.3.13",
@@ -4041,7 +4042,7 @@ dependencies = [
  "move-deps",
  "network",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde-reflection",
  "serde_yaml 0.8.26",
  "structopt 0.3.26",
@@ -4216,7 +4217,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "thiserror",
 ]
@@ -4428,7 +4429,7 @@ dependencies = [
  "levenshtein",
  "log",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_regex",
  "similar",
@@ -4635,7 +4636,7 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -4814,7 +4815,7 @@ dependencies = [
  "array_tool",
  "env_logger 0.7.1",
  "log",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
 ]
 
@@ -4827,7 +4828,7 @@ dependencies = [
  "base64 0.13.0",
  "pem 1.1.0",
  "ring",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "simple_asn1",
 ]
@@ -4841,7 +4842,7 @@ dependencies = [
  "base64 0.13.0",
  "bytes 1.2.1",
  "chrono",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde-value",
  "serde_json",
 ]
@@ -4875,7 +4876,7 @@ dependencies = [
  "openssl",
  "pem 0.8.3",
  "pin-project",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_yaml 0.8.26",
  "static_assertions",
@@ -4955,7 +4956,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "vm-genesis",
 ]
 
@@ -4979,7 +4980,7 @@ dependencies = [
  "language-e2e-tests",
  "move-deps",
  "proptest",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5095,7 +5096,7 @@ dependencies = [
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
  "rand 0.8.5",
- "serde 1.0.143",
+ "serde 1.0.144",
  "sha2 0.9.9",
  "typenum",
 ]
@@ -5189,7 +5190,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.143",
+ "serde 1.0.144",
  "value-bag",
 ]
 
@@ -5277,7 +5278,7 @@ dependencies = [
  "async-trait",
  "claim",
  "futures",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
  "tokio",
 ]
@@ -5425,7 +5426,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5439,7 +5440,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "ref-cast",
- "serde 1.0.143",
+ "serde 1.0.144",
  "variant_count",
 ]
 
@@ -5460,7 +5461,7 @@ dependencies = [
  "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5541,7 +5542,7 @@ dependencies = [
  "read-write-set",
  "read-write-set-dynamic",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_yaml 0.8.26",
  "tempfile",
@@ -5561,7 +5562,7 @@ dependencies = [
  "move-core-types",
  "num-bigint 0.4.3",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
  "sha2 0.9.9",
  "walkdir",
 ]
@@ -5608,7 +5609,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "ref-cast",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
 ]
 
@@ -5629,7 +5630,7 @@ dependencies = [
  "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5699,7 +5700,7 @@ dependencies = [
  "num 0.4.0",
  "once_cell",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5713,7 +5714,7 @@ dependencies = [
  "move-command-line-common",
  "move-core-types",
  "move-model",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5790,7 +5791,7 @@ dependencies = [
  "move-core-types",
  "move-symbol-pool",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5816,7 +5817,7 @@ dependencies = [
  "num 0.4.0",
  "once_cell",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5846,7 +5847,7 @@ dependencies = [
  "ptree",
  "regex",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
  "tempfile",
@@ -5885,7 +5886,7 @@ dependencies = [
  "once_cell",
  "pretty",
  "rand 0.8.5",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "simplelog",
  "tokio",
@@ -5914,7 +5915,7 @@ dependencies = [
  "pretty",
  "rand 0.8.5",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "tera",
  "tokio",
@@ -5939,7 +5940,7 @@ dependencies = [
  "anyhow",
  "move-binary-format",
  "move-core-types",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5954,7 +5955,7 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5981,7 +5982,7 @@ dependencies = [
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -5999,7 +6000,7 @@ dependencies = [
  "move-model",
  "move-stackless-bytecode",
  "num 0.4.0",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -6030,7 +6031,7 @@ version = "0.1.0"
 source = "git+https://github.com/move-language/move?rev=413955ea9246356b18af006584eb73283e9508da#413955ea9246356b18af006584eb73283e9508da"
 dependencies = [
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -6140,7 +6141,7 @@ dependencies = [
  "move-table-extension",
  "move-vm-types",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -6153,7 +6154,7 @@ dependencies = [
  "move-core-types",
  "once_cell",
  "proptest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "smallvec",
 ]
 
@@ -6247,7 +6248,7 @@ dependencies = [
  "memsocket",
  "pin-project",
  "proxy",
- "serde 1.0.143",
+ "serde 1.0.144",
  "tokio",
  "tokio-util 0.7.3",
  "url",
@@ -6289,7 +6290,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_bytes",
  "serde_json",
  "short-hex-str",
@@ -6319,7 +6320,7 @@ dependencies = [
  "network",
  "network-discovery",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "tokio",
 ]
 
@@ -6805,7 +6806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "599fe9aefc2ca0df4a96179b3075faee2cacb89d4cf947a00b9a89152dfffc9d"
 dependencies = [
  "base64 0.13.0",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -6844,7 +6845,7 @@ dependencies = [
  "network",
  "once_cell",
  "peer-monitoring-service-types",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
  "tokio",
 ]
@@ -6855,7 +6856,7 @@ version = "0.1.0"
 dependencies = [
  "aptos-config",
  "network",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -6887,9 +6888,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
+checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -6897,9 +6898,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13570633aff33c6d22ce47dd566b10a3b9122c2fe9d8e7501895905be532b91"
+checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6907,9 +6908,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c567e5702efdc79fb18859ea74c3eb36e14c43da7b8c1f098a4ed6514ec7a0"
+checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
 dependencies = [
  "pest",
  "pest_meta",
@@ -6920,9 +6921,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb32be5ee3bbdafa8c7a18b0a8a8d962b66cfa2ceee4037f49267a50ee821fe"
+checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
 dependencies = [
  "once_cell",
  "pest",
@@ -7093,7 +7094,7 @@ dependencies = [
  "regex",
  "rfc7239",
  "rustls-pemfile 1.0.1",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
@@ -7135,10 +7136,10 @@ dependencies = [
  "poem",
  "poem-openapi-derive",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_urlencoded",
- "serde_yaml 0.9.9",
+ "serde_yaml 0.9.10",
  "thiserror",
  "tokio",
  "url",
@@ -7164,10 +7165,11 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
 dependencies = [
+ "autocfg",
  "cfg-if 1.0.0",
  "libc",
  "log",
@@ -7371,7 +7373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f6a3f14ff35c16b51ac796d1dc73c15ad6472c48836c6c467f6d52266648"
 dependencies = [
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "time 0.3.13",
  "url",
@@ -7500,7 +7502,7 @@ dependencies = [
  "config",
  "directories",
  "petgraph 0.6.2",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde-value",
  "tint",
 ]
@@ -7853,7 +7855,7 @@ dependencies = [
  "proc-macro-hack",
  "rustls 0.20.6",
  "rustls-pemfile 1.0.1",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -7880,7 +7882,7 @@ dependencies = [
  "futures",
  "http",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "task-local-extensions",
  "thiserror",
 ]
@@ -8110,7 +8112,7 @@ dependencies = [
  "proptest",
  "rand 0.7.3",
  "rusty-fork",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -8253,9 +8255,9 @@ checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -8270,7 +8272,7 @@ dependencies = [
  "heck 0.3.3",
  "include_dir 0.6.2",
  "maplit",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde-reflection",
  "serde_bytes",
  "serde_yaml 0.8.26",
@@ -8296,7 +8298,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -8306,7 +8308,7 @@ version = "0.3.5"
 source = "git+https://github.com/aptos-labs/serde-reflection?rev=839aed62a20ddccf043c08961cfe74875741ccba#839aed62a20ddccf043c08961cfe74875741ccba"
 dependencies = [
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -8317,7 +8319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -8326,7 +8328,7 @@ version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -8336,14 +8338,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -8352,14 +8354,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "indexmap",
  "itoa 1.0.3",
  "ryu",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -8368,7 +8370,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -8378,7 +8380,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -8401,7 +8403,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 1.0.3",
  "ryu",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -8414,7 +8416,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_with_macros",
  "time 0.3.13",
@@ -8440,20 +8442,20 @@ checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
- "serde 1.0.143",
+ "serde 1.0.144",
  "yaml-rust",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50845f68d5c693aac7d72a25415ddd21cb8182c04eafe447b73af55a05f9e1b"
+checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
 dependencies = [
  "indexmap",
  "itoa 1.0.3",
  "ryu",
- "serde 1.0.143",
+ "serde 1.0.144",
  "unsafe-libyaml",
 ]
 
@@ -8552,7 +8554,7 @@ dependencies = [
  "hex",
  "mirai-annotations",
  "proptest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "static_assertions",
  "thiserror",
 ]
@@ -8807,7 +8809,7 @@ dependencies = [
  "rand 0.7.3",
  "schemadb",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "storage-service-client",
  "storage-service-types",
@@ -8848,7 +8850,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rayon",
  "scratchpad",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -8890,7 +8892,7 @@ dependencies = [
  "network",
  "once_cell",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
  "storage-interface",
  "storage-service-types",
  "thiserror",
@@ -8909,7 +8911,7 @@ dependencies = [
  "claim",
  "num-traits 0.2.15",
  "proptest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "thiserror",
 ]
 
@@ -9109,7 +9111,7 @@ dependencies = [
  "pest_derive",
  "rand 0.8.5",
  "regex",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "slug",
  "unic-segment",
@@ -9275,7 +9277,7 @@ dependencies = [
  "itoa 1.0.3",
  "libc",
  "num_threads",
- "serde 1.0.143",
+ "serde 1.0.144",
  "time-macros",
 ]
 
@@ -9309,7 +9311,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
 ]
 
@@ -9495,7 +9497,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -9507,7 +9509,7 @@ dependencies = [
  "combine",
  "indexmap",
  "itertools",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -9702,7 +9704,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "reqwest",
- "serde 1.0.143",
+ "serde 1.0.144",
  "termion",
  "tokio",
  "url",
@@ -9722,7 +9724,7 @@ checksum = "e7f408301c7480f9e6294eb779cfc907f54bd901a9660ef24d7f233ed5376485"
 dependencies = [
  "glob",
  "once_cell",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_derive",
  "serde_json",
  "termcolor",
@@ -9979,7 +9981,7 @@ dependencies = [
  "native-tls",
  "once_cell",
  "qstring",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "url",
 ]
@@ -9994,14 +9996,14 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
 name = "utcnow"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9835442f055fab72d40eb8e5164f2b98e70ebadedbf4506aac23ca7d623053"
+checksum = "80b49db848e09c50db9e7d15aee89030b6ebb8c55e77aff2cef22aeb6844c8b5"
 dependencies = [
  "const_fn",
  "errno",
@@ -10026,7 +10028,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom 0.2.7",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -10093,7 +10095,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.7.3",
- "serde 1.0.143",
+ "serde 1.0.144",
 ]
 
 [[package]]
@@ -10175,7 +10177,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "scoped-tls",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -10509,7 +10511,7 @@ dependencies = [
  "rustls 0.20.6",
  "rustls-pemfile 0.3.0",
  "seahash",
- "serde 1.0.143",
+ "serde 1.0.144",
  "serde_json",
  "time 0.3.13",
  "tokio",

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -22,6 +22,7 @@ use short_hex_str::AsShortHexStr;
 use std::{
     collections::{HashMap, HashSet},
     convert::TryFrom,
+    fmt,
     path::PathBuf,
     string::ToString,
     time::Duration,
@@ -429,7 +430,7 @@ pub type PeerSet = HashMap<PeerId, Peer>;
 /// Downstream -> Downstream, defining a controlled downstream that I always want to connect
 /// Known -> A known peer, but it has no particular role assigned to it
 /// Unknown -> Undiscovered peer, likely due to a non-mutually authenticated connection always downstream
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum PeerRole {
     Validator = 0,
     PreferredUpstream,
@@ -440,10 +441,36 @@ pub enum PeerRole {
     Unknown,
 }
 
+impl PeerRole {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PeerRole::Validator => "validator",
+            PeerRole::PreferredUpstream => "preferred_upstream_peer",
+            PeerRole::Upstream => "upstream_peer",
+            PeerRole::ValidatorFullNode => "validator_fullnode",
+            PeerRole::Downstream => "downstream_peer",
+            PeerRole::Known => "known_peer",
+            PeerRole::Unknown => "unknown_peer",
+        }
+    }
+}
+
 impl Default for PeerRole {
     /// Default to least trusted
     fn default() -> Self {
         PeerRole::Unknown
+    }
+}
+
+impl fmt::Debug for PeerRole {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
+impl fmt::Display for PeerRole {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/crates/aptos-telemetry-service/Cargo.toml
+++ b/crates/aptos-telemetry-service/Cargo.toml
@@ -16,6 +16,7 @@ aptos-types = { path = "../../types" }
 bcs = "0.1.3"
 chrono = "0.4"
 clap = "3.1.8"
+flate2 = "1.0.24"
 gcp-bigquery-client = "0.13"
 hex = "0.4.3"
 jsonwebtoken = "8.1"

--- a/crates/aptos-telemetry-service/src/clients/humio.rs
+++ b/crates/aptos-telemetry-service/src/clients/humio.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
 use anyhow::anyhow;
 use flate2::{write::GzEncoder, Compression};
 use reqwest::{self, Url};

--- a/crates/aptos-telemetry-service/src/clients/humio.rs
+++ b/crates/aptos-telemetry-service/src/clients/humio.rs
@@ -28,12 +28,12 @@ impl IngestClient {
         }
     }
 
-    pub async fn ingest_unstructured_logs(
+    pub async fn ingest_unstructured_log(
         &self,
-        unstructured_logs: &Vec<UnstructuredLog>,
+        unstructured_log: UnstructuredLog,
     ) -> Result<reqwest::Response, anyhow::Error> {
         let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::default());
-        serde_json::to_writer(&mut gzip_encoder, unstructured_logs)
+        serde_json::to_writer(&mut gzip_encoder, &vec![unstructured_log])
             .map_err(|e| anyhow!("unable to serialize json: {}", e))?;
         let compressed_bytes = gzip_encoder.finish()?;
 

--- a/crates/aptos-telemetry-service/src/clients/humio.rs
+++ b/crates/aptos-telemetry-service/src/clients/humio.rs
@@ -1,0 +1,46 @@
+use anyhow::anyhow;
+use flate2::{write::GzEncoder, Compression};
+use reqwest::{self, Url};
+
+use crate::types::humio::UnstructuredLog;
+
+pub const PEER_ID_FIELD_NAME: &str = "peer_id";
+pub const EPOCH_FIELD_NAME: &str = "epoch";
+pub const PEER_ROLE_TAG_NAME: &str = "peer_role";
+pub const CHAIN_ID_TAG_NAME: &str = "chain_id";
+
+#[derive(Clone)]
+pub struct IngestClient {
+    inner: reqwest::Client,
+    base_url: Url,
+    auth_token: String,
+}
+
+impl IngestClient {
+    pub fn new(base_url: Url, auth_token: String) -> Self {
+        Self {
+            inner: reqwest::Client::new(),
+            base_url,
+            auth_token,
+        }
+    }
+
+    pub async fn ingest_unstructured_logs(
+        &self,
+        unstructured_logs: &Vec<UnstructuredLog>,
+    ) -> Result<reqwest::Response, anyhow::Error> {
+        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::default());
+        serde_json::to_writer(&mut gzip_encoder, unstructured_logs)
+            .map_err(|e| anyhow!("unable to serialize json: {}", e))?;
+        let compressed_bytes = gzip_encoder.finish()?;
+
+        self.inner
+            .post(format!("{}api/v1/ingest/humio-unstructured", self.base_url))
+            .bearer_auth(self.auth_token.clone())
+            .header("Content-Encoding", "gzip")
+            .body(compressed_bytes)
+            .send()
+            .await
+            .map_err(|e| anyhow!("failed to post metrics: {}", e))
+    }
+}

--- a/crates/aptos-telemetry-service/src/clients/mod.rs
+++ b/crates/aptos-telemetry-service/src/clients/mod.rs
@@ -1,5 +1,4 @@
-// Copyright (c) Aptos
-// SPDX-License-Identifier: Apache-2.0
+pub mod humio;
 
 pub mod aptos_api {
 

--- a/crates/aptos-telemetry-service/src/clients/mod.rs
+++ b/crates/aptos-telemetry-service/src/clients/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod humio;
 
 pub mod aptos_api {

--- a/crates/aptos-telemetry-service/src/constants.rs
+++ b/crates/aptos-telemetry-service/src/constants.rs
@@ -1,0 +1,3 @@
+
+// The maximum content length to accept in the http body.
+pub const MAX_CONTENT_LENGTH: u64 = 1024 * 1024;

--- a/crates/aptos-telemetry-service/src/constants.rs
+++ b/crates/aptos-telemetry-service/src/constants.rs
@@ -1,3 +1,5 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
 
 // The maximum content length to accept in the http body.
 pub const MAX_CONTENT_LENGTH: u64 = 1024 * 1024;

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -4,8 +4,8 @@
 use std::{convert::Infallible, sync::Arc};
 
 use crate::{
-    clients::victoria_metrics_api::Client as MetricsClient, validator_cache::ValidatorSetCache,
-    GCPBigQueryConfig, TelemetryServiceConfig,
+    clients::humio, clients::victoria_metrics_api::Client as MetricsClient,
+    validator_cache::ValidatorSetCache, GCPBigQueryConfig, TelemetryServiceConfig,
 };
 use aptos_crypto::noise;
 use gcp_bigquery_client::Client as BQClient;
@@ -24,6 +24,8 @@ pub struct Context {
 
     pub jwt_encoding_key: EncodingKey,
     pub jwt_decoding_key: DecodingKey,
+
+    pub humio_client: humio::IngestClient,
 }
 
 impl Context {
@@ -32,6 +34,7 @@ impl Context {
         validator_cache: ValidatorSetCache,
         gcp_bigquery_client: Option<BQClient>,
         victoria_metrics_client: Option<MetricsClient>,
+        humio_client: humio::IngestClient,
     ) -> Self {
         let private_key = config.server_private_key.private_key();
         Self {
@@ -45,6 +48,8 @@ impl Context {
 
             jwt_encoding_key: EncodingKey::from_secret(config.jwt_signing_key.as_bytes()),
             jwt_decoding_key: DecodingKey::from_secret(config.jwt_signing_key.as_bytes()),
+
+            humio_client,
         }
     }
 

--- a/crates/aptos-telemetry-service/src/index.rs
+++ b/crates/aptos-telemetry-service/src/index.rs
@@ -1,7 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{auth, context::Context, custom_event, error::ServiceError, prometheus_push_metrics};
+use crate::{
+    auth, context::Context, custom_event, error::ServiceError, log_ingest, prometheus_push_metrics,
+};
 use std::convert::Infallible;
 use warp::{
     body::BodyDeserializeError,
@@ -14,7 +16,8 @@ pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Inf
     index(context.clone())
         .or(auth::auth(context.clone()))
         .or(custom_event::custom_event(context.clone()))
-        .or(prometheus_push_metrics::metrics_ingest(context))
+        .or(prometheus_push_metrics::metrics_ingest(context.clone()))
+        .or(log_ingest::log_ingest(context))
         .recover(handle_rejection)
 }
 

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use warp::{Filter, Reply};
 
 use crate::{
-    clients::humio::{self, IngestClient},
+    clients::humio,
     clients::victoria_metrics_api::Client as MetricsClient,
     context::Context,
     index::routes,

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use warp::{Filter, Reply};
 
 use crate::{
+    clients::humio::{self, IngestClient},
     clients::victoria_metrics_api::Client as MetricsClient,
     context::Context,
     index::routes,
@@ -25,11 +26,13 @@ use crate::{
 
 mod auth;
 mod clients;
+mod constants;
 mod context;
 mod custom_event;
 mod error;
 mod index;
 mod jwt_auth;
+mod log_ingest;
 mod prometheus_push_metrics;
 #[cfg(any(test))]
 pub(crate) mod tests;
@@ -70,11 +73,17 @@ impl AptosTelemetryServiceArgs {
             config.victoria_metrics_token.clone(),
         );
 
+        let humio_client = humio::IngestClient::new(
+            Url::parse(&config.humio_url).unwrap(),
+            config.humio_auth_token.clone(),
+        );
+
         let context = Context::new(
             &config,
             cache.clone(),
             Some(gcp_bigquery_client),
             Some(victoria_metrics_client),
+            humio_client,
         );
 
         ValidatorSetCacheUpdater::new(cache, &config).run();
@@ -116,6 +125,8 @@ pub struct TelemetryServiceConfig {
     pub gcp_bq_config: GCPBigQueryConfig,
     pub victoria_metrics_base_url: String,
     pub victoria_metrics_token: String,
+    pub humio_url: String,
+    pub humio_auth_token: String,
 }
 
 impl TelemetryServiceConfig {

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -66,17 +66,17 @@ pub async fn handle_log_ingest(
     tags.insert(CHAIN_ID_TAG_NAME.into(), claims.chain_id.to_string());
     tags.insert(PEER_ROLE_TAG_NAME.into(), claims.peer_role.to_string());
 
-    let structured_log = UnstructuredLog {
+    let unstructured_log = UnstructuredLog {
         fields,
         tags,
         messages: log_messages,
     };
 
-    debug!("ingesting to humio: {:?}", structured_log);
+    debug!("ingesting to humio: {:?}", unstructured_log);
 
     let res = context
         .humio_client
-        .ingest_unstructured_logs(&vec![structured_log])
+        .ingest_unstructured_logs(&vec![unstructured_log])
         .await;
 
     match res {

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -76,7 +76,7 @@ pub async fn handle_log_ingest(
 
     let res = context
         .humio_client
-        .ingest_unstructured_logs(&vec![unstructured_log])
+        .ingest_unstructured_log(unstructured_log)
         .await;
 
     match res {

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -1,0 +1,99 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    auth::with_auth,
+    clients::humio::{CHAIN_ID_TAG_NAME, EPOCH_FIELD_NAME, PEER_ID_FIELD_NAME, PEER_ROLE_TAG_NAME},
+    constants::MAX_CONTENT_LENGTH,
+    context::Context,
+    error::ServiceError,
+    types::{auth::Claims, humio::UnstructuredLog},
+};
+use aptos_config::config::PeerRole;
+use aptos_logger::{debug, error};
+use flate2::bufread::GzDecoder;
+use reqwest::{header::CONTENT_ENCODING, StatusCode};
+use std::collections::HashMap;
+use warp::{filters::BoxedFilter, reject, reply, Buf, Filter, Rejection, Reply};
+
+pub fn log_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("log_ingest")
+        .and(warp::post())
+        .and(context.clone().filter())
+        .and(with_auth(
+            context,
+            vec![PeerRole::Validator, PeerRole::Unknown],
+        ))
+        .and(warp::header::optional(CONTENT_ENCODING.as_str()))
+        .and(warp::body::content_length_limit(MAX_CONTENT_LENGTH))
+        .and(warp::body::aggregate())
+        .and_then(handle_log_ingest)
+        .boxed()
+}
+
+pub async fn handle_log_ingest(
+    context: Context,
+    claims: Claims,
+    encoding: Option<String>,
+    body: impl Buf,
+) -> anyhow::Result<impl Reply, Rejection> {
+    debug!("handling log ingest");
+
+    let log_messages: Vec<String> = if let Some(encoding) = encoding {
+        if encoding.eq_ignore_ascii_case("gzip") {
+            let decoder = GzDecoder::new(body.reader());
+            serde_json::from_reader(decoder).map_err(|e| {
+                debug!("unable to decode and deserialize body: {}", e);
+                ServiceError::bad_request("Unexpected payload body. Payload should be an array of strings possibly in gzip format.")
+            })?
+        } else {
+            return Err(reject::custom(ServiceError::bad_request(
+                "Unexpected content encoding. Supported encodings are: gzip.",
+            )));
+        }
+    } else {
+        serde_json::from_reader(body.reader()).map_err(|e| {
+            error!("unable to deserialize body: {}", e);
+            ServiceError::bad_request("Unexpected payload body. Payload should be an array of strings possibly in gzip format")
+        })?
+    };
+
+    let mut fields = HashMap::new();
+    fields.insert(PEER_ID_FIELD_NAME.into(), claims.peer_id.to_string());
+    fields.insert(EPOCH_FIELD_NAME.into(), claims.epoch.to_string());
+
+    let mut tags = HashMap::new();
+    tags.insert(CHAIN_ID_TAG_NAME.into(), claims.chain_id.to_string());
+    tags.insert(PEER_ROLE_TAG_NAME.into(), claims.peer_role.to_string());
+
+    let structured_log = UnstructuredLog {
+        fields,
+        tags,
+        messages: log_messages,
+    };
+
+    debug!("ingesting to humio: {:?}", structured_log);
+
+    let res = context
+        .humio_client
+        .ingest_unstructured_logs(&vec![structured_log])
+        .await;
+
+    match res {
+        Ok(res) => {
+            if res.status().is_success() {
+                debug!("log ingested into humio succeessfully");
+            } else {
+                error!(
+                    "humio log ingestion failed: {}",
+                    res.error_for_status().err().unwrap()
+                );
+            }
+        }
+        Err(err) => {
+            error!("error sending log ingest request: {}", err);
+        }
+    }
+
+    Ok(reply::with_status(reply::reply(), StatusCode::CREATED))
+}

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -3,12 +3,14 @@
 
 use std::collections::HashMap;
 
+use crate::clients::humio;
 use crate::GCPBigQueryConfig;
 use crate::{context::Context, index, validator_cache::ValidatorSetCache, TelemetryServiceConfig};
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::{x25519, Uniform};
 use aptos_rest_client::aptos_api_types::mime_types;
 use rand::SeedableRng;
+use reqwest::Url;
 use serde_json::Value;
 use warp::http::header::CONTENT_TYPE;
 use warp::http::Response;
@@ -33,10 +35,15 @@ pub async fn new_test_context() -> TestContext {
         },
         victoria_metrics_base_url: "".into(),
         victoria_metrics_token: "".into(),
+        humio_url: "".into(),
+        humio_auth_token: "".into(),
     };
     let cache = ValidatorSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
-
-    TestContext::new(Context::new(config, cache, None, None))
+    let humio_client = humio::IngestClient::new(
+        Url::parse("http://localhost/".into()).unwrap(),
+        config.humio_auth_token.clone(),
+    );
+    TestContext::new(Context::new(config, cache, None, None, humio_client))
 }
 
 #[derive(Clone)]

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -40,7 +40,7 @@ pub async fn new_test_context() -> TestContext {
     };
     let cache = ValidatorSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
     let humio_client = humio::IngestClient::new(
-        Url::parse("http://localhost/".into()).unwrap(),
+        Url::parse("http://localhost/").unwrap(),
         config.humio_auth_token.clone(),
     );
     TestContext::new(Context::new(config, cache, None, None, humio_client))

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -32,3 +32,15 @@ pub mod common {
         }
     }
 }
+
+pub mod humio {
+    use std::collections::HashMap;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Deserialize, Serialize, Clone, Debug)]
+    pub struct UnstructuredLog {
+        pub fields: HashMap<String, String>,
+        pub tags: HashMap<String, String>,
+        pub messages: Vec<String>,
+    }
+}

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -34,8 +34,8 @@ pub mod common {
 }
 
 pub mod humio {
-    use std::collections::HashMap;
     use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
 
     #[derive(Deserialize, Serialize, Clone, Debug)]
     pub struct UnstructuredLog {


### PR DESCRIPTION
### Description

This PR introduces the log ingestion endpoint in the telemetry service to accept push logs from Aptos nodes. The logs will be ingested into humio using the configured credentials. Client-side changes are in #3151.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

I and @bchocho tested e2e by running a local validator node and a service and validated that logs were sent to humio.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3254)
<!-- Reviewable:end -->
