### PR TITLE
[forge] add new capacity for cluster autoselection

### DIFF
--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -27,7 +27,7 @@ fi
 
 # available clusters to choose from
 # forge-1 is used for continuous testing exclusively
-FORGE_CLUSTERS=("aptos-forge-0" "aptos-forge-2")
+FORGE_CLUSTERS=("aptos-forge-big-0" "aptos-forge-big-1" "aptos-forge-0")
 
 # ensure the script is run from project root
 pwd | grep -qE 'aptos-core$' || (echo "Please run from aptos-core root directory" && exit 1)


### PR DESCRIPTION
### Description

This should balance 66% of the traffic to the new `forge-big-*` clusters, which can support 4x the max capacity. Once these are stable, we can fully roll out the big clusters and tear down the old ones .

Note: this change does not need to be made to the new forge python wrapper as that does cluster selection by regex from all running clusters, rather than selecting from a hardcoded list

### Test Plan

Spun up 3 new forge-big clusters, 2 of which will be used here. On each, I've run some load testing and can see that they can burst up to at least 600 nodes, barring intermittent txn emitter failures

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3432)
<!-- Reviewable:end -->
