### PR TITLE
Make TS SDK examples use npmjs package

### DIFF
--- a/.github/workflows/check-docs-site-examples.yaml
+++ b/.github/workflows/check-docs-site-examples.yaml
@@ -13,6 +13,9 @@
 # This CI checks the second type of compatability, the sdk-release.yaml CI
 # steps check the first type.
 
+# NOTE: This is all subject to change soon, see this PR:
+# https://github.com/aptos-labs/aptos-core/pull/3485
+
 name: "Check docs site examples"
 on:
   pull_request:
@@ -65,6 +68,21 @@ jobs:
           max_attempts: 3
           timeout_minutes: 15
           command: cd ./developer-docs-site/static/examples/typescript && yarn first_nft
+
+      - uses: nick-fields/retry@v2
+        name: ts-example-test
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          command: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install && yarn test
+
+      - uses: nick-fields/retry@v2
+        name: js-example-test
+        with:
+          max_attempts: 3
+          timeout_minutes: 15
+          command: cd ./ecosystem/typescript/sdk/examples/javascript && yarn install && yarn test
+
 
   # Note: We do not check first-coin yet.
   test-rust-examples:

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -113,21 +113,6 @@ jobs:
           command: cd ./ecosystem/typescript/sdk && yarn test
       - run: cd ./ecosystem/typescript/sdk && yarn build
 
-      # Run example code in typescript.
-      - uses: nick-fields/retry@v2
-        name: ts-example-test
-        with:
-          max_attempts: 3
-          timeout_minutes: 15
-          command: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install && yarn test
-      # Run example code in javascript.
-      - uses: nick-fields/retry@v2
-        name: js-example-test
-        with:
-          max_attempts: 3
-          timeout_minutes: 15
-          command: cd ./ecosystem/typescript/sdk/examples/javascript && yarn install && yarn test
-
       # Ensure the version, changelog, etc. are valid.
       - run: cd ./ecosystem/typescript/sdk && ./check.sh
         if: github.event_name == 'push' && github.ref_name == 'devnet'

--- a/ecosystem/typescript/sdk/examples/README.md
+++ b/ecosystem/typescript/sdk/examples/README.md
@@ -1,25 +1,5 @@
-**NOTE**: These examples are tested to work with the SDK in the parent
-directory, meaning these examples on a given commit X are only tested
-against the SDK from commit X. Therefore, there is no guarantee that
-these examples work with devnet. As such, to test these examples, you
-must run a local testnet, something like this:
-```
-cargo run -p aptos -- node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
-```
+**NOTE**: These examples are tested to work with the [latest SDK published to npmjs](https://www.npmjs.com/package/aptos), not the SDK in the parent directory. Accordingly, these examples should be run against devnet. This is how the examples work by default.
 
-Before running these examples, make sure to run the following in the parent
-directory (`ecosystem/typescript/sdk`). This is necessary because the tests
-in the example import the code directly from the parent, rather than from
-npm.js, to ensure that code is matching when being tested.
-
-```
-yarn install
-yarn build
-```
-
-Every time you change the SDK, you must re-run the above steps and then run
-this in each of the examples directories:
-```
-rm yarn.lock && yarn install
-```
-
+If you'd like to learn more about how these examples work, please see the following tutorials:
+- [Your first transaction](https://aptos.dev/tutorials/your-first-transaction-sdk)
+- [Your first NFT](https://aptos.dev/tutorials/your-first-nft-sdk)

--- a/ecosystem/typescript/sdk/examples/javascript/package.json
+++ b/ecosystem/typescript/sdk/examples/javascript/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aptos": "file:../../",
+    "aptos": "^1.3.9",
     "dotenv": "^16.0.1"
   }
 }

--- a/ecosystem/typescript/sdk/examples/typescript/package.json
+++ b/ecosystem/typescript/sdk/examples/typescript/package.json
@@ -14,13 +14,13 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aptos": "file:./../../",
+    "aptos": "^1.3.9",
     "dotenv": "^16.0.1"
   },
   "devDependencies": {
     "@types/node": "^18.6.2",
     "npm-run-all": "^4.1.5",
     "ts-node": "^10.9.1",
-    "typescript": "^4.7.4"
+    "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
### Description
We previously decided that we would consolidate our examples so they only exist in the SDK directory, meaning we delete the examples directly within developer-docs-site. As part of this, since these examples are used in the dev docs site tutorials and are a key way folks learn how to use our SDK, they should be built to work against the network that they build against, devnet. So instead of depending on the SDK locally, they should depend on the npmjs SDK, which is what they'll do themselves with their own dapps. When mainnet rolls around nothing much will change here; we'll make the SDK on npmjs work for mainnet, and have pre-release devnet versions, like `1.3.8-devnet.1`.

Coming up next in another PR, deleting the dev docs site examples and updating that CI accordingly.

### Test Plan
```
cd ecosystem/typescript/sdk/examples/typescript
yarn install
yarn test
```
```
cd ecosystem/typescript/sdk/examples/javascript
yarn install
yarn test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3485)
<!-- Reviewable:end -->
