### PR TITLE
[forge] Increase timeout for pre release test

### DIFF
--- a/.github/workflows/continuous-e2e-release-test.yaml
+++ b/.github/workflows/continuous-e2e-release-test.yaml
@@ -13,10 +13,13 @@ on:
 jobs:
   # Run a faster chaos forge to quickly surface correctness failures
   run-release-blocking-forge:
+    # Set the job timeout to 12 hours, however run for 10 hours
+    timeout-minutes: 720
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-release-blocking
+      # Run for 10 hours
       FORGE_RUNNER_DURATION_SECS: 36000
       FORGE_RUNNER_TPS_THRESHOLD: 5000
       FORGE_TEST_SUITE: land_blocking


### PR DESCRIPTION
Pre release test has a runtime of 10 hours, however github action has default limit of 6 hours :|

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

Test Plan: land + verify, its not production critical right now

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3478)
<!-- Reviewable:end -->
