### PR TITLE
[CP] Add Whitepaper to Main / Footer navigation

### DIFF
--- a/ecosystem/platform/server/app/components/footer_component.rb
+++ b/ecosystem/platform/server/app/components/footer_component.rb
@@ -11,6 +11,8 @@ class FooterComponent < ViewComponent::Base
     NavItem.new('/currents', 'Currents'),
     NavItem.new('/careers', 'Careers'),
     NavItem.new('https://www.linkedin.com/company/aptoslabs', 'Team'),
+    NavItem.new('https://aptos.dev/papers/whitepaper.pdf',
+                'Whitepaper'),
     NavItem.new('/privacy', 'Privacy'),
     NavItem.new('/terms', 'Terms')
   ].freeze

--- a/ecosystem/platform/server/app/components/header_component.rb
+++ b/ecosystem/platform/server/app/components/header_component.rb
@@ -34,7 +34,11 @@ class HeaderComponent < ViewComponent::Base
       NavItem.new('#', 'About', 'About Aptos'),
       [
         NavItem.new('/currents', 'Currents', 'Aptos Currents'),
-        NavItem.new('/careers', 'Careers', 'Aptos Careers')
+        NavItem.new('/careers', 'Careers', 'Aptos Careers'),
+        NavItem.new(
+          'https://aptos.dev/papers/whitepaper.pdf',
+          'Whitepaper', 'Aptos Whitepaper'
+        )
       ]
     )
   ].freeze


### PR DESCRIPTION
### Description

Add Whitepaper link to Main navigation dropdown (About) and within Footer links. 

### Test Plan

Ensure "Whitepaper" positioning within menus makes sense and URL is correct.
 
<img width="1731" alt="image" src="https://user-images.githubusercontent.com/98909677/186017977-cef04631-8aee-49af-a646-fff0ee8d9b15.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3303)
<!-- Reviewable:end -->
