### PR TITLE
[forge] always run genesis from initial_version

### DIFF
--- a/.github/workflows/continuous-e2e-compat-test.yaml
+++ b/.github/workflows/continuous-e2e-compat-test.yaml
@@ -19,7 +19,7 @@ jobs:
       FORGE_CLUSTER_NAME: aptos-forge-big-1
       # Run for 5 minutes
       FORGE_RUNNER_DURATION_SECS: 300
-      # This will upgrade from devnet to the latest main
+      # This will upgrade from testnet branch to the latest main
       FORGE_TEST_SUITE: compat
-      IMAGE_TAG: devnet
+      IMAGE_TAG: testnet
       POST_TO_SLACK: true

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -272,6 +272,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
         Ok(())
     }
 
+    /// Get the initial version based on test configuration
     pub fn initial_version(&self) -> Version {
         let versions = self.factory.versions();
         match self.tests.initial_version {
@@ -279,13 +280,6 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
             InitialVersion::Newest => versions.max(),
         }
         .expect("There has to be at least 1 version")
-    }
-
-    pub fn genesis_version(&self) -> Version {
-        self.factory
-            .versions()
-            .max()
-            .expect("There has to be at least 1 version")
     }
 
     pub fn run(&self) -> Result<TestReport> {
@@ -305,7 +299,8 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     .collect::<Vec<_>>()
             );
             let initial_version = self.initial_version();
-            let genesis_version = self.genesis_version();
+            // The genesis version should always match the initial node version
+            let genesis_version = initial_version.clone();
             let runtime = Runtime::new().unwrap();
             let mut rng = ::rand::rngs::StdRng::from_seed(OsRng.gen());
             let mut swarm = runtime.block_on(self.factory.launch_swarm(


### PR DESCRIPTION
### Description

This PR makes it such that we always run genesis with the same version as the nodes at network startup. 

Specifically, within the test runner, make `genesis_version (of the genesis process) == initial_version (of the validators)`. Previously, `initial_version` was being set to the oldest image provided, whereas `genesis_version` was being set to the newest image. This means that for compat tests, we were spinning up genesis and validators at different versions. While this scenario is not likely, it technically constitutes a breaking/backwards incompatible change to genesis.

For example, this run https://github.com/aptos-labs/aptos-core/runs/8073630388?check_suite_focus=true (and many like it), is running compat upgrading image tags `devnet` ==> `279066e8c63360acf9fa722d12d519cd655badca`. It fails to achieve liveness due to validator crash at startup due to incompatible genesis, likely because genesis was done at `279066e8c63360acf9fa722d12d519cd655badca` rather than at `devnet`

```
[VM] Unexpected verifier/deserialization error! This likely means there is code stored on chain that is unverifiable!\nError: VMError { major_status: MISSING_DEPENDENCY, sub_status: None, message: None, exec_state: None, location: Module(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000001, name: Identifier(\"from_bcs\") }), indices: [(FunctionHandle, 0)], offsets: [] }"
```

### Test Plan

Run Forge on PR. Then compat test 

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3594)
<!-- Reviewable:end -->
