### PR TITLE
Add tool that calls NHC for all VFNs on chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aptos-vfn-check-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-node-checker",
+ "aptos-sdk",
+ "clap 3.2.17",
+ "env_logger 0.9.0",
+ "futures",
+ "gcp-bigquery-client",
+ "log",
+ "reqwest",
+ "serde 1.0.144",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "aptos-vm"
 version = "0.1.0"
 dependencies = [
@@ -3514,6 +3532,19 @@ name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime 2.1.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
 dependencies = [
  "atty",
  "humantime 2.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
     "crates/transaction-emitter-lib",
     "ecosystem/indexer",
     "ecosystem/node-checker",
+    "ecosystem/node-checker/vfn-check-client",
     "ecosystem/sf-indexer/aptos-sf-indexer",
     "ecosystem/sf-indexer/firehose-stream",
     "execution/db-bootstrapper",

--- a/docker/build-rust-all.sh
+++ b/docker/build-rust-all.sh
@@ -13,6 +13,7 @@ RUSTFLAGS="--cfg tokio_unstable" cargo build --release \
         -p aptos-node-checker \
         -p aptos-openapi-spec-generator \
         -p aptos-telemetry-service \
+        -p aptos-vfn-check-client \
         -p backup-cli \
         -p db-bootstrapper \
         -p forge-cli \
@@ -29,6 +30,7 @@ BINS=(
     aptos-node-checker
     aptos-openapi-spec-generator
     aptos-telemetry-service
+    aptos-vfn-check-client
     db-backup
     db-backup-verify
     db-bootstrapper

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -146,6 +146,7 @@ COPY --link --from=builder /aptos/dist/db-backup-verify /usr/local/bin/db-backup
 COPY --link --from=builder /aptos/dist/db-restore /usr/local/bin/db-restore
 COPY --link --from=builder /aptos/dist/aptos /usr/local/bin/aptos
 COPY --link --from=builder /aptos/dist/aptos-openapi-spec-generator /usr/local/bin/aptos-openapi-spec-generator
+COPY --link --from=builder /aptos/dist/aptos-vfn-check-client /usr/local/bin/aptos-vfn-check-client
 COPY --link --from=builder /aptos/dist/transaction-emitter /usr/local/bin/transaction-emitter
 
 ### Get Aptos Move releases for genesis ceremony

--- a/ecosystem/node-checker/Cargo.toml
+++ b/ecosystem/node-checker/Cargo.toml
@@ -38,5 +38,6 @@ aptos-sdk = { path = "../../sdk" }
 
 transaction-emitter-lib = { path = "../../crates/transaction-emitter-lib" }
 
-[[bin]]
-name = "aptos-node-checker"
+[lib]
+name = "aptos_node_checker_lib"
+path = "src/lib.rs"

--- a/ecosystem/node-checker/src/bin/aptos-node-checker.rs
+++ b/ecosystem/node-checker/src/bin/aptos-node-checker.rs
@@ -1,15 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-mod common_args;
-mod configuration;
-mod evaluator;
-mod evaluators;
-mod metric_collector;
-mod runner;
-mod server;
-
 use anyhow::Result;
+use aptos_node_checker_lib::{configuration, server};
 use clap::{Parser, Subcommand};
 
 #[derive(Clone, Debug, Subcommand)]

--- a/ecosystem/node-checker/src/evaluator/types.rs
+++ b/ecosystem/node-checker/src/evaluator/types.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use poem_openapi::Object as PoemObject;
+use serde::{Deserialize, Serialize};
 
 // TODO: Should I find a way to have typed actual + expected fields?
-#[derive(Clone, Debug, PoemObject)]
+#[derive(Clone, Debug, Deserialize, PoemObject, Serialize)]
 pub struct EvaluationResult {
     /// Headline of the evaluation, e.g. "Healthy!" or "Metrics missing!".
     pub headline: String,
@@ -25,7 +26,7 @@ pub struct EvaluationResult {
     pub links: Vec<String>,
 }
 
-#[derive(Clone, Debug, PoemObject)]
+#[derive(Clone, Debug, Deserialize, PoemObject, Serialize)]
 pub struct EvaluationSummary {
     /// Results from all the evaluations NHC ran.
     pub evaluation_results: Vec<EvaluationResult>,

--- a/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
@@ -74,7 +74,7 @@ impl NodeIdentityEvaluator {
                 ),
                 0,
                 format!(
-                    "The node under investigation reported the {} {}  while the \
+                    "The node under investigation reported the {} {} while the \
                 baseline reported {}. These values should match. Confirm that \
                 the baseline you're using is appropriate for the node you're testing.",
                     attribute_str, target_value, baseline_value

--- a/ecosystem/node-checker/src/lib.rs
+++ b/ecosystem/node-checker/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod common_args;
+pub mod configuration;
+mod evaluator;
+mod evaluators;
+mod metric_collector;
+mod runner;
+pub mod server;
+
+pub use evaluator::EvaluationSummary;

--- a/ecosystem/node-checker/vfn-check-client/Cargo.toml
+++ b/ecosystem/node-checker/vfn-check-client/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "aptos-vfn-check-client"
+version = "0.1.0"
+authors = ["Aptos Labs <opensource@aptoslabs.com>"]
+description = "Tool to check the health of all VFNs registed in the validator set of an Aptos network"
+repository = "https://github.com/aptos-labs/aptos-core"
+homepage = "https://aptoslabs.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+anyhow = "1.0.62"
+aptos-node-checker = { path = "../" }
+aptos-sdk = { path = "../../../sdk" }
+clap = "3.2.17"
+env_logger = "0.9.0"
+futures = "0.3.21"
+gcp-bigquery-client = "0.13.0"
+log = "0.4.17"
+reqwest = "0.11.11"
+serde = "1.0.144"
+serde_json = "1.0.85"
+tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }

--- a/ecosystem/node-checker/vfn-check-client/README.md
+++ b/ecosystem/node-checker/vfn-check-client/README.md
@@ -1,0 +1,41 @@
+# Validator FullNode (VFN) NHC periodic checker
+
+## Description
+This tool is a client to NHC that does the following:
+1. Get the validator set from any node participating in a network we want to test.
+2. Process that to create a map from operator account address to VFN network addresses.
+3. Query NHC for each VFN.
+4. Push the results to BigQuery.
+
+The original intent behind this tool is to confirm operators are running quality, operational VFNs as part of AIT3. This tool can be easily adapted for other use cases down the line.
+
+## Local development
+Run a local network with both a validator and VFNs:
+```
+cargo run -p forge-cli -- --suite "run_forever" --num-validators 4 --num-validator-fullnodes 2 --mempool-backlog 5000 test local-swarm
+```
+
+Run local NHC:
+```
+cargo run -p aptos-node-checker -- server run --baseline-node-config-paths ~/a/internal-ops/infra/apps/node-checker/configs/ait3_vfn.yaml --listen-address 0.0.0.0
+```
+
+Run the tool:
+```
+cargo run -p aptos-vfn-check-client -- --node-address http://127.0.0.1:8080 --nhc-address http://127.0.0.1:20121 --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json
+```
+Output: https://gist.github.com/banool/29e18a863709c1998891551da1dfb429.
+
+Submitting to BigQuery instead:
+```
+cargo run -p aptos-vfn-check-client -- --node-address http://127.0.0.1:8080 --nhc-address http://127.0.0.1:20121 --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json --output-style big-query
+```
+
+## Deployment
+This is automatically built into the tools image.
+
+## Helpful stuff
+This command will show you the validator set on chain using the CLI:
+```
+aptos node show-validator-set --url https://fullnode.devnet.aptoslabs.com
+```

--- a/ecosystem/node-checker/vfn-check-client/src/big_query.rs
+++ b/ecosystem/node-checker/vfn-check-client/src/big_query.rs
@@ -1,0 +1,191 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Context, Result};
+use aptos_sdk::types::account_address::AccountAddress;
+use clap::Parser;
+use gcp_bigquery_client::error::BQError;
+use gcp_bigquery_client::model::dataset::Dataset;
+use gcp_bigquery_client::model::table::Table;
+use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
+use gcp_bigquery_client::model::table_field_schema::TableFieldSchema;
+use gcp_bigquery_client::model::table_schema::TableSchema;
+use gcp_bigquery_client::Client as BigQueryClient;
+use log::info;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::path::PathBuf;
+
+use crate::check::SingleCheck;
+
+#[derive(Debug, Parser)]
+pub struct BigQueryArgs {
+    /// Path to the BigQuery key file.
+    #[clap(long, parse(from_os_str))]
+    pub big_query_key_path: PathBuf,
+
+    /// GCP project ID.
+    #[clap(long, default_value = "analytics-test-345723")]
+    pub gcp_project_id: String,
+
+    /// BigQuery dataset ID.
+    #[clap(long, default_value = "ait3_vfn_nhc")]
+    pub big_query_dataset_id: String,
+
+    /// BigQuery table ID.
+    #[clap(long, default_value = "nhc_response_data")]
+    pub big_query_table_id: String,
+}
+
+// This struct formats the data into a format that BigQuery expects.
+#[derive(Debug, Serialize)]
+pub struct MyBigQueryRow {
+    pub account_address: String,
+    pub nhc_response_json: String,
+    pub time_response_received: u64,
+}
+
+impl TryFrom<(AccountAddress, SingleCheck)> for MyBigQueryRow {
+    type Error = anyhow::Error;
+
+    fn try_from(
+        (account_address, single_check): (AccountAddress, SingleCheck),
+    ) -> Result<Self, Self::Error> {
+        Ok(Self {
+            account_address: account_address.to_string(),
+            nhc_response_json: serde_json::to_string(&single_check.result)
+                .context("Failed to encode result data as JSON")?,
+            time_response_received: single_check.timestamp.as_secs(),
+        })
+    }
+}
+
+/// Instead of reading whether the dataset / table exists and then conditionally
+/// creating them, we just try every time and ignore the ALREADY_EXISTS error.
+/// This function does that check.
+fn ignore_already_exists_error<T>(result: Result<T, BQError>) -> Result<(), BQError> {
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) => match err {
+            BQError::ResponseError { ref error } => {
+                if error.error.status == "ALREADY_EXISTS" {
+                    Ok(())
+                } else {
+                    Err(err)
+                }
+            }
+            wildcard => Err(wildcard),
+        },
+    }
+}
+
+/// Make a table field required, as part of the table creation request.
+fn make_required(mut table_field_schema: TableFieldSchema) -> TableFieldSchema {
+    table_field_schema.mode = Some("REQUIRED".to_string());
+    table_field_schema
+}
+
+/// Write the response data to BigQuery. Note: On the first run this fails
+/// sometimes because it doesn't seem BigQuery offers read-what-you-wrote.
+/// As in, it'll make the table, but then fail to insert the data because
+/// the table apparently doesn't exist, but then succeed the next time.
+pub async fn write_to_big_query(
+    big_query_args: &BigQueryArgs,
+    nhc_responses: HashMap<AccountAddress, Vec<SingleCheck>>,
+) -> Result<()> {
+    let client = BigQueryClient::from_service_account_key_file(
+        big_query_args
+            .big_query_key_path
+            .to_str()
+            .context("Big query key path was invalid")?,
+    )
+    .await;
+
+    info!(
+        "Creating dataset if necessary: {}",
+        big_query_args.big_query_dataset_id
+    );
+
+    // Create the dataset if necessary.
+    ignore_already_exists_error(
+        client
+            .dataset()
+            .create(
+                Dataset::new(
+                    &big_query_args.gcp_project_id,
+                    &big_query_args.big_query_dataset_id,
+                )
+                .location("US")
+                .friendly_name("NHC AIT3 1"),
+            )
+            .await,
+    )
+    .context("Failed to create the dataset")?;
+
+    info!("Created dataset / confirmed it was there");
+
+    info!(
+        "Creating table if necessary: {}",
+        big_query_args.big_query_table_id
+    );
+
+    // Create the table if necessary.
+    ignore_already_exists_error(
+        client
+            .table()
+            .create(
+                Table::new(
+                    &big_query_args.gcp_project_id,
+                    &big_query_args.big_query_dataset_id,
+                    &big_query_args.big_query_table_id,
+                    TableSchema::new(vec![
+                        make_required(TableFieldSchema::string("account_address")),
+                        // TODO: Consider using a record instead to give it more structure.
+                        make_required(TableFieldSchema::string("nhc_response_json")),
+                        make_required(TableFieldSchema::timestamp("time_response_received")),
+                    ]),
+                )
+                .friendly_name("NHC response data")
+                .description("NHC check responses from vfn-check-client for AIT3 VFN checks"),
+            )
+            .await,
+    )
+    .context("Failed to create the table")?;
+
+    info!("Created table / confirmed it was there");
+
+    // Build the request to send to BigQuery.
+    let mut insert_request = TableDataInsertAllRequest::new();
+    for (account_address, check_results) in nhc_responses {
+        for single_check_result in check_results {
+            insert_request.add_row(
+                None,
+                MyBigQueryRow::try_from((account_address, single_check_result))?,
+            )?;
+        }
+    }
+
+    info!("Inserting {} rows to BigQuery", insert_request.len());
+
+    // Submit the request.
+    let response = client
+        .tabledata()
+        .insert_all(
+            &big_query_args.gcp_project_id,
+            &big_query_args.big_query_dataset_id,
+            &big_query_args.big_query_table_id,
+            insert_request,
+        )
+        .await
+        .context("Failed to insert data to BigQuery")?;
+
+    // Confirm it was successful.
+    if response.insert_errors.is_some() {
+        bail!("Failed to insert data to BigQuery: {:?}", response);
+    }
+
+    info!("Inserted data to BigQuery successfully");
+
+    Ok(())
+}

--- a/ecosystem/node-checker/vfn-check-client/src/check.rs
+++ b/ecosystem/node-checker/vfn-check-client/src/check.rs
@@ -1,0 +1,369 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context;
+use anyhow::Result;
+use aptos_node_checker_lib::EvaluationSummary;
+use aptos_sdk::rest_client::Client as AptosClient;
+use aptos_sdk::types::account_address::AccountAddress;
+use aptos_sdk::types::account_config::CORE_CODE_ADDRESS;
+use aptos_sdk::types::network_address::NetworkAddress;
+use aptos_sdk::types::on_chain_config::ValidatorSet;
+use aptos_sdk::types::validator_info::ValidatorInfo;
+use clap::Parser;
+use log::{debug, info};
+use reqwest::Client as ReqwestClient;
+use reqwest::Url;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use tokio::sync::Semaphore;
+
+use crate::helpers::extract_network_address;
+
+// Unfortunately we don't have any way, on chain or not, to know what the API
+// port is, so we just assume it is one of these. If their VFN is inaccessible at,
+// any of these ports, e.g. because it runs on 7777 and they have an LB not registered
+// on chain in front of it that listens at 80 just for the API, we're just out of luck.
+// If we get this kind of information from elsewhere at some point, we could look at
+// joining it here.
+pub const API_PORTS: &[u16] = &[80, 8080, 443];
+
+#[derive(Debug, Parser)]
+pub struct CheckArgs {
+    /// Address of any node (of any type) connected to the network you want
+    /// to evaluate.
+    #[clap(long)]
+    pub node_address: Url,
+
+    /// Address where NHC is running.
+    #[clap(long)]
+    pub nhc_address: Url,
+
+    /// Baseline config to use when talking to NHC.
+    #[clap(long)]
+    pub nhc_baseline_config_name: String,
+
+    /// How long to wait when talking to NHC. The check should be quick unless
+    /// we're using the TPS evaluator.
+    #[clap(long, default_value_t = 60)]
+    pub nhc_timeout_secs: u64,
+
+    /// Max number of requests to NHC we can have running concurrently.
+    #[clap(long, default_value_t = 4)]
+    pub max_concurrent_nhc_requests: u16,
+
+    /// Only run against these account addresses.
+    #[clap(long)]
+    pub account_address_allowlist: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SingleCheck {
+    pub result: SingleCheckResult,
+    pub timestamp: Duration,
+    pub vfn_address: Option<NetworkAddress>,
+}
+
+impl SingleCheck {
+    pub fn new(result: SingleCheckResult, vfn_address: Option<NetworkAddress>) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Failed to get current time");
+        Self {
+            result,
+            timestamp: now,
+            vfn_address,
+        }
+    }
+}
+
+/// We use this struct to capture the result of checking a node, or the lack thereof.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SingleCheckResult {
+    /// The node was successfully checked. Note: The evaulation itself could
+    /// indicate, a problem with the node, this just states that we were able
+    /// to check the node sucessfully with NHC.
+    Success(EvaluationSummary),
+
+    /// Something went wrong with checking the node.
+    Failure(SingleCheckFailure),
+
+    /// The account does not have a VFN registered on chain.
+    NoVfnRegistered(NoVfnRegistered),
+}
+
+#[derive(Debug, Serialize)]
+pub struct SingleCheckFailure {
+    pub message: String,
+    pub code: SingleCheckFailureCode,
+}
+
+impl SingleCheckFailure {
+    pub fn new(message: String, code: SingleCheckFailureCode) -> Self {
+        Self { message, code }
+    }
+}
+
+#[derive(Debug, PartialEq, Serialize)]
+pub enum SingleCheckFailureCode {
+    // The network address in the validator set config cannot be used for
+    // querying NHC.
+    UnsupportedNetworkAddressType,
+
+    // Something went wrong when sending / receiving the request.
+    RequestFlowError,
+
+    // The response from NHC was not a 200, implying a problem with NHC.
+    ResponseNot200,
+
+    // The response from NHC couldn't be deserialized.
+    CouldNotDeserializeResponse,
+
+    // NHC returned an evaluation that indicates that the API port is closed.
+    ApiPortClosed,
+}
+
+// This is necessary because we can't just use a unit type for this enum variant.
+#[derive(Debug, Serialize)]
+pub struct NoVfnRegistered;
+
+/// Get all the on chain validator info.
+pub async fn get_validator_info(node_address: Url) -> Result<Vec<ValidatorInfo>> {
+    let client = AptosClient::new(node_address.clone());
+    let response = client
+        .get_account_resource_bcs::<ValidatorSet>(CORE_CODE_ADDRESS, "0x1::stake::ValidatorSet")
+        .await?;
+    let active_validators = response.into_inner().active_validators;
+    info!(
+        "Pulled {} active validators. First: {}. Last: {}",
+        active_validators.len(),
+        active_validators.first().unwrap().account_address(),
+        active_validators.last().unwrap().account_address()
+    );
+    Ok(active_validators)
+}
+
+/// Check all VFNs from the validator set.
+pub async fn check_vfns(
+    nhc_client: &ReqwestClient,
+    check_args: &CheckArgs,
+    validator_infos: Vec<ValidatorInfo>,
+) -> Result<HashMap<AccountAddress, Vec<SingleCheck>>> {
+    let mut nhc_address = check_args.nhc_address.clone();
+    nhc_address.set_path("/check_node");
+
+    let semaphore = Arc::new(Semaphore::new(
+        check_args.max_concurrent_nhc_requests as usize,
+    ));
+
+    let mut nhc_responses = HashMap::new();
+    let mut futures = vec![];
+    for validator_info in validator_infos {
+        let account_address = validator_info.account_address();
+        if !check_args.account_address_allowlist.is_empty()
+            && !check_args
+                .account_address_allowlist
+                .contains(&account_address.to_string())
+        {
+            continue;
+        }
+        let vfn_addresses = validator_info
+            .config()
+            .fullnode_network_addresses()
+            .context("Failed to deserialize VFN network addresses")?;
+        if vfn_addresses.is_empty() {
+            nhc_responses
+                .entry(*account_address)
+                .or_insert_with(Vec::new)
+                .push(SingleCheck::new(
+                    SingleCheckResult::NoVfnRegistered(NoVfnRegistered),
+                    None,
+                ));
+            continue;
+        }
+        for vfn_address in vfn_addresses.into_iter() {
+            let single_check_future = check_single_vfn_wrapper(
+                *account_address,
+                nhc_client,
+                &nhc_address,
+                &check_args.nhc_baseline_config_name,
+                vfn_address,
+                semaphore.clone(),
+            );
+            futures.push(single_check_future);
+        }
+    }
+    let checks = futures::future::join_all(futures).await;
+    for (account_address, vfn_address, single_check_result) in checks {
+        match single_check_result {
+            SingleCheckResult::Success(_) => {
+                info!("NHC returned a 200 for {}", vfn_address);
+            }
+            SingleCheckResult::Failure(_) => {
+                info!("NHC returned a non 200 for {}", vfn_address);
+            }
+            SingleCheckResult::NoVfnRegistered(_) => panic!("Shouldn't be possible"),
+        }
+        nhc_responses
+            .entry(account_address)
+            .or_insert_with(Vec::new)
+            .push(SingleCheck::new(single_check_result, Some(vfn_address)));
+    }
+    Ok(nhc_responses)
+}
+
+// This just exists to make joining futures easy.
+async fn check_single_vfn_wrapper(
+    account_address: AccountAddress,
+    nhc_client: &ReqwestClient,
+    nhc_address: &Url,
+    nhc_baseline_config_name: &str,
+    vfn_address: NetworkAddress,
+    semaphore: Arc<Semaphore>,
+) -> (AccountAddress, NetworkAddress, SingleCheckResult) {
+    let _permit = semaphore.acquire().await.unwrap();
+    info!("Checking VFNs for account {}", account_address,);
+    (
+        account_address,
+        vfn_address.clone(),
+        check_single_vfn(
+            nhc_client,
+            nhc_address,
+            nhc_baseline_config_name,
+            vfn_address,
+        )
+        .await,
+    )
+}
+
+/// Make a query to NHC for a single VFN. This may result in multiple queries to
+/// NHC as we try different API ports.
+async fn check_single_vfn(
+    nhc_client: &ReqwestClient,
+    nhc_address: &Url,
+    nhc_baseline_config_name: &str,
+    vfn_address: NetworkAddress,
+) -> SingleCheckResult {
+    // Get a string representation of the vfn address if possible.
+    let vfn_url_string = match extract_network_address(&vfn_address) {
+        Ok(vfn_url_string) => vfn_url_string,
+        Err(e) => {
+            return SingleCheckResult::Failure(SingleCheckFailure::new(
+                format!("Network address was an unsupported type: {}", e),
+                SingleCheckFailureCode::UnsupportedNetworkAddressType,
+            ));
+        }
+    };
+
+    info!("Checking VFN {}", vfn_url_string);
+
+    let mut index = 0;
+    loop {
+        let single_check_result = check_single_vfn_one_api_port(
+            nhc_client,
+            nhc_address,
+            nhc_baseline_config_name,
+            &vfn_url_string,
+            API_PORTS[index],
+        )
+        .await;
+        // If the response was a success, return.
+        if let SingleCheckResult::Success(_) = &single_check_result {
+            break single_check_result;
+        }
+        // If the response was a failure, return unless it was because it
+        // seems like the API wasn't open, in which case we keep looping
+        // to try another port.
+        if let SingleCheckResult::Failure(failure) = &single_check_result {
+            if failure.code != SingleCheckFailureCode::ApiPortClosed {
+                break single_check_result;
+            }
+        }
+        // We've tried every port, return the last result.
+        if index == API_PORTS.len() - 1 {
+            break single_check_result;
+        }
+        index += 1;
+    }
+}
+
+/// Check NHC just once, with a single VFN for a single API port.
+async fn check_single_vfn_one_api_port(
+    nhc_client: &ReqwestClient,
+    nhc_address: &Url,
+    nhc_baseline_config_name: &str,
+    vfn_url_string: &str,
+    api_port: u16,
+) -> SingleCheckResult {
+    // Build up query params.
+    let mut params = HashMap::new();
+    let api_port_string = api_port.to_string();
+    params.insert("node_url", vfn_url_string);
+    params.insert("api_port", &api_port_string);
+    params.insert("baseline_configuration_name", nhc_baseline_config_name);
+
+    debug!(
+        "Querying NHC at address: {}:{}",
+        vfn_url_string, api_port_string
+    );
+
+    // Send the request and parse the response.
+    let response = match nhc_client
+        .get(nhc_address.clone())
+        .query(&params)
+        .send()
+        .await
+    {
+        Ok(response) => response,
+        Err(e) => {
+            return SingleCheckResult::Failure(SingleCheckFailure::new(
+                format!("Error with request flow to NHC: {:#}", e),
+                SingleCheckFailureCode::RequestFlowError,
+            ));
+        }
+    };
+
+    // Handle the case where NHC itself throws an error (as opposed to a success
+    // response from NHC indicating evaluation where the node performed poorly).
+    if let Err(e) = response.error_for_status_ref() {
+        return SingleCheckResult::Failure(SingleCheckFailure::new(
+            format!("{:#}: {:?}", e, response.text().await),
+            SingleCheckFailureCode::ResponseNot200,
+        ));
+    };
+
+    // Confirm the response is valid JSON.
+    let evaluation_summary = match response.json::<EvaluationSummary>().await {
+        Ok(evaluation_summary) => evaluation_summary,
+        Err(e) => {
+            return SingleCheckResult::Failure(SingleCheckFailure::new(
+                format!("{:#}", e),
+                SingleCheckFailureCode::CouldNotDeserializeResponse,
+            ))
+        }
+    };
+
+    // Check specifically if the API port is closed.
+    if evaluation_summary
+        .evaluation_results
+        .iter()
+        .any(|evaluation_result| {
+            evaluation_result.evaluator_name == "index_response" && evaluation_result.score == 0
+        })
+    {
+        return SingleCheckResult::Failure(SingleCheckFailure::new(
+            format!(
+                "Couldn't talk to API on any of the expected ports {:?}: {:?}",
+                API_PORTS, evaluation_summary
+            ),
+            SingleCheckFailureCode::ApiPortClosed,
+        ));
+    }
+
+    SingleCheckResult::Success(evaluation_summary)
+}

--- a/ecosystem/node-checker/vfn-check-client/src/helpers.rs
+++ b/ecosystem/node-checker/vfn-check-client/src/helpers.rs
@@ -1,0 +1,24 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use aptos_sdk::types::network_address::NetworkAddress;
+use std::net::{SocketAddr, ToSocketAddrs};
+
+// This function takes a NetworkAddress and returns a string representation
+// of it if it is a format we can send to NHC. Otherwise we return an error.
+pub fn extract_network_address(network_address: &NetworkAddress) -> Result<String> {
+    let mut socket_addrs = network_address
+        .to_socket_addrs()
+        .with_context(|| format!("Failed to parse network address as SocketAddr, this might imply that the domain name doesn't resolve to an IP: {}", network_address))?;
+    let socket_addr = socket_addrs
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No socket address found"))?;
+    match socket_addr {
+        SocketAddr::V4(addr) => Ok(format!("http://{}", addr.ip())),
+        SocketAddr::V6(addr) => Err(anyhow::anyhow!(
+            "We do not not support IPv6 addresses: {}",
+            addr
+        )),
+    }
+}

--- a/ecosystem/node-checker/vfn-check-client/src/main.rs
+++ b/ecosystem/node-checker/vfn-check-client/src/main.rs
@@ -1,0 +1,83 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod big_query;
+mod check;
+mod helpers;
+
+use anyhow::{Context, Result};
+use big_query::BigQueryArgs;
+use check::CheckArgs;
+use clap::Parser;
+use log::info;
+use reqwest::Client as ReqwestClient;
+use std::time::Duration;
+
+use crate::{
+    big_query::write_to_big_query,
+    check::{check_vfns, get_validator_info},
+};
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum OutputStyle {
+    Stdout,
+    BigQuery,
+}
+
+#[derive(Debug, Parser)]
+pub struct Args {
+    #[clap(flatten)]
+    pub check_args: CheckArgs,
+
+    #[clap(flatten)]
+    big_query_args: BigQueryArgs,
+
+    /// How to output the results.
+    #[clap(long, value_enum, default_value = "stdout", case_insensitive = true)]
+    output_style: OutputStyle,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    let args = Args::parse();
+    info!("Running with args: {:#?}", args);
+
+    let nhc_client = ReqwestClient::builder()
+        .timeout(Duration::from_secs(args.check_args.nhc_timeout_secs))
+        .build()
+        .unwrap();
+
+    let validator_infos = get_validator_info(args.check_args.node_address.clone())
+        .await
+        .context("Failed to get on chain validator info")?;
+
+    let nhc_responses = check_vfns(&nhc_client, &args.check_args, validator_infos)
+        .await
+        .context("Failed to check nodes unexpectedly")?;
+
+    info!(
+        "Got {} responses from NHC, will now output to {:?}",
+        nhc_responses.len(),
+        args.output_style
+    );
+
+    match args.output_style {
+        OutputStyle::Stdout => {
+            println!(
+                "{}",
+                serde_json::to_string(&nhc_responses).context("Failed to encode data as JSON")?
+            );
+        }
+        OutputStyle::BigQuery => {
+            write_to_big_query(&args.big_query_args, nhc_responses)
+                .await
+                .context("Failed to write to BigQuery")?;
+        }
+    }
+
+    info!("Done!");
+
+    Ok(())
+}


### PR DESCRIPTION
### Description
We will use this tool to periodically check how the VFNs in AIT 3 and beyond are going.

### Test Plan
Run local NHC:
```
cargo run -p aptos-node-checker -- server run --baseline-node-config-paths ~/a/internal-ops/infra/apps/node-checker/configs/ait3_vfn.yaml --listen-address 0.0.0.0
```

Run local testnet:
```
cargo run -p aptos -- node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
```

Run the tool:
```
cargo run -p aptos-vfn-check-client -- --node-address http://127.0.0.1:8080 --nhc-address http://127.0.0.1:20121 --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json
```
Output: https://gist.github.com/banool/cf54430db439e216e5216d884d83b44b.

Submitting to BigQuery instead:
```
cargo run -p aptos-vfn-check-client -- --node-address http://127.0.0.1:8080 --nhc-address http://127.0.0.1:20121 --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json --output-style big-query
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3373)
<!-- Reviewable:end -->
