### PR TITLE
[aptos-telemetry] set default for role type and auth bug fix

### DIFF
--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -22,7 +22,7 @@ pub fn log_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
         .and(context.clone().filter())
         .and(with_auth(
             context,
-            vec![PeerRole::Validator, PeerRole::Unknown],
+            vec![PeerRole::Validator, PeerRole::ValidatorFullNode],
         ))
         .and(warp::header::optional(CONTENT_ENCODING.as_str()))
         .and(warp::body::content_length_limit(MAX_CONTENT_LENGTH))

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -4,6 +4,7 @@
 use crate::{auth::with_auth, context::Context, types::auth::Claims};
 use aptos_config::config::PeerRole;
 use aptos_logger::{debug, error};
+use reqwest::StatusCode;
 use warp::{filters::BoxedFilter, hyper::body::Bytes, reply, Filter, Rejection, Reply};
 
 pub fn metrics_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
@@ -12,7 +13,7 @@ pub fn metrics_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
         .and(context.clone().filter())
         .and(with_auth(
             context,
-            vec![PeerRole::Validator, PeerRole::Unknown],
+            vec![PeerRole::Validator, PeerRole::ValidatorFullNode],
         ))
         .and(warp::body::bytes())
         .and_then(handle_metrics_ingest)
@@ -48,7 +49,7 @@ pub async fn handle_metrics_ingest(
         }
     }
 
-    Ok(reply::reply())
+    Ok(reply::with_status(reply::reply(), StatusCode::CREATED))
 }
 
 fn claims_to_extra_labels(claims: &Claims) -> Vec<String> {

--- a/crates/aptos-telemetry-service/src/types/auth.rs
+++ b/crates/aptos-telemetry-service/src/types/auth.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 pub struct AuthRequest {
     pub chain_id: ChainId,
     pub peer_id: PeerId,
+    #[serde(default = "default_role_type")]
     pub role_type: RoleType,
     pub server_public_key: x25519::PublicKey,
     pub handshake_msg: Vec<u8>,
@@ -28,4 +29,8 @@ pub struct Claims {
     pub epoch: u64,
     pub exp: usize,
     pub iat: usize,
+}
+
+fn default_role_type() -> RoleType {
+    RoleType::Validator
 }

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -90,8 +90,6 @@ impl TelemetrySender {
     ) -> Result<(), anyhow::Error> {
         debug!("Sending Prometheus Metrics");
 
-        let token = self.get_auth_token().await?;
-
         let scraped_metrics =
             prometheus::TextEncoder::new().encode_to_string(&registry.gather())?;
 
@@ -104,7 +102,6 @@ impl TelemetrySender {
                 self.client
                     .post(format!("{}/push-metrics", self.base_url))
                     .header(CONTENT_ENCODING, "gzip")
-                    .bearer_auth(token)
                     .body(compressed_bytes),
             )
             .await;


### PR DESCRIPTION
### Description

- Set default role type in AuthRequest for backwards compatibility
- Set proper with_auth roles for prometheus and log ingest
- Bug fix: Remove multiple auth token set in header for push metrics endpoint
- Bug fix: Add ability to handle multiple auth tokens in header at service as fix for currently running validators

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Hot fix was deployed and I validated that the service is working fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3441)
<!-- Reviewable:end -->
