### PR TITLE
[gha] bring back forge compat against devnet

### DIFF
--- a/.github/workflows/continuous-e2e-compat-test.yaml
+++ b/.github/workflows/continuous-e2e-compat-test.yaml
@@ -10,6 +10,7 @@ on:
     # Run every hour - TODO: Decrease the frequency once things stabilizes
     - cron: "0 */3 * * *"
 
+jobs:
   run-forge-compat:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
@@ -22,4 +23,5 @@ on:
       FORGE_RUNNER_TPS_THRESHOLD: 5000
       # This will upgrade from devnet to the latest main
       FORGE_TEST_SUITE: compat
+      IMAGE_TAG: devnet
       POST_TO_SLACK: true

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -8,6 +8,10 @@ on:
         required: false
         type: string
         description: The git SHA1 to test. If not specified, Forge will check the latest commits on the current branch
+      IMAGE_TAG:
+        required: false
+        type: string
+        description: The docker image tag to test. If not specified, falls back on GIT_SHA, and then to the latest commits on the current branch
       FORGE_NAMESPACE:
         required: true
         type: string
@@ -51,7 +55,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: us-west-2
-  IMAGE_TAG: ${{ inputs.GIT_SHA }}
+  IMAGE_TAG: ${{ inputs.IMAGE_TAG || inputs.GIT_SHA }}
   FORGE_ENABLED: ${{ secrets.FORGE_ENABLED }}
   FORGE_BLOCKING: ${{ secrets.FORGE_BLOCKING }}
   FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}
@@ -79,8 +83,8 @@ jobs:
         if: env.FORGE_ENABLED == 'true'
         with:
           ref: ${{ inputs.GIT_SHA }}
-          # get the last 10 commits if IMAGE_TAG is not specified
-          fetch-depth: env.IMAGE_TAG != null && 0 || 10
+          # get the last 10 commits if GIT_SHA is not specified
+          fetch-depth: inputs.GIT_SHA != null && 0 || 10
       - uses: actions/setup-python@v4
         if: env.FORGE_ENABLED == 'true'
       - name: Install python deps


### PR DESCRIPTION
### Description

Fix the workflow spec.

Also add a new parameter `IMAGE_TAG`, which overrides `GIT_SHA`. This allows us to do compat against `devnet` and also fetch enough git history to get the latest main. Planning on using `devnet` or `testnet` going forward -- whatever mutable image tag we're using for the long-running (longevity) testnets

### Test Plan

Trigger on push: https://github.com/aptos-labs/aptos-core/actions/runs/2935741904

```
Compatibility test results for devnet ==> 8c9ffb8a50dbd7c5e8194d02a3ace24ec80fe3e6 (PR)
1. Check liveness of validators at old version: devnet
compatibility::simple-validator-upgrade::liveness-check : 10831 TPS, 2809 ms latency, 5000 ms p99 latency,no expired txns
2. Upgrading first Validator to new version: 8c9ffb8a50dbd7c5e8194d02a3ace24ec80fe3e6
compatibility::simple-validator-upgrade::single-validator-upgrade : 9905 TPS, 4850 ms latency, 8050 ms p99 latency,no expired txns
3. Upgrading rest of first batch to new version: 8c9ffb8a50dbd7c5e8194d02a3ace24ec80fe3e6
compatibility::simple-validator-upgrade::half-validator-upgrade : 9778 TPS, 3185 ms latency, 4050 ms p99 latency,no expired txns
4. upgrading second batch to new version: 8c9ffb8a50dbd7c5e8194d02a3ace24ec80fe3e6
compatibility::simple-validator-upgrade::rest-validator-upgrade : 10452 TPS, 2932 ms latency, 6000 ms p99 latency,no expired txns
5. check swarm health
Compatibility test for devnet ==> 8c9ffb8a50dbd7c5e8194d02a3ace24ec80fe3e6 passed
Test Ok
```

The image selection logic is working too:
```
Testing image tags:
  forge: 8c9ffb8a50dbd7c5e8194d02a3ace24ec80fe3e6
  base: devnet
  upgrade (if applicable): 8c9ffb8a50dbd7c5e8194d02a3ace24ec80fe3e6
```


<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3530)
<!-- Reviewable:end -->
