### PR TITLE
[mempool] add max capacity in bytes

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default, deny_unknown_fields)]
 pub struct MempoolConfig {
     pub capacity: usize,
+    pub capacity_bytes: usize,
     pub capacity_per_user: usize,
     // number of failovers to broadcast to when the primary network is alive
     pub default_failovers: usize,
@@ -36,6 +37,7 @@ impl Default for MempoolConfig {
             max_broadcasts_per_peer: 1,
             mempool_snapshot_interval_secs: 180,
             capacity: 2_000_000,
+            capacity_bytes: 2_147_483_648,
             capacity_per_user: 100,
             default_failovers: 3,
             system_transaction_timeout_secs: 600,

--- a/mempool/src/core_mempool/mod.rs
+++ b/mempool/src/core_mempool/mod.rs
@@ -9,4 +9,7 @@ mod ttl_cache;
 
 #[cfg(test)]
 pub use self::ttl_cache::TtlCache;
-pub use self::{index::TxnPointer, mempool::Mempool as CoreMempool, transaction::TimelineState};
+pub use self::{
+    index::TxnPointer, mempool::Mempool as CoreMempool, transaction::MempoolTransaction,
+    transaction::TimelineState, transaction_store::TXN_INDEX_ESTIMATED_BYTES,
+};

--- a/mempool/src/core_mempool/transaction.rs
+++ b/mempool/src/core_mempool/transaction.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::core_mempool::TXN_INDEX_ESTIMATED_BYTES;
 use aptos_crypto::HashValue;
 use aptos_types::{
     account_address::AccountAddress, account_config::AccountSequenceInfo,
@@ -46,6 +47,9 @@ impl MempoolTransaction {
     }
     pub(crate) fn get_committed_hash(&self) -> HashValue {
         self.txn.clone().committed_hash()
+    }
+    pub(crate) fn get_estimated_bytes(&self) -> usize {
+        std::mem::size_of_val(self) + TXN_INDEX_ESTIMATED_BYTES
     }
 }
 

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -255,6 +255,7 @@ impl TransactionStore {
             counters::TRANSACTION_HASH_INDEX_LABEL,
             self.hash_index.len(),
         );
+        counters::core_mempool_index_size(counters::SIZE_BYTES_LABEL, self.size_bytes);
     }
 
     /// Checks if Mempool is full.

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -18,6 +18,7 @@ pub const SYSTEM_TTL_INDEX_LABEL: &str = "system_ttl";
 pub const TIMELINE_INDEX_LABEL: &str = "timeline";
 pub const PARKING_LOT_INDEX_LABEL: &str = "parking_lot";
 pub const TRANSACTION_HASH_INDEX_LABEL: &str = "transaction_hash";
+pub const SIZE_BYTES_LABEL: &str = "size_bytes";
 
 // Core mempool commit stages labels
 pub const GET_BLOCK_STAGE_LABEL: &str = "get_block";

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    core_mempool::{CoreMempool, TimelineState, TtlCache},
+    core_mempool::{CoreMempool, MempoolTransaction, TimelineState, TtlCache},
     tests::common::{
         add_signed_txn, add_txn, add_txns_to_mempool, exist_in_metrics_cache, setup_mempool,
         TestTransaction,
@@ -10,6 +10,7 @@ use crate::{
 };
 use aptos_config::config::NodeConfig;
 use aptos_crypto::HashValue;
+use aptos_types::mempool_status::MempoolStatusCode;
 use aptos_types::{account_config::AccountSequenceInfo, transaction::SignedTransaction};
 use std::{
     collections::HashSet,
@@ -509,6 +510,66 @@ fn test_capacity() {
     assert!(add_txn(&mut pool, TestTransaction::new(1, 2, 1)).is_err());
     pool.gc();
     assert!(add_txn(&mut pool, TestTransaction::new(1, 2, 1)).is_ok());
+}
+
+#[test]
+fn test_capacity_bytes() {
+    let mut config = NodeConfig::random();
+    config.mempool.capacity = 1_000; // Won't hit this limit.
+    config.mempool.capacity_bytes = 2_048;
+    let mut pool = CoreMempool::new(&config);
+    let address = 1;
+
+    let mut size_bytes: usize = 0;
+    let mut seq_no = 1_000;
+    let mut txns = vec![];
+    let last_txn;
+    loop {
+        let txn = new_test_mempool_transaction(address, seq_no);
+        let txn_bytes = txn.get_estimated_bytes();
+
+        if size_bytes <= config.mempool.capacity_bytes {
+            txns.push(txn);
+            seq_no -= 1;
+            size_bytes += txn_bytes;
+        } else {
+            last_txn = Some(txn);
+            break;
+        }
+    }
+    assert!(txns.len() > 0);
+    assert!(last_txn.is_some());
+
+    txns.into_iter().for_each(|txn| {
+        let status = pool.add_txn(
+            txn.txn,
+            txn.ranking_score,
+            txn.sequence_info.account_sequence_number_type,
+            txn.timeline_state,
+        );
+        assert_eq!(status.code, MempoolStatusCode::Accepted);
+    });
+
+    if let Some(txn) = last_txn {
+        let status = pool.add_txn(
+            txn.txn,
+            txn.ranking_score,
+            txn.sequence_info.account_sequence_number_type,
+            txn.timeline_state,
+        );
+        assert_eq!(status.code, MempoolStatusCode::MempoolIsFull);
+    }
+}
+
+fn new_test_mempool_transaction(address: usize, sequence_number: u64) -> MempoolTransaction {
+    let signed_txn = TestTransaction::new(address, sequence_number, 1).make_signed_transaction();
+    MempoolTransaction::new(
+        signed_txn,
+        Duration::from_secs(1),
+        1,
+        TimelineState::NotReady,
+        AccountSequenceInfo::Sequential(0),
+    )
 }
 
 #[test]

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -535,7 +535,7 @@ fn test_capacity_bytes() {
             break;
         }
     }
-    assert!(txns.len() > 0);
+    assert!(!txns.is_empty());
     assert!(last_txn.is_some());
 
     // Set exact limit


### PR DESCRIPTION
### Description

This can prevent larger transactions from adding memory pressure or OOMing the node.
Did _not_ add a per-user limit. This assumes (max txn size) * (max txn per user) << max capacity in bytes.

Also noticed we are now caching BCS txn bytes which is unnecessary and removed this.

### Test Plan
Added unit test for capacity in bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3608)
<!-- Reviewable:end -->
