### PR TITLE
[indexer] Fix logic and remove panics and unwraps

### DIFF
--- a/ecosystem/indexer/src/database.rs
+++ b/ecosystem/indexer/src/database.rs
@@ -53,8 +53,7 @@ where
     let debug = diesel::debug_query::<diesel::pg::Pg, _>(&query).to_string();
     aptos_logger::debug!("Executing query: {:?}", debug);
     let res = query.execute(conn);
-    if res.is_err() {
-        let e = res.as_ref().err().unwrap();
+    if let Err(ref e) = res {
         aptos_logger::warn!("Error running query: {:?}\n{}", e, debug);
     }
     res

--- a/ecosystem/indexer/src/indexer/tailer.rs
+++ b/ecosystem/indexer/src/indexer/tailer.rs
@@ -204,8 +204,11 @@ impl Tailer {
             for t in &transactions[start_index..end_index] {
                 txns.push(t.clone());
             }
-            let task = tokio::task::spawn(async move { self2.process_transactions(txns).await });
-            tasks.push(task);
+            if !txns.is_empty() {
+                let task =
+                    tokio::task::spawn(async move { self2.process_transactions(txns).await });
+                tasks.push(task);
+            }
         }
         let results: Vec<Result<Vec<Result<ProcessingResult, TransactionProcessingError>>>> =
             await_tasks(tasks).await;
@@ -242,10 +245,12 @@ pub async fn await_tasks<T: Debug>(tasks: Vec<JoinHandle<T>>) -> Vec<T> {
     let mut results = vec![];
     for task in tasks {
         let result = task.await;
-        if result.is_err() {
-            aptos_logger::error!("Error joining task: {:?}", &result);
+        match result {
+            Ok(_) => results.push(result.unwrap()),
+            Err(err) => {
+                panic!("Error joining task: {:?}", err);
+            }
         }
-        results.push(result.unwrap());
     }
     results
 }

--- a/ecosystem/indexer/src/indexer/transaction_processor.rs
+++ b/ecosystem/indexer/src/indexer/transaction_processor.rs
@@ -70,6 +70,10 @@ pub trait TransactionProcessor: Send + Sync + Debug {
         &self,
         txns: Vec<Transaction>,
     ) -> Result<ProcessingResult, TransactionProcessingError> {
+        assert!(
+            !txns.is_empty(),
+            "Must provide at least one transaction to this function"
+        );
         PROCESSOR_INVOCATIONS
             .with_label_values(&[self.name()])
             .inc();

--- a/ecosystem/indexer/src/main.rs
+++ b/ecosystem/indexer/src/main.rs
@@ -71,16 +71,20 @@ async fn main() -> std::io::Result<()> {
 
     info!("Starting indexer...");
 
-    let conn_pool = new_db_pool(&args.pg_uri).unwrap();
+    let conn_pool = new_db_pool(&args.pg_uri).expect("Failed to create connection pool");
     info!("Created the connection pool... ");
 
-    let mut tailer = Tailer::new(&args.node_url, conn_pool.clone()).unwrap();
+    let mut tailer =
+        Tailer::new(&args.node_url, conn_pool.clone()).expect("Failed to start tailer");
 
     if !args.skip_migrations {
         tailer.run_migrations();
     }
 
-    tailer.check_or_update_chain_id().await.unwrap();
+    tailer
+        .check_or_update_chain_id()
+        .await
+        .expect("Failed to get initial chain id");
     let pg_transaction_processor = DefaultTransactionProcessor::new(conn_pool.clone());
     tailer.add_processor(Arc::new(pg_transaction_processor));
     if args.index_token_data {

--- a/ecosystem/indexer/src/models/events.rs
+++ b/ecosystem/indexer/src/models/events.rs
@@ -28,7 +28,8 @@ impl Event {
         Event {
             transaction_hash,
             key: event.key.to_string(),
-            sequence_number: BigDecimal::from_u64(event.sequence_number.0).unwrap(),
+            sequence_number: BigDecimal::from_u64(event.sequence_number.0)
+                .expect("Should be able to convert U64 to big decimal"),
             type_: event.typ.to_string(),
             data: event.data.clone(),
             inserted_at: chrono::Utc::now().naive_utc(),

--- a/ecosystem/indexer/src/models/metadata.rs
+++ b/ecosystem/indexer/src/models/metadata.rs
@@ -27,14 +27,14 @@ pub struct Metadata {
 
 impl Metadata {
     pub fn from_token_uri_meta(token_uri: TokenMetaFromURI, token_id_str: String) -> Option<Self> {
-        if token_uri.image.is_some() {
+        if let Some(image) = token_uri.image {
             Some(Self {
                 token_id: token_id_str,
                 name: token_uri.name,
                 symbol: token_uri.symbol,
                 seller_fee_basis_points: token_uri.seller_fee_basis_points,
                 description: token_uri.description,
-                image: token_uri.image.unwrap(),
+                image,
                 external_url: token_uri.external_url,
                 animation_url: token_uri.animation_url,
                 attributes: token_uri.attributes,

--- a/ecosystem/indexer/src/models/processor_statuses.rs
+++ b/ecosystem/indexer/src/models/processor_statuses.rs
@@ -22,7 +22,8 @@ impl ProcessorStatus {
     pub fn new(name: &'static str, version: u64, success: bool, details: Option<String>) -> Self {
         Self {
             name,
-            version: bigdecimal::BigDecimal::from_u64(version).unwrap(),
+            version: bigdecimal::BigDecimal::from_u64(version)
+                .expect("Should be able to convert u64 to big decimal"),
             success,
             details,
             last_updated: chrono::Utc::now().naive_utc(),

--- a/ecosystem/indexer/src/models/token.rs
+++ b/ecosystem/indexer/src/models/token.rs
@@ -138,35 +138,27 @@ impl TokenEvent {
     pub fn from_event(event: &Event) -> Option<TokenEvent> {
         let data = event.data.clone();
         match event.type_.as_str() {
-            "0x3::token::WithdrawEvent" => {
-                let event = serde_json::from_value::<WithdrawEventType>(data).unwrap();
-                Some(TokenEvent::WithdrawEvent(event))
-            }
-            "0x3::token::DepositEvent" => {
-                let event = serde_json::from_value::<DepositEventType>(data).unwrap();
-                Some(TokenEvent::DepositEvent(event))
-            }
-            "0x3::token::CreateTokenDataEvent" => {
-                let event = serde_json::from_value::<CreateTokenDataEventType>(data).unwrap();
-                Some(TokenEvent::CreateTokenDataEvent(event))
-            }
-            "0x3::token::CreateCollectionEvent" => {
-                let event = serde_json::from_value::<CreateCollectionEventType>(data).unwrap();
-                Some(TokenEvent::CollectionCreationEvent(event))
-            }
-            "0x3::token::BurnTokenEvent" => {
-                let event = serde_json::from_value::<BurnTokenEventType>(data).unwrap();
-                Some(TokenEvent::BurnTokenEvent(event))
-            }
-            "0x3::token::MutateTokenPropertyMapEvent" => {
-                let event =
-                    serde_json::from_value::<MutateTokenPropertyMapEventType>(data).unwrap();
-                Some(TokenEvent::MutateTokenPropertyMapEvent(event))
-            }
-            "0x3::token::MintTokenEvent" => {
-                let event = serde_json::from_value::<MintTokenEventType>(data).unwrap();
-                Some(TokenEvent::MintTokenEvent(event))
-            }
+            "0x3::token::WithdrawEvent" => serde_json::from_value(data)
+                .map(|inner| Some(TokenEvent::WithdrawEvent(inner)))
+                .unwrap_or(None),
+            "0x3::token::DepositEvent" => serde_json::from_value(data)
+                .map(|inner| Some(TokenEvent::DepositEvent(inner)))
+                .unwrap_or(None),
+            "0x3::token::CreateTokenDataEvent" => serde_json::from_value(data)
+                .map(|inner| Some(TokenEvent::CreateTokenDataEvent(inner)))
+                .unwrap_or(None),
+            "0x3::token::CreateCollectionEvent" => serde_json::from_value(data)
+                .map(|inner| Some(TokenEvent::CollectionCreationEvent(inner)))
+                .unwrap_or(None),
+            "0x3::token::BurnTokenEvent" => serde_json::from_value(data)
+                .map(|inner| Some(TokenEvent::BurnTokenEvent(inner)))
+                .unwrap_or(None),
+            "0x3::token::MutateTokenPropertyMapEvent" => serde_json::from_value(data)
+                .map(|inner| Some(TokenEvent::MutateTokenPropertyMapEvent(inner)))
+                .unwrap_or(None),
+            "0x3::token::MintTokenEvent" => serde_json::from_value(data)
+                .map(|inner| Some(TokenEvent::MintTokenEvent(inner)))
+                .unwrap_or(None),
             _ => None,
         }
     }

--- a/ecosystem/indexer/src/models/transactions.rs
+++ b/ecosystem/indexer/src/models/transactions.rs
@@ -205,7 +205,8 @@ impl Transaction {
             APITransaction::UserTransaction(tx) => (
                 Self::from_transaction_info(
                     &tx.info,
-                    serde_json::to_value(&tx.request.payload).unwrap(),
+                    serde_json::to_value(&tx.request.payload)
+                        .expect("Unable to deserialize transaction payload"),
                     transaction.type_str().to_string(),
                 ),
                 Some(Either::Left(UserTransaction::from_transaction(tx))),
@@ -218,7 +219,8 @@ impl Transaction {
             APITransaction::GenesisTransaction(tx) => (
                 Self::from_transaction_info(
                     &tx.info,
-                    serde_json::to_value(&tx.payload).unwrap(),
+                    serde_json::to_value(&tx.payload)
+                        .expect("Unable to deserialize Genesis transaction"),
                     transaction.type_str().to_string(),
                 ),
                 None,
@@ -361,7 +363,8 @@ impl UserTransaction {
     pub fn from_transaction(tx: &APIUserTransaction) -> Self {
         Self {
             hash: tx.info.hash.to_string(),
-            signature: serde_json::to_value(&tx.request.signature).unwrap(),
+            signature: serde_json::to_value(&tx.request.signature)
+                .expect("Unable to deserialize txn signature"),
             sender: tx.request.sender.inner().to_hex_literal(),
             sequence_number: u64_to_bigdecimal(tx.request.sequence_number.0),
             max_gas_amount: u64_to_bigdecimal(tx.request.max_gas_amount.0),
@@ -412,13 +415,14 @@ impl BlockMetadataTransaction {
             epoch: u64_to_bigdecimal(tx.epoch.0),
             previous_block_votes_bitvec: serde_json::to_value(&tx.previous_block_votes_bitvec)
                 .unwrap(),
-            failed_proposer_indices: serde_json::to_value(&tx.failed_proposer_indices).unwrap(),
+            failed_proposer_indices: serde_json::to_value(&tx.failed_proposer_indices)
+                .expect("Should be able to parse proposer indices"),
         }
     }
 }
 
 fn parse_timestamp(ts: U64, version: U64) -> chrono::NaiveDateTime {
-    chrono::NaiveDateTime::from_timestamp_opt(*ts.inner() as i64 / 1000000, 0)
+    chrono::NaiveDateTime::from_timestamp_opt((*ts.inner() / 1000000) as i64, 0)
         .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
 }
 

--- a/ecosystem/indexer/src/models/write_set_changes.rs
+++ b/ecosystem/indexer/src/models/write_set_changes.rs
@@ -45,7 +45,7 @@ impl WriteSetChange {
                 hash: state_key_hash.clone(),
                 type_: write_set_change.type_str().to_string(),
                 address: address.to_string(),
-                module: serde_json::to_value(module).unwrap(),
+                module: serde_json::to_value(module).expect("Should be able to parse module"),
                 resource: Default::default(),
                 data: Default::default(),
                 inserted_at: chrono::Utc::now().naive_utc(),
@@ -60,7 +60,7 @@ impl WriteSetChange {
                 type_: write_set_change.type_str().to_string(),
                 address: address.to_string(),
                 module: Default::default(),
-                resource: serde_json::to_value(resource).unwrap(),
+                resource: serde_json::to_value(resource).expect("Should be able to parse resource"),
                 data: Default::default(),
                 inserted_at: chrono::Utc::now().naive_utc(),
             },
@@ -107,7 +107,8 @@ impl WriteSetChange {
                 address: address.to_string(),
                 module: Default::default(),
                 resource: Default::default(),
-                data: serde_json::to_value(data).unwrap(),
+                data: serde_json::to_value(data)
+                    .expect("Should be able to parse write resource data"),
                 inserted_at: chrono::Utc::now().naive_utc(),
             },
             APIWriteSetChange::WriteTableItem(WriteTableItem {

--- a/ecosystem/indexer/src/token_processor.rs
+++ b/ecosystem/indexer/src/token_processor.rs
@@ -70,8 +70,8 @@ fn update_mint_token(
             last_minted_at.eq(last_mint_time),
         ))
         .get_result::<TokenData>(conn);
-    if result.is_err() {
-        aptos_logger::warn!("Error running query: {:?}", result.as_ref().err().unwrap());
+    if let Err(e) = result {
+        aptos_logger::warn!("Error running query: {:?}", e);
     }
 }
 
@@ -79,10 +79,10 @@ async fn get_all_metadata(uris: &Vec<(String, String)>, res: &mut Vec<Metadata>)
     let fetcher = MetaDataFetcher::new();
     for (tid, uri) in uris {
         let token_metadata = fetcher.get_metadata(uri.clone()).await;
-        if token_metadata.is_some() {
-            let metadata = Metadata::from_token_uri_meta(token_metadata.unwrap(), tid.clone());
-            if metadata.is_some() {
-                res.push(metadata.unwrap());
+        if let Some(token_metadata) = token_metadata {
+            let metadata = Metadata::from_token_uri_meta(token_metadata, tid.clone());
+            if let Some(metadata) = metadata {
+                res.push(metadata);
             }
         }
     }

--- a/ecosystem/indexer/src/util.rs
+++ b/ecosystem/indexer/src/util.rs
@@ -4,11 +4,11 @@
 use bigdecimal::{FromPrimitive, Signed, ToPrimitive, Zero};
 
 pub fn u64_to_bigdecimal(val: u64) -> bigdecimal::BigDecimal {
-    bigdecimal::BigDecimal::from_u64(val).unwrap()
+    bigdecimal::BigDecimal::from_u64(val).expect("Unable to convert u64 to big decimal")
 }
 
 pub fn bigdecimal_to_u64(val: &bigdecimal::BigDecimal) -> u64 {
-    val.to_u64().unwrap()
+    val.to_u64().expect("Unable to convert big decimal to u64")
 }
 
 pub fn ensure_not_negative(val: bigdecimal::BigDecimal) -> bigdecimal::BigDecimal {


### PR DESCRIPTION
### Description
There's a ton of messy indexer code here that's doing unwraps when it shouldn't, or panicking when it shouldn't.  I left one panic on if a batch of transactions isn't found.  Everything else should try until the program ends.

### Test Plan
None, but this should be better

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3547)
<!-- Reviewable:end -->
