### PR TITLE
Fix binary path

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -992,7 +992,7 @@ fi
 
 install_python3
 pip3 install pre-commit
-pre-commit install
+~/.local/bin/pre-commit install
 
 if [[ "${BATCH_MODE}" == "false" ]]; then
 cat <<EOF


### PR DESCRIPTION
`~/.local/bin` hasn't been added to `PATH` so we much use the relative path to `pre-commit`

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3400)
<!-- Reviewable:end -->
