### PR TITLE
[Aptos Node] Improve error messages for config file loading.

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -133,17 +133,26 @@ impl AptosNodeArgs {
             )
             .expect("Test mode should start correctly");
         } else {
-            // Load the config file
+            // Get the config file path
             let config_path = self.config.expect("Config is required to launch node");
+            if !config_path.exists() {
+                panic!(
+                    "The node config file could not be found! Ensure the given path is correct: {:?}",
+                    config_path.display()
+                )
+            }
+
+            // A config file exists, attempt to parse the config
             let config = NodeConfig::load(config_path.clone()).unwrap_or_else(|error| {
                 panic!(
-                    "Failed to load node config file! Given file path: {:?}. Error: {:?}",
-                    config_path, error
+                    "Failed to parse node config file! Given file path: {:?}. Error: {:?}",
+                    config_path.display(),
+                    error
                 )
             });
-            println!("Using node config {:?}", &config);
 
             // Start the node
+            println!("Using node config {:?}", &config);
             start(config, None).expect("Node should start correctly");
         };
     }

--- a/config/src/config/error.rs
+++ b/config/src/config/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     Yaml(String, #[source] serde_yaml::Error),
     #[error("Config is missing expected value: {0}")]
     Missing(&'static str),
+    #[error("Unexpected error: {0}")]
+    Unexpected(String),
 }
 
 pub fn invariant(cond: bool, msg: String) -> Result<(), Error> {

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -56,13 +56,41 @@ impl Default for ExecutionConfig {
 impl ExecutionConfig {
     pub fn load(&mut self, root_dir: &RootPath) -> Result<(), Error> {
         if !self.genesis_file_location.as_os_str().is_empty() {
-            let path = root_dir.full_path(&self.genesis_file_location);
-            let mut file = File::open(&path).map_err(|e| Error::IO("genesis".into(), e))?;
+            // Ensure the genesis file exists
+            let genesis_path = root_dir.full_path(&self.genesis_file_location);
+            if !genesis_path.exists() {
+                return Err(Error::Unexpected(format!(
+                    "The genesis file could not be found! Ensure the given path is correct: {:?}",
+                    genesis_path.display()
+                )));
+            }
+
+            // Open the genesis file and read the bytes
+            let mut file = File::open(&genesis_path).map_err(|error| {
+                Error::Unexpected(format!(
+                    "Failed to open the genesis file: {:?}. Error: {:?}",
+                    genesis_path.display(),
+                    error
+                ))
+            })?;
             let mut buffer = vec![];
-            file.read_to_end(&mut buffer)
-                .map_err(|e| Error::IO("genesis".into(), e))?;
-            let data = bcs::from_bytes(&buffer).map_err(|e| Error::BCS("genesis", e))?;
-            self.genesis = Some(data);
+            file.read_to_end(&mut buffer).map_err(|error| {
+                Error::Unexpected(format!(
+                    "Failed to read the genesis file into a buffer: {:?}. Error: {:?}",
+                    genesis_path.display(),
+                    error
+                ))
+            })?;
+
+            // Deserialize the genesis file and store it
+            let genesis = bcs::from_bytes(&buffer).map_err(|error| {
+                Error::Unexpected(format!(
+                    "Failed to BCS deserialize the genesis file: {:?}. Error: {:?}",
+                    genesis_path.display(),
+                    error
+                ))
+            })?;
+            self.genesis = Some(genesis);
         }
 
         Ok(())


### PR DESCRIPTION
### Description
This PR provides some basic improvements to the error messages displayed when starting up a node and attempting to the load the config, genesis blob and waypoint. This relates to: https://github.com/aptos-labs/aptos-core/issues/2399.

Examples:
1. Failed to find config file
```
thread 'main' panicked at 'The node config file could not be found! Ensure the given path is correct: "./broken_full_node.yaml123"', aptos-node/src/lib.rs:139:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

2. Failed to find genesis blob
```
thread 'main' panicked at 'Failed to parse node config file! Given file path: "./broken_full_node.yaml". Error: Unexpected("The genesis file could not be found! Ensure the given path is correct: \".../aptos/clone/aptos-core/genesis.blob234\"")', aptos-node/src/lib.rs:147:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

3. Failed to find waypoint file
```
details = '''panicked at 'Waypoint file not found! Ensure the given path is correct: ".../aptos/clone/aptos-core/waypoint.txt123"', config/src/config/mod.rs:137:21'''
```

4. Invalid genesis blob (e.g., version mismatch between genesis blob and code)
```
thread 'main' panicked at 'Failed to parse node config file! Given file path: "./broken_full_node.yaml". Error: Unexpected("Failed to BCS deserialize the genesis file: \".../aptos/clone/aptos-core/genesis.blob\". Error: Custom(\"invalid value: integer `237`, expected variant index 0 <= i < 1\")")', aptos-node/src/lib.rs:147:17
```

Note: all of this code could use a clean up. Even this PR isn't super clean. But, I'm punting on this because of priorities 😄 

### Test Plan
Manual verification. But, at some point, we should think about tests for the entire process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3399)
<!-- Reviewable:end -->
