### PR TITLE
[aptos-cli] Have Aptos CLI estimate gas parameters automatically

### DIFF
--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -31,7 +31,7 @@ impl CliCommand<TransactionSummary> for CreateAccount {
     async fn execute(self) -> CliTypedResult<TransactionSummary> {
         let address = self.account;
         self.txn_options
-            .submit_transaction(aptos_stdlib::aptos_account_create_account(address))
+            .submit_transaction(aptos_stdlib::aptos_account_create_account(address), None)
             .await
             .map(TransactionSummary::from)
     }

--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -84,10 +84,13 @@ impl CliCommand<CreateResourceAccountSummary> for CreateResourceAccount {
             vec![]
         };
         self.txn_options
-            .submit_transaction(resource_account_create_resource_account(
-                bcs::to_bytes(&self.seed)?,
-                authentication_key,
-            ))
+            .submit_transaction(
+                resource_account_create_resource_account(
+                    bcs::to_bytes(&self.seed)?,
+                    authentication_key,
+                ),
+                None,
+            )
             .await
             .map(CreateResourceAccountSummary::from)
     }

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -38,7 +38,10 @@ impl CliCommand<TransferSummary> for TransferCoins {
 
     async fn execute(self) -> CliTypedResult<TransferSummary> {
         self.txn_options
-            .submit_transaction(aptos_stdlib::aptos_coin_transfer(self.account, self.amount))
+            .submit_transaction(
+                aptos_stdlib::aptos_coin_transfer(self.account, self.amount),
+                Some(self.amount),
+            )
             .await
             .map(TransferSummary::from)
     }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1208,13 +1208,20 @@ impl TransactionOptions {
             .value
             .0;
 
-        let max_possible_gas = if let Some(amount) = amount_transfer {
+        let max_possible_gas = if gas_price == 0 {
+            MAX_POSSIBLE_GAS_UNITS
+        } else if let Some(amount) = amount_transfer {
             std::cmp::min(
-                account_balance.saturating_sub(amount) / gas_price,
+                account_balance
+                    .saturating_sub(amount)
+                    .saturating_div(gas_price),
                 MAX_POSSIBLE_GAS_UNITS,
             )
         } else {
-            std::cmp::min(account_balance / gas_price, MAX_POSSIBLE_GAS_UNITS)
+            std::cmp::min(
+                account_balance.saturating_div(gas_price),
+                MAX_POSSIBLE_GAS_UNITS,
+            )
         };
 
         let transaction_factory = TransactionFactory::new(chain_id(&client).await?)

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -93,7 +93,7 @@ impl CliCommand<ProposalSubmissionSummary> for SubmitProposal {
         );
         prompt_yes_with_override(
             "Do you want to submit this proposal?",
-            self.compile_proposal_args.prompt_options,
+            self.txn_options.prompt_options,
         )?;
 
         let txn = self
@@ -223,8 +223,6 @@ pub struct SubmitVote {
     pub(crate) no: bool,
 
     #[clap(flatten)]
-    pub(crate) prompt_options: PromptOptions,
-    #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
     #[clap(flatten)]
     pub(crate) pool_address_args: PoolAddressArgs,
@@ -251,7 +249,7 @@ impl CliCommand<TransactionSummary> for SubmitVote {
 
         prompt_yes_with_override(
             &format!("Are you sure you want to vote {}", vote_str),
-            self.prompt_options,
+            self.txn_options.prompt_options,
         )?;
 
         self.txn_options

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -98,12 +98,15 @@ impl CliCommand<ProposalSubmissionSummary> for SubmitProposal {
 
         let txn = self
             .txn_options
-            .submit_transaction(aptos_stdlib::aptos_governance_create_proposal(
-                self.pool_address_args.pool_address,
-                script_hash.to_vec(),
-                self.metadata_url.to_string().as_bytes().to_vec(),
-                metadata_hash.to_hex().as_bytes().to_vec(),
-            ))
+            .submit_transaction(
+                aptos_stdlib::aptos_governance_create_proposal(
+                    self.pool_address_args.pool_address,
+                    script_hash.to_vec(),
+                    self.metadata_url.to_string().as_bytes().to_vec(),
+                    metadata_hash.to_hex().as_bytes().to_vec(),
+                ),
+                None,
+            )
             .await?;
         let txn_summary = TransactionSummary::from(&txn);
         if let Transaction::UserTransaction(inner) = txn {
@@ -253,11 +256,14 @@ impl CliCommand<TransactionSummary> for SubmitVote {
         )?;
 
         self.txn_options
-            .submit_transaction(aptos_stdlib::aptos_governance_vote(
-                self.pool_address_args.pool_address,
-                self.proposal_id,
-                vote,
-            ))
+            .submit_transaction(
+                aptos_stdlib::aptos_governance_vote(
+                    self.pool_address_args.pool_address,
+                    self.proposal_id,
+                    vote,
+                ),
+                None,
+            )
             .await
             .map(TransactionSummary::from)
     }
@@ -379,7 +385,7 @@ impl CliCommand<TransactionSummary> for ExecuteProposal {
         let txn = TransactionPayload::Script(Script::new(bytecode, vec![], args));
 
         self.txn_options
-            .submit_transaction(txn)
+            .submit_transaction(txn, None)
             .await
             .map(TransactionSummary::from)
     }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -509,9 +509,10 @@ impl CliCommand<TransactionSummary> for PublishPackage {
         if legacy_flow {
             // Send the compiled module using a module bundle
             txn_options
-                .submit_transaction(TransactionPayload::ModuleBundle(ModuleBundle::new(
-                    compiled_units,
-                )))
+                .submit_transaction(
+                    TransactionPayload::ModuleBundle(ModuleBundle::new(compiled_units)),
+                    None,
+                )
                 .await
                 .map(TransactionSummary::from)
         } else {
@@ -532,7 +533,7 @@ impl CliCommand<TransactionSummary> for PublishPackage {
                 )));
             }
             txn_options
-                .submit_transaction(payload)
+                .submit_transaction(payload, None)
                 .await
                 .map(TransactionSummary::from)
         }
@@ -750,12 +751,15 @@ impl CliCommand<TransactionSummary> for RunFunction {
         }
 
         self.txn_options
-            .submit_transaction(TransactionPayload::EntryFunction(EntryFunction::new(
-                self.function_id.module_id,
-                self.function_id.member_id,
-                type_args,
-                args,
-            )))
+            .submit_transaction(
+                TransactionPayload::EntryFunction(EntryFunction::new(
+                    self.function_id.module_id,
+                    self.function_id.member_id,
+                    type_args,
+                    args,
+                )),
+                None,
+            )
             .await
             .map(TransactionSummary::from)
     }

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -270,13 +270,16 @@ impl CliCommand<TransactionSummary> for InitializeValidator {
             };
 
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_initialize_validator(
-                consensus_public_key.to_bytes().to_vec(),
-                consensus_proof_of_possession.to_bytes().to_vec(),
-                // BCS encode, so that we can hide the original type
-                bcs::to_bytes(&validator_network_addresses)?,
-                bcs::to_bytes(&full_node_network_addresses)?,
-            ))
+            .submit_transaction(
+                aptos_stdlib::stake_initialize_validator(
+                    consensus_public_key.to_bytes().to_vec(),
+                    consensus_proof_of_possession.to_bytes().to_vec(),
+                    // BCS encode, so that we can hide the original type
+                    bcs::to_bytes(&validator_network_addresses)?,
+                    bcs::to_bytes(&full_node_network_addresses)?,
+                ),
+                None,
+            )
             .await
             .map(|inner| inner.into())
     }
@@ -334,7 +337,7 @@ impl CliCommand<TransactionSummary> for JoinValidatorSet {
             .address_fallback_to_txn(&self.txn_options)?;
 
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_join_validator_set(address))
+            .submit_transaction(aptos_stdlib::stake_join_validator_set(address), None)
             .await
             .map(|inner| inner.into())
     }
@@ -361,7 +364,7 @@ impl CliCommand<TransactionSummary> for LeaveValidatorSet {
             .address_fallback_to_txn(&self.txn_options)?;
 
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_leave_validator_set(address))
+            .submit_transaction(aptos_stdlib::stake_leave_validator_set(address), None)
             .await
             .map(|inner| inner.into())
     }
@@ -644,11 +647,14 @@ impl CliCommand<TransactionSummary> for UpdateConsensusKey {
             .validator_consensus_key_args
             .get_consensus_proof_of_possession(&operator_config)?;
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_rotate_consensus_key(
-                address,
-                consensus_public_key.to_bytes().to_vec(),
-                consensus_proof_of_possession.to_bytes().to_vec(),
-            ))
+            .submit_transaction(
+                aptos_stdlib::stake_rotate_consensus_key(
+                    address,
+                    consensus_public_key.to_bytes().to_vec(),
+                    consensus_proof_of_possession.to_bytes().to_vec(),
+                ),
+                None,
+            )
             .await
             .map(|inner| inner.into())
     }
@@ -702,12 +708,15 @@ impl CliCommand<TransactionSummary> for UpdateValidatorNetworkAddresses {
             };
 
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_update_network_and_fullnode_addresses(
-                address,
-                // BCS encode, so that we can hide the original type
-                bcs::to_bytes(&validator_network_addresses)?,
-                bcs::to_bytes(&full_node_network_addresses)?,
-            ))
+            .submit_transaction(
+                aptos_stdlib::stake_update_network_and_fullnode_addresses(
+                    address,
+                    // BCS encode, so that we can hide the original type
+                    bcs::to_bytes(&validator_network_addresses)?,
+                    bcs::to_bytes(&full_node_network_addresses)?,
+                ),
+                None,
+            )
             .await
             .map(|inner| inner.into())
     }

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -58,7 +58,10 @@ impl CliCommand<TransactionSummary> for AddStake {
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_add_stake(self.amount))
+            .submit_transaction(
+                aptos_stdlib::stake_add_stake(self.amount),
+                Some(self.amount),
+            )
             .await
             .map(|inner| inner.into())
     }
@@ -85,7 +88,7 @@ impl CliCommand<TransactionSummary> for UnlockStake {
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_unlock(self.amount))
+            .submit_transaction(aptos_stdlib::stake_unlock(self.amount), None)
             .await
             .map(|inner| inner.into())
     }
@@ -113,7 +116,7 @@ impl CliCommand<TransactionSummary> for WithdrawStake {
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.node_op_options
-            .submit_transaction(aptos_stdlib::stake_withdraw(self.amount))
+            .submit_transaction(aptos_stdlib::stake_withdraw(self.amount), None)
             .await
             .map(|inner| inner.into())
     }
@@ -136,7 +139,7 @@ impl CliCommand<TransactionSummary> for IncreaseLockup {
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_increase_lockup())
+            .submit_transaction(aptos_stdlib::stake_increase_lockup(), None)
             .await
             .map(|inner| inner.into())
     }
@@ -177,11 +180,14 @@ impl CliCommand<TransactionSummary> for InitializeStakeOwner {
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         let owner_address = self.txn_options.sender_address()?;
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_initialize_stake_owner(
-                self.initial_stake_amount,
-                self.operator_address.unwrap_or(owner_address),
-                self.voter_address.unwrap_or(owner_address),
-            ))
+            .submit_transaction(
+                aptos_stdlib::stake_initialize_stake_owner(
+                    self.initial_stake_amount,
+                    self.operator_address.unwrap_or(owner_address),
+                    self.voter_address.unwrap_or(owner_address),
+                ),
+                Some(self.initial_stake_amount),
+            )
             .await
             .map(|inner| inner.into())
     }
@@ -208,7 +214,10 @@ impl CliCommand<TransactionSummary> for SetOperator {
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_set_operator(self.operator_address))
+            .submit_transaction(
+                aptos_stdlib::stake_set_operator(self.operator_address),
+                None,
+            )
             .await
             .map(|inner| inner.into())
     }
@@ -235,7 +244,10 @@ impl CliCommand<TransactionSummary> for SetDelegatedVoter {
 
     async fn execute(mut self) -> CliTypedResult<TransactionSummary> {
         self.txn_options
-            .submit_transaction(aptos_stdlib::stake_set_delegated_voter(self.voter_address))
+            .submit_transaction(
+                aptos_stdlib::stake_set_delegated_voter(self.voter_address),
+                None,
+            )
             .await
             .map(|inner| inner.into())
     }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -793,6 +793,7 @@ impl CliTestFramework {
                 .unwrap(),
             rest_options: self.rest_options(),
             gas_options: gas_options.unwrap_or_default(),
+            prompt_options: PromptOptions::yes(),
             ..Default::default()
         }
     }

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -3,6 +3,7 @@
 
 use crate::smoke_test_environment::SwarmBuilder;
 use aptos::account::create::DEFAULT_FUNDED_COINS;
+use aptos::common::types::GasOptions;
 use aptos_keygen::KeyGen;
 
 #[tokio::test]
@@ -44,4 +45,40 @@ async fn test_account_flow() {
         .unwrap();
     cli.assert_account_balance_now(2, DEFAULT_FUNDED_COINS)
         .await;
+
+    // Test gas options
+    // Override gas unit price should use it instead of the estimated one
+    let summary = cli
+        .transfer_coins(
+            2,
+            1,
+            5,
+            Some(GasOptions {
+                gas_unit_price: Some(2),
+                max_gas: None,
+            }),
+        )
+        .await
+        .unwrap();
+    assert_eq!(2, summary.gas_unit_price);
+    let gas_used = summary.gas_used * summary.gas_unit_price;
+
+    cli.assert_account_balance_now(2, DEFAULT_FUNDED_COINS - gas_used - 5)
+        .await;
+    // Setting max gas skips simulation (this should fail for too little gas units, but be charged gas)
+    // If it was simulated, it wouldn't charge gas, and it would need to be caught by the VM.  Mempool
+    // submission doesn't check max gas is correct, just that the user has enough to pay it
+    cli.transfer_coins(
+        2,
+        1,
+        5,
+        Some(GasOptions {
+            gas_unit_price: None,
+            max_gas: Some(1),
+        }),
+    )
+    .await
+    .unwrap_err();
+
+    assert!(cli.account_balance_now(2).await.unwrap() < DEFAULT_FUNDED_COINS - gas_used - 5);
 }

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -3,7 +3,6 @@
 
 use crate::smoke_test_environment::SwarmBuilder;
 use aptos::account::create::DEFAULT_FUNDED_COINS;
-use aptos::common::types::{GasOptions, DEFAULT_GAS_UNIT_PRICE, DEFAULT_MAX_GAS};
 use aptos_keygen::KeyGen;
 
 #[tokio::test]
@@ -20,15 +19,7 @@ async fn test_account_flow() {
 
     let transfer_amount = 100;
     let response = cli
-        .transfer_coins(
-            0,
-            1,
-            transfer_amount,
-            Some(GasOptions {
-                gas_unit_price: DEFAULT_GAS_UNIT_PRICE * 2,
-                max_gas: DEFAULT_MAX_GAS,
-            }),
-        )
+        .transfer_coins(0, 1, transfer_amount, None)
         .await
         .unwrap();
     let expected_sender_amount =

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -248,7 +248,7 @@ async fn test_nodes_rewards() {
     )
     .await;
 
-    cli.fund_account(validator_cli_indices[3], Some(10000))
+    cli.fund_account(validator_cli_indices[3], Some(30000))
         .await
         .unwrap();
 
@@ -591,7 +591,8 @@ async fn test_join_and_leave_validator() {
     let rest_client = swarm.validators().next().unwrap().rest_client();
 
     let mut keygen = KeyGen::from_os_rng();
-    let (validator_cli_index, keys) = init_validator_account(&mut cli, &mut keygen, None).await;
+    let (validator_cli_index, keys) =
+        init_validator_account(&mut cli, &mut keygen, Some(DEFAULT_FUNDED_COINS * 3)).await;
     let mut gas_used = 0;
 
     // faucet can make our root LocalAccount sequence number get out of sync.
@@ -619,7 +620,7 @@ async fn test_join_and_leave_validator() {
 
     assert_validator_set_sizes(&cli, 1, 0, 0).await;
 
-    cli.assert_account_balance_now(validator_cli_index, DEFAULT_FUNDED_COINS - gas_used)
+    cli.assert_account_balance_now(validator_cli_index, (3 * DEFAULT_FUNDED_COINS) - gas_used)
         .await;
 
     let stake_coins = 7;
@@ -631,7 +632,7 @@ async fn test_join_and_leave_validator() {
 
     cli.assert_account_balance_now(
         validator_cli_index,
-        DEFAULT_FUNDED_COINS - stake_coins - gas_used,
+        (3 * DEFAULT_FUNDED_COINS) - stake_coins - gas_used,
     )
     .await;
 
@@ -696,7 +697,7 @@ async fn test_join_and_leave_validator() {
 
     cli.assert_account_balance_now(
         validator_cli_index,
-        DEFAULT_FUNDED_COINS - stake_coins - gas_used,
+        (3 * DEFAULT_FUNDED_COINS) - stake_coins - gas_used,
     )
     .await;
 
@@ -721,7 +722,7 @@ async fn test_join_and_leave_validator() {
 
     cli.assert_account_balance_now(
         validator_cli_index,
-        DEFAULT_FUNDED_COINS - stake_coins + withdraw_stake - gas_used,
+        (3 * DEFAULT_FUNDED_COINS) - stake_coins + withdraw_stake - gas_used,
     )
     .await;
 }

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -3,7 +3,6 @@
 
 use crate::smoke_test_environment::SwarmBuilder;
 use anyhow::anyhow;
-use aptos::common::types::{GasOptions, DEFAULT_GAS_UNIT_PRICE, DEFAULT_MAX_GAS};
 use aptos::test::INVALID_ACCOUNT;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_config::config::PersistableConfig;
@@ -193,15 +192,7 @@ async fn test_account_balance() {
     // Send money, and expect the gas and fees to show up accordingly
     const TRANSFER_AMOUNT: u64 = 5000;
     let response = cli
-        .transfer_coins(
-            0,
-            1,
-            TRANSFER_AMOUNT,
-            Some(GasOptions {
-                gas_unit_price: DEFAULT_GAS_UNIT_PRICE * 2,
-                max_gas: DEFAULT_MAX_GAS,
-            }),
-        )
+        .transfer_coins(0, 1, TRANSFER_AMOUNT, None)
         .await
         .unwrap();
     account_1_balance -= TRANSFER_AMOUNT + response.gas_used * response.gas_unit_price;
@@ -215,14 +206,7 @@ async fn test_account_balance() {
 
     // Failed transaction spends gas
     let _ = cli
-        .transfer_invalid_addr(
-            0,
-            TRANSFER_AMOUNT,
-            Some(GasOptions {
-                gas_unit_price: DEFAULT_GAS_UNIT_PRICE * 2,
-                max_gas: DEFAULT_MAX_GAS,
-            }),
-        )
+        .transfer_invalid_addr(0, TRANSFER_AMOUNT, None)
         .await
         .unwrap_err();
 
@@ -1068,14 +1052,7 @@ async fn test_invalid_transaction_gas_charged() {
     // Now let's see some transfers
     const TRANSFER_AMOUNT: u64 = 5000;
     let _ = cli
-        .transfer_invalid_addr(
-            0,
-            TRANSFER_AMOUNT,
-            Some(GasOptions {
-                gas_unit_price: DEFAULT_GAS_UNIT_PRICE * 2,
-                max_gas: DEFAULT_MAX_GAS,
-            }),
-        )
+        .transfer_invalid_addr(0, TRANSFER_AMOUNT, None)
         .await
         .unwrap_err();
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -3,6 +3,7 @@
 
 use crate::smoke_test_environment::SwarmBuilder;
 use anyhow::anyhow;
+use aptos::common::types::GasOptions;
 use aptos::test::INVALID_ACCOUNT;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_config::config::PersistableConfig;
@@ -206,7 +207,14 @@ async fn test_account_balance() {
 
     // Failed transaction spends gas
     let _ = cli
-        .transfer_invalid_addr(0, TRANSFER_AMOUNT, None)
+        .transfer_invalid_addr(
+            0,
+            TRANSFER_AMOUNT,
+            Some(GasOptions {
+                gas_unit_price: None,
+                max_gas: Some(1000),
+            }),
+        )
         .await
         .unwrap_err();
 
@@ -1052,7 +1060,14 @@ async fn test_invalid_transaction_gas_charged() {
     // Now let's see some transfers
     const TRANSFER_AMOUNT: u64 = 5000;
     let _ = cli
-        .transfer_invalid_addr(0, TRANSFER_AMOUNT, None)
+        .transfer_invalid_addr(
+            0,
+            TRANSFER_AMOUNT,
+            Some(GasOptions {
+                gas_unit_price: None,
+                max_gas: Some(1000),
+            }),
+        )
         .await
         .unwrap_err();
 


### PR DESCRIPTION
### Description
If Rosetta can do it, why not make the CLI estimate the gas parameters accordingly.

Additionally, asks you if you want to spend the estimated amount (when it's more than 1).  You can always provide the gas price in another CLI call which will override that.

### Test Plan

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3440)
<!-- Reviewable:end -->
