### PR TITLE
[Consensus] Delay proposal processing in case of sync_only mode

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -101,6 +101,7 @@ pub struct BlockStore {
     time_service: Arc<dyn TimeService>,
     // consistent with round type
     back_pressure_limit: Round,
+    #[cfg(any(test, feature = "fuzzing"))]
     back_pressure_for_test: AtomicBool,
 }
 
@@ -217,8 +218,10 @@ impl BlockStore {
             storage,
             time_service,
             back_pressure_limit,
+            #[cfg(any(test, feature = "fuzzing"))]
             back_pressure_for_test: AtomicBool::new(false),
         };
+
         for block in blocks {
             block_store
                 .execute_and_insert_block(block)

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -28,6 +28,7 @@ use executor_types::{Error, StateComputeResult};
 use futures::executor::block_on;
 #[cfg(test)]
 use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{sync::Arc, time::Duration};
 
 #[cfg(test)]
@@ -100,6 +101,7 @@ pub struct BlockStore {
     time_service: Arc<dyn TimeService>,
     // consistent with round type
     back_pressure_limit: Round,
+    back_pressure_for_test: AtomicBool,
 }
 
 impl BlockStore {
@@ -215,6 +217,7 @@ impl BlockStore {
             storage,
             time_service,
             back_pressure_limit,
+            back_pressure_for_test: AtomicBool::new(false),
         };
         for block in blocks {
             block_store
@@ -471,6 +474,27 @@ impl BlockStore {
         wlock.update_commit_root(next_root_id);
         wlock.process_pruned_blocks(id_to_remove.clone());
         id_to_remove
+    }
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub fn set_back_pressure_for_test(&self, back_pressure: bool) {
+        self.back_pressure_for_test
+            .store(back_pressure, Ordering::Relaxed)
+    }
+
+    pub fn back_pressure(&self) -> bool {
+        #[cfg(any(test, feature = "fuzzing"))]
+        {
+            if self.back_pressure_for_test.load(Ordering::Relaxed) {
+                return true;
+            }
+        }
+        let commit_round = self.commit_root().round();
+        let ordered_round = self.ordered_root().round();
+        counters::OP_COUNTERS
+            .gauge("back_pressure")
+            .set((ordered_round - commit_round) as i64);
+        ordered_round > self.back_pressure_limit + commit_round
     }
 }
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -647,6 +647,7 @@ impl EpochManager {
             self.config.sync_only,
             onchain_config,
             round_manager_tx,
+            self.config.round_initial_timeout_ms,
         );
 
         round_manager.init(last_vote).await;

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -627,6 +627,14 @@ impl EpochManager {
             onchain_config.max_failed_authors_to_store(),
         );
 
+        let (round_manager_tx, round_manager_rx) = aptos_channel::new(
+            QueueStyle::LIFO,
+            1,
+            Some(&counters::ROUND_MANAGER_CHANNEL_MSGS),
+        );
+
+        self.round_manager_tx = Some(round_manager_tx.clone());
+
         let mut round_manager = RoundManager::new(
             epoch_state,
             block_store.clone(),
@@ -638,15 +646,11 @@ impl EpochManager {
             self.storage.clone(),
             self.config.sync_only,
             onchain_config,
+            round_manager_tx,
         );
 
         round_manager.init(last_vote).await;
-        let (round_manager_tx, round_manager_rx) = aptos_channel::new(
-            QueueStyle::LIFO,
-            1,
-            Some(&counters::ROUND_MANAGER_CHANNEL_MSGS),
-        );
-        self.round_manager_tx = Some(round_manager_tx);
+
         let (close_tx, close_rx) = oneshot::channel();
         self.round_manager_close_tx = Some(close_tx);
         tokio::spawn(round_manager.start(round_manager_rx, close_rx));

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -252,6 +252,10 @@ impl NetworkSender {
         let msg = ConsensusMsg::CommitDecisionMsg(Box::new(CommitDecision::new(ledger_info)));
         self.send(msg, vec![self.author]).await
     }
+
+    pub fn author(&self) -> Author {
+        self.author
+    }
 }
 
 pub struct NetworkTask {

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -174,6 +174,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         false,
         OnChainConsensusConfig::default(),
         round_manager_tx,
+        2000,
     )
 }
 

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -156,6 +156,8 @@ fn create_node_for_fuzzing() -> RoundManager {
     // TODO: have two different nodes, one for proposing, one for accepting a proposal
     let proposer_election = Box::new(RotatingProposer::new(vec![signer.author()], 1));
 
+    let (round_manager_tx, _) = aptos_channel::new(QueueStyle::LIFO, 1, None);
+
     // event processor
     RoundManager::new(
         epoch_state,
@@ -171,6 +173,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         storage,
         false,
         OnChainConsensusConfig::default(),
+        round_manager_tx,
     )
 }
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -230,6 +230,7 @@ impl NodeSetup {
             false,
             OnChainConsensusConfig::default(),
             round_manager_tx,
+            2000,
         );
         block_on(round_manager.init(last_vote_sent));
         Self {

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -355,7 +355,7 @@ fn vote_on_successful_proposal() {
 }
 
 #[test]
-/// In sync only mode, verify that the proposals are processed after we get out of the sync only mode.
+/// In back pressure mode, verify that the proposals are processed after we get out of back pressure.
 fn delay_proposal_processing_in_sync_only() {
     let mut runtime = consensus_runtime();
     let mut playground = NetworkPlayground::new(runtime.handle().clone());
@@ -384,16 +384,6 @@ fn delay_proposal_processing_in_sync_only() {
         let proposal_id = proposal.id();
         node.round_manager
             .process_proposal(proposal.clone())
-            .await
-            .unwrap();
-
-        // Wait for some time to ensure that the proposal was not processed
-        timeout(Duration::from_millis(200), node.next_vote())
-            .await
-            .unwrap_err();
-
-        node.round_manager
-            .process_verified_proposal(proposal.clone())
             .await
             .unwrap();
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -370,7 +370,9 @@ fn delay_proposal_processing_in_sync_only() {
         node.next_proposal().await;
 
         // Set sync only to true so that new proposal processing is delayed.
-        node.round_manager.set_sync_only(true);
+        node.round_manager
+            .block_store
+            .set_back_pressure_for_test(true);
         let proposal = Block::new_proposal(
             Payload::empty(),
             1,
@@ -401,7 +403,9 @@ fn delay_proposal_processing_in_sync_only() {
             .unwrap_err();
 
         // Clear the sync only mode and process verified proposal and ensure it is processed now
-        node.round_manager.set_sync_only(false);
+        node.round_manager
+            .block_store
+            .set_back_pressure_for_test(false);
 
         node.round_manager
             .process_verified_proposal(proposal)

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -265,7 +265,7 @@ impl<'cfg> Default for ForgeConfig<'cfg> {
             genesis_helm_config_fn: None,
             node_helm_config_fn: None,
             emit_job_request: EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
-                mempool_backlog: 30000,
+                mempool_backlog: 40000,
             }),
             success_criteria,
         }


### PR DESCRIPTION
### Description

Previously, in case of back pressure (sync_only) mode, the voters simply ignore all proposal messages and rely on round timeout, which is 1.5 seconds. However, it is possible that the backpressure is resolved before the round timeout and they can still vote on the proposal instead of timing out. Waiting for 1.5s blindly in case of backpressure cause performance degradation as seen on Forge and this PR will address that. 

### Test Plan

Ran Forge and we can do ~7.5k TPS after this change. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3580)
<!-- Reviewable:end -->
