### PR TITLE
[State Sync] Increase the default batch size and prefetcher.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -111,8 +111,8 @@ impl Default for StorageServiceConfig {
             max_network_chunk_bytes: MAX_APPLICATION_MESSAGE_SIZE as u64,
             max_state_chunk_size: 2000,
             max_subscription_period_ms: 5000,
-            max_transaction_chunk_size: 1000,
-            max_transaction_output_chunk_size: 1000,
+            max_transaction_chunk_size: 2000,
+            max_transaction_output_chunk_size: 2000,
             storage_summary_refresh_interval_ms: 50,
         }
     }
@@ -151,7 +151,7 @@ impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
             global_summary_refresh_interval_ms: 50,
-            max_concurrent_requests: 2,
+            max_concurrent_requests: 3,
             max_concurrent_state_requests: 4,
             max_data_stream_channel_sizes: 1000,
             max_request_retry: 3,


### PR DESCRIPTION
### Description
This PR increases the default batch size for state sync (from 1k to 2k txns/outputs per batch), and also bumps the prefetcher (from 2 to 3 concurrent requests). These values provide a more stable experience when the system is running under max. load for sustained periods.

### Test Plan
Existing tests and also a forge run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3333)
<!-- Reviewable:end -->
