### PR TITLE
[helm] add resource requests for metrics-server, autoscaler, and waypoint

### DIFF
--- a/terraform/aptos-node-testnet/addons.tf
+++ b/terraform/aptos-node-testnet/addons.tf
@@ -17,6 +17,17 @@ resource "helm_release" "metrics-server" {
       coredns = {
         maxReplicas = var.num_validators
       }
+      # https://github.com/kubernetes-sigs/metrics-server#scaling
+      metrics-server = {
+        # 1m core per node
+        # 2MiB memory per node
+        resources = {
+          requests = {
+            cpu    = var.validator_instance_max_num > 0 ? "${var.validator_instance_max_num}m" : null,
+            memory = var.validator_instance_max_num > 0 ? "${var.validator_instance_max_num * 2}Mi" : null,
+          }
+        }
+      }
       autoscaler = {
         enabled     = true
         clusterName = module.validator.aws_eks_cluster.name

--- a/terraform/helm/k8s-metrics/templates/autoscaler.yaml
+++ b/terraform/helm/k8s-metrics/templates/autoscaler.yaml
@@ -153,7 +153,7 @@ spec:
         - image: {{ .Values.autoscaler.image.repo }}:{{ .Values.autoscaler.image.tag }}
           name: cluster-autoscaler
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.autoscaler.resources | nindent 12 }}
           command:
             - ./cluster-autoscaler
             - --v=4

--- a/terraform/helm/k8s-metrics/values.yaml
+++ b/terraform/helm/k8s-metrics/values.yaml
@@ -2,6 +2,12 @@ coredns:
   maxReplicas: 2
   minReplicas: 2
 
+metrics-server:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 200Mi
+
 autoscaler:
   enabled:
   clusterName:

--- a/terraform/helm/testnet-addons/templates/waypoint.yaml
+++ b/terraform/helm/testnet-addons/templates/waypoint.yaml
@@ -38,6 +38,8 @@ spec:
     spec:
       containers:
       - name: http
+        resources:
+          {{- toYaml .Values.autoscaler.resources | nindent 10 }}
         image: pierrezemb/gostatic
         imagePullPolicy: IfNotPresent
         args: ["-port", "8080", "-enable-health"]

--- a/terraform/helm/testnet-addons/values.yaml
+++ b/terraform/helm/testnet-addons/values.yaml
@@ -13,6 +13,10 @@ waypoint:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
 
 load_test:
   # -- Whether to enable the load test CronJob


### PR DESCRIPTION
### Description

Few changes that explicitly set resource requests. Autoscaler and metrics-server must scale to 1000 node Forge. Waypoint has issues with devnet and sherrynet genesis downloads.
* fix bug in autoscaler resource request. it now requests 1CPU, 1Gi Memory
* metrics-server has now resource request based on the max number of nodes, if specified. 1m CPU per node, 2Mi Memory per node
* waypoint didn't have resources set. set it

### Test Plan

Apply to my cluster 

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3472)
<!-- Reviewable:end -->
