### PR TITLE
[Token] enable PropertyMap to read primitive types

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/any.move
@@ -8,7 +8,7 @@ module aptos_std::any {
     friend aptos_std::copyable_any;
 
     /// The type provided for `unpack` is not the same as was given for `pack`.
-    const ETYPE_MISMATCH: u64 = 0;
+    const ETYPE_MISMATCH: u64 = 1;
 
     /// A type which can represent a value of any type. This allows for representation of 'unknown' future
     /// values. For example, to define a resource such that it can be later be extended without breaking

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -1115,7 +1115,7 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xAF, owner = @0xBB)]
-    #[expected_failure(abort_code = 3)]
+    #[expected_failure(abort_code = 393219)]
     fun test_mutate_token_property_fail(creator: &signer) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
 


### PR DESCRIPTION
### Description
we can directly read the value in the original type on chain as shown the in unit test

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
add a unit test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3313)
<!-- Reviewable:end -->
