### PR TITLE
[nextest] Add retries and don fail fast in CI

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -147,7 +147,7 @@ jobs:
       - uses: taiki-e/install-action@v1.5.6
         with:
           tool: nextest
-      - run: cargo nextest run --profile ci --workspace --exclude smoke-test --exclude backup-cli --exclude testcases
+      - run: cargo nextest run --profile ci --workspace --exclude smoke-test --exclude backup-cli --exclude testcases --retries 3 --no-fail-fast
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 


### PR DESCRIPTION
Its an unfortunate reality of life that unittests can be flaky, especially when
they're creating databases or interacting with files or both!

To deal with this reality lets not fail PR / main when we have a flaky test,
however in tandem we need to monitor the flaky test in main and work to remove
the flakiness.

Test Plan: 

https://github.com/aptos-labs/aptos-core/runs/7983894955?check_suite_focus=true

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3360)
<!-- Reviewable:end -->
