### PR TITLE
fix(ts-sdk): failed to find function in abiMap if address have preceding zeros

### DIFF
--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -358,6 +358,7 @@ export class TransactionBuilderRemoteABI {
    * @returns RawTransaction
    */
   async build(func: Gen.EntryFunctionId, ty_tags: Gen.MoveType[], args: any[]): Promise<RawTransaction> {
+    /* eslint no-param-reassign: ["off"] */
     const normlize = (s: string) => s.replace(/^0[xX]0*/g, "0x");
     func = normlize(func);
     const funcNameParts = func.split("::");

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -358,6 +358,8 @@ export class TransactionBuilderRemoteABI {
    * @returns RawTransaction
    */
   async build(func: Gen.EntryFunctionId, ty_tags: Gen.MoveType[], args: any[]): Promise<RawTransaction> {
+    const normlize = (s: string) => s.replace(/^0[xX]0*/g, "0x");
+    func = normlize(func);
     const funcNameParts = func.split("::");
     if (funcNameParts.length !== 3) {
       throw new Error(


### PR DESCRIPTION
### Description
If address has preceding zeros, e.g, 0x027c2f73843c53f046be43a18cc7c2c20ad956d1708d51e478a89ea1d755c526, fetchABI will return address without zeros, so that it will fail when find a function with full-length address.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3569)
<!-- Reviewable:end -->
