### PR TITLE
[cli] Command to rotate account auth keys

### DIFF
--- a/aptos-move/e2e-move-tests/tests/rotate_auth_key.rs
+++ b/aptos-move/e2e-move-tests/tests/rotate_auth_key.rs
@@ -8,27 +8,11 @@ use aptos_types::{
     transaction::authenticator::AuthenticationKey,
 };
 
+use aptos::account::key_rotation::RotationProofChallenge;
 use cached_packages::aptos_stdlib;
 use e2e_move_tests::{assert_success, MoveHarness};
 use language_e2e_tests::account::Account;
 use move_deps::move_core_types::parser::parse_struct_tag;
-use serde::{Deserialize, Serialize};
-
-// This struct includes TypeInfo (account_address, module_name, and struct_name)
-// and RotationProofChallenge-specific information (sequence_number, originator, current_auth_key, and new_public_key)
-// Since the struct RotationProofChallenge is defined in "0x1::account::RotationProofChallenge",
-// we will be passing in "0x1" to `account_address`, "account" to `module_name`, and "RotationProofChallenge" to `struct_name`
-// Originator refers to the user's address
-#[derive(Serialize, Deserialize)]
-struct RotationProofChallenge {
-    account_address: AccountAddress,
-    module_name: String,
-    struct_name: String,
-    sequence_number: u64,
-    originator: AccountAddress,
-    current_auth_key: AccountAddress,
-    new_public_key: Vec<u8>,
-}
 
 #[test]
 fn rotate_auth_key_ed25519_to_ed25519() {

--- a/aptos-move/e2e-move-tests/tests/rotate_auth_key.rs
+++ b/aptos-move/e2e-move-tests/tests/rotate_auth_key.rs
@@ -8,7 +8,7 @@ use aptos_types::{
     transaction::authenticator::AuthenticationKey,
 };
 
-use aptos::account::key_rotation::RotationProofChallenge;
+use aptos::common::types::RotationProofChallenge;
 use cached_packages::aptos_stdlib;
 use e2e_move_tests::{assert_success, MoveHarness};
 use language_e2e_tests::account::Account;

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -930,14 +930,14 @@ impl Client {
         })
     }
 
-    pub async fn get_table_item<K: Serialize>(
+    pub async fn get_table_item<H: ToString, K: Serialize>(
         &self,
-        table_handle: u128,
+        table_handle: H,
         key_type: &str,
         value_type: &str,
         key: K,
     ) -> AptosResult<Response<Value>> {
-        let url = self.build_path(&format!("tables/{}/item", table_handle))?;
+        let url = self.build_path(&format!("tables/{}/item", table_handle.to_string()))?;
         let data = json!({
             "key_type": key_type,
             "value_type": value_type,

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -930,14 +930,14 @@ impl Client {
         })
     }
 
-    pub async fn get_table_item<H: ToString, K: Serialize>(
+    pub async fn get_table_item<K: Serialize>(
         &self,
-        table_handle: H,
+        table_handle: AccountAddress,
         key_type: &str,
         value_type: &str,
         key: K,
     ) -> AptosResult<Response<Value>> {
-        let url = self.build_path(&format!("tables/{}/item", table_handle.to_string()))?;
+        let url = self.build_path(&format!("tables/{}/item", table_handle))?;
         let data = json!({
             "key_type": key_type,
             "value_type": value_type,

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common::types::{
+    CliCommand, CliError, CliTypedResult, TransactionOptions, TransactionSummary,
+};
+use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, SigningKey};
+use aptos_types::{account_address::AccountAddress, account_config::CORE_CODE_ADDRESS};
+use async_trait::async_trait;
+use cached_packages::aptos_stdlib;
+use clap::Parser;
+use serde::{Deserialize, Serialize};
+
+// This struct includes TypeInfo (account_address, module_name, and struct_name)
+// and RotationProofChallenge-specific information (sequence_number, originator, current_auth_key, and new_public_key)
+// Since the struct RotationProofChallenge is defined in "0x1::account::RotationProofChallenge",
+// we will be passing in "0x1" to `account_address`, "account" to `module_name`, and "RotationProofChallenge" to `struct_name`
+// Originator refers to the user's address
+#[derive(Serialize, Deserialize)]
+pub struct RotationProofChallenge {
+    // Should be `CORE_CODE_ADDRESS`
+    pub account_address: AccountAddress,
+    // Should be `account`
+    pub module_name: String,
+    // Should be `RotationProofChallenge`
+    pub struct_name: String,
+    pub sequence_number: u64,
+    pub originator: AccountAddress,
+    pub current_auth_key: AccountAddress,
+    pub new_public_key: Vec<u8>,
+}
+
+/// Command to rotate the account auth key
+///
+#[derive(Debug, Parser)]
+pub struct RotateKey {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+
+    /// Private key encoded in a type as shown in `encoding`
+    #[clap(long)]
+    new_private_key: String,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for RotateKey {
+    fn command_name(&self) -> &'static str {
+        "RotateKey"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        let key = self.new_private_key.as_bytes().to_vec();
+        let new_private_key = self
+            .txn_options
+            .encoding_options
+            .encoding
+            .decode_key::<Ed25519PrivateKey>("--new-private-key", key)?;
+
+        let sender_address = self.txn_options.sender_address()?;
+
+        // Get sequence number for account
+        let sequence_number = self.txn_options.sequence_number(sender_address).await?;
+        let auth_key = self.txn_options.auth_key(sender_address).await?;
+
+        let rotation_proof = RotationProofChallenge {
+            account_address: CORE_CODE_ADDRESS,
+            module_name: "account".to_string(),
+            struct_name: "RotationProofChallenge".to_string(),
+            sequence_number,
+            originator: sender_address,
+            current_auth_key: AccountAddress::from_bytes(&auth_key)
+                .map_err(|err| CliError::UnableToParse("auth_key", err.to_string()))?,
+            new_public_key: new_private_key.public_key().to_bytes().to_vec(),
+        };
+
+        let rotation_msg = bcs::to_bytes(&rotation_proof);
+
+        // Signs the struct using both the current private key and the next private key
+        let rotation_proof_signed_by_current_private_key = self
+            .txn_options
+            .private_key()?
+            .sign_arbitrary_message(&rotation_msg.clone().unwrap());
+        let rotation_proof_signed_by_new_private_key =
+            new_private_key.sign_arbitrary_message(&rotation_msg.unwrap());
+
+        self.txn_options
+            .submit_transaction(aptos_stdlib::account_rotate_authentication_key_ed25519(
+                rotation_proof_signed_by_current_private_key
+                    .to_bytes()
+                    .to_vec(),
+                rotation_proof_signed_by_new_private_key.to_bytes().to_vec(),
+                // Existing public key
+                self.txn_options
+                    .private_key()?
+                    .public_key()
+                    .to_bytes()
+                    .to_vec(),
+                // New public key
+                new_private_key.public_key().to_bytes().to_vec(),
+            ))
+            .await
+            .map(TransactionSummary::from)
+    }
+}

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -1,69 +1,87 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
 
 use crate::common::{
     types::{
-        CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, ProfileConfig,
-        PromptOptions, TransactionOptions, TransactionSummary,
+        CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, EncodingOptions,
+        EncodingType, ExtractPublicKey, ParsePrivateKey, ProfileConfig, ProfileOptions,
+        PublicKeyInputOptions, RestOptions, RotationProofChallenge, TransactionOptions,
+        TransactionSummary,
     },
     utils::{prompt_yes_with_override, read_line},
 };
-use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, SigningKey};
-use aptos_types::{account_address::AccountAddress, account_config::CORE_CODE_ADDRESS};
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    PrivateKey, SigningKey,
+};
+use aptos_rest_client::Client;
+use aptos_types::{
+    account_address::AccountAddress, account_config::CORE_CODE_ADDRESS,
+    transaction::authenticator::AuthenticationKey,
+};
 use async_trait::async_trait;
 use cached_packages::aptos_stdlib;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-// This struct includes TypeInfo (account_address, module_name, and struct_name)
-// and RotationProofChallenge-specific information (sequence_number, originator, current_auth_key, and new_public_key)
-// Since the struct RotationProofChallenge is defined in "0x1::account::RotationProofChallenge",
-// we will be passing in "0x1" to `account_address`, "account" to `module_name`, and "RotationProofChallenge" to `struct_name`
-// Originator refers to the user's address
-#[derive(Serialize, Deserialize)]
-pub struct RotationProofChallenge {
-    // Should be `CORE_CODE_ADDRESS`
-    pub account_address: AccountAddress,
-    // Should be `account`
-    pub module_name: String,
-    // Should be `RotationProofChallenge`
-    pub struct_name: String,
-    pub sequence_number: u64,
-    pub originator: AccountAddress,
-    pub current_auth_key: AccountAddress,
-    pub new_public_key: Vec<u8>,
-}
-
-/// Command to rotate the account auth key
+/// Command to rotate an account's authentication key
 ///
 #[derive(Debug, Parser)]
 pub struct RotateKey {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
 
-    #[clap(flatten)]
-    pub(crate) prompt_options: PromptOptions,
+    /// File name that contains the new private key
+    #[clap(long, group = "private_key_to_rotate_to", parse(from_os_str))]
+    pub(crate) new_private_key_file: Option<PathBuf>,
+    /// New private key encoded in a type as shown in `encoding`
+    #[clap(long, group = "private_key_to_roate_to")]
+    pub(crate) new_private_key: Option<String>,
 
-    /// Private key encoded in a type as shown in `encoding`
+    /// Name of the profile to save the new private key
     #[clap(long)]
-    pub(crate) new_private_key: String,
+    pub(crate) save_to_profile: Option<String>,
+}
+
+impl ParsePrivateKey for RotateKey {}
+
+impl RotateKey {
+    /// Extract private key from CLI args
+    pub fn extract_private_key(
+        &self,
+        encoding: EncodingType,
+    ) -> CliTypedResult<Option<Ed25519PrivateKey>> {
+        self.parse_private_key(
+            encoding,
+            self.new_private_key_file.clone(),
+            self.new_private_key.clone(),
+        )
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct RotateSummary {
+    message: Option<String>,
+    transaction: TransactionSummary,
 }
 
 #[async_trait]
-impl CliCommand<()> for RotateKey {
+impl CliCommand<RotateSummary> for RotateKey {
     fn command_name(&self) -> &'static str {
         "RotateKey"
     }
 
-    async fn execute(self) -> CliTypedResult<()> {
-        let key = self.new_private_key.as_bytes().to_vec();
+    async fn execute(self) -> CliTypedResult<RotateSummary> {
         let new_private_key = self
-            .txn_options
-            .encoding_options
-            .encoding
-            .decode_key::<Ed25519PrivateKey>("--new-private-key", key)?;
+            .extract_private_key(self.txn_options.encoding_options.encoding)?
+            .ok_or_else(|| {
+                CliError::CommandArgumentError(
+                    "One of ['--new-private-key', '--new-private-key-file'] must be used"
+                        .to_string(),
+                )
+            })?;
 
         let sender_address = self.txn_options.sender_address()?;
 
@@ -82,88 +100,135 @@ impl CliCommand<()> for RotateKey {
             new_public_key: new_private_key.public_key().to_bytes().to_vec(),
         };
 
-        let rotation_msg = bcs::to_bytes(&rotation_proof);
+        let rotation_msg =
+            bcs::to_bytes(&rotation_proof).map_err(|err| CliError::BCS("rotation_proof", err))?;
 
         // Signs the struct using both the current private key and the next private key
         let rotation_proof_signed_by_current_private_key = self
             .txn_options
             .private_key()?
-            .sign_arbitrary_message(&rotation_msg.clone().unwrap());
+            .sign_arbitrary_message(&rotation_msg.clone());
         let rotation_proof_signed_by_new_private_key =
-            new_private_key.sign_arbitrary_message(&rotation_msg.unwrap());
+            new_private_key.sign_arbitrary_message(&rotation_msg);
 
         let txn_summary = self
             .txn_options
-            .submit_transaction(aptos_stdlib::account_rotate_authentication_key_ed25519(
-                rotation_proof_signed_by_current_private_key
-                    .to_bytes()
-                    .to_vec(),
-                rotation_proof_signed_by_new_private_key.to_bytes().to_vec(),
-                // Existing public key
-                self.txn_options
-                    .private_key()?
-                    .public_key()
-                    .to_bytes()
-                    .to_vec(),
-                // New public key
-                new_private_key.public_key().to_bytes().to_vec(),
-            ))
+            .submit_transaction(
+                aptos_stdlib::account_rotate_authentication_key(
+                    0,
+                    // Existing public key
+                    self.txn_options
+                        .private_key()?
+                        .public_key()
+                        .to_bytes()
+                        .to_vec(),
+                    0,
+                    // New public key
+                    new_private_key.public_key().to_bytes().to_vec(),
+                    rotation_proof_signed_by_current_private_key
+                        .to_bytes()
+                        .to_vec(),
+                    rotation_proof_signed_by_new_private_key.to_bytes().to_vec(),
+                ),
+                None,
+            )
             .await
             .map(TransactionSummary::from)?;
 
         let string = serde_json::to_string_pretty(&txn_summary)
-            .map_err(|err| CliError::UnableToParse("trasaction summary", err.to_string()))?;
+            .map_err(|err| CliError::UnableToParse("transaction summary", err.to_string()))?;
 
         eprintln!("{}", string);
 
         if let Some(txn_success) = txn_summary.success {
             if !txn_success {
                 return Err(CliError::ApiError(
-                    "transaction was not executed successfully".to_string(),
+                    "Transaction was not executed successfully".to_string(),
                 ));
             }
         } else {
             return Err(CliError::UnexpectedError(
-                "Mailformed transaction response".to_string(),
+                "Malformed transaction response".to_string(),
             ));
         }
 
-        // Asks user if they want to create a new Profile. Overriding profile is a bit of risky, we create a new one
-        // instead.
+        let mut profile_name: String;
 
-        if let Err(cli_err) = prompt_yes_with_override(
-            "Do you want to create a profile with the new private key?",
-            self.prompt_options,
-        ) {
-            match cli_err {
-                CliError::AbortedError => {
-                    return Ok(());
+        if self.save_to_profile.is_none() {
+            if let Err(cli_err) = prompt_yes_with_override(
+                "Do you want to create a profile for the new key?",
+                self.txn_options.prompt_options,
+            ) {
+                match cli_err {
+                    CliError::AbortedError => {
+                        return Ok(RotateSummary {
+                            transaction: txn_summary,
+                            message: None,
+                        });
+                    }
+                    _ => {
+                        return Err(cli_err);
+                    }
                 }
-                _ => {
-                    return Err(cli_err);
+            }
+
+            eprintln!("Enter the name for the profile");
+            profile_name = read_line("Profile name")?.trim().to_string();
+        } else {
+            // We can safely unwrap here
+            profile_name = self.save_to_profile.unwrap();
+        }
+
+        // Check if profile name exists
+        let mut config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
+
+        if let Some(ref profiles) = config.profiles {
+            if profiles.contains_key(&profile_name) {
+                if let Err(cli_err) = prompt_yes_with_override(
+                    format!(
+                        "Profile {} exits. Do you want to provide a new profile name?",
+                        profile_name
+                    )
+                    .as_str(),
+                    self.txn_options.prompt_options,
+                ) {
+                    match cli_err {
+                        CliError::AbortedError => {
+                            return Ok(RotateSummary {
+                                transaction: txn_summary,
+                                message: None,
+                            });
+                        }
+                        _ => {
+                            return Err(cli_err);
+                        }
+                    }
                 }
+
+                eprintln!("Enter the name for the profile");
+                profile_name = read_line("Profile name")?.trim().to_string();
             }
         }
 
-        eprintln!("Enter the name for the profile");
-        let profile_name = read_line("Profile name")?.trim().to_string();
-
         if profile_name.is_empty() {
-            return Ok(());
+            return Err(CliError::AbortedError);
         }
 
-        let profile_config = ProfileConfig {
+        let mut profile_config = ProfileConfig {
             private_key: Some(new_private_key.clone()),
             public_key: Some(new_private_key.public_key()),
+            account: Some(sender_address),
             ..self.txn_options.profile_options.profile()?
         };
 
-        let mut config = CliConfig::load(ConfigSearchMode::CurrentDirAndParents)?;
+        if let Some(url) = self.txn_options.rest_options.url {
+            profile_config.rest_url = Some(url.into());
+        }
 
         if config.profiles.is_none() {
-            // This should not happen. The command requires a profile exist to rotate key
             config.profiles = Some(BTreeMap::new());
         }
+
         config
             .profiles
             .as_mut()
@@ -173,6 +238,86 @@ impl CliCommand<()> for RotateKey {
 
         eprintln!("Profile {} is saved.", profile_name);
 
-        Ok(())
+        Ok(RotateSummary {
+            transaction: txn_summary,
+            message: Some(format!("Profile {} is saved.", profile_name)),
+        })
+    }
+}
+
+/// Command to lookup the account adress through on-chain lookup table
+///
+#[derive(Debug, Parser)]
+pub struct LookupAddress {
+    #[clap(flatten)]
+    pub(crate) encoding_options: EncodingOptions,
+
+    #[clap(flatten)]
+    pub(crate) public_key_options: PublicKeyInputOptions,
+
+    #[clap(flatten)]
+    pub(crate) profile_options: ProfileOptions,
+
+    #[clap(flatten)]
+    pub(crate) rest_options: RestOptions,
+}
+
+impl LookupAddress {
+    pub(crate) fn public_key(&self) -> CliTypedResult<Ed25519PublicKey> {
+        self.public_key_options.extract_public_key(
+            self.encoding_options.encoding,
+            &self.profile_options.profile,
+        )
+    }
+
+    /// Builds a rest client
+    fn rest_client(&self) -> CliTypedResult<Client> {
+        self.rest_options.client(&self.profile_options.profile)
+    }
+}
+
+#[async_trait]
+impl CliCommand<AccountAddress> for LookupAddress {
+    fn command_name(&self) -> &'static str {
+        "LookupAddress"
+    }
+
+    async fn execute(self) -> CliTypedResult<AccountAddress> {
+        let originating_resource = self
+            .rest_client()?
+            .get_account_resource(CORE_CODE_ADDRESS, "0x1::account::OriginatingAddress")
+            .await
+            .map_err(|err| CliError::ApiError(err.to_string()))?
+            .into_inner()
+            .ok_or_else(|| CliError::UnexpectedError("Unable to parse API response.".to_string()))?
+            .data;
+
+        let table_handle = originating_resource["address_map"]["handle"]
+            .as_str()
+            .ok_or_else(|| {
+                CliError::UnexpectedError("Unable to parse table handle.".to_string())
+            })?;
+
+        // The derived address that can be used to look up the original address
+        let address_key = AuthenticationKey::ed25519(&self.public_key()?).derived_address();
+
+        Ok(AccountAddress::from_hex_literal(
+            self.rest_client()?
+                .get_table_item(
+                    AccountAddress::from_str(table_handle)
+                        .map_err(|err| CliError::UnableToParse("table_handle", err.to_string()))?,
+                    "address",
+                    "address",
+                    address_key.to_hex_literal(),
+                )
+                .await
+                .map_err(|err| CliError::ApiError(err.to_string()))?
+                .into_inner()
+                .as_str()
+                .ok_or_else(|| {
+                    CliError::UnexpectedError("Unable to parse API response.".to_string())
+                })?,
+        )
+        .map_err(|err| CliError::UnableToParse("AccountAddress", err.to_string()))?)
     }
 }

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -21,6 +21,7 @@ pub enum AccountTool {
     CreateResourceAccount(create_resource_account::CreateResourceAccount),
     FundWithFaucet(fund::FundWithFaucet),
     List(list::ListAccount),
+    LookupAddress(key_rotation::LookupAddress),
     RotateKey(key_rotation::RotateKey),
     Transfer(transfer::TransferCoins),
 }
@@ -32,6 +33,7 @@ impl AccountTool {
             AccountTool::CreateResourceAccount(tool) => tool.execute_serialized().await,
             AccountTool::FundWithFaucet(tool) => tool.execute_serialized().await,
             AccountTool::List(tool) => tool.execute_serialized().await,
+            AccountTool::LookupAddress(tool) => tool.execute_serialized().await,
             AccountTool::RotateKey(tool) => tool.execute_serialized().await,
             AccountTool::Transfer(tool) => tool.execute_serialized().await,
         }

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -7,6 +7,7 @@ use clap::Subcommand;
 pub mod create;
 pub mod create_resource_account;
 pub mod fund;
+pub mod key_rotation;
 pub mod list;
 pub mod transfer;
 
@@ -20,6 +21,7 @@ pub enum AccountTool {
     CreateResourceAccount(create_resource_account::CreateResourceAccount),
     FundWithFaucet(fund::FundWithFaucet),
     List(list::ListAccount),
+    RotateKey(key_rotation::RotateKey),
     Transfer(transfer::TransferCoins),
 }
 
@@ -30,6 +32,7 @@ impl AccountTool {
             AccountTool::CreateResourceAccount(tool) => tool.execute_serialized().await,
             AccountTool::FundWithFaucet(tool) => tool.execute_serialized().await,
             AccountTool::List(tool) => tool.execute_serialized().await,
+            AccountTool::RotateKey(tool) => tool.execute_serialized().await,
             AccountTool::Transfer(tool) => tool.execute_serialized().await,
         }
     }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -362,24 +362,28 @@ pub struct ProfileOptions {
 
 impl ProfileOptions {
     pub fn account_address(&self) -> CliTypedResult<AccountAddress> {
-        if let Some(profile) =
-            CliConfig::load_profile(&self.profile, ConfigSearchMode::CurrentDirAndParents)?
-        {
-            if let Some(account) = profile.account {
-                return Ok(account);
-            }
+        let profile = self.profile()?;
+        if let Some(account) = profile.account {
+            return Ok(account);
         }
 
         Err(CliError::ConfigNotFoundError(self.profile.clone()))
     }
 
     pub fn public_key(&self) -> CliTypedResult<Ed25519PublicKey> {
+        let profile = self.profile()?;
+        if let Some(public_key) = profile.public_key {
+            return Ok(public_key);
+        }
+
+        Err(CliError::ConfigNotFoundError(self.profile.clone()))
+    }
+
+    pub fn profile(&self) -> CliTypedResult<ProfileConfig> {
         if let Some(profile) =
             CliConfig::load_profile(&self.profile, ConfigSearchMode::CurrentDirAndParents)?
         {
-            if let Some(public_key) = profile.public_key {
-                return Ok(public_key);
-            }
+            return Ok(profile);
         }
 
         Err(CliError::ConfigNotFoundError(self.profile.clone()))

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -7,7 +7,7 @@ use crate::{
         init::{DEFAULT_FAUCET_URL, DEFAULT_REST_URL},
         utils::{
             chain_id, check_if_file_exists, create_dir_if_not_exist, dir_default_to_current,
-            get_sequence_number, read_from_file, start_logger, to_common_result,
+            get_auth_key, get_sequence_number, read_from_file, start_logger, to_common_result,
             to_common_success_result, write_to_file, write_to_file_with_opts,
             write_to_user_only_file,
         },
@@ -367,6 +367,18 @@ impl ProfileOptions {
         {
             if let Some(account) = profile.account {
                 return Ok(account);
+            }
+        }
+
+        Err(CliError::ConfigNotFoundError(self.profile.clone()))
+    }
+
+    pub fn public_key(&self) -> CliTypedResult<Ed25519PublicKey> {
+        if let Some(profile) =
+            CliConfig::load_profile(&self.profile, ConfigSearchMode::CurrentDirAndParents)?
+        {
+            if let Some(public_key) = profile.public_key {
+                return Ok(public_key);
             }
         }
 
@@ -1098,7 +1110,7 @@ pub struct TransactionOptions {
 
 impl TransactionOptions {
     /// Retrieves the private key
-    fn private_key(&self) -> CliTypedResult<Ed25519PrivateKey> {
+    pub(crate) fn private_key(&self) -> CliTypedResult<Ed25519PrivateKey> {
         self.private_key_options.extract_private_key(
             self.encoding_options.encoding,
             &self.profile_options.profile,
@@ -1124,6 +1136,21 @@ impl TransactionOptions {
         }
     }
 
+    /// Gets the auth key by account address. We need to fetch the auth key from Rest API rather than creating an
+    /// auth key out of the public key.
+    pub(crate) async fn auth_key(
+        &self,
+        sender_address: AccountAddress,
+    ) -> CliTypedResult<AuthenticationKey> {
+        let client = self.rest_client()?;
+        get_auth_key(&client, sender_address).await
+    }
+
+    pub async fn sequence_number(&self, sender_address: AccountAddress) -> CliTypedResult<u64> {
+        let client = self.rest_client()?;
+        get_sequence_number(&client, sender_address).await
+    }
+
     /// Submit a transaction
     pub async fn submit_transaction(
         &self,
@@ -1137,7 +1164,7 @@ impl TransactionOptions {
         let sender_address = self.sender_address()?;
 
         // Get sequence number for account
-        let sequence_number = get_sequence_number(&client, sender_address).await?;
+        let sequence_number = self.sequence_number(sender_address).await?;
 
         // Ask to confirm price if the gas unit price is estimated above the lowest value when
         // it is automatically estimated

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -8,8 +8,8 @@ use crate::{
 use aptos_build_info::build_information;
 use aptos_crypto::HashValue;
 use aptos_logger::{debug, Level};
-use aptos_rest_client::Client;
-use aptos_types::chain_id::ChainId;
+use aptos_rest_client::{Account, Client};
+use aptos_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
 use itertools::Itertools;
 use move_deps::move_core_types::account_address::AccountAddress;
 use reqwest::Url;
@@ -205,17 +205,33 @@ pub fn append_file_extension(
     }
 }
 
-/// Retrieves sequence number from the rest client
-pub async fn get_sequence_number(
+/// Retrieves account resource from the rest client
+pub async fn get_account(
     client: &aptos_rest_client::Client,
     address: AccountAddress,
-) -> CliTypedResult<u64> {
+) -> CliTypedResult<Account> {
     let account_response = client
         .get_account(address)
         .await
         .map_err(|err| CliError::ApiError(err.to_string()))?;
     let account = account_response.inner();
-    Ok(account.sequence_number)
+    Ok(account.clone())
+}
+
+/// Retrieves sequence number from the rest client
+pub async fn get_sequence_number(
+    client: &aptos_rest_client::Client,
+    address: AccountAddress,
+) -> CliTypedResult<u64> {
+    Ok(get_account(client, address).await?.sequence_number)
+}
+
+/// Retrieves the auth key from the rest client
+pub async fn get_auth_key(
+    client: &aptos_rest_client::Client,
+    address: AccountAddress,
+) -> CliTypedResult<AuthenticationKey> {
+    Ok(get_account(client, address).await?.authentication_key)
 }
 
 /// Retrieves the chain id from the rest client

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -4,6 +4,7 @@
 use crate::account::{
     create::{CreateAccount, DEFAULT_FUNDED_COINS},
     fund::FundWithFaucet,
+    key_rotation::RotateKey,
     list::{ListAccount, ListQuery},
     transfer::{TransferCoins, TransferSummary},
 };
@@ -175,6 +176,20 @@ impl CliTestFramework {
             faucet_options: self.faucet_options(),
             amount: amount.unwrap_or(DEFAULT_FUNDED_COINS),
             rest_options: self.rest_options(),
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn rotate_key(&self, index: usize, new_private_key: String) -> CliTypedResult<()> {
+        RotateKey {
+            txn_options: self.transaction_options(index, None),
+            // Do not save profile
+            prompt_options: PromptOptions {
+                assume_yes: false,
+                assume_no: true,
+            },
+            new_private_key,
         }
         .execute()
         .await

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -4,7 +4,7 @@
 use crate::account::{
     create::{CreateAccount, DEFAULT_FUNDED_COINS},
     fund::FundWithFaucet,
-    key_rotation::RotateKey,
+    key_rotation::{RotateKey, RotateSummary},
     list::{ListAccount, ListQuery},
     transfer::{TransferCoins, TransferSummary},
 };
@@ -181,15 +181,29 @@ impl CliTestFramework {
         .await
     }
 
-    pub async fn rotate_key(&self, index: usize, new_private_key: String) -> CliTypedResult<()> {
+    pub async fn rotate_key(
+        &self,
+        index: usize,
+        new_private_key: String,
+    ) -> CliTypedResult<RotateSummary> {
         RotateKey {
-            txn_options: self.transaction_options(index, None),
-            // Do not save profile
-            prompt_options: PromptOptions {
-                assume_yes: false,
-                assume_no: true,
+            txn_options: TransactionOptions {
+                private_key_options: PrivateKeyInputOptions::from_private_key(
+                    self.private_key(index),
+                )
+                .unwrap(),
+                rest_options: self.rest_options(),
+                gas_options: Default::default(),
+                prompt_options: PromptOptions {
+                    assume_yes: false,
+                    assume_no: true,
+                },
+                estimate_max_gas: true,
+                ..Default::default()
             },
-            new_private_key,
+            new_private_key: Some(new_private_key),
+            save_to_profile: None,
+            new_private_key_file: None,
         }
         .execute()
         .await

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -4,6 +4,7 @@
 use crate::smoke_test_environment::SwarmBuilder;
 use aptos::account::create::DEFAULT_FUNDED_COINS;
 use aptos::common::types::GasOptions;
+use aptos_crypto::PrivateKey;
 use aptos_keygen::KeyGen;
 use aptos_types::{
     account_address::AccountAddress, account_config::CORE_CODE_ADDRESS,
@@ -122,7 +123,7 @@ async fn test_account_key_rotation() {
         AccountAddress::from_hex_literal(
             rest_client
                 .get_table_item(
-                    table_handle,
+                    table_handle.parse().unwrap(),
                     "address",
                     "address",
                     new_address.to_hex_literal(),

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -5,6 +5,11 @@ use crate::smoke_test_environment::SwarmBuilder;
 use aptos::account::create::DEFAULT_FUNDED_COINS;
 use aptos::common::types::GasOptions;
 use aptos_keygen::KeyGen;
+use aptos_types::{
+    account_address::AccountAddress, account_config::CORE_CODE_ADDRESS,
+    transaction::authenticator::AuthenticationKey,
+};
+use forge::NodeExt;
 
 #[tokio::test]
 async fn test_account_flow() {
@@ -81,4 +86,54 @@ async fn test_account_flow() {
     .unwrap_err();
 
     assert!(cli.account_balance_now(2).await.unwrap() < DEFAULT_FUNDED_COINS - gas_used - 5);
+}
+
+#[tokio::test]
+async fn test_account_key_rotation() {
+    let (swarm, cli, _faucet) = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .build_with_cli(1)
+        .await;
+
+    let mut keygen = KeyGen::from_os_rng();
+    let new_private_key = keygen.generate_ed25519_private_key();
+
+    cli.rotate_key(0, hex::encode(new_private_key.to_bytes()))
+        .await
+        .unwrap();
+
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+
+    let originating_resource = rest_client
+        .get_account_resource(CORE_CODE_ADDRESS, "0x1::account::OriginatingAddress")
+        .await
+        .unwrap()
+        .into_inner()
+        .unwrap()
+        .data;
+
+    let table_handle = originating_resource["address_map"]["handle"]
+        .as_str()
+        .unwrap();
+
+    let new_address = AuthenticationKey::ed25519(&new_private_key.public_key()).derived_address();
+
+    assert_eq!(
+        AccountAddress::from_hex_literal(
+            rest_client
+                .get_table_item(
+                    table_handle,
+                    "address",
+                    "address",
+                    new_address.to_hex_literal(),
+                )
+                .await
+                .unwrap()
+                .into_inner()
+                .as_str()
+                .unwrap()
+        )
+        .unwrap(),
+        cli.account_id(0)
+    );
 }


### PR DESCRIPTION
### Description
Add a CLI command to rotate an account's auth key. 



### Test Plan
Smoke test + 
![Screen Shot 2022-08-26 at 4 53 13 PM](https://user-images.githubusercontent.com/962285/187005066-5e1d6eae-9834-45e5-84e5-412a7100a671.png)
![Screen Shot 2022-08-26 at 4 53 21 PM](https://user-images.githubusercontent.com/962285/187005074-19e8b32c-7503-49e3-b430-1d66fdb9f621.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3438)
<!-- Reviewable:end -->
