### PR TITLE
[Docker] Use rocks db secure storage by default.

### DIFF
--- a/docker/compose/aptos-node/validator.yaml
+++ b/docker/compose/aptos-node/validator.yaml
@@ -9,8 +9,8 @@ consensus:
     service:
       type: "local"
     backend:
-      type: "on_disk_storage"
-      path: /opt/aptos/data/secure-data.json
+      type: "rocks_db_storage"
+      path: secure_storage_db
       namespace: ~
     initial_safety_rules_config:
       from_file:

--- a/terraform/helm/aptos-node/files/configs/validator.yaml
+++ b/terraform/helm/aptos-node/files/configs/validator.yaml
@@ -9,8 +9,8 @@ consensus:
     service:
       type: "local"
     backend:
-      type: "on_disk_storage"
-      path: /opt/aptos/data/secure-data.json
+      type: "rocks_db_storage"
+      path: secure_storage_db
       namespace: ~
     initial_safety_rules_config:
       from_file:


### PR DESCRIPTION
### Description
This PR updates the docker configs to use rocks db for secure storage. Note: the path only needs to specify the name of the file (the actual file location will be the data directory used by the node).

### Test Plan
Manually ran a node with this config. Also will verify CI/CD can build and deploy the docker images.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3464)
<!-- Reviewable:end -->
