### PR TITLE
[Indexer] Switch old indexer to blocks instead of transactions

### DIFF
--- a/ecosystem/indexer/README.md
+++ b/ecosystem/indexer/README.md
@@ -11,7 +11,7 @@ result in an error if some or all of the processing had previously been complete
 Example invocation:
 
 ```bash
-cargo run -- --pg-uri "postgresql://localhost/postgres" --node-url "https://fullnode.devnet.aptoslabs.com" --emit-every 25 --batch-size 100
+cargo run -- --pg-uri "postgresql://localhost/devnet_old_indexer" --node-url "https://fullnode.devnet.aptoslabs.com" --emit-every 10
 ```
 
 Try running the indexer with `--help` to get more details

--- a/ecosystem/indexer/migrations/2022-08-23-053128_switch_to_block/down.sql
+++ b/ecosystem/indexer/migrations/2022-08-23-053128_switch_to_block/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE v2_processor_statuses;

--- a/ecosystem/indexer/migrations/2022-08-23-053128_switch_to_block/up.sql
+++ b/ecosystem/indexer/migrations/2022-08-23-053128_switch_to_block/up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE v2_processor_statuses (
+  name VARCHAR(50) NOT NULL,
+  block_height BIGINT NOT NULL,
+  success BOOLEAN NOT NULL,
+  details TEXT,
+  last_updated TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (name, block_height)
+);

--- a/ecosystem/indexer/src/counters.rs
+++ b/ecosystem/indexer/src/counters.rs
@@ -71,3 +71,21 @@ pub static FETCHED_TRANSACTION: Lazy<IntCounter> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Number of times the indexer has been unable to fetch a block. Ideally zero.
+pub static UNABLE_TO_FETCH_BLOCK: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "indexer_unable_to_fetch_block_count",
+        "Number of times the indexer has been unable to fetch a block"
+    )
+    .unwrap()
+});
+
+/// Number of times the indexer has been able to fetch a block
+pub static FETCHED_BLOCK: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "indexer_fetched_block_count",
+        "Number of times the indexer has been able to fetch a block"
+    )
+    .unwrap()
+});

--- a/ecosystem/indexer/src/indexer/fetcher.rs
+++ b/ecosystem/indexer/src/indexer/fetcher.rs
@@ -1,39 +1,40 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::counters::{FETCHED_TRANSACTION, UNABLE_TO_FETCH_TRANSACTION};
+use crate::counters::{FETCHED_BLOCK, UNABLE_TO_FETCH_BLOCK};
+
 use aptos_rest_client::{Client as RestClient, State, Transaction};
 use std::time::Duration;
-use tokio::sync::Mutex;
 use url::Url;
 
 // TODO: make this configurable
 const RETRY_TIME_MILLIS: u64 = 5000;
-const TRANSACTION_FETCH_BATCH_SIZE: u16 = 500;
 
 #[derive(Debug)]
 pub struct TransactionFetcher {
     client: RestClient,
-    version: u64,
-    transactions_buffer: Mutex<Vec<Transaction>>,
+    block_height: u64,
 }
 
 impl TransactionFetcher {
-    pub fn new(node_url: Url, starting_version: Option<u64>) -> Self {
+    pub fn new(node_url: Url, starting_block: Option<u64>) -> Self {
         let client = RestClient::new(node_url);
 
         Self {
             client,
-            version: starting_version.unwrap_or(0),
-            transactions_buffer: Default::default(),
+            block_height: starting_block.unwrap_or(0),
         }
     }
 }
 
 #[async_trait::async_trait]
 impl TransactionFetcherTrait for TransactionFetcher {
-    fn set_version(&mut self, version: u64) {
-        self.version = version;
+    fn get_block_height(&mut self) -> u64 {
+        self.block_height
+    }
+
+    fn set_block_height(&mut self, block_height: u64) {
+        self.block_height = block_height;
     }
 
     async fn fetch_ledger_info(&mut self) -> State {
@@ -44,73 +45,33 @@ impl TransactionFetcherTrait for TransactionFetcher {
             .into_inner()
     }
 
-    /// Fetches the next version based on its internal version counter
-    /// Under the hood, it fetches TRANSACTION_FETCH_BATCH_SIZE versions in bulk (when needed), and uses that buffer to feed out
-    /// In the event it can't fetch, it will keep retrying every RETRY_TIME_MILLIS ms
-    async fn fetch_next(&mut self) -> Transaction {
-        let mut transactions_buffer = self.transactions_buffer.lock().await;
-        if transactions_buffer.is_empty() {
-            // Fill it up!
-            loop {
-                let res = self
-                    .client
-                    .get_transactions(Some(self.version), Some(TRANSACTION_FETCH_BATCH_SIZE))
-                    .await;
-                match res {
-                    Ok(response) => {
-                        FETCHED_TRANSACTION.inc();
-                        let mut transactions = response.into_inner();
-                        transactions.reverse();
-                        *transactions_buffer = transactions;
-                        break;
-                    }
-                    Err(err) => {
-                        let err_str = err.to_string();
-                        // If it's a 404, then we're all caught up; no need to increment the `UNABLE_TO_FETCH_TRANSACTION` counter
-                        if err_str.contains("404") {
-                            aptos_logger::debug!(
-                            "Could not fetch {} transactions starting at {}: all caught up. Will check again in {}ms.",
-                            TRANSACTION_FETCH_BATCH_SIZE,
-                            self.version,
+    /// Fetches all transactions within a block. If block height is not available, set block height using
+    /// the starting version
+    async fn fetch_block(&mut self) -> Vec<Transaction> {
+        loop {
+            let res = self.client.get_block(self.block_height, true).await;
+            match res {
+                Ok(response) => {
+                    FETCHED_BLOCK.inc();
+                    return response.into_inner().transactions.unwrap_or_else(|| {
+                        panic!("Block {} missing transactions", self.block_height)
+                    });
+                }
+                Err(err) => {
+                    let err_str = err.to_string();
+                    // If it's a 404, then we're all caught up; no need to increment the `UNABLE_TO_FETCH_TRANSACTION` counter
+                    if err_str.contains("404") {
+                        aptos_logger::debug!(
+                            "Could not fetch block {}: all caught up. Will check again in {}ms.",
+                            self.block_height,
                             RETRY_TIME_MILLIS,
-                        );
-                            tokio::time::sleep(Duration::from_millis(RETRY_TIME_MILLIS)).await;
-                            continue;
-                        }
-                        UNABLE_TO_FETCH_TRANSACTION.inc();
-                        aptos_logger::error!(
-                            "Could not fetch {} transactions starting at {}, will retry in {}ms. Err: {:?}",
-                            TRANSACTION_FETCH_BATCH_SIZE,
-                            self.version,
-                            RETRY_TIME_MILLIS,
-                            err
                         );
                         tokio::time::sleep(Duration::from_millis(RETRY_TIME_MILLIS)).await;
                     }
-                };
-            }
-        }
-        // At this point we're guaranteed to have something in the buffer
-        let transaction = transactions_buffer.pop().unwrap();
-        self.version += 1;
-        transaction
-    }
-
-    /// fetches one version; this used for error checking/repair/etc
-    /// In the event it can't, it will keep retrying every RETRY_TIME_MILLIS ms
-    async fn fetch_version(&self, version: u64) -> Transaction {
-        loop {
-            let res = self.client.get_transaction_by_version(version).await;
-            match res {
-                Ok(response) => {
-                    FETCHED_TRANSACTION.inc();
-                    return response.into_inner();
-                }
-                Err(err) => {
-                    UNABLE_TO_FETCH_TRANSACTION.inc();
+                    UNABLE_TO_FETCH_BLOCK.inc();
                     aptos_logger::error!(
-                        "Could not fetch version {}, will retry in {}ms. Err: {:?}",
-                        version,
+                        "Could not fetch block {}: all caught up. Will check again in {}ms. Error: {:?}",
+                        self.block_height,
                         RETRY_TIME_MILLIS,
                         err
                     );
@@ -119,16 +80,34 @@ impl TransactionFetcherTrait for TransactionFetcher {
             };
         }
     }
+
+    async fn fetch_block_height_from_version(&self, version: u64) -> u64 {
+        *self
+            .client
+            .get_block_info(version)
+            .await
+            .unwrap_or_else(|err| {
+                panic!(
+                    "Could not fetch block info for version {}. Error: {:?}",
+                    version, err
+                )
+            })
+            .inner()
+            .block_height
+            .inner()
+    }
 }
 
 /// For mocking TransactionFetcher in tests
 #[async_trait::async_trait]
 pub trait TransactionFetcherTrait: Send + Sync {
-    fn set_version(&mut self, version: u64);
+    fn set_block_height(&mut self, block_height: u64);
+
+    fn get_block_height(&mut self) -> u64;
+
+    async fn fetch_block(&mut self) -> Vec<Transaction>;
 
     async fn fetch_ledger_info(&mut self) -> State;
 
-    async fn fetch_next(&mut self) -> Transaction;
-
-    async fn fetch_version(&self, _version: u64) -> Transaction;
+    async fn fetch_block_height_from_version(&self, version: u64) -> u64;
 }

--- a/ecosystem/indexer/src/indexer/processing_result.rs
+++ b/ecosystem/indexer/src/indexer/processing_result.rs
@@ -4,11 +4,11 @@
 #[derive(Debug)]
 pub struct ProcessingResult {
     pub name: &'static str,
-    pub version: u64,
+    pub block_height: u64,
 }
 
 impl ProcessingResult {
-    pub fn new(name: &'static str, version: u64) -> Self {
-        Self { name, version }
+    pub fn new(name: &'static str, block_height: u64) -> Self {
+        Self { name, block_height }
     }
 }

--- a/ecosystem/indexer/src/indexer/transaction_processor.rs
+++ b/ecosystem/indexer/src/indexer/transaction_processor.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::bigdecimal_to_u64;
 use crate::{
     counters::{
         GOT_CONNECTION, PROCESSOR_ERRORS, PROCESSOR_INVOCATIONS, PROCESSOR_SUCCESSES,
@@ -9,14 +8,15 @@ use crate::{
     },
     database::{execute_with_better_error, PgDbPool, PgPoolConnection},
     indexer::{errors::TransactionProcessingError, processing_result::ProcessingResult},
-    models::processor_statuses::ProcessorStatusModel,
+    models::v2_processor_statuses::ProcessorStatusModel,
     schema,
 };
 use aptos_rest_client::Transaction;
 use async_trait::async_trait;
-use diesel::{prelude::*, RunQueryDsl};
-use schema::processor_statuses::{self, dsl};
-use std::{fmt::Debug, sync::Arc};
+use diesel::sql_types::{BigInt, Text};
+use diesel::{sql_query, RunQueryDsl};
+use schema::v2_processor_statuses::{self, dsl};
+use std::fmt::Debug;
 
 /// The `TransactionProcessor` is used by an instance of a `Tailer` to process transactions
 #[async_trait]
@@ -25,12 +25,12 @@ pub trait TransactionProcessor: Send + Sync + Debug {
     /// This will get stored in the database for each (`TransactionProcessor`, transaction_version) pair
     fn name(&self) -> &'static str;
 
-    /// Accepts a transaction, and processes it. This method will be called from `process_transaction_with_status`
-    /// In case a transaction cannot be processed, returns an error: the `Tailer` will mark it as failed in the database,
-    /// and it will be retried next time the indexer is started.
-    async fn process_transaction(
+    /// Accepts transactions within a block and processes it. This method will be called from `process_transaction_with_status`
+    /// In case a transaction cannot be processed, we will fail the entire block.
+    async fn process_transactions(
         &self,
-        transaction: Arc<Transaction>,
+        transactions: Vec<Transaction>,
+        block_height: u64,
     ) -> Result<ProcessingResult, TransactionProcessingError>;
 
     /// Gets a reference to the connection pool
@@ -62,17 +62,18 @@ pub trait TransactionProcessor: Send + Sync + Debug {
     }
 
     /// This is a helper method, tying together the other helper methods to allow tracking status in the DB
-    async fn process_transaction_with_status(
+    async fn process_transactions_with_status(
         &self,
-        transaction: Arc<Transaction>,
+        txns: Vec<Transaction>,
+        block_height: u64,
     ) -> Result<ProcessingResult, TransactionProcessingError> {
         PROCESSOR_INVOCATIONS
             .with_label_values(&[self.name()])
             .inc();
 
-        self.mark_version_started(transaction.version().unwrap());
-        let res = self.process_transaction(transaction).await;
-        // Handle version success/failure
+        self.mark_block_started(block_height);
+        let res = self.process_transactions(txns, block_height).await;
+        // Handle block success/failure
         match res.as_ref() {
             Ok(processing_result) => self.update_status_success(processing_result),
             Err(tpe) => self.update_status_err(tpe),
@@ -80,38 +81,33 @@ pub trait TransactionProcessor: Send + Sync + Debug {
         res
     }
 
-    /// Writes that a version has been started for this `TransactionProcessor` to the DB
-    fn mark_version_started(&self, version: u64) {
+    /// Writes that a block has errored for this `TransactionProcessor` to the DB
+    fn update_status_err(&self, tpe: &TransactionProcessingError) {
+        aptos_logger::debug!("[{}] Marking processing block Err: {:?}", self.name(), tpe);
+        PROCESSOR_ERRORS.with_label_values(&[self.name()]).inc();
+        let psm = ProcessorStatusModel::from_transaction_processing_err(tpe);
+        self.apply_processor_status(&psm);
+    }
+    /// Writes that a block has been started for this `TransactionProcessor` to the DB
+    fn mark_block_started(&self, block_height: u64) {
         aptos_logger::debug!(
-            "[{}] Marking processing version started: {}",
+            "[{}] Marking processing block started: {}",
             self.name(),
-            version
+            block_height
         );
-        let psm = ProcessorStatusModel::for_mark_started(self.name(), version);
+        let psm = ProcessorStatusModel::for_mark_started(self.name(), block_height);
         self.apply_processor_status(&psm);
     }
 
-    /// Writes that a version has been completed successfully for this `TransactionProcessor` to the DB
+    /// Writes that a block_height has been completed successfully for this `TransactionProcessor` to the DB
     fn update_status_success(&self, processing_result: &ProcessingResult) {
         aptos_logger::debug!(
-            "[{}] Marking processing version OK: {}",
+            "[{}] Marking processing block OK: {}",
             self.name(),
-            processing_result.version
+            processing_result.block_height
         );
         PROCESSOR_SUCCESSES.with_label_values(&[self.name()]).inc();
         let psm = ProcessorStatusModel::from_processing_result_ok(processing_result);
-        self.apply_processor_status(&psm);
-    }
-
-    /// Writes that a version has errored for this `TransactionProcessor` to the DB
-    fn update_status_err(&self, tpe: &TransactionProcessingError) {
-        aptos_logger::debug!(
-            "[{}] Marking processing version Err: {:?}",
-            self.name(),
-            tpe
-        );
-        PROCESSOR_ERRORS.with_label_values(&[self.name()]).inc();
-        let psm = ProcessorStatusModel::from_transaction_processing_err(tpe);
         self.apply_processor_status(&psm);
     }
 
@@ -120,45 +116,76 @@ pub trait TransactionProcessor: Send + Sync + Debug {
         let conn = self.get_conn();
         execute_with_better_error(
             &conn,
-            diesel::insert_into(processor_statuses::table)
+            diesel::insert_into(v2_processor_statuses::table)
                 .values(psm)
-                .on_conflict((dsl::name, dsl::version))
+                .on_conflict((dsl::name, dsl::block_height))
                 .do_update()
                 .set(psm),
         )
         .expect("Error updating Processor Status!");
     }
 
-    /// Gets all versions which were not successfully processed for this `TransactionProcessor` from the DB
-    /// This is so the `Tailer` can know which versions to retry
-    fn get_error_versions(&self) -> Vec<u64> {
+    /// Gets the highest block for this `SubstreamProcessor` from the DB
+    /// This is so we know where to resume from on restarts.
+    /// If a block has any unprocessed transactions, we will restart processing the entire block.
+    fn get_start_block(&self) -> Option<i64> {
         let conn = self.get_conn();
-
-        dsl::processor_statuses
-            .select(dsl::version)
-            .filter(
-                dsl::success
-                    .eq(false)
-                    .and(dsl::name.eq(self.name().to_string())),
-            )
-            .load::<bigdecimal::BigDecimal>(&conn)
-            .expect("Error loading the error versions only query")
-            .iter()
-            .map(bigdecimal_to_u64)
-            .collect()
-    }
-
-    /// Gets the highest version for this `TransactionProcessor` from the DB
-    /// This is so we know where to resume from on restarts
-    fn get_max_version(&self) -> Option<u64> {
-        let conn = self.get_conn();
-
-        let res = dsl::processor_statuses
-            .select(diesel::dsl::max(dsl::version))
-            .filter(dsl::name.eq(self.name().to_string()))
-            .first::<Option<bigdecimal::BigDecimal>>(&conn);
-
-        res.expect("Error loading the max version query")
-            .map(|v| bigdecimal_to_u64(&v))
+        let sql = "
+        WITH boundaries AS
+        (
+            SELECT
+                MAX(block_height) AS MAX_V,
+                MIN(block_height) AS MIN_V
+            FROM
+                v2_processor_statuses
+            WHERE
+                name = $1
+                AND success = TRUE
+        ),
+        gap AS
+        (
+            SELECT
+                MIN(block_height) + 1 AS maybe_gap
+            FROM
+                (
+                    SELECT
+                        block_height,
+                        LEAD(block_height) OVER (
+                    ORDER BY
+                        block_height ASC) AS next_block_height
+                    FROM
+                        v2_processor_statuses,
+                        boundaries
+                    WHERE
+                        name = $1
+                        AND success = TRUE
+                        AND block_height >= MAX_V - 1000000
+                ) a
+            WHERE
+                block_height + 1 <> next_block_height
+        )
+        SELECT
+            CASE
+                WHEN
+                    MIN_V <> 0
+                THEN
+                    0
+                ELSE
+                    COALESCE(maybe_gap, MAX_V + 1)
+            END
+            AS block_height
+        FROM
+            gap, boundaries
+        ";
+        #[derive(Debug, QueryableByName)]
+        pub struct Gap {
+            #[sql_type = "BigInt"]
+            pub block_height: i64,
+        }
+        let mut res: Vec<Option<Gap>> = sql_query(sql)
+            .bind::<Text, _>(self.name())
+            .get_results(&conn)
+            .unwrap();
+        res.pop().unwrap().map(|g| g.block_height)
     }
 }

--- a/ecosystem/indexer/src/models/metadata.rs
+++ b/ecosystem/indexer/src/models/metadata.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::schema::metadatas;
+use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Associations, Debug, Identifiable, Insertable, Queryable, Serialize, Clone)]
+#[derive(
+    Associations, Debug, FieldCount, Identifiable, Insertable, Queryable, Serialize, Clone,
+)]
 #[diesel(table_name = "metadata")]
 #[primary_key(token_id)]
 pub struct Metadata {
@@ -45,7 +48,7 @@ impl Metadata {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, FieldCount)]
 pub struct TokenMetaFromURI {
     pub name: Option<String>,
     pub symbol: Option<String>,

--- a/ecosystem/indexer/src/models/mod.rs
+++ b/ecosystem/indexer/src/models/mod.rs
@@ -6,7 +6,7 @@ pub mod events;
 pub mod ledger_info;
 pub mod metadata;
 pub mod ownership;
-pub mod processor_statuses;
+pub mod v2_processor_statuses;
 pub mod token;
 pub mod token_property;
 pub mod transactions;

--- a/ecosystem/indexer/src/models/v2_processor_statuses.rs
+++ b/ecosystem/indexer/src/models/v2_processor_statuses.rs
@@ -1,0 +1,56 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::extra_unused_lifetimes)]
+use crate::{
+    indexer::{errors::TransactionProcessingError, processing_result::ProcessingResult},
+    schema::v2_processor_statuses as processor_statuss,
+};
+
+#[derive(AsChangeset, Debug, Insertable, Queryable)]
+#[diesel(table_name = processor_statuses)]
+pub struct ProcessorStatus {
+    pub name: &'static str,
+    pub block_height: i64,
+    pub success: bool,
+    pub details: Option<String>,
+    pub last_updated: chrono::NaiveDateTime,
+}
+
+impl ProcessorStatus {
+    pub fn new(
+        name: &'static str,
+        block_height: i64,
+        success: bool,
+        details: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            block_height,
+            success,
+            details,
+            last_updated: chrono::Utc::now().naive_utc(),
+        }
+    }
+
+    pub fn from_processing_result_ok(processing_result: &ProcessingResult) -> Self {
+        Self::new(
+            processing_result.name,
+            processing_result.block_height as i64,
+            true,
+            None,
+        )
+    }
+
+    pub fn from_transaction_processing_err(tpe: &TransactionProcessingError) -> Self {
+        let (error, block_height, name) = tpe.inner();
+
+        Self::new(name, *block_height as i64, false, Some(error.to_string()))
+    }
+
+    pub fn for_mark_started(name: &'static str, block_height: u64) -> Self {
+        Self::new(name, block_height as i64, false, None)
+    }
+}
+
+// Prevent conflicts with other things named `ProcessorStatus`
+pub type ProcessorStatusModel = ProcessorStatus;

--- a/ecosystem/indexer/src/schema.rs
+++ b/ecosystem/indexer/src/schema.rs
@@ -1,6 +1,3 @@
-// Copyright (c) Aptos
-// SPDX-License-Identifier: Apache-2.0
-
 table! {
     block_metadata_transactions (hash) {
         hash -> Varchar,
@@ -166,6 +163,16 @@ table! {
 }
 
 table! {
+    v2_processor_statuses (name, block_height) {
+        name -> Varchar,
+        block_height -> Int8,
+        success -> Bool,
+        details -> Nullable<Text>,
+        last_updated -> Timestamp,
+    }
+}
+
+table! {
     write_set_changes (transaction_hash, hash) {
         transaction_hash -> Varchar,
         hash -> Varchar,
@@ -192,5 +199,6 @@ allow_tables_to_appear_in_same_query!(
     token_propertys,
     transactions,
     user_transactions,
+    v2_processor_statuses,
     write_set_changes,
 );

--- a/ecosystem/indexer/src/util.rs
+++ b/ecosystem/indexer/src/util.rs
@@ -1,14 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use bigdecimal::{FromPrimitive, Signed, ToPrimitive, Zero};
+use bigdecimal::{FromPrimitive, Signed, Zero};
 
 pub fn u64_to_bigdecimal(val: u64) -> bigdecimal::BigDecimal {
     bigdecimal::BigDecimal::from_u64(val).unwrap()
-}
-
-pub fn bigdecimal_to_u64(val: &bigdecimal::BigDecimal) -> u64 {
-    val.to_u64().unwrap()
 }
 
 pub fn ensure_not_negative(val: bigdecimal::BigDecimal) -> bigdecimal::BigDecimal {


### PR DESCRIPTION
### Description
We're very close to the new indexer but the old indexer will still be used for AIT3 so we need to make some performance upgrades prior to AIT3. The most promising upgrade is to fetch, transform, and insert an entire block instead of random batch of transactions. This PR makes that happen

### Test Plan
cargo test
```
cargo run -- --pg-uri "postgresql://localhost/devnet_old" --node-url "http://localhost:8080" --emit-every 10
```
```
2022-08-23T07:33:15.026793Z [main] INFO ecosystem/indexer/src/main.rs:97 Indexing loop started!
2022-08-23T07:33:16.510705Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 10 blocks
2022-08-23T07:33:17.113632Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 20 blocks
2022-08-23T07:33:17.670543Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 30 blocks
2022-08-23T07:33:18.426356Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 40 blocks
2022-08-23T07:33:18.974837Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 50 blocks
2022-08-23T07:33:19.549392Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 60 blocks
2022-08-23T07:33:20.177636Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 70 blocks
2022-08-23T07:33:20.793604Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 80 blocks
2022-08-23T07:33:21.547673Z [main] INFO ecosystem/indexer/src/main.rs:112 Indexer has processed 90 blocks
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3325)
<!-- Reviewable:end -->
