### PR TITLE
[Forge] Re-enable validator and FN restart check

### DIFF
--- a/testsuite/testcases/src/performance_with_fullnode_test.rs
+++ b/testsuite/testcases/src/performance_with_fullnode_test.rs
@@ -3,6 +3,7 @@
 
 use crate::generate_traffic;
 use forge::{NetworkContext, NetworkTest, Result, Test};
+use tokio::runtime::Runtime;
 
 pub struct PerformanceBenchmarkWithFN;
 
@@ -29,10 +30,9 @@ impl NetworkTest for PerformanceBenchmarkWithFN {
         // ensure we meet the success criteria
         ctx.check_for_success(&txn_stat, &duration)?;
 
-        // This is currently flaky in main, turn off to mitigate impact on devs
-        // let runtime = Runtime::new().unwrap();
-        // runtime.block_on(ctx.swarm().ensure_no_validator_restart())?;
-        // runtime.block_on(ctx.swarm().ensure_no_fullnode_restart())?;
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(ctx.swarm().ensure_no_validator_restart())?;
+        runtime.block_on(ctx.swarm().ensure_no_fullnode_restart())?;
 
         // TODO(skedia) enable them after resolving failure in
         // https://github.com/aptos-labs/aptos-core/runs/7904217460?check_suite_focus=true


### PR DESCRIPTION
### Description

This was disabled because of memory leak SEV, which has been resolved now. 

### Test Plan
Run Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3349)
<!-- Reviewable:end -->
