### PR TITLE
[sdk][typescript] fix unthrottled requests in `waitForTransactionWithResult`

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -458,16 +458,9 @@ export class AptosClient {
           break;
         }
       } catch (e) {
-        if (e instanceof Gen.ApiError) {
-          if (e.status === 404) {
-            isPending = true;
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-          if (e.status >= 400) {
-            throw e;
-          }
-        } else {
+        const isApiError = e instanceof Gen.ApiError;
+        const isRequestError = isApiError && e.status !== 404 && e.status >= 400 && e.status < 500;
+        if (!isApiError || isRequestError) {
           throw e;
         }
       }


### PR DESCRIPTION
### Description
`AptosClient.waitForTransactionWithResult` is skipping the sleep, causing many requests per second.
This fixes it

### Test Plan
Will test that polling is done once per second as expected

Closes #3553

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3554)
<!-- Reviewable:end -->
