### PR TITLE
Validated end-to-end governance upgrade

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -22,17 +22,8 @@ use aptos_keygen::KeyGen;
 use aptos_rest_client::aptos_api_types::HashValue;
 use aptos_rest_client::error::RestError;
 use aptos_rest_client::{Client, Transaction};
-use aptos_sdk::{
-    move_types::{
-        ident_str,
-        language_storage::{ModuleId, TypeTag},
-    },
-    transaction_builder::TransactionFactory,
-    types::LocalAccount,
-};
-use aptos_types::transaction::{
-    authenticator::AuthenticationKey, EntryFunction, TransactionPayload,
-};
+use aptos_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
+use aptos_types::transaction::{authenticator::AuthenticationKey, TransactionPayload};
 use async_trait::async_trait;
 use clap::{ArgEnum, Parser};
 use hex::FromHexError;
@@ -1104,24 +1095,6 @@ impl TransactionOptions {
     pub fn sender_address(&self) -> CliTypedResult<AccountAddress> {
         let sender_key = self.private_key()?;
         Ok(account_address_from_public_key(&sender_key.public_key()))
-    }
-
-    /// Submits an entry function based on module name and function inputs
-    pub async fn submit_entry_function(
-        &self,
-        address: AccountAddress,
-        module: &'static str,
-        function: &'static str,
-        type_args: Vec<TypeTag>,
-        args: Vec<Vec<u8>>,
-    ) -> CliTypedResult<Transaction> {
-        let txn = TransactionPayload::EntryFunction(EntryFunction::new(
-            ModuleId::new(address, ident_str!(module).to_owned()),
-            ident_str!(function).to_owned(),
-            type_args,
-            args,
-        ));
-        self.submit_transaction(txn).await
     }
 
     /// Submit a transaction


### PR DESCRIPTION
* Accidentally confused myself on hash values and ported the script hash to use the same as the block, which is address (u32) -- this is up for debate, but it is ... kinda nicer
* There were breakages in the CLI tool possibly due to not using the aptos_stdlib generated transaction builder
* Simplified the execute proposal so that people like me can use it easier
* Removed submit_entry_function from the CLI since it isn't used and should have no usage for the foreseeable future

Somethings one has to do to test (and sadly I wiped away some of my changes):

```
diff --git a/aptos-move/framework/aptos-framework/sources/aptos_governance.move b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
index 5ea08f34b1..85310e666a 100644
--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -247,6 +247,8 @@ module aptos_framework::aptos_governance {
             let total_supply = *option::borrow(&total_voting_token_supply);
             // 50% + 1 to avoid rounding errors.
             early_resolution_vote_threshold = option::some(total_supply / 2 + 1);
+        } else {
+            early_resolution_vote_threshold = option::some(0);
         };

         let proposal_id = voting::create_proposal(
diff --git a/aptos-move/vm-genesis/src/lib.rs b/aptos-move/vm-genesis/src/lib.rs
index 4517926885..48b4786b57 100644
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -598,7 +598,7 @@ pub fn generate_mainnet_genesis(
             is_test: false,
             min_stake: 1_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 1M APT
             // 400M APT
-            min_voting_threshold: (400_000_000 * APTOS_COINS_BASE_WITH_DECIMALS as u128),
+            min_voting_threshold: (00_000_000 * APTOS_COINS_BASE_WITH_DECIMALS as u128),
             max_stake: 50_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 50M APT.
             recurring_lockup_duration_secs: 30 * 24 * 3600,         // 1 month
             required_proposer_stake: 1_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 1M APT
```

Also the metadata submission is not great, since it requires and active URL with the proper json blob. I propose we offer a URL and an optional path to a local file -- that will be uploaded assuming all goes well. Future PRs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3279)
<!-- Reviewable:end -->
