### PR TITLE
[CP] Fix spacing issue on Safari due to <style> tag placement

### DIFF
--- a/ecosystem/platform/server/app/views/layouts/it3.html.erb
+++ b/ecosystem/platform/server/app/views/layouts/it3.html.erb
@@ -3,9 +3,11 @@
 <% content_for(:meta) do %>
   <meta property="og:image" content="https://aptoslabs.com/images/meta/aptos_meta_og_ait3.jpg">
 <% end %>
-<style>#global-announcement { display: none }</style>
 
 <%= render 'layouts/application' do %>
+
+  <style type="text/css">#global-announcement { display: none; }</style>
+
   <div class="bg-neutral-900 text-white h-full">
     <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 md:px-8 py-12 sm:py-24">
       <h3 class="text-base uppercase text-teal-400 mb-2 font-mono">Community</h3>

--- a/ecosystem/platform/server/app/views/static_page/incentivized_testnet.html.erb
+++ b/ecosystem/platform/server/app/views/static_page/incentivized_testnet.html.erb
@@ -3,7 +3,8 @@
 <% content_for(:meta) do %>
   <meta property="og:image" content="https://aptoslabs.com/images/meta/aptos_meta_og_ait3.jpg">
 <% end %>
-<style>#global-announcement { display: none }</style>
+
+<style type="text/css">#global-announcement { display: none }</style>
 
   <div class="bg-neutral-900 text-neutral-50 h-full">
     <div class="max-w-screen-2xl mx-auto px-6 pb-24">
@@ -70,8 +71,8 @@
       </section>
       <section class="py-12 lg:py-32 lg:grid grid-cols-12">
         <div class="lg:col-start-4 lg:col-span-7">
-          <h3 class="font-display text-3xl text-neutral-100 mb-4">Aptos Incentivized Testnet 3</h3>
-          <p class="text-neutral-400 mb-8 text-3xl lg:text-4xl max-w-4xl">Aptos Labs remains focused on launching Mainnet to bring the community the safest, fastest and most reliable foundation for building within Web3.</p>
+          <h3 class="font-display text-3xl text-neutral-100 mb-4">Aptos Incentivized <span class="whitespace-nowrap">Testnet 3</span></h3>
+          <p class="text-neutral-400 mb-8 text-2xl md:text-3xl lg:text-4xl max-w-4xl">Aptos Labs remains focused on launching Mainnet to bring the community the safest, fastest and most reliable foundation for building within Web3.</p>
           <div class="flex flex-col md:flex-row justify-start items-start gap-4 mb-16">
             <%= render ButtonComponent.new(href: it3_path, title: 'Aptos Incentivized Testnet 3 details', target: 'blank', size: :large, scheme: :primary, class: '') do %>
               Get Started


### PR DESCRIPTION
### Description

- Fix Footer spacing issues due to placement of `<style>` tag outside of `render 'layouts/application'`
- Address text wrapping for "Incentivized Testnet 3" on mobile as it was creating a widow

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/98909677/186748743-1fae2863-32e5-46ad-814f-51f775e5e9c2.png">

### Test Plan
Ensure footer layout is correct on Safari:

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/98909677/186749204-a0d3357c-fbec-4e6a-997f-9174c0b59f8d.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3476)
<!-- Reviewable:end -->
