### PR TITLE
[cli] Enable setting epoch range from the end ( i.e. -2) in analyze validators, and show partial newest epochs 

### DIFF
--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -376,11 +376,11 @@ impl CliTestFramework {
 
     pub async fn analyze_validator_performance(
         &self,
-        start_epoch: Option<u64>,
-        end_epoch: Option<u64>,
+        start_epoch: Option<i64>,
+        end_epoch: Option<i64>,
     ) -> CliTypedResult<()> {
         AnalyzeValidatorPerformance {
-            start_epoch,
+            start_epoch: start_epoch.unwrap_or(-2),
             end_epoch,
             rest_options: self.rest_options(),
             profile_options: Default::default(),


### PR DESCRIPTION
### Description

### Test Plan
cargo run -p aptos -- node analyze-validator-performance --analyze-mode=all --url=https://sherryx.aptosdev.com --start-epoch=-5 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3416)
<!-- Reviewable:end -->
