### PR TITLE
[telemetry] Add flush to allow panics to be logged through telemetry

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -171,6 +171,7 @@ pub fn start(config: NodeConfig, log_file: Option<PathBuf>) -> anyhow::Result<()
         .is_async(config.logger.is_async)
         .level(config.logger.level)
         .telemetry_level(config.logger.telemetry_level)
+        .enable_telemetry_flush(config.logger.enable_telemetry_flush)
         .console_port(config.logger.console_port)
         .read_env();
     if config.logger.enable_backtrace {

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -17,6 +17,7 @@ use aptos_config::{
 use aptos_data_client::aptosnet::AptosNetDataClient;
 use aptos_fh_stream::runtime::bootstrap as bootstrap_fh_stream;
 use aptos_infallible::RwLock;
+use aptos_logger::telemetry_log_writer::TelemetryLog;
 use aptos_logger::{prelude::*, Level};
 use aptos_state_view::account_with_state_view::AsAccountWithStateView;
 use aptos_time_service::TimeService;
@@ -481,7 +482,7 @@ fn setup_state_sync_storage_service(
 
 pub fn setup_environment(
     node_config: NodeConfig,
-    remote_log_rx: Option<mpsc::Receiver<String>>,
+    remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
 ) -> anyhow::Result<AptosHandle> {
     // Start the node inspection service
     let node_config_clone = node_config.clone();

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -19,6 +19,7 @@ pub struct LoggerConfig {
     // tokio-console port
     pub console_port: Option<u16>,
     pub enable_telemetry_remote_log: bool,
+    pub enable_telemetry_flush: bool,
     pub telemetry_level: Level,
 }
 
@@ -30,7 +31,8 @@ impl Default for LoggerConfig {
             is_async: true,
             level: Level::Info,
             console_port: Some(6669),
-            enable_telemetry_remote_log: true,
+            enable_telemetry_remote_log: false,
+            enable_telemetry_flush: true,
             telemetry_level: Level::Error,
         }
     }

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -30,7 +30,7 @@ impl Default for LoggerConfig {
             is_async: true,
             level: Level::Info,
             console_port: Some(6669),
-            enable_telemetry_remote_log: false,
+            enable_telemetry_remote_log: true,
             telemetry_level: Level::Error,
         }
     }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -544,17 +544,6 @@ impl RoundManager {
             .proposer_election
             .get_valid_proposer(proposal_round + 1);
 
-        if self.epoch_state.epoch == 5 && proposal_round == 10 {
-            error!(
-                "BCHO log: injecting panic at {}, {}",
-                self.epoch_state.epoch, proposal_round
-            );
-            panic!(
-                "BCHO panic: injecting panic at {}, {}",
-                self.epoch_state.epoch, proposal_round
-            );
-        }
-
         info!(
             self.new_log(LogEvent::Vote).remote_peer(recipient),
             "{}", vote

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -543,6 +543,18 @@ impl RoundManager {
         let recipient = self
             .proposer_election
             .get_valid_proposer(proposal_round + 1);
+
+        if self.epoch_state.epoch == 5 && proposal_round == 10 {
+            error!(
+                "BCHO log: injecting panic at {}, {}",
+                self.epoch_state.epoch, proposal_round
+            );
+            panic!(
+                "BCHO panic: injecting panic at {}, {}",
+                self.epoch_state.epoch, proposal_round
+            );
+        }
+
         info!(
             self.new_log(LogEvent::Vote).remote_peer(recipient),
             "{}", vote

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -593,8 +593,9 @@ impl LoggerService {
                         if self.facade.enable_telemetry_flush {
                             match writer.flush() {
                                 Ok(rx) => {
-                                    let flush_result = rx.recv_timeout(FLUSH_TIMEOUT);
-                                    eprintln!("flushed with result: {}", flush_result.is_ok());
+                                    if let Err(err) = rx.recv_timeout(FLUSH_TIMEOUT) {
+                                        eprintln!("flush recv failed: {}", err);
+                                    }
                                 }
                                 Err(err) => {
                                     eprintln!("flush failed: {}", err);

--- a/crates/aptos-logger/src/lib.rs
+++ b/crates/aptos-logger/src/lib.rs
@@ -151,7 +151,7 @@ mod logger;
 mod macros;
 mod metadata;
 pub mod sample;
-mod telemetry_log_writer;
+pub mod telemetry_log_writer;
 pub mod tracing_adapter;
 
 mod security;

--- a/crates/aptos-logger/src/logger.rs
+++ b/crates/aptos-logger/src/logger.rs
@@ -74,7 +74,7 @@ pub fn set_global_logger(logger: Arc<dyn Logger>, console_port: Option<u16>) {
     }
 }
 
-/// Flush the global `Logger`
+/// Flush the global `Logger`. Note this is expensive, only use off the critical path.
 pub fn flush() {
     if let Some(logger) = LOGGER.get() {
         logger.flush();

--- a/crates/aptos-logger/src/telemetry_log_writer.rs
+++ b/crates/aptos-logger/src/telemetry_log_writer.rs
@@ -2,16 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::counters::{APTOS_LOG_INGEST_WRITER_DISCONNECTED, APTOS_LOG_INGEST_WRITER_FULL};
-use futures::channel::mpsc;
+use futures::channel;
 use std::io::{Error, ErrorKind};
+use std::sync;
+
+#[derive(Debug)]
+pub enum TelemetryLog {
+    Log(String),
+    Flush(sync::mpsc::SyncSender<()>),
+}
 
 #[derive(Debug)]
 pub(crate) struct TelemetryLogWriter {
-    tx: mpsc::Sender<String>,
+    tx: channel::mpsc::Sender<TelemetryLog>,
 }
 
 impl TelemetryLogWriter {
-    pub fn new(tx: mpsc::Sender<String>) -> Self {
+    pub fn new(tx: channel::mpsc::Sender<TelemetryLog>) -> Self {
         Self { tx }
     }
 }
@@ -19,7 +26,7 @@ impl TelemetryLogWriter {
 impl TelemetryLogWriter {
     pub fn write(&mut self, log: String) -> std::io::Result<usize> {
         let len = log.len();
-        match self.tx.try_send(log) {
+        match self.tx.try_send(TelemetryLog::Log(log)) {
             Ok(_) => Ok(len),
             Err(err) => {
                 if err.is_full() {
@@ -34,8 +41,17 @@ impl TelemetryLogWriter {
     }
 
     #[allow(dead_code)]
-    // TODO: hook up flush when it is implemented in LoggerService
-    pub fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
+    pub fn flush(&mut self) -> std::io::Result<sync::mpsc::Receiver<()>> {
+        let (tx, rx) = sync::mpsc::sync_channel(1);
+        match self.tx.try_send(TelemetryLog::Flush(tx)) {
+            Ok(_) => Ok(rx),
+            Err(err) => {
+                if err.is_full() {
+                    Err(Error::new(ErrorKind::WouldBlock, "Channel full"))
+                } else {
+                    Err(Error::new(ErrorKind::ConnectionRefused, "Disconnected"))
+                }
+            }
+        }
     }
 }

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -5,6 +5,7 @@
 
 use aptos_config::config::NodeConfig;
 use aptos_logger::prelude::*;
+use aptos_logger::telemetry_log_writer::TelemetryLog;
 use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
 use aptos_types::chain_id::ChainId;
 use futures::channel::mpsc;
@@ -78,7 +79,7 @@ pub fn start_telemetry_service(
     node_config: NodeConfig,
     chain_id: ChainId,
     build_info: BTreeMap<String, String>,
-    remote_log_rx: Option<mpsc::Receiver<String>>,
+    remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
 ) -> Option<Runtime> {
     // Don't start the service if telemetry has been disabled
     if telemetry_is_disabled() {


### PR DESCRIPTION
### Description

With this change, panics can make it into humio. Flush is expensive -- today it is only called from `handle_panic`.

### Test Plan

End-to-end test with an instrumented panic. Previously the panic did not make it to humio; now it does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3351)
<!-- Reviewable:end -->
