### PR TITLE
[Indexer] Switch starting version to starting block

### DIFF
--- a/config/src/config/firehose_streamer_config.rs
+++ b/config/src/config/firehose_streamer_config.rs
@@ -7,8 +7,11 @@ use serde::{Deserialize, Serialize};
 #[serde(default, deny_unknown_fields)]
 pub struct FirehoseStreamerConfig {
     pub enabled: bool,
-    // The version to start pushing out indexed data from, for the StreamingFast Firehose indexer
-    // Alternatively can set the `STARTING_VERSION` env var
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[deprecated = "please use starting_block instead"]
     pub starting_version: Option<u64>,
+    // The block to start pushing out indexed data from, for the StreamingFast Firehose indexer
+    // Alternatively can set the `STARTING_BLOCK` env var
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub starting_block: Option<u64>,
 }

--- a/ecosystem/sf-indexer/firehose-stream/src/runtime.rs
+++ b/ecosystem/sf-indexer/firehose-stream/src/runtime.rs
@@ -44,13 +44,15 @@ pub fn bootstrap(
     runtime.spawn(async move {
         let context = Context::new(chain_id, db, mp_sender.clone(), node_config.clone());
         let context_arc = Arc::new(context);
-        // Let the env variable take precedence over the config file
-        let config_starting_version = node_config.firehose_stream.starting_version.unwrap_or(0);
-        let starting_version = std::env::var("STARTING_VERSION")
-            .map(|v| v.parse::<u64>().unwrap_or(config_starting_version))
-            .unwrap_or(config_starting_version);
-
-        let mut streamer = FirehoseStreamer::new(context_arc, starting_version, Some(mp_sender));
+        // Let the env variable take precedence over the config file, (if env is not set it just default to 0)
+        let config_starting_block = node_config.firehose_stream.starting_block.unwrap_or(0);
+        let mut starting_block = std::env::var("STARTING_BLOCK")
+            .map(|v| v.parse::<u64>().unwrap_or(0))
+            .unwrap_or(0);
+        if starting_block == 0 {
+            starting_block = config_starting_block;
+        }
+        let mut streamer = FirehoseStreamer::new(context_arc, starting_block, Some(mp_sender));
         streamer.start().await;
     });
     Some(Ok(runtime))
@@ -68,17 +70,17 @@ pub struct FirehoseStreamer {
 impl FirehoseStreamer {
     pub fn new(
         context: Arc<Context>,
-        starting_version: u64,
+        starting_block: u64,
         mp_client_sender: Option<MempoolClientSender>,
     ) -> Self {
         let resolver = Arc::new(context.move_resolver().unwrap());
-        let (_block_start_version, _block_last_versionn, block_event) = context
+        let (_block_start_version, _block_last_version, block_event) = context
             .db
-            .get_block_info_by_version(starting_version)
+            .get_block_info_by_height(starting_block)
             .unwrap_or_else(|_| {
                 panic!(
-                    "Could not get block_info for starting version {}",
-                    starting_version,
+                    "Could not get block_info for starting block {}",
+                    starting_block,
                 )
             });
 


### PR DESCRIPTION
### Description
Firehose is sending us starting block instead of starting version. Switching to starting version is non trivial on the firehose side and will incur additional processing, so we should just change it to starting block on our side. We are keeping starting_version in the config to keep backward compatibility. 

### Test Plan
Node still runs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3607)
<!-- Reviewable:end -->
