### PR TITLE
[Indexer] Fix diesel exceed max number of params during insert error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "clap 3.2.17",
  "diesel",
  "diesel_migrations",
+ "field_count",
  "futures",
  "once_cell",
  "reqwest",
@@ -3683,6 +3684,25 @@ name = "fiat-crypto"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35354cf6bf9d259374646f419a25c7dd0bb208d291e44dc73db557542fe017fc"
+
+[[package]]
+name = "field_count"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284d5f85dd574cf01094bca24aefa69a43539dbfc72b1326f038d540b2daadc7"
+dependencies = [
+ "field_count_derive",
+]
+
+[[package]]
+name = "field_count_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1320970ff3b1c1cacc6a38e8cdb1aced955f29627697cd992c5ded82eb646a8"
+dependencies = [
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
 
 [[package]]
 name = "fixedbitset"

--- a/ecosystem/indexer/Cargo.toml
+++ b/ecosystem/indexer/Cargo.toml
@@ -17,6 +17,7 @@ chrono = { version = "0.4.19", default-features = false, features = ["clock", "s
 clap = "3.1.17"
 diesel = { version = "1.4.8", features = ["chrono", "postgres", "r2d2", "numeric", "serde_json"] }
 diesel_migrations = { version = "1.4.0", features = ["postgres"] }
+field_count = "0.1.1"
 futures = "0.3.21"
 once_cell = "1.10.0"
 reqwest = { version = "0.11.10", features = ["json", "cookies"] }

--- a/ecosystem/indexer/src/database.rs
+++ b/ecosystem/indexer/src/database.rs
@@ -3,7 +3,7 @@
 
 //! Database-related functions
 #![allow(clippy::extra_unused_lifetimes)]
-use std::sync::Arc;
+use std::{cmp::min, sync::Arc};
 
 use diesel::{
     pg::PgConnection,
@@ -14,6 +14,25 @@ use diesel::{
 pub type PgPool = diesel::r2d2::Pool<ConnectionManager<PgConnection>>;
 pub type PgDbPool = Arc<PgPool>;
 pub type PgPoolConnection = PooledConnection<ConnectionManager<PgConnection>>;
+
+pub const MAX_DIESEL_PARAM_SIZE: u16 = u16::MAX;
+
+/// Given diesel has a limit of how many parameters can be inserted in a single operation (u16::MAX)
+/// we may need to chunk an array of items based on how many columns are in the table.
+/// This function returns boundaries of chunks in the form of (start_index, end_index)
+pub fn get_chunks(num_items_to_insert: usize, column_count: usize) -> Vec<(usize, usize)> {
+    let max_item_size = MAX_DIESEL_PARAM_SIZE as usize / column_count;
+    let mut chunk: (usize, usize) = (0, min(num_items_to_insert, max_item_size));
+    let mut chunks = vec![chunk];
+    while chunk.1 != num_items_to_insert {
+        chunk = (
+            chunk.0 + max_item_size,
+            min(num_items_to_insert, chunk.1 + max_item_size),
+        );
+        chunks.push(chunk);
+    }
+    chunks
+}
 
 pub fn new_db_pool(database_url: &str) -> Result<PgDbPool, PoolError> {
     let manager = ConnectionManager::<PgConnection>::new(database_url);
@@ -39,4 +58,28 @@ where
         aptos_logger::warn!("Error running query: {:?}\n{}", e, debug);
     }
     res
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_chunks_logic() {
+        assert_eq!(get_chunks(10, 5), vec![(0, 10)]);
+        assert_eq!(get_chunks(65535, 1), vec![(0, 65535)]);
+        // 200,000 total items will take 6 buckets. Each bucket can only be 3276 size.
+        assert_eq!(
+            get_chunks(10000, 20),
+            vec![(0, 3276), (3276, 6552), (6552, 9828), (9828, 10000)]
+        );
+        assert_eq!(
+            get_chunks(65535, 2),
+            vec![(0, 32767), (32767, 65534), (65534, 65535)]
+        );
+        assert_eq!(
+            get_chunks(65535, 3),
+            vec![(0, 21845), (21845, 43690), (43690, 65535)]
+        );
+    }
 }

--- a/ecosystem/indexer/src/models/events.rs
+++ b/ecosystem/indexer/src/models/events.rs
@@ -4,9 +4,10 @@
 use crate::{models::transactions::Transaction, schema::events};
 use aptos_rest_client::aptos_api_types::Event as APIEvent;
 use bigdecimal::{BigDecimal, FromPrimitive};
+use field_count::FieldCount;
 use serde::Serialize;
 
-#[derive(Associations, Debug, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Associations, Debug, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
 #[diesel(table_name = "events")]
 #[belongs_to(Transaction, foreign_key = "transaction_hash")]
 #[primary_key(key, sequence_number)]

--- a/ecosystem/indexer/src/models/write_set_changes.rs
+++ b/ecosystem/indexer/src/models/write_set_changes.rs
@@ -6,10 +6,13 @@ use aptos_rest_client::aptos_api_types::{
     DeleteModule, DeleteResource, DeleteTableItem, WriteModule, WriteResource,
     WriteSetChange as APIWriteSetChange, WriteTableItem,
 };
+use field_count::FieldCount;
 use serde::Serialize;
 use serde_json::json;
 
-#[derive(AsChangeset, Associations, Debug, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(
+    AsChangeset, Associations, Debug, FieldCount, Identifiable, Insertable, Queryable, Serialize,
+)]
 #[diesel(table_name = "write_set_changes")]
 #[belongs_to(Transaction, foreign_key = "transaction_hash")]
 #[primary_key(transaction_hash, hash)]


### PR DESCRIPTION
### Description
Diesel has a limitation of 65535 items (parameters) per insert (https://github.com/diesel-rs/diesel/issues/2414). We need to chunk inserts while respecting this limit

Running indexer would throw. `Error running query: DatabaseError(UnableToSendCommand, "number of parameters must be between 0 and 65535\n")`
```
cargo run -- --pg-uri "postgresql://localhost/postgres" --node-url "https://fullnode.devnet.aptoslabs.com/v1" --emit-every 25 --batch-size 100 --start-from-version 2871943 --skip-previous-errors
```

### Test Plan
Same command above would not throw. 
I want to add some tests around the chunking logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3269)
<!-- Reviewable:end -->
