### PR TITLE
[codeowners] update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,9 @@
 # Owners for the `/aptos-move` directory and its subdirectories:`aptos-gas`, `aptos-vm`, `framework` and `framework/aptos-stdlib/sources/cryptography`. 
 /aptos-move/aptos-gas/ @vgao1996
 /aptos-move/aptos-vm/ @davidiw @wrwg @zekun000
+/aptos-move/e2e-tests/src/account.rs @alinush
 /aptos-move/framework/ @davidiw @movekevin @wrwg
+/aptos-move/framework/aptos-framework/sources/account.move @alinush
 /aptos-move/framework/aptos-stdlib/sources/cryptography/ @alinush
 
 # Owner for aptos-token, cryptography natives, parallel-executor and vm-genesis.
@@ -66,3 +68,5 @@
 
 # Owners for the `/terraform` directory and all its subdirectories.
 /terraform/ @aptos-labs/prod-eng
+
+/types/src/transaction/authenticator.rs @alinush


### PR DESCRIPTION
### Description

Adding myself as a code owner for the TypeScript implementation of an Aptos account, due to the cryptographic operations there.

...and for other crypto-related things.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3589)
<!-- Reviewable:end -->
