### PR TITLE
[ECO] Fast Indexer

### DIFF
--- a/ecosystem/indexer/src/default_processor.rs
+++ b/ecosystem/indexer/src/default_processor.rs
@@ -16,10 +16,8 @@ use crate::{
 };
 use aptos_rest_client::Transaction;
 use async_trait::async_trait;
-use diesel::Connection;
 use field_count::FieldCount;
-use futures::future::Either;
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 pub struct DefaultTransactionProcessor {
     connection_pool: PgDbPool,
@@ -68,65 +66,75 @@ fn insert_write_set_changes(conn: &PgPoolConnection, write_set_changes: &Vec<Wri
     }
 }
 
-fn insert_transaction(conn: &PgPoolConnection, version: u64, transaction_model: &TransactionModel) {
-    aptos_logger::trace!(
-        "[default_processor] inserting 'transaction' version {} with hash {}",
-        version,
-        transaction_model.hash
-    );
-    execute_with_better_error(
-        conn,
-        diesel::insert_into(schema::transactions::table)
-            .values(transaction_model)
-            .on_conflict(schema::transactions::dsl::hash)
-            .do_update()
-            .set(transaction_model),
-    )
-    .expect("Error inserting row into database");
+fn insert_transactions(conn: &PgPoolConnection, txns: &[TransactionModel]) {
+    let chunks = get_chunks(txns.len(), TransactionModel::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::transactions::table)
+                .values(&txns[start_ind..end_ind])
+                .on_conflict_do_nothing(),
+        )
+        .expect("Error inserting row into database");
+    }
 }
 
-fn insert_user_transaction(
-    conn: &PgPoolConnection,
-    version: u64,
-    transaction_model: &TransactionModel,
-    user_transaction_model: &UserTransactionModel,
-) {
-    aptos_logger::trace!(
-        "[default_processor] inserting 'user_transaction' version {} with hash {}",
-        version,
-        &transaction_model.hash
-    );
-    execute_with_better_error(
-        conn,
-        diesel::insert_into(schema::user_transactions::table)
-            .values(user_transaction_model)
-            .on_conflict(schema::user_transactions::dsl::hash)
-            .do_update()
-            .set(user_transaction_model),
-    )
-    .expect("Error inserting row into database");
+fn insert_user_transactions(conn: &PgPoolConnection, user_txns: &[UserTransactionModel]) {
+    let chunks = get_chunks(user_txns.len(), UserTransactionModel::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::user_transactions::table)
+                .values(&user_txns[start_ind..end_ind])
+                .on_conflict_do_nothing(),
+        )
+        .expect("Error inserting row into database");
+    }
 }
 
-fn insert_block_metadata_transaction(
+fn insert_block_metadata_transactions(
     conn: &PgPoolConnection,
-    version: u64,
-    transaction_model: &TransactionModel,
-    block_metadata_transaction_model: &BlockMetadataTransactionModel,
+    bm_txns: &[BlockMetadataTransactionModel],
 ) {
+    let chunks = get_chunks(bm_txns.len(), UserTransactionModel::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::block_metadata_transactions::table)
+                .values(&bm_txns[start_ind..end_ind])
+                .on_conflict_do_nothing(),
+        )
+        .expect("Error inserting row into database");
+    }
+}
+
+fn insert_to_db(
+    conn: &PgPoolConnection,
+    name: &'static str,
+    start_version: u64,
+    end_version: u64,
+    txns: Vec<TransactionModel>,
+    user_txns: Vec<UserTransactionModel>,
+    bm_txns: Vec<BlockMetadataTransactionModel>,
+    events: Vec<EventModel>,
+    wscs: Vec<WriteSetChangeModel>,
+) -> Result<(), diesel::result::Error> {
     aptos_logger::trace!(
-        "[default_processor] inserting 'block_metadata_transaction' version {} with hash {}",
-        version,
-        &transaction_model.hash
+        "[{}] inserting versions {} to {}",
+        name,
+        start_version,
+        end_version
     );
-    execute_with_better_error(
-        conn,
-        diesel::insert_into(schema::block_metadata_transactions::table)
-            .values(block_metadata_transaction_model)
-            .on_conflict(schema::block_metadata_transactions::dsl::hash)
-            .do_update()
-            .set(block_metadata_transaction_model),
-    )
-    .expect("Error inserting row into database");
+    conn.build_transaction()
+        .read_write()
+        .run::<_, diesel::result::Error, _>(|| {
+            insert_transactions(conn, &txns);
+            insert_user_transactions(conn, &user_txns);
+            insert_block_metadata_transactions(conn, &bm_txns);
+            insert_events(conn, &events);
+            insert_write_set_changes(conn, &wscs);
+            Ok(())
+        })
 }
 
 #[async_trait]
@@ -135,54 +143,37 @@ impl TransactionProcessor for DefaultTransactionProcessor {
         "default_processor"
     }
 
-    async fn process_transaction(
+    async fn process_transactions(
         &self,
-        transaction: Arc<Transaction>,
+        transactions: Vec<Transaction>,
+        start_version: u64,
+        end_version: u64,
     ) -> Result<ProcessingResult, TransactionProcessingError> {
-        let version = transaction.version().unwrap_or(0);
-
-        let (transaction_model, maybe_details_model, maybe_events, maybe_write_set_changes) =
-            TransactionModel::from_transaction(&transaction);
+        let (txns, user_txns, bm_txns, events, write_set_changes) =
+            TransactionModel::from_transactions(&transactions);
 
         let conn = self.get_conn();
-
-        let tx_result = conn.transaction::<(), diesel::result::Error, _>(|| {
-            insert_transaction(&conn, version, &transaction_model);
-            if let Some(tx_details_model) = maybe_details_model {
-                match tx_details_model {
-                    Either::Left(user_transaction_model) => {
-                        insert_user_transaction(
-                            &conn,
-                            version,
-                            &transaction_model,
-                            &user_transaction_model,
-                        );
-                    }
-                    Either::Right(block_metadata_transaction_model) => {
-                        insert_block_metadata_transaction(
-                            &conn,
-                            version,
-                            &transaction_model,
-                            &block_metadata_transaction_model,
-                        );
-                    }
-                };
-            };
-
-            if let Some(events) = maybe_events {
-                insert_events(&conn, &events);
-            };
-            if let Some(write_set_changes) = maybe_write_set_changes {
-                insert_write_set_changes(&conn, &write_set_changes);
-            };
-            Ok(())
-        });
-
+        let tx_result = insert_to_db(
+            &conn,
+            self.name(),
+            start_version,
+            end_version,
+            txns,
+            user_txns,
+            bm_txns,
+            events,
+            write_set_changes,
+        );
         match tx_result {
-            Ok(_) => Ok(ProcessingResult::new(self.name(), version)),
+            Ok(_) => Ok(ProcessingResult::new(
+                self.name(),
+                start_version,
+                end_version,
+            )),
             Err(err) => Err(TransactionProcessingError::TransactionCommitError((
                 anyhow::Error::from(err),
-                version,
+                start_version,
+                end_version,
                 self.name(),
             ))),
         }

--- a/ecosystem/indexer/src/indexer/errors.rs
+++ b/ecosystem/indexer/src/indexer/errors.rs
@@ -3,7 +3,8 @@
 
 use anyhow::Error;
 
-type ErrorWithVersionAndName = (Error, u64, &'static str);
+// Error, start_version, end_version, name
+type ErrorWithVersionAndName = (Error, u64, u64, &'static str);
 
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]

--- a/ecosystem/indexer/src/indexer/fetcher.rs
+++ b/ecosystem/indexer/src/indexer/fetcher.rs
@@ -3,40 +3,45 @@
 
 use crate::counters::{FETCHED_TRANSACTION, UNABLE_TO_FETCH_TRANSACTION};
 use aptos_rest_client::{Client as RestClient, State, Transaction};
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+use serde_json::Value;
 use std::time::Duration;
-use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 use url::Url;
 
 // TODO: make this configurable
-const RETRY_TIME_MILLIS: u64 = 5000;
+const RETRY_TIME_MILLIS: u64 = 1000;
 const TRANSACTION_FETCH_BATCH_SIZE: u16 = 500;
+const TRANSACTION_CHANNEL_SIZE: usize = 50_000;
+const MAX_THREADS: usize = 10;
+const MAX_RETRIES: usize = 5;
 
 #[derive(Debug)]
-pub struct TransactionFetcher {
+pub struct Fetcher {
     client: RestClient,
-    version: u64,
-    transactions_buffer: Mutex<Vec<Transaction>>,
+    chain_id: u8,
+    current_version: u64,
+    highest_known_version: u64,
+    transactions_sender: mpsc::Sender<Vec<Transaction>>,
 }
 
-impl TransactionFetcher {
-    pub fn new(node_url: Url, starting_version: Option<u64>) -> Self {
-        let client = RestClient::new(node_url);
-
+impl Fetcher {
+    pub fn new(
+        client: RestClient,
+        current_version: u64,
+        transactions_sender: mpsc::Sender<Vec<Transaction>>,
+    ) -> Self {
         Self {
             client,
-            version: starting_version.unwrap_or(0),
-            transactions_buffer: Default::default(),
+            chain_id: 0,
+            current_version,
+            highest_known_version: current_version,
+            transactions_sender,
         }
     }
-}
 
-#[async_trait::async_trait]
-impl TransactionFetcherTrait for TransactionFetcher {
-    fn set_version(&mut self, version: u64) {
-        self.version = version;
-    }
-
-    async fn fetch_ledger_info(&mut self) -> State {
+    pub async fn fetch_ledger_info(&mut self) -> State {
         self.client
             .get_ledger_information()
             .await
@@ -44,56 +49,130 @@ impl TransactionFetcherTrait for TransactionFetcher {
             .into_inner()
     }
 
-    /// Fetches the next version based on its internal version counter
-    /// Under the hood, it fetches TRANSACTION_FETCH_BATCH_SIZE versions in bulk (when needed), and uses that buffer to feed out
-    /// In the event it can't fetch, it will keep retrying every RETRY_TIME_MILLIS ms
-    async fn fetch_next(&mut self) -> Transaction {
-        let mut transactions_buffer = self.transactions_buffer.lock().await;
-        if transactions_buffer.is_empty() {
-            // Fill it up!
-            loop {
-                let res = self
-                    .client
-                    .get_transactions(Some(self.version), Some(TRANSACTION_FETCH_BATCH_SIZE))
-                    .await;
-                match res {
-                    Ok(response) => {
-                        FETCHED_TRANSACTION.inc();
-                        let mut transactions = response.into_inner();
-                        transactions.reverse();
-                        *transactions_buffer = transactions;
-                        break;
-                    }
-                    Err(err) => {
-                        let err_str = err.to_string();
-                        // If it's a 404, then we're all caught up; no need to increment the `UNABLE_TO_FETCH_TRANSACTION` counter
-                        if err_str.contains("404") {
-                            aptos_logger::debug!(
-                            "Could not fetch {} transactions starting at {}: all caught up. Will check again in {}ms.",
-                            TRANSACTION_FETCH_BATCH_SIZE,
-                            self.version,
-                            RETRY_TIME_MILLIS,
-                        );
-                            tokio::time::sleep(Duration::from_millis(RETRY_TIME_MILLIS)).await;
-                            continue;
-                        }
-                        UNABLE_TO_FETCH_TRANSACTION.inc();
-                        aptos_logger::error!(
-                            "Could not fetch {} transactions starting at {}, will retry in {}ms. Err: {:?}",
-                            TRANSACTION_FETCH_BATCH_SIZE,
-                            self.version,
-                            RETRY_TIME_MILLIS,
-                            err
-                        );
-                        tokio::time::sleep(Duration::from_millis(RETRY_TIME_MILLIS)).await;
-                    }
-                };
+    pub async fn set_highest_known_version(&mut self) {
+        let info = self.client.get_ledger_information().await;
+        let res = info.unwrap();
+        let state = res.state();
+        self.highest_known_version = state.version;
+        self.chain_id = state.chain_id;
+    }
+
+    pub async fn run(&mut self) {
+        loop {
+            if self.current_version == self.highest_known_version {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                self.set_highest_known_version().await;
+            }
+
+            let num_missing = self.highest_known_version - self.current_version;
+            let num_batches = std::cmp::min(
+                (num_missing as f64 / TRANSACTION_FETCH_BATCH_SIZE as f64).ceil() as u64,
+                MAX_THREADS as u64,
+            ) as usize;
+            let mut futures = vec![];
+            for i in 0..num_batches {
+                futures.push(fetch_nexts(
+                    self.client.clone(),
+                    self.current_version + (i as u64 * TRANSACTION_FETCH_BATCH_SIZE as u64),
+                ));
+            }
+            let mut res: Vec<Vec<Transaction>> = futures::future::join_all(futures).await;
+            res.sort_by(|a, b| {
+                a.first()
+                    .unwrap()
+                    .version()
+                    .unwrap()
+                    .cmp(&b.first().unwrap().version().unwrap())
+            });
+
+            for batch in res {
+                self.current_version = batch.last().unwrap().version().unwrap();
+                self.transactions_sender.send(batch).await.unwrap();
             }
         }
-        // At this point we're guaranteed to have something in the buffer
-        let transaction = transactions_buffer.pop().unwrap();
-        self.version += 1;
-        transaction
+    }
+}
+
+/// Fetches the next version based on its internal version counter
+/// Under the hood, it fetches TRANSACTION_FETCH_BATCH_SIZE versions in bulk (when needed), and uses that buffer to feed out
+/// In the event it can't fetch, it will keep retrying every RETRY_TIME_MILLIS ms
+async fn fetch_nexts(client: RestClient, starting_version: u64) -> Vec<Transaction> {
+    let mut retries = 0;
+    while retries < MAX_RETRIES {
+        retries += 1;
+
+        let res = client
+            .get_transactions(Some(starting_version), Some(TRANSACTION_FETCH_BATCH_SIZE))
+            .await;
+
+        match res {
+            Ok(response) => {
+                FETCHED_TRANSACTION.inc();
+                return remove_null_bytes_from_txns(response.into_inner());
+            }
+            Err(err) => {
+                let err_str = err.to_string();
+                // If it's a 404, then we're all caught up; no need to increment the `UNABLE_TO_FETCH_TRANSACTION` counter
+                if err_str.contains("404") {
+                    aptos_logger::debug!(
+                            "Could not fetch {} transactions starting at {}: all caught up. Will check again in {}ms.",
+                            TRANSACTION_FETCH_BATCH_SIZE,
+                            starting_version,
+                            RETRY_TIME_MILLIS,
+                        );
+                }
+                UNABLE_TO_FETCH_TRANSACTION.inc();
+                aptos_logger::error!(
+                    "Could not fetch {} transactions starting at {}, will retry in {}ms. Err: {:?}",
+                    TRANSACTION_FETCH_BATCH_SIZE,
+                    starting_version,
+                    RETRY_TIME_MILLIS,
+                    err
+                );
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(RETRY_TIME_MILLIS)).await;
+    }
+
+    panic!(
+        "Could not fetch {} transactions starting at {}!",
+        TRANSACTION_FETCH_BATCH_SIZE, starting_version
+    );
+}
+
+#[derive(Debug)]
+pub struct TransactionFetcher {
+    starting_version: u64,
+    client: RestClient,
+    fetcher_handle: Option<JoinHandle<()>>,
+    transactions_sender: Option<mpsc::Sender<Vec<Transaction>>>,
+    transaction_receiver: mpsc::Receiver<Vec<Transaction>>,
+}
+
+impl TransactionFetcher {
+    pub fn new(node_url: Url, starting_version: Option<u64>) -> Self {
+        let (transactions_sender, transaction_receiver) =
+            mpsc::channel::<Vec<Transaction>>(TRANSACTION_CHANNEL_SIZE);
+
+        let client = RestClient::new(node_url);
+
+        Self {
+            starting_version: starting_version.unwrap_or(0),
+            client,
+            fetcher_handle: None,
+            transactions_sender: Some(transactions_sender),
+            transaction_receiver,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TransactionFetcherTrait for TransactionFetcher {
+    /// Fetches the next batch based on its internal version counter
+    /// Under the hood, it fetches TRANSACTION_FETCH_BATCH_SIZE versions in bulk (when needed), and uses that buffer to feed out
+    /// In the event it can't fetch, it will keep retrying every RETRY_TIME_MILLIS ms
+    async fn fetch_next_batch(&mut self) -> Vec<Transaction> {
+        self.transaction_receiver.next().await.unwrap()
     }
 
     /// fetches one version; this used for error checking/repair/etc
@@ -119,16 +198,83 @@ impl TransactionFetcherTrait for TransactionFetcher {
             };
         }
     }
+
+    async fn fetch_ledger_info(&mut self) -> State {
+        self.client
+            .get_ledger_information()
+            .await
+            .expect("ledger info must be present")
+            .into_inner()
+    }
+
+    async fn set_version(&mut self, version: u64) {
+        if self.fetcher_handle.is_some() {
+            panic!("TransactionFetcher already started!");
+        }
+        self.starting_version = version;
+    }
+
+    async fn start(&mut self) {
+        if self.fetcher_handle.is_some() {
+            panic!("TransactionFetcher already started!");
+        }
+        let client = self.client.clone();
+        let transactions_sender = self.transactions_sender.take().unwrap();
+        let starting_version = self.starting_version;
+        let fetcher_handle = tokio::spawn(async move {
+            let mut fetcher = Fetcher::new(client, starting_version, transactions_sender);
+            fetcher.run().await;
+        });
+        self.fetcher_handle = Some(fetcher_handle);
+    }
+}
+
+pub fn string_null_byte_replacement(value: &mut str) -> String {
+    value.replace('\u{0000}', "").replace("\\u0000", "")
+}
+
+pub fn recurse_remove_null_bytes_from_json(sub_json: &mut Value) {
+    match sub_json {
+        Value::Array(array) => {
+            for item in array {
+                recurse_remove_null_bytes_from_json(item);
+            }
+        }
+        Value::Object(object) => {
+            for (_key, value) in object {
+                recurse_remove_null_bytes_from_json(value);
+            }
+        }
+        Value::String(str) => {
+            if !str.is_empty() {
+                let replacement = string_null_byte_replacement(str);
+                *str = replacement;
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn remove_null_bytes_from_txns(txns: Vec<Transaction>) -> Vec<Transaction> {
+    txns.iter()
+        .map(|txn| {
+            let mut txn_json = serde_json::to_value(txn).unwrap();
+            recurse_remove_null_bytes_from_json(&mut txn_json);
+            serde_json::from_value::<Transaction>(txn_json).unwrap()
+        })
+        .collect::<Vec<Transaction>>()
 }
 
 /// For mocking TransactionFetcher in tests
 #[async_trait::async_trait]
 pub trait TransactionFetcherTrait: Send + Sync {
-    fn set_version(&mut self, version: u64);
+    async fn fetch_next_batch(&mut self) -> Vec<Transaction>;
+
+    async fn fetch_version(&self, version: u64) -> Transaction;
 
     async fn fetch_ledger_info(&mut self) -> State;
 
-    async fn fetch_next(&mut self) -> Transaction;
+    async fn set_version(&mut self, version: u64);
 
-    async fn fetch_version(&self, _version: u64) -> Transaction;
+    async fn start(&mut self);
 }

--- a/ecosystem/indexer/src/indexer/processing_result.rs
+++ b/ecosystem/indexer/src/indexer/processing_result.rs
@@ -4,11 +4,16 @@
 #[derive(Debug)]
 pub struct ProcessingResult {
     pub name: &'static str,
-    pub version: u64,
+    pub start_version: u64,
+    pub end_version: u64,
 }
 
 impl ProcessingResult {
-    pub fn new(name: &'static str, version: u64) -> Self {
-        Self { name, version }
+    pub fn new(name: &'static str, start_version: u64, end_version: u64) -> Self {
+        Self {
+            name,
+            start_version,
+            end_version,
+        }
     }
 }

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -121,7 +121,7 @@ impl Tailer {
                 for version in errored_versions {
                     let txn = self2.get_txn(version).await;
                     if processor2
-                        .process_transactions_with_status(vec![txn.into()])
+                        .process_transactions_with_status(vec![txn])
                         .await
                         .is_ok()
                     {
@@ -830,10 +830,8 @@ mod test {
             }
         )).unwrap();
 
-        tailer
-            .process_transactions(vec![message_txn.clone()])
-            .await
-            .unwrap();
+        let txns = crate::indexer::fetcher::remove_null_bytes_from_txns(vec![message_txn.clone()]);
+        tailer.process_transactions(txns).await.unwrap();
 
         let (_conn_pool, tailer) = setup_indexer().unwrap();
         tailer.set_fetcher_version(4).await;

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -15,49 +15,15 @@ use anyhow::{ensure, Context, Result};
 use aptos_logger::info;
 use aptos_rest_client::Transaction;
 use diesel::{prelude::*, RunQueryDsl};
-use serde_json::Value;
 use std::{fmt::Debug, sync::Arc};
 use tokio::{sync::Mutex, task::JoinHandle};
 use url::{ParseError, Url};
 
 diesel_migrations::embed_migrations!();
 
-pub fn string_null_byte_replacement(value: &mut str) -> String {
-    value.replace('\u{0000}', "").replace("\\u0000", "")
-}
-
-pub fn recurse_remove_null_bytes_from_json(sub_json: &mut Value) {
-    match sub_json {
-        Value::Array(array) => {
-            for item in array {
-                recurse_remove_null_bytes_from_json(item);
-            }
-        }
-        Value::Object(object) => {
-            for (_key, value) in object {
-                recurse_remove_null_bytes_from_json(value);
-            }
-        }
-        Value::String(str) => {
-            if !str.is_empty() {
-                let replacement = string_null_byte_replacement(str);
-                *str = replacement;
-            }
-        }
-        _ => {}
-    }
-}
-
-pub fn remove_null_bytes_from_txn(txn: Arc<Transaction>) -> Arc<Transaction> {
-    let mut txn_json = serde_json::to_value(txn).unwrap();
-    recurse_remove_null_bytes_from_json(&mut txn_json);
-    let txn: Transaction = serde_json::from_value::<Transaction>(txn_json).unwrap();
-    Arc::new(txn)
-}
-
 #[derive(Clone)]
 pub struct Tailer {
-    transaction_fetcher: Arc<Mutex<dyn TransactionFetcherTrait>>,
+    pub transaction_fetcher: Arc<Mutex<dyn TransactionFetcherTrait>>,
     processors: Vec<Arc<dyn TransactionProcessor>>,
     connection_pool: PgDbPool,
 }
@@ -155,7 +121,7 @@ impl Tailer {
                 for version in errored_versions {
                     let txn = self2.get_txn(version).await;
                     if processor2
-                        .process_transaction_with_status(txn)
+                        .process_transactions_with_status(vec![txn.into()])
                         .await
                         .is_ok()
                     {
@@ -195,16 +161,13 @@ impl Tailer {
     }
 
     pub async fn set_fetcher_version(&self, version: u64) -> u64 {
-        self.transaction_fetcher.lock().await.set_version(version);
+        self.transaction_fetcher
+            .lock()
+            .await
+            .set_version(version)
+            .await;
         aptos_logger::info!("Will start fetching from version {}", version);
         version
-    }
-
-    pub async fn process_next(
-        &mut self,
-    ) -> anyhow::Result<Vec<Result<ProcessingResult, TransactionProcessingError>>> {
-        let txn = self.get_next_txn().await;
-        self.process_transaction(txn).await
     }
 
     pub async fn process_version(
@@ -212,36 +175,53 @@ impl Tailer {
         version: u64,
     ) -> anyhow::Result<Vec<Result<ProcessingResult, TransactionProcessingError>>> {
         let txn = self.get_txn(version).await;
-        self.process_transaction(txn).await
+        self.process_transactions(vec![txn]).await
     }
 
     pub async fn process_next_batch(
-        &mut self,
+        &self,
         batch_size: u8,
-    ) -> Vec<anyhow::Result<Vec<Result<ProcessingResult, TransactionProcessingError>>>> {
+    ) -> (
+        usize,
+        Vec<Result<Vec<Result<ProcessingResult, TransactionProcessingError>>>>,
+    ) {
+        let transactions = self
+            .transaction_fetcher
+            .lock()
+            .await
+            .fetch_next_batch()
+            .await;
+        let num_txns = transactions.len();
         let mut tasks = vec![];
-        for _ in 0..batch_size {
-            let mut self2 = self.clone();
-            let task = tokio::task::spawn(async move { self2.process_next().await });
+        let num_batches = (transactions.len() as f64 / batch_size as f64).ceil() as usize;
+        for ind in 0..num_batches {
+            let self2 = self.clone();
+            let (start_index, end_index) = (
+                ind * batch_size as usize,
+                std::cmp::min((ind + 1) * batch_size as usize, transactions.len()),
+            );
+            let mut txns = vec![];
+            for t in &transactions[start_index..end_index] {
+                txns.push(t.clone());
+            }
+            let task = tokio::task::spawn(async move { self2.process_transactions(txns).await });
             tasks.push(task);
         }
-        let results = await_tasks(tasks).await;
-        results
+        let results: Vec<Result<Vec<Result<ProcessingResult, TransactionProcessingError>>>> =
+            await_tasks(tasks).await;
+        (num_txns, results)
     }
 
-    pub async fn process_transaction(
+    pub async fn process_transactions(
         &self,
-        txn: Arc<Transaction>,
+        txns: Vec<Transaction>,
     ) -> anyhow::Result<Vec<Result<ProcessingResult, TransactionProcessingError>>> {
         let mut tasks = vec![];
-        let txn = remove_null_bytes_from_txn(txn.clone());
         for processor in &self.processors {
             let processor2 = processor.clone();
-            let txn2 = txn.clone();
+            let txns2 = txns.clone();
             let task = tokio::task::spawn(async move {
-                processor2
-                    .process_transaction_with_status(txn2.clone())
-                    .await
+                processor2.process_transactions_with_status(txns2).await
             });
             tasks.push(task);
         }
@@ -249,18 +229,12 @@ impl Tailer {
         Ok(results)
     }
 
-    pub async fn get_next_txn(&mut self) -> Arc<Transaction> {
-        Arc::new(self.transaction_fetcher.lock().await.fetch_next().await)
-    }
-
-    pub async fn get_txn(&self, version: u64) -> Arc<Transaction> {
-        Arc::new(
-            self.transaction_fetcher
-                .lock()
-                .await
-                .fetch_version(version)
-                .await,
-        )
+    pub async fn get_txn(&self, version: u64) -> Transaction {
+        self.transaction_fetcher
+            .lock()
+            .await
+            .fetch_version(version)
+            .await
     }
 }
 
@@ -305,10 +279,12 @@ mod test {
 
     #[async_trait::async_trait]
     impl TransactionFetcherTrait for FakeFetcher {
-        fn set_version(&mut self, version: u64) {
-            self.version = version;
-            // Super hacky way of mocking chain_id
-            self.chain_id = version as u8;
+        async fn fetch_next_batch(&mut self) -> Vec<Transaction> {
+            unimplemented!();
+        }
+
+        async fn fetch_version(&self, _version: u64) -> Transaction {
+            unimplemented!();
         }
 
         async fn fetch_ledger_info(&mut self) -> State {
@@ -323,12 +299,14 @@ mod test {
             }
         }
 
-        async fn fetch_next(&mut self) -> Transaction {
-            unimplemented!();
+        async fn set_version(&mut self, version: u64) {
+            self.version = version;
+            // Super hacky way of mocking chain_id
+            self.chain_id = version as u8;
         }
 
-        async fn fetch_version(&self, _version: u64) -> Transaction {
-            unimplemented!();
+        async fn start(&mut self) {
+            // do nothing
         }
     }
 
@@ -574,7 +552,7 @@ mod test {
         )).unwrap();
 
         tailer
-            .process_transaction(Arc::new(genesis_txn.clone()))
+            .process_transactions(vec![genesis_txn.clone()])
             .await
             .unwrap();
 
@@ -652,7 +630,7 @@ mod test {
         )).unwrap();
 
         tailer
-            .process_transaction(Arc::new(block_metadata_transaction.clone()))
+            .process_transactions(vec![block_metadata_transaction.clone()])
             .await
             .unwrap();
 
@@ -765,11 +743,11 @@ mod test {
 
         // We run it twice to ensure we don't explode. Idempotency!
         tailer
-            .process_transaction(Arc::new(user_txn.clone()))
+            .process_transactions(vec![user_txn.clone()])
             .await
             .unwrap();
         tailer
-            .process_transaction(Arc::new(user_txn.clone()))
+            .process_transactions(vec![user_txn.clone()])
             .await
             .unwrap();
 
@@ -853,7 +831,7 @@ mod test {
         )).unwrap();
 
         tailer
-            .process_transaction(Arc::new(message_txn.clone()))
+            .process_transactions(vec![message_txn.clone()])
             .await
             .unwrap();
 

--- a/ecosystem/indexer/src/indexer/transaction_processor.rs
+++ b/ecosystem/indexer/src/indexer/transaction_processor.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::database::get_chunks;
 use crate::util::bigdecimal_to_u64;
 use crate::{
     counters::{
@@ -14,9 +15,11 @@ use crate::{
 };
 use aptos_rest_client::Transaction;
 use async_trait::async_trait;
+use diesel::pg::upsert::excluded;
 use diesel::{prelude::*, RunQueryDsl};
+use field_count::FieldCount;
 use schema::processor_statuses::{self, dsl};
-use std::{fmt::Debug, sync::Arc};
+use std::fmt::Debug;
 
 /// The `TransactionProcessor` is used by an instance of a `Tailer` to process transactions
 #[async_trait]
@@ -25,12 +28,13 @@ pub trait TransactionProcessor: Send + Sync + Debug {
     /// This will get stored in the database for each (`TransactionProcessor`, transaction_version) pair
     fn name(&self) -> &'static str;
 
-    /// Accepts a transaction, and processes it. This method will be called from `process_transaction_with_status`
-    /// In case a transaction cannot be processed, returns an error: the `Tailer` will mark it as failed in the database,
-    /// and it will be retried next time the indexer is started.
-    async fn process_transaction(
+    /// Process all transactions within a block and processes it. This method will be called from `process_transaction_with_status`
+    /// In case a transaction cannot be processed, we will fail the entire block.
+    async fn process_transactions(
         &self,
-        transaction: Arc<Transaction>,
+        transactions: Vec<Transaction>,
+        start_version: u64,
+        end_version: u64,
     ) -> Result<ProcessingResult, TransactionProcessingError>;
 
     /// Gets a reference to the connection pool
@@ -62,17 +66,23 @@ pub trait TransactionProcessor: Send + Sync + Debug {
     }
 
     /// This is a helper method, tying together the other helper methods to allow tracking status in the DB
-    async fn process_transaction_with_status(
+    async fn process_transactions_with_status(
         &self,
-        transaction: Arc<Transaction>,
+        txns: Vec<Transaction>,
     ) -> Result<ProcessingResult, TransactionProcessingError> {
         PROCESSOR_INVOCATIONS
             .with_label_values(&[self.name()])
             .inc();
 
-        self.mark_version_started(transaction.version().unwrap());
-        let res = self.process_transaction(transaction).await;
-        // Handle version success/failure
+        let (start_version, end_version) = (
+            txns.first().unwrap().version().unwrap(),
+            txns.last().unwrap().version().unwrap(),
+        );
+        self.mark_versions_started(start_version, end_version);
+        let res = self
+            .process_transactions(txns, start_version, end_version)
+            .await;
+        // Handle block success/failure
         match res.as_ref() {
             Ok(processing_result) => self.update_status_success(processing_result),
             Err(tpe) => self.update_status_err(tpe),
@@ -81,26 +91,40 @@ pub trait TransactionProcessor: Send + Sync + Debug {
     }
 
     /// Writes that a version has been started for this `TransactionProcessor` to the DB
-    fn mark_version_started(&self, version: u64) {
+    fn mark_versions_started(&self, start_version: u64, end_version: u64) {
         aptos_logger::debug!(
-            "[{}] Marking processing version started: {}",
+            "[{}] Marking processing versions started from versions {} to {}",
             self.name(),
-            version
+            start_version,
+            end_version
         );
-        let psm = ProcessorStatusModel::for_mark_started(self.name(), version);
-        self.apply_processor_status(&psm);
+        let psms = ProcessorStatusModel::from_versions(
+            self.name(),
+            start_version,
+            end_version,
+            false,
+            None,
+        );
+        self.apply_processor_status(&psms);
     }
 
     /// Writes that a version has been completed successfully for this `TransactionProcessor` to the DB
     fn update_status_success(&self, processing_result: &ProcessingResult) {
         aptos_logger::debug!(
-            "[{}] Marking processing version OK: {}",
+            "[{}] Marking processing version OK from versions {} to {}",
             self.name(),
-            processing_result.version
+            processing_result.start_version,
+            processing_result.end_version
         );
         PROCESSOR_SUCCESSES.with_label_values(&[self.name()]).inc();
-        let psm = ProcessorStatusModel::from_processing_result_ok(processing_result);
-        self.apply_processor_status(&psm);
+        let psms = ProcessorStatusModel::from_versions(
+            self.name(),
+            processing_result.start_version,
+            processing_result.end_version,
+            true,
+            None,
+        );
+        self.apply_processor_status(&psms);
     }
 
     /// Writes that a version has errored for this `TransactionProcessor` to the DB
@@ -116,17 +140,24 @@ pub trait TransactionProcessor: Send + Sync + Debug {
     }
 
     /// Actually performs the write for a `ProcessorStatusModel` changeset
-    fn apply_processor_status(&self, psm: &ProcessorStatusModel) {
+    fn apply_processor_status(&self, psms: &[ProcessorStatusModel]) {
         let conn = self.get_conn();
-        execute_with_better_error(
-            &conn,
-            diesel::insert_into(processor_statuses::table)
-                .values(psm)
-                .on_conflict((dsl::name, dsl::version))
-                .do_update()
-                .set(psm),
-        )
-        .expect("Error updating Processor Status!");
+        let chunks = get_chunks(psms.len(), ProcessorStatusModel::field_count());
+        for (start_ind, end_ind) in chunks {
+            execute_with_better_error(
+                &conn,
+                diesel::insert_into(processor_statuses::table)
+                    .values(&psms[start_ind..end_ind])
+                    .on_conflict((dsl::name, dsl::version))
+                    .do_update()
+                    .set((
+                        dsl::success.eq(excluded(dsl::success)),
+                        dsl::details.eq(excluded(dsl::details)),
+                        dsl::last_updated.eq(excluded(dsl::last_updated)),
+                    )),
+            )
+            .expect("Error updating Processor Status!");
+        }
     }
 
     /// Gets all versions which were not successfully processed for this `TransactionProcessor` from the DB

--- a/ecosystem/indexer/src/models/metadata.rs
+++ b/ecosystem/indexer/src/models/metadata.rs
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::schema::metadatas;
+use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Associations, Debug, Identifiable, Insertable, Queryable, Serialize, Clone)]
+#[derive(
+    Associations, Debug, FieldCount, Identifiable, Insertable, Queryable, Serialize, Clone,
+)]
 #[diesel(table_name = "metadata")]
 #[primary_key(token_id)]
 pub struct Metadata {

--- a/ecosystem/indexer/src/token_processor.rs
+++ b/ecosystem/indexer/src/token_processor.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::database::get_chunks;
 use crate::models::token::{
     CreateCollectionEventType, CreateTokenDataEventType, MintTokenEventType,
     MutateTokenPropertyMapEventType, TokenData, TokenEvent,
@@ -28,8 +29,8 @@ use crate::{
 use aptos_rest_client::Transaction;
 use async_trait::async_trait;
 use diesel::{Connection, ExpressionMethods, QueryDsl, RunQueryDsl};
-use futures::future::Either;
-use std::{fmt::Debug, sync::Arc};
+use field_count::FieldCount;
+use std::fmt::Debug;
 
 pub struct TokenTransactionProcessor {
     connection_pool: PgDbPool,
@@ -196,7 +197,7 @@ fn insert_collection(
 fn process_token_on_chain_data(
     conn: &PgPoolConnection,
     events: &[EventModel],
-    txn: &UserTransaction,
+    txns: &[UserTransaction],
     uris: &mut Vec<(String, String)>,
 ) {
     // filter events to only keep token events
@@ -212,23 +213,33 @@ fn process_token_on_chain_data(
             TokenEvent::CreateTokenDataEvent(event_data) => {
                 let uri = event_data.uri.clone();
                 let t_data_id = event_data.id.to_string();
-                insert_token_data(conn, event_data, txn);
+                insert_token_data(conn, event_data, &txns[0]);
                 uris.push((t_data_id, uri));
             }
             TokenEvent::MintTokenEvent(event_data) => {
-                update_mint_token(conn, event_data, txn);
+                update_mint_token(conn, event_data, &txns[0]);
             }
             TokenEvent::CollectionCreationEvent(event_data) => {
-                insert_collection(conn, event_data, txn);
+                insert_collection(conn, event_data, &txns[0]);
             }
             TokenEvent::DepositEvent(event_data) => {
-                update_token_ownership(conn, event_data.id.to_string(), txn, event_data.amount);
+                update_token_ownership(
+                    conn,
+                    event_data.id.to_string(),
+                    &txns[0],
+                    event_data.amount,
+                );
             }
             TokenEvent::WithdrawEvent(event_data) => {
-                update_token_ownership(conn, event_data.id.to_string(), txn, -event_data.amount);
+                update_token_ownership(
+                    conn,
+                    event_data.id.to_string(),
+                    &txns[0],
+                    -event_data.amount,
+                );
             }
             TokenEvent::MutateTokenPropertyMapEvent(event_data) => {
-                insert_token_properties(conn, event_data, txn);
+                insert_token_properties(conn, event_data, &txns[0]);
             }
             _ => (),
         }
@@ -241,31 +252,27 @@ impl TransactionProcessor for TokenTransactionProcessor {
         "token_processor"
     }
 
-    async fn process_transaction(
+    async fn process_transactions(
         &self,
-        transaction: Arc<Transaction>,
+        transactions: Vec<Transaction>,
+        start_version: u64,
+        end_version: u64,
     ) -> Result<ProcessingResult, TransactionProcessingError> {
-        let version = transaction.version().unwrap_or(0);
-
-        let (_, maybe_details_model, maybe_events, _) =
-            TransactionModel::from_transaction(&transaction);
+        let (_, user_txns, _, events, _) = TransactionModel::from_transactions(&transactions);
 
         let conn = self.get_conn();
         let mut token_uris: Vec<(String, String)> = vec![];
 
         let mut tx_result = conn.transaction::<(), diesel::result::Error, _>(|| {
-            if let Some(Either::Left(user_txn)) = maybe_details_model {
-                if let Some(events) = maybe_events {
-                    process_token_on_chain_data(&conn, &events, &user_txn, &mut token_uris);
-                }
-            }
+            process_token_on_chain_data(&conn, &events, &user_txns, &mut token_uris);
             Ok(())
         });
 
         if let Err(err) = tx_result {
             return Err(TransactionProcessingError::TransactionCommitError((
                 anyhow::Error::from(err),
-                version,
+                start_version,
+                end_version,
                 self.name(),
             )));
         };
@@ -273,11 +280,12 @@ impl TransactionProcessor for TokenTransactionProcessor {
             let mut res: Vec<Metadata> = vec![];
             get_all_metadata(&token_uris, &mut res).await;
             tx_result = conn.transaction::<(), diesel::result::Error, _>(|| {
-                for metadata in res {
+                let chunks = get_chunks(res.len(), Metadata::field_count());
+                for (start_ind, end_ind) in chunks {
                     execute_with_better_error(
                         &conn,
                         diesel::insert_into(schema::metadatas::table)
-                            .values(&metadata)
+                            .values(&res[start_ind..end_ind])
                             .on_conflict_do_nothing(),
                     )
                     .expect("Error inserting row into metadatas");
@@ -286,10 +294,15 @@ impl TransactionProcessor for TokenTransactionProcessor {
             });
         }
         match tx_result {
-            Ok(_) => Ok(ProcessingResult::new(self.name(), version)),
+            Ok(_) => Ok(ProcessingResult::new(
+                self.name(),
+                start_version,
+                end_version,
+            )),
             Err(err) => Err(TransactionProcessingError::TransactionCommitError((
                 anyhow::Error::from(err),
-                version,
+                start_version,
+                end_version,
                 self.name(),
             ))),
         }


### PR DESCRIPTION
### Description

Separate threads for fetching data, and separate threads for pushing it to DB in parallel

increases (locally) performance of (old) indexer from 1.4k TPS, to 2.7k TPS (locally, running against sherrynet)

Pushing from local to RDS performance went from 20TPS to ~150 TPS with bulk fetch, and to 600 TPS with batch write.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3372)
<!-- Reviewable:end -->
