### PR TITLE
[indexer] Fix token ownership data to work with batching

### DIFF
--- a/ecosystem/indexer/src/models/transactions.rs
+++ b/ecosystem/indexer/src/models/transactions.rs
@@ -315,6 +315,22 @@ impl Transaction {
         }
         (txns, user_txns, bm_txns, events, wscs)
     }
+
+    pub fn from_transactions_for_tokens(
+        transactions: &[APITransaction],
+    ) -> Vec<(UserTransaction, Vec<EventModel>)> {
+        let mut txns = vec![];
+        for (_, maybe_user_txn, maybe_event_list, _) in
+            transactions.iter().map(Self::from_transaction)
+        {
+            if let Some(Either::Left(user_txn)) = maybe_user_txn {
+                if let Some(event_list) = maybe_event_list {
+                    txns.push((user_txn, event_list))
+                }
+            }
+        }
+        txns
+    }
 }
 
 #[derive(


### PR DESCRIPTION
### Description
The code wasn't built for batch transactions, and now it should handle most cases with it.


### Test Plan
I ran it locally, but we should check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3541)
<!-- Reviewable:end -->
