### PR TITLE
[aptos-telemetry] change error logs to debug

### DIFF
--- a/crates/aptos-telemetry/src/cli_metrics.rs
+++ b/crates/aptos-telemetry/src/cli_metrics.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{service, utils};
-use aptos_logger::error;
+use aptos_logger::debug;
 use aptos_telemetry_service::types::telemetry::TelemetryEvent;
 use std::{collections::BTreeMap, time::Duration};
 
@@ -39,7 +39,7 @@ pub async fn send_cli_telemetry_event(
     // event is processed before terminating the cli command).
     let join_handle = service::send_telemetry_event_with_ip(user_id, None, telemetry_event).await;
     if let Err(error) = join_handle.await {
-        error!(
+        debug!(
             "Failed to send telemetry event with join error: {:?}",
             error
         );

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -10,7 +10,7 @@ use aptos_crypto::{
     x25519,
 };
 use aptos_infallible::{Mutex, RwLock};
-use aptos_logger::{debug, error};
+use aptos_logger::debug;
 use aptos_telemetry_service::types::{
     auth::{AuthRequest, AuthResponse},
     telemetry::TelemetryDump,
@@ -129,7 +129,7 @@ impl TelemetrySender {
 
     pub(crate) async fn try_push_prometheus_metrics(&self) {
         self.push_prometheus_metrics().await.map_or_else(
-            |e| error!("Failed to push Prometheus Metrics: {}", e),
+            |e| debug!("Failed to push Prometheus Metrics: {}", e),
             |_| debug!("Prometheus Metrics pushed successfully."),
         );
     }
@@ -153,11 +153,11 @@ impl TelemetrySender {
                 }
                 Err(error) => {
                     increment_log_ingest_failures_by(batch.len() as u64);
-                    error!("Failed send log of length: {} with error: {}", len, error);
+                    debug!("Failed send log of length: {} with error: {}", len, error);
                 }
             }
         } else {
-            error!("Failed json serde of batch: {:?}", batch);
+            debug!("Failed json serde of batch: {:?}", batch);
         }
     }
 
@@ -214,7 +214,7 @@ impl TelemetrySender {
                 metrics::increment_telemetry_service_successes(&event_name);
             }
             Err(error) => {
-                error!("Failed to send telemetry event: Error: {}", error);
+                debug!("Failed to send telemetry event: Error: {}", error);
                 metrics::increment_telemetry_service_failures(&event_name);
             }
         }
@@ -345,7 +345,7 @@ impl TelemetrySender {
         let resp = match error_for_status_with_body(response).await {
             Ok(response) => Ok(response.json::<AuthResponse>().await?),
             Err(err) => {
-                error!(
+                debug!(
                     "[telemetry-client] Error sending authentication request: {}",
                     err,
                 );

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -329,7 +329,7 @@ fn spawn_telemetry_event_sender(
                     );
                     metrics::increment_telemetry_successes(&event_name);
                 } else {
-                    error!(
+                    debug!(
                         "Failed to send telemetry event! Status: {}, event: {}.",
                         response.status(),
                         event_name
@@ -339,7 +339,7 @@ fn spawn_telemetry_event_sender(
                 }
             }
             Err(error) => {
-                error!(
+                debug!(
                     "Failed to send telemetry event: {}. Error: {:?}",
                     event_name, error
                 );


### PR DESCRIPTION
### Description

Changing all the error logs to debug in telemetry service because it is very noisy but not useful for our validator operators. We will rely on metric counts for now and improve error logging in the future.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3371)
<!-- Reviewable:end -->
