### PR TITLE
telemetry-service: optimize label naming for readability and compatibility

### DIFF
--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -24,16 +24,7 @@ pub async fn handle_metrics_ingest(
     claims: Claims,
     metrics_body: Bytes,
 ) -> anyhow::Result<impl Reply, Rejection> {
-    let extra_labels = vec![
-        format!("peer_id={}", claims.peer_id),
-        format!("peer_role={}", claims.peer_role as u16),
-        format!("chain_name={}", claims.chain_id),
-        format!("namespace={}", "telemetry-service"),
-        format!(
-            "kubernetes_pod_name={}/{}",
-            claims.peer_role as u16, claims.peer_id
-        ),
-    ];
+    let extra_labels = claims_to_extra_labels(&claims);
 
     let res = context
         .victoria_metrics_client
@@ -58,4 +49,46 @@ pub async fn handle_metrics_ingest(
     }
 
     Ok(reply::reply())
+}
+
+fn claims_to_extra_labels(claims: &Claims) -> Vec<String> {
+    vec![
+        format!("role={}", claims.peer_role),
+        format!("chain_name={}", claims.chain_id),
+        format!("namespace={}", "telemetry-service"),
+        // for community nodes we cannot determine which pod name they run in (or whether they run in k8s at all), so we use the peer id as an approximation/replacement for pod_name
+        // This works well with our existing grafana dashboards
+        format!(
+            "kubernetes_pod_name=peer_id:{}",
+            claims.peer_id.to_hex_literal()
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use super::*;
+    use aptos_types::{chain_id::ChainId, PeerId};
+    #[test]
+    fn verify_labels() {
+        let claims = claims_to_extra_labels(&super::Claims {
+            chain_id: ChainId::new(25),
+            peer_id: PeerId::from_str("0x1").unwrap(),
+            peer_role: PeerRole::Validator,
+            epoch: 3,
+            exp: 123,
+            iat: 123,
+        });
+        assert_eq!(
+            claims,
+            vec![
+                "role=validator",
+                "chain_name=25",
+                "namespace=telemetry-service",
+                "kubernetes_pod_name=peer_id:0x1",
+            ]
+        );
+    }
 }


### PR DESCRIPTION
…ility with our existing grafana dashboards

### Description

This changes some of the metrics label ingestion naming in the telemetry service.
Previously the service was ingesting a numerical value for `peer_role`. Our grafana dashboards expect the attribute to be named `role` and be of type string. Also changed some of the other labels.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3519)
<!-- Reviewable:end -->
