### PR TITLE
[forge] Add account creation continuous forge test and having loadtest params per test

### DIFF
--- a/.github/workflows/continuous-e2-account-creation-state-sync.yaml
+++ b/.github/workflows/continuous-e2-account-creation-state-sync.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E Account Creation State Sync Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  ### Please remember to use different namespace for different tests
+  # Performance test in an optimal setting
+  run-forge-account-creation-ss:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-account-creation-ss
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      FORGE_RUNNER_DURATION_SECS: 1800
+      FORGE_TEST_SUITE: account_creation_state_sync
+      POST_TO_SLACK: true

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -106,7 +106,6 @@ pub struct EmitJobRequest {
 
     gas_price: u64,
     invalid_transaction_ratio: usize,
-    pub duration: Duration,
     reuse_accounts: bool,
     mint_to_root: bool,
 
@@ -127,7 +126,6 @@ impl Default for EmitJobRequest {
             },
             gas_price: 0,
             invalid_transaction_ratio: 0,
-            duration: Duration::from_secs(300),
             reuse_accounts: false,
             mint_to_root: false,
             transaction_mix: vec![(TransactionType::P2P, 1)],
@@ -175,11 +173,6 @@ impl EmitJobRequest {
 
     pub fn reuse_accounts(mut self) -> Self {
         self.reuse_accounts = true;
-        self
-    }
-
-    pub fn duration(mut self, duration: Duration) -> Self {
-        self.duration = duration;
         self
     }
 
@@ -522,8 +515,11 @@ impl<'t> TxnEmitter<'t> {
         }
     }
 
-    pub async fn emit_txn_for(&mut self, emit_job_request: EmitJobRequest) -> Result<TxnStats> {
-        let duration = emit_job_request.duration;
+    pub async fn emit_txn_for(
+        &mut self,
+        emit_job_request: EmitJobRequest,
+        duration: Duration,
+    ) -> Result<TxnStats> {
         let job = self.start_job(emit_job_request).await?;
         info!("Starting emitting txns for {} secs", duration.as_secs());
         time::sleep(duration).await;
@@ -536,9 +532,9 @@ impl<'t> TxnEmitter<'t> {
     pub async fn emit_txn_for_with_stats(
         &mut self,
         emit_job_request: EmitJobRequest,
+        duration: Duration,
         interval_secs: u64,
     ) -> Result<TxnStats> {
-        let duration = emit_job_request.duration;
         info!("Starting emitting txns for {} secs", duration.as_secs());
         let job = self.start_job(emit_job_request).await?;
         self.periodic_stat(&job, duration, interval_secs).await;

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -65,14 +65,17 @@ pub async fn emit_transactions_with_cluster(
             .mode(emitter_mode)
             .invalid_transaction_ratio(args.invalid_tx)
             .transaction_mix(transaction_mix)
-            .duration(duration)
             .txn_expiration_time_secs(args.txn_expiration_time_secs)
             .gas_price(1);
     if reuse_accounts {
         emit_job_request = emit_job_request.reuse_accounts();
     }
     let stats = emitter
-        .emit_txn_for_with_stats(emit_job_request, min(10, max(args.duration / 5, 1)))
+        .emit_txn_for_with_stats(
+            emit_job_request,
+            duration,
+            min(10, max(args.duration / 5, 1)),
+        )
         .await?;
     Ok(stats)
 }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -25,10 +25,6 @@ use url::Url;
 
 #[derive(StructOpt, Debug)]
 struct Args {
-    #[structopt(long, default_value = "30000")]
-    mempool_backlog: usize,
-    #[structopt(long, default_value = "0")]
-    target_tps: usize,
     #[structopt(long, default_value = "300")]
     duration_secs: usize,
     #[structopt(flatten)]
@@ -179,20 +175,17 @@ fn main() -> Result<()> {
 
     let args = Args::from_args();
     let duration = Duration::from_secs(args.duration_secs as u64);
-    let emitter_mode = EmitJobMode::create(args.mempool_backlog, args.target_tps);
-
-    let global_emit_job_request = EmitJobRequest::default()
-        .duration(Duration::from_secs(args.duration_secs as u64))
-        .mode(emitter_mode);
+    let suite_name: &str = args.suite.as_ref();
 
     let runtime = Runtime::new()?;
     match args.cli_cmd {
         // cmd input for test
         CliCommand::Test(ref test_cmd) => {
             // Identify the test suite to run
-            let mut test_suite = get_test_suite(args.suite.as_ref(), duration)?;
+            let mut test_suite = get_test_suite(suite_name, duration)?;
 
             // Identify the number of validators and fullnodes to run
+            // (if overriding what test has specified)
             if let Some(num_validators) = args.num_validators {
                 let num_validators_non_zero = NonZeroUsize::new(num_validators)
                     .context("--num-validators must be positive!")?;
@@ -216,14 +209,17 @@ fn main() -> Result<()> {
             match test_cmd {
                 TestCommand::LocalSwarm(..) => {
                     // Loosen all criteria for local runs
-                    let test_suite =
-                        test_suite.with_success_criteria(SuccessCriteria::new(400, 60000, None));
+                    let test_suite = test_suite
+                        .with_success_criteria(SuccessCriteria::new(400, 60000, None))
+                        .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
+                            mempool_backlog: 5000,
+                        }));
                     run_forge(
+                        duration,
                         test_suite,
                         LocalFactory::from_workspace()?,
                         &args.options,
                         args.changelog.clone(),
-                        global_emit_job_request,
                     )
                 }
                 TestCommand::K8sSwarm(k8s) => {
@@ -231,6 +227,7 @@ fn main() -> Result<()> {
                         test_suite = test_suite.with_genesis_modules_path(move_modules_dir.clone());
                     }
                     run_forge(
+                        duration,
                         test_suite,
                         K8sFactory::new(
                             k8s.namespace.clone(),
@@ -244,7 +241,6 @@ fn main() -> Result<()> {
                         .unwrap(),
                         &args.options,
                         args.changelog,
-                        global_emit_job_request,
                     )?;
                     Ok(())
                 }
@@ -289,13 +285,13 @@ fn main() -> Result<()> {
 }
 
 pub fn run_forge<F: Factory>(
+    global_duration: Duration,
     tests: ForgeConfig<'_>,
     factory: F,
     options: &Options,
     logs: Option<Vec<String>>,
-    global_job_request: EmitJobRequest,
 ) -> Result<()> {
-    let forge = Forge::new(options, tests, factory, global_job_request);
+    let forge = Forge::new(options, tests, global_duration, factory);
 
     if options.list {
         forge.list()?;
@@ -449,6 +445,25 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_network_tests(&[&PerformanceBenchmarkWithFN])
             .with_success_criteria(SuccessCriteria::new(
                 5000,
+                10000,
+                Some(Duration::from_secs(240)),
+            )),
+        "account_creation_state_sync" => config
+            .with_network_tests(&[&PerformanceBenchmarkWithFN])
+            .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
+            .with_initial_fullnode_count(3)
+            .with_genesis_helm_config_fn(Arc::new(|helm_values| {
+                helm_values["chain"]["epoch_duration_secs"] = 1200.into();
+            }))
+            .with_emit_job(
+                EmitJobRequest::default()
+                    .mode(EmitJobMode::MaxLoad {
+                        mempool_backlog: 30000,
+                    })
+                    .transaction_type(TransactionType::AccountGeneration),
+            )
+            .with_success_criteria(SuccessCriteria::new(
+                4000,
                 10000,
                 Some(Duration::from_secs(240)),
             )),

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -21,7 +21,8 @@ pub struct NetworkContext<'t> {
     core: CoreContext,
     swarm: &'t mut dyn Swarm,
     pub report: &'t mut TestReport,
-    pub global_job: EmitJobRequest,
+    pub global_duration: Duration,
+    pub emit_job: EmitJobRequest,
     pub success_criteria: SuccessCriteria,
     runtime: Runtime,
 }
@@ -31,14 +32,16 @@ impl<'t> NetworkContext<'t> {
         core: CoreContext,
         swarm: &'t mut dyn Swarm,
         report: &'t mut TestReport,
-        global_job: EmitJobRequest,
+        global_duration: Duration,
+        emit_job: EmitJobRequest,
         success_criteria: SuccessCriteria,
     ) -> Self {
         Self {
             core,
             swarm,
             report,
-            global_job,
+            global_duration,
+            emit_job,
             success_criteria,
             runtime: Runtime::new().unwrap(),
         }

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -91,7 +91,7 @@ impl Default for Format {
 }
 
 pub fn forge_main<F: Factory>(tests: ForgeConfig<'_>, factory: F, options: &Options) -> Result<()> {
-    let forge = Forge::new(options, tests, factory, EmitJobRequest::default());
+    let forge = Forge::new(options, tests, Duration::from_secs(300), factory);
 
     if options.list {
         forge.list()?;
@@ -139,6 +139,9 @@ pub struct ForgeConfig<'cfg> {
 
     /// Optional node helm values init function
     node_helm_config_fn: Option<NodeConfigFn>,
+
+    /// Transaction workload to run on the swarm
+    emit_job_request: EmitJobRequest,
 
     /// Success criteria
     success_criteria: SuccessCriteria,
@@ -199,6 +202,11 @@ impl<'cfg> ForgeConfig<'cfg> {
         self
     }
 
+    pub fn with_emit_job(mut self, emit_job_request: EmitJobRequest) -> Self {
+        self.emit_job_request = emit_job_request;
+        self
+    }
+
     pub fn with_success_criteria(mut self, success_criteria: SuccessCriteria) -> Self {
         self.success_criteria = success_criteria;
         self
@@ -229,6 +237,9 @@ impl<'cfg> Default for ForgeConfig<'cfg> {
             genesis_config: None,
             genesis_helm_config_fn: None,
             node_helm_config_fn: None,
+            emit_job_request: EmitJobRequest::default().mode(EmitJobMode::MaxLoad {
+                mempool_backlog: 30000,
+            }),
             success_criteria: SuccessCriteria::new(3500, 10000, None),
         }
     }
@@ -237,22 +248,22 @@ impl<'cfg> Default for ForgeConfig<'cfg> {
 pub struct Forge<'cfg, F> {
     options: &'cfg Options,
     tests: ForgeConfig<'cfg>,
+    global_duration: Duration,
     factory: F,
-    global_job_request: EmitJobRequest,
 }
 
 impl<'cfg, F: Factory> Forge<'cfg, F> {
     pub fn new(
         options: &'cfg Options,
         tests: ForgeConfig<'cfg>,
+        global_duration: Duration,
         factory: F,
-        global_job_request: EmitJobRequest,
     ) -> Self {
         Self {
             options,
             tests,
+            global_duration,
             factory,
-            global_job_request,
         }
     }
 
@@ -310,8 +321,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 &initial_version,
                 &genesis_version,
                 self.tests.genesis_config.as_ref(),
-                self.global_job_request.duration
-                    + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
+                self.global_duration + Duration::from_secs(NAMESPACE_CLEANUP_DURATION_BUFFER_SECS),
                 self.tests.genesis_helm_config_fn.clone(),
                 self.tests.node_helm_config_fn.clone(),
             ))?;
@@ -345,7 +355,8 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     CoreContext::from_rng(&mut rng),
                     &mut *swarm,
                     &mut report,
-                    self.global_job_request.clone(),
+                    self.global_duration,
+                    self.tests.emit_job_request.clone(),
                     self.tests.success_criteria.clone(),
                 );
                 let result = run_test(|| test.run(&mut network_ctx));

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -124,7 +124,7 @@ class ForgeRunnerTests(unittest.TestCase):
     def testLocalRunner(self) -> None:
         shell = SpyShell(OrderedDict([
             (
-                'cargo run -p forge-cli -- --suite banana --mempool-backlog 500'
+                'cargo run -p forge-cli -- --suite banana'
                 '0 --avg-tps 593943 --max-latency-ms 6000 --duration-secs 123 t'
                 'est k8s-swarm --image-tag asdf --upgrade-image-tag upgrade_asd'
                 'f --namespace potato --port-forward',

--- a/testsuite/run_forge.sh
+++ b/testsuite/run_forge.sh
@@ -253,7 +253,7 @@ if [ "$FORGE_RUNNER_MODE" = "local" ]; then
     kubectl port-forward -n default svc/aptos-node-mon-aptos-monitoring-prometheus 9090:9090 >/dev/null 2>&1 &
     prometheus_port_forward_pid=$!
 
-    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --mempool-backlog 5000 --duration-secs $FORGE_RUNNER_DURATION_SECS \
+    cargo run -p forge-cli -- --suite $FORGE_TEST_SUITE --duration-secs $FORGE_RUNNER_DURATION_SECS \
         test k8s-swarm \
         --image-tag $IMAGE_TAG \
         --upgrade-image-tag $UPGRADE_IMAGE_TAG \

--- a/testsuite/smoke-test/src/txn_emitter.rs
+++ b/testsuite/smoke-test/src/txn_emitter.rs
@@ -40,14 +40,15 @@ pub async fn generate_traffic(
     emit_job_request = emit_job_request
         .rest_clients(validator_clients)
         .gas_price(gas_price)
-        .duration(duration)
         .transaction_mix(vec![
             (TransactionType::P2P, 70),
             (TransactionType::AccountGeneration, 20),
             (TransactionType::NftMint, 10),
         ])
         .mode(EmitJobMode::ConstTps { tps: 20 });
-    emitter.emit_txn_for_with_stats(emit_job_request, 3).await
+    emitter
+        .emit_txn_for_with_stats(emit_job_request, duration, 3)
+        .await
 }
 
 #[tokio::test]

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -74,7 +74,7 @@ pub fn generate_traffic<'t>(
         .collect::<Vec<_>>();
     let all_node_clients = [&fullnode_clients[..], &validator_clients[..]].concat();
 
-    let mut emit_job_request = ctx.global_job.clone();
+    let mut emit_job_request = ctx.emit_job.clone();
     let chain_info = ctx.swarm().chain_info();
     let transaction_factory = TransactionFactory::new(chain_info.chain_id).with_gas_unit_price(1);
     let mut emitter = TxnEmitter::new(
@@ -87,9 +87,8 @@ pub fn generate_traffic<'t>(
 
     emit_job_request = emit_job_request
         .rest_clients(all_node_clients)
-        .gas_price(gas_price)
-        .duration(duration);
-    let stats = rt.block_on(emitter.emit_txn_for(emit_job_request))?;
+        .gas_price(gas_price);
+    let stats = rt.block_on(emitter.emit_txn_for(emit_job_request, duration))?;
 
     Ok(stats)
 }

--- a/testsuite/testcases/src/network_bandwidth_test.rs
+++ b/testsuite/testcases/src/network_bandwidth_test.rs
@@ -22,7 +22,7 @@ impl Test for NetworkBandwidthTest {
 
 impl NetworkTest for NetworkBandwidthTest {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = ctx.global_job.duration;
+        let duration = ctx.global_duration;
         let bandwidth = SwarmChaos::Bandwidth(SwarmNetworkBandwidth {
             rate: RATE_MBPS,
             limit: LIMIT_BYTES,

--- a/testsuite/testcases/src/network_latency_test.rs
+++ b/testsuite/testcases/src/network_latency_test.rs
@@ -19,7 +19,7 @@ impl Test for NetworkLatencyTest {
 
 impl NetworkTest for NetworkLatencyTest {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = ctx.global_job.duration;
+        let duration = ctx.global_duration;
         let delay = SwarmChaos::Delay(SwarmNetworkDelay {
             latency_ms: LATENCY_MS,
             jitter_ms: JITTER_MS,

--- a/testsuite/testcases/src/network_loss_test.rs
+++ b/testsuite/testcases/src/network_loss_test.rs
@@ -18,7 +18,7 @@ impl Test for NetworkLossTest {
 
 impl NetworkTest for NetworkLossTest {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = ctx.global_job.duration;
+        let duration = ctx.global_duration;
         let loss_percentage = LOSS_PERCENTAGE;
         let correlation_percentage = CORRELATION_PERCENTAGE;
         let loss = SwarmChaos::Loss(SwarmNetworkLoss {

--- a/testsuite/testcases/src/network_partition_test.rs
+++ b/testsuite/testcases/src/network_partition_test.rs
@@ -17,7 +17,7 @@ impl Test for NetworkPartitionTest {
 
 impl NetworkTest for NetworkPartitionTest {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = ctx.global_job.duration;
+        let duration = ctx.global_duration;
 
         let partition = SwarmChaos::Partition(SwarmNetworkPartition {
             partition_percentage: PARTITION_PERCENTAGE,

--- a/testsuite/testcases/src/performance_test.rs
+++ b/testsuite/testcases/src/performance_test.rs
@@ -15,7 +15,7 @@ impl Test for PerformanceBenchmark {
 
 impl NetworkTest for PerformanceBenchmark {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = ctx.global_job.duration;
+        let duration = ctx.global_duration;
         let all_validators = ctx
             .swarm()
             .validators()

--- a/testsuite/testcases/src/performance_with_fullnode_test.rs
+++ b/testsuite/testcases/src/performance_with_fullnode_test.rs
@@ -15,7 +15,7 @@ impl Test for PerformanceBenchmarkWithFN {
 
 impl NetworkTest for PerformanceBenchmarkWithFN {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let duration = ctx.global_job.duration;
+        let duration = ctx.global_duration;
 
         let all_fullnodes = ctx
             .swarm()

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -20,7 +20,7 @@ impl Test for StateSyncPerformance {
 
 impl NetworkTest for StateSyncPerformance {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let emit_txn_duration = ctx.global_job.duration; // How long we'll emit txns for
+        let emit_txn_duration = ctx.global_duration; // How long we'll emit txns for
         let fullnode_sync_duration = emit_txn_duration.saturating_mul(2); // Limits state sync to half txn throughput
 
         // Generate some traffic through the fullnodes


### PR DESCRIPTION
- Moved duration out of load test params, and into Forge.
- load tests is now specified together with SuccessCriteria, and not via CLI as duration is.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3609)
<!-- Reviewable:end -->
