### PR TITLE
[State Sync] Add backpressure to execute-commit pipeline.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -152,8 +152,8 @@ impl Default for DataStreamingServiceConfig {
         Self {
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: 3,
-            max_concurrent_state_requests: 4,
-            max_data_stream_channel_sizes: 1000,
+            max_concurrent_state_requests: 6,
+            max_data_stream_channel_sizes: 500,
             max_request_retry: 3,
             max_notification_id_mappings: 300,
             progress_check_interval_ms: 100,

--- a/state-sync/aptos-data-client/src/lib.rs
+++ b/state-sync/aptos-data-client/src/lib.rs
@@ -161,7 +161,7 @@ pub enum ResponseError {
 /// This trait provides a simple feedback mechanism for users of the Data Client
 /// to alert it to bad responses so that the peers responsible for providing this
 /// data can be penalized.
-pub trait ResponseCallback: fmt::Debug + Send + 'static {
+pub trait ResponseCallback: fmt::Debug + Send + Sync + 'static {
     // TODO(philiphayes): ideally this would take a `self: Box<Self>`, i.e.,
     // consume the callback, which better communicates that you should only report
     // an error once. however, the current state-sync-v2 code makes this difficult...

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -24,8 +24,8 @@ use aptos_data_client::{
 use aptos_id_generator::{IdGenerator, U64IdGenerator};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
-use channel::{aptos_channel, message_queues::QueueStyle};
-use futures::{stream::FusedStream, Stream};
+use futures::channel::mpsc;
+use futures::{stream::FusedStream, SinkExt, Stream};
 use std::{
     collections::{BTreeMap, VecDeque},
     pin::Pin,
@@ -79,7 +79,7 @@ pub struct DataStream<T> {
     notifications_to_responses: BTreeMap<NotificationId, ResponseContext>,
 
     // The channel on which to send data notifications when they are ready.
-    notification_sender: channel::aptos_channel::Sender<(), DataNotification>,
+    notification_sender: mpsc::Sender<DataNotification>,
 
     // A unique notification ID generator
     notification_id_generator: Arc<U64IdGenerator>,
@@ -108,11 +108,8 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
         advertised_data: &AdvertisedData,
     ) -> Result<(Self, DataStreamListener), Error> {
         // Create a new data stream listener
-        let (notification_sender, notification_receiver) = aptos_channel::new(
-            QueueStyle::FIFO, // If the stream overflows, drop the new messages
-            config.max_data_stream_channel_sizes as usize,
-            None,
-        );
+        let (notification_sender, notification_receiver) =
+            mpsc::channel(config.max_data_stream_channel_sizes as usize);
         let data_stream_listener = DataStreamListener::new(data_stream_id, notification_receiver);
 
         // Create a new stream engine
@@ -276,8 +273,13 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
         pending_client_response
     }
 
-    fn send_data_notification(&mut self, data_notification: DataNotification) -> Result<(), Error> {
-        if let Err(error) = self.notification_sender.push((), data_notification) {
+    // TODO(joshlind): this function shouldn't be blocking when trying to send! If there are
+    // multiple streams, a single blocked stream could cause them all to block.
+    async fn send_data_notification(
+        &mut self,
+        data_notification: DataNotification,
+    ) -> Result<(), Error> {
+        if let Err(error) = self.notification_sender.send(data_notification).await {
             let error = Error::UnexpectedErrorEncountered(error.to_string());
             warn!(
                 (LogSchema::new(LogEntry::StreamNotification)
@@ -298,7 +300,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
         self.send_failure
     }
 
-    fn send_end_of_stream_notification(&mut self) -> Result<(), Error> {
+    async fn send_end_of_stream_notification(&mut self) -> Result<(), Error> {
         // Create end of stream notification
         let notification_id = self.notification_id_generator.next();
         let data_notification = DataNotification {
@@ -314,12 +316,12 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
                 .message("Sent the end of stream notification"))
         );
         self.stream_end_notification_id = Some(notification_id);
-        self.send_data_notification(data_notification)
+        self.send_data_notification(data_notification).await
     }
 
     /// Processes any data client responses that have been received. Note: the
     /// responses must be processed in FIFO order.
-    pub fn process_data_responses(
+    pub async fn process_data_responses(
         &mut self,
         global_data_summary: GlobalDataSummary,
     ) -> Result<(), Error> {
@@ -328,7 +330,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
             || self.send_failure
         {
             if !self.send_failure && self.stream_end_notification_id.is_none() {
-                self.send_end_of_stream_notification()?;
+                self.send_end_of_stream_notification().await?;
             }
             return Ok(()); // There's nothing left to do
         }
@@ -336,17 +338,18 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
         // Process any ready data responses
         for _ in 0..self.get_max_concurrent_requests() {
             if let Some(pending_response) = self.pop_pending_response_queue() {
-                let mut pending_response = pending_response.lock();
                 let client_response = pending_response
+                    .lock()
                     .client_response
                     .take()
                     .expect("The client response should be ready!");
-                let client_request = &pending_response.client_request;
+                let client_request = &pending_response.lock().client_request.clone();
 
                 match client_response {
                     Ok(client_response) => {
                         if sanity_check_client_response(client_request, &client_response) {
-                            self.send_data_notification_to_client(client_request, client_response)?;
+                            self.send_data_notification_to_client(client_request, client_response)
+                                .await?;
                         } else {
                             self.handle_sanity_check_failure(
                                 client_request,
@@ -457,7 +460,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
     }
 
     /// Sends a data notification to the client along the stream
-    fn send_data_notification_to_client(
+    async fn send_data_notification_to_client(
         &mut self,
         data_client_request: &DataClientRequest,
         data_client_response: Response<ResponsePayload>,
@@ -487,7 +490,7 @@ impl<T: AptosDataClient + Send + Clone + 'static> DataStream<T> {
                         notification_id
                     )))
             );
-            self.send_data_notification(data_notification)?;
+            self.send_data_notification(data_notification).await?;
 
             // Reset the failure count. We've sent a notification and can move on.
             self.request_failure_count = 0;
@@ -606,7 +609,7 @@ impl<T> Drop for DataStream<T> {
 #[derive(Debug)]
 pub struct DataStreamListener {
     pub data_stream_id: DataStreamId,
-    notification_receiver: channel::aptos_channel::Receiver<(), DataNotification>,
+    notification_receiver: mpsc::Receiver<DataNotification>,
 
     /// Stores the number of consecutive timeouts encountered when listening to this stream
     pub num_consecutive_timeouts: u64,
@@ -615,7 +618,7 @@ pub struct DataStreamListener {
 impl DataStreamListener {
     pub fn new(
         data_stream_id: DataStreamId,
-        notification_receiver: channel::aptos_channel::Receiver<(), DataNotification>,
+        notification_receiver: mpsc::Receiver<DataNotification>,
     ) -> Self {
         Self {
             data_stream_id,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -71,6 +71,7 @@ async fn test_stream_blocked() {
         // Process the data responses and force a data re-fetch
         data_stream
             .process_data_responses(global_data_summary.clone())
+            .await
             .unwrap();
 
         // If we're sent a data notification, verify it's an end of stream notification!
@@ -130,6 +131,7 @@ async fn test_stream_garbage_collection() {
         // Process the data response
         data_stream
             .process_data_responses(global_data_summary.clone())
+            .await
             .unwrap();
 
         // Process the data response
@@ -199,6 +201,7 @@ async fn test_stream_data_error() {
     // Process the responses and verify the data client request was resent to the network
     data_stream
         .process_data_responses(global_data_summary)
+        .await
         .unwrap();
     assert_none!(stream_listener.select_next_some().now_or_never());
     verify_client_request_resubmitted(&mut data_stream, client_request);
@@ -236,6 +239,7 @@ async fn test_stream_invalid_response() {
     // Process the responses and verify the data client request was resent to the network
     data_stream
         .process_data_responses(global_data_summary)
+        .await
         .unwrap();
     assert_none!(stream_listener.select_next_some().now_or_never());
     verify_client_request_resubmitted(&mut data_stream, client_request);
@@ -270,6 +274,7 @@ async fn test_epoch_stream_out_of_order_responses() {
     set_epoch_ending_response_in_queue(&mut data_stream, 1);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     assert_none!(stream_listener.select_next_some().now_or_never());
 
@@ -277,6 +282,7 @@ async fn test_epoch_stream_out_of_order_responses() {
     set_epoch_ending_response_in_queue(&mut data_stream, 0);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     for _ in 0..2 {
         verify_epoch_ending_notification(
@@ -292,6 +298,7 @@ async fn test_epoch_stream_out_of_order_responses() {
     set_epoch_ending_response_in_queue(&mut data_stream, 2);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     verify_epoch_ending_notification(
         &mut stream_listener,
@@ -305,6 +312,7 @@ async fn test_epoch_stream_out_of_order_responses() {
     set_epoch_ending_response_in_queue(&mut data_stream, 2);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     for _ in 0..3 {
         verify_epoch_ending_notification(
@@ -342,6 +350,7 @@ async fn test_state_stream_out_of_order_responses() {
     set_num_state_values_response_in_queue(&mut data_stream, 0);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
 
     // Verify at least six requests have been made
@@ -355,6 +364,7 @@ async fn test_state_stream_out_of_order_responses() {
     set_state_value_response_in_queue(&mut data_stream, 1);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     assert_none!(stream_listener.select_next_some().now_or_never());
 
@@ -362,6 +372,7 @@ async fn test_state_stream_out_of_order_responses() {
     set_state_value_response_in_queue(&mut data_stream, 0);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     for _ in 0..2 {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
@@ -377,6 +388,7 @@ async fn test_state_stream_out_of_order_responses() {
     set_state_value_response_in_queue(&mut data_stream, 2);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
     assert_matches!(
@@ -390,6 +402,7 @@ async fn test_state_stream_out_of_order_responses() {
     set_state_value_response_in_queue(&mut data_stream, 2);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     for _ in 0..3 {
         let data_notification = get_data_notification(&mut stream_listener).await.unwrap();
@@ -430,6 +443,7 @@ async fn test_stream_listener_dropped() {
     set_epoch_ending_response_in_queue(&mut data_stream, 0);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     verify_epoch_ending_notification(
         &mut stream_listener,
@@ -449,6 +463,7 @@ async fn test_stream_listener_dropped() {
     set_epoch_ending_response_in_queue(&mut data_stream, 0);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap_err();
     let (_, sent_notifications) = data_stream.get_sent_requests_and_notifications();
     assert_eq!(sent_notifications.len(), 2);
@@ -457,6 +472,7 @@ async fn test_stream_listener_dropped() {
     set_epoch_ending_response_in_queue(&mut data_stream, 0);
     data_stream
         .process_data_responses(global_data_summary.clone())
+        .await
         .unwrap();
     let (_, sent_notifications) = data_stream.get_sent_requests_and_notifications();
     assert_eq!(sent_notifications.len(), 2);

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
@@ -15,8 +15,8 @@ use crate::{
     },
     tests::utils::{create_ledger_info, initialize_logger},
 };
-use channel::{aptos_channel, message_queues::QueueStyle};
 use claim::assert_ok;
+use futures::channel::mpsc;
 use futures::{executor::block_on, FutureExt, StreamExt};
 use std::thread::JoinHandle;
 
@@ -284,12 +284,8 @@ fn spawn_service_and_respond_with_error(
 }
 
 /// Creates and returns a new data stream sender and listener pair.
-fn new_data_stream_sender_listener() -> (
-    channel::aptos_channel::Sender<(), DataNotification>,
-    DataStreamListener,
-) {
-    let (notification_sender, notification_receiver) =
-        aptos_channel::new(QueueStyle::KLAST, 1, None);
+fn new_data_stream_sender_listener() -> (mpsc::Sender<DataNotification>, DataStreamListener) {
+    let (notification_sender, notification_receiver) = mpsc::channel(100);
     let data_stream_listener = DataStreamListener::new(0, notification_receiver);
 
     (notification_sender, data_stream_listener)

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.52"
+async-trait = "0.1.53"
 bcs = "0.1.3"
 futures = "0.3.21"
 once_cell = "1.10.0"

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -1096,12 +1096,14 @@ impl<
                     let num_transaction_outputs = transaction_outputs_with_proof
                         .transactions_and_outputs
                         .len();
-                    self.storage_synchronizer.apply_transaction_outputs(
-                        notification_id,
-                        transaction_outputs_with_proof,
-                        proof_ledger_info,
-                        end_of_epoch_ledger_info,
-                    )?;
+                    self.storage_synchronizer
+                        .apply_transaction_outputs(
+                            notification_id,
+                            transaction_outputs_with_proof,
+                            proof_ledger_info,
+                            end_of_epoch_ledger_info,
+                        )
+                        .await?;
                     num_transaction_outputs
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(
@@ -1117,12 +1119,14 @@ impl<
             BootstrappingMode::ExecuteTransactionsFromGenesis => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     let num_transactions = transaction_list_with_proof.transactions.len();
-                    self.storage_synchronizer.execute_transactions(
-                        notification_id,
-                        transaction_list_with_proof,
-                        proof_ledger_info,
-                        end_of_epoch_ledger_info,
-                    )?;
+                    self.storage_synchronizer
+                        .execute_transactions(
+                            notification_id,
+                            transaction_list_with_proof,
+                            proof_ledger_info,
+                            end_of_epoch_ledger_info,
+                        )
+                        .await?;
                     num_transactions
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -251,12 +251,14 @@ impl<
                         let num_transaction_outputs = transaction_outputs_with_proof
                             .transactions_and_outputs
                             .len();
-                        self.storage_synchronizer.apply_transaction_outputs(
-                            notification_id,
-                            transaction_outputs_with_proof,
-                            ledger_info_with_signatures.clone(),
-                            None,
-                        )?;
+                        self.storage_synchronizer
+                            .apply_transaction_outputs(
+                                notification_id,
+                                transaction_outputs_with_proof,
+                                ledger_info_with_signatures.clone(),
+                                None,
+                            )
+                            .await?;
                         num_transaction_outputs
                     } else {
                         self.reset_active_stream(Some(NotificationAndFeedback::new(
@@ -272,12 +274,14 @@ impl<
                 ContinuousSyncingMode::ExecuteTransactions => {
                     if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                         let num_transactions = transaction_list_with_proof.transactions.len();
-                        self.storage_synchronizer.execute_transactions(
-                            notification_id,
-                            transaction_list_with_proof,
-                            ledger_info_with_signatures.clone(),
-                            None,
-                        )?;
+                        self.storage_synchronizer
+                            .execute_transactions(
+                                notification_id,
+                                transaction_list_with_proof,
+                                ledger_info_with_signatures.clone(),
+                                None,
+                            )
+                            .await?;
                         num_transactions
                     } else {
                         self.reset_active_stream(Some(NotificationAndFeedback::new(

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
@@ -27,6 +27,7 @@ use data_streaming_service::{
     data_notification::{DataNotification, DataPayload},
     streaming_client::NotificationFeedback,
 };
+use futures::SinkExt;
 use mockall::{predicate::eq, Sequence};
 use std::sync::Arc;
 use storage_service_types::Epoch;
@@ -128,7 +129,7 @@ async fn test_data_stream_transactions_with_target() {
     // Create the mock streaming client
     let mut mock_streaming_client = create_mock_streaming_client();
     let mut expectation_sequence = Sequence::new();
-    let (notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let (mut notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
     let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
     let data_stream_id_1 = data_stream_listener_1.data_stream_id;
     for data_stream_listener in [data_stream_listener_1, data_stream_listener_2] {
@@ -182,7 +183,7 @@ async fn test_data_stream_transactions_with_target() {
             TransactionOutputListWithProof::new_empty(),
         ),
     };
-    notification_sender_1.push((), data_notification).unwrap();
+    notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error
     let error = continuous_syncer
@@ -213,7 +214,7 @@ async fn test_data_stream_transaction_outputs() {
     // Create the mock streaming client
     let mut mock_streaming_client = create_mock_streaming_client();
     let mut expectation_sequence = Sequence::new();
-    let (notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
+    let (mut notification_sender_1, data_stream_listener_1) = create_data_stream_listener();
     let (_notification_sender_2, data_stream_listener_2) = create_data_stream_listener();
     let data_stream_id_1 = data_stream_listener_1.data_stream_id;
     for data_stream_listener in [data_stream_listener_1, data_stream_listener_2] {
@@ -266,7 +267,7 @@ async fn test_data_stream_transaction_outputs() {
             transaction_output_with_proof,
         ),
     };
-    notification_sender_1.push((), data_notification).unwrap();
+    notification_sender_1.send(data_notification).await.unwrap();
 
     // Drive progress again and ensure we get a verification error
     let error = continuous_syncer

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/mocks.rs
@@ -422,8 +422,9 @@ mock! {
 // This automatically creates a MockStorageSynchronizer.
 mock! {
     pub StorageSynchronizer {}
+    #[async_trait]
     impl StorageSynchronizerInterface for StorageSynchronizer {
-        fn apply_transaction_outputs(
+        async fn apply_transaction_outputs(
             &mut self,
             notification_id: NotificationId,
             output_list_with_proof: TransactionOutputListWithProof,
@@ -431,7 +432,7 @@ mock! {
             end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
         ) -> Result<(), crate::error::Error>;
 
-        fn execute_transactions(
+        async fn execute_transactions(
             &mut self,
             notification_id: NotificationId,
             transaction_list_with_proof: TransactionListWithProof,

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -78,6 +78,7 @@ async fn test_apply_transaction_outputs() {
             create_epoch_ending_ledger_info(),
             None,
         )
+        .await
         .unwrap();
 
     // Verify we get a mempool and event notification. Also verify that there's no pending data.
@@ -113,6 +114,7 @@ async fn test_apply_transaction_outputs_error() {
             create_epoch_ending_ledger_info(),
             None,
         )
+        .await
         .unwrap();
 
     // Verify we get an error notification and that there's no pending data
@@ -145,6 +147,7 @@ async fn test_commit_chunk_error() {
             create_epoch_ending_ledger_info(),
             None,
         )
+        .await
         .unwrap();
 
     // Verify we get an error notification and that there's no pending data
@@ -191,6 +194,7 @@ async fn test_execute_transactions() {
             create_epoch_ending_ledger_info(),
             None,
         )
+        .await
         .unwrap();
 
     // Verify we get a mempool and event notification. Also verify that there's no pending data.
@@ -226,6 +230,7 @@ async fn test_execute_transactions_error() {
             create_epoch_ending_ledger_info(),
             None,
         )
+        .await
         .unwrap();
 
     // Verify we get an error notification and that there's no pending data

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -30,11 +30,11 @@ use aptos_types::{
     waypoint::Waypoint,
     write_set::WriteSet,
 };
-use channel::{aptos_channel, aptos_channel::Sender, message_queues::QueueStyle};
 use data_streaming_service::{
     data_notification::DataNotification, data_stream::DataStreamListener, streaming_client::Epoch,
 };
 use event_notifications::EventNotificationListener;
+use futures::channel::mpsc;
 use futures::StreamExt;
 use mempool_notifications::{CommittedTransaction, MempoolNotificationListener};
 use move_deps::move_core_types::language_storage::TypeTag;
@@ -43,9 +43,8 @@ use rand::Rng;
 use storage_service_types::responses::CompleteDataRange;
 
 /// Creates a new data stream listener and notification sender pair
-pub fn create_data_stream_listener() -> (Sender<(), DataNotification>, DataStreamListener) {
-    let (notification_sender, notification_receiver) =
-        aptos_channel::new(QueueStyle::KLAST, 100, None);
+pub fn create_data_stream_listener() -> (mpsc::Sender<DataNotification>, DataStreamListener) {
+    let (notification_sender, notification_receiver) = mpsc::channel(100);
     let data_stream_listener = DataStreamListener::new(create_random_u64(), notification_receiver);
 
     (notification_sender, data_stream_listener)


### PR DESCRIPTION
### Description
This PR makes two changes to the state sync logic:
1. We use channels that apply back pressure between the driver, executor and committer. This means when the pipeline becomes full, the code will block before sending any more data (as opposed to previously dropping the messages and waiting for the pipelines to flush).
2. Adds some additional metrics around these operations, for better visibility.

### Test Plan
Existing unit and smoke tests should cover this. Likewise, we deployed it on a testnet to verify the behaviour.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3433)
<!-- Reviewable:end -->
