### PR TITLE
[crypto] replace old ed25519-dalek-fiat dependency

### DIFF
--- a/developer-docs-site/static/examples/rust/first_transaction/Cargo.toml
+++ b/developer-docs-site/static/examples/rust/first_transaction/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-ed25519-dalek = { version = "0.1.0", package = "ed25519-dalek-fiat", default-features = false, features = ["std", "serde", "fiat_u64_backend"] }
+ed25519-dalek = { version = "1.0.1", features = ["std", "serde"] }
 hex = "0.4.3"
 rand = "0.8.5"
 reqwest = { version = "0.11.11", features = ["blocking", "json"] }


### PR DESCRIPTION
### Description

Just replacing an old dependency with what we use throughout the rest of the repo.

We'll revisit using `fiat-crypto` throughout our repo in the future (@davidiw).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3359)
<!-- Reviewable:end -->
