### PR TITLE
[docker] upgrade and pin docker base images

### DIFF
--- a/docker/rosetta/rosetta.Dockerfile
+++ b/docker/rosetta/rosetta.Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:20.04 AS ubuntu-base
+FROM ubuntu:20.04@sha256:a06ae92523384c2cd182dcfe7f8b2bf09075062e937d5653d7d0db0375ad2221 AS ubuntu-base
 
 ## get rust build environment ready
-FROM rust:1.61-buster AS rust-base
+FROM rust:1.63.0-buster@sha256:0110d1b4193029735f1db1c0ed661676ed4b6f705b11b1ebe95c655b52e6906f AS rust-base
 
 WORKDIR /aptos
 RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -1,13 +1,13 @@
 #syntax=docker/dockerfile:1.4
 
-FROM debian:buster-20220228@sha256:fd510d85d7e0691ca551fe08e8a2516a86c7f24601a940a299b5fe5cdd22c03a AS debian-base
+FROM debian:buster-20220822@sha256:faa416b9eeda2cbdb796544422eedd698e716dbd99841138521a94db51bf6123 AS debian-base
 
 # Add Tini to make sure the binaries receive proper SIGTERM signals when Docker is shut down
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
 RUN chmod +x /tini
 ENTRYPOINT ["/tini", "--"]
 
-FROM rust:1.61-buster AS rust-base
+FROM rust:1.63.0-buster@sha256:0110d1b4193029735f1db1c0ed661676ed4b6f705b11b1ebe95c655b52e6906f AS rust-base
 WORKDIR /aptos
 RUN apt-get update && apt-get install -y cmake curl clang git pkg-config libssl-dev libpq-dev
 

--- a/ecosystem/indexer-server/Dockerfile
+++ b/ecosystem/indexer-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as builder
+FROM node:16@sha256:ca988c6e7f4a41a18030a7adae34a5ea6f9faf7e4f84c8d886ce1afa0080d84a as builder
 ARG PATH
 
 WORKDIR /usr

--- a/ecosystem/platform/server/Dockerfile
+++ b/ecosystem/platform/server/Dockerfile
@@ -2,7 +2,7 @@
 
 # NOTE: We're only using this base image for the preinstalled dependencies. We
 # are using Puma as the app server, not Passenger.
-FROM phusion/passenger-full:2.3.0
+FROM phusion/passenger-full:2.3.0@sha256:dfd15f7a63ae07b8637df6a01a603f8ae82cbbdf684bfd696d09ae130c034fd1
 
 RUN npm install -g yarn && \
   rm -f /etc/my_init.d/10_syslog-ng.init && \


### PR DESCRIPTION
### Description

Pin and upgrade docker base images
Notably, upgrade rust-all debian-base to `debian:buster-20220822`, and the `builder` to `rust:1.63.0-buster`

### Test Plan

Build in CI

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3482)
<!-- Reviewable:end -->
