### PR TITLE
[dependency][consensus][bug-fix] Pin dependency to fix failing tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,6 +2541,7 @@ dependencies = [
  "fail 0.5.0",
  "fallible",
  "futures",
+ "futures-channel",
  "itertools",
  "mirai-annotations",
  "move-deps",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -16,7 +16,9 @@ bcs = "0.1.3"
 byteorder = { version = "1.4.3" }
 bytes = "1.1.0"
 fail = "0.5.0"
-futures = "0.3.21"
+# Pinning futures to 0.3.21, since release v0.3.23 is causing the network_tests to fail because messages are not received in the channel.
+futures = "= 0.3.21"
+futures-channel = "= 0.3.21"
 itertools = { version = "0.10.3", default-features = false }
 mirai-annotations = { version = "1.12.0", default-features = false }
 num-derive = { version = "0.3.3", default-features = false }


### PR DESCRIPTION
### Description

Noticed an issue with `v0.3.23` of futures crate that causing the network_tests to fail in the consensus crate because messages are not received in the channel. Pinning it to `v0.3.21` to unblock development.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

`cargo test -p consensus` passes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3298)
<!-- Reviewable:end -->
