### PR TITLE
[helm][monitoring] do not drop other namespaces for cadvisor

### DIFF
--- a/terraform/helm/monitoring/files/prometheus.yml
+++ b/terraform/helm/monitoring/files/prometheus.yml
@@ -89,18 +89,11 @@ scrape_configs:
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 
- {{ if not .Values.monitoring.prometheus.fullKubernetesScrape }}
+  {{ if not .Values.monitoring.prometheus.fullKubernetesScrape }}
   metric_relabel_configs:
-  - source_labels: [namespace, pod]
+  - source_labels: [pod]
     action: keep
-    regex: "{{ .Release.Namespace }};{{ .Release.Name }}-.*"
-  # Explicitly drop spammy metrics
-  - source_labels: [__name__]
-    regex: 'container_tasks_state'
-    action: drop
-  - source_labels: [__name__]
-    regex: 'container_memory_(!working_set_bytes).*'
-    action: drop
+    regex: "{{ .Release.Name }}-.*"
   {{ end }}
 
 - job_name: "prom-pod-annotation"


### PR DESCRIPTION
### Description

Previously, cAdvisor scrape config was dropping metrics that did not match the deployment namespace if `fullKubernetesScrape = false` (which recently became the default value). This doesn't work in Forge case, since swarms are created in non-default namespaces.

### Test Plan

Apply and check that we get cAdvisor metrics. This un-breaks the Forge metrics checking for CPU and memory

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3601)
<!-- Reviewable:end -->
