### PR TITLE
[community] Fix wallet download link

### DIFF
--- a/ecosystem/platform/server/app/views/it3s/show.html.erb
+++ b/ecosystem/platform/server/app/views/it3s/show.html.erb
@@ -69,7 +69,7 @@
                     <% elsif step.name == :connect_wallet %>
                       <p class="font-light">
                       An Aptos wallet must be installed to continue.
-                      <%= render(LinkComponent.new(href: 'https://aptos.dev/guides/building-wallet-extension#step-1-install-the-wallet-on-chrome', target: '_blank')) { 'Learn more' } %></p>
+                      <%= render(LinkComponent.new(href: 'https://chrome.google.com/webstore/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci', target: '_blank')) { 'Learn more' } %></p>
                     <% end %>
                   <% end %>
                 <% end %>


### PR DESCRIPTION
### Description
We now have the wallet live on the chrome store and should just have them download it from there

### Test Plan

https://user-images.githubusercontent.com/19931667/186287826-65bdfe4d-c3d1-4fbc-9d06-d2ee0c5b3c26.mov

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3370)
<!-- Reviewable:end -->
