### PR TITLE
[Aptos Data Client] Remove peer id from various metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,7 +481,6 @@ dependencies = [
  "network",
  "rand 0.7.3",
  "serde 1.0.144",
- "short-hex-str",
  "storage-service-client",
  "storage-service-server",
  "storage-service-types",

--- a/state-sync/aptos-data-client/Cargo.toml
+++ b/state-sync/aptos-data-client/Cargo.toml
@@ -29,7 +29,6 @@ aptos-types = { path = "../../types" }
 
 netcore = { path = "../../network/netcore" }
 network = { path = "../../network" }
-short-hex-str = { path = "../../crates/short-hex-str" }
 storage-service-client = { path = "../storage-service/client" }
 storage-service-types = { path = "../storage-service/types" }
 


### PR DESCRIPTION
### Description
This PR removes the peer id from various Aptos Data Client metrics. These were useful in a previous life, but now the code has stabilized enough that it's okay not to collect them.

### Test Plan
Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3532)
<!-- Reviewable:end -->
