### PR TITLE
[forge] decommission old clusters

### DIFF
--- a/.github/workflows/continuous-e2e-chaos-test.yaml
+++ b/.github/workflows/continuous-e2e-chaos-test.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-chaos
-      FORGE_CLUSTER_NAME: aptos-forge-1
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
       # Run for 30 minutes
       FORGE_RUNNER_DURATION_SECS: 1800
       # Pre release has chaos applied

--- a/.github/workflows/continuous-e2e-compat-test.yaml
+++ b/.github/workflows/continuous-e2e-compat-test.yaml
@@ -16,7 +16,7 @@ jobs:
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-compat
-      FORGE_CLUSTER_NAME: aptos-forge-1
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
       # Run for 5 minutes
       FORGE_RUNNER_DURATION_SECS: 300
       # This will upgrade from devnet to the latest main

--- a/.github/workflows/continuous-e2e-performance-test.yaml
+++ b/.github/workflows/continuous-e2e-performance-test.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-performance
-      FORGE_CLUSTER_NAME: aptos-forge-1
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
       # Run for 2 hours
       FORGE_RUNNER_DURATION_SECS: 7200
       # Land blocking is performance test

--- a/.github/workflows/continuous-e2e-single-vfn-test.yaml
+++ b/.github/workflows/continuous-e2e-single-vfn-test.yaml
@@ -14,7 +14,7 @@ jobs:
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-continuous-e2e-single-vfn
-      FORGE_CLUSTER_NAME: aptos-forge-1
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
       # Run for 8 minutes
       FORGE_RUNNER_DURATION_SECS: 480
       FORGE_TEST_SUITE: single_vfn_perf

--- a/testsuite/fixtures/testDashboardLink.fixture
+++ b/testsuite/fixtures/testDashboardLink.fixture
@@ -1,1 +1,1 @@
-https://o11y.aptosdev.com/grafana/d/overview/overview?orgId=1&refresh=10s&var-Datasource=Remote%20Prometheus%20Devinfra&var-namespace=forge-pr-2983&var-chain_name=forge-1&refresh=10s&from=now-15m&to=now
+https://o11y.aptosdev.com/grafana/d/overview/overview?orgId=1&refresh=10s&var-Datasource=Remote%20Prometheus%20Devinfra&var-namespace=forge-pr-2983&var-chain_name=forge-big-1&refresh=10s&from=now-15m&to=now

--- a/testsuite/fixtures/testMain.fixture
+++ b/testsuite/fixtures/testMain.fixture
@@ -1,4 +1,4 @@
-Using forge cluster: forge-1
+Using forge cluster: forge-big-1
 === Start temp-pre-comment ===
 ### Forge is running with `output`
 * [Grafana dashboard (auto-refresh)](https://banana)

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -232,9 +232,9 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
     def testDashboardLink(self) -> None:
         self.assertFixture(
             get_dashboard_link(
-                "aptos-forge-1",
+                "aptos-forge-big-1",
                 "forge-pr-2983",
-                "forge-1",
+                "forge-big-1",
                 True,
             ),
             "testDashboardLink.fixture",
@@ -263,7 +263,7 @@ class ForgeMainTests(unittest.TestCase, AssertFixtureMixin):
             )
             result = runner.invoke(main, [
                 "test", "--dry-run",
-                "--forge-cluster-name", "forge-1",
+                "--forge-cluster-name", "forge-big-1",
                 "--forge-report", "temp-report",
                 "--forge-pre-comment", "temp-pre-comment",
                 "--forge-comment", "temp-comment",

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -27,7 +27,7 @@ fi
 
 # available clusters to choose from
 # forge-1 is used for continuous testing exclusively
-FORGE_CLUSTERS=("aptos-forge-big-0" "aptos-forge-big-1" "aptos-forge-0")
+FORGE_CLUSTERS=("aptos-forge-big-0" "aptos-forge-big-1")
 
 # ensure the script is run from project root
 pwd | grep -qE 'aptos-core$' || (echo "Please run from aptos-core root directory" && exit 1)

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -26,8 +26,7 @@ else
 fi
 
 # available clusters to choose from
-# forge-1 is used for continuous testing exclusively
-FORGE_CLUSTERS=("aptos-forge-big-0" "aptos-forge-big-1")
+FORGE_CLUSTERS=("aptos-forge-big-0" "aptos-forge-big-2")
 
 # ensure the script is run from project root
 pwd | grep -qE 'aptos-core$' || (echo "Please run from aptos-core root directory" && exit 1)


### PR DESCRIPTION
### Description

`forge-$i` clusters have been replaced by `forge-big-$i` (new) clusters, which have 4x the maximum capacity. This PR removes all the original `forge-$i` clusters from CI and land-blocking Forge. 

Land-blocking forge is load-balanced between `forge-big-0` and `forge-big-2`.
Continuous forge runs on `forge-big-1`


To roll this out, I'll keep the old clusters around for at least a few days since unmerged PRs using old `run_forge.sh` will continue to hit the old clusters. After that, we'll either need devs to rebase on main to bring in the new script changes to use the new clusters, or we turn on the new python forge wrapper (which simply selects from all clusters named `forge-*`

### Test Plan

2/3 of land-blocking forge has been scheduled on `forge-big-$i` clusters.

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3559)
<!-- Reviewable:end -->
