### PR TITLE
[Data Streaming Service] Improve stream visibility and termination.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8802,6 +8802,7 @@ dependencies = [
  "move-deps",
  "network",
  "once_cell",
+ "rand 0.7.3",
  "schemadb",
  "scratchpad",
  "serde 1.0.143",

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -155,7 +155,7 @@ impl Default for DataStreamingServiceConfig {
             max_concurrent_state_requests: 4,
             max_data_stream_channel_sizes: 1000,
             max_request_retry: 3,
-            max_notification_id_mappings: 2000,
+            max_notification_id_mappings: 300,
             progress_check_interval_ms: 100,
         }
     }

--- a/state-sync/state-sync-v2/data-streaming-service/src/logging.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/logging.rs
@@ -40,6 +40,7 @@ pub enum LogEntry {
     RespondToStreamRequest,
     SendDataRequests,
     StreamNotification,
+    TerminateStream,
 }
 
 #[derive(Clone, Copy, Serialize)]

--- a/state-sync/state-sync-v2/data-streaming-service/src/metrics.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/metrics.rs
@@ -2,9 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{
-    register_histogram_vec, register_int_counter_vec, HistogramTimer, HistogramVec, IntCounterVec,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+    HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge,
 };
 use once_cell::sync::Lazy;
+
+/// Counter for the number of active data streams
+pub static ACTIVE_DATA_STREAMS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_data_streaming_service_active_data_streams",
+        "Counters related to the number of active data streams",
+    )
+    .unwrap()
+});
+
+/// Counter for the number of times there was a send failure
+pub static DATA_STREAM_SEND_FAILURE: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_data_streaming_service_stream_send_failure",
+        "Counters related to send failures along the data stream",
+    )
+    .unwrap()
+});
 
 /// Counter for the creation of new data streams
 pub static CREATE_DATA_STREAM: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -87,8 +106,13 @@ pub static DATA_REQUEST_PROCESSING_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
 });
 
 /// Increments the given counter with the provided label values.
-pub fn increment_counter(counter: &Lazy<IntCounterVec>, label: String) {
-    counter.with_label_values(&[&label]).inc();
+pub fn increment_counter(counter: &Lazy<IntCounterVec>, label: &str) {
+    counter.with_label_values(&[label]).inc();
+}
+
+/// Sets the number of active data streams
+pub fn set_active_data_streams(value: usize) {
+    ACTIVE_DATA_STREAMS.set(value as i64);
 }
 
 /// Starts the timer for the provided histogram and label values.

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
@@ -23,6 +23,7 @@ use tokio_stream::wrappers::IntervalStream;
 const GLOBAL_DATA_REFRESH_LOG_FREQ_SECS: u64 = 3;
 const NO_DATA_TO_FETCH_LOG_FREQ_SECS: u64 = 3;
 const STREAM_REQUEST_ERROR_LOG_FREQ_SECS: u64 = 3;
+const TERMINATE_NO_FEEDBACK: &str = "no_feedback";
 
 /// The data streaming service that responds to data stream requests.
 pub struct DataStreamingService<T> {
@@ -123,44 +124,58 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
         }
     }
 
-    /// Processes a request for terminating the stream that sent a specific
-    /// notification ID.
+    /// Processes a request for terminating a data stream.
     /// TODO(joshlind): once this is exposed to the wild, we'll need automatic
     /// garbage collection for misbehaving clients.
     fn process_terminate_stream_request(
         &mut self,
         terminate_request: &TerminateStreamRequest,
     ) -> Result<(), Error> {
+        // Grab the stream id and feedback
+        let data_stream_id = &terminate_request.data_stream_id;
+        let notification_and_feedback = &terminate_request.notification_and_feedback;
+
         // Increment the stream termination counter
-        let notification_feedback = &terminate_request.notification_feedback;
-        metrics::increment_counter(
-            &metrics::TERMINATE_DATA_STREAM,
-            notification_feedback.get_label().into(),
-        );
-
-        // Find the data stream that sent the notification
-        let notification_id = &terminate_request.notification_id;
-        let data_stream_ids = self.get_all_data_stream_ids();
-        for data_stream_id in &data_stream_ids {
-            let data_stream = self.get_data_stream(data_stream_id);
-            if data_stream.sent_notification(notification_id) {
-                info!(LogSchema::new(LogEntry::HandleTerminateRequest)
-                    .stream_id(*data_stream_id)
-                    .event(LogEvent::Success)
-                    .message(&format!(
-                        "Terminating the stream that sent notification ID: {:?}. Feedback: {:?}",
-                        notification_id, notification_feedback,
-                    )));
-                data_stream.handle_notification_feedback(notification_id, notification_feedback)?;
-                self.data_streams.remove(notification_id);
-                return Ok(());
+        let feedback_label = match notification_and_feedback {
+            Some(notification_and_feedback) => {
+                notification_and_feedback.notification_feedback.get_label()
             }
-        }
+            None => TERMINATE_NO_FEEDBACK,
+        };
+        metrics::increment_counter(&metrics::TERMINATE_DATA_STREAM, feedback_label);
 
-        panic!(
-            "Unable to find the stream that sent notification ID: {:?}. Feedback: {:?}",
-            notification_id, notification_feedback,
-        );
+        // Remove the data stream
+        if let Some(data_stream) = self.data_streams.remove(data_stream_id) {
+            info!(LogSchema::new(LogEntry::HandleTerminateRequest)
+                .stream_id(*data_stream_id)
+                .event(LogEvent::Success)
+                .message(&format!(
+                    "Terminating the data stream with ID: {:?}. Notification and feedback: {:?}",
+                    data_stream_id, notification_and_feedback,
+                )));
+
+            // Handle any notification feedback
+            if let Some(notification_and_feedback) = notification_and_feedback {
+                let notification_id = &notification_and_feedback.notification_id;
+                let feedback = &notification_and_feedback.notification_feedback;
+                if data_stream.sent_notification(notification_id) {
+                    data_stream.handle_notification_feedback(notification_id, feedback)?;
+                    Ok(())
+                } else {
+                    Err(Error::UnexpectedErrorEncountered(format!(
+                        "Data stream ID: {:?} did not appear to send notification ID: {:?}",
+                        data_stream_id, notification_id,
+                    )))
+                }
+            } else {
+                Ok(())
+            }
+        } else {
+            Err(Error::UnexpectedErrorEncountered(format!(
+                "Unable to find data stream with ID: {:?}. Notification and feedback: {:?}",
+                data_stream_id, notification_and_feedback,
+            )))
+        }
     }
 
     /// Creates a new stream and ensures the data for that stream is available
@@ -171,7 +186,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
         // Increment the stream creation counter
         metrics::increment_counter(
             &metrics::CREATE_DATA_STREAM,
-            request_message.stream_request.get_label().into(),
+            request_message.stream_request.get_label(),
         );
 
         // Refresh the cached global data summary
@@ -213,10 +228,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
     /// Refreshes the global data summary by communicating with the Aptos data client
     fn refresh_global_data_summary(&mut self) {
         if let Err(error) = self.fetch_global_data_summary() {
-            metrics::increment_counter(
-                &metrics::GLOBAL_DATA_SUMMARY_ERROR,
-                error.get_label().into(),
-            );
+            metrics::increment_counter(&metrics::GLOBAL_DATA_SUMMARY_ERROR, error.get_label());
             sample!(
                 SampleRate::Duration(Duration::from_secs(GLOBAL_DATA_REFRESH_LOG_FREQ_SECS)),
                 error!(LogSchema::new(LogEntry::RefreshGlobalData)
@@ -244,6 +256,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
 
     /// Ensures that all existing data streams are making progress
     fn check_progress_of_all_data_streams(&mut self) {
+        // Drive the progress of each stream
         let data_stream_ids = self.get_all_data_stream_ids();
         for data_stream_id in &data_stream_ids {
             if let Err(error) = self.update_progress_of_data_stream(data_stream_id) {
@@ -258,7 +271,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
                 } else {
                     metrics::increment_counter(
                         &metrics::CHECK_STREAM_PROGRESS_ERROR,
-                        error.get_label().into(),
+                        error.get_label(),
                     );
                     error!(LogSchema::new(LogEntry::CheckStreamProgress)
                         .stream_id(*data_stream_id)
@@ -267,6 +280,9 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
                 }
             }
         }
+
+        // Update the metrics
+        metrics::set_active_data_streams(data_stream_ids.len());
     }
 
     /// Ensures that a data stream has in-flight data requests and handles
@@ -277,7 +293,26 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
     ) -> Result<(), Error> {
         let global_data_summary = self.global_data_summary.clone();
 
-        let data_stream = self.get_data_stream_mut(data_stream_id);
+        // If there was a send failure, terminate the stream
+        let data_stream = self.get_data_stream(data_stream_id);
+        if data_stream.send_failure() {
+            info!(
+                (LogSchema::new(LogEntry::TerminateStream)
+                    .stream_id(*data_stream_id)
+                    .event(LogEvent::Success)
+                    .message("There was a send failure, terminating the stream."))
+            );
+            metrics::DATA_STREAM_SEND_FAILURE.inc();
+            if self.data_streams.remove(data_stream_id).is_none() {
+                return Err(Error::UnexpectedErrorEncountered(format!(
+                    "Failed to terminate stream id {:?} for send failure! Stream not found.",
+                    data_stream_id
+                )));
+            }
+            return Ok(());
+        }
+
+        // Drive data stream progress
         if !data_stream.data_requests_initialized() {
             // Initialize the request batch by sending out data client requests
             data_stream.initialize_data_requests(global_data_summary)?;
@@ -304,18 +339,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStreamingService<T> {
 
     /// Returns the data stream associated with the given `data_stream_id`.
     /// Note: this method assumes the caller has already verified the stream exists.
-    fn get_data_stream(&self, data_stream_id: &DataStreamId) -> &DataStream<T> {
-        self.data_streams.get(data_stream_id).unwrap_or_else(|| {
-            panic!(
-                "Expected a data stream with ID: {:?}, but found None!",
-                data_stream_id
-            )
-        })
-    }
-
-    /// Returns the data stream associated with the given `data_stream_id`.
-    /// Note: this method assumes the caller has already verified the stream exists.
-    fn get_data_stream_mut(&mut self, data_stream_id: &DataStreamId) -> &mut DataStream<T> {
+    fn get_data_stream(&mut self, data_stream_id: &DataStreamId) -> &mut DataStream<T> {
         self.data_streams
             .get_mut(data_stream_id)
             .unwrap_or_else(|| {
@@ -341,5 +365,232 @@ fn verify_optimal_chunk_sizes(optimal_chunk_sizes: &OptimalChunkSizes) -> Result
         )))
     } else {
         Ok(())
+    }
+}
+
+/// Unit tests for the streaming service. We place these here to inspect
+/// the internal state of the object.
+#[cfg(test)]
+mod streaming_service_tests {
+    use crate::data_stream::{DataStreamId, DataStreamListener};
+    use crate::error::Error;
+    use crate::streaming_client::{
+        GetAllStatesRequest, NotificationAndFeedback, NotificationFeedback, StreamRequest,
+        StreamRequestMessage, TerminateStreamRequest,
+    };
+    use crate::tests;
+    use crate::tests::utils::MIN_ADVERTISED_STATES;
+    use futures::channel::oneshot;
+    use futures::channel::oneshot::Receiver;
+    use futures::FutureExt;
+    use futures::StreamExt;
+    use std::ops::Add;
+    use std::time::{Duration, Instant};
+    use tokio::time::timeout;
+
+    const MAX_STREAM_WAIT_SECS: u64 = 60;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_drop_data_streams() {
+        // Create a new streaming service
+        let (_, mut streaming_service) =
+            tests::streaming_service::create_streaming_client_and_server(false, false, true);
+
+        // Create multiple data streams
+        let num_data_streams = 10;
+        let mut stream_ids = vec![];
+        for _ in 0..num_data_streams {
+            // Create a new data stream
+            let (new_stream_request, response_receiver) = create_new_stream_request();
+            streaming_service.handle_stream_request_message(new_stream_request);
+            let data_stream_listener = response_receiver.now_or_never().unwrap().unwrap().unwrap();
+            let data_stream_id = data_stream_listener.data_stream_id;
+
+            // Remember the data stream id and drop the listener
+            stream_ids.push(data_stream_id);
+        }
+
+        // Verify the number of active data streams
+        assert_eq!(
+            streaming_service.get_all_data_stream_ids().len(),
+            num_data_streams
+        );
+
+        // Drive progress of the streaming service (the streaming service
+        // should detect the dropped listeners and remove the streams).
+        let timeout_deadline = Instant::now().add(Duration::from_secs(MAX_STREAM_WAIT_SECS));
+        while Instant::now() < timeout_deadline {
+            streaming_service.check_progress_of_all_data_streams();
+            if streaming_service.get_all_data_stream_ids().is_empty() {
+                return; // All streams were dropped!
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        panic!("The streaming service failed to drop the data streams!");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_terminate_data_streams() {
+        // Create a new streaming service
+        let (_, mut streaming_service) =
+            tests::streaming_service::create_streaming_client_and_server(false, false, true);
+
+        // Verify there are no data streams
+        assert!(streaming_service.get_all_data_stream_ids().is_empty());
+
+        // Create multiple data streams
+        let num_data_streams = 10;
+        let mut stream_ids_and_listeners = vec![];
+        for _ in 0..num_data_streams {
+            // Create a new data stream
+            let (new_stream_request, response_receiver) = create_new_stream_request();
+            streaming_service.handle_stream_request_message(new_stream_request);
+            let data_stream_listener = response_receiver.now_or_never().unwrap().unwrap().unwrap();
+            let data_stream_id = data_stream_listener.data_stream_id;
+
+            // Verify the data stream is actively held by the streaming service
+            let all_data_stream_ids = streaming_service.get_all_data_stream_ids();
+            assert!(all_data_stream_ids.contains(&data_stream_id));
+
+            // Remember the data stream id and listener
+            stream_ids_and_listeners.push((data_stream_id, data_stream_listener));
+        }
+
+        // Verify the number of active data streams
+        assert_eq!(
+            streaming_service.get_all_data_stream_ids().len(),
+            num_data_streams
+        );
+
+        // Try to terminate a data stream with an incorrect ID and verify
+        // an error is returned.
+        let terminate_stream_request = TerminateStreamRequest {
+            data_stream_id: 1919123,
+            notification_and_feedback: None,
+        };
+        streaming_service
+            .process_terminate_stream_request(&terminate_stream_request)
+            .unwrap_err();
+
+        // Terminate all the streams and verify they're no longer held
+        for (data_stream_id, _) in stream_ids_and_listeners {
+            // Terminate the data stream (with no feedback)
+            let (terminate_stream_request, _) =
+                create_terminate_stream_request(data_stream_id, None);
+            streaming_service.handle_stream_request_message(terminate_stream_request);
+
+            // Verify the stream has been removed
+            let all_data_stream_ids = streaming_service.get_all_data_stream_ids();
+            assert!(!all_data_stream_ids.contains(&data_stream_id));
+        }
+
+        // Verify there are no data streams
+        assert!(streaming_service.get_all_data_stream_ids().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_terminate_data_streams_feedback() {
+        // Verify stream termination even if invalid feedback is given (i.e., id mismatch)
+        for invalid_feedback in [false, true] {
+            // Create a new streaming service
+            let (_, mut streaming_service) =
+                tests::streaming_service::create_streaming_client_and_server(false, false, true);
+
+            // Create multiple data streams
+            let num_data_streams = 10;
+            let mut stream_ids_and_listeners = vec![];
+            for _ in 0..num_data_streams {
+                // Create a new data stream
+                let (new_stream_request, response_receiver) = create_new_stream_request();
+                streaming_service.handle_stream_request_message(new_stream_request);
+                let data_stream_listener =
+                    response_receiver.now_or_never().unwrap().unwrap().unwrap();
+                let data_stream_id = data_stream_listener.data_stream_id;
+
+                // Remember the data stream id and listener
+                stream_ids_and_listeners.push((data_stream_id, data_stream_listener));
+            }
+
+            // Fetch a notification from each data stream and terminate the stream
+            for (data_stream_id, data_stream_listener) in &mut stream_ids_and_listeners {
+                let timeout_deadline =
+                    Instant::now().add(Duration::from_secs(MAX_STREAM_WAIT_SECS));
+                while Instant::now() < timeout_deadline {
+                    streaming_service.check_progress_of_all_data_streams();
+                    if let Ok(data_notification) = timeout(
+                        Duration::from_secs(1),
+                        data_stream_listener.select_next_some(),
+                    )
+                    .await
+                    {
+                        // Terminate the data stream
+                        let notification_id = if invalid_feedback {
+                            10101010 // Invalid notification id
+                        } else {
+                            data_notification.notification_id
+                        };
+                        let notification_and_feedback = Some(NotificationAndFeedback {
+                            notification_id,
+                            notification_feedback: NotificationFeedback::InvalidPayloadData,
+                        });
+                        let (terminate_stream_request, _) = create_terminate_stream_request(
+                            *data_stream_id,
+                            notification_and_feedback,
+                        );
+                        streaming_service.handle_stream_request_message(terminate_stream_request);
+
+                        // Verify the stream has been removed
+                        let all_data_stream_ids = streaming_service.get_all_data_stream_ids();
+                        assert!(!all_data_stream_ids.contains(data_stream_id));
+                        break;
+                    }
+                }
+            }
+
+            // Verify there are no data streams
+            assert!(streaming_service.get_all_data_stream_ids().is_empty());
+        }
+    }
+
+    /// Creates a new stream request message for state values
+    fn create_new_stream_request() -> (
+        StreamRequestMessage,
+        Receiver<Result<DataStreamListener, Error>>,
+    ) {
+        let stream_request = StreamRequest::GetAllStates(GetAllStatesRequest {
+            version: MIN_ADVERTISED_STATES,
+            start_index: 0,
+        });
+        create_request_message_and_receiver(stream_request)
+    }
+
+    /// Creates a new terminate stream request message
+    fn create_terminate_stream_request(
+        data_stream_id: DataStreamId,
+        notification_and_feedback: Option<NotificationAndFeedback>,
+    ) -> (
+        StreamRequestMessage,
+        Receiver<Result<DataStreamListener, Error>>,
+    ) {
+        let stream_request = StreamRequest::TerminateStream(TerminateStreamRequest {
+            data_stream_id,
+            notification_and_feedback,
+        });
+        create_request_message_and_receiver(stream_request)
+    }
+
+    /// Creates a new stream request message and response receiver
+    fn create_request_message_and_receiver(
+        stream_request: StreamRequest,
+    ) -> (
+        StreamRequestMessage,
+        Receiver<Result<DataStreamListener, Error>>,
+    ) {
+        let (response_sender, response_receiver) = oneshot::channel();
+        let request_message = StreamRequestMessage {
+            stream_request,
+            response_sender,
+        };
+        (request_message, response_receiver)
     }
 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
@@ -4,5 +4,5 @@
 mod data_stream;
 mod stream_engine;
 mod streaming_client;
-mod streaming_service;
-mod utils;
+pub mod streaming_service;
+pub mod utils;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::streaming_client::NotificationAndFeedback;
 use crate::{
     data_notification::DataPayload,
     error::Error,
@@ -107,8 +108,11 @@ async fn test_notifications_state_values_limited_chunks() {
             // Terminate the stream and fetch a new one (we hit non-contiguous data)
             streaming_client
                 .terminate_stream_with_feedback(
-                    data_notification.notification_id,
-                    NotificationFeedback::InvalidPayloadData,
+                    stream_listener.data_stream_id,
+                    Some(NotificationAndFeedback::new(
+                        data_notification.notification_id,
+                        NotificationFeedback::InvalidPayloadData,
+                    )),
                 )
                 .await
                 .unwrap();
@@ -146,8 +150,11 @@ async fn test_notifications_state_values_multiple_streams() {
                     // Terminate the stream
                     streaming_client
                         .terminate_stream_with_feedback(
-                            data_notification.notification_id,
-                            NotificationFeedback::InvalidPayloadData,
+                            stream_listener.data_stream_id,
+                            Some(NotificationAndFeedback::new(
+                                data_notification.notification_id,
+                                NotificationFeedback::InvalidPayloadData,
+                            )),
                         )
                         .await
                         .unwrap();
@@ -327,8 +334,11 @@ async fn test_notifications_continuous_outputs_limited_chunks() {
             // Terminate the stream and fetch a new one (we hit non-contiguous data)
             streaming_client
                 .terminate_stream_with_feedback(
-                    data_notification.notification_id,
-                    NotificationFeedback::InvalidPayloadData,
+                    stream_listener.data_stream_id,
+                    Some(NotificationAndFeedback::new(
+                        data_notification.notification_id,
+                        NotificationFeedback::InvalidPayloadData,
+                    )),
                 )
                 .await
                 .unwrap();
@@ -386,8 +396,11 @@ async fn test_notifications_continuous_outputs_multiple_streams() {
                     // Terminate the stream
                     streaming_client
                         .terminate_stream_with_feedback(
-                            data_notification.notification_id,
-                            NotificationFeedback::InvalidPayloadData,
+                            stream_listener.data_stream_id,
+                            Some(NotificationAndFeedback::new(
+                                data_notification.notification_id,
+                                NotificationFeedback::InvalidPayloadData,
+                            )),
                         )
                         .await
                         .unwrap();
@@ -527,8 +540,11 @@ async fn test_notifications_continuous_transactions_limited_chunks() {
             // Terminate the stream and fetch a new one (we hit non-contiguous data)
             streaming_client
                 .terminate_stream_with_feedback(
-                    data_notification.notification_id,
-                    NotificationFeedback::InvalidPayloadData,
+                    stream_listener.data_stream_id,
+                    Some(NotificationAndFeedback::new(
+                        data_notification.notification_id,
+                        NotificationFeedback::InvalidPayloadData,
+                    )),
                 )
                 .await
                 .unwrap();
@@ -675,8 +691,11 @@ async fn test_notifications_epoch_ending_limited_chunks() {
             // Terminate the stream and fetch a new one (we hit non-contiguous data)
             streaming_client
                 .terminate_stream_with_feedback(
-                    data_notification.notification_id,
-                    NotificationFeedback::InvalidPayloadData,
+                    stream_listener.data_stream_id,
+                    Some(NotificationAndFeedback::new(
+                        data_notification.notification_id,
+                        NotificationFeedback::InvalidPayloadData,
+                    )),
                 )
                 .await
                 .unwrap();
@@ -711,8 +730,11 @@ async fn test_notifications_epoch_ending_multiple_streams() {
                     // Terminate the stream
                     streaming_client
                         .terminate_stream_with_feedback(
-                            data_notification.notification_id,
-                            NotificationFeedback::InvalidPayloadData,
+                            stream_listener.data_stream_id,
+                            Some(NotificationAndFeedback::new(
+                                data_notification.notification_id,
+                                NotificationFeedback::InvalidPayloadData,
+                            )),
                         )
                         .await
                         .unwrap();
@@ -919,8 +941,11 @@ async fn test_notifications_transaction_outputs_limited_chunks() {
             // Terminate the stream and fetch a new one (we hit non-contiguous data)
             streaming_client
                 .terminate_stream_with_feedback(
-                    data_notification.notification_id,
-                    NotificationFeedback::InvalidPayloadData,
+                    stream_listener.data_stream_id,
+                    Some(NotificationAndFeedback::new(
+                        data_notification.notification_id,
+                        NotificationFeedback::InvalidPayloadData,
+                    )),
                 )
                 .await
                 .unwrap();
@@ -1022,8 +1047,11 @@ async fn test_notifications_transactions_limited_chunks() {
             // Terminate the stream and fetch a new one (we hit non-contiguous data)
             streaming_client
                 .terminate_stream_with_feedback(
-                    data_notification.notification_id,
-                    NotificationFeedback::InvalidPayloadData,
+                    stream_listener.data_stream_id,
+                    Some(NotificationAndFeedback::new(
+                        data_notification.notification_id,
+                        NotificationFeedback::InvalidPayloadData,
+                    )),
                 )
                 .await
                 .unwrap();
@@ -1071,8 +1099,11 @@ async fn test_notifications_transactions_multiple_streams() {
                     // Terminate the stream
                     streaming_client
                         .terminate_stream_with_feedback(
-                            data_notification.notification_id,
-                            NotificationFeedback::InvalidPayloadData,
+                            stream_listener.data_stream_id,
+                            Some(NotificationAndFeedback::new(
+                                data_notification.notification_id,
+                                NotificationFeedback::InvalidPayloadData,
+                            )),
                         )
                         .await
                         .unwrap();
@@ -1391,8 +1422,11 @@ async fn test_terminate_complete_stream() {
             DataPayload::EndOfStream => {
                 let result = streaming_client
                     .terminate_stream_with_feedback(
-                        data_notification.notification_id,
-                        NotificationFeedback::InvalidPayloadData,
+                        stream_listener.data_stream_id,
+                        Some(NotificationAndFeedback::new(
+                            data_notification.notification_id,
+                            NotificationFeedback::InvalidPayloadData,
+                        )),
                     )
                     .await;
                 assert_ok!(result);
@@ -1426,8 +1460,11 @@ async fn test_terminate_stream() {
     // Terminate the stream
     let result = streaming_client
         .terminate_stream_with_feedback(
-            data_notification.notification_id,
-            NotificationFeedback::InvalidPayloadData,
+            stream_listener.data_stream_id,
+            Some(NotificationAndFeedback::new(
+                data_notification.notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )),
         )
         .await;
     assert_ok!(result);
@@ -1444,22 +1481,39 @@ async fn test_terminate_stream() {
 }
 
 fn create_streaming_client_and_service() -> StreamingServiceClient {
-    create_streaming_client_with_mocks(false, false, false)
+    create_streaming_client_and_spawn_server(false, false, false)
 }
 
 fn create_streaming_client_and_service_with_data_delay() -> StreamingServiceClient {
-    create_streaming_client_with_mocks(true, false, false)
+    create_streaming_client_and_spawn_server(true, false, false)
 }
 
 fn create_streaming_client_and_service_with_chunk_limits() -> StreamingServiceClient {
-    create_streaming_client_with_mocks(false, true, true)
+    create_streaming_client_and_spawn_server(false, true, true)
 }
 
-fn create_streaming_client_with_mocks(
+fn create_streaming_client_and_spawn_server(
     data_beyond_highest_advertised: bool,
     limit_chunk_sizes: bool,
     skip_emulate_network_latencies: bool,
 ) -> StreamingServiceClient {
+    let (client, service) = create_streaming_client_and_server(
+        data_beyond_highest_advertised,
+        limit_chunk_sizes,
+        skip_emulate_network_latencies,
+    );
+    tokio::spawn(service.start_service());
+    client
+}
+
+pub fn create_streaming_client_and_server(
+    data_beyond_highest_advertised: bool,
+    limit_chunk_sizes: bool,
+    skip_emulate_network_latencies: bool,
+) -> (
+    StreamingServiceClient,
+    DataStreamingService<MockAptosDataClient>,
+) {
     initialize_logger();
 
     // Create a new streaming client and listener
@@ -1486,7 +1540,6 @@ fn create_streaming_client_with_mocks(
         aptos_data_client,
         streaming_service_listener,
     );
-    tokio::spawn(streaming_service.start_service());
 
-    streaming_client
+    (streaming_client, streaming_service)
 }

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -42,6 +42,7 @@ async-trait = "0.1.53"
 bcs = "0.1.3"
 claim = "0.5.0"
 mockall = "0.11.0"
+rand = "0.7.3"
 
 aptos-crypto = { path = "../../../crates/aptos-crypto" }
 aptos-genesis = { path = "../../../crates/aptos-genesis", features = ["testing"] }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -24,6 +24,7 @@ use aptos_types::{
     transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
     waypoint::Waypoint,
 };
+use data_streaming_service::streaming_client::NotificationAndFeedback;
 use data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     data_stream::DataStreamListener,
@@ -351,15 +352,15 @@ impl<
     }
 
     /// Marks bootstrapping as complete and notifies any listeners
-    pub fn bootstrapping_complete(&mut self) -> Result<(), Error> {
+    pub async fn bootstrapping_complete(&mut self) -> Result<(), Error> {
         info!(LogSchema::new(LogEntry::Bootstrapper)
             .message("The node has successfully bootstrapped!"));
         self.bootstrapped = true;
-        self.notify_listeners_if_bootstrapped()
+        self.notify_listeners_if_bootstrapped().await
     }
 
     /// Subscribes the specified channel to bootstrap completion notifications
-    pub fn subscribe_to_bootstrap_notifications(
+    pub async fn subscribe_to_bootstrap_notifications(
         &mut self,
         bootstrap_notifier_channel: oneshot::Sender<Result<(), Error>>,
     ) -> Result<(), Error> {
@@ -368,11 +369,11 @@ impl<
         }
 
         self.bootstrap_notifier_channel = Some(bootstrap_notifier_channel);
-        self.notify_listeners_if_bootstrapped()
+        self.notify_listeners_if_bootstrapped().await
     }
 
     /// Notifies any listeners if we've now bootstrapped
-    fn notify_listeners_if_bootstrapped(&mut self) -> Result<(), Error> {
+    async fn notify_listeners_if_bootstrapped(&mut self) -> Result<(), Error> {
         if self.bootstrapped {
             if let Some(notifier_channel) = self.bootstrap_notifier_channel.take() {
                 if let Err(error) = notifier_channel.send(Ok(())) {
@@ -382,7 +383,7 @@ impl<
                     )));
                 }
             }
-            self.reset_active_stream();
+            self.reset_active_stream(None).await?;
             self.storage_synchronizer.finish_chunk_executor(); // The bootstrapper is now complete
         }
 
@@ -416,7 +417,7 @@ impl<
         }
 
         // Check if we've now bootstrapped
-        self.notify_listeners_if_bootstrapped()
+        self.notify_listeners_if_bootstrapped().await
     }
 
     /// Returns true iff the bootstrapper should continue to fetch epoch ending
@@ -450,7 +451,7 @@ impl<
 
         // If we've already synced to the highest known version, there's nothing to do
         if highest_synced_version >= highest_known_ledger_version {
-            return self.bootstrapping_complete();
+            return self.bootstrapping_complete().await;
         }
 
         // Bootstrap according to the mode
@@ -513,7 +514,7 @@ impl<
                 // We've already bootstrapped to an initial state snapshot. If this a fullnode, the
                 // continuous syncer will take control and get the node up-to-date. If this is a
                 // validator, consensus will take control and sync depending on how it sees fit.
-                self.bootstrapping_complete()
+                self.bootstrapping_complete().await
             } else {
                 panic!("Snapshot syncing is currently unsupported for nodes with existing state! \
                         You are currently {:?} versions behind the latest snapshot version ({:?}). Either \
@@ -532,7 +533,7 @@ impl<
         if matches!(result, Err(Error::CriticalDataStreamTimeout(_))) {
             // If the stream has timed out too many times, we need to reset it
             warn!("Resetting the currently active data stream due to too many timeouts!");
-            self.reset_active_stream();
+            self.reset_active_stream(None).await?;
         }
         result
     }
@@ -822,8 +823,11 @@ impl<
         // Verify the payload start index is valid
         let expected_start_index = self.state_value_syncer.next_state_index_to_process;
         if expected_start_index != state_value_chunk_with_proof.first_index {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::VerificationError(format!(
                 "The start index of the state values was invalid! Expected: {:?}, received: {:?}",
                 expected_start_index, state_value_chunk_with_proof.first_index
@@ -840,8 +844,11 @@ impl<
             })?;
         let num_state_values = state_value_chunk_with_proof.raw_values.len() as u64;
         if expected_num_state_values != num_state_values {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::VerificationError(format!(
                 "The expected number of state values was invalid! Expected: {:?}, received: {:?}",
                 expected_num_state_values, num_state_values,
@@ -857,8 +864,11 @@ impl<
                 Error::IntegerOverflow("The expected end of index has overflown!".into())
             })?;
         if expected_end_index != state_value_chunk_with_proof.last_index {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::VerificationError(format!(
                 "The expected end index was invalid! Expected: {:?}, received: {:?}",
                 expected_num_state_values, state_value_chunk_with_proof.last_index,
@@ -879,8 +889,11 @@ impl<
         if self.should_fetch_epoch_ending_ledger_infos()
             || !matches!(bootstrapping_mode, BootstrappingMode::DownloadLatestStates)
         {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::InvalidPayload(
                 "Received an unexpected state values payload!".into(),
             ));
@@ -925,8 +938,11 @@ impl<
             .ensure_state_checkpoint_hash()
             .expect("Must be at state checkpoint.");
         if state_value_chunk_with_proof.root_hash != expected_root_hash {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::VerificationError(format!(
                 "The states chunk with proof root hash: {:?} didn't match the expected hash: {:?}!",
                 state_value_chunk_with_proof.root_hash, expected_root_hash,
@@ -939,8 +955,11 @@ impl<
             .storage_synchronizer
             .save_state_values(notification_id, state_value_chunk_with_proof)
         {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::InvalidPayload(format!(
                 "The states chunk with proof was invalid! Error: {:?}",
                 error,
@@ -966,8 +985,11 @@ impl<
     ) -> Result<(), Error> {
         // Verify that we're expecting epoch ending ledger info payloads
         if !self.should_fetch_epoch_ending_ledger_infos() {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::InvalidPayload(
                 "Received an unexpected epoch ending payload!".into(),
             ));
@@ -975,8 +997,11 @@ impl<
 
         // Verify the payload isn't empty
         if epoch_ending_ledger_infos.is_empty() {
-            self.terminate_active_stream(notification_id, NotificationFeedback::EmptyPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::EmptyPayloadData,
+            )))
+            .await?;
             return Err(Error::VerificationError(
                 "The epoch ending payload was empty!".into(),
             ));
@@ -989,10 +1014,10 @@ impl<
                 &epoch_ending_ledger_info,
                 &self.driver_configuration.waypoint,
             ) {
-                self.terminate_active_stream(
+                self.reset_active_stream(Some(NotificationAndFeedback::new(
                     notification_id,
                     NotificationFeedback::PayloadProofFailed,
-                )
+                )))
                 .await?;
                 return Err(error);
             }
@@ -1018,8 +1043,11 @@ impl<
             || (matches!(bootstrapping_mode, BootstrappingMode::DownloadLatestStates)
                 && self.state_value_syncer.transaction_output_to_sync.is_some())
         {
-            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::InvalidPayloadData,
+            )))
+            .await?;
             return Err(Error::InvalidPayload(
                 "Received an unexpected transaction or output payload!".into(),
             ));
@@ -1076,10 +1104,10 @@ impl<
                     )?;
                     num_transaction_outputs
                 } else {
-                    self.terminate_active_stream(
+                    self.reset_active_stream(Some(NotificationAndFeedback::new(
                         notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
+                    )))
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transaction outputs with proof!".into(),
@@ -1097,10 +1125,10 @@ impl<
                     )?;
                     num_transactions
                 } else {
-                    self.terminate_active_stream(
+                    self.reset_active_stream(Some(NotificationAndFeedback::new(
                         notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
+                    )))
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transactions with proof!".into(),
@@ -1157,10 +1185,10 @@ impl<
                             .set_transaction_output_to_sync(transaction_outputs_with_proof);
                     }
                     Err(error) => {
-                        self.terminate_active_stream(
+                        self.reset_active_stream(Some(NotificationAndFeedback::new(
                             notification_id,
                             NotificationFeedback::PayloadProofFailed,
-                        )
+                        )))
                         .await?;
                         return Err(Error::VerificationError(format!(
                             "Transaction outputs with proof is invalid! Error: {:?}",
@@ -1169,20 +1197,20 @@ impl<
                     }
                 }
             } else {
-                self.terminate_active_stream(
+                self.reset_active_stream(Some(NotificationAndFeedback::new(
                     notification_id,
                     NotificationFeedback::InvalidPayloadData,
-                )
+                )))
                 .await?;
                 return Err(Error::InvalidPayload(
                     "Payload does not contain a single transaction info!".into(),
                 ));
             }
         } else {
-            self.terminate_active_stream(
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
                 notification_id,
                 NotificationFeedback::PayloadTypeIsIncorrect,
-            )
+            )))
             .await?;
             return Err(Error::InvalidPayload(
                 "Did not receive transaction outputs with proof!".into(),
@@ -1201,10 +1229,10 @@ impl<
     ) -> Result<Version, Error> {
         if let Some(payload_start_version) = payload_start_version {
             if payload_start_version != expected_start_version {
-                self.terminate_active_stream(
+                self.reset_active_stream(Some(NotificationAndFeedback::new(
                     notification_id,
                     NotificationFeedback::InvalidPayloadData,
-                )
+                )))
                 .await?;
                 Err(Error::VerificationError(format!(
                     "The payload start version does not match the expected version! Start: {:?}, expected: {:?}",
@@ -1214,8 +1242,11 @@ impl<
                 Ok(payload_start_version)
             }
         } else {
-            self.terminate_active_stream(notification_id, NotificationFeedback::EmptyPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::EmptyPayloadData,
+            )))
+            .await?;
             Err(Error::VerificationError(
                 "The playload starting version is missing!".into(),
             ))
@@ -1240,10 +1271,10 @@ impl<
                         .transactions_and_outputs
                         .len()
                 } else {
-                    self.terminate_active_stream(
+                    self.reset_active_stream(Some(NotificationAndFeedback::new(
                         notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
+                    )))
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transaction outputs with proof!".into(),
@@ -1254,10 +1285,10 @@ impl<
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     transaction_list_with_proof.transactions.len()
                 } else {
-                    self.terminate_active_stream(
+                    self.reset_active_stream(Some(NotificationAndFeedback::new(
                         notification_id,
                         NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
+                    )))
                     .await?;
                     return Err(Error::InvalidPayload(
                         "Did not receive transactions with proof!".into(),
@@ -1307,29 +1338,23 @@ impl<
         &mut self,
         data_notification: DataNotification,
     ) -> Result<(), Error> {
-        self.reset_active_stream();
+        // Calculate the feedback based on the notification
+        let notification_feedback = match data_notification.data_payload {
+            DataPayload::EndOfStream => NotificationFeedback::EndOfStream,
+            _ => NotificationFeedback::PayloadTypeIsIncorrect,
+        };
+        let notification_and_feedback =
+            NotificationAndFeedback::new(data_notification.notification_id, notification_feedback);
 
-        utils::handle_end_of_stream_or_invalid_payload(
-            &mut self.streaming_client,
-            data_notification,
-        )
-        .await
-    }
+        // Reset the stream
+        self.reset_active_stream(Some(notification_and_feedback))
+            .await?;
 
-    /// Terminates the currently active stream with the provided feedback
-    pub async fn terminate_active_stream(
-        &mut self,
-        notification_id: NotificationId,
-        notification_feedback: NotificationFeedback,
-    ) -> Result<(), Error> {
-        self.reset_active_stream();
-
-        utils::terminate_stream_with_feedback(
-            &mut self.streaming_client,
-            notification_id,
-            notification_feedback,
-        )
-        .await
+        // Return an error if the payload was invalid
+        match data_notification.data_payload {
+            DataPayload::EndOfStream => Ok(()),
+            _ => Err(Error::InvalidPayload("Unexpected payload type!".into())),
+        }
     }
 
     /// Returns the speculative stream state. Assumes that the state exists.
@@ -1340,9 +1365,23 @@ impl<
     }
 
     /// Resets the currently active data stream and speculative state
-    fn reset_active_stream(&mut self) {
-        self.speculative_stream_state = None;
+    pub async fn reset_active_stream(
+        &mut self,
+        notification_and_feedback: Option<NotificationAndFeedback>,
+    ) -> Result<(), Error> {
+        if let Some(active_data_stream) = &self.active_data_stream {
+            let data_stream_id = active_data_stream.data_stream_id;
+            utils::terminate_stream_with_feedback(
+                &mut self.streaming_client,
+                data_stream_id,
+                notification_and_feedback,
+            )
+            .await?;
+        }
+
         self.active_data_stream = None;
+        self.speculative_stream_state = None;
+        Ok(())
     }
 
     /// Returns the verified epoch states struct for testing purposes

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -16,6 +16,7 @@ use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
 };
+use data_streaming_service::streaming_client::NotificationAndFeedback;
 use data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     data_stream::DataStreamListener,
@@ -151,7 +152,7 @@ impl<
         if matches!(result, Err(Error::CriticalDataStreamTimeout(_))) {
             // If the stream has timed out too many times, we need to reset it
             warn!("Resetting the currently active data stream due to too many timeouts!");
-            self.reset_active_stream();
+            self.reset_active_stream(None).await?;
         }
         result
     }
@@ -258,10 +259,10 @@ impl<
                         )?;
                         num_transaction_outputs
                     } else {
-                        self.terminate_active_stream(
+                        self.reset_active_stream(Some(NotificationAndFeedback::new(
                             notification_id,
                             NotificationFeedback::PayloadTypeIsIncorrect,
-                        )
+                        )))
                         .await?;
                         return Err(Error::InvalidPayload(
                             "Did not receive transaction outputs with proof!".into(),
@@ -279,10 +280,10 @@ impl<
                         )?;
                         num_transactions
                     } else {
-                        self.terminate_active_stream(
+                        self.reset_active_stream(Some(NotificationAndFeedback::new(
                             notification_id,
                             NotificationFeedback::PayloadTypeIsIncorrect,
-                        )
+                        )))
                         .await?;
                         return Err(Error::InvalidPayload(
                             "Did not receive transactions with proof!".into(),
@@ -313,10 +314,10 @@ impl<
             .expected_next_version()?;
         if let Some(payload_start_version) = payload_start_version {
             if payload_start_version != expected_version {
-                self.terminate_active_stream(
+                self.reset_active_stream(Some(NotificationAndFeedback::new(
                     notification_id,
                     NotificationFeedback::InvalidPayloadData,
-                )
+                )))
                 .await?;
                 Err(Error::VerificationError(format!(
                     "The payload start version does not match the expected version! Start: {:?}, expected: {:?}",
@@ -326,8 +327,11 @@ impl<
                 Ok(payload_start_version)
             }
         } else {
-            self.terminate_active_stream(notification_id, NotificationFeedback::EmptyPayloadData)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::EmptyPayloadData,
+            )))
+            .await?;
             Err(Error::VerificationError(
                 "The playload starting version is missing!".into(),
             ))
@@ -351,10 +355,10 @@ impl<
             let sync_request_version = sync_request_target.ledger_info().version();
             let proof_version = ledger_info_with_signatures.ledger_info().version();
             if sync_request_version < proof_version {
-                self.terminate_active_stream(
+                self.reset_active_stream(Some(NotificationAndFeedback::new(
                     notification_id,
                     NotificationFeedback::PayloadProofFailed,
-                )
+                )))
                 .await?;
                 return Err(Error::VerificationError(format!(
                     "Proof version is higher than the sync target. Proof version: {:?}, sync version: {:?}.",
@@ -368,8 +372,11 @@ impl<
             .get_speculative_stream_state()
             .verify_ledger_info_with_signatures(ledger_info_with_signatures)
         {
-            self.terminate_active_stream(notification_id, NotificationFeedback::PayloadProofFailed)
-                .await?;
+            self.reset_active_stream(Some(NotificationAndFeedback::new(
+                notification_id,
+                NotificationFeedback::PayloadProofFailed,
+            )))
+            .await?;
             Err(error)
         } else {
             Ok(())
@@ -382,29 +389,23 @@ impl<
         &mut self,
         data_notification: DataNotification,
     ) -> Result<(), Error> {
-        self.reset_active_stream();
+        // Calculate the feedback based on the notification
+        let notification_feedback = match data_notification.data_payload {
+            DataPayload::EndOfStream => NotificationFeedback::EndOfStream,
+            _ => NotificationFeedback::PayloadTypeIsIncorrect,
+        };
+        let notification_and_feedback =
+            NotificationAndFeedback::new(data_notification.notification_id, notification_feedback);
 
-        utils::handle_end_of_stream_or_invalid_payload(
-            &mut self.streaming_client,
-            data_notification,
-        )
-        .await
-    }
+        // Reset the stream
+        self.reset_active_stream(Some(notification_and_feedback))
+            .await?;
 
-    /// Terminates the currently active stream with the provided feedback
-    pub async fn terminate_active_stream(
-        &mut self,
-        notification_id: NotificationId,
-        notification_feedback: NotificationFeedback,
-    ) -> Result<(), Error> {
-        self.reset_active_stream();
-
-        utils::terminate_stream_with_feedback(
-            &mut self.streaming_client,
-            notification_id,
-            notification_feedback,
-        )
-        .await
+        // Return an error if the payload was invalid
+        match data_notification.data_payload {
+            DataPayload::EndOfStream => Ok(()),
+            _ => Err(Error::InvalidPayload("Unexpected payload type!".into())),
+        }
     }
 
     /// Returns the speculative stream state. Assumes that the state exists.
@@ -415,8 +416,22 @@ impl<
     }
 
     /// Resets the currently active data stream and speculative state
-    pub fn reset_active_stream(&mut self) {
-        self.speculative_stream_state = None;
+    pub async fn reset_active_stream(
+        &mut self,
+        notification_and_feedback: Option<NotificationAndFeedback>,
+    ) -> Result<(), Error> {
+        if let Some(active_data_stream) = &self.active_data_stream {
+            let data_stream_id = active_data_stream.data_stream_id;
+            utils::terminate_stream_with_feedback(
+                &mut self.streaming_client,
+                data_stream_id,
+                notification_and_feedback,
+            )
+            .await?;
+        }
+
         self.active_data_stream = None;
+        self.speculative_stream_state = None;
+        Ok(())
     }
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
@@ -157,6 +157,13 @@ impl ConsensusSyncRequest {
     pub fn get_sync_target(&self) -> LedgerInfoWithSignatures {
         self.consensus_sync_notification.target.clone()
     }
+
+    pub fn get_sync_target_version(&self) -> Version {
+        self.consensus_sync_notification
+            .target
+            .ledger_info()
+            .version()
+    }
 }
 
 /// A simple handler for consensus notifications
@@ -182,7 +189,7 @@ impl ConsensusNotificationHandler {
     }
 
     /// Returns the active sync request that consensus is waiting on
-    pub fn get_consensus_sync_request(&self) -> Arc<Mutex<Option<ConsensusSyncRequest>>> {
+    pub fn get_sync_request(&self) -> Arc<Mutex<Option<ConsensusSyncRequest>>> {
         self.consensus_sync_request.clone()
     }
 
@@ -230,7 +237,7 @@ impl ConsensusNotificationHandler {
         latest_synced_ledger_info: LedgerInfoWithSignatures,
     ) -> Result<(), Error> {
         // Fetch the sync target version
-        let consensus_sync_request = self.get_consensus_sync_request();
+        let consensus_sync_request = self.get_sync_request();
         let sync_target_version = consensus_sync_request.lock().as_ref().map(|sync_request| {
             sync_request
                 .consensus_sync_notification
@@ -253,7 +260,7 @@ impl ConsensusNotificationHandler {
 
             // Check if we've hit the target
             if latest_committed_version == sync_target_version {
-                let consensus_sync_request = self.get_consensus_sync_request().lock().take();
+                let consensus_sync_request = self.get_sync_request().lock().take();
                 if let Some(consensus_sync_request) = consensus_sync_request {
                     self.respond_to_sync_notification(
                         consensus_sync_request.consensus_sync_notification,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -30,10 +30,12 @@ use aptos_types::{
     },
 };
 use async_trait::async_trait;
+use data_streaming_service::data_stream::DataStreamId;
+use data_streaming_service::streaming_client::NotificationAndFeedback;
 use data_streaming_service::{
     data_notification::NotificationId,
     data_stream::DataStreamListener,
-    streaming_client::{DataStreamingClient, Epoch, NotificationFeedback},
+    streaming_client::{DataStreamingClient, Epoch},
 };
 use executor_types::{ChunkCommitNotification, ChunkExecutorTrait};
 use mockall::mock;
@@ -410,8 +412,8 @@ mock! {
 
         async fn terminate_stream_with_feedback(
             &self,
-            notification_id: NotificationId,
-            notification_feedback: NotificationFeedback,
+            data_stream_id: DataStreamId,
+            notification_and_feedback: Option<NotificationAndFeedback>,
         ) -> Result<(), data_streaming_service::error::Error>;
     }
     impl Clone for StreamingClient {

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -38,13 +38,15 @@ use event_notifications::EventNotificationListener;
 use futures::StreamExt;
 use mempool_notifications::{CommittedTransaction, MempoolNotificationListener};
 use move_deps::move_core_types::language_storage::TypeTag;
+use rand::rngs::OsRng;
+use rand::Rng;
 use storage_service_types::responses::CompleteDataRange;
 
 /// Creates a new data stream listener and notification sender pair
 pub fn create_data_stream_listener() -> (Sender<(), DataNotification>, DataStreamListener) {
     let (notification_sender, notification_receiver) =
         aptos_channel::new(QueueStyle::KLAST, 100, None);
-    let data_stream_listener = DataStreamListener::new(notification_receiver);
+    let data_stream_listener = DataStreamListener::new(create_random_u64(), notification_receiver);
 
     (notification_sender, data_stream_listener)
 }
@@ -129,6 +131,12 @@ pub fn create_epoch_state(epoch: u64) -> EpochState {
     let mut epoch_state = create_empty_epoch_state();
     epoch_state.epoch = epoch;
     epoch_state
+}
+
+/// Returns a random u64
+fn create_random_u64() -> u64 {
+    let mut rng = OsRng;
+    rng.gen()
 }
 
 /// Creates a test state value chunk with proof


### PR DESCRIPTION
### Description
This PR makes several fixes and improvements to the data streaming service to ensure that data streams are being terminated correctly:
1. First, we fix a small bug where data streams weren't being removed because the removal code was using `notification_id` instead of `data_stream_id`.
2. Second, we update the driver logic to ensure that all streams are terminated, whether or not the reason was due to a bad notification (i.e., notification feedback is now optional).
3. Third, we add logic to the streaming service to ensure that dropped data stream listeners result in the data stream being removed from the service. This protects against bad clients that don't terminate the stream before dropping it.
4. Finally, we've added a new metric to help track the number of active data streams maintained by the storage service.

Note: I've also done various small cleanups along the way.

### Test Plan
This PR adds a bunch of new unit tests around termination, including: (i) verifying that dropped streams are removed from the service; and (ii) ensuring that streams are correctly terminated even if the feedback is invalid.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3290)
<!-- Reviewable:end -->
