### PR TITLE
Add publish module for publishing code to resource accounts

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/publish.move
+++ b/aptos-move/framework/aptos-framework/sources/publish.move
@@ -1,0 +1,41 @@
+/// Module for publishing packages to resource accounts.
+module aptos_framework::publish {
+    use std::signer;
+    use aptos_framework::account::{Self, SignerCapability};
+
+    public entry fun publish_package_txn(
+        deployer: &signer,
+        seed: vector<u8>,
+        metadata_serialized: vector<u8>,
+        code: vector<vector<u8>>,
+    ) {
+        let (resource, resource_signer_cap) = account::create_resource_account(deployer, seed);
+        aptos_framework::code::publish_package_txn(&resource, metadata_serialized, code);
+        store_signer_cap(resource_signer_cap);
+    }
+
+    /// Holds the SignerCapability.
+    /// This can only ever be held by the resource account itself.
+    struct SignerCapabilityStore has key, drop {
+        /// The SignerCapability of the resource.
+        resource_signer_cap: SignerCapability
+    }
+
+    /// Stores the [SignerCapability].
+    public fun store_signer_cap(
+        resource_signer_cap: SignerCapability,
+    ) {
+        let resource = account::create_signer_with_capability(&resource_signer_cap);
+        move_to(&resource, SignerCapabilityStore { resource_signer_cap });
+    }
+
+    /// When called by the resource account, it will retrieve the capability associated with that
+    /// account and rotate the account's auth key to 0x0 making the account inaccessible without
+    /// the SignerCapability.
+    public fun retrieve_resource_account_cap(
+        resource: &signer
+    ): SignerCapability acquires SignerCapabilityStore {
+        let SignerCapabilityStore { resource_signer_cap } = move_from<SignerCapabilityStore>(signer::address_of(resource));
+        resource_signer_cap
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/publish.move
+++ b/aptos-move/framework/aptos-framework/sources/publish.move
@@ -4,7 +4,7 @@ module aptos_framework::publish {
     use aptos_framework::account::{Self, SignerCapability};
 
     /// Holds the SignerCapability.
-    /// This can only ever be held by the resource account itself.
+    /// This can only ever be held by the deployer.
     struct SignerCapabilityStore has key, drop {
         /// The SignerCapability of the resource.
         resource_signer_cap: SignerCapability
@@ -18,15 +18,15 @@ module aptos_framework::publish {
     ) {
         let (resource, resource_signer_cap) = account::create_resource_account(deployer, seed);
         aptos_framework::code::publish_package_txn(&resource, metadata_serialized, code);
-        move_to(&resource, SignerCapabilityStore { resource_signer_cap });
+        move_to(deployer, SignerCapabilityStore { resource_signer_cap });
     }
 
     /// Retrieves the resource account signer capability once, allowing the package to be able
     /// to sign as itself.
     public fun retrieve_resource_account_cap(
-        resource: &signer
+        deployer: &signer
     ): SignerCapability acquires SignerCapabilityStore {
-        let SignerCapabilityStore { resource_signer_cap } = move_from<SignerCapabilityStore>(signer::address_of(resource));
+        let SignerCapabilityStore { resource_signer_cap } = move_from<SignerCapabilityStore>(signer::address_of(deployer));
         resource_signer_cap
     }
 }


### PR DESCRIPTION
### Description

This is useful for publishing modules that may have coins associated with them.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3522)
<!-- Reviewable:end -->
