### PR TITLE
[CP] Fix typo in Explorer Address URL

### DIFF
--- a/ecosystem/platform/server/app/views/leaderboard/it3.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it3.html.erb
@@ -107,7 +107,7 @@
                   <%= metric.rank %>
                 <% end %>
                 <%= tr.with_column(class: 'max-w-0 2xl:max-w-full w-full 2xl:w-auto truncate', title: metric.owner_address) do %>
-                  <a href="https://explorer.devnet.aptos.dev/address/<%= metric.owner_address %>?network=ait3" target="_blank" title="View Account Address on Explorer"><%= metric.owner_address %></a>
+                  <a href="https://explorer.devnet.aptos.dev/account/<%= metric.owner_address %>?network=ait3" target="_blank" title="View Account Address on Explorer"><%= metric.owner_address %></a>
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">


### PR DESCRIPTION
### Description

Fix typo in Explorer Address URL from `address` to `account` within AIT-3 Validator Status table

### Test Plan
Ensure URL is correct when clicking rows within AIT-3 Validator Status table

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3614)
<!-- Reviewable:end -->
