### PR TITLE
[aptos-rosetta] Sort operations in transactions

### DIFF
--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -78,13 +78,16 @@ pub struct Version {
 }
 
 /// An internal enum to support Operation typing
-#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum OperationType {
+    // Create must always be first for ordering
     CreateAccount,
-    Deposit,
+    // Withdraw must come before deposit
     Withdraw,
-    Fee,
+    Deposit,
     SetOperator,
+    // Fee must always be last for ordering
+    Fee,
 }
 
 impl OperationType {
@@ -97,8 +100,8 @@ impl OperationType {
     pub fn all() -> Vec<OperationType> {
         vec![
             OperationType::CreateAccount,
-            OperationType::Deposit,
             OperationType::Withdraw,
+            OperationType::Deposit,
             OperationType::Fee,
             OperationType::SetOperator,
         ]


### PR DESCRIPTION
### Description
Sort operations in transactions so that we have a predictable order

### Test Plan
E2E test now tests negative balances at end of transactions to ensure this doesn't happen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3348)
<!-- Reviewable:end -->
