### PR TITLE
[helm][monitoring] drop spammy metrics

### DIFF
--- a/terraform/helm/monitoring/files/prometheus.yml
+++ b/terraform/helm/monitoring/files/prometheus.yml
@@ -18,7 +18,7 @@ rule_files:
 {{- end }}
 
 scrape_configs:
-{{ if .Values.monitoring.fullKubernetesScrape }}
+{{ if .Values.monitoring.prometheus.fullKubernetesScrape }}
 - job_name: 'kubernetes-apiservers'
   scheme: https
   tls_config:
@@ -51,11 +51,15 @@ scrape_configs:
   kubernetes_sd_configs:
   - role: node
 
-  {{ if not .Values.monitoring.fullKubernetesScrape }}
+  {{ if not .Values.monitoring.prometheus.fullKubernetesScrape }}
   metric_relabel_configs:
   - source_labels: [namespace]
     action: keep
     regex: "{{ .Release.Namespace }}"
+  # Explicitly drop spammy metrics
+  - source_labels: [__name__]
+    regex: 'storage_operation_duration_seconds_bucket'
+    action: drop
   {{ end }}
 
   relabel_configs:
@@ -85,18 +89,19 @@ scrape_configs:
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 
- {{ if not .Values.monitoring.fullKubernetesScrape }}
+ {{ if not .Values.monitoring.prometheus.fullKubernetesScrape }}
   metric_relabel_configs:
   - source_labels: [namespace, pod]
     action: keep
     regex: "{{ .Release.Namespace }};{{ .Release.Name }}-.*"
+  # Explicitly drop spammy metrics
+  - source_labels: [__name__]
+    regex: 'container_tasks_state'
+    action: drop
+  - source_labels: [__name__]
+    regex: 'container_memory_(!working_set_bytes).*'
+    action: drop
   {{ end }}
-
-{{ if .Values.monitoring.useKubeStateMetrics }}
-- job_name: 'kube-state-metrics'
-  static_configs:
-  - targets: ['kube-state-metrics.default.svc.cluster.local:8080']
-{{ end }}
 
 - job_name: "prom-pod-annotation"
 
@@ -122,10 +127,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: kubernetes_pod_name
-
-  metric_relabel_configs:
-  - source_labels: [__name__]
-    regex: 'vector_files_(.+)_total'
+  # Explicitly drop all vector metrics
+  - source_labels: [namespace]
+    regex: 'vector'
     action: drop
 
 - job_name: "aptos-procs"

--- a/terraform/helm/monitoring/values.yaml
+++ b/terraform/helm/monitoring/values.yaml
@@ -4,9 +4,8 @@ validator:
   name:
 
 monitoring:
-  fullKubernetesScrape: true
-  useKubeStateMetrics: false
   prometheus:
+    fullKubernetesScrape: false
     deleteWal: false
     remote_write:
       enabled: false


### PR DESCRIPTION
### Description

Do a few things to reduce metrics volume for onboard prometheus in the `monitoring` helm chart.
* Explicitly drop a few known spammy metrics (found via tsdb stats), using `metric_relabel_configs`. These include metrics from EBS CSI driver, vector, and `container_tasks_state` fromcAdvisor
* Rename `monitoring.fullKubernetesScrape` to `monitoring.prometheus.fullKubernetesScrape`, and set it to `false` by default. This reduces all the metrics load from kube API servers and a few spammy (kube node) metrics, which most folks should not be concerned with. This is fine IMO for reference monitoring solution

### Test Plan

Apply to testnet, and prometheus targets are greatly minimized. 

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3486)
<!-- Reviewable:end -->
