### PR TITLE
[code upgrade] Verify package dependency policy on chain

### DIFF
--- a/aptos-move/e2e-move-tests/src/aggregator.rs
+++ b/aptos-move/e2e-move-tests/src/aggregator.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::assert_success;
 use crate::harness::MoveHarness;
 use aptos_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use language_e2e_tests::account::Account;
@@ -9,13 +10,13 @@ use std::path::PathBuf;
 pub fn initialize(path: PathBuf) -> (MoveHarness, Account) {
     let mut harness = MoveHarness::new();
     let account = harness.new_account_at(AccountAddress::ONE);
-    harness.publish_package(&account, &path);
-    harness.run_entry_function(
+    assert_success!(harness.publish_package(&account, &path));
+    assert_success!(harness.run_entry_function(
         &account,
         str::parse("0x1::aggregator_test::initialize").unwrap(),
         vec![],
         vec![],
-    );
+    ));
     (harness, account)
 }
 

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -112,13 +112,13 @@ impl MoveHarness {
         account: &Account,
         payload: TransactionPayload,
     ) -> SignedTransaction {
-        // We initialize for some reason with 10, so use 10 as the first value here too
         let seq_no_ref = self.txn_seq_no.get_mut(account.address()).unwrap();
         let seq_no = *seq_no_ref;
         *seq_no_ref += 1;
         account
             .transaction()
             .sequence_number(seq_no)
+            .max_gas_amount(1_000_000)
             .gas_unit_price(1)
             .payload(payload)
             .sign()
@@ -308,10 +308,11 @@ macro_rules! assert_success {
 #[macro_export]
 macro_rules! assert_abort {
     ($s:expr, $c:pat) => {{
-        use aptos_types::transaction::*;
         assert!(matches!(
             $s,
-            TransactionStatus::Keep(ExecutionStatus::MoveAbort { code: $c, .. })
+            aptos_types::transaction::TransactionStatus::Keep(
+                aptos_types::transaction::ExecutionStatus::MoveAbort { code: $c, .. }
+            ),
         ));
     }};
 }

--- a/aptos-move/e2e-move-tests/src/package_builder.rs
+++ b/aptos-move/e2e-move-tests/src/package_builder.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use framework::natives::code::UpgradePolicy;
 use itertools::Itertools;
 use move_deps::move_command_line_common::files::MOVE_EXTENSION;
 use move_deps::move_package::compilation::package_layout::CompiledPackageLayout;
@@ -11,6 +12,7 @@ use tempfile::{tempdir, TempDir};
 #[derive(Debug, Clone)]
 pub struct PackageBuilder {
     name: String,
+    policy: UpgradePolicy,
     deps: Vec<String>,
     aliases: Vec<(String, String)>,
     sources: Vec<(String, String)>,
@@ -20,10 +22,15 @@ impl PackageBuilder {
     pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
+            policy: UpgradePolicy::compat(),
             deps: vec![],
             aliases: vec![],
             sources: vec![],
         }
+    }
+
+    pub fn with_policy(self, policy: UpgradePolicy) -> Self {
+        Self { policy, ..self }
     }
 
     pub fn add_dep(&mut self, dep: &str) {
@@ -48,11 +55,13 @@ impl PackageBuilder {
 [package]
 name = \"{}\"
 version = \"0.0.0\"
+upgrade_policy = \"{}\"
 [addresses]
 {}
 [dependencies]
 {}",
                 self.name,
+                self.policy,
                 self.aliases
                     .into_iter()
                     .map(|(k, v)| format!("{} = \"{}\"", k, v))

--- a/aptos-move/e2e-move-tests/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/tests/code_publishing.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::account_address::AccountAddress;
+use e2e_move_tests::package_builder::PackageBuilder;
 use e2e_move_tests::{assert_abort, assert_success, assert_vm_status, MoveHarness};
-use framework::natives::code::PackageRegistry;
+use framework::natives::code::{PackageRegistry, UpgradePolicy};
 use move_deps::move_core_types::parser::parse_struct_tag;
 use move_deps::move_core_types::vm_status::StatusCode;
 use serde::{Deserialize, Serialize};
@@ -60,8 +61,6 @@ fn code_publishing_basic() {
     assert_eq!(state.value, 42)
 }
 
-// Ignored because we've disabled incompatible upgrade policy.
-#[ignore]
 #[test]
 fn code_publishing_upgrade_success_no_compat() {
     let mut h = MoveHarness::new_no_parallel();
@@ -220,4 +219,57 @@ fn code_publishing_framework_upgrade_fail() {
         &common::test_dir_path("code_publishing.data/pack_stdlib_incompat"),
     );
     assert_vm_status!(result, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE)
+}
+
+#[test]
+fn code_publishing_weak_dep_fail() {
+    let mut h = MoveHarness::new_no_parallel();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    let mut weak = PackageBuilder::new("WeakPackage").with_policy(UpgradePolicy::arbitrary());
+    weak.add_source("weak", "module 0xcafe::weak { public fun f() {} }");
+
+    let weak_dir = weak.write_to_temp().unwrap();
+    assert_success!(h.publish_package(&acc, weak_dir.path()));
+
+    let mut normal = PackageBuilder::new("Package").with_policy(UpgradePolicy::compat());
+    normal.add_dep(&format!(
+        "WeakPackage = {{ local = \"{}\" }}",
+        weak_dir.path().display()
+    ));
+    normal.add_source(
+        "normal",
+        "module 0xcafe::normal { use 0xcafe::weak; public fun f() { weak::f() } }",
+    );
+    let normal_dir = normal.write_to_temp().unwrap();
+    let status = h.publish_package(&acc, normal_dir.path());
+    assert_abort!(status, 0x10006 /*invalid_arhument(EDEP_WEAKER_POLICY)*/);
+}
+
+#[test]
+fn code_publishing_arbitray_dep_different_address() {
+    let mut h = MoveHarness::new_no_parallel();
+    let acc1 = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    let acc2 = h.new_account_at(AccountAddress::from_hex_literal("0xdeaf").unwrap());
+
+    let mut pack1 = PackageBuilder::new("Package1").with_policy(UpgradePolicy::arbitrary());
+    pack1.add_source("m", "module 0xcafe::m { public fun f() {} }");
+    let pack1_dir = pack1.write_to_temp().unwrap();
+
+    let mut pack2 = PackageBuilder::new("Package2").with_policy(UpgradePolicy::arbitrary());
+    pack2.add_dep(&format!(
+        "Package1 = {{ local = \"{}\" }}",
+        pack1_dir.path().display()
+    ));
+    pack2.add_source(
+        "m",
+        "module 0xdeaf::m { use 0xcafe::m; public fun f() { m::f() } }",
+    );
+    let pack2_dir = pack2.write_to_temp().unwrap();
+
+    assert_success!(h.publish_package(&acc1, pack1_dir.path()));
+    assert_abort!(
+        h.publish_package(&acc2, pack2_dir.path()),
+        0x10007 /*EDEP_ARBITRARY_NOT_SAME_ADDRESS*/
+    );
 }

--- a/aptos-move/framework/aptos-stdlib/sources/any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/any.move
@@ -4,6 +4,8 @@ module aptos_std::any {
     use std::error;
     use std::string::String;
 
+    friend aptos_std::copyable_any;
+
     /// The type provided for `unpack` is not the same as was given for `pack`.
     const ETYPE_MISMATCH: u64 = 0;
 

--- a/aptos-move/framework/aptos-stdlib/sources/copyable_any.move
+++ b/aptos-move/framework/aptos-stdlib/sources/copyable_any.move
@@ -1,0 +1,45 @@
+module aptos_std::copyable_any {
+    use aptos_std::type_info;
+    use aptos_std::any::from_bytes;
+    use std::bcs;
+    use std::error;
+    use std::string::String;
+
+    /// The type provided for `unpack` is not the same as was given for `pack`.
+    const ETYPE_MISMATCH: u64 = 0;
+
+    /// The same as `any::Any` but with the copy ability.
+    struct Any has drop, store, copy {
+        type_name: String,
+        data: vector<u8>
+    }
+
+    /// Pack a value into the `Any` representation. Because Any can be stored, dropped, and copied this is
+    /// also required from `T`.
+    public fun pack<T: drop + store + copy>(x: T): Any {
+        Any {
+            type_name: type_info::type_name<T>(),
+            data: bcs::to_bytes(&x)
+        }
+    }
+
+    /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
+    public fun unpack<T>(x: Any): T {
+        assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ETYPE_MISMATCH));
+        from_bytes<T>(x.data)
+    }
+
+    /// Returns the type name of this Any
+    public fun type_name(x: &Any): &String {
+        &x.type_name
+    }
+
+    #[test_only]
+    struct S has store, drop, copy { x: u64 }
+
+    #[test]
+    fun test_any() {
+        assert!(unpack<u64>(pack(22)) == 22, 1);
+        assert!(unpack<S>(pack(S{x:22})) == S{x: 22}, 2);
+    }
+}

--- a/aptos-move/framework/src/natives/any.rs
+++ b/aptos-move/framework/src/natives/any.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::natives::{util, GasParameters};
+use anyhow::bail;
 use move_deps::move_vm_runtime::native_functions::NativeFunction;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 /// Rust representation of the Move Any type
@@ -11,6 +13,25 @@ pub struct Any {
     pub type_name: String,
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
+}
+
+impl Any {
+    pub fn pack<T: Serialize>(move_name: &str, x: T) -> Any {
+        Any {
+            type_name: move_name.to_string(),
+            data: bcs::to_bytes(&x).unwrap(),
+        }
+    }
+
+    pub fn unpack<T: DeserializeOwned>(move_name: &str, x: Any) -> anyhow::Result<T> {
+        let Any { type_name, data } = x;
+        if type_name == move_name {
+            let y = bcs::from_bytes::<T>(&data)?;
+            Ok(y)
+        } else {
+            bail!("type mismatch")
+        }
+    }
 }
 
 // The Any module hijacks just one function, from_bytes, from the util module. This

--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -34,7 +34,25 @@ pub struct MoveOption<T> {
 
 impl<T> Default for MoveOption<T> {
     fn default() -> Self {
+        MoveOption::none()
+    }
+}
+
+impl<T> MoveOption<T> {
+    pub fn none() -> Self {
         Self { value: vec![] }
+    }
+
+    pub fn some(x: T) -> Self {
+        Self { value: vec![x] }
+    }
+
+    pub fn is_none(&self) -> bool {
+        self.value.is_empty()
+    }
+
+    pub fn is_some(&self) -> bool {
+        !self.value.is_empty()
     }
 }
 
@@ -53,15 +71,25 @@ pub struct PackageMetadata {
     pub upgrade_policy: UpgradePolicy,
     pub upgrade_number: u64,
     pub source_digest: String,
+    #[serde(with = "serde_bytes")]
     pub manifest: Vec<u8>,
     pub modules: Vec<ModuleMetadata>,
+    pub deps: Vec<PackageDep>,
     pub extension: MoveOption<Any>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+pub struct PackageDep {
+    pub account: AccountAddress,
+    pub package_name: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModuleMetadata {
     pub name: String,
+    #[serde(with = "serde_bytes")]
     pub source: Vec<u8>,
+    #[serde(with = "serde_bytes")]
     pub source_map: Vec<u8>,
     pub extension: MoveOption<Any>,
 }

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -8,7 +8,7 @@ use cached_packages::aptos_stdlib;
 use clap::Parser;
 
 // TODO(Gas): double check if this is correct
-pub const DEFAULT_FUNDED_COINS: u64 = 10_000;
+pub const DEFAULT_FUNDED_COINS: u64 = 50_000;
 
 /// Command to create a new account on-chain
 ///


### PR DESCRIPTION
### Description

This implements a new policy for package dependencies: A package is not allowed to refer to another package which has a lower upgrade policy. For example, an immutable package cannot refer to a compatible package. This check wasn't yet implemented and is added in this PR. 

This PR also suggests to reenable policy `arbitrary` with a semantics such that is suited for the 'app' developer (in contrast to the library developer): references to packages with `arbitrary` upgrade policy are allowed only if the dependency is _at the same address_ (plus the above condition is fulfilled). This allows an app developer to update their packages following other notions of compatibility. For example, the current compatible policy does not allow to remove public functions. But someone can very well remove such functions together with all call sites -- if all code is owned. 


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added new tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3448)
<!-- Reviewable:end -->
