### PR TITLE
[Mempool] Tune mempool capacity configuration for AIT/mainnet

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -35,7 +35,7 @@ impl Default for MempoolConfig {
             shared_mempool_max_concurrent_inbound_syncs: 4,
             max_broadcasts_per_peer: 1,
             mempool_snapshot_interval_secs: 180,
-            capacity: 1_000_000,
+            capacity: 2_000_000,
             capacity_per_user: 100,
             default_failovers: 3,
             system_transaction_timeout_secs: 600,


### PR DESCRIPTION
### Description

Increase mempool capacity from 1M -> 2M. See https://www.notion.so/aptoslabs/Blockchain-default-config-review-c0ec77c6fc4341b4a270e013eb4a33f7

### Test Plan

Forge run.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3406)
<!-- Reviewable:end -->
