### PR TITLE
[community] Fix redirect to /it3 after sign in.

### DIFF
--- a/ecosystem/platform/server/app/controllers/it3s_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it3s_controller.rb
@@ -6,11 +6,11 @@
 class It3sController < ApplicationController
   layout 'it3'
 
+  before_action :authenticate_user!
   before_action :ensure_confirmed!
+  before_action :ensure_registration_open!
 
   def show
-    redirect_to root_path unless user_signed_in?
-    redirect_to root_path unless Flipper.enabled?(:it3_registration_open)
     @it3_registration_closed = Flipper.enabled?(:it3_registration_closed, current_user)
     @steps = [
       connect_discord_step,
@@ -41,6 +41,10 @@ class It3sController < ApplicationController
   end
 
   private
+
+  def ensure_registration_open!
+    redirect_to root_path unless Flipper.enabled?(:it3_registration_open)
+  end
 
   def connect_discord_step
     completed = current_user.authorizations.where(provider: :discord).exists?

--- a/ecosystem/platform/server/test/controllers/it3s_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/it3s_controller_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+class It3sControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    Flipper.enable(:it3_registration_open)
+    @user = FactoryBot.create(:user)
+    sign_in @user
+  end
+
+  teardown do
+    sign_out @user
+  end
+
+  test 'it loads correctly' do
+    get it3_path
+    assert_response :success
+  end
+
+  test 'if logged out, it redirects to sign in, then redirects back to /it3' do
+    sign_out @user
+    get it3_path
+    assert_redirected_to new_user_session_path
+
+    sign_in @user
+    post user_session_path
+
+    assert_redirected_to it3_path
+  end
+end


### PR DESCRIPTION
### Description

If you go to /it3 when signed out, it's supposed to redirect back to /it3 after you sign in. This wasn't working previously because the controller didn't use `authenticate_user!`.

### Test Plan
I wrote automated tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3334)
<!-- Reviewable:end -->
