### PR TITLE
[code publishing] Improve test speed, ensure error maps are included in build code

### DIFF
--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -173,8 +173,13 @@ impl MoveHarness {
 
     /// Creates a transaction which publishes the Move Package found at the given path on behalf
     /// of the given account.
-    pub fn create_publish_package(&mut self, account: &Account, path: &Path) -> SignedTransaction {
-        let package = BuiltPackage::build(path.to_owned(), BuildOptions::default())
+    pub fn create_publish_package(
+        &mut self,
+        account: &Account,
+        path: &Path,
+        options: Option<BuildOptions>,
+    ) -> SignedTransaction {
+        let package = BuiltPackage::build(path.to_owned(), options.unwrap_or_default())
             .expect("building package must succeed");
         let code = package.extract_code();
         let metadata = package
@@ -191,7 +196,18 @@ impl MoveHarness {
 
     /// Runs transaction which publishes the Move Package.
     pub fn publish_package(&mut self, account: &Account, path: &Path) -> TransactionStatus {
-        let txn = self.create_publish_package(account, path);
+        let txn = self.create_publish_package(account, path, None);
+        self.run(txn)
+    }
+
+    /// Runs transaction which publishes the Move Package.
+    pub fn publish_package_with_options(
+        &mut self,
+        account: &Account,
+        path: &Path,
+        options: BuildOptions,
+    ) -> TransactionStatus {
+        let txn = self.create_publish_package(account, path, Some(options));
         self.run(txn)
     }
 

--- a/aptos-move/e2e-move-tests/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/tests/code_publishing.rs
@@ -170,11 +170,13 @@ fn code_publishing_upgrade_loader_cache_consistency() {
         h.create_publish_package(
             &acc,
             &common::test_dir_path("code_publishing.data/pack_initial"),
+            None,
         ),
         // Compatible with above package
         h.create_publish_package(
             &acc,
             &common::test_dir_path("code_publishing.data/pack_upgrade_compat"),
+            None,
         ),
         // Not compatible with above package, but with first one.
         // Correct behavior: should create backward_incompatible error
@@ -182,6 +184,7 @@ fn code_publishing_upgrade_loader_cache_consistency() {
         h.create_publish_package(
             &acc,
             &common::test_dir_path("code_publishing.data/pack_compat_first_not_second"),
+            None,
         ),
     ];
     let result = h.run_block(txns);

--- a/aptos-move/e2e-move-tests/tests/error_map.rs
+++ b/aptos-move/e2e-move-tests/tests/error_map.rs
@@ -6,6 +6,7 @@ extern crate core;
 use aptos_types::account_address::AccountAddress;
 use aptos_types::transaction::{ExecutionStatus, TransactionStatus};
 use e2e_move_tests::{assert_success, MoveHarness};
+use framework::BuildOptions;
 use move_deps::move_core_types::value::MoveValue;
 use serde::{Deserialize, Serialize};
 
@@ -23,7 +24,14 @@ fn error_map() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("error_map.data/pack")));
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        &common::test_dir_path("error_map.data/pack"),
+        BuildOptions {
+            with_error_map: true,
+            ..BuildOptions::default()
+        }
+    ));
 
     // Now send transactions which abort with one of two errors, depending on the boolean parameter.
     let result = h.run_entry_function(

--- a/aptos-move/e2e-move-tests/tests/init_module.rs
+++ b/aptos-move/e2e-move-tests/tests/init_module.rs
@@ -20,7 +20,7 @@ fn init_module() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("init_module.data/pack"),));
+    assert_success!(h.publish_package(&acc, &common::test_dir_path("init_module.data/pack")));
 
     // Verify that init_module was called.
     let module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();

--- a/aptos-move/e2e-move-tests/tests/string_args.rs
+++ b/aptos-move/e2e-move-tests/tests/string_args.rs
@@ -20,7 +20,7 @@ fn string_args() {
 
     // Load the code
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack"),));
+    assert_success!(h.publish_package(&acc, &common::test_dir_path("string_args.data/pack")));
 
     let module_data = parse_struct_tag("0xCAFE::test::ModuleData").unwrap();
 

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -27,11 +27,11 @@ pub const UPGRADE_POLICY_CUSTOM_FIELD: &str = "upgrade_policy";
 /// Represents a set of options for building artifacts from Move.
 #[derive(Debug, Clone, Parser, Serialize, Deserialize)]
 pub struct BuildOptions {
-    #[clap(long, default_value = "true")]
+    #[clap(long)]
     pub with_srcs: bool,
-    #[clap(long, default_value = "true")]
+    #[clap(long)]
     pub with_abis: bool,
-    #[clap(long, default_value = "true")]
+    #[clap(long)]
     pub with_source_maps: bool,
     #[clap(long, default_value = "true")]
     pub with_error_map: bool,
@@ -47,9 +47,9 @@ pub struct BuildOptions {
 impl Default for BuildOptions {
     fn default() -> Self {
         Self {
-            with_srcs: true,
-            with_abis: true,
-            with_source_maps: true,
+            with_srcs: false,
+            with_abis: false,
+            with_source_maps: false,
             with_error_map: true,
             install_dir: None,
             named_addresses: Default::default(),

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -408,7 +408,8 @@ impl IncludedArtifacts {
                 with_srcs: false,
                 with_abis: false,
                 with_source_maps: false,
-                with_error_map: false,
+                // Always enable error map bytecode injection
+                with_error_map: true,
                 named_addresses,
                 install_dir: Option::None,
             },
@@ -416,7 +417,7 @@ impl IncludedArtifacts {
                 with_srcs: true,
                 with_abis: false,
                 with_source_maps: false,
-                with_error_map: false,
+                with_error_map: true,
                 named_addresses,
                 install_dir: Option::None,
             },


### PR DESCRIPTION
### Description

Small PR which slightly speeds up the e2e Move tests, avoiding creation of artifacts which aren't needed for a test. Flamegraph did show that those tests spend a lot of time in artifact generation.

This also fixes a small bug which let error maps be injected into bytecode only under certain settings. Error maps should always be injected, they aren't longer part of the package metadata.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3267)
<!-- Reviewable:end -->
