### PR TITLE
[Aptos Framework][Voting] Add a field to track proposal's resolution timestamp

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -87,6 +87,8 @@ module aptos_framework::voting {
 
         /// Whether the proposal has been resolved.
         is_resolved: bool,
+        /// Resolution timestamp if the proposal has been resolved. 0 otherwise.
+        resolution_time_secs: u64,
     }
 
     struct VotingForum<ProposalType: store> has key {
@@ -193,6 +195,7 @@ module aptos_framework::voting {
             yes_votes: 0,
             no_votes: 0,
             is_resolved: false,
+            resolution_time_secs: 0,
         });
 
         event::emit_event<CreateProposalEvent>(
@@ -257,6 +260,7 @@ module aptos_framework::voting {
 
         let resolved_early = can_be_resolved_early(proposal);
         proposal.is_resolved = true;
+        proposal.resolution_time_secs = timestamp::now_seconds();
 
         assert!(
             transaction_context::get_script_hash() == proposal.execution_hash,


### PR DESCRIPTION
### Description
Title

### Test Plan
Unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3410)
<!-- Reviewable:end -->
