### PR TITLE
[Txn emitter] Various fixes for the transaction emitter

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -434,7 +434,7 @@ pub async fn execute_and_wait_transactions(
 
     let state = state_mutex.into_inner();
 
-    async fn wait_for_signed_transactions_bsc(
+    async fn wait_for_signed_transactions_bcs(
         client: &RestClient,
         txn: &SignedTransaction,
     ) -> Result<Response<TransactionOnChainData>, RestError> {
@@ -443,7 +443,7 @@ pub async fn execute_and_wait_transactions(
 
     for txn in state.txns.iter() {
         RETRY_POLICY
-            .retry(move || wait_for_signed_transactions_bsc(client, txn))
+            .retry(move || wait_for_signed_transactions_bcs(client, txn))
             .await
             .map_err(|e| format_err!("Failed to wait for transactions: {}", e))?;
     }

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::emitter::{wait_for_account_exists, wait_for_single_account_sequence};
+use crate::emitter::wait_for_single_account_sequence;
 use crate::{
     emitter::{MAX_TXNS, MAX_TXN_BATCH_SIZE, RETRY_POLICY, SEND_AMOUNT},
     query_sequence_numbers, EmitJobRequest,


### PR DESCRIPTION
### Description

Sometimes, we see the emitter fails complaining about sending account doesn't exists. This is because of REST end point is not up to date with the latest ledger state. This diff adds waiting for the REST end point to catch up to the ledger state so that the account exists. 

Also add retry for waiting for transaction call which was failing sometime. 

### Test Plan
Run Forge

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3431)
<!-- Reviewable:end -->
