### PR TITLE
[tf][aws] maximize subnset size

### DIFF
--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -23,6 +23,8 @@ locals {
 module "validator" {
   source = "../aptos-node/aws"
 
+  maximize_single_az_capacity = var.maximize_single_az_capacity
+
   region   = var.region
   iam_path = var.iam_path
   zone_id  = var.zone_id
@@ -36,6 +38,8 @@ module "validator" {
 
   # if forge enabled, standardize the helm release name for ease of operations
   helm_release_name_override = var.enable_forge ? "aptos-node" : ""
+  # Forge testing does not require calico for validator NetworkPolicies
+  enable_calico = !var.enable_forge
 
   k8s_api_sources = var.admin_sources_ipv4
   k8s_admin_roles = var.k8s_admin_roles
@@ -51,10 +55,12 @@ module "validator" {
   num_fullnode_groups = var.num_fullnode_groups
   helm_values         = var.aptos_node_helm_values
 
-  # allow all nodegroups to surge to 2x their size, in case of total nodes replacement
-  validator_instance_num = var.num_validator_instance > 0 ? 2 * var.num_validator_instance : var.num_validators
+  # allow all nodegroups to surge to 2x their size by default, in case of total nodes replacement
+  validator_instance_num     = var.num_validator_instance > 0 ? 2 * var.num_validator_instance : var.num_validators
+  validator_instance_max_num = var.validator_instance_max_num
   # create one utility instance per validator, since HAProxy requires resources 1.5 CPU, 2Gi memory for now
-  utility_instance_num = var.num_utility_instance > 0 ? var.num_utility_instance : var.num_validators
+  utility_instance_num     = var.num_utility_instance > 0 ? var.num_utility_instance : var.num_validators
+  utility_instance_max_num = var.utility_instance_max_num
 
   utility_instance_type   = var.utility_instance_type
   validator_instance_type = var.validator_instance_type

--- a/terraform/aptos-node-testnet/variables.tf
+++ b/terraform/aptos-node-testnet/variables.tf
@@ -4,6 +4,11 @@ variable "region" {
   description = "AWS region"
 }
 
+variable "maximize_single_az_capacity" {
+  description = "TEST ONLY: Whether to maximize the capacity of the cluster by allocating a large CIDR block to the first AZ"
+  default     = false
+}
+
 variable "zone_id" {
   description = "Route53 Zone ID to create records in"
   default     = ""
@@ -155,6 +160,16 @@ variable "num_utility_instance" {
 
 variable "num_validator_instance" {
   description = "Number of instances for validator node pool, when it's 0, it will be set to 2 * var.num_validators"
+  default     = 0
+}
+
+variable "utility_instance_max_num" {
+  description = "Maximum number of instances for utilities. If left 0, defaults to 2 * var.num_validators"
+  default     = 0
+}
+
+variable "validator_instance_max_num" {
+  description = "Maximum number of instances for utilities. If left 0, defaults to 2 * var.num_validators"
   default     = 0
 }
 

--- a/terraform/aptos-node/aws/kubernetes.tf
+++ b/terraform/aptos-node/aws/kubernetes.tf
@@ -100,6 +100,7 @@ resource "kubernetes_namespace" "tigera-operator" {
 }
 
 resource "helm_release" "calico" {
+  count      = var.enable_calico ? 1 : 0
   name       = "calico"
   repository = "https://docs.projectcalico.org/charts"
   chart      = "tigera-operator"

--- a/terraform/aptos-node/aws/network.tf
+++ b/terraform/aptos-node/aws/network.tf
@@ -1,24 +1,47 @@
+locals {
+  num_azs = length(local.aws_availability_zones)
+
+  # Maximize the capacity of the nodegroup in a single AZ. Otherwise, the CIDR ranges are divided equally.
+  # This gives us a max of /17 for the first AZ, which supports 32,768 hosts. The number of pods this can support
+  # varies, but with c5.4xlarge gets us ~600 validators. See https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt
+  # The other way to increase the cluster capacity is to allocate a new CIDR block to the VPC and associate
+  # it via configuring CNI, which is more complex: https://aws.amazon.com/premiumsupport/knowledge-center/eks-multiple-cidr-ranges/
+  num_other_subnets = local.num_azs * 2 - 1
+  max_subnet_cidr_ranges = cidrsubnets(var.vpc_cidr_block, 1, [for x in range(local.num_other_subnets): 1 + ceil(pow(local.num_other_subnets, 0.5))]...)
+  
+  # The subnet CIDR ranges in the case we want a maximally large one
+  max_private_subnet_cidr_ranges = slice(local.max_subnet_cidr_ranges, 0, local.num_azs)
+  max_public_subnet_cidr_ranges  = slice(local.max_subnet_cidr_ranges, local.num_azs, local.num_azs * 2)
+
+  # The subnet CIDR ranges in the case all are equally sized
+  default_public_subnet_cidr_ranges  = [for x in range(local.num_azs) : cidrsubnet(cidrsubnet(aws_vpc.vpc.cidr_block, 1, 0), 2, x)]
+  default_private_subnet_cidr_ranges = [for x in range(local.num_azs) : cidrsubnet(cidrsubnet(aws_vpc.vpc.cidr_block, 1, 1), 2, x)]
+
+  public_subnet_cidr_ranges  = var.maximize_single_az_capacity ? local.max_public_subnet_cidr_ranges : local.default_public_subnet_cidr_ranges
+  private_subnet_cidr_ranges = var.maximize_single_az_capacity ? local.max_private_subnet_cidr_ranges : local.default_private_subnet_cidr_ranges
+}
+
 resource "aws_vpc" "vpc" {
   cidr_block           = var.vpc_cidr_block
   enable_dns_hostnames = true
 
   tags = merge(local.default_tags, {
-    Name                                                 = "aptos-${local.workspace_name}"
+    Name                                                  = "aptos-${local.workspace_name}"
     "kubernetes.io/cluster/aptos-${local.workspace_name}" = "shared"
   })
 }
 
 resource "aws_subnet" "public" {
-  count                   = length(local.aws_availability_zones)
+  count                   = local.num_azs
   vpc_id                  = aws_vpc.vpc.id
-  cidr_block              = cidrsubnet(cidrsubnet(aws_vpc.vpc.cidr_block, 1, 0), 2, count.index)
+  cidr_block              = local.public_subnet_cidr_ranges[count.index]
   availability_zone       = local.aws_availability_zones[count.index]
   map_public_ip_on_launch = true
 
   tags = merge(local.default_tags, {
-    Name                                                 = "aptos-${local.workspace_name}/public-${local.aws_availability_zones[count.index]}"
+    Name                                                  = "aptos-${local.workspace_name}/public-${local.aws_availability_zones[count.index]}"
     "kubernetes.io/cluster/aptos-${local.workspace_name}" = "shared"
-    "kubernetes.io/role/elb"                             = "1"
+    "kubernetes.io/role/elb"                              = "1"
   })
 }
 
@@ -44,21 +67,21 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route_table_association" "public" {
-  count          = length(local.aws_availability_zones)
+  count          = local.num_azs
   subnet_id      = element(aws_subnet.public.*.id, count.index)
   route_table_id = aws_route_table.public.id
 }
 
 resource "aws_subnet" "private" {
-  count             = length(local.aws_availability_zones)
+  count             = local.num_azs
   vpc_id            = aws_vpc.vpc.id
-  cidr_block        = cidrsubnet(cidrsubnet(aws_vpc.vpc.cidr_block, 1, 1), 2, count.index)
+  cidr_block        = local.private_subnet_cidr_ranges[count.index]
   availability_zone = local.aws_availability_zones[count.index]
 
   tags = merge(local.default_tags, {
-    Name                                                 = "aptos-${local.workspace_name}/private-${local.aws_availability_zones[count.index]}"
+    Name                                                  = "aptos-${local.workspace_name}/private-${local.aws_availability_zones[count.index]}"
     "kubernetes.io/cluster/aptos-${local.workspace_name}" = "shared"
-    "kubernetes.io/role/internal-elb"                    = "1"
+    "kubernetes.io/role/internal-elb"                     = "1"
   })
 }
 
@@ -90,7 +113,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route_table_association" "private" {
-  count          = length(local.aws_availability_zones)
+  count          = local.num_azs
   subnet_id      = element(aws_subnet.private.*.id, count.index)
   route_table_id = aws_route_table.private.id
 }

--- a/terraform/aptos-node/aws/variables.tf
+++ b/terraform/aptos-node/aws/variables.tf
@@ -3,6 +3,11 @@ variable "region" {
   type        = string
 }
 
+variable "num_azs" {
+  description = "Number of availability zones"
+  default     = 3
+}
+
 variable "kubernetes_version" {
   description = "Version of Kubernetes to use for EKS cluster"
   default     = "1.22"
@@ -135,6 +140,11 @@ variable "vpc_cidr_block" {
   description = "VPC CIDR Block"
 }
 
+variable "maximize_single_az_capacity" {
+  description = "Whether to maximize the capacity of the cluster by allocating more IPs to the first AZ"
+  default     = false
+}
+
 variable "helm_enable_validator" {
   description = "Enable deployment of the validator Helm chart"
   default     = true
@@ -183,6 +193,11 @@ variable "validator_instance_max_num" {
 variable "workspace_name_override" {
   description = "If specified, overrides the usage of Terraform workspace for naming purposes"
   default     = ""
+}
+
+variable "enable_calico" {
+  description = "Enable Calico networking for NetworkPolicy"
+  default     = true
 }
 
 variable "enable_logger" {

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -182,7 +182,12 @@ if [ -z "$FORGE_CLUSTER_NAME" ]; then
     FORGE_CLUSTER_NAME=${FORGE_CLUSTERS[ $RANDOM % ${#FORGE_CLUSTERS[@]} ]}
 fi
 
-aws eks update-kubeconfig --name $FORGE_CLUSTER_NAME
+context=$(kubectl config current-context)
+echo $context | grep $FORGE_CLUSTER_NAME
+if [ "$?" -ne 0 ]; then
+    echo "WARN: current context is not set to ${FORGE_CLUSTER_NAME}. Switching to ${FORGE_CLUSTER_NAME}..."
+    aws eks update-kubeconfig --name $FORGE_CLUSTER_NAME
+fi
 
 # determine cluster name from kubectl context and set o11y resources
 echo "Using cluster ${FORGE_CLUSTER_NAME}"


### PR DESCRIPTION
### Description

Provide variable `maximize_single_az_capacity` for AWS `aptos-node` Terraform to be able to more greedily allocate larger CIDR blocks to the subnet the NodeGroups are in. This lets us increase our Forge test capacity by 4x to roughly 16-20 concurrent tests in a single EKS cluster (based off of https://github.com/awslabs/amazon-eks-ami/blob/master/files/eni-max-pods.txt). My plan is to create at least 3 of these clusters (to replace the existing 3 we have). We will have one dedicated to Land-blocking tests, one for long-running continuous tests, and at least one more for backup capacity / manual testing.

We can have more too, as the cost to having these around is minimal since the autoscaler spins down to the cluster to near-zero when idle.

#### Alternatives

The other way around this is to add another CIDR block to the VPC, but that requires tuning the CNI https://aws.amazon.com/blogs/containers/optimize-ip-addresses-usage-by-pods-in-your-amazon-eks-cluster/, which doesn't look like it can be easily automatable. https://medium.com/webstep/dont-let-your-eks-clusters-eat-up-all-your-ip-addresses-1519614e9daa

Long term we can re-implement `aptos-node-testnet` in GKE, since they allocate a whole lot more IPs for pods (`/8` by default, last I checked), but between getting the right addons to work and bake and other Forge requirements, I'll probably get around to that later post-mainnet.

### Test Plan

Apply (re-creates) my existing testnet, and use it to stress test forge. Also apply against an existing testnet to make sure that there are no unintended side effects

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3376)
<!-- Reviewable:end -->
