### PR TITLE
[tf][indexer] tune db_iops and enable logical replication

### DIFF
--- a/terraform/modules/indexer/rds.tf
+++ b/terraform/modules/indexer/rds.tf
@@ -29,6 +29,12 @@ resource "aws_db_parameter_group" "indexer" {
     value = "1"
   }
 
+  parameter {
+    name         = "rds.logical_replication"
+    apply_method = "pending-reboot"
+    value        = "1"
+  }
+
   lifecycle {
     ignore_changes = [
       parameter
@@ -43,6 +49,8 @@ resource "aws_db_instance" "indexer" {
   instance_class        = var.db_instance_class
   allocated_storage     = var.db_allocated_storage
   max_allocated_storage = var.db_max_allocated_storage
+
+  iops = var.db_iops > 0 ? var.db_iops : null
 
   engine                       = var.db_engine
   engine_version               = var.db_engine_version

--- a/terraform/modules/indexer/variables.tf
+++ b/terraform/modules/indexer/variables.tf
@@ -77,6 +77,11 @@ variable "db_max_allocated_storage" {
   default     = 500
 }
 
+variable "db_iops" {
+  description = "IOPS for the RDS DB"
+  default     = 0
+}
+
 variable "db_parameter_group_family" {
   description = "Parameter group family name for the RDS DB. Must be compatible with the db_engine and db_engine_version. https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_WorkingWithDBInstanceParamGroups.html"
   default     = "postgres14"


### PR DESCRIPTION
### Description

Add new parameter for `rds.logical_replication`, and also ability to tune db iops

### Test Plan

Apply to new stack. Existing stacks look fine

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3354)
<!-- Reviewable:end -->
