### PR TITLE
[mempool] update configs for better VFN -> validator throughput

### DIFF
--- a/.github/workflows/continuous-e2e-single-vfn-test.yaml
+++ b/.github/workflows/continuous-e2e-single-vfn-test.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E Single VFN Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Test transaction processing throughput at a single VFN
+  run-forge-chaos:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-chaos
+      FORGE_CLUSTER_NAME: aptos-forge-1
+      # Run for 8 minutes
+      FORGE_RUNNER_DURATION_SECS: 480
+      FORGE_RUNNER_TPS_THRESHOLD: 5000
+      FORGE_TEST_SUITE: single_vfn_perf
+      POST_TO_SLACK: true
+      USE_NEW_WRAPPER: true

--- a/.github/workflows/continuous-e2e-single-vfn-test.yaml
+++ b/.github/workflows/continuous-e2e-single-vfn-test.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-chaos
+      FORGE_NAMESPACE: forge-continuous-e2e-single-vfn
       FORGE_CLUSTER_NAME: aptos-forge-1
       # Run for 8 minutes
       FORGE_RUNNER_DURATION_SECS: 480

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -149,8 +149,10 @@ fullnode:
     logger: {}
     mempool:
       shared_mempool_max_concurrent_inbound_syncs: 16 # default 4
-      max_broadcasts_per_peer: 2 # default 1
+      max_broadcasts_per_peer: 4 # default 1
       default_failovers: 0 # default 3
+      shared_mempool_batch_size: 200 # default 100
+      shared_mempool_tick_interval_ms: 10 # default 50
     metrics: {}
     peer_monitoring_service: {}
     api: {}

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -451,6 +451,10 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
         "setup_test" => config
             .with_initial_fullnode_count(1)
             .with_network_tests(&[&ForgeSetupTest]),
+        "single_vfn_perf" => config
+            .with_initial_validator_count(NonZeroUsize::new(1).unwrap())
+            .with_initial_fullnode_count(1)
+            .with_network_tests(&[&PerformanceBenchmarkWithFN]),
         _ => return Err(format_err!("Invalid --suite given: {:?}", test_name)),
     };
     Ok(single_test_suite)


### PR DESCRIPTION
### Description

With these changes, a single VFN can push 5K TPS to the validator.
The previous configs would only allow up to 2K (20 broadcasts/s * 100 txn/broadcast).
Also add a forge test to detect any regressions. It is not scheduled, pending testing it via github.

### Test Plan
Ran the forge test, saw > 5K TPS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3363)
<!-- Reviewable:end -->
