### PR TITLE
[api] log 4xx status messages at info (sampled)

### DIFF
--- a/api/src/log.rs
+++ b/api/src/log.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use crate::metrics::{HISTOGRAM, RESPONSE_STATUS};
 use aptos_logger::{
-    debug, error,
+    debug, error, info,
     prelude::{sample, SampleRate},
     sample::Sampling,
     Schema,
@@ -48,6 +48,8 @@ pub async fn middleware_log<E: Endpoint>(next: E, request: Request) -> Result<Re
 
     if log.status >= 500 {
         sample!(SampleRate::Duration(Duration::from_secs(1)), error!(log));
+    } else if log.status >= 400 {
+        sample!(SampleRate::Duration(Duration::from_secs(60)), info!(log));
     } else {
         sample!(SampleRate::Duration(Duration::from_secs(1)), debug!(log));
     }


### PR DESCRIPTION
### Description

5xx are logged at error, and others were logged at debug. Having some 4xx messages in info can be useful.

### Test Plan

Simple change in code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3316)
<!-- Reviewable:end -->
