### PR TITLE
[Data Streaming Service] Limit the backlog on data chunks under saturation

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -153,7 +153,7 @@ impl Default for DataStreamingServiceConfig {
             global_summary_refresh_interval_ms: 50,
             max_concurrent_requests: 3,
             max_concurrent_state_requests: 6,
-            max_data_stream_channel_sizes: 500,
+            max_data_stream_channel_sizes: 300,
             max_request_retry: 3,
             max_notification_id_mappings: 300,
             progress_check_interval_ms: 100,


### PR DESCRIPTION
### Description
This PR decreases the potential backlog of data streams under complete node saturation.

### Test Plan
Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3477)
<!-- Reviewable:end -->
