### PR TITLE
cicd: optimize docker build caching

### DIFF
--- a/.github/workflows/build-images.yaml
+++ b/.github/workflows/build-images.yaml
@@ -118,6 +118,8 @@ jobs:
 
       - uses: ./.github/actions/docker-buildx-setup
 
+      - uses: imjasonh/setup-crane@v0.1
+
       - name: Build and Push Rust images
         run: docker/docker-bake-rust-all.sh
         env:

--- a/docker/docker-bake-rust-all.sh
+++ b/docker/docker-bake-rust-all.sh
@@ -16,16 +16,11 @@ export GIT_BRANCH=$(git symbolic-ref --short HEAD)
 export GIT_TAG=$(git tag -l --contains HEAD)
 export BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 export BUILT_VIA_BUILDKIT="true"
+export NORMALIZED_GIT_BRANCH_OR_PR=$(printf "$TARGET_CACHE_ID" | sed -e 's/[^a-zA-Z0-9]/-/g')
 
 if [ "$CI" == "true" ]; then
-  # builder target is the one that builds the rust binaries and is the most expensive.
-  # Its output is used by all the other targets that follow.
-  # This will also push the builder image as an image to GCP (+ inline cache manifests) even though we don't use this image directly
-  TARGET_REGISTRY=gcp docker buildx bake --progress=plain --file docker/docker-bake-rust-all.hcl builder --push
-  # build and push the actual images that we use (+ inline cache manifests)
-  TARGET_REGISTRY=gcp docker buildx bake --progress=plain --file docker/docker-bake-rust-all.hcl all --push
-  # push everything also to AWS - this step will literally just reuse the layers from the previous step so should be kinda fast
-  TARGET_REGISTRY=aws docker buildx bake --progress=plain --file docker/docker-bake-rust-all.hcl all --push
+  TARGET_REGISTRY=remote docker buildx bake --progress=plain --file docker/docker-bake-rust-all.hcl all --push
+  REGISTRY_BASE="$GCP_DOCKER_ARTIFACT_REPO" SOURCE_TAG="cache-$NORMALIZED_GIT_BRANCH_OR_PR" TARGET_TAG="cache-$GIT_SHA" ./docker/retag-rust-images.sh
 else
   BUILD_TARGET="${1:-all}"
   TARGET_REGISTRY=local docker buildx bake --file docker/docker-bake-rust-all.hcl $BUILD_TARGET

--- a/docker/retag-rust-images.sh
+++ b/docker/retag-rust-images.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+
+IMAGES=(
+  validator
+  indexer
+  node-checker
+  tools
+  faucet
+  forge
+  telemetry-service
+)
+
+for IMAGE in "${IMAGES[@]}"
+do
+    crane copy "$REGISTRY_BASE/$IMAGE:$SOURCE_TAG" "$REGISTRY_BASE/$IMAGE:$TARGET_TAG"
+done

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -31,7 +31,7 @@ RUN ARCHITECTURE=$(uname -m | sed -e "s/arm64/arm_64/g" | sed -e "s/aarch64/aarc
     && chmod +x "/usr/local/bin/protoc" \
     && rm "protoc-21.5-linux-$ARCHITECTURE.zip"
 
-RUN --mount=type=cache,target=/aptos/target --mount=type=cache,target=$CARGO_HOME/registry docker/build-rust-all.sh && rm -rf $CARGO_HOME/registry/index
+RUN docker/build-rust-all.sh && rm -rf $CARGO_HOME && rm -rf target 
 
 ### Validator Image ###
 FROM debian-base AS validator


### PR DESCRIPTION
This optimizes our docker builds a bit.
1. First runs the image building step in a single step / docker invocation instead of 3 seperate ones. This seems to speed things a bit.
2. Also we're changing from an `inline` cache to `registry,mode=max` as cache strategy. The main difference between inline and the mode=max one is that inline will only cache the final docker layers whereas the mode=max  one will cache each layer, incl. intermediate ones seperately.
3. We're using a seperate `retag` step via `crane` which simply retags some of the images from <branch_name> to <git_sha> which is also used as cache source. Had to do this in a seperate step since docker buildx can only push one cache manifest per image by itself.
4. It removes the cache mounts from the step that compiles the rust code and deletes the CARGO_HOME and the `target` directory before the end of the layer instructions. This leads to a smaller layer to cache which speeds up calculating the layer cache key and upload/download time of that layer. The cache mount was only useful for building the image locally, which we're doing rarely (in comparison to how often we build it on github actions).

Overall these optimizations seem to cut down our docker build time from ~25min to ~18min.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3561)
<!-- Reviewable:end -->
