### PR TITLE
[Aptos Framework] Add a module for creating staking contracts between stakers and operators and a vesting module

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_account.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_account.move
@@ -1,10 +1,17 @@
 module aptos_framework::aptos_account {
+    use std::error;
+
     use aptos_framework::account;
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin;
 
     friend aptos_framework::genesis;
     friend aptos_framework::resource_account;
+
+    /// Account does not exist.
+    const EACCOUNT_NOT_FOUND: u64 = 1;
+    /// Account is not registered to receive APT.
+    const EACCOUNT_NOT_REGISTERED_FOR_APT: u64 = 2;
 
     ///////////////////////////////////////////////////////////////////////////
     /// Basic account creation methods.
@@ -20,6 +27,15 @@ module aptos_framework::aptos_account {
             create_account(to)
         };
         coin::transfer<AptosCoin>(source, to, amount)
+    }
+
+    public fun assert_account_exists(addr: address) {
+        assert!(account::exists_at(addr), error::not_found(EACCOUNT_NOT_FOUND));
+    }
+
+    public fun assert_account_is_registered_for_apt(addr: address) {
+        assert_account_exists(addr);
+        assert!(coin::is_account_registered<AptosCoin>(addr), error::not_found(EACCOUNT_NOT_REGISTERED_FOR_APT));
     }
 
     #[test(alice = @0xa11ce, core = @0x1)]

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -1306,6 +1306,27 @@ module aptos_framework::stake {
         initialize_for_test_custom(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 1000000);
     }
 
+    #[test_only]
+    public fun join_validator_set_for_test(
+        operator: &signer,
+        pool_address: address,
+        should_end_epoch: bool,
+    ) acquires AptosCoinCapabilities, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
+        rotate_consensus_key(operator, pool_address, CONSENSUS_KEY_1, CONSENSUS_POP_1);
+        join_validator_set(operator, pool_address);
+        if (should_end_epoch) {
+            end_epoch();
+        }
+    }
+
+    #[test_only]
+    public fun fast_forward_to_unlock(pool_address: address)
+    acquires AptosCoinCapabilities, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
+        let expiration_time = get_lockup_secs(pool_address);
+        timestamp::update_global_time_for_test_secs(expiration_time);
+        end_epoch();
+    }
+
     // Convenient function for setting up all required stake initializations.
     #[test_only]
     public fun initialize_for_test_custom(
@@ -2442,5 +2463,11 @@ module aptos_framework::stake {
         account::create_account_for_test(addr);
         coin::register<AptosCoin>(validator);
         initialize_stake_owner(validator, 0, addr, addr);
+    }
+
+    #[test_only]
+    public fun with_rewards(amount: u64): u64 {
+        let (numerator, denominator) = staking_config::get_reward_rate(&staking_config::get());
+        amount + amount * numerator / denominator
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -1,0 +1,1132 @@
+/// Allow stakers and operators to enter a staking contract with reward sharing.
+/// The main accounting logic in a staking contract consists of 2 parts:
+/// 1. Tracks how much commission needs to be paid out to the operator. This is tracked with an increasing principal
+/// amount that's updated every time the operator requests commission, the staker withdraws funds, or the staker
+/// switches operators.
+/// 2. Distributions of funds to operators (commissions) and stakers (stake withdrawals) use the shares model provided
+/// by the pool_u64 to track shares that increase in price as the stake pool accumulates rewards.
+///
+/// Example flow:
+/// 1. A staker creates a staking contract with an operator by calling create_staking_contract() with 100 coins of
+/// initial stake and commission = 10%. This means the operator will receive 10% of any accumulated rewards. A new stake
+/// pool will be created and hosted in a separate account that's controlled by the staking contract.
+/// 2. The operator sets up a validator node and, once ready, joins the validator set by calling stake::join_validator_set
+/// 3. After some time, the stake pool gains rewards and now has 150 coins.
+/// 4. Operator can now call request_commission. 10% of (150 - 100) = 5 coins will be unlocked from the stake pool. The
+/// staker's principal is now updated from 100 to 145 (150 coins - 5 coins of commission). The pending distribution pool
+/// has 5 coins total and the operator owns all 5 shares of it.
+/// 5. Some more time has passed. The pool now has 50 more coins in rewards and a total balance of 195. The operator
+/// calls request_commission again. Since the previous 5 coins have now become withdrawable, it'll be deposited into the
+/// operator's account first. Their new commission will be 10% of (195 coins - 145 principal) = 5 coins. Principal is
+/// updated to be 190 (195 - 5). Pending distribution pool has 5 coins and operator owns all 5 shares.
+/// 6. Staker calls unlock_stake to unlock 50 coins of stake, which gets added to the pending distribution pool. Based
+/// on shares math, staker will be owning 50 shares and operator still owns 5 shares of the 55-coin pending distribution
+/// pool.
+/// 7. Some time passes and the 55 coins become fully withdrawable from the stake pool. Due to accumulated rewards, the
+/// 55 coins become 70 coins. Calling distribute() distributes 6 coins to the operator and 64 coins to the validator.
+module aptos_framework::staking_contract {
+    use std::bcs;
+    use std::error;
+    use std::signer;
+    use std::vector;
+
+    use aptos_std::event::{EventHandle, emit_event};
+    use aptos_std::pool_u64::{Self, Pool};
+    use aptos_std::simple_map::{Self, SimpleMap};
+
+    use aptos_framework::account::{Self, SignerCapability};
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::stake::{Self, OwnerCapability};
+    use aptos_framework::staking_config;
+
+    const SALT: vector<u8> = b"aptos_framework::staking_contract";
+
+    /// Store amount must be at least the min stake required for a stake pool to join the validator set.
+    const EINSUFFICIENT_STAKE_AMOUNT: u64 = 1;
+    /// Commission percentage has to be between 0 and 100.
+    const EINVALID_COMMISSION_PERCENTAGE: u64 = 2;
+    /// Staker has no staking contracts.
+    const ENO_STAKING_CONTRACT_FOUND_FOR_STAKER: u64 = 3;
+    /// No staking contract between the staker and operator found.
+    const ENO_STAKING_CONTRACT_FOUND_FOR_OPERATOR: u64 = 4;
+    /// Staking contracts can't be merged.
+    const ECANT_MERGE_STAKING_CONTRACTS: u64 = 5;
+    /// The staking contract already exists and cannot be re-created.
+    const ESTAKING_CONTRACT_ALREADY_EXISTS: u64 = 6;
+    /// Not enough active stake to withdraw. Some stake might still pending and will be active in the next epoch.
+    const EINSUFFICIENT_ACTIVE_STAKE_TO_WITHDRAW: u64 = 7;
+    /// Caller must be either the staker or operator.
+    const ENOT_STAKER_OR_OPERATOR: u64 = 8;
+
+    /// Maximum number of distributions a stake pool can support.
+    const MAXIMUM_PENDING_DISTRIBUTIONS: u64 = 20;
+
+    struct StakingContract has store {
+        // Recorded principal after the last commission distribution.
+        // This is only used to calculate the commission the operator should be receiving.
+        principal: u64,
+        pool_address: address,
+        // The stake pool's owner capability. This can be used to control funds in the stake pool.
+        owner_cap: OwnerCapability,
+        commission_percentage: u64,
+        // Current distributions, including operator commission withdrawals and staker's partial withdrawals.
+        distribution_pool: Pool,
+        // Just in case we need the SignerCap for stake pool account in the future.
+        signer_cap: SignerCapability,
+    }
+
+    struct Store has key {
+        staking_contracts: SimpleMap<address, StakingContract>,
+
+        // Events.
+        create_staking_contract_events: EventHandle<CreateStakingContractEvent>,
+        update_voter_events: EventHandle<UpdateVoterEvent>,
+        reset_lockup_events: EventHandle<ResetLockupEvent>,
+        add_stake_events: EventHandle<AddStakeEvent>,
+        request_commission_events: EventHandle<RequestCommissionEvent>,
+        unlock_stake_events: EventHandle<UnlockStakeEvent>,
+        switch_operator_events: EventHandle<SwitchOperatorEvent>,
+        add_distribution_events: EventHandle<AddDistributionEvent>,
+        distribute_events: EventHandle<DistributeEvent>,
+    }
+
+    struct CreateStakingContractEvent has drop, store {
+        operator: address,
+        voter: address,
+        pool_address: address,
+        principal: u64,
+        commission_percentage: u64,
+    }
+
+    struct UpdateVoterEvent has drop, store {
+        operator: address,
+        pool_address: address,
+        old_voter: address,
+        new_voter: address,
+    }
+
+    struct ResetLockupEvent has drop, store {
+        operator: address,
+        pool_address: address,
+    }
+
+    struct AddStakeEvent has drop, store {
+        operator: address,
+        pool_address: address,
+        amount: u64
+    }
+
+    struct RequestCommissionEvent has drop, store {
+        operator: address,
+        pool_address: address,
+        accumulated_rewards: u64,
+        commission_amount: u64,
+    }
+
+    struct UnlockStakeEvent has drop, store {
+        operator: address,
+        pool_address: address,
+        amount: u64,
+        commission_paid: u64,
+    }
+
+    struct SwitchOperatorEvent has drop, store {
+        old_operator: address,
+        new_operator: address,
+        pool_address: address,
+    }
+
+    struct AddDistributionEvent has drop, store {
+        operator: address,
+        pool_address: address,
+        amount: u64,
+    }
+
+    struct DistributeEvent has drop, store {
+        operator: address,
+        pool_address: address,
+        recipient: address,
+        amount: u64,
+    }
+
+    public fun stake_pool_address(staker: address, operator: address): address acquires Store {
+        let staking_contracts = &borrow_global<Store>(staker).staking_contracts;
+        simple_map::borrow(staking_contracts, &operator).pool_address
+    }
+
+    public fun last_recorded_principal(staker: address, operator: address): u64 acquires Store {
+        let staking_contracts = &borrow_global<Store>(staker).staking_contracts;
+        simple_map::borrow(staking_contracts, &operator).principal
+    }
+
+    public fun commission_percentage(staker: address, operator: address): u64 acquires Store {
+        let staking_contracts = &borrow_global<Store>(staker).staking_contracts;
+        simple_map::borrow(staking_contracts, &operator).commission_percentage
+    }
+
+    public fun staking_contract_amounts(staker: address, operator: address): (u64, u64, u64) acquires Store {
+        let staking_contracts = &borrow_global<Store>(staker).staking_contracts;
+        let staking_contract = simple_map::borrow(staking_contracts, &operator);
+        get_staking_contract_amounts_internal(staking_contract)
+    }
+
+    public fun pending_distribution_counts(staker: address, operator: address): u64 acquires Store {
+        let staking_contracts = &borrow_global<Store>(staker).staking_contracts;
+        pool_u64::shareholders_count(&simple_map::borrow(staking_contracts, &operator).distribution_pool)
+    }
+
+    /// Staker can call this function to create a simple staking contract with a specified operator.
+    public entry fun create_staking_contract(
+        staker: &signer,
+        operator: address,
+        voter: address,
+        amount: u64,
+        commission_percentage: u64,
+        // Optional seed used when creating the staking contract account.
+        contract_creation_seed: vector<u8>,
+    ) acquires Store {
+        let staked_coins = coin::withdraw<AptosCoin>(staker, amount);
+        create_staking_contract_with_coins(
+            staker, operator, voter, staked_coins, commission_percentage, contract_creation_seed);
+    }
+
+    /// Staker can call this function to create a simple staking contract with a specified operator.
+    public fun create_staking_contract_with_coins(
+        staker: &signer,
+        operator: address,
+        voter: address,
+        coins: Coin<AptosCoin>,
+        commission_percentage: u64,
+        // Optional seed used when creating the staking contract account.
+        contract_creation_seed: vector<u8>,
+    ): address acquires Store {
+        assert!(
+            commission_percentage >= 0 && commission_percentage <= 100,
+            error::invalid_argument(EINVALID_COMMISSION_PERCENTAGE),
+        );
+        // The amount should be at least the min_stake_required, so the stake pool will be eligible to join the
+        // validator set.
+        let (min_stake_required, _) = staking_config::get_required_stake(&staking_config::get());
+        let principal = coin::value(&coins);
+        assert!(principal >= min_stake_required, error::invalid_argument(EINSUFFICIENT_STAKE_AMOUNT));
+
+        // Initialize Store resource if this is the first time the staker has delegated to anyone.
+        let staker_address = signer::address_of(staker);
+        if (!exists<Store>(staker_address)) {
+            move_to(staker, new_staking_contracts_holder(staker));
+        };
+
+        // Cannot create the staking contract if it already exists.
+        let store = borrow_global_mut<Store>(staker_address);
+        let staking_contracts = &mut store.staking_contracts;
+        assert!(
+            !simple_map::contains_key(staking_contracts, &operator),
+            error::already_exists(ESTAKING_CONTRACT_ALREADY_EXISTS)
+        );
+
+        // Initialize the stake pool in a new resource account. This allows the same staker to contract with multiple
+        // different operators.
+        let (stake_pool_signer, stake_pool_signer_cap, owner_cap) =
+            create_stake_pool(staker, operator, voter, contract_creation_seed);
+
+        // Add the stake to the stake pool.
+        stake::add_stake_with_cap(&owner_cap, coins);
+
+        // Create the contract record.
+        let pool_address = signer::address_of(&stake_pool_signer);
+        simple_map::add(staking_contracts, operator, StakingContract {
+            principal,
+            pool_address,
+            owner_cap,
+            commission_percentage,
+            // Make sure we don't have too many pending recipients in the distribution pool.
+            // Otherwise, a griefing attack is possible where the staker can keep switching operators and create too
+            // many pending distributions. This can lead to out-of-gas failure whenever distribute() is called.
+            distribution_pool: pool_u64::create(MAXIMUM_PENDING_DISTRIBUTIONS),
+            signer_cap: stake_pool_signer_cap,
+        });
+
+        emit_event(
+            &mut store.create_staking_contract_events,
+            CreateStakingContractEvent { operator, voter, pool_address, principal, commission_percentage },
+        );
+        pool_address
+    }
+
+    /// Add more stake to an existing staking contract.
+    public entry fun add_stake(staker: &signer, operator: address, amount: u64) acquires Store {
+        let staker_address = signer::address_of(staker);
+        assert_staking_contract_exists(staker_address, operator);
+
+        let store = borrow_global_mut<Store>(staker_address);
+        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+
+        // Add the stake to the stake pool.
+        let staked_coins = coin::withdraw<AptosCoin>(staker, amount);
+        stake::add_stake_with_cap(&staking_contract.owner_cap, staked_coins);
+
+        staking_contract.principal = staking_contract.principal + amount;
+        let pool_address = staking_contract.pool_address;
+        emit_event(
+            &mut store.add_stake_events,
+            AddStakeEvent { operator, pool_address, amount },
+        );
+    }
+
+    /// Convenient function to allow the staker to update the voter address in a staking contract they made.
+    public entry fun update_voter(staker: &signer, operator: address, new_voter: address) acquires Store {
+        let staker_address = signer::address_of(staker);
+        assert_staking_contract_exists(staker_address, operator);
+
+        let store = borrow_global_mut<Store>(staker_address);
+        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        let pool_address = staking_contract.pool_address;
+        let old_voter = stake::get_delegated_voter(pool_address);
+        stake::set_delegated_voter_with_cap(&staking_contract.owner_cap, new_voter);
+
+        emit_event(
+            &mut store.update_voter_events,
+            UpdateVoterEvent { operator, pool_address, old_voter, new_voter },
+        );
+    }
+
+    /// Convenient function to allow the staker to reset their stake pool's lockup period to start now.
+    public entry fun reset_lockup(staker: &signer, operator: address) acquires Store {
+        let staker_address = signer::address_of(staker);
+        assert_staking_contract_exists(staker_address, operator);
+
+        let store = borrow_global_mut<Store>(staker_address);
+        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        let pool_address = staking_contract.pool_address;
+        stake::increase_lockup_with_cap(&staking_contract.owner_cap);
+
+        emit_event(&mut store.reset_lockup_events, ResetLockupEvent { operator, pool_address });
+    }
+
+    /// Unlock commission amount from the stake pool. Operator needs to wait for the amount to become withdrawable
+    /// at the end of the stake pool's lockup period before they can actually can withdraw_commission.
+    ///
+    /// Only staker or operator can call this.
+    public entry fun request_commission(account: &signer, staker: address, operator: address) acquires Store {
+        let account_addr = signer::address_of(account);
+        assert!(account_addr == staker || account_addr == operator, error::unauthenticated(ENOT_STAKER_OR_OPERATOR));
+        assert_staking_contract_exists(staker, operator);
+
+        let store = borrow_global_mut<Store>(staker);
+        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        // Short-circuit if zero commission.
+        if (staking_contract.commission_percentage == 0) {
+            return
+        };
+
+        // Force distribution of any already inactive stake.
+        distribute_internal(staker, operator, staking_contract, &mut store.distribute_events);
+
+        request_commission_internal(
+            operator,
+            staking_contract,
+            &mut store.add_distribution_events,
+            &mut store.request_commission_events,
+        );
+    }
+
+    fun request_commission_internal(
+        operator: address,
+        staking_contract: &mut StakingContract,
+        add_distribution_events: &mut EventHandle<AddDistributionEvent>,
+        request_commission_events: &mut EventHandle<RequestCommissionEvent>,
+    ): u64 {
+        // Unlock just the commission portion from the stake pool.
+        let (total_active_stake, accumulated_rewards, commission_amount) =
+            get_staking_contract_amounts_internal(staking_contract);
+        staking_contract.principal = total_active_stake - commission_amount;
+
+        // Short-circuit if there's no commission to pay.
+        if (commission_amount == 0) {
+            return 0
+        };
+
+        // Add a distribution for the operator.
+        add_distribution(operator, staking_contract, operator, commission_amount, add_distribution_events);
+
+        // Request to unlock the commission from the stake pool.
+        // This won't become fully unlocked until the stake pool's lockup expires.
+        stake::unlock_with_cap(commission_amount, &staking_contract.owner_cap);
+
+        let pool_address = staking_contract.pool_address;
+        emit_event(
+            request_commission_events,
+            RequestCommissionEvent { operator, pool_address, accumulated_rewards, commission_amount },
+        );
+
+        commission_amount
+    }
+
+    /// Staker can call this to request withdrawal of part or all of their staking_contract.
+    /// This also triggers paying commission to the operator for accounting simplicity.
+    public entry fun unlock_stake(staker: &signer, operator: address, amount: u64) acquires Store {
+        // Short-circuit if amount is 0.
+        if (amount == 0) return;
+
+        let staker_address = signer::address_of(staker);
+        assert_staking_contract_exists(staker_address, operator);
+
+        let store = borrow_global_mut<Store>(staker_address);
+        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+
+        // Force distribution of any already inactive stake.
+        distribute_internal(staker_address, operator, staking_contract, &mut store.distribute_events);
+
+        // For simplicity, we request commission to be paid out first. This avoids having to ensure to staker doesn't
+        // withdraw into the commission portion.
+        let commission_paid = request_commission_internal(
+            operator,
+            staking_contract,
+            &mut store.add_distribution_events,
+            &mut store.request_commission_events,
+        );
+
+        // If there's less active stake remaining than the amount requested (potentially due to commission),
+        // only withdraw up to the active amount.
+        let (active, _, _, _) = stake::get_stake(staking_contract.pool_address);
+        if (active < amount) {
+            amount = active;
+        };
+        staking_contract.principal = staking_contract.principal - amount;
+
+        // Record a distribution for the staker.
+        add_distribution(
+            operator, staking_contract, staker_address, amount, &mut store.add_distribution_events);
+
+        // Request to unlock the distribution amount from the stake pool.
+        // This won't become fully unlocked until the stake pool's lockup expires.
+        stake::unlock_with_cap(amount, &staking_contract.owner_cap);
+
+        let pool_address = staking_contract.pool_address;
+        emit_event(
+            &mut store.unlock_stake_events,
+            UnlockStakeEvent { pool_address, operator, amount, commission_paid },
+        );
+    }
+
+    /// Unlock all accumulated rewards since the last recorded principals.
+    public entry fun unlock_rewards(staker: &signer, operator: address) acquires Store {
+        let staker_address = signer::address_of(staker);
+        assert_staking_contract_exists(staker_address, operator);
+
+        // Calculate how much rewards belongs to the staker after commission is paid.
+        let (_, accumulated_rewards, unpaid_commission) = staking_contract_amounts(staker_address, operator);
+        let staker_rewards = accumulated_rewards - unpaid_commission;
+        unlock_stake(staker, operator, staker_rewards);
+    }
+
+    /// Allows staker to switch operator without going through the lenghthy process to unstake.
+    public entry fun switch_operator(
+        staker: &signer,
+        old_operator: address,
+        new_operator: address,
+        new_commission_percentage: u64,
+    ) acquires Store {
+        let staker_address = signer::address_of(staker);
+        assert_staking_contract_exists(staker_address, old_operator);
+
+        // Merging two existing staking contracts is too complex as we'd need to merge two separate stake pools.
+        let store = borrow_global_mut<Store>(staker_address);
+        let staking_contracts = &mut store.staking_contracts;
+        assert!(
+            !simple_map::contains_key(staking_contracts, &new_operator),
+            error::invalid_state(ECANT_MERGE_STAKING_CONTRACTS),
+        );
+
+        let (_, staking_contract) = simple_map::remove(staking_contracts, &old_operator);
+        // Force distribution of any already inactive stake.
+        distribute_internal(staker_address, old_operator, &mut staking_contract, &mut store.distribute_events);
+
+        // For simplicity, we request commission to be paid out first. This avoids having to ensure to staker doesn't
+        // withdraw into the commission portion.
+        request_commission_internal(
+            old_operator,
+            &mut staking_contract,
+            &mut store.add_distribution_events,
+            &mut store.request_commission_events,
+        );
+
+        // Update the staking contract's commission rate and stake pool's operator.
+        stake::set_operator_with_cap(&staking_contract.owner_cap, new_operator);
+        staking_contract.commission_percentage = new_commission_percentage;
+
+        let pool_address = staking_contract.pool_address;
+        simple_map::add(staking_contracts, new_operator, staking_contract);
+        emit_event(
+            &mut store.switch_operator_events,
+            SwitchOperatorEvent { pool_address, old_operator, new_operator }
+        );
+    }
+
+    /// Allow anyone to distribute already unlocked funds. This does not affect reward compounding and therefore does
+    /// not need to be restricted to just the staker or operator.
+    public entry fun distribute(staker: address, operator: address) acquires Store {
+        assert_staking_contract_exists(staker, operator);
+        let store = borrow_global_mut<Store>(staker);
+        let staking_contract = simple_map::borrow_mut(&mut store.staking_contracts, &operator);
+        distribute_internal(staker, operator, staking_contract, &mut store.distribute_events);
+    }
+
+    /// Distribute all unlocked (inactive) funds according to distribution shares.
+    fun distribute_internal(
+        staker: address,
+        operator: address,
+        staking_contract: &mut StakingContract,
+        distribute_events: &mut EventHandle<DistributeEvent>,
+    ) {
+        let pool_address = staking_contract.pool_address;
+        let (_, inactive, _, pending_inactive) = stake::get_stake(pool_address);
+        let total_potential_withdrawable = inactive + pending_inactive;
+        let coins = stake::withdraw_with_cap(&staking_contract.owner_cap, total_potential_withdrawable);
+        let distribution_amount =  coin::value(&coins);
+        if (distribution_amount == 0) {
+            coin::destroy_zero(coins);
+            return
+        };
+
+        let distribution_pool = &mut staking_contract.distribution_pool;
+        update_distribution_pool(
+            distribution_pool, distribution_amount, operator, staking_contract.commission_percentage);
+
+        // Buy all recipients out of the distribution pool.
+        while (pool_u64::shareholders_count(distribution_pool) > 0) {
+            let recipients = pool_u64::shareholders(distribution_pool);
+            let recipient = *vector::borrow(&mut recipients, 0);
+            let current_shares = pool_u64::shares(distribution_pool, recipient);
+            let amount_to_distribute = pool_u64::redeem_shares(distribution_pool, recipient, current_shares);
+            coin::deposit(recipient, coin::extract(&mut coins, amount_to_distribute));
+
+            emit_event(
+                distribute_events,
+                DistributeEvent { operator, pool_address, recipient, amount: amount_to_distribute }
+            );
+        };
+
+        // In case there's any dust left, send them all to the staker.
+        if (coin::value(&coins) > 0) {
+            coin::deposit(staker, coins);
+        } else {
+            coin::destroy_zero(coins);
+        }
+    }
+
+    // Assert that a staking_contract exists for the staker/operator pair.
+    fun assert_staking_contract_exists(staker: address, operator: address) acquires Store {
+        assert!(exists<Store>(staker), error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_STAKER));
+        let staking_contracts = &mut borrow_global_mut<Store>(staker).staking_contracts;
+        assert!(
+            simple_map::contains_key(staking_contracts, &operator),
+            error::not_found(ENO_STAKING_CONTRACT_FOUND_FOR_OPERATOR),
+        );
+    }
+
+    // Add a new distribution for `recipient` and `amount` to the staking contract's distributions list.
+    fun add_distribution(
+        operator: address,
+        staking_contract: &mut StakingContract,
+        recipient: address,
+        coins_amount: u64,
+        add_distribution_events: &mut EventHandle<AddDistributionEvent>,
+    ) {
+        let distribution_pool = &mut staking_contract.distribution_pool;
+        let (_, _, _, total_distribution_amount) = stake::get_stake(staking_contract.pool_address);
+        update_distribution_pool(
+            distribution_pool, total_distribution_amount, operator, staking_contract.commission_percentage);
+
+        pool_u64::buy_in(distribution_pool, recipient, coins_amount);
+        let pool_address = staking_contract.pool_address;
+        emit_event(
+            add_distribution_events,
+            AddDistributionEvent { operator, pool_address, amount: coins_amount }
+        );
+    }
+
+    // Calculate accumulated rewards and commissions since last update.
+    fun get_staking_contract_amounts_internal(staking_contract: &StakingContract): (u64, u64, u64) {
+        // Pending_inactive is not included in the calculation because pending_inactive can only come from:
+        // 1. Outgoing commissions. This means commission has already been extracted.
+        // 2. Stake withdrawals from stakers. This also means commission has already been extracted as
+        // request_commission_internal is called in unlock_stake
+        let (active, _, pending_active, _) = stake::get_stake(staking_contract.pool_address);
+        let total_active_stake = active + pending_active;
+        let accumulated_rewards = total_active_stake - staking_contract.principal;
+        let commission_amount = accumulated_rewards * staking_contract.commission_percentage / 100;
+
+        (total_active_stake, accumulated_rewards, commission_amount)
+    }
+
+    fun create_stake_pool(
+        staker: &signer,
+        operator: address,
+        voter: address,
+        contract_creation_seed: vector<u8>,
+    ): (signer, SignerCapability, OwnerCapability)  {
+        // Generate a seed that will be used to create the resource account that hosts the staking contract.
+        let seed = bcs::to_bytes(&signer::address_of(staker));
+        vector::append(&mut seed, bcs::to_bytes(&operator));
+        // Include a salt to avoid conflicts with any other modules out there that might also generate
+        // deterministic resource accounts for the same staker + operator addresses.
+        vector::append(&mut seed, SALT);
+        // Add an extra salt given by the staker in case an account with the same address has already been created.
+        vector::append(&mut seed, contract_creation_seed);
+
+        let (stake_pool_signer, stake_pool_signer_cap) = account::create_resource_account(staker, seed);
+        stake::initialize_stake_owner(&stake_pool_signer, 0, operator, voter);
+
+        // Extract owner_cap from the StakePool, so we have control over it in the staking_contracts flow.
+        // This is stored as part of the staking_contract. Thus, the staker would not have direct control over it without
+        // going through well-defined functions in this module.
+        let owner_cap = stake::extract_owner_cap(&stake_pool_signer);
+
+        (stake_pool_signer, stake_pool_signer_cap, owner_cap)
+    }
+
+    fun update_distribution_pool(
+        distribution_pool: &mut Pool,
+        updated_total_coins: u64,
+        operator: address,
+        commission_percentage: u64,
+    ) {
+        // Short-circuit and do nothing if the pool's total value has not changed.
+        if (pool_u64::total_coins(distribution_pool) == updated_total_coins) {
+            return
+        };
+
+        // Charge all stakeholders (except for the operator themselves) commission on any rewards earnt relatively to the
+        // previous value of the distribution pool.
+        let shareholders = &pool_u64::shareholders(distribution_pool);
+        let len = vector::length(shareholders);
+        let i = 0;
+        while (i < len) {
+            let shareholder = *vector::borrow(shareholders, i);
+            if (shareholder != operator) {
+                let shares = pool_u64::shares(distribution_pool, shareholder);
+                let previous_worth = pool_u64::balance(distribution_pool, shareholder);
+                let current_worth = pool_u64::shares_to_amount_with_total_coins(
+                    distribution_pool, shares, updated_total_coins);
+                let unpaid_commission = (current_worth - previous_worth) * commission_percentage / 100;
+                // Transfer shares from current shareholder to the operator as payment.
+                // The value of the shares should use the updated pool's total value.
+                let shares_to_transfer = pool_u64::amount_to_shares_with_total_coins(
+                    distribution_pool, unpaid_commission, updated_total_coins);
+                pool_u64::transfer_shares(distribution_pool, shareholder, operator, shares_to_transfer);
+            };
+
+            i = i + 1;
+        };
+
+        pool_u64::update_total_coins(distribution_pool, updated_total_coins);
+    }
+
+    // Create a new staking_contracts resource.
+    fun new_staking_contracts_holder(staker: &signer): Store {
+        Store {
+            staking_contracts: simple_map::create<address, StakingContract>(),
+
+            // Events.
+            create_staking_contract_events: account::new_event_handle<CreateStakingContractEvent>(staker),
+            update_voter_events: account::new_event_handle<UpdateVoterEvent>(staker),
+            reset_lockup_events: account::new_event_handle<ResetLockupEvent>(staker),
+            add_stake_events: account::new_event_handle<AddStakeEvent>(staker),
+            request_commission_events: account::new_event_handle<RequestCommissionEvent>(staker),
+            unlock_stake_events: account::new_event_handle<UnlockStakeEvent>(staker),
+            switch_operator_events: account::new_event_handle<SwitchOperatorEvent>(staker),
+            add_distribution_events: account::new_event_handle<AddDistributionEvent>(staker),
+            distribute_events: account::new_event_handle<DistributeEvent>(staker),
+        }
+    }
+
+    #[test_only]
+    const VALIDATOR_STATUS_ACTIVE: u64 = 2;
+    #[test_only]
+    const VALIDATOR_STATUS_INACTIVE: u64 = 4;
+
+    #[test_only]
+    use aptos_framework::stake::with_rewards;
+
+    #[test_only]
+    const INITIAL_BALANCE: u64 = 100000000000000; // 1M APT coins with 8 decimals.
+
+    #[test_only]
+    const MAXIMUM_STAKE: u64 = 100000000000000000; // 1B APT coins with 8 decimals.
+
+    #[test_only]
+    public fun setup(aptos_framework: &signer, staker: &signer, operator: &signer, initial_balance: u64) {
+        // Reward rate of 0.1% per epoch.
+        stake::initialize_for_test_custom(aptos_framework, INITIAL_BALANCE, MAXIMUM_STAKE, 3600, true, 10, 10000, 1000000);
+
+        account::create_account_for_test(signer::address_of(staker));
+        account::create_account_for_test(signer::address_of(operator));
+        stake::mint(staker, initial_balance);
+        stake::mint(operator, initial_balance);
+    }
+
+    #[test_only]
+    public fun setup_staking_contract(
+        aptos_framework: &signer,
+        staker: &signer,
+        operator: &signer,
+        amount: u64,
+        commission: u64,
+    ) acquires Store {
+        setup(aptos_framework, staker, operator, amount);
+        let operator_address = signer::address_of(operator);
+
+        // Voter is initially set to operator but then updated to be staker.
+        create_staking_contract(staker, operator_address, operator_address, amount, commission, vector::empty<u8>());
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_end_to_end(aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store {
+        setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+        assert_staking_contract_exists(staker_address, operator_address);
+        assert_staking_contract(staker_address, operator_address, INITIAL_BALANCE, 10);
+
+        // Verify that the stake pool has been set up properly.
+        let pool_address = stake_pool_address(staker_address, operator_address);
+        stake::assert_stake_pool(pool_address, INITIAL_BALANCE, 0, 0, 0);
+        assert!(last_recorded_principal(staker_address, operator_address) == INITIAL_BALANCE, 0);
+
+        // Operator joins the validator set.
+        stake::join_validator_set_for_test(operator, pool_address, true);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 1);
+
+        // Fast forward to generate rewards.
+        stake::end_epoch();
+        let new_balance = with_rewards(INITIAL_BALANCE);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
+
+        // Operator claims 10% of rewards so far as commissions.
+        let expected_commission_1 = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        new_balance = new_balance - expected_commission_1;
+        request_commission(operator, staker_address, operator_address);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, expected_commission_1);
+        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+        assert_distribution(staker_address, operator_address, operator_address, expected_commission_1);
+        stake::fast_forward_to_unlock(pool_address);
+
+        // Both original stake and operator commissions have received rewards.
+        expected_commission_1 = with_rewards(expected_commission_1);
+        new_balance = with_rewards(new_balance);
+        stake::assert_stake_pool(pool_address, new_balance, expected_commission_1, 0, 0);
+        distribute(staker_address, operator_address);
+        let operator_balance = coin::balance<AptosCoin>(operator_address);
+        let expected_operator_balance = INITIAL_BALANCE + expected_commission_1;
+        assert!(operator_balance == expected_operator_balance, operator_balance);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
+        assert_no_pending_distributions(staker_address, operator_address);
+
+        // Staker adds more stake.
+        stake::mint(staker, INITIAL_BALANCE);
+        let previous_principal = last_recorded_principal(staker_address, operator_address);
+        add_stake(staker, operator_address, INITIAL_BALANCE);
+        stake::assert_stake_pool(pool_address, new_balance, 0, INITIAL_BALANCE, 0);
+        assert!(last_recorded_principal(staker_address, operator_address) == previous_principal + INITIAL_BALANCE, 0);
+
+        // The newly added stake didn't receive any rewards because it was only added in the new epoch.
+        stake::end_epoch();
+        new_balance = with_rewards(new_balance) + INITIAL_BALANCE;
+
+        // Second round of commission request/withdrawal.
+        let expected_commission_2 = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        new_balance = new_balance - expected_commission_2;
+        request_commission(operator, staker_address, operator_address);
+        assert_distribution(staker_address, operator_address, operator_address, expected_commission_2);
+        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+        stake::fast_forward_to_unlock(pool_address);
+        expected_commission_2 = with_rewards(expected_commission_2);
+        distribute(staker_address, operator_address);
+        operator_balance = coin::balance<AptosCoin>(operator_address);
+        expected_operator_balance = expected_operator_balance + expected_commission_2;
+        assert!(operator_balance == expected_operator_balance, operator_balance);
+        assert_no_pending_distributions(staker_address, operator_address);
+        new_balance = with_rewards(new_balance);
+
+        // New rounds of rewards.
+        stake::fast_forward_to_unlock(pool_address);
+        new_balance = with_rewards(new_balance);
+
+        // Staker withdraws all stake, which should also request commission distribution.
+        let unpaid_commission = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        unlock_stake(staker, operator_address, new_balance);
+        stake::assert_stake_pool(pool_address, 0, 0, 0, new_balance);
+        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission);
+        let withdrawn_amount = new_balance - unpaid_commission;
+        assert_distribution(staker_address, operator_address, staker_address, withdrawn_amount);
+        assert!(last_recorded_principal(staker_address, operator_address) == 0, 0);
+
+        // End epoch. The stake pool should get kicked out of the validator set as it has 0 remaining active stake.
+        stake::fast_forward_to_unlock(pool_address);
+        // Operator should still earn 10% commission on the rewards on top of the staker's withdrawn_amount.
+        let commission_on_withdrawn_amount = (with_rewards(withdrawn_amount) - withdrawn_amount) / 10;
+        unpaid_commission = with_rewards(unpaid_commission) + commission_on_withdrawn_amount;
+        withdrawn_amount = with_rewards(withdrawn_amount) - commission_on_withdrawn_amount;
+        stake::assert_stake_pool(pool_address, 0, with_rewards(new_balance), 0, 0);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE, 0);
+
+        // Distribute and verify balances.
+        distribute(staker_address, operator_address);
+        assert_no_pending_distributions(staker_address, operator_address);
+        operator_balance = coin::balance<AptosCoin>(operator_address);
+        assert!(operator_balance == expected_operator_balance + unpaid_commission, operator_balance);
+        let staker_balance = coin::balance<AptosCoin>(staker_address);
+        // Staker receives the extra dust due to rounding error.
+        assert!(staker_balance == withdrawn_amount + 1, staker_balance);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_operator_cannot_request_same_commission_multiple_times(
+        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store {
+
+        setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+        let pool_address = stake_pool_address(staker_address, operator_address);
+
+        // Operator joins the validator set.
+        stake::join_validator_set_for_test(operator, pool_address, true);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 1);
+
+        // Fast forward to generate rewards.
+        stake::end_epoch();
+        let new_balance = with_rewards(INITIAL_BALANCE);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
+
+        // Operator tries to request commision multiple times. But their distribution shouldn't change.
+        let expected_commission = (new_balance - last_recorded_principal(staker_address, operator_address)) / 10;
+        request_commission(operator, staker_address, operator_address);
+        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+        request_commission(operator, staker_address, operator_address);
+        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+        request_commission(operator, staker_address, operator_address);
+        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_unlock_rewards(
+        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store {
+
+        setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+        let pool_address = stake_pool_address(staker_address, operator_address);
+
+        // Operator joins the validator set.
+        stake::join_validator_set_for_test(operator, pool_address, true);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 1);
+
+        // Fast forward to generate rewards.
+        stake::end_epoch();
+        let new_balance = with_rewards(INITIAL_BALANCE);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
+
+        // Staker withdraws all accumulated rewards, which should pay commission first.
+        unlock_rewards(staker, operator_address);
+        let accumulated_rewards = new_balance - INITIAL_BALANCE;
+        let expected_commission = accumulated_rewards / 10;
+        let staker_rewards = accumulated_rewards - expected_commission;
+        assert_distribution(staker_address, operator_address, staker_address, staker_rewards);
+        assert_distribution(staker_address, operator_address, operator_address, expected_commission);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    #[expected_failure(abort_code = 0x80006)]
+    public entry fun test_staker_cannot_create_same_staking_contract_multiple_times(
+        aptos_framework: &signer,
+        staker: &signer,
+        operator: &signer,
+    ) acquires Store {
+        setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
+        let operator_address = signer::address_of(operator);
+        stake::mint(staker, INITIAL_BALANCE);
+        create_staking_contract(staker, operator_address, operator_address, INITIAL_BALANCE, 10, vector::empty<u8>());
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    #[expected_failure(abort_code = 0x10002)]
+    public entry fun test_staker_cannot_create_staking_contract_with_invalid_commission(
+        aptos_framework: &signer,
+        staker: &signer,
+        operator: &signer,
+    ) acquires Store {
+        setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 101);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    #[expected_failure(abort_code = 0x10001)]
+    public entry fun test_staker_cannot_create_staking_contract_with_less_than_min_stake_required(
+        aptos_framework: &signer,
+        staker: &signer,
+        operator: &signer,
+    ) acquires Store {
+        setup_staking_contract(aptos_framework, staker, operator, 50, 100);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_update_voter(
+        aptos_framework: &signer,
+        staker: &signer,
+        operator: &signer,
+    ) acquires Store {
+        setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+
+        // Voter is initially set to operator but then updated to be staker.
+        let pool_address = stake_pool_address(staker_address, operator_address);
+        assert!(stake::get_delegated_voter(pool_address) == operator_address, 0);
+        update_voter(staker, operator_address, staker_address);
+        assert!(stake::get_delegated_voter(pool_address) == staker_address, 1);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_reset_lockup(
+        aptos_framework: &signer,
+        staker: &signer,
+        operator: &signer,
+    ) acquires Store {
+        setup_staking_contract(aptos_framework, staker, operator, INITIAL_BALANCE, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+        let pool_address = stake_pool_address(staker_address, operator_address);
+
+        let origin_lockup_expiration = stake::get_lockup_secs(pool_address);
+        reset_lockup(staker, operator_address);
+        assert!(origin_lockup_expiration < stake::get_lockup_secs(pool_address), 0);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator_1 = @0x234, operator_2 = @0x345)]
+    public entry fun test_staker_can_switch_operator(
+        aptos_framework: &signer,
+        staker: &signer,
+        operator_1: &signer,
+        operator_2: &signer,
+    ) acquires Store {
+        setup_staking_contract(aptos_framework, staker, operator_1, INITIAL_BALANCE, 10);
+        account::create_account_for_test(signer::address_of(operator_2));
+        stake::mint(operator_2, INITIAL_BALANCE);
+        let staker_address = signer::address_of(staker);
+        let operator_1_address = signer::address_of(operator_1);
+        let operator_2_address = signer::address_of(operator_2);
+
+        // Join validator set and earn some rewards.
+        let pool_address = stake_pool_address(staker_address, operator_1_address);
+        stake::join_validator_set_for_test(operator_1, pool_address, true);
+        stake::end_epoch();
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 0);
+
+        // Switch operators.
+        switch_operator(staker, operator_1_address, operator_2_address, 20);
+        // The staking_contract is now associated with operator 2 but there should be a pending distribution of unpaid
+        // commission to operator 1.
+        let new_balance = with_rewards(INITIAL_BALANCE);
+        let commission_for_operator_1 = (new_balance - INITIAL_BALANCE) / 10;
+        assert_distribution(staker_address, operator_2_address, operator_1_address, commission_for_operator_1);
+        // Unpaid commission should be unlocked from the stake pool.
+        new_balance = new_balance - commission_for_operator_1;
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, commission_for_operator_1);
+        assert!(last_recorded_principal(staker_address, operator_2_address) == new_balance, 0);
+
+        // The stake pool's validator should not have left the validator set.
+        assert!(stake_pool_address(staker_address, operator_2_address) == pool_address, 1);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 2);
+
+        // End epoch to get more rewards.
+        stake::fast_forward_to_unlock(pool_address);
+        new_balance = with_rewards(new_balance);
+        // Rewards on the commission being paid to operator_1 should still be charged commission that will go to
+        // operator_2;
+        let commission_on_operator_1_distribution =
+            (with_rewards(commission_for_operator_1) - commission_for_operator_1) / 5;
+        commission_for_operator_1 = with_rewards(commission_for_operator_1) - commission_on_operator_1_distribution;
+
+        // Verify that when commissions are withdrawn, previous pending distribution to operator 1 also happens.
+        // Then new commission of 20% is paid to operator 2.
+        let commission_for_operator_2 =
+            (new_balance - last_recorded_principal(staker_address, operator_2_address)) / 5;
+        new_balance = new_balance - commission_for_operator_2;
+        request_commission(operator_2, staker_address, operator_2_address);
+        assert_distribution(staker_address, operator_2_address, operator_2_address, commission_for_operator_2);
+        let operator_1_balance = coin::balance<AptosCoin>(operator_1_address);
+        assert!(operator_1_balance == INITIAL_BALANCE + commission_for_operator_1, operator_1_balance);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, commission_for_operator_2);
+        assert!(last_recorded_principal(staker_address, operator_2_address) == new_balance, 0);
+        stake::fast_forward_to_unlock(pool_address);
+
+        // Operator 2's commission is distributed.
+        distribute(staker_address, operator_2_address);
+        let operator_2_balance = coin::balance<AptosCoin>(operator_2_address);
+        new_balance = with_rewards(new_balance);
+        commission_for_operator_2 = with_rewards(commission_for_operator_2);
+        assert!(
+            operator_2_balance == INITIAL_BALANCE + commission_for_operator_2 + commission_on_operator_1_distribution,
+            operator_2_balance,
+        );
+        stake::assert_stake_pool(
+            pool_address,
+            new_balance,
+            0,
+            0,
+            0,
+        );
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_staker_can_withdraw_partial_stake(
+        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store {
+        let initial_balance = INITIAL_BALANCE * 2;
+        setup_staking_contract(aptos_framework, staker, operator, initial_balance, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+        let pool_address = stake_pool_address(staker_address, operator_address);
+
+        // Operator joins the validator set so rewards are generated.
+        stake::join_validator_set_for_test(operator, pool_address, true);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 1);
+
+        // Fast forward to generate rewards.
+        stake::end_epoch();
+        let new_balance = with_rewards(initial_balance);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
+
+        // Staker withdraws 1/4 of the stake, which should also request commission distribution.
+        let withdrawn_stake = new_balance / 4;
+        let unpaid_commission = (new_balance - initial_balance) / 10;
+        let new_balance = new_balance - withdrawn_stake - unpaid_commission;
+        unlock_stake(staker, operator_address, withdrawn_stake);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake + unpaid_commission);
+        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission);
+        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
+        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+
+        // The validator is still in the active set as its remaining stake is still above min required.
+        stake::fast_forward_to_unlock(pool_address);
+        new_balance = with_rewards(new_balance);
+        unpaid_commission = with_rewards(unpaid_commission);
+        // Commission should still be charged on the rewards on top of withdrawn_stake.
+        // So the operator should receive 10% of the rewards on top of withdrawn_stake.
+        let commission_on_withdrawn_stake = (with_rewards(withdrawn_stake) - withdrawn_stake) / 10;
+        unpaid_commission = unpaid_commission + commission_on_withdrawn_stake;
+        withdrawn_stake = with_rewards(withdrawn_stake) - commission_on_withdrawn_stake;
+        stake::assert_stake_pool(pool_address, new_balance, withdrawn_stake + unpaid_commission, 0, 0);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 0);
+
+        // Distribute and verify balances.
+        distribute(staker_address, operator_address);
+        assert_no_pending_distributions(staker_address, operator_address);
+        let operator_balance = coin::balance<AptosCoin>(operator_address);
+        assert!(operator_balance == initial_balance + unpaid_commission, operator_balance);
+        let staker_balance = coin::balance<AptosCoin>(staker_address);
+        assert!(staker_balance == withdrawn_stake, staker_balance);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_staker_can_withdraw_partial_stake_if_operator_never_joined_validator_set(
+        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store {
+        let initial_balance = INITIAL_BALANCE * 2;
+        setup_staking_contract(aptos_framework, staker, operator, initial_balance, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+        let pool_address = stake_pool_address(staker_address, operator_address);
+
+        // Epoch ended, but since validator never joined the set, no rewards were minted.
+        stake::end_epoch();
+        stake::assert_stake_pool(pool_address, initial_balance, 0, 0, 0);
+
+        // Staker withdraws 1/4 of the stake, which doesn't create any commission distribution as there's no rewards.
+        let withdrawn_stake = initial_balance / 4;
+        let new_balance = initial_balance - withdrawn_stake;
+        unlock_stake(staker, operator_address, withdrawn_stake);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake);
+        assert_distribution(staker_address, operator_address, operator_address, 0);
+        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
+        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+
+        // Distribute and verify balances.
+        distribute(staker_address, operator_address);
+        assert_no_pending_distributions(staker_address, operator_address);
+        // Operator's balance shouldn't change as there are no rewards.
+        let operator_balance = coin::balance<AptosCoin>(operator_address);
+        assert!(operator_balance == initial_balance, operator_balance);
+        // Staker receives back the withdrawn amount (no rewards).
+        let staker_balance = coin::balance<AptosCoin>(staker_address);
+        assert!(staker_balance == withdrawn_stake, staker_balance);
+    }
+
+    #[test(aptos_framework = @0x1, staker = @0x123, operator = @0x234)]
+    public entry fun test_multiple_distributions_added_before_distribute(
+        aptos_framework: &signer, staker: &signer, operator: &signer) acquires Store {
+        let initial_balance = INITIAL_BALANCE * 2;
+        setup_staking_contract(aptos_framework, staker, operator, initial_balance, 10);
+        let staker_address = signer::address_of(staker);
+        let operator_address = signer::address_of(operator);
+        let pool_address = stake_pool_address(staker_address, operator_address);
+
+        // Operator joins the validator set so rewards are generated.
+        stake::join_validator_set_for_test(operator, pool_address, true);
+        assert!(stake::get_validator_state(pool_address) == VALIDATOR_STATUS_ACTIVE, 1);
+
+        // Fast forward to generate rewards.
+        stake::end_epoch();
+        let new_balance = with_rewards(initial_balance);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, 0);
+
+        // Staker withdraws 1/4 of the stake, which should also request commission distribution.
+        let withdrawn_stake = new_balance / 4;
+        let unpaid_commission = (new_balance - initial_balance) / 10;
+        let new_balance = new_balance - withdrawn_stake - unpaid_commission;
+        unlock_stake(staker, operator_address, withdrawn_stake);
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake + unpaid_commission);
+        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission);
+        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
+        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+
+        // End epoch to generate some rewards. Staker withdraws another 1/4 of the stake.
+        // Commission should be charged on the the rewards earned on the previous 1/4 stake withdrawal.
+        stake::end_epoch();
+        let commission_on_withdrawn_stake = (with_rewards(withdrawn_stake) - withdrawn_stake) / 10;
+        let commission_on_new_balance = (with_rewards(new_balance) - new_balance) / 10;
+        unpaid_commission = with_rewards(unpaid_commission) + commission_on_withdrawn_stake + commission_on_new_balance;
+        new_balance = with_rewards(new_balance) - commission_on_new_balance;
+        let new_withdrawn_stake = new_balance / 4;
+        unlock_stake(staker, operator_address, new_withdrawn_stake);
+        new_balance = new_balance - new_withdrawn_stake;
+        withdrawn_stake = with_rewards(withdrawn_stake) - commission_on_withdrawn_stake + new_withdrawn_stake;
+        stake::assert_stake_pool(pool_address, new_balance, 0, 0, withdrawn_stake + unpaid_commission);
+        // There's some small rounding error here.
+        assert_distribution(staker_address, operator_address, operator_address, unpaid_commission - 1);
+        assert_distribution(staker_address, operator_address, staker_address, withdrawn_stake);
+        assert!(last_recorded_principal(staker_address, operator_address) == new_balance, 0);
+    }
+
+    #[test_only]
+    public fun assert_staking_contract(
+        staker: address, operator: address, principal: u64, commission_percentage: u64) acquires Store {
+        let staking_contract = simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
+        assert!(staking_contract.principal == principal, staking_contract.principal);
+        assert!(staking_contract.commission_percentage == commission_percentage, staking_contract.commission_percentage);
+    }
+
+    #[test_only]
+    public fun assert_no_pending_distributions(staker: address, operator: address) acquires Store {
+        let staking_contract = simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
+        let shareholders_count = pool_u64::shareholders_count(&staking_contract.distribution_pool);
+        assert!(shareholders_count == 0, shareholders_count);
+    }
+
+    #[test_only]
+    public fun assert_distribution(
+        staker: address, operator: address, recipient: address, coins_amount: u64) acquires Store {
+        let staking_contract = simple_map::borrow(&borrow_global<Store>(staker).staking_contracts, &operator);
+        let distribution_balance = pool_u64::balance(&staking_contract.distribution_pool, recipient);
+        assert!(distribution_balance == coins_amount, distribution_balance);
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/system_addresses.move
+++ b/aptos-move/framework/aptos-framework/sources/system_addresses.move
@@ -31,22 +31,27 @@ module aptos_framework::system_addresses {
     }
 
     public fun assert_framework_reserved_address(account: &signer) {
-        let addr = signer::address_of(account);
         assert!(
-            addr == @aptos_framework ||
-            addr == @0x2 ||
-            addr == @0x3 ||
-            addr == @0x4 ||
-            addr == @0x5 ||
-            addr == @0x6 ||
-            addr == @0x7 ||
-            addr == @0x8 ||
-            addr == @0x9 ||
-            addr == @0xa,
+            is_framework_reserved_address(signer::address_of(account)),
             error::permission_denied(ENOT_FRAMEWORK_RESERVED_ADDRESS),
         )
     }
 
+    /// Return true if `addr` is 0x0 or under the on chain governance's control.
+    public fun is_framework_reserved_address(addr: address): bool {
+        is_aptos_framework_address(addr) ||
+        addr == @0x2 ||
+        addr == @0x3 ||
+        addr == @0x4 ||
+        addr == @0x5 ||
+        addr == @0x6 ||
+        addr == @0x7 ||
+        addr == @0x8 ||
+        addr == @0x9 ||
+        addr == @0xa
+    }
+
+    /// Return true if `addr` is 0x1.
     public fun is_aptos_framework_address(addr: address): bool {
         addr == @aptos_framework
     }
@@ -56,7 +61,18 @@ module aptos_framework::system_addresses {
         assert!(is_vm(account), error::permission_denied(EVM))
     }
 
+    /// Return true if `addr` is a reserved address for the VM to call system modules.
     public fun is_vm(account: &signer): bool {
-        signer::address_of(account) == @vm_reserved
+        is_vm_address(signer::address_of(account))
+    }
+
+    /// Return true if `addr` is a reserved address for the VM to call system modules.
+    public fun is_vm_address(addr: address): bool {
+        addr == @vm_reserved
+    }
+
+    /// Return true if `addr` is either the VM address or an Aptos Framework address.
+    public fun is_reserved_address(addr: address): bool {
+        is_aptos_framework_address(addr) || is_vm_address(addr)
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/timestamp.move
+++ b/aptos-move/framework/aptos-framework/sources/timestamp.move
@@ -73,7 +73,12 @@ module aptos_framework::timestamp {
     }
 
     #[test_only]
+    public fun update_global_time_for_test_secs(timestamp_seconds: u64) acquires CurrentTimeMicroseconds {
+        update_global_time_for_test(timestamp_seconds * 1000000);
+    }
+
+    #[test_only]
     public fun fast_forward_seconds(timestamp_seconds: u64) acquires CurrentTimeMicroseconds {
-        update_global_time_for_test(now_microseconds() + timestamp_seconds * 1000000);
+        update_global_time_for_test_secs(now_seconds() + timestamp_seconds);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -1,0 +1,1251 @@
+/*
+ * Simple vesting contract that allows specifying how much APT coins should be vesting in each fixed-size period. The
+ * vesting contract also comes with staking and allows shareholders to withdraw rewards anytime.
+ *
+ * Vesting schedule is represented as a vector of distributions. For example, a vesting schedule of
+ * [3/48, 3/48, 1/48] means that after the vesting starts:
+ * 1. The first and second periods will vest 3/48 of the total original grant.
+ * 2. The third period will vest 1/48.
+ * 3. All subsequent periods will also vest 1/48 (last distribution in the schedule) until the original grant runs out.
+ *
+ * Shareholder flow:
+ * 1. Admin calls create_vesting_contract with a schedule of [3/48, 3/48, 1/48] with a vesting cliff of 1 year and
+ * vesting period of 1 month.
+ * 2. After a month, a shareholder calls unlock_rewards to request rewards. They can also call vest() which would also
+ * unlocks rewards but since the 1 year cliff has not passed (vesting has not started), vest() would not release any of
+ * the original grant.
+ * 3. After the unlocked rewards become fully withdrawable (as it's subject to staking lockup), shareholders can call
+ * distribute() to send all withdrawable funds to all shareholders based on the original grant's shares structure.
+ * 4. After 1 year and 1 month, the vesting schedule now starts. Shareholders call vest() to unlock vested coins. vest()
+ * checks the schedule and unlocks 3/48 of the original grant in addition to any accumulated rewards since last
+ * unlock_rewards(). Once the unlocked coins become withdrawable, shareholders can call distribute().
+ * 5. Assuming the shareholders forgot to call vest() for 2 months, when they call vest() again, they will unlock vested
+ * tokens for the next period since last vest. This would be for the first month they missed. They can call vest() a
+ * second time to unlock for the second month they missed.
+ *
+ * Admin flow:
+ * 1. After creating the vesting contract, admin cannot change the vesting schedule.
+ * 2. Admin can call update_voter, update_operator, or reset_lockup at any time to update the underlying staking
+ * contract.
+ * 3. Admin can also call update_beneficiary for any shareholder. This would send all distributions (rewards, vested
+ * coins) of that shareholder to the beneficiary account. By defalt, if a beneficiary is not set, the distributions are
+ * send directly to the shareholder account.
+ * 4. Admin can call terminate_vesting_contract to terminate the vesting. This would first finish any distribution but
+ * will prevent any further rewards or vesting distributions from being created. Once the locked up stake becomes
+ * withdrawable, admin can call admin_withdraw to withdraw all funds to the vesting contract's withdrawal address.
+ */
+module aptos_framework::vesting {
+    use std::bcs;
+    use std::error;
+    use std::fixed_point32::{Self, FixedPoint32};
+    use std::signer;
+    use std::vector;
+
+    use aptos_std::event::{EventHandle, emit_event};
+    use aptos_std::pool_u64::{Self, Pool};
+    use aptos_std::simple_map::{Self, SimpleMap};
+
+    use aptos_framework::account::{Self, SignerCapability, new_event_handle};
+    use aptos_framework::aptos_account::assert_account_is_registered_for_apt;
+    use aptos_framework::aptos_coin::AptosCoin;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::stake;
+    use aptos_framework::staking_contract;
+    use aptos_framework::system_addresses;
+    use aptos_framework::timestamp;
+
+    friend aptos_framework::genesis;
+
+    const VESTING_POOL_SALT: vector<u8> = b"aptos_framework::vesting";
+
+    /// Withdrawal address is invalid.
+    const EINVALID_WITHDRAWAL_ADDRESS: u64 = 1;
+    /// Vesting schedule cannot be empty.
+    const EEMPTY_VESTING_SCHEDULE: u64 = 2;
+    /// Vesting period cannot be 0.
+    const EZERO_VESTING_SCHEDULE_PERIOD: u64 = 3;
+    /// Shareholders list cannot be empty.
+    const ENO_SHAREHOLDERS: u64 = 4;
+    /// The length of shareholders and shares lists don't match.
+    const ESHARES_LENGTH_MISMATCH: u64 = 5;
+    /// Vesting cannot start before or at the current block timestamp. Has to be in the future.
+    const EVESTING_START_TOO_SOON: u64 = 6;
+    /// The signer is not the admin of the vesting contract.
+    const ENOT_ADMIN: u64 = 7;
+    /// Vesting contract needs to be in active state.
+    const EVESTING_CONTRACT_NOT_ACTIVE: u64 = 8;
+    /// Admin can only withdraw from an inactive (paused or terminated) vesting contract.
+    const EVESTING_CONTRACT_STILL_ACTIVE: u64 = 9;
+    /// No vesting contract found at provided address.
+    const EVESTING_CONTRACT_NOT_FOUND: u64 = 10;
+    /// Cannot terminate the vesting contract with pending active stake. Need to wait until next epoch.
+    const EPENDING_STAKE_FOUND: u64 = 11;
+    /// Grant amount cannot be 0.
+    const EZERO_GRANT: u64 = 12;
+
+    /// Maximum number of shareholders a vesting pool can support.
+    const MAXIMUM_SHAREHOLDERS: u64 = 30;
+
+    /// Vesting contract states.
+    /// Vesting contract is active and distributions can be made.
+    const VESTING_POOL_ACTIVE: u64 = 1;
+    /// Vesting contract has been terminated and all funds have been released back to the withdrawal address.
+    const VESTING_POOL_TERMINATED: u64 = 2;
+
+    struct VestingSchedule has copy, drop, store {
+        // The vesting schedule as a list of fractions that vest for each period. The last number is repeated until the
+        // vesting amount runs out.
+        // For example [1/24, 1/24, 1/48] with a period of 1 month means that after vesting starts, the first two months
+        // will vest 1/24 of the original total amount. From the third month only, 1/48 will vest until the vesting fund
+        // runs out.
+        // u32/u32 should be sufficient to support vesting schedule fractions.
+        schedule: vector<FixedPoint32>,
+        // When the vesting should start.
+        start_timestamp_secs: u64,
+        // How long each vesting period is. For example 1 month.
+        period_duration: u64,
+        // Last vesting period, 1-indexed. For example if 2 months have passed, the last vesting period, if distribution
+        // was requested, would be 2. Default value is 0 which means there have been no vesting periods yet.
+        last_vested_period: u64,
+    }
+
+    struct StakingInfo has store {
+        // Where the vesting's stake pool is located at. Included for convenience.
+        pool_address: address,
+        // The currently assigned operator.
+        operator: address,
+        // The currently assigned voter.
+        voter: address,
+        // Commission paid to the operator of the stake pool.
+        commission_percentage: u64,
+    }
+
+    struct VestingContract has key {
+        state: u64,
+        admin: address,
+        grant_pool: Pool,
+        beneficiaries: SimpleMap<address, address>,
+        vesting_schedule: VestingSchedule,
+        // Withdrawal address where all funds would be released back to if the admin ends the vesting for a specific
+        // account or terminates the entire vesting contract.
+        withdrawal_address: address,
+        staking: StakingInfo,
+        // Remaining amount in the grant. For calculating accumulated rewards.
+        remaining_grant: u64,
+        // Used to control staking.
+        signer_cap: SignerCapability,
+
+        // Events.
+        update_operator_events: EventHandle<UpdateOperatorEvent>,
+        update_voter_events: EventHandle<UpdateVoterEvent>,
+        reset_lockup_events: EventHandle<ResetLockupEvent>,
+        set_beneficiary_events: EventHandle<SetBeneficiaryEvent>,
+        unlock_rewards_events: EventHandle<UnlockRewardsEvent>,
+        vest_events: EventHandle<VestEvent>,
+        distribute_events: EventHandle<DistributeEvent>,
+        terminate_events: EventHandle<TerminateEvent>,
+        admin_withdraw_events: EventHandle<AdminWithdrawEvent>,
+    }
+
+    struct AdminStore has key {
+        vesting_contracts: vector<address>,
+        // Used to create resource accounts for new vesting contracts so there's no address collision.
+        nonce: u64,
+
+        create_events: EventHandle<CreateVestingContractEvent>,
+    }
+
+    struct CreateVestingContractEvent has drop, store {
+        operator: address,
+        voter: address,
+        grant_amount: u64,
+        withdrawal_address: address,
+        vesting_contract_address: address,
+        staking_pool_address: address,
+        commission_percentage: u64,
+    }
+
+    struct UpdateOperatorEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        staking_pool_address: address,
+        old_operator: address,
+        new_operator: address,
+        commission_percentage: u64,
+    }
+
+    struct UpdateVoterEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        staking_pool_address: address,
+        old_voter: address,
+        new_voter: address,
+    }
+
+    struct ResetLockupEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        staking_pool_address: address,
+        new_lockup_expiration_secs: u64,
+    }
+
+    struct SetBeneficiaryEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        shareholder: address,
+        old_beneficiary: address,
+        new_beneficiary: address,
+    }
+
+    struct UnlockRewardsEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        staking_pool_address: address,
+        amount: u64,
+    }
+
+    struct VestEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        staking_pool_address: address,
+        period_vested: u64,
+        amount: u64,
+    }
+
+    struct DistributeEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        amount: u64,
+    }
+
+    struct TerminateEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+    }
+
+    struct AdminWithdrawEvent has drop, store {
+        admin: address,
+        vesting_contract_address: address,
+        amount: u64,
+    }
+
+    public fun stake_pool_address(vesting_contract_address: address): address acquires VestingContract {
+        assert_vesting_contract_exists(vesting_contract_address);
+        borrow_global<VestingContract>(vesting_contract_address).staking.pool_address
+    }
+
+    public fun vesting_start_secs(vesting_contract_address: address): u64 acquires VestingContract {
+        assert_vesting_contract_exists(vesting_contract_address);
+        borrow_global<VestingContract>(vesting_contract_address).vesting_schedule.start_timestamp_secs
+    }
+
+    public fun remaining_grant(vesting_contract_address: address): u64 acquires VestingContract {
+        assert_vesting_contract_exists(vesting_contract_address);
+        borrow_global<VestingContract>(vesting_contract_address).remaining_grant
+    }
+
+    public fun beneficiary(vesting_contract_address: address, shareholder: address): address acquires VestingContract {
+        assert_vesting_contract_exists(vesting_contract_address);
+        get_beneficiary(borrow_global<VestingContract>(vesting_contract_address), shareholder)
+    }
+
+    /// Create a vesting schedule with the given schedule of distributions, a vesting start time and period duration.
+    public fun create_vesting_schedule(
+        schedule: vector<FixedPoint32>,
+        start_timestamp_secs: u64,
+        period_duration: u64,
+    ): VestingSchedule {
+        assert!(vector::length(&schedule) > 0, error::invalid_argument(EEMPTY_VESTING_SCHEDULE));
+        assert!(period_duration > 0, error::invalid_argument(EZERO_VESTING_SCHEDULE_PERIOD));
+        assert!(
+            start_timestamp_secs >= timestamp::now_seconds(),
+            error::invalid_argument(EVESTING_START_TOO_SOON),
+        );
+
+        VestingSchedule {
+            schedule,
+            start_timestamp_secs,
+            period_duration,
+            last_vested_period: 0,
+        }
+    }
+
+    /// Create a vesting contract with a given configurations.
+    public fun create_vesting_contract(
+        admin: &signer,
+        shareholders: &vector<address>,
+        buy_ins: SimpleMap<address, Coin<AptosCoin>>,
+        vesting_schedule: VestingSchedule,
+        withdrawal_address: address,
+        operator: address,
+        voter: address,
+        commission_percentage: u64,
+        // Optional seed used when creating the staking contract account.
+        contract_creation_seed: vector<u8>,
+    ): address acquires AdminStore {
+        assert!(
+            !system_addresses::is_reserved_address(withdrawal_address),
+            error::invalid_argument(EINVALID_WITHDRAWAL_ADDRESS),
+        );
+        assert_account_is_registered_for_apt(withdrawal_address);
+        assert!(vector::length(shareholders) > 0, error::invalid_argument(ENO_SHAREHOLDERS));
+        assert!(
+            simple_map::length(&buy_ins) == vector::length(shareholders),
+            error::invalid_argument(ESHARES_LENGTH_MISMATCH),
+        );
+
+        // Create a coins pool to track shareholders and shares of the grant.
+        let grant = coin::zero<AptosCoin>();
+        let grant_amount = 0;
+        let grant_pool = pool_u64::create(MAXIMUM_SHAREHOLDERS);
+        let len = vector::length(shareholders);
+        let i = 0;
+        while (i < len) {
+            let shareholder = *vector::borrow(shareholders, i);
+            let (_, buy_in) = simple_map::remove(&mut buy_ins, &shareholder);
+            let buy_in_amount = coin::value(&buy_in);
+            coin::merge(&mut grant, buy_in);
+            pool_u64::buy_in(
+                &mut grant_pool,
+                *vector::borrow(shareholders, i),
+                buy_in_amount,
+            );
+            grant_amount = grant_amount + buy_in_amount;
+
+            i = i + 1;
+        };
+        assert!(grant_amount > 0, error::invalid_argument(EZERO_GRANT));
+        pool_u64::update_total_coins(&mut grant_pool, grant_amount);
+
+        // If this is the first time this admin account has created a vesting contract, initialize the admin store.
+        let admin_address = signer::address_of(admin);
+        if (!exists<AdminStore>(admin_address)) {
+            move_to(admin, AdminStore {
+                vesting_contracts: vector::empty<address>(),
+                nonce: 0,
+                create_events: new_event_handle<CreateVestingContractEvent>(admin),
+            });
+        };
+
+        // Initialize the vesting contract in a new resource account. This allows the same admin to create multiple
+        // pools.
+        let (contract_signer, contract_signer_cap) = create_vesting_contract_account(admin, contract_creation_seed);
+        let pool_address = staking_contract::create_staking_contract_with_coins(
+            &contract_signer, operator, voter, grant, commission_percentage, contract_creation_seed);
+
+        // Add the newly created vesting contract's address to the admin store.
+        let contract_address = signer::address_of(&contract_signer);
+        let admin_store = borrow_global_mut<AdminStore>(admin_address);
+        vector::push_back(&mut admin_store.vesting_contracts, contract_address);
+        emit_event(
+            &mut admin_store.create_events,
+            CreateVestingContractEvent {
+                operator,
+                voter,
+                withdrawal_address,
+                grant_amount,
+                vesting_contract_address: contract_address,
+                staking_pool_address: pool_address,
+                commission_percentage,
+            },
+        );
+
+        move_to(&contract_signer, VestingContract {
+            state: VESTING_POOL_ACTIVE,
+            admin: admin_address,
+            grant_pool,
+            beneficiaries: simple_map::create<address, address>(),
+            vesting_schedule,
+            withdrawal_address,
+            staking: StakingInfo { pool_address, operator, voter, commission_percentage },
+            remaining_grant: grant_amount,
+            signer_cap: contract_signer_cap,
+
+            update_operator_events: new_event_handle<UpdateOperatorEvent>(&contract_signer),
+            update_voter_events: new_event_handle<UpdateVoterEvent>(&contract_signer),
+            reset_lockup_events: new_event_handle<ResetLockupEvent>(&contract_signer),
+            set_beneficiary_events: new_event_handle<SetBeneficiaryEvent>(&contract_signer),
+            unlock_rewards_events: new_event_handle<UnlockRewardsEvent>(&contract_signer),
+            vest_events: new_event_handle<VestEvent>(&contract_signer),
+            distribute_events: new_event_handle<DistributeEvent>(&contract_signer),
+            terminate_events: new_event_handle<TerminateEvent>(&contract_signer),
+            admin_withdraw_events: new_event_handle<AdminWithdrawEvent>(&contract_signer),
+        });
+
+        simple_map::destroy_empty(buy_ins);
+        contract_address
+    }
+
+    /// Unlock any accumulated rewards.
+    public entry fun unlock_rewards(contract_address: address) acquires VestingContract {
+        assert_active_vesting_contract(contract_address);
+
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        let contract_signer = &account::create_signer_with_capability(&vesting_contract.signer_cap);
+        staking_contract::unlock_rewards(contract_signer, vesting_contract.staking.operator);
+    }
+
+    /// Unlock any vested portion of the grant.
+    public entry fun vest(contract_address: address) acquires VestingContract {
+        // Unlock all rewards first, if any.
+        unlock_rewards(contract_address);
+
+        // Unlock the vested amount. This amount will become withdrawable when the underlying stake pool's lockup
+        // expires.
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        // Short-circuit if vesting hasn't started yet.
+        if (vesting_contract.vesting_schedule.start_timestamp_secs > timestamp::now_seconds()) {
+            return
+        };
+
+        let vested_amount = compute_vested_amount(vesting_contract);
+        if (vested_amount > 0) {
+            vesting_contract.remaining_grant = vesting_contract.remaining_grant - vested_amount;
+            let vesting_schedule = &mut vesting_contract.vesting_schedule;
+            vesting_schedule.last_vested_period = vesting_schedule.last_vested_period + 1;
+            let period_vested = vesting_schedule.last_vested_period;
+            unlock_stake(vesting_contract, vested_amount);
+
+            emit_event(
+                &mut vesting_contract.vest_events,
+                VestEvent {
+                    admin: vesting_contract.admin,
+                    vesting_contract_address: contract_address,
+                    staking_pool_address: vesting_contract.staking.pool_address,
+                    period_vested,
+                    amount: vested_amount,
+                },
+            );
+        }
+    }
+
+    fun compute_vested_amount(vesting_contract: &VestingContract): u64 {
+        // Check if the next vested period has already passed.
+        let vesting_schedule = &vesting_contract.vesting_schedule;
+        let last_vested_period = vesting_schedule.last_vested_period;
+        let next_period_to_vest = last_vested_period + 1;
+        let last_completed_period =
+            (timestamp::now_seconds() - vesting_schedule.start_timestamp_secs) / vesting_schedule.period_duration;
+        // Short-circuit if the next period to vest has not ended yet.
+        if (last_completed_period < next_period_to_vest) {
+            return 0
+        };
+
+        // Calculate how much has vested, excluding rewards.
+        // Index is 0-based while period is 1-based so we need to subtract 1.
+        let schedule = &vesting_schedule.schedule;
+        let schedule_index = next_period_to_vest - 1;
+        let vesting_fraction = if (schedule_index < vector::length(schedule)) {
+            *vector::borrow(schedule, schedule_index)
+        } else {
+            // Last vesting schedule fraction will repeat until the grant runs out.
+            *vector::borrow(schedule, vector::length(schedule) - 1)
+        };
+        let total_grant = pool_u64::total_coins(&vesting_contract.grant_pool);
+        fixed_point32::multiply_u64(total_grant, vesting_fraction)
+    }
+
+    /// Distribute any withdrawable stake from the stake pool.
+    public entry fun distribute(contract_address: address) acquires VestingContract {
+        assert_active_vesting_contract(contract_address);
+
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        let coins = withdraw_stake(vesting_contract, contract_address);
+        let total_distribution_amount = coin::value(&coins);
+        if (total_distribution_amount == 0) {
+            coin::destroy_zero(coins);
+            return
+        };
+
+        // Distribute coins to all shareholders in the vesting contract.
+        let grant_pool = &vesting_contract.grant_pool;
+        let shareholders = &pool_u64::shareholders(grant_pool);
+        let len = vector::length(shareholders);
+        let i = 0;
+        while (i < len) {
+            let shareholder = *vector::borrow(shareholders, i);
+            let shares = pool_u64::shares(grant_pool, shareholder);
+            let amount = pool_u64::shares_to_amount_with_total_coins(grant_pool, shares, total_distribution_amount);
+            let share_of_coins = coin::extract(&mut coins, amount);
+            let recipient_address = get_beneficiary(vesting_contract, shareholder);
+            coin::deposit(recipient_address, share_of_coins);
+
+            i = i + 1;
+        };
+
+        // Send any remaining "dust" (leftover due to rounding error) to the withdrawal address.
+        if (coin::value(&coins) > 0) {
+            coin::deposit(vesting_contract.withdrawal_address, coins);
+        } else {
+            coin::destroy_zero(coins);
+        };
+
+        emit_event(
+            &mut vesting_contract.distribute_events,
+            DistributeEvent {
+                admin: vesting_contract.admin,
+                vesting_contract_address: contract_address,
+                amount: total_distribution_amount,
+            },
+        );
+    }
+
+    /// Terminate the vesting contract and send all funds back to the withdrawal address.
+    public entry fun terminate_vesting_contract(admin: &signer, contract_address: address) acquires VestingContract {
+        assert_active_vesting_contract(contract_address);
+
+        // Distribute all withdrawable coins, which should have been from previous rewards withdrawal or vest.
+        distribute(contract_address);
+
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        verify_admin(admin, vesting_contract);
+        let (active_stake, _, pending_active_stake, _) = stake::get_stake(vesting_contract.staking.pool_address);
+        assert!(pending_active_stake == 0, error::invalid_state(EPENDING_STAKE_FOUND));
+
+        // Unlock all remaining active stake.
+        vesting_contract.state = VESTING_POOL_TERMINATED;
+        vesting_contract.remaining_grant = 0;
+        unlock_stake(vesting_contract, active_stake);
+
+        emit_event(
+            &mut vesting_contract.terminate_events,
+            TerminateEvent {
+                admin: vesting_contract.admin,
+                vesting_contract_address: contract_address,
+            },
+        );
+    }
+
+    /// Withdraw all funds to the preset vesting contract's withdrawal address. This can only be called if the contract
+    /// has already been terminated.
+    public entry fun admin_withdraw(admin: &signer, contract_address: address) acquires VestingContract {
+        let vesting_contract = borrow_global<VestingContract>(contract_address);
+        assert!(vesting_contract.state == VESTING_POOL_TERMINATED, error::invalid_state(EVESTING_CONTRACT_STILL_ACTIVE));
+
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        verify_admin(admin, vesting_contract);
+        let coins = withdraw_stake(vesting_contract, contract_address);
+        let amount = coin::value(&coins);
+        if (amount == 0) {
+            coin::destroy_zero(coins);
+            return
+        };
+        coin::deposit(vesting_contract.withdrawal_address, coins);
+
+        emit_event(
+            &mut vesting_contract.admin_withdraw_events,
+            AdminWithdrawEvent {
+                admin: vesting_contract.admin,
+                vesting_contract_address: contract_address,
+                amount,
+            },
+        );
+    }
+
+    public entry fun update_operator(
+        admin: &signer,
+        contract_address: address,
+        new_operator: address,
+        commission_percentage: u64,
+    ) acquires VestingContract {
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        verify_admin(admin, vesting_contract);
+        let contract_signer = &account::create_signer_with_capability(&vesting_contract.signer_cap);
+        let old_operator = vesting_contract.staking.operator;
+        staking_contract::switch_operator(contract_signer, old_operator, new_operator, commission_percentage);
+        vesting_contract.staking.operator = new_operator;
+
+        emit_event(
+            &mut vesting_contract.update_operator_events,
+            UpdateOperatorEvent {
+                admin: vesting_contract.admin,
+                vesting_contract_address: contract_address,
+                staking_pool_address: vesting_contract.staking.pool_address,
+                old_operator,
+                new_operator,
+                commission_percentage,
+            },
+        );
+    }
+
+    public entry fun update_voter(
+        admin: &signer,
+        contract_address: address,
+        new_voter: address,
+    ) acquires VestingContract {
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        verify_admin(admin, vesting_contract);
+        let contract_signer = &account::create_signer_with_capability(&vesting_contract.signer_cap);
+        let old_voter = vesting_contract.staking.voter;
+        staking_contract::update_voter(contract_signer, vesting_contract.staking.operator, new_voter);
+        vesting_contract.staking.voter = new_voter;
+
+        emit_event(
+            &mut vesting_contract.update_voter_events,
+            UpdateVoterEvent {
+                admin: vesting_contract.admin,
+                vesting_contract_address: contract_address,
+                staking_pool_address: vesting_contract.staking.pool_address,
+                old_voter,
+                new_voter,
+            },
+        );
+    }
+
+    public entry fun reset_lockup(
+        admin: &signer,
+        contract_address: address,
+    ) acquires VestingContract {
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        verify_admin(admin, vesting_contract);
+        let contract_signer = &account::create_signer_with_capability(&vesting_contract.signer_cap);
+        staking_contract::reset_lockup(contract_signer, vesting_contract.staking.operator);
+
+        emit_event(
+            &mut vesting_contract.reset_lockup_events,
+            ResetLockupEvent {
+                admin: vesting_contract.admin,
+                vesting_contract_address: contract_address,
+                staking_pool_address: vesting_contract.staking.pool_address,
+                new_lockup_expiration_secs: stake::get_lockup_secs(vesting_contract.staking.pool_address),
+            },
+        );
+    }
+
+    public entry fun set_beneficiary(
+        admin: &signer,
+        contract_address: address,
+        shareholder: address,
+        new_beneficiary: address,
+    ) acquires VestingContract {
+        // Verify that the beneficiary account is set up to receive APT. This is a requirement so distribute() wouldn't
+        // fail and block all other accounts from receiving APT if one beneficiary is not registered.
+        assert_account_is_registered_for_apt(new_beneficiary);
+
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        verify_admin(admin, vesting_contract);
+
+        let old_beneficiary = get_beneficiary(vesting_contract, shareholder);
+        let beneficiaries = &mut vesting_contract.beneficiaries;
+        if (simple_map::contains_key(beneficiaries, &shareholder)) {
+            let beneficiary = simple_map::borrow_mut(beneficiaries, &shareholder);
+            *beneficiary = new_beneficiary;
+        } else {
+            simple_map::add(beneficiaries, shareholder, new_beneficiary);
+        };
+
+        emit_event(
+            &mut vesting_contract.set_beneficiary_events,
+            SetBeneficiaryEvent {
+                admin: vesting_contract.admin,
+                vesting_contract_address: contract_address,
+                shareholder,
+                old_beneficiary,
+                new_beneficiary,
+            },
+        );
+    }
+
+    /// For emergency use in case the admin needs emergency control of vesting contract account.
+    /// This doesn't give the admin total power as the admin would still need to follow the rules set by
+    /// staking_contract and stake modules.
+    public fun get_vesting_account_signer(admin: &signer, contract_address: address): signer acquires VestingContract {
+        let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
+        verify_admin(admin, vesting_contract);
+        account::create_signer_with_capability(&vesting_contract.signer_cap)
+    }
+
+    // Create a salt for generating the resource accounts that will be holding the VestingContract.
+    // This address should be deterministic for the same admin and vesting contract creation nonce.
+    fun create_vesting_contract_account(
+        admin: &signer,
+        contract_creation_seed: vector<u8>,
+    ): (signer, SignerCapability) acquires AdminStore {
+        let admin_store = borrow_global_mut<AdminStore>(signer::address_of(admin));
+        let seed = bcs::to_bytes(admin);
+        vector::append(&mut seed, bcs::to_bytes(&admin_store.nonce));
+        admin_store.nonce = admin_store.nonce + 1;
+
+        // Include a salt to avoid conflicts with any other modules out there that might also generate
+        // deterministic resource accounts for the same admin address + nonce.
+        vector::append(&mut seed, VESTING_POOL_SALT);
+        vector::append(&mut seed, contract_creation_seed);
+
+        let (account_signer, signer_cap) = account::create_resource_account(admin, seed);
+        // Register the vesting contract account to receive APT as it'll be sent to it when claiming unlocked stake from
+        // the underlying staking contract.
+        coin::register<AptosCoin>(&account_signer);
+
+        (account_signer, signer_cap)
+    }
+
+    fun verify_admin(admin: &signer, vesting_contract: &VestingContract) {
+        assert!(signer::address_of(admin) == vesting_contract.admin, error::unauthenticated(ENOT_ADMIN));
+    }
+
+    fun assert_vesting_contract_exists(contract_address: address) {
+        assert!(exists<VestingContract>(contract_address), error::not_found(EVESTING_CONTRACT_NOT_FOUND));
+    }
+
+    fun assert_active_vesting_contract(contract_address: address) acquires VestingContract {
+        assert_vesting_contract_exists(contract_address);
+        let vesting_contract = borrow_global<VestingContract>(contract_address);
+        assert!(vesting_contract.state == VESTING_POOL_ACTIVE, error::invalid_state(EVESTING_CONTRACT_NOT_ACTIVE));
+    }
+
+    fun unlock_stake(vesting_contract: &VestingContract, amount: u64) {
+        let contract_signer = &account::create_signer_with_capability(&vesting_contract.signer_cap);
+        staking_contract::unlock_stake(contract_signer, vesting_contract.staking.operator, amount);
+    }
+
+    fun withdraw_stake(vesting_contract: &VestingContract, contract_address: address): Coin<AptosCoin> {
+        // Claim any withdrawable distribution from the staking contract. The withdrawn coins will be sent directly to
+        // the vesting contract's account.
+        staking_contract::distribute(contract_address, vesting_contract.staking.operator);
+        let withdrawn_coins = coin::balance<AptosCoin>(contract_address);
+        let contract_signer = &account::create_signer_with_capability(&vesting_contract.signer_cap);
+        coin::withdraw<AptosCoin>(contract_signer, withdrawn_coins)
+    }
+
+    fun get_beneficiary(contract: &VestingContract, shareholder: address): address {
+        if (simple_map::contains_key(&contract.beneficiaries, &shareholder)) {
+            *simple_map::borrow(&contract.beneficiaries, &shareholder)
+        } else {
+            shareholder
+        }
+    }
+
+    #[test_only]
+    use aptos_framework::stake::with_rewards;
+
+    #[test_only]
+    use aptos_framework::account::create_account_for_test;
+
+    #[test_only]
+    const MIN_STAKE: u64 = 100000000000000; // 1M APT coins with 8 decimals.
+
+    #[test_only]
+    const GRANT_AMOUNT: u64 = 20000000000000000; // 200M APT coins with 8 decimals.
+
+    #[test_only]
+    const VESTING_SCHEDULE_CLIFF: u64 = 31536000; // 1 year
+
+    #[test_only]
+    const VESTING_PERIOD: u64 = 2592000; // 30 days
+
+    #[test_only]
+    const VALIDATOR_STATUS_PENDING_ACTIVE: u64 = 1;
+    #[test_only]
+    const VALIDATOR_STATUS_ACTIVE: u64 = 2;
+    #[test_only]
+    const VALIDATOR_STATUS_INACTIVE: u64 = 4;
+
+    #[test_only]
+    public entry fun setup(aptos_framework: &signer, accounts: &vector<address>) {
+        use aptos_framework::aptos_account::create_account;
+
+        stake::initialize_for_test_custom(aptos_framework, MIN_STAKE, GRANT_AMOUNT * 10, 3600, true, 10, 10000, 1000000);
+
+        let len = vector::length(accounts);
+        let i = 0;
+        while (i < len) {
+            create_account(*vector::borrow(accounts, i));
+            i = i + 1;
+        };
+    }
+
+    #[test_only]
+    public fun setup_vesting_contract(
+        admin: &signer,
+        shareholders: &vector<address>,
+        shares: &vector<u64>,
+        withdrawal_address: address,
+        commission_percentage: u64,
+    ): address acquires AdminStore {
+
+        let vesting_schedule = create_vesting_schedule(
+            vector[
+                fixed_point32::create_from_rational(3, 48),
+                fixed_point32::create_from_rational(2, 48),
+                fixed_point32::create_from_rational(1, 48),
+            ],
+            timestamp::now_seconds() + VESTING_SCHEDULE_CLIFF,
+            VESTING_PERIOD,
+        );
+
+        let admin_address = signer::address_of(admin);
+        let buy_ins = simple_map::create<address, Coin<AptosCoin>>();
+        let i = 0;
+        let len = vector::length(shares);
+        while (i < len) {
+            let shareholder = *vector::borrow(shareholders, i);
+            simple_map::add(&mut buy_ins, shareholder, stake::mint_coins(*vector::borrow(shares, i)));
+            i = i + 1;
+        };
+
+        create_vesting_contract(
+            admin,
+            shareholders,
+            buy_ins,
+            vesting_schedule,
+            withdrawal_address,
+            admin_address,
+            admin_address,
+            commission_percentage,
+            vector[],
+        )
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder_1 = @0x234, shareholder_2 = @0x345, withdrawal = @111)]
+    public entry fun test_end_to_end(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder_1: &signer,
+        shareholder_2: &signer,
+        withdrawal: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let withdrawal_address = signer::address_of(withdrawal);
+        let shareholder_1_address = signer::address_of(shareholder_1);
+        let shareholder_2_address = signer::address_of(shareholder_2);
+        let shareholders = &vector[shareholder_1_address, shareholder_2_address];
+        let shareholder_1_share = GRANT_AMOUNT / 4;
+        let shareholder_2_share = GRANT_AMOUNT * 3 / 4;
+        let shares = &vector[shareholder_1_share, shareholder_2_share];
+
+        // Create the vesting contract.
+        setup(
+            aptos_framework, &vector[admin_address, withdrawal_address, shareholder_1_address, shareholder_2_address]);
+        let contract_address = setup_vesting_contract(admin, shareholders, shares, withdrawal_address, 0);
+        assert!(vector::length(&borrow_global<AdminStore>(admin_address).vesting_contracts) == 1, 0);
+        let stake_pool_address = stake_pool_address(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, 0);
+
+        // The stake pool is still in pending active stake, so unlock_rewards and vest shouldn't do anything.
+        stake::join_validator_set_for_test(admin, stake_pool_address, false);
+        assert!(stake::get_validator_state(stake_pool_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 1);
+        unlock_rewards(contract_address);
+        vest(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, 0);
+
+        // Wait for the validator to join the validator set. No rewards are earnt yet so unlock_rewards and vest should
+        // still do nothing.
+        stake::end_epoch();
+        assert!(stake::get_validator_state(stake_pool_address) == VALIDATOR_STATUS_ACTIVE, 2);
+        unlock_rewards(contract_address);
+        vest(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, 0);
+
+        // Stake pool earns some rewards. unlock_rewards should unlock the right amount.
+        stake::end_epoch();
+        let rewards = get_accumulated_rewards(contract_address);
+        unlock_rewards(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, rewards);
+        assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
+
+        // Stake pool earns more rewards. vest should unlock the rewards but no vested tokens as vesting hasn't started.
+        stake::end_epoch();
+        rewards = with_rewards(rewards); // Pending inactive stake still earns rewards.
+        rewards = rewards + get_accumulated_rewards(contract_address);
+        vest(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, rewards);
+        assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
+
+        // Fast forward to stake lockup expiration so rewards are fully unlocked.
+        // In the mean time, rewards still earn rewards.
+        // Calling distribute() should send rewards to the shareholders.
+        stake::fast_forward_to_unlock(stake_pool_address);
+        rewards = with_rewards(rewards);
+        distribute(contract_address);
+        let shareholder_1_bal = coin::balance<AptosCoin>(shareholder_1_address);
+        let shareholder_2_bal = coin::balance<AptosCoin>(shareholder_2_address);
+        // Distribution goes by the shares of the vesting contract.
+        assert!(shareholder_1_bal == rewards / 4, shareholder_1_bal);
+        assert!(shareholder_2_bal == rewards * 3 / 4, shareholder_2_bal);
+
+        // Fast forward time to the vesting start.
+        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address));
+        // Calling vest only unlocks rewards but not any vested token as the first vesting period hasn't passed yet.
+        rewards = get_accumulated_rewards(contract_address);
+        vest(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, rewards);
+        assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
+
+        // Fast forward to the end of the first period. vest() should now unlock 3/48 of the tokens.
+        timestamp::fast_forward_seconds(VESTING_PERIOD);
+        vest(contract_address);
+        let vested_amount = fraction(GRANT_AMOUNT, 3, 48);
+        let remaining_grant = GRANT_AMOUNT - vested_amount;
+        let pending_distribution = rewards + vested_amount;
+        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        assert!(remaining_grant(contract_address) == remaining_grant, 0);
+
+        // Fast forward to the end of the fourth period. We can call vest() 3 times to vest the last 3 periods.
+        timestamp::fast_forward_seconds(VESTING_PERIOD * 3);
+        vest(contract_address);
+        vested_amount = fraction(GRANT_AMOUNT, 2, 48);
+        remaining_grant = remaining_grant - vested_amount;
+        pending_distribution = pending_distribution + vested_amount;
+        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        vest(contract_address);
+        vested_amount = fraction(GRANT_AMOUNT, 1, 48);
+        remaining_grant = remaining_grant - vested_amount;
+        pending_distribution = pending_distribution + vested_amount;
+        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        // The last vesting fraction (1/48) is repeated beyond the first 3 periods.
+        vest(contract_address);
+        remaining_grant = remaining_grant - vested_amount;
+        pending_distribution = pending_distribution + vested_amount;
+        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, pending_distribution);
+        assert!(remaining_grant(contract_address) == remaining_grant, 0);
+
+        stake::end_epoch();
+        let total_active = with_rewards(remaining_grant);
+        pending_distribution = with_rewards(pending_distribution);
+        distribute(contract_address);
+        stake::assert_stake_pool(stake_pool_address, total_active, 0, 0, 0);
+        assert!(coin::balance<AptosCoin>(shareholder_1_address) == shareholder_1_bal + pending_distribution / 4, 0);
+        assert!(coin::balance<AptosCoin>(shareholder_2_address) == shareholder_2_bal + pending_distribution * 3 / 4, 1);
+        // Withdrawal address receives the left-over dust of 1 coin due to rounding error.
+        assert!(coin::balance<AptosCoin>(withdrawal_address) == 1, 0);
+
+        // Admin terminates the vesting contract.
+        terminate_vesting_contract(admin, contract_address);
+        stake::assert_stake_pool(stake_pool_address, 0, 0, 0, total_active);
+        assert!(remaining_grant(contract_address) == 0, 0);
+        stake::fast_forward_to_unlock(stake_pool_address);
+        let withdrawn_amount = with_rewards(total_active);
+        stake::assert_stake_pool(stake_pool_address, 0, withdrawn_amount, 0, 0);
+        let previous_bal = coin::balance<AptosCoin>(withdrawal_address);
+        admin_withdraw(admin, contract_address);
+        assert!(coin::balance<AptosCoin>(withdrawal_address) == previous_bal + withdrawn_amount, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x1000C)]
+    public entry fun test_create_vesting_contract_with_zero_grant_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        setup_vesting_contract(admin, &vector[@1], &vector[0], admin_address, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x10004)]
+    public entry fun test_create_vesting_contract_with_no_shareholders_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        setup_vesting_contract(admin, &vector[], &vector[], admin_address, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x10005)]
+    public entry fun test_create_vesting_contract_with_mistmaching_shareholders_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        setup_vesting_contract(admin, &vector[@1, @2], &vector[1], admin_address, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x10001)]
+    public entry fun test_create_vesting_contract_with_invalid_withdrawal_address_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @5, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x60001)]
+    public entry fun test_create_vesting_contract_with_missing_withdrawal_account_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @11, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x60002)]
+    public entry fun test_create_vesting_contract_with_unregistered_withdrawal_account_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        create_account_for_test(@11);
+        setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @11, 0);
+    }
+
+    #[test(aptos_framework = @0x1)]
+    #[expected_failure(abort_code = 0x10002)]
+    public entry fun test_create_empty_vesting_schedule_should_fail(aptos_framework: &signer) {
+        setup(aptos_framework, &vector[]);
+        create_vesting_schedule(vector[], 1, 1);
+    }
+
+    #[test(aptos_framework = @0x1)]
+    #[expected_failure(abort_code = 0x10003)]
+    public entry fun test_create_vesting_schedule_with_zero_period_duration_should_fail(aptos_framework: &signer) {
+        setup(aptos_framework, &vector[]);
+        create_vesting_schedule(vector[fixed_point32::create_from_rational(1, 1)], 1, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x10006)]
+    public entry fun test_create_vesting_schedule_with_invalid_vesting_start_should_fail(aptos_framework: &signer) {
+        setup(aptos_framework, &vector[]);
+        timestamp::update_global_time_for_test_secs(1000);
+        create_vesting_schedule(
+            vector[fixed_point32::create_from_rational(1, 1)],
+            900,
+            1);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
+    public entry fun test_vest_twice_should_not_double_count(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let shareholder_address = signer::address_of(shareholder);
+        setup(aptos_framework, &vector[admin_address, shareholder_address]);
+        let contract_address = setup_vesting_contract(
+            admin,&vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+
+        // Operator needs to join the validator set for the stake pool to earn rewards.
+        let stake_pool_address = stake_pool_address(contract_address);
+        stake::join_validator_set_for_test(admin, stake_pool_address, true);
+
+        // Fast forward to the end of the first period. vest() should now unlock 3/48 of the tokens.
+        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address) + VESTING_PERIOD);
+        vest(contract_address);
+        let vested_amount = fraction(GRANT_AMOUNT, 3, 48);
+        let remaining_grant = GRANT_AMOUNT - vested_amount;
+        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, vested_amount);
+        assert!(remaining_grant(contract_address) == remaining_grant, 0);
+
+        // Calling vest() a second time shouldn't change anything.
+        vest(contract_address);
+        stake::assert_stake_pool(stake_pool_address, remaining_grant, 0, 0, vested_amount);
+        assert!(remaining_grant(contract_address) == remaining_grant, 0);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
+    public entry fun test_unlock_rewards_twice_should_not_double_count(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let shareholder_address = signer::address_of(shareholder);
+        setup(aptos_framework, &vector[admin_address, shareholder_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+
+        // Operator needs to join the validator set for the stake pool to earn rewards.
+        let stake_pool_address = stake_pool_address(contract_address);
+        stake::join_validator_set_for_test(admin, stake_pool_address, true);
+
+        // Stake pool earns some rewards. unlock_rewards should unlock the right amount.
+        stake::end_epoch();
+        let rewards = get_accumulated_rewards(contract_address);
+        unlock_rewards(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, rewards);
+        assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
+
+        // Calling unlock_rewards a second time shouldn't change anything as no new rewards has accumulated.
+        unlock_rewards(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, rewards);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234, operator = @0x345)]
+    public entry fun test_unlock_rewards_should_pay_commission_first(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder: &signer,
+        operator: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let operator_address = signer::address_of(operator);
+        let shareholder_address = signer::address_of(shareholder);
+        setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+
+        // 10% commission will be paid to the operator.
+        update_operator(admin, contract_address, operator_address, 10);
+
+        // Operator needs to join the validator set for the stake pool to earn rewards.
+        let stake_pool_address = stake_pool_address(contract_address);
+        stake::join_validator_set_for_test(operator, stake_pool_address, true);
+
+        // Stake pool earns some rewards. unlock_rewards should unlock the right amount.
+        stake::end_epoch();
+        let accumulated_rewards = get_accumulated_rewards(contract_address);
+        let commission = accumulated_rewards / 10; // 10%.
+        let staker_rewards = accumulated_rewards - commission;
+        unlock_rewards(contract_address);
+        stake::assert_stake_pool(stake_pool_address, GRANT_AMOUNT, 0, 0, accumulated_rewards);
+        assert!(remaining_grant(contract_address) == GRANT_AMOUNT, 0);
+
+        // Distribution should pay commission to operator first and remaining amount to shareholders.
+        stake::fast_forward_to_unlock(stake_pool_address);
+        stake::assert_stake_pool(stake_pool_address, with_rewards(GRANT_AMOUNT), with_rewards(accumulated_rewards), 0, 0);
+        // Operator also earns more commission from the rewards earnt on the withdrawn rewards.
+        let commission_on_staker_rewards = (with_rewards(staker_rewards) - staker_rewards) / 10;
+        staker_rewards = with_rewards(staker_rewards) - commission_on_staker_rewards;
+        commission = with_rewards(commission) + commission_on_staker_rewards;
+        distribute(contract_address);
+        // Rounding error leads to a dust amount of 1 transferred to the staker.
+        assert!(coin::balance<AptosCoin>(shareholder_address) == staker_rewards + 1, 0);
+        assert!(coin::balance<AptosCoin>(operator_address) == commission - 1, 1);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
+    #[expected_failure(abort_code = 0x30008)]
+    public entry fun test_cannot_unlock_rewards_after_contract_is_terminated(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let shareholder_address = signer::address_of(shareholder);
+        setup(aptos_framework, &vector[admin_address, shareholder_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+
+        // Immediately terminate. Calling unlock_rewards should now fail.
+        terminate_vesting_contract(admin, contract_address);
+        unlock_rewards(contract_address);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
+    #[expected_failure(abort_code = 0x30008)]
+    public entry fun test_cannot_vest_after_contract_is_terminated(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let shareholder_address = signer::address_of(shareholder);
+        setup(aptos_framework, &vector[admin_address, shareholder_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+
+        // Immediately terminate. Calling vest should now fail.
+        terminate_vesting_contract(admin, contract_address);
+        vest(contract_address);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
+    #[expected_failure(abort_code = 0x30008)]
+    public entry fun test_cannot_terminate_twice(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let shareholder_address = signer::address_of(shareholder);
+        setup(aptos_framework, &vector[admin_address, shareholder_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+
+        // Call terminate_vesting_contract twice should fail.
+        terminate_vesting_contract(admin, contract_address);
+        terminate_vesting_contract(admin, contract_address);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123, shareholder = @0x234)]
+    #[expected_failure(abort_code = 0x30009)]
+    public entry fun test_cannot_call_admin_withdraw_if_contract_is_not_terminated(
+        aptos_framework: &signer,
+        admin: &signer,
+        shareholder: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        let shareholder_address = signer::address_of(shareholder);
+        setup(aptos_framework, &vector[admin_address, shareholder_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
+
+        // Calling admin_withdraw should fail as contract has not been terminated.
+        admin_withdraw(admin, contract_address);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x60001)]
+    public entry fun test_set_beneficiary_with_missing_account_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address, 0);
+        set_beneficiary(admin, contract_address, @1, @11);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    #[expected_failure(abort_code = 0x60002)]
+    public entry fun test_set_beneficiary_with_unregistered_account_should_fail(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address, 0);
+        create_account_for_test(@11);
+        set_beneficiary(admin, contract_address, @1, @11);
+    }
+
+    #[test(aptos_framework = @0x1, admin = @0x123)]
+    public entry fun test_set_beneficiary_should_send_distribution(
+        aptos_framework: &signer,
+        admin: &signer,
+    ) acquires AdminStore, VestingContract {
+        let admin_address = signer::address_of(admin);
+        setup(aptos_framework, &vector[admin_address, @11]);
+        let contract_address = setup_vesting_contract(
+            admin, &vector[@1], &vector[GRANT_AMOUNT], admin_address, 0);
+        set_beneficiary(admin, contract_address, @1, @11);
+        assert!(beneficiary(contract_address, @1) == @11, 0);
+
+        // Fast forward to the end of the first period. vest() should now unlock 3/48 of the tokens.
+        timestamp::update_global_time_for_test_secs(vesting_start_secs(contract_address) + VESTING_PERIOD);
+        vest(contract_address);
+
+        // Distribution should go to the beneficiary account.
+        stake::end_epoch();
+        // No rewards as validator never joined the validator set.
+        let vested_amount = fraction(GRANT_AMOUNT, 3, 48);
+        distribute(contract_address);
+        let balance = coin::balance<AptosCoin>(@11);
+        assert!(balance == vested_amount, balance);
+    }
+
+    #[test_only]
+    fun get_accumulated_rewards(contract_address: address): u64 acquires VestingContract {
+        let vesting_contract = borrow_global<VestingContract>(contract_address);
+        let (active_stake, _, _, _) = stake::get_stake(vesting_contract.staking.pool_address);
+        active_stake - vesting_contract.remaining_grant
+    }
+
+    #[test_only]
+    fun fraction(total: u64, numerator: u64, denominator: u64): u64 {
+        fixed_point32::multiply_u64(total, fixed_point32::create_from_rational(numerator, denominator))
+    }
+}


### PR DESCRIPTION
### Description

This creates a separate StakePool per delegation (from a delegator to an operator) and does not allow pooling funds from multiple delegators at all.

### Test Plan
Unit + e2e tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3570)
<!-- Reviewable:end -->
