### PR TITLE
[api] fix up goldens to be less noisy

### DIFF
--- a/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_entry_function_payload.json
+++ b/api/goldens/aptos_api__tests__transactions_test__test_get_transactions_output_user_transaction_with_entry_function_payload.json
@@ -52,11 +52,7 @@
         "state_key_hash": "",
         "data": {
           "type": "0x1::state_storage::StateStorageUsage",
-          "data": {
-            "bytes": "297183",
-            "epoch": "1",
-            "items": "100"
-          }
+          "data": "state storage omitted"
         },
         "type": "write_resource"
       },


### PR DESCRIPTION
the initial approach to stripping out some data seemed to work for only
a limited type that isn't even being tracked any more :O

this makes the code a lot more general purpose for all possible
resources...

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3273)
<!-- Reviewable:end -->
