### PR TITLE
CICD: overhaul secrets management and move from github actions's secret management to GCP Secrets Manager

### DIFF
--- a/.github/actions/gar-auth/action.yaml
+++ b/.github/actions/gar-auth/action.yaml
@@ -5,6 +5,7 @@ inputs:
     required: true
   GCP_SERVICE_ACCOUNT_EMAIL:
     required: true
+    default: "github-actions@aptos-ci.iam.gserviceaccount.com"
 
 runs:
   using: composite
@@ -13,9 +14,8 @@ runs:
       name: "Authenticate to Google Cloud"
       uses: "google-github-actions/auth@v0"
       with:
-        create_credentials_file: false
         token_format: "access_token"
-        workload_identity_provider: ${{ inputs.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        workload_identity_provider: projects/865717136349/locations/global/workloadIdentityPools/github-actions/providers/github-actions
         service_account: ${{ inputs.GCP_SERVICE_ACCOUNT_EMAIL }}
 
     - name: Login to Google Artifact Registry

--- a/.github/actions/load-ci-env/action.yaml
+++ b/.github/actions/load-ci-env/action.yaml
@@ -1,0 +1,8 @@
+name: Load and common environment variables from ci-config branch
+
+runs:
+  using: composite
+  steps:
+    - name: fetch and set ci config env
+      shell: bash
+      run: curl https://raw.githubusercontent.com/aptos-labs/aptos-core/ci-config/ci.env >> $GITHUB_ENV

--- a/.github/actions/load-secrets/action.yaml
+++ b/.github/actions/load-secrets/action.yaml
@@ -1,0 +1,53 @@
+name: Load Secrets from GCP Secrets Manager
+
+inputs:
+  expose_env:
+    description: "Expose the secrets also as environment variables (default: false). For safety reasons it's recommended to use explicit outputs than environment variables."
+    required: false
+    default: "false"
+outputs:
+  AWS_ACCOUNT_NUM:
+    value: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}
+  AWS_ACCESS_KEY_ID:
+    value: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY:
+    value: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
+  PUSH_GATEWAY:
+    value: ${{ steps.secrets.outputs.PUSH_GATEWAY }}
+  PUSH_GATEWAY_USER: 
+    value: ${{ steps.secrets.outputs.PUSH_GATEWAY_USER }}
+  PUSH_GATEWAY_PASSWORD: 
+    value: ${{ steps.secrets.outputs.PUSH_GATEWAY_PASSWORD }}
+  NPM_JS_AUTH_TOKEN:
+    value: ${{ steps.secrets.outputs.NPM_JS_AUTH_TOKEN }}
+  GCP_DOCKER_ARTIFACT_REPO:
+    value: ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}
+
+runs:
+  using: composite
+  steps:
+    - id: "secrets"
+      uses: "google-github-actions/get-secretmanager-secrets@v0"
+      with:
+        secrets: |-
+          AWS_ACCOUNT_NUM:aptos-ci/AWS_ACCOUNT_NUM
+          AWS_ACCESS_KEY_ID:aptos-ci/AWS_ACCESS_KEY_ID
+          AWS_SECRET_ACCESS_KEY:aptos-ci/AWS_SECRET_ACCESS_KEY
+          PUSH_GATEWAY:aptos-ci/PUSH_GATEWAY
+          PUSH_GATEWAY_USER:aptos-ci/PUSH_GATEWAY_USER
+          PUSH_GATEWAY_PASSWORD:aptos-ci/PUSH_GATEWAY_PASSWORD
+          NPM_JS_AUTH_TOKEN:aptos-ci/NPM_JS_AUTH_TOKEN
+          GCP_DOCKER_ARTIFACT_REPO:aptos-ci/GCP_DOCKER_ARTIFACT_REPO
+
+    - name: Expose secrets as environment variables
+      if: inputs.expose_env == 'true'
+      shell: bash
+      run: |
+        echo "AWS_ACCOUNT_NUM=${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}" >> $GITHUB_ENV
+        echo "AWS_ACCESS_KEY_ID=${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}" >> $GITHUB_ENV
+        echo "AWS_SECRET_ACCESS_KEY=${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}" >> $GITHUB_ENV
+        echo "PUSH_GATEWAY=${{ steps.secrets.outputs.PUSH_GATEWAY }}" >> $GITHUB_ENV
+        echo "PUSH_GATEWAY_USER=${{ steps.secrets.outputs.PUSH_GATEWAY_USER }}" >> $GITHUB_ENV
+        echo "PUSH_GATEWAY_PASSWORD=${{ steps.secrets.outputs.PUSH_GATEWAY_PASSWORD }}" >> $GITHUB_ENV
+        echo "NPM_JS_AUTH_TOKEN=${{ steps.secrets.outputs.NPM_JS_AUTH_TOKEN }}" >> $GITHUB_ENV
+        echo "GCP_DOCKER_ARTIFACT_REPO=${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}" >> $GITHUB_ENV

--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -1,20 +1,5 @@
-## IMPORTANT NOTE TO EDITORS OF THIS FILE ##
 
-## Note that when you create a PR the jobs in this file are triggered off the
-## `pull_request_target` event instead of `pull_request` event. This is because
-## the `pull_request` event makes secrets only available to PRs from branches,
-## not from forks, and some of these jobs require secrets. So with `pull_request_target`
-## we're making secrets available to fork-based PRs too. Using `pull_request_target"
-## has a side effect, which is that the workflow execution will be driven by the
-## state of the <workflow>.yaml on the `main` (=target) branch, even if you edited
-## the <workflow>.yaml in your PR. So when you for example add a new job here, you
-## won't see that job appear in the PR itself. It will only become effective once
-## you merge the PR to main. Therefore, if you want to add a new job here and want
-## to test it's functionality prior to a merge to main, you have to to _temporarily_
-## change the trigger event from `pull_request_target` to `pull_request`.
-
-## Additionally, because `pull_request_target` gets secrets injected for forked PRs
-## we use `https://github.com/sushichop/action-repository-permission` to ensure these
+## We use `https://github.com/sushichop/action-repository-permission` to ensure these
 ## jobs are only executed when a repo member with "write" permission has triggered
 ## the workflow (directly through a push or indirectly by applying a label or enabling
 ## auto_merge).
@@ -23,7 +8,7 @@ name: "Build+Push Images"
 on: # build on main branch OR when a PR is labeled with `CICD:build-images`
   # Allow us to run this specific workflow without a PR
   workflow_dispatch:
-  pull_request_target:
+  pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
   push:
     branches:
@@ -42,8 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
-  AWS_ECR_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   # In case of pull_request events by default github actions merges main into the PR branch and then runs the tests etc
   # on the prospective merge result instead of only on the tip of the PR.
   # For more info also see https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
@@ -105,16 +88,16 @@ jobs:
           ref: ${{ env.GIT_SHA }}
 
       - uses: ./.github/actions/gar-auth
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: ./.github/actions/load-secrets
+        id: secrets
 
       - name: Login to ECR
         uses: docker/login-action@v2
         with:
-          registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
+          username: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          password: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
 
       - uses: ./.github/actions/docker-buildx-setup
 
@@ -122,6 +105,8 @@ jobs:
         run: docker/docker-bake-rust-all.sh
         env:
           LAST_GREEN_COMMIT: ${{ needs.determine-last-green-commit.outputs.lastGreenCommit }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}
+          AWS_ACCOUNT_NUM: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}
 
   sdk-release:
     needs: rust-images
@@ -166,16 +151,16 @@ jobs:
           ref: ${{ env.GIT_SHA }}
 
       - uses: ./.github/actions/gar-auth
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: ./.github/actions/load-secrets
+        id: secrets
 
       - name: Login to ECR
         uses: docker/login-action@v2
         with:
-          registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
+          username: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          password: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
 
       - uses: ./.github/actions/docker-buildx-setup
 
@@ -183,6 +168,9 @@ jobs:
         run: |
           cd ecosystem/platform/server
           docker buildx bake --progress=plain --push -f ./docker-bake.hcl
+        env:
+          GCP_DOCKER_ARTIFACT_REPO: ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}
+          AWS_ACCOUNT_NUM: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}
 
   indexer-server:
     needs: [permission-check]
@@ -193,16 +181,16 @@ jobs:
           ref: ${{ env.GIT_SHA }}
 
       - uses: ./.github/actions/gar-auth
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: ./.github/actions/load-secrets
+        id: secrets
 
       - name: Login to ECR
         uses: docker/login-action@v2
         with:
-          registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
+          username: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          password: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
 
       - uses: ./.github/actions/docker-buildx-setup
 
@@ -210,3 +198,6 @@ jobs:
         run: |
           cd ecosystem/indexer-server
           docker buildx bake --progress=plain --push -f ./docker-bake.hcl
+        env:
+          GCP_DOCKER_ARTIFACT_REPO: ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}
+          AWS_ACCOUNT_NUM: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -30,33 +30,32 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: ./.github/actions/gar-auth
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: ./.github/actions/load-secrets
 
       - name: Login to ECR
         uses: docker/login-action@v2
         with:
-          registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          registry: ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
+          username: ${{ steps.secrets.outputs.AWS_ACCESS_KEY_ID }}
+          password: ${{ steps.secrets.outputs.AWS_SECRET_ACCESS_KEY }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
+          username: ${{ steps.secrets.outputs.DOCKERHUB_USERNAME }}
+          password: ${{ steps.secrets.outputs.DOCKERHUB_PASSWORD }}
 
       - name: Push Images to Dockerhub
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ github.sha }}
+          src: ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ github.sha }}
           dst: |
             docker.io/aptoslab/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
             docker.io/aptoslab/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
             docker.io/aptoslabs/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
             docker.io/aptoslabs/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
-            ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
-            ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
-            ${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com/aptos/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
-            ${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com/aptos/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
+            ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
+            ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
+            ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com/aptos/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
+            ${{ steps.secrets.outputs.AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com/aptos/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}

--- a/.github/workflows/deploy-community-platform.yaml
+++ b/.github/workflows/deploy-community-platform.yaml
@@ -35,17 +35,18 @@ jobs:
           check-regexp: "community-platform.*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - id: auth
-        uses: "google-github-actions/auth@v0"
+      - uses: "./.github/actions/gar-auth"
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: ./.github/actions/load-secrets
+        id: secrets
 
       - id: deploy-app
         uses: "google-github-actions/deploy-cloudrun@v0"
         with:
           service: community
-          image: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/community-platform:${{ env.GIT_SHA }}
+          image: ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/community-platform:${{ env.GIT_SHA }}
           project_id: aptos-community-${{ inputs.aptos_env }}
           region: us-west1
 
@@ -53,6 +54,6 @@ jobs:
         uses: "google-github-actions/deploy-cloudrun@v0"
         with:
           service: community-worker
-          image: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/community-platform:${{ env.GIT_SHA }}
+          image: ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/community-platform:${{ env.GIT_SHA }}
           project_id: aptos-community-${{ inputs.aptos_env }}
           region: us-west1

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -42,13 +42,8 @@ on:
         default: false
         description: Set to true to enable new wrapper
 env:
-  AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: us-west-2
   IMAGE_TAG: ${{ inputs.GIT_SHA }}
-  FORGE_ENABLED: ${{ secrets.FORGE_ENABLED }}
-  FORGE_BLOCKING: ${{ secrets.FORGE_BLOCKING }}
   FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}
   FORGE_OUTPUT: forge_output.txt
   FORGE_REPORT: forge_report.json
@@ -68,13 +63,23 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
     steps:
+
       - uses: actions/checkout@v3
-        if: env.FORGE_ENABLED == 'true'
         with:
           ref: ${{ inputs.GIT_SHA }}
           # get the last 10 commits if IMAGE_TAG is not specified
           fetch-depth: env.IMAGE_TAG != null && 0 || 10
+   
+      - uses: ./.github/actions/load-ci-env
+
+      - uses: ./.github/actions/gar-auth
+
+      - uses: ./.github/actions/load-secrets
+        with:
+          expose_env: "true"
+
       - uses: actions/setup-python@v4
         if: env.FORGE_ENABLED == 'true'
       - name: Install python deps
@@ -108,9 +113,9 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         shell: bash
         env:
-          PUSH_GATEWAY: ${{ secrets.PUSH_GATEWAY }}
-          PUSH_GATEWAY_USER: ${{ secrets.PUSH_GATEWAY_USER }}
-          PUSH_GATEWAY_PASSWORD: ${{ secrets.PUSH_GATEWAY_PASSWORD }}
+          PUSH_GATEWAY: ${{ steps.secrets.outputs.PUSH_GATEWAY }}
+          PUSH_GATEWAY_USER: ${{ steps.secrets.outputs.PUSH_GATEWAY_USER }}
+          PUSH_GATEWAY_PASSWORD: ${{ steps.secrets.outputs.PUSH_GATEWAY_PASSWORD }}
         run: |
           set +e
 
@@ -151,4 +156,4 @@ jobs:
               "text": "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} ${{ github.job }}(suite: `${{ inputs.FORGE_TEST_SUITE }}`, namespace: `${{ inputs.FORGE_NAMESPACE }}`): <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|link>"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.FORGE_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.FORGE_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -1,9 +1,5 @@
 ## IMPORTANT NOTE TO EDITORS OF THIS FILE ##
 
-## If you are trying to change how this CI works, you MUST go read the important
-## note at the top of build-images. In short, to test this, you must temporarily
-## change build-images to use the pull_request trigger instead of pull_request_target.
-
 ## Make sure to add the CICD:CICD:build-images and CICD:run-e2e-tests labels to test
 ## this within an in-review PR.
 
@@ -43,9 +39,9 @@ jobs:
           ref: ${{ inputs.GIT_SHA }}
 
       - uses: ./.github/actions/gar-auth
-        with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - uses: ./.github/actions/load-secrets
+        id: secrets
 
       - uses: actions/setup-node@v3
         with:
@@ -69,13 +65,13 @@ jobs:
         with:
           max_attempts: 3
           timeout_minutes: 20
-          command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f yaml -o /specs/spec.yaml
+          command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f yaml -o /specs/spec.yaml
       - uses: nick-fields/retry@v2
         name: generate-json-spec
         with:
           max_attempts: 3
           timeout_minutes: 20
-          command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f json -o /specs/spec.json
+          command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f json -o /specs/spec.json
 
       # Confirm that the specs we built here are the same as those checked in.
       - run: echo "If this step fails, run the following commands locally to fix it:"
@@ -101,7 +97,7 @@ jobs:
       - run: git diff --no-index --ignore-space-at-eol --ignore-blank-lines ./ecosystem/typescript/sdk/src/generated/ /tmp/generated_client/
 
       # Run a local testnet built from the same commit.
-      - run: docker run -p 8080:8080 -p 8081:8081 --name=local-testnet --detach ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos node run-local-testnet --with-faucet
+      - run: docker run -p 8080:8080 -p 8081:8081 --name=local-testnet --detach ${{ steps.secrets.outputs.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos node run-local-testnet --with-faucet
 
       # Wait for the API and faucet to startup.
       - run: npm install -g wait-on
@@ -144,7 +140,7 @@ jobs:
       - run: cd ./ecosystem/typescript/sdk && yarn checked-publish
         if: github.event_name == 'push' && github.ref_name == 'devnet'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_JS_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ steps.secrets.outputs.NPM_JS_AUTH_TOKEN }}
 
       - name: Print docker-compose testnet logs on failure
         if: ${{ failure() }}

--- a/docker/docker-bake-rust-all.hcl
+++ b/docker/docker-bake-rust-all.hcl
@@ -26,7 +26,7 @@ variable "LAST_GREEN_COMMIT" {}
 
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 
-variable "AWS_ECR_ACCOUNT_NUM" {}
+variable "AWS_ACCOUNT_NUM" {}
 
 variable "TARGET_REGISTRY" {
   // must be "aws" | "gcp" | "local", informs which docker tags are being generated
@@ -34,7 +34,7 @@ variable "TARGET_REGISTRY" {
 }
 
 variable "ecr_base" {
-  default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
+  default = "${AWS_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
 }
 
 variable "normalized_branch_or_pr" {

--- a/ecosystem/indexer-server/docker-bake.hcl
+++ b/ecosystem/indexer-server/docker-bake.hcl
@@ -5,10 +5,10 @@
 
 variable "GIT_SHA" {}
 variable "TARGET_CACHE_ID" {}
-variable "AWS_ECR_ACCOUNT_NUM" {}
+variable "AWS_ACCOUNT_NUM" {}
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 variable "ecr_base" {
-  default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
+  default = "${AWS_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
 }
 variable "normalized_target_cache_id" {
   default = regex_replace("${TARGET_CACHE_ID}", "[^a-zA-Z0-9]", "-")

--- a/ecosystem/platform/server/docker-bake.hcl
+++ b/ecosystem/platform/server/docker-bake.hcl
@@ -5,10 +5,10 @@
 
 variable "TARGET_CACHE_ID" {}
 variable "GIT_SHA" {}
-variable "AWS_ECR_ACCOUNT_NUM" {}
+variable "AWS_ACCOUNT_NUM" {}
 variable "GCP_DOCKER_ARTIFACT_REPO" {}
 variable "ecr_base" {
-  default = "${AWS_ECR_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
+  default = "${AWS_ACCOUNT_NUM}.dkr.ecr.us-west-2.amazonaws.com/aptos"
 }
 
 variable "normalized_target_cache_id" {


### PR DESCRIPTION
### Description

This PR does an overhaul of how we inject secrets into GitHub jobs.
Previously we exclusively used Github's secret management to both inject actual secrets and to set (not-really-secret) environment variables like `FORGE_BLOCKING`. Since Github's secret management doesn't inject secrets into pull_request events created by forks we implemented a sophisticated workaround using pull_request_target, which sorta worked fine for a bit but caused a lot of confusion and testability issues when trying to change a workflow.

This PR aims to solves this by:
1. We switch primarily to GCP's Secret Manager for actual secrets management using https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions?authuser=1. In short secrets are now stored in GCP Secrets manager and github PRs that are triggered or approved by a trusted user (=aptos-employee) have the ability to fetch secrets from GCP secrets manager. The trust is established via OIDC and an explicit allowlist of github user ids that can trigger the job.
The corresponding GCP setup can be found here https://github.com/aptos-labs/internal-ops/pull/411 .
Note that new secrets must be created manually in the GCP console or the gcloud CLI. If you add the secret name to the secrets.ts list the pulumi program will also tell you exactly what command to run to create the secret.
New aptos employees must be added to the eng.ts file and the ci pulumi project must be applied. I'll add some more docs about these steps into the onboaring docs after this PR has been approved/merged.
Note that there are a few secrest, such as the buildpulse secrets etc. that I didn't bother to move over since those jobs are conditionally run only when these secrets are present anyways and they also didn't leverage the pull_request_target hack.
Furthermore you'll see that there is one secret in the community deployment workflow which I haven't moved over. This is also intentional for now since that secret is injected via Github's Environment feature which is branch aware etc.. We don't use pull_request_target for that one either, so it's fine.

2. There are a few environment variables that aren't really secrets. I moved these to a special branch and config file which can be fetched by a github job and injected. https://github.com/aptos-labs/aptos-core/blob/ci-config/ci.env#L1-L3 . This is leveraged in the run-forge.yaml workflow. In order to change any of the settings and have global effect, one simply has to change the config file in that special branch (can be done via web ui imo).

Besides the PR does a few general cleanups:
- More consistent naming of AWS account num environment variable.


### Test Plan
This is gonna be a bit hard to test to be honest. I can only verify that the jobs triggered by pull_request on this PR pass, which they seem to. I also verified that secrets are not available for github jobs triggered by random users (removed myself from the allowlist and verified it couldn't fetch secrets).
Once this is merged I'll keep a close eye for a few hours/days on our jobs to see if this change introduced any regressions.

Note you will see most of the pull_request_target jobs fail on this PR since I changed a few environment variables in the docker configs for consistency but the pull_request_target job will still inject the old environment variable name from main (this is one of the gotchas/problems this PR aims to solve by moving away from it).
Just look/verify that all the pull_request events on this PR pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3317)
<!-- Reviewable:end -->
