### PR TITLE
[community] Update IT3 registration pages.

### DIFF
--- a/ecosystem/platform/server/app/views/layouts/_application.html.erb
+++ b/ecosystem/platform/server/app/views/layouts/_application.html.erb
@@ -40,7 +40,6 @@
   <body class="flex flex-col h-screen justify-between antialiased bg-neutral-900 <%= content_for(:body_class) %>">
     <div class="flex flex-col flex-1">
       <%= render HeaderComponent.new(user: current_user) %>
-      <%= render GlobalAnnouncementComponent.new(id: 'global-announcement', class: 'flex') %>
       <main class="flex-1">
         <%= yield %>
       </main>

--- a/ecosystem/platform/server/app/views/static_page/incentivized_testnet.html.erb
+++ b/ecosystem/platform/server/app/views/static_page/incentivized_testnet.html.erb
@@ -55,8 +55,8 @@
             </div>
             <div class="absolute top-full pt-2 text-center w-full flex flex-col items-center">
               <h4 class="text-lg md:text-xl lg:text-2xl font-mono capitalize text-teal-400 whitespace-nowrap">AIT-3</h4>
-              <%= render ButtonComponent.new(href: it3_path, title: 'Aptos Incentivized Testnet 3', size: :tiny, scheme: :primary, class: 'mt-2') do %>
-                Register
+              <%= render ButtonComponent.new(href: it3_path, title: 'Aptos Incentivized Testnet 3 results', size: :tiny, scheme: :secondary, class: 'mt-2') do %>
+                Results
               <% end %>
             </div>
           </div>
@@ -74,8 +74,8 @@
           <h3 class="font-display text-3xl text-neutral-100 mb-4">Aptos Incentivized <span class="whitespace-nowrap">Testnet 3</span></h3>
           <p class="text-neutral-400 mb-8 text-2xl md:text-3xl lg:text-4xl max-w-4xl">Aptos Labs remains focused on launching Mainnet to bring the community the safest, fastest and most reliable foundation for building within Web3.</p>
           <div class="flex flex-col md:flex-row justify-start items-start gap-4 mb-16">
-            <%= render ButtonComponent.new(href: it3_path, title: 'Aptos Incentivized Testnet 3 details', target: 'blank', size: :large, scheme: :primary, class: '') do %>
-              Get Started
+            <%= render ButtonComponent.new(href: it3_path, title: 'Aptos Incentivized Testnet 3 results', target: 'blank', size: :large, scheme: :primary, class: '') do %>
+              View Results
             <% end %>
             <%= render ButtonComponent.new(href: 'https://aptoslabs.medium.com/welcome-to-aptos-incentivized-testnet-3-9d7ce888205c', title: 'Aptos Incentivized Testnet 3 details', target: 'blank', size: :large, scheme: :secondary, class: '') do %>
               More Details

--- a/ecosystem/platform/server/config/routes.rb
+++ b/ecosystem/platform/server/config/routes.rb
@@ -68,19 +68,15 @@ Rails.application.routes.draw do
   # Health check
   get 'health', to: 'health#health'
 
-  # IT3
-  resource :it3, only: %i[show update]
-  resources :it3_profiles, except: %i[index destroy]
-  resources :it3_surveys, except: %i[index destroy]
-
   # Leaderboards
   get 'leaderboard/it1', to: redirect('/it1')
   get 'leaderboard/it2', to: redirect('/it2')
-  get 'leaderboard/it3'
+  get 'leaderboard/it3', to: redirect('/it3')
 
   # IT1
   get 'it1', to: 'leaderboard#it1'
   get 'it2', to: 'leaderboard#it2'
+  get 'it3', to: 'leaderboard#it3'
 
   # Projects
   resources :projects

--- a/ecosystem/platform/server/test/controllers/it3_profiles_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/it3_profiles_controller_test.rb
@@ -19,11 +19,13 @@ class It3ProfilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'new profile page' do
+    skip('it3 registration closed')
     get new_it3_profile_path
     assert_response :success
   end
 
   test 'create new profile' do
+    skip('it3 registration closed')
     assert_nil @user.it3_profile
     post it3_profiles_path, params: { it3_profile: {
       owner_key: '0xecaa0d44b821a745bc29767713cd78dbc88da73679e3ccdf5c145a2b4f7b17ac',
@@ -43,6 +45,7 @@ class It3ProfilesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'update existing profile' do
+    skip('it3 registration closed')
     it3_profile = FactoryBot.create(:it3_profile, user: @user)
 
     patch it3_profile_path(it3_profile), params: { it3_profile: {

--- a/ecosystem/platform/server/test/controllers/it3s_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/it3s_controller_test.rb
@@ -19,11 +19,13 @@ class It3sControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'it loads correctly' do
+    skip('it3 registration closed')
     get it3_path
     assert_response :success
   end
 
   test 'if logged out, it redirects to sign in, then redirects back to /it3' do
+    skip('it3 registration closed')
     sign_out @user
     get it3_path
     assert_redirected_to new_user_session_path


### PR DESCRIPTION
### Description

- Show the IT3 leaderboard at /it3
- Remove the global IT3 announcement
- Change register CTA to "view results" on IT landing page
- Skip IT3 registration tests

![image](https://user-images.githubusercontent.com/310773/187254486-fe71bd11-6806-4cc4-9d1a-17e81c4758bf.png)


### Test Plan
Manual

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3590)
<!-- Reviewable:end -->
