### PR TITLE
[CP] Make AIT3 registration positive for flipper

### DIFF
--- a/ecosystem/platform/server/app/controllers/it3_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it3_profiles_controller.rb
@@ -172,7 +172,7 @@ class It3ProfilesController < ApplicationController
 
   def ensure_registration_enabled!
     redirect_to root_path unless Flipper.enabled?(:it3_registration_open)
-    redirect_to it3_path if Flipper.enabled?(:it3_node_registration_disabled,
+    redirect_to it3_path if Flipper.enabled?(:it3_node_registration_enabled,
                                              current_user) || Flipper.enabled?(:it3_registration_closed, current_user)
   end
 end

--- a/ecosystem/platform/server/app/controllers/it3s_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it3s_controller.rb
@@ -68,7 +68,7 @@ class It3sController < ApplicationController
     completed = !current_user.it3_survey.nil?
     {
       name: :survey,
-      disabled: Flipper.enabled?(:it3_node_registration_disabled, current_user),
+      disabled: !Flipper.enabled?(:it3_node_registration_enabled, current_user),
       completed:,
       href: completed ? edit_it3_survey_path(current_user.it3_survey) : new_it3_survey_path
     }
@@ -79,7 +79,7 @@ class It3sController < ApplicationController
     {
       name: :node_registration,
       completed:,
-      disabled: Flipper.enabled?(:it3_node_registration_disabled, current_user),
+      disabled: !Flipper.enabled?(:it3_node_registration_enabled, current_user),
       href: completed ? edit_it3_profile_path(current_user.it3_profile) : new_it3_profile_path
     }
   end


### PR DESCRIPTION
### Description
Flipper doesn't allow actor-specific overrides for negative statements, i.e they only allow overriding `enabled` per actor, not disabled. This means we can't conditionally enable per user for most of our actions.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3574)
<!-- Reviewable:end -->
