### PR TITLE
[package metadata] Add `Any` extension field to package metadata

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error_map::generate_error_map;
-use crate::natives::code::{ModuleMetadata, PackageMetadata, UpgradePolicy};
+use crate::natives::code::{ModuleMetadata, MoveOption, PackageMetadata, UpgradePolicy};
 use crate::{zip_metadata, zip_metadata_str, RuntimeModuleMetadata, APTOS_METADATA_KEY};
 use aptos_module_verifier::module_init::verify_module_init_function;
 use aptos_types::account_address::AccountAddress;
@@ -181,6 +181,7 @@ impl BuiltPackage {
                 name,
                 source,
                 source_map,
+                extension: MoveOption::default(),
             })
         }
         Ok(PackageMetadata {
@@ -190,6 +191,7 @@ impl BuiltPackage {
             source_digest,
             manifest,
             modules,
+            extension: MoveOption::default(),
         })
     }
 }

--- a/aptos-move/framework/src/natives/any.rs
+++ b/aptos-move/framework/src/natives/any.rs
@@ -3,6 +3,15 @@
 
 use crate::natives::{util, GasParameters};
 use move_deps::move_vm_runtime::native_functions::NativeFunction;
+use serde::{Deserialize, Serialize};
+
+/// Rust representation of the Move Any type
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Any {
+    pub type_name: String,
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+}
 
 // The Any module hijacks just one function, from_bytes, from the util module. This
 // is a friend function which cannot be used across packages, so we have it both

--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::natives::any::Any;
 use anyhow::bail;
 use aptos_types::transaction::ModuleBundle;
 use aptos_types::vm_status::StatusCode;
@@ -24,6 +25,19 @@ use std::fmt;
 use std::str::FromStr;
 use std::sync::Arc;
 
+/// A wrapper around the representation of a Move Option, which is a vector with 0 or 1 element.
+/// TODO: move this elsewhere for reuse?
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct MoveOption<T> {
+    pub value: Vec<T>,
+}
+
+impl<T> Default for MoveOption<T> {
+    fn default() -> Self {
+        Self { value: vec![] }
+    }
+}
+
 /// The package registry at the given address.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct PackageRegistry {
@@ -41,6 +55,7 @@ pub struct PackageMetadata {
     pub source_digest: String,
     pub manifest: Vec<u8>,
     pub modules: Vec<ModuleMetadata>,
+    pub extension: MoveOption<Any>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -48,6 +63,7 @@ pub struct ModuleMetadata {
     pub name: String,
     pub source: Vec<u8>,
     pub source_map: Vec<u8>,
+    pub extension: MoveOption<Any>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/aptos-move/framework/src/release_bundle.rs
+++ b/aptos-move/framework/src/release_bundle.rs
@@ -4,6 +4,7 @@
 use crate::built_package::BuiltPackage;
 use crate::natives::code::PackageMetadata;
 use crate::path_in_crate;
+use anyhow::Context;
 use aptos_types::account_address::AccountAddress;
 use move_deps::move_binary_format::access::ModuleAccess;
 use move_deps::move_binary_format::errors::PartialVMError;
@@ -50,13 +51,15 @@ impl ReleaseBundle {
 
     /// Read a release bundle from a file.
     pub fn read(file: PathBuf) -> anyhow::Result<ReleaseBundle> {
-        let content = std::fs::read(file)?;
+        let content =
+            std::fs::read(&file).with_context(|| format!("while reading `{}`", file.display()))?;
         Ok(bcs::from_bytes::<ReleaseBundle>(&content)?)
     }
 
     /// Write a release bundle to file
     pub fn write(&self, path: PathBuf) -> anyhow::Result<()> {
-        std::fs::write(path, bcs::to_bytes(self)?)?;
+        std::fs::write(&path, bcs::to_bytes(self)?)
+            .with_context(|| format!("while writing `{}`", path.display()))?;
         Ok(())
     }
 


### PR DESCRIPTION
### Description

This allows us to extend package metdata without breaking change and without scattering data over multiple resources.

As a side-effect also closes #2399.



### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

NA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3350)
<!-- Reviewable:end -->
