### PR TITLE
[docs] fix coin initialize expects u8 for decimals

### DIFF
--- a/developer-docs-site/static/examples/python/first_coin.py
+++ b/developer-docs-site/static/examples/python/first_coin.py
@@ -22,7 +22,7 @@ class FirstCoin(RestClient):
             "arguments": [
                 "Moon Coin".encode("utf-8").hex(),
                 "MOON".encode("utf-8").hex(),
-                "6",
+                6,
                 False,
             ],
         }

--- a/developer-docs-site/static/examples/rust/first_coin/src/lib.rs
+++ b/developer-docs-site/static/examples/rust/first_coin/src/lib.rs
@@ -25,7 +25,7 @@ impl FirstCoinClient {
             "arguments": [
                 hex::encode("Moon Coin".as_bytes()),
                 hex::encode("MOON".as_bytes()),
-                "6",
+                6,
                 false,
             ]
         });


### PR DESCRIPTION
0x1::managed_coin::initialize expects u8 for decimals, not string
'The given transaction is invalid: Failed to parse transaction
payload: parse arguments[2] failed, expect integer, caused by error:
 invalid type: string "6", expected u8'

### Description

### Test Plan
To follow the tutorial in the docs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3272)
<!-- Reviewable:end -->
