### PR TITLE
fix resource_account has no AptosCoin register

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/resource_account.move
+++ b/aptos-move/framework/aptos-framework/sources/resource_account.move
@@ -40,6 +40,8 @@ module aptos_framework::resource_account {
     use std::signer;
     use std::vector;
     use aptos_framework::account;
+    use aptos_framework::coin;
+    use aptos_framework::aptos_coin::AptosCoin;
     use aptos_std::simple_map::{Self, SimpleMap};
 
     /// Container resource not found in account
@@ -58,6 +60,7 @@ module aptos_framework::resource_account {
         optional_auth_key: vector<u8>,
     ) acquires Container {
         let (resource, resource_signer_cap) = account::create_resource_account(origin, seed);
+        coin::register<AptosCoin>(&resource);
 
         let origin_addr = signer::address_of(origin);
         if (!exists<Container>(origin_addr)) {


### PR DESCRIPTION
### Description
the issue shows the description https://github.com/aptos-labs/aptos-core/issues/3454
I'm a dapp developer from AnimeSwap Team.
The bug breaks my dapp, currently there is no way to use `aptos_framework::resource_account.move` as expected

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
No test needed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3514)
<!-- Reviewable:end -->
