### PR TITLE
[sdk][typescript] fix bug of deserialize of MultiEd25519

### DIFF
--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/multi_ed25519.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/multi_ed25519.test.ts
@@ -3,6 +3,7 @@
 
 /* eslint-disable max-len */
 import { HexString } from "../../hex_string";
+import { bcsToBytes, Deserializer } from "../bcs";
 import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
 import { MultiEd25519PublicKey, MultiEd25519Signature } from "./multi_ed25519";
 
@@ -26,6 +27,27 @@ describe("MultiEd25519", () => {
     );
   });
 
+  it("public key deserializes from bytes correctly", async () => {
+    const publicKey1 = "b9c6ee1630ef3e711144a648db06bbb2284f7274cfbee53ffcee503cc1a49200";
+    const publicKey2 = "aef3f4a4b8eca1dfc343361bf8e436bd42de9259c04b8314eb8e2054dd6e82ab";
+    const publicKey3 = "8a5762e21ac1cdb3870442c77b4c3af58c7cedb8779d0270e6d4f1e2f7367d74";
+
+    const pubKeyMultiSig = new MultiEd25519PublicKey(
+      [
+        new Ed25519PublicKey(new HexString(publicKey1).toUint8Array()),
+        new Ed25519PublicKey(new HexString(publicKey2).toUint8Array()),
+        new Ed25519PublicKey(new HexString(publicKey3).toUint8Array()),
+      ],
+      2,
+    );
+    const deserialzed = MultiEd25519PublicKey.deserialize(new Deserializer(bcsToBytes(pubKeyMultiSig)));
+    expect(
+      HexString.fromUint8Array(deserialzed.toBytes()).noPrefix()
+    ).toEqual(
+      HexString.fromUint8Array(pubKeyMultiSig.toBytes()).noPrefix()
+    );
+  });
+
   it("signature serializes to bytes correctly", async () => {
     // eslint-disable-next-line operator-linebreak
     const sig1 =
@@ -45,6 +67,31 @@ describe("MultiEd25519", () => {
 
     expect(HexString.fromUint8Array(multisig.toBytes()).noPrefix()).toEqual(
       "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a88052ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102c0000000",
+    );
+  });
+
+  it("signature deserializes from bytes correctly", async () => {
+    // eslint-disable-next-line operator-linebreak
+    const sig1 =
+      "e6f3ba05469b2388492397840183945d4291f0dd3989150de3248e06b4cefe0ddf6180a80a0f04c045ee8f362870cb46918478cd9b56c66076f94f3efd5a8805";
+    // eslint-disable-next-line operator-linebreak
+    const sig2 =
+      "2ae0818b7e51b853f1e43dc4c89a1f5fabc9cb256030a908f9872f3eaeb048fb1e2b4ffd5a9d5d1caedd0c8b7d6155ed8071e913536fa5c5a64327b6f2d9a102";
+    const bitmap = "c0000000";
+
+    const multisig = new MultiEd25519Signature(
+      [
+        new Ed25519Signature(new HexString(sig1).toUint8Array()),
+        new Ed25519Signature(new HexString(sig2).toUint8Array()),
+      ],
+      new HexString(bitmap).toUint8Array(),
+    );
+
+    const deserialzed = MultiEd25519Signature.deserialize(new Deserializer(bcsToBytes(multisig)));
+    expect(
+      HexString.fromUint8Array(deserialzed.toBytes()).noPrefix()
+    ).toEqual(
+      HexString.fromUint8Array(multisig.toBytes()).noPrefix()
     );
   });
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/multi_ed25519.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/aptos_types/multi_ed25519.ts
@@ -52,8 +52,8 @@ export class MultiEd25519PublicKey {
 
     const keys: Seq<Ed25519PublicKey> = [];
 
-    for (let i = 0; i < bytes.length; i += Ed25519PublicKey.LENGTH) {
-      const begin = i * Ed25519PublicKey.LENGTH;
+    for (let i = 0; i < bytes.length - 1; i += Ed25519PublicKey.LENGTH) {
+      const begin = i;
       keys.push(new Ed25519PublicKey(bytes.subarray(begin, begin + Ed25519PublicKey.LENGTH)));
     }
     return new MultiEd25519PublicKey(keys, threshold);
@@ -149,8 +149,8 @@ export class MultiEd25519Signature {
 
     const sigs: Seq<Ed25519Signature> = [];
 
-    for (let i = 0; i < bytes.length; i += Ed25519Signature.LENGTH) {
-      const begin = i * Ed25519Signature.LENGTH;
+    for (let i = 0; i < bytes.length - bitmap.length; i += Ed25519Signature.LENGTH) {
+      const begin = i;
       sigs.push(new Ed25519Signature(bytes.subarray(begin, begin + Ed25519Signature.LENGTH)));
     }
     return new MultiEd25519Signature(sigs, bitmap);


### PR DESCRIPTION
### Description

Fixed minor bug with deserialization of `Ed25519Signature` and `MultiEd25519PublicKey` and added unit tests for them.

The check failed because of the 'API rate limit'.
 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3565)
<!-- Reviewable:end -->
