### PR TITLE
[helm][aptos-node] option to pass in entire NodeConfig

### DIFF
--- a/terraform/aptos-node-testnet/addons.tf
+++ b/terraform/aptos-node-testnet/addons.tf
@@ -216,6 +216,7 @@ resource "helm_release" "external-dns" {
 }
 
 resource "helm_release" "testnet-addons" {
+  count       = var.enable_forge ? 0 : 1
   name        = "testnet-addons"
   chart       = local.testnet_addons_helm_chart_path
   max_history = 5

--- a/terraform/helm/aptos-node/files/configs/fullnode.yaml
+++ b/terraform/helm/aptos-node/files/configs/fullnode.yaml
@@ -8,20 +8,12 @@ execution:
 
 storage:
   backup_service_address: "0.0.0.0:6186"
-  storage_pruner_config:
-    ledger_pruner_config:
-      enable: {{ $.Values.validator.config.enable_ledger_pruner }}
-      prune_window: {{ int $.Values.validator.config.ledger_prune_window }}
-      batch_size: {{ int $.Values.validator.config.ledger_pruning_batch_size }}
-    state_merkle_pruner_config:
-      enable: {{ $.Values.validator.config.enable_state_store_pruner }}
-      prune_window: {{ int $.Values.validator.config.state_store_prune_window }}
-      batch_size: {{ int $.Values.validator.config.state_store_pruning_batch_size }}
+{{- if $.Values.fullnode.config.storage -}}{{- toYaml $.Values.fullnode.config.storage | nindent 4 }}{{- end }}
 
+{{ if $.Values.fullnode.config.mempool -}}
 mempool:
-  shared_mempool_max_concurrent_inbound_syncs: {{ .Values.fullnode.config.shared_mempool_max_concurrent_inbound_syncs }}
-  max_broadcasts_per_peer: {{ .Values.fullnode.config.max_broadcasts_per_peer }}
-  default_failovers: {{ .Values.fullnode.config.default_failovers }}
+{{- toYaml $.Values.fullnode.config.mempool | nindent 4 }}
+{{- end }}
 
 full_node_networks:
 - network_id:
@@ -32,22 +24,9 @@ full_node_networks:
       addresses:
       - "/dns4/{{ include "aptos-validator.fullname" $ }}-{{$.Values.i}}-validator/tcp/6181/noise-ik/f0274c2774519281a8332d0bb9d8101bd58bc7bb154b38039bc9096ce04e1237/handshake/0"
       role: "Validator"
-
-- network_id: "public"
-  discovery_method: "onchain"
-  listen_address: "/ip4/0.0.0.0/tcp/6182"
-  identity:
-    type: "from_file"
-    path: "/opt/aptos/genesis/validator-full-node-identity.yaml"
-  {{- if $.Values.haproxy.config.send_proxy_protocol }}
-  enable_proxy_protocol: true
-  {{- end }}
-  max_inbound_connections: {{ $.Values.fullnode.config.max_inbound_connections }}
-  {{- if $.Values.fullnode.identity }}
-  {{- end }}
-  seeds:
-    {{- $.Values.fullnode.config.seeds | default dict | toYaml | nindent 6 }}
+{{- if $.Values.fullnode.config.full_node_networks -}}{{- toYaml $.Values.fullnode.config.full_node_networks | nindent 2 }}{{- end }}
 
 api:
   enabled: true
   address: "0.0.0.0:8080"
+{{- if $.Values.fullnode.config.api -}}{{- toYaml $.Values.fullnode.config.api | nindent 4 }}{{- end }}

--- a/terraform/helm/aptos-node/files/configs/validator.yaml
+++ b/terraform/helm/aptos-node/files/configs/validator.yaml
@@ -2,6 +2,7 @@ base:
   role: validator
   waypoint:
     from_file: /opt/aptos/genesis/waypoint.txt
+{{- if $.Values.validator.config.base -}}{{- toYaml $.Values.validator.config.base | nindent 4 -}}{{- end }}
 
 consensus:
   safety_rules:
@@ -16,44 +17,23 @@ consensus:
         waypoint:
           from_file: /opt/aptos/genesis/waypoint.txt
         identity_blob_path: /opt/aptos/genesis/validator-identity.yaml
-  sync_only: {{ $.Values.validator.config.sync_only | default false}}
-  {{- if $.Values.validator.config.round_initial_timeout_ms }}
-  round_initial_timeout_ms: {{ $.Values.validator.config.round_initial_timeout_ms }}
-  {{- end }}
-  {{- if $.Values.validator.config.max_block_size }}
-  max_block_size: {{ $.Values.validator.config.max_block_size}}
-  {{- end }}
-  {{- if $.Values.validator.config.quorum_store_poll_count }}
-  quorum_store_poll_count: {{ $.Values.validator.config.quorum_store_poll_count}}
-  {{- end }}
+{{- if $.Values.validator.config.consensus -}}{{- toYaml $.Values.validator.config.consensus | nindent 4 -}}{{- end }}
 
+{{ if $.Values.validator.config.storage -}}
 storage:
-  storage_pruner_config:
-    ledger_pruner_config:
-      enable: {{ $.Values.validator.config.enable_ledger_pruner }}
-      prune_window: {{ int $.Values.validator.config.ledger_prune_window }}
-      batch_size: {{ int $.Values.validator.config.ledger_pruning_batch_size }}
-    state_merkle_pruner_config:
-      enable: {{ $.Values.validator.config.enable_state_store_pruner }}
-      prune_window: {{ int $.Values.validator.config.state_store_prune_window }}
-      batch_size: {{ int $.Values.validator.config.state_store_pruning_batch_size }}
+{{- toYaml $.Values.validator.config.storage | nindent 4 -}}
+{{- end }}
 
 execution:
   genesis_file_location: /opt/aptos/genesis/genesis.blob
-  concurrency_level: {{ int $.Values.validator.config.concurrency_level }}
+{{- if $.Values.validator.config.execution -}}{{- toYaml $.Values.validator.config.execution | nindent 4 -}}{{- end }}
 
 validator_network:
   discovery_method: "onchain"
-  {{- if $.Values.validator.config.networking_runtime_thread }}
-  runtime_threads: {{ $.Values.validator.config.networking_runtime_thread}}
-  {{- end }}
-  mutual_authentication: true
-  {{- if $.Values.haproxy.config.send_proxy_protocol }}
-  enable_proxy_protocol: true
-  {{- end }}
   identity:
     type: "from_file"
     path: /opt/aptos/genesis/validator-identity.yaml
+{{- if $.Values.validator.config.validator_network -}}{{- toYaml $.Values.validator.config.validator_network | nindent 4 -}}{{- end }}
 
 full_node_networks:
 - network_id:
@@ -63,7 +43,9 @@ full_node_networks:
     type: "from_config"
     key: "b0f405a3e75516763c43a2ae1d70423699f34cd68fa9f8c6bb2d67aa87d0af69"
     peer_id: "00000000000000000000000000000000d58bc7bb154b38039bc9096ce04e1237"
+{{- if $.Values.validator.config.full_node_networks -}}{{- toYaml $.Values.validator.config.full_node_networks | nindent 2 -}}{{- end }}
 
 api:
   enabled: true
   address: "0.0.0.0:8080"
+{{- if $.Values.validator.config.api -}}{{- toYaml $.Values.validator.config.api | nindent 4 -}}{{- end }}

--- a/terraform/helm/aptos-node/templates/NOTES.txt
+++ b/terraform/helm/aptos-node/templates/NOTES.txt
@@ -1,6 +1,13 @@
 Your {{ .Chart.Name }} deployment named {{ .Release.Name }} is now deployed.
 
-To start the nodes, specify either .Values.loadTestGenesis or populate the following configmaps with genesis data:
+To start the nodes, specify either .Values.loadTestGenesis or populate the following Secrets with genesis data:
 {{- range $i, $e := until (int .Values.numValidators) }}
     - {{ include "aptos-validator.fullname" $ }}-{{$i}}-genesis-e{{ $.Values.chain.era }}
+{{- end }}
+
+{{- if .Values.overrideNodeConfig }}
+NodeConfig overrides must also be populated into the following ConfigMaps:
+{{- range $i, $e := until (int .Values.numValidators) }}
+    - {{ include "aptos-validator.fullname" $ }}-{{$i}}
+{{- end }}
 {{- end }}

--- a/terraform/helm/aptos-node/templates/configmap.yaml
+++ b/terraform/helm/aptos-node/templates/configmap.yaml
@@ -1,4 +1,5 @@
 # TODO(rustielin): make option to specify node config for each validator/fullnode
+{{- if not .Values.overrideNodeConfig }}
 {{- range $i, $e := until (int .Values.numValidators) }}
 ---
 # make the validator index available in tpl using $.Values.i 
@@ -11,4 +12,5 @@ metadata:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
 data:
 {{ tpl ($.Files.Glob "files/configs/*.yaml").AsConfig $ | indent 2 }}
+{{- end }}
 {{- end }}

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -14,6 +14,41 @@ numValidators: 1
 # -- Total number of fullnode groups to deploy
 numFullnodeGroups: 1
 
+# -- Specify validator and fullnode NodeConfigs via named ConfigMaps, rather than the generated ones from this chart.
+overrideNodeConfig: false
+
+haproxy:
+  # -- Enable HAProxy deployment in front of validator and fullnodes
+  enabled: true
+  # -- Number of HAProxy replicas
+  replicas: 1
+  image:
+    # -- Image repo to use for HAProxy images
+    repo: haproxy
+    # -- Image tag to use for HAProxy images
+    tag: 2.2.14@sha256:36aa98fff27dcb2d12c93e68515a6686378c783ea9b1ab1d01ce993a5cbc73e1
+    # -- Image pull policy to use for HAProxy images
+    pullPolicy: IfNotPresent
+  resources:
+    limits:
+      cpu: 1.5
+      memory: 2Gi
+    requests:
+      cpu: 1.5
+      memory: 2Gi
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  limits:
+    validator:
+      # -- Limit the number of connections per IP address per minute
+      connectionsPerIPPerMin: 2
+  config:
+    # -- Whether to send Proxy Protocol v2
+    send_proxy_protocol: &send_proxy_protocol false
+  # -- Name of the Kubernetes TLS secret to use for HAProxy
+  tls_secret:
+
 validator:
   # -- Internal: name of your validator for use in labels
   name:
@@ -47,24 +82,33 @@ validator:
   affinity: {}
   # -- Validator configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs
   config:
-    sync_only: false
-    concurrency_level: 8
-    round_initial_timeout_ms:
-    quorum_store_poll_count: 5
-    enable_state_store_pruner: true
-    enable_ledger_pruner: true
-    ledger_prune_window: 10000000
-    state_store_prune_window: 1000000
-    ledger_pruning_batch_size: 10000
-    state_store_pruning_batch_size: 10000
+    base: {}
+    consensus: {}
+    execution: {}
+    full_node_networks: []
+    inspection_service: {}
+    logger: {}
+    mempool:
+      shared_mempool_max_concurrent_inbound_syncs: 16 # default 4
+      max_broadcasts_per_peer: 2 # default 1
+      default_failovers: 0 # default 3
+    metrics: {}
+    peer_monitoring_service: {}
+    api: {}
+    state_sync: {}
+    firehose_stream: {}
+    storage: {}
+    test: {}
+    validator_network: {}
+    failpoints: {}
   # -- Lock down network ingress and egress with Kubernetes NetworkPolicy
   enableNetworkPolicy: true
 
 fullnode:
   # -- Specify fullnode groups by `name` and number of `replicas`
   groups:
-  - name: fullnode
-    replicas: 1
+    - name: fullnode
+      replicas: 1
   resources:
     limits:
       cpu: 15.5
@@ -84,50 +128,44 @@ fullnode:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  # -- Validator configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs
+  # -- Fullnode configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs
   config:
-    max_inbound_connections: 100
-    shared_mempool_max_concurrent_inbound_syncs: 16
-    max_broadcasts_per_peer: 2
-    default_failovers: 0
-
-haproxy:
-  # -- Enable HAProxy deployment in front of validator and fullnodes
-  enabled: true
-  # -- Number of HAProxy replicas
-  replicas: 1
-  image:
-    # -- Image repo to use for HAProxy images
-    repo: haproxy
-    # -- Image tag to use for HAProxy images
-    tag: 2.2.14@sha256:36aa98fff27dcb2d12c93e68515a6686378c783ea9b1ab1d01ce993a5cbc73e1
-    # -- Image pull policy to use for HAProxy images
-    pullPolicy: IfNotPresent
-  resources:
-    limits:
-      cpu: 1.5
-      memory: 2Gi
-    requests:
-      cpu: 1.5
-      memory: 2Gi
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
-  limits:
-    validator:
-      # -- Limit the number of connections per IP address per minute
-      connectionsPerIPPerMin: 2
-  config:
-    # -- Whether to send Proxy Protocol v2
-    send_proxy_protocol: false
-  # -- Name of the Kubernetes TLS secret to use for HAProxy
-  tls_secret:
+    base: {}
+    consensus: {}
+    execution: {}
+    # The below default values correctly configure a VFN to the onboard validator
+    # It's not recommended that you change it unless you know what you're doing
+    full_node_networks:
+      - network_id: "public"
+        discovery_method: "onchain"
+        listen_address: "/ip4/0.0.0.0/tcp/6182"
+        identity:
+          type: "from_file"
+          path: "/opt/aptos/genesis/validator-full-node-identity.yaml"
+        enable_proxy_protocol: *send_proxy_protocol
+        max_inbound_connections: 100
+        seeds: {}
+    inspection_service: {}
+    logger: {}
+    mempool:
+      shared_mempool_max_concurrent_inbound_syncs: 16 # default 4
+      max_broadcasts_per_peer: 2 # default 1
+      default_failovers: 0 # default 3
+    metrics: {}
+    peer_monitoring_service: {}
+    api: {}
+    state_sync: {}
+    firehose_stream: {}
+    storage: {}
+    test: {}
+    validator_network: {}
+    failpoints: {}
 
 service:
   # -- If set, the base domain name to use for External DNS
   domain:
   validator:
-    external: 
+    external:
       # -- The Kubernetes ServiceType to use for validator
       type: LoadBalancer
     # -- The externalTrafficPolicy for the validator service


### PR DESCRIPTION
### Description

Passing in individual helm values and having to template them in the validator/fullnode NodeConfigs is confusing and error prone. Especially is the case when the helm values do not match the same YAML structure as the NodeConfig struct in rust, nor the final/templated YAML. This PR gives operators two options for configuring their validators/fullnodes in the aptos-node hem chart:
1. Provide NodeConfig values in the structure as they are expected, in `.Values.validator.config` and `.Values.fullnode.config`. 
2. Option to specify `.Values.overrideNodeConfig`, and generate your own k8s ConfigMaps that hold the desired NodeConfig. One potential downside to this though is that operators would need to know the exact paths to the waypoint, genesis, etc which are specific to the helm chart since they're mounted at specific paths. This is why option (1) is probably preferred in most cases.

This unblocks Forge tests from having a cleaner programatic ability to change NodeConfigs from rust code. This also makes the helm chart in general more in tune with the actual configs expected by the rust code, without sacrificing usability or readability, and being more flexible at the same time.

### Test Plan

Apply in a testnet

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3257)
<!-- Reviewable:end -->
