### PR TITLE
fix: fix the txn waiting bug

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,15 +5,20 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
 ## Unreleased
+
 N/A
 
+## 1.3.10 (2022-08-26)
+
+- Fix the bug in `waitForTransactionWithResult`. When API returns `404`, the function should continue waiting rather than returning early. The reason is that the txn might not be committed promptly. `waitForTransactionWithResult` should either timeout or get an error in such case.
+
 ## 1.3.9 (2022-08-25)
+
 - **[Breaking Change]** Reimplemented the JSON transaction submission interfaces with BCS. This is a breaking change. `createSigningMessage` is removed. Before the changes, the transaction payloads take string aruguments. But now, Typescript payload arguments have to match the smart contract arugment types. e.g. `number` matches `u8`, `number | bigint` matches `u64` and `u128`, etc.
 - **[Breaking Change]** `getTokenBalance` and `getTokenBalanceForAccount` have been renamed to `getToken` and `getTokenForAccount`, since they were never getting just the balance, but the full token.
 - Added `CoinClient` to help working with coins. This contains common operations such as `transfer`, `checkBalance`, etc.
 - Added `generateSignSubmitWaitForTransaction`, a function that provides a simple way to execute the full end to end transaction submission flow. You may also leverage `generateSignSubmit`, a helper that does the same but without waiting, instead returning teh transaction hash.
 - Added `fromDerivePath` to `AptosAccount`. You can use this to create an `AptosAccount` (which is a local representation of an account) using a bip44 path and mnemonics.
-
 
 ## 1.3.7 (2022-08-17)
 

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -62,5 +62,5 @@
     "ts-node": "^10.9.1",
     "typescript": "4.7.4"
   },
-  "version": "1.3.9"
+  "version": "1.3.10"
 }

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -10,7 +10,6 @@ import {
   TxnBuilderTypes,
   TransactionBuilderMultiEd25519,
   BCS,
-  TransactionBuilder,
   TransactionBuilderRemoteABI,
 } from "./transaction_builder";
 import { TokenClient } from "./token_client";

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -450,7 +450,8 @@ export class AptosClient {
         if (e instanceof Gen.ApiError) {
           if (e.status === 404) {
             isPending = true;
-            break;
+            // eslint-disable-next-line no-continue
+            continue;
           }
           if (e.status >= 400) {
             throw e;


### PR DESCRIPTION
### Description

Fix the bug in `waitForTransactionWithResult`. When API returns `404`, the function should continue waiting rather than returning early. The reason is that the txn might not be committed promptly. `waitForTransactionWithResult` should either timeout or get an error in such case.

### Test Plan
Ran all the tests and ran the examples against devnet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3518)
<!-- Reviewable:end -->
