### PR TITLE
[on-chain package data] Consolidate on-chain package data

### DIFF
--- a/aptos-move/aptos-sdk-builder/tests/generation.rs
+++ b/aptos-move/aptos-sdk-builder/tests/generation.rs
@@ -84,8 +84,10 @@ test = false
 // transaction builder does not support (it doesn't supported typed functions yet).
 #[ignore]
 fn test_that_rust_entry_fun_code_compiles() {
+    // TODO: need a way to get abis to reactivate this test
+    let abis = vec![];
     test_rust(
-        &cached_packages::head_release_bundle().abis(),
+        &abis, // &cached_packages::head_release_bundle().abis(),
         "examples/rust/script_fun_demo.rs",
         EXPECTED_SCRIPT_FUN_OUTPUT,
     );

--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -17,13 +17,9 @@ fn main() {
         println!("cargo:rerun-if-changed=../move-stdlib/sources");
         println!("cargo:rerun-if-changed=../move-stdlib/Move.toml");
         ReleaseTarget::Head
-            .create_release(
-                true,
-                Some(
-                    PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR defined"))
-                        .join("head.mrb"),
-                ),
-            )
+            .create_release(Some(
+                PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR defined")).join("head.mrb"),
+            ))
             .expect("release build failed");
     }
 }

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -104,15 +104,6 @@ pub enum EntryFunctionCall {
         should_pass: bool,
     },
 
-    /// Same as `publish_package_txn` but allows to split the metadata into multiple parts for working around
-    /// size constraints.
-    CodePublishPackageChunk3Txn {
-        metadata_chunk1: Vec<u8>,
-        metadata_chunk2: Vec<u8>,
-        metadata_chunk3: Vec<u8>,
-        code: Vec<Vec<u8>>,
-    },
-
     /// Same as `publish_package` but as an entry function which can be called as a transaction. Because
     /// of current restrictions for txn parameters, the metadata needs to be passed in serialized form.
     CodePublishPackageTxn {
@@ -318,17 +309,6 @@ impl EntryFunctionCall {
                 proposal_id,
                 should_pass,
             } => aptos_governance_vote(stake_pool, proposal_id, should_pass),
-            CodePublishPackageChunk3Txn {
-                metadata_chunk1,
-                metadata_chunk2,
-                metadata_chunk3,
-                code,
-            } => code_publish_package_chunk3_txn(
-                metadata_chunk1,
-                metadata_chunk2,
-                metadata_chunk3,
-                code,
-            ),
             CodePublishPackageTxn {
                 metadata_serialized,
                 code,
@@ -630,33 +610,6 @@ pub fn aptos_governance_vote(
             bcs::to_bytes(&stake_pool).unwrap(),
             bcs::to_bytes(&proposal_id).unwrap(),
             bcs::to_bytes(&should_pass).unwrap(),
-        ],
-    ))
-}
-
-/// Same as `publish_package_txn` but allows to split the metadata into multiple parts for working around
-/// size constraints.
-pub fn code_publish_package_chunk3_txn(
-    metadata_chunk1: Vec<u8>,
-    metadata_chunk2: Vec<u8>,
-    metadata_chunk3: Vec<u8>,
-    code: Vec<Vec<u8>>,
-) -> TransactionPayload {
-    TransactionPayload::EntryFunction(EntryFunction::new(
-        ModuleId::new(
-            AccountAddress::new([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 1,
-            ]),
-            ident_str!("code").to_owned(),
-        ),
-        ident_str!("publish_package_chunk3_txn").to_owned(),
-        vec![],
-        vec![
-            bcs::to_bytes(&metadata_chunk1).unwrap(),
-            bcs::to_bytes(&metadata_chunk2).unwrap(),
-            bcs::to_bytes(&metadata_chunk3).unwrap(),
-            bcs::to_bytes(&code).unwrap(),
         ],
     ))
 }
@@ -1249,21 +1202,6 @@ mod decoder {
         }
     }
 
-    pub fn code_publish_package_chunk3_txn(
-        payload: &TransactionPayload,
-    ) -> Option<EntryFunctionCall> {
-        if let TransactionPayload::EntryFunction(script) = payload {
-            Some(EntryFunctionCall::CodePublishPackageChunk3Txn {
-                metadata_chunk1: bcs::from_bytes(script.args().get(0)?).ok()?,
-                metadata_chunk2: bcs::from_bytes(script.args().get(1)?).ok()?,
-                metadata_chunk3: bcs::from_bytes(script.args().get(2)?).ok()?,
-                code: bcs::from_bytes(script.args().get(3)?).ok()?,
-            })
-        } else {
-            None
-        }
-    }
-
     pub fn code_publish_package_txn(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::CodePublishPackageTxn {
@@ -1580,10 +1518,6 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "aptos_governance_vote".to_string(),
             Box::new(decoder::aptos_governance_vote),
-        );
-        map.insert(
-            "code_publish_package_chunk3_txn".to_string(),
-            Box::new(decoder::code_publish_package_chunk3_txn),
         );
         map.insert(
             "code_publish_package_txn".to_string(),

--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -86,7 +86,7 @@ impl ReleaseTarget {
         ReleaseBundle::read(path)
     }
 
-    pub fn create_release(self, strip: bool, out: Option<PathBuf>) -> anyhow::Result<()> {
+    pub fn create_release(self, out: Option<PathBuf>) -> anyhow::Result<()> {
         let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let packages = self
             .packages()
@@ -99,7 +99,7 @@ impl ReleaseTarget {
             build_options: BuildOptions {
                 with_srcs: true,
                 with_abis: true,
-                with_source_maps: true,
+                with_source_maps: false,
                 with_error_map: true,
                 named_addresses: Default::default(),
                 install_dir: None,
@@ -122,7 +122,7 @@ impl ReleaseTarget {
                 PathBuf::from(self.file_name())
             },
         };
-        options.create_release(strip)
+        options.create_release()
     }
 }
 

--- a/aptos-move/framework/src/lib.rs
+++ b/aptos-move/framework/src/lib.rs
@@ -38,16 +38,25 @@ pub(crate) fn path_relative_to_crate(path: PathBuf) -> PathBuf {
     path.strip_prefix(crate_path).unwrap_or(&path).to_path_buf()
 }
 
-pub fn zip_metadata(data: &[u8]) -> anyhow::Result<String> {
+pub fn zip_metadata(data: &[u8]) -> anyhow::Result<Vec<u8>> {
     let mut e = GzEncoder::new(Vec::new(), Compression::best());
     e.write_all(data)?;
-    Ok(base64::encode(e.finish()?))
+    Ok(e.finish()?)
 }
 
-pub fn unzip_metadata(data: &str) -> anyhow::Result<Vec<u8>> {
-    let bytes = base64::decode(data)?;
-    let mut d = GzDecoder::new(bytes.as_slice());
+pub fn zip_metadata_str(s: &str) -> anyhow::Result<Vec<u8>> {
+    zip_metadata(s.as_bytes())
+}
+
+pub fn unzip_metadata(data: &[u8]) -> anyhow::Result<Vec<u8>> {
+    let mut d = GzDecoder::new(data);
     let mut res = vec![];
     d.read_to_end(&mut res)?;
     Ok(res)
+}
+
+pub fn unzip_metadata_str(data: &[u8]) -> anyhow::Result<String> {
+    let r = unzip_metadata(data)?;
+    let s = String::from_utf8(r)?;
+    Ok(s)
 }

--- a/aptos-move/framework/src/main.rs
+++ b/aptos-move/framework/src/main.rs
@@ -39,7 +39,7 @@ struct CustomRelease {
 
 impl CustomRelease {
     fn execute(self) -> anyhow::Result<()> {
-        self.options.create_release(true)
+        self.options.create_release()
     }
 }
 
@@ -53,14 +53,10 @@ struct StandardRelease {
     /// some packages may be available in testnet, but aren't in mainnet.
     #[clap(long, default_value = "head")]
     target: ReleaseTarget,
-    /// Whether to reduce metadata to a minimum for saving space. This is currently the default
-    /// until we figured a better solution for the sice problem.
-    #[clap(long, default_value = "true")]
-    strip: bool,
 }
 
 impl StandardRelease {
     fn execute(self) -> anyhow::Result<()> {
-        self.target.create_release(self.strip, None)
+        self.target.create_release(None)
     }
 }

--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -17,7 +17,7 @@ use move_deps::{
         loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
     },
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use smallvec::smallvec;
 use std::collections::{BTreeSet, VecDeque};
 use std::fmt;
@@ -31,34 +31,23 @@ pub struct PackageRegistry {
     pub packages: Vec<PackageMetadata>,
 }
 
-/// The PackageMetadata type. All blobs are encoded as base64-gzipped.
+/// The PackageMetadata type. This must be kept in sync with `code.move`. Documentation is
+/// also found there.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PackageMetadata {
-    /// Name of this package.
     pub name: String,
-    /// The upgrade policy of this package.
     pub upgrade_policy: UpgradePolicy,
-    /// The numbers of times this module has been upgraded. Also serves as the on-chain version.
-    /// This field will be automatically assigned on successful upgrade.
     pub upgrade_number: u64,
-    /// Build info, in BuildInfo.yaml format
-    pub build_info: String,
-    /// The package manifest, in the Move.toml format.
-    pub manifest: String,
-    /// The list of modules installed by this package.
+    pub source_digest: String,
+    pub manifest: Vec<u8>,
     pub modules: Vec<ModuleMetadata>,
-    /// ABIs, in compressed BCS
-    pub abis: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModuleMetadata {
-    /// Name of the module.
     pub name: String,
-    /// Source text if available, in compressed form.
-    pub source: String,
-    /// Source map, in BCS encoding, in compressed form.
-    pub source_map: String,
+    pub source: Vec<u8>,
+    pub source_map: Vec<u8>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -98,43 +87,6 @@ impl fmt::Display for UpgradePolicy {
             _ => "immutable",
         })
     }
-}
-
-// ========================================================================================
-// Duplication for JSON
-
-// For JSON we need attributes on fields which aren't compatible with BCS, therefore we
-// need to duplicate the definitions...
-
-fn deserialize_from_string<'de, D, T>(deserializer: D) -> Result<T, D::Error>
-where
-    D: Deserializer<'de>,
-    T: FromStr,
-    <T as FromStr>::Err: std::fmt::Display,
-{
-    use serde::de::Error;
-
-    let s = <String>::deserialize(deserializer)?;
-    s.parse::<T>().map_err(D::Error::custom)
-}
-
-/// The package registry at the given address.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct PackageRegistryJson {
-    pub packages: Vec<PackageMetadataJson>,
-}
-
-/// The PackageMetadata type, with an annotation on `upgrade_number`.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct PackageMetadataJson {
-    pub name: String,
-    pub upgrade_policy: UpgradePolicy,
-    #[serde(deserialize_with = "deserialize_from_string")]
-    pub upgrade_number: u64,
-    pub build_info: String,
-    pub manifest: String,
-    pub modules: Vec<ModuleMetadata>,
-    pub abis: Vec<String>,
 }
 
 // ========================================================================================

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -472,13 +472,13 @@ impl CliCommand<TransactionSummary> for PublishPackage {
                 compiled_units,
             );
             let size = bcs::serialized_size(&payload)?;
+            println!("package size {} bytes", size);
             if !override_size_check && size > MAX_PUBLISH_PACKAGE_SIZE {
                 return Err(CliError::UnexpectedError(format!(
-                    "The package is larger than {}k ({}k)! To lower the size \
+                    "The package is larger than {} bytes ({} bytes)! To lower the size \
                 you may want to include less artifacts via `--included_artifacts`. \
                 You can also override this check with `--override-size-check",
-                    MAX_PUBLISH_PACKAGE_SIZE / 1000,
-                    size / 1000
+                    MAX_PUBLISH_PACKAGE_SIZE, size
                 )));
             }
             txn_options
@@ -537,7 +537,7 @@ impl CliCommand<&'static str> for DownloadPackage {
         }
         let package_path = output_dir.join(package.name());
         package
-            .save_package_to_disk(package_path.as_path(), true)
+            .save_package_to_disk(package_path.as_path())
             .map_err(|e| CliError::UnexpectedError(format!("Failed to save package: {}", e)))?;
         println!(
             "Saved package with {} module(s) to `{}`",
@@ -605,11 +605,8 @@ impl CliCommand<&'static str> for ListPackage {
                     println!("package {}", data.name());
                     println!("  upgrade_policy: {}", data.upgrade_policy());
                     println!("  upgrade_number: {}", data.upgrade_number());
+                    println!("  source_digest: {}", data.source_digest());
                     println!("  modules: {}", data.module_names().into_iter().join(", "));
-                    println!(
-                        "  build_info:\n    {}",
-                        data.build_info().replace('\n', "\n    ")
-                    );
                 }
             }
         }

--- a/crates/aptos/src/move_tool/package_hooks.rs
+++ b/crates/aptos/src/move_tool/package_hooks.rs
@@ -47,7 +47,7 @@ async fn maybe_download_package(info: &CustomDepInfo) -> anyhow::Result<()> {
         )
         .await?;
         let package = registry.get_package(info.package_name).await?;
-        package.save_package_to_disk(info.download_to.as_path(), true)
+        package.save_package_to_disk(info.download_to.as_path())
     } else {
         Ok(())
     }

--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -4,15 +4,12 @@
 use anyhow::bail;
 use aptos_rest_client::Client;
 use aptos_types::account_address::AccountAddress;
-use aptos_types::transaction::EntryABI;
-use framework::natives::code::{
-    ModuleMetadata, PackageMetadata, PackageRegistry, PackageRegistryJson, UpgradePolicy,
-};
-use framework::unzip_metadata;
+use framework::natives::code::{ModuleMetadata, PackageMetadata, PackageRegistry, UpgradePolicy};
+use framework::unzip_metadata_str;
 use move_deps::move_package::compilation::package_layout::CompiledPackageLayout;
 use reqwest::Url;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 // TODO: this is a first naive implementation of the package registry. Before mainnet
 // we need to use tables for the package registry.
@@ -37,11 +34,10 @@ impl CachedPackageRegistry {
     pub async fn create(url: Url, addr: AccountAddress) -> anyhow::Result<Self> {
         let client = Client::new(url);
         // Need to use a different type to deserialize JSON
-        let from_json = client
-            .get_resource::<PackageRegistryJson>(addr, "0x1::code::PackageRegistry")
+        let inner = client
+            .get_account_resource_bcs::<PackageRegistry>(addr, "0x1::code::PackageRegistry")
             .await?
             .into_inner();
-        let inner = bcs::from_bytes::<PackageRegistry>(&bcs::to_bytes(&from_json)?)?;
         Ok(Self { inner })
     }
 
@@ -98,16 +94,12 @@ impl<'a> CachedPackageMetadata<'a> {
         self.metadata.upgrade_number
     }
 
-    pub fn build_info(&self) -> &str {
-        &self.metadata.build_info
+    pub fn source_digest(&self) -> &str {
+        &self.metadata.source_digest
     }
 
-    pub fn manifest(&self) -> &str {
-        &self.metadata.manifest
-    }
-
-    pub fn abis(&self) -> &[String] {
-        self.metadata.abis.as_slice()
+    pub fn manifest(&self) -> anyhow::Result<String> {
+        unzip_metadata_str(&self.metadata.manifest)
     }
 
     pub fn module_names(&self) -> Vec<&str> {
@@ -128,45 +120,17 @@ impl<'a> CachedPackageMetadata<'a> {
         bail!("module `{}` not found", name)
     }
 
-    pub fn save_package_to_disk(
-        &self,
-        path: &Path,
-        with_derived_artifacts: bool,
-    ) -> anyhow::Result<()> {
+    pub fn save_package_to_disk(&self, path: &Path) -> anyhow::Result<()> {
         fs::create_dir_all(path)?;
-        fs::write(path.join("Move.toml"), &self.metadata.manifest)?;
-        fs::write(path.join("BuildInfo.yaml"), &self.metadata.build_info)?;
+        fs::write(
+            path.join("Move.toml"),
+            unzip_metadata_str(&self.metadata.manifest)?,
+        )?;
         let sources_dir = path.join(CompiledPackageLayout::Sources.path());
         fs::create_dir_all(&sources_dir)?;
         for module in &self.metadata.modules {
-            let source = std::str::from_utf8(&unzip_metadata(&module.source)?)?.to_string();
+            let source = unzip_metadata_str(&module.source)?;
             fs::write(sources_dir.join(format!("{}.move", module.name)), source)?;
-        }
-        if with_derived_artifacts {
-            let abis_dir = path.join(CompiledPackageLayout::CompiledABIs.path());
-            for abi_blob in &self.metadata.abis {
-                let abi = bcs::from_bytes::<EntryABI>(&unzip_metadata(abi_blob)?)?;
-                let path = match abi {
-                    EntryABI::TransactionScript(abi) => {
-                        PathBuf::from(format!("{}.abi", abi.name()))
-                    }
-                    EntryABI::EntryFunction(abi) => {
-                        PathBuf::from(abi.module_name().name().as_str())
-                            .join(format!("{}.abi", abi.name()))
-                    }
-                };
-                let dest = abis_dir.join(path);
-                fs::create_dir_all(&dest.parent().unwrap())?;
-                fs::write(dest, abi_blob)?
-            }
-            let source_map_dir = path.join(CompiledPackageLayout::SourceMaps.path());
-            fs::create_dir_all(&source_map_dir)?;
-            for module in &self.metadata.modules {
-                fs::write(
-                    source_map_dir.join(format!("{}.mvsm", module.name)),
-                    &unzip_metadata(&module.source_map)?,
-                )?;
-            }
         }
         Ok(())
     }
@@ -177,11 +141,11 @@ impl<'a> CachedModuleMetadata<'a> {
         &self.metadata.name
     }
 
-    pub fn zipped_source(&self) -> &str {
+    pub fn zipped_source(&self) -> &[u8] {
         &self.metadata.source
     }
 
-    pub fn zipped_source_map_raw(&self) -> &str {
+    pub fn zipped_source_map_raw(&self) -> &[u8] {
         &self.metadata.source_map
     }
 }


### PR DESCRIPTION
### Description

This consolidates on-chain package data and finalizes the on-chain representation:

- Remove all hacks for JSON via the API. Instead request BCS. This allows us to make the representation on-chain as it is supposed to be logically.
- Remove ABIs from metadata because they are clearly derivable from byte code (as the existing API code for list of modules already shows).
- Remove the verbose BuildInfo from metadata, instead have a dedicated field `source_digest`, the real information one needs.
- Moving composition of chunks for publish from entry function to client.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3281)
<!-- Reviewable:end -->
