### PR TITLE
[crypto+move] oops, Move Scalar type should not have 'key'

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/ristretto255.move
@@ -82,7 +82,7 @@ module aptos_std::ristretto255 {
 
     /// This struct represents a scalar as a little-endian byte encoding of an integer in $\mathbb{Z}_\ell$, which is
     /// stored in `data`. Here, \ell denotes the order of the scalar field (and the underlying elliptic curve group).
-    struct Scalar has key, copy, store, drop {
+    struct Scalar has copy, store, drop {
         data: vector<u8>
     }
 


### PR DESCRIPTION
### Description

Move `Scalar` type should not have `key`. Oops.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3402)
<!-- Reviewable:end -->
