### PR TITLE
Remove 'buffer' dependency from Typescript SDK

### DIFF
--- a/ecosystem/typescript/sdk/jest.config.js
+++ b/ecosystem/typescript/sdk/jest.config.js
@@ -1,13 +1,14 @@
 /** @type {import("ts-jest/dist/types").InitialOptionsTsJest} */
 module.exports = {
   preset: "ts-jest",
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   testEnvironment: "node",
   coveragePathIgnorePatterns: ["generated/*", "transaction_builder/aptos_types/*"],
   testPathIgnorePatterns: ["dist/*"],
   collectCoverage: true,
-  setupFiles: [
-    "dotenv/config",
-  ],
+  setupFiles: ["dotenv/config"],
   coverageThreshold: {
     global: {
       branches: 50, // 90,

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "@scure/bip39": "^1.1.0",
     "axios": "^0.27.2",
-    "buffer": "^6.0.3",
     "ed25519-hd-key": "^1.2.0",
     "js-sha3": "^0.8.0",
     "tweetnacl": "^1.0.3",

--- a/ecosystem/typescript/sdk/src/aptos_account.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.test.ts
@@ -60,7 +60,7 @@ test("Serializes/Deserializes", () => {
 
 test("Signs Strings", () => {
   const a1 = AptosAccount.fromAptosAccountObject(aptosAccountObject);
-  expect(a1.signHexString("0x77777").hex()).toBe(
+  expect(a1.signHexString("0x7777").hex()).toBe(
     // eslint-disable-next-line max-len
     "0xc5de9e40ac00b371cd83b1c197fa5b665b7449b33cd3cdd305bb78222e06a671a49625ab9aea8a039d4bb70e275768084d62b094bc1b31964f2357b7c1af7e0d",
   );

--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -3,9 +3,9 @@
 
 import * as Nacl from "tweetnacl";
 import * as SHA3 from "js-sha3";
-import { Buffer } from "buffer/"; // the trailing slash is important!
 import { derivePath } from "ed25519-hd-key";
 import * as bip39 from "@scure/bip39";
+import { bytesToHex } from "@movingco/bytes-to-hex";
 import { HexString, MaybeHexString } from "./hex_string";
 import * as Gen from "./generated/index";
 
@@ -63,7 +63,7 @@ export class AptosAccount {
       .map((part) => part.toLowerCase())
       .join(" ");
 
-    const { key } = derivePath(path, Buffer.from(bip39.mnemonicToSeedSync(normalizeMnemonics)).toString("hex"));
+    const { key } = derivePath(path, bytesToHex(bip39.mnemonicToSeedSync(normalizeMnemonics)));
 
     return new AptosAccount(new Uint8Array(key));
   }
@@ -104,7 +104,7 @@ export class AptosAccount {
   authKey(): HexString {
     if (!this.authKeyCached) {
       const hash = SHA3.sha3_256.create();
-      hash.update(Buffer.from(this.signingKey.publicKey));
+      hash.update(this.signingKey.publicKey);
       hash.update("\x00");
       this.authKeyCached = new HexString(hash.hex());
     }
@@ -117,7 +117,7 @@ export class AptosAccount {
    * @returns The public key for the associated account
    */
   pubKey(): HexString {
-    return HexString.ensure(Buffer.from(this.signingKey.publicKey).toString("hex"));
+    return HexString.fromUint8Array(this.signingKey.publicKey);
   }
 
   /**
@@ -125,9 +125,9 @@ export class AptosAccount {
    * @param buffer A buffer to sign
    * @returns A signature HexString
    */
-  signBuffer(buffer: Buffer): HexString {
+  signBuffer(buffer: Uint8Array): HexString {
     const signature = Nacl.sign(buffer, this.signingKey.secretKey);
-    return HexString.ensure(Buffer.from(signature).toString("hex").slice(0, 128));
+    return HexString.fromUint8Array(signature.slice(0, 64));
   }
 
   /**
@@ -136,7 +136,7 @@ export class AptosAccount {
    * @returns A signature HexString
    */
   signHexString(hexString: MaybeHexString): HexString {
-    const toSign = HexString.ensure(hexString).toBuffer();
+    const toSign = HexString.ensure(hexString).toUint8Array();
     return this.signBuffer(toSign);
   }
 

--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -5,7 +5,7 @@ import * as Nacl from "tweetnacl";
 import * as SHA3 from "js-sha3";
 import { derivePath } from "ed25519-hd-key";
 import * as bip39 from "@scure/bip39";
-import { bytesToHex } from "@movingco/bytes-to-hex";
+import { bytesToHex } from "./bytes_to_hex.js";
 import { HexString, MaybeHexString } from "./hex_string";
 import * as Gen from "./generated/index";
 

--- a/ecosystem/typescript/sdk/src/bytes_to_hex.test.ts
+++ b/ecosystem/typescript/sdk/src/bytes_to_hex.test.ts
@@ -1,0 +1,35 @@
+import { bytesToHex, hexToBytes } from "./bytes_to_hex.js";
+
+describe("bytesToHex", () => {
+  describe("bytesToHex", () => {
+    it("should pad", () => {
+      expect(bytesToHex(new Uint8Array([0x1, 0x2, 0x3]))).toBe("010203");
+    });
+
+    it("should support zero bytes", () => {
+      expect(bytesToHex(new Uint8Array([0, 0x2, 0x3]))).toBe("000203");
+    });
+
+    it("should support ff", () => {
+      expect(bytesToHex(new Uint8Array([0xff, 0x2, 0x3]))).toBe("ff0203");
+    });
+  });
+
+  describe("hexToBytes", () => {
+    it("works with non-zero", () => {
+      expect(hexToBytes("abcdef")).toEqual(new Uint8Array([0xab, 0xcd, 0xef]));
+    });
+
+    it("zero pads", () => {
+      expect(hexToBytes("00102")).toEqual(new Uint8Array([0x0, 0x1, 0x2]));
+    });
+
+    it("works with empty", () => {
+      expect(hexToBytes("")).toEqual(new Uint8Array([]));
+    });
+
+    it("works with null bytes", () => {
+      expect(hexToBytes("00")).toEqual(new Uint8Array([0x0]));
+    });
+  });
+});

--- a/ecosystem/typescript/sdk/src/bytes_to_hex.ts
+++ b/ecosystem/typescript/sdk/src/bytes_to_hex.ts
@@ -1,0 +1,38 @@
+/**
+ * Converts a {@link Uint8Array} to a hexadecimal string.
+ * @param buffer The buffer to convert.
+ * @returns
+ */
+export const bytesToHex = (buffer: Uint8Array): string =>
+  [...buffer].map((x) => x.toString(16).padStart(2, "0")).join("");
+
+/**
+ * Checks if a string is a valid string of hex characters.
+ * @param maybeHex
+ * @returns
+ */
+export const isValidHexString = (maybeHex: string) => !/[^a-fA-F0-9]/u.test(maybeHex);
+
+/**
+ * Zero pads a hex string to make it a byte string.
+ * @param hex
+ * @returns
+ */
+export const zeroPadHex = (hex: string): string => (hex.length % 2 === 1 ? `0${hex}` : hex);
+
+/**
+ * Converts a hexadecimal string to a {@link Uint8Array}.
+ *
+ * @param buffer The buffer to convert.
+ * @returns
+ */
+export const hexToBytes = (hex: string): Uint8Array => {
+  if (hex.length === 0) {
+    return new Uint8Array();
+  }
+  const hexNormalized = zeroPadHex(hex);
+  if (!isValidHexString(hexNormalized)) {
+    throw new Error(`Invalid hex string: ${hex}`);
+  }
+  return Uint8Array.from((hexNormalized.match(/.{1,2}/g) ?? []).map((byte) => parseInt(byte, 16)));
+};

--- a/ecosystem/typescript/sdk/src/generated/core/request.ts
+++ b/ecosystem/typescript/sdk/src/generated/core/request.ts
@@ -49,6 +49,7 @@ const base64 = (str: string): string => {
     try {
         return btoa(str);
     } catch (err) {
+        // @ts-ignore
         return Buffer.from(str).toString('base64');
     }
 };

--- a/ecosystem/typescript/sdk/src/generated/core/request.ts
+++ b/ecosystem/typescript/sdk/src/generated/core/request.ts
@@ -49,7 +49,6 @@ const base64 = (str: string): string => {
     try {
         return btoa(str);
     } catch (err) {
-        // @ts-ignore
         return Buffer.from(str).toString('base64');
     }
 };

--- a/ecosystem/typescript/sdk/src/hex_string.test.ts
+++ b/ecosystem/typescript/sdk/src/hex_string.test.ts
@@ -13,12 +13,6 @@ function validate(hexString: HexString) {
   expect(hexString.noPrefix()).toBe(withoutPrefix);
 }
 
-test("from/to buffer", () => {
-  const hs = new HexString(withPrefix);
-  expect(hs.toBuffer().toString("hex")).toBe(withoutPrefix);
-  expect(HexString.fromBuffer(hs.toBuffer()).hex()).toBe(withPrefix);
-});
-
 test("from/to Uint8Array", () => {
   const hs = new HexString(withoutPrefix);
   expect(HexString.fromUint8Array(hs.toUint8Array()).hex()).toBe(withPrefix);

--- a/ecosystem/typescript/sdk/src/hex_string.ts
+++ b/ecosystem/typescript/sdk/src/hex_string.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-import { bytesToHex, hexToBytes } from "@movingco/bytes-to-hex";
+import { bytesToHex, hexToBytes } from "./bytes_to_hex.js";
 import { HexEncodedBytes } from "./generated";
 
 // eslint-disable-next-line no-use-before-define

--- a/ecosystem/typescript/sdk/src/hex_string.ts
+++ b/ecosystem/typescript/sdk/src/hex_string.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-import { Buffer } from "buffer/"; // the trailing slash is important!
+import { bytesToHex, hexToBytes } from "@movingco/bytes-to-hex";
 import { HexEncodedBytes } from "./generated";
 
 // eslint-disable-next-line no-use-before-define
@@ -20,8 +20,8 @@ export class HexString {
    * @param buffer A buffer to convert
    * @returns New HexString
    */
-  static fromBuffer(buffer: Buffer): HexString {
-    return new HexString(buffer.toString("hex"));
+  static fromBuffer(buffer: Uint8Array): HexString {
+    return HexString.fromUint8Array(buffer);
   }
 
   /**
@@ -30,7 +30,7 @@ export class HexString {
    * @returns New HexString
    */
   static fromUint8Array(arr: Uint8Array): HexString {
-    return HexString.fromBuffer(Buffer.from(arr));
+    return new HexString(bytesToHex(arr));
   }
 
   /**
@@ -113,18 +113,10 @@ export class HexString {
   }
 
   /**
-   * Converts hex string to a Buffer in hex encoding
-   * @returns Buffer from inner hexString without prefix
-   */
-  toBuffer(): Buffer {
-    return Buffer.from(this.noPrefix(), "hex");
-  }
-
-  /**
    * Converts hex string to a Uint8Array
    * @returns Uint8Array from inner hexString without prefix
    */
   toUint8Array(): Uint8Array {
-    return Uint8Array.from(this.toBuffer());
+    return Uint8Array.from(hexToBytes(this.noPrefix()));
   }
 }

--- a/ecosystem/typescript/sdk/src/index.ts
+++ b/ecosystem/typescript/sdk/src/index.ts
@@ -4,6 +4,7 @@
 // All parts of our package are accessible as imports, but we re-export our higher level API here for convenience
 export * from "./aptos_account";
 export * from "./aptos_client";
+export * from "./bytes_to_hex";
 export * from "./coin_client";
 export * from "./faucet_client";
 export * from "./hex_string";

--- a/ecosystem/typescript/sdk/src/index.ts
+++ b/ecosystem/typescript/sdk/src/index.ts
@@ -4,7 +4,7 @@
 // All parts of our package are accessible as imports, but we re-export our higher level API here for convenience
 export * from "./aptos_account";
 export * from "./aptos_client";
-export * from "./bytes_to_hex";
+export * from "./bytes_to_hex.js";
 export * from "./coin_client";
 export * from "./faucet_client";
 export * from "./hex_string";

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/authentication_key.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/authentication_key.ts
@@ -40,7 +40,7 @@ export class AuthenticationKey {
     bytes.set([AuthenticationKey.MULTI_ED25519_SCHEME], pubKeyBytes.length);
 
     const hash = SHA3.sha3_256.create();
-    hash.update(Buffer.from(bytes));
+    hash.update(bytes);
 
     return new AuthenticationKey(new Uint8Array(hash.arrayBuffer()));
   }

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/index.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/index.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-import { Buffer } from "buffer/";
-
 export * from "./account_address";
 export * from "./authenticator";
 export * from "./transaction";
@@ -12,4 +10,4 @@ export * from "./ed25519";
 export * from "./multi_ed25519";
 export * from "./authentication_key";
 
-export type SigningMessage = Buffer;
+export type SigningMessage = Uint8Array;

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/transaction.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/transaction.ts
@@ -563,7 +563,7 @@ export abstract class Transaction {
 
   getHashSalt(): Bytes {
     const hash = SHA3.sha3_256.create();
-    hash.update(Buffer.from("APTOS::Transaction"));
+    hash.update("APTOS::Transaction");
     return new Uint8Array(hash.arrayBuffer());
   }
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as SHA3 from "js-sha3";
-import { Buffer } from "buffer/";
 import { MemoizeExpiring } from "typescript-memoize";
 import {
   Ed25519PublicKey,
@@ -77,13 +76,7 @@ export class TransactionBuilder<F extends SigningFn> {
 
     const prefix = new Uint8Array(hash.arrayBuffer());
 
-    const body = bcsToBytes(rawTxn);
-
-    const mergedArray = new Uint8Array(prefix.length + body.length);
-    mergedArray.set(prefix);
-    mergedArray.set(body, prefix.length);
-
-    return Buffer.from(mergedArray);
+    return Uint8Array.from([...prefix, ...bcsToBytes(rawTxn)]);
   }
 }
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -76,7 +76,13 @@ export class TransactionBuilder<F extends SigningFn> {
 
     const prefix = new Uint8Array(hash.arrayBuffer());
 
-    return Uint8Array.from([...prefix, ...bcsToBytes(rawTxn)]);
+    const body = bcsToBytes(rawTxn);
+
+    const mergedArray = new Uint8Array(prefix.length + body.length);
+    mergedArray.set(prefix);
+    mergedArray.set(body, prefix.length);
+
+    return mergedArray;
   }
 }
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
@@ -3,6 +3,7 @@
 
 /* eslint-disable max-len */
 import * as Nacl from "tweetnacl";
+import { bytesToHex } from "@movingco/bytes-to-hex";
 import { bcsSerializeUint64, bcsToBytes, Bytes } from "./bcs";
 import { HexString } from "../hex_string";
 
@@ -38,7 +39,7 @@ function hexToBytes(hex: string) {
 }
 
 function hexSignedTxn(signedTxn: Uint8Array): string {
-  return Buffer.from(signedTxn).toString("hex");
+  return bytesToHex(signedTxn);
 }
 
 function sign(rawTxn: RawTransaction): Bytes {

--- a/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable max-len */
 import * as Nacl from "tweetnacl";
-import { bytesToHex } from "@movingco/bytes-to-hex";
+import { bytesToHex } from "../bytes_to_hex.js";
 import { bcsSerializeUint64, bcsToBytes, Bytes } from "./bcs";
 import { HexString } from "../hex_string";
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/transaction_vector.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/transaction_vector.test.ts
@@ -11,6 +11,7 @@
 import path from "path";
 import * as Nacl from "tweetnacl";
 import fs from "fs";
+import { bytesToHex } from "@movingco/bytes-to-hex";
 import {
   AccountAddress,
   ChainId,
@@ -156,7 +157,7 @@ function sign(rawTxn: RawTransaction, privateKey: string): string {
     publicKey,
   );
 
-  return Buffer.from(txnBuilder.sign(rawTxn)).toString("hex");
+  return bytesToHex(txnBuilder.sign(rawTxn));
 }
 
 type IRawTxn = {

--- a/ecosystem/typescript/sdk/src/transaction_builder/transaction_vector.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/transaction_vector.test.ts
@@ -11,7 +11,7 @@
 import path from "path";
 import * as Nacl from "tweetnacl";
 import fs from "fs";
-import { bytesToHex } from "@movingco/bytes-to-hex";
+import { bytesToHex } from "../bytes_to_hex.js";
 import {
   AccountAddress,
   ChainId,

--- a/ecosystem/typescript/sdk/tsconfig.json
+++ b/ecosystem/typescript/sdk/tsconfig.json
@@ -14,7 +14,5 @@
     "target": "es2020",
     "pretty": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
### Description

Removes the `buffer` dependency from the Aptos TypeScript SDK, helping to reduce bundle size.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3456)
<!-- Reviewable:end -->
