### PR TITLE
[Docs] REST API docstrings. Initial test.

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -29,7 +29,7 @@ test-api-spec-v1:
 	$(call test_api_spec,spec.yaml)
 
 serve:
-	cd doc && python -m http.server 8888
+	cd doc && python3 -m http.server 8888
 
 define test_api_spec
 	- pkill aptos-node

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -31,8 +31,10 @@ paths:
       tags:
       - Accounts
       summary: Get account
-      description: Return high level information about an account such as its sequence
-        number.
+      description: |-
+        Return the authentication key and the sequence number for an account
+        address. Optionally, a ledger version can be specified. If the ledger
+        version is not specified in the request, the latest ledger version is used.
       parameters:
       - name: address
         schema:
@@ -363,8 +365,8 @@ paths:
       - Accounts
       summary: Get account resources
       description: |-
-        This endpoint returns all account resources at a given address at a
-        specific ledger version (AKA transaction version). If the ledger
+        This endpoint returns all the account resources at a given address at a
+        specific ledger version (i.e., transaction version). If the ledger
         version is not specified in the request, the latest ledger version is used.
 
         The Aptos nodes prune account state history, via a configurable time window (link).

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -40,7 +40,9 @@ pub struct AccountsApi {
 impl AccountsApi {
     /// Get account
     ///
-    /// Return high level information about an account such as its sequence number.
+    /// Return the authentication key and the sequence number for an account 
+    /// address. Optionally, a ledger version can be specified. If the ledger
+    /// version is not specified in the request, the latest ledger version is used.
     #[oai(
         path = "/accounts/:address",
         method = "get",
@@ -62,8 +64,8 @@ impl AccountsApi {
 
     /// Get account resources
     ///
-    /// This endpoint returns all account resources at a given address at a
-    /// specific ledger version (AKA transaction version). If the ledger
+    /// This endpoint returns all the account resources at a given address at a
+    /// specific ledger version (i.e., transaction version). If the ledger
     /// version is not specified in the request, the latest ledger version is used.
     ///
     /// The Aptos nodes prune account state history, via a configurable time window (link).

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -170,7 +170,7 @@ const sidebars = {
     {
       type: 'link',
       label: 'REST API Docs', // The link label
-      href: '/api/latest-api.html', // The internal path
+      href: '/api/latest-api.html#/', // The internal path
     },
     "reference/telemetry",
     "aptos-white-paper",

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -167,6 +167,11 @@ const sidebars = {
       link: { type: "doc", id: "cli-tools/aptos-cli-tool/index" },
       items: ["cli-tools/aptos-cli-tool/install-aptos-cli", "cli-tools/aptos-cli-tool/use-aptos-cli"],
     },
+    {
+      type: 'link',
+      label: 'REST API Docs', // The link label
+      href: '/api/latest-api.html', // The internal path
+    },
     "reference/telemetry",
     "aptos-white-paper",
     "reference/glossary",

--- a/developer-docs-site/static/api/latest-api.html
+++ b/developer-docs-site/static/api/latest-api.html
@@ -15,7 +15,6 @@
       router="hash"
       layout="sidebar"
       hideInternal="true"
-      hideTryIt="true"
     />
   </body>
 </html>

--- a/developer-docs-site/static/api/latest-api.html
+++ b/developer-docs-site/static/api/latest-api.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <elements-api id="spec_viewer"
-      apiDescriptionUrl="https://raw.githubusercontent.com/aptos-labs/aptos-core/main/api/doc/spec.yaml"
+      apiDescriptionUrl="https://raw.githubusercontent.com/aptos-labs/aptos-core/cbbca042910882ed335420ee44dca0e7588d0094/api/doc/spec.yaml"
       router="hash"
       layout="sidebar"
       hideInternal="true"


### PR DESCRIPTION
In this initial commit I am testing if Netlify will build the docstring changes I made in the accounts.rs source. I will split the API docs into multiple PRs for easier review. 

For the record, I am following these steps:

1. Change Rust source comment, i.e., docstring in any source file in `aptos-core/api/src` directory.
2. cd into ` ~/aptos-core/api/openapi-spec-generator` and run `cargo run -- -o ../doc/spec.yaml`. This will generate a new "spec.yaml" that contains the docstring changes I made in (1) above.
3. In the `~/aptos-core/api` directory run `make serve` (I changed `python` to `python3` in the Makefile)
4. Go to `localhost:8888` and see the changes in the HTML docs. 
5. If I did not kill the HTTP server fired up in (3), then I only need to do steps 1 and 2 to see the HTML changes dynamically.

**Update**:  So we can now see the edited API docs by clicking on the sidebar item **REST API Docs** and **refreshing the page once or twice**.  This way, any docstring changes I push to this PR, you can see it rendered also, for a better view. Let's use this sidebar link for reviewing this PR. I will remove it before merging.

**Next, I will start adding API docstrings and ask you to review when I am ready.**  

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3397)
<!-- Reviewable:end -->
