### PR TITLE
[storage] correct state storage usage calculation when there's overlapping chunks and/or resuming in a snapshot restore

### DIFF
--- a/aptos-move/aptos-aggregator/src/aggregator_extension.rs
+++ b/aptos-move/aptos-aggregator/src/aggregator_extension.rs
@@ -366,7 +366,8 @@ pub fn extension_error(message: impl ToString) -> PartialVMError {
 mod test {
     use super::*;
     use crate::delta_change_set::serialize;
-    use aptos_state_view::{state_storage_usage::StateStorageUsage, StateView};
+    use aptos_state_view::StateView;
+    use aptos_types::state_store::state_storage_usage::StateStorageUsage;
     use aptos_types::{
         account_address::AccountAddress,
         state_store::{state_key::StateKey, table::TableHandle as AptosTableHandle},

--- a/aptos-move/aptos-aggregator/src/delta_change_set.rs
+++ b/aptos-move/aptos-aggregator/src/delta_change_set.rs
@@ -291,7 +291,7 @@ impl ::std::iter::IntoIterator for DeltaChangeSet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aptos_state_view::state_storage_usage::StateStorageUsage;
+    use aptos_types::state_store::state_storage_usage::StateStorageUsage;
     use claim::{assert_err, assert_matches, assert_ok, assert_ok_eq};
     use once_cell::sync::Lazy;
     use std::collections::HashMap;

--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -6,8 +6,8 @@ mod storage_interface;
 pub use crate::storage_interface::DBDebuggerInterface;
 
 use anyhow::{anyhow, Result};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::StateView;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::CORE_CODE_ADDRESS,

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -7,8 +7,8 @@ use crate::{counters::CRITICAL_ERRORS, create_access_path, logging::AdapterLogSc
 use anyhow::format_err;
 use anyhow::Error;
 use aptos_logger::prelude::*;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::{StateView, StateViewId};
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     access_path::AccessPath,
     on_chain_config::ConfigStorage,

--- a/aptos-move/aptos-vm/src/delta_state_view.rs
+++ b/aptos-move/aptos-vm/src/delta_state_view.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use aptos_state_view::{state_storage_usage::StateStorageUsage, StateView, StateViewId};
+use aptos_state_view::{StateView, StateViewId};
 use aptos_types::state_store::state_key::StateKey;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::write_set::{WriteOp, WriteSet};
 
 pub struct DeltaStateView<'a, 'b, S> {

--- a/aptos-move/aptos-vm/src/parallel_executor/storage_wrapper.rs
+++ b/aptos-move/aptos-vm/src/parallel_executor/storage_wrapper.rs
@@ -4,8 +4,8 @@
 use crate::data_cache::{IntoMoveResolver, StorageAdapterOwned};
 use aptos_aggregator::delta_change_set::{deserialize, serialize};
 use aptos_parallel_executor::executor::{MVHashMapView, ReadResult};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::{StateView, StateViewId};
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     state_store::state_key::StateKey,
     vm_status::{StatusCode, VMStatus},

--- a/aptos-move/e2e-tests/src/data_store.rs
+++ b/aptos-move/e2e-tests/src/data_store.rs
@@ -5,8 +5,8 @@
 
 use crate::account::AccountData;
 use anyhow::Result;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::StateView;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     access_path::AccessPath,
     account_config::CoinInfoResource,

--- a/aptos-move/framework/src/natives/state_storage.rs
+++ b/aptos-move/framework/src/natives/state_storage.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::vm_status::StatusCode;
 use better_any::{Tid, TidAble};
 use move_deps::move_binary_format::errors::PartialVMError;

--- a/aptos-move/vm-genesis/src/genesis_context.rs
+++ b/aptos-move/vm-genesis/src/genesis_context.rs
@@ -4,8 +4,8 @@
 #![forbid(unsafe_code)]
 
 use anyhow::Result;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::StateView;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{access_path::AccessPath, state_store::state_key::StateKey};
 use move_deps::move_core_types::language_storage::ModuleId;
 use std::collections::HashMap;

--- a/execution/executor-types/src/in_memory_state_calculator.rs
+++ b/execution/executor-types/src/in_memory_state_calculator.rs
@@ -9,7 +9,7 @@ use once_cell::sync::Lazy;
 use crate::{ParsedTransactionOutput, ProofReader};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_state_view::account_with_state_cache::AsAccountWithStateCache;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     account_view::AccountView,

--- a/execution/executor/src/mock_vm/mock_vm_test.rs
+++ b/execution/executor/src/mock_vm/mock_vm_test.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeMap;
 
 use super::{balance_ap, encode_mint_transaction, encode_transfer_transaction, seqnum_ap, MockVM};
 use anyhow::Result;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::StateView;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     account_address::AccountAddress, state_store::state_key::StateKey, write_set::WriteOp,
 };

--- a/storage/aptosdb/src/aptosdb_test.rs
+++ b/storage/aptosdb/src/aptosdb_test.rs
@@ -15,9 +15,9 @@ use aptos_config::config::{
     StateMerklePrunerConfig, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD, TARGET_SNAPSHOT_SIZE,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_temppath::TempPath;
 use aptos_types::ledger_info::LedgerInfoWithSignatures;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::transaction::{TransactionToCommit, Version};
 use aptos_types::{
     proof::SparseMerkleLeafNode,

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -62,8 +62,8 @@ use aptos_crypto::hash::HashValue;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_rocksdb_options::gen_rocksdb_options;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_types::proof::TransactionAccumulatorSummary;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{new_block_event_key, NewBlockEvent},

--- a/storage/aptosdb/src/pruner/state_store/test.rs
+++ b/storage/aptosdb/src/pruner/state_store/test.rs
@@ -6,8 +6,8 @@ use proptest::{prelude::*, proptest};
 use std::{collections::HashMap, sync::Arc};
 
 use aptos_crypto::HashValue;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_temppath::TempPath;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,

--- a/storage/aptosdb/src/schema/db_metadata/mod.rs
+++ b/storage/aptosdb/src/schema/db_metadata/mod.rs
@@ -11,6 +11,7 @@
 
 use crate::schema::DB_METADATA_CF_NAME;
 use anyhow::Result;
+use aptos_jellyfish_merkle::StateSnapshotProgress;
 use aptos_types::transaction::Version;
 use schemadb::{
     define_schema,
@@ -22,12 +23,21 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 pub(crate) enum DbMetadataValue {
     Version(Version),
+    StateSnapshotProgress(StateSnapshotProgress),
 }
 
 impl DbMetadataValue {
     pub fn expect_version(self) -> Version {
         match self {
-            Self::Version(v) => v,
+            Self::Version(version) => version,
+            _ => unreachable!("expected Version, got {:?}", self),
+        }
+    }
+
+    pub fn expect_state_snapshot_progress(self) -> StateSnapshotProgress {
+        match self {
+            Self::StateSnapshotProgress(progress) => progress,
+            _ => unreachable!("expected KeyHashAndUsage, got {:?}", self),
         }
     }
 }
@@ -38,6 +48,7 @@ pub enum DbMetadataKey {
     LedgerPrunerProgress,
     StateMerklePrunerProgress,
     EpochEndingStateMerklePrunerProgress,
+    StateSnapshotRestoreProgress(Version),
 }
 
 define_schema!(

--- a/storage/aptosdb/src/schema/version_data/mod.rs
+++ b/storage/aptosdb/src/schema/version_data/mod.rs
@@ -15,7 +15,7 @@
 use super::VERSION_DATA_CF_NAME;
 use crate::schema::ensure_slice_len_eq;
 use anyhow::Result;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::transaction::Version;
 use byteorder::{BigEndian, ReadBytesExt};
 #[cfg(any(test, feature = "fuzzing"))]

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -24,7 +24,8 @@ use aptos_jellyfish_merkle::{
     iterator::JellyfishMerkleIterator, restore::StateSnapshotRestore, StateValueWriter,
 };
 use aptos_logger::info;
-use aptos_state_view::{state_storage_usage::StateStorageUsage, StateViewId};
+use aptos_state_view::StateViewId;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     proof::{definition::LeafCount, SparseMerkleProofExt, SparseMerkleRangeProof},
     state_store::{

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     stale_state_value_index::StaleStateValueIndexSchema,
     state_merkle_db::StateMerkleDb,
     state_store::buffered_state::BufferedState,
-    version_data::{VersionData, VersionDataSchema},
+    version_data::VersionDataSchema,
     AptosDbError, LedgerStore, StaleNodeIndexCrossEpochSchema, StaleNodeIndexSchema,
     StatePrunerManager, TransactionStore, OTHER_TIMERS_SECONDS,
 };
@@ -779,14 +779,9 @@ impl StateValueWriter<StateKey, StateValue> for StateStore {
         self.ledger_db.write_schemas(batch)
     }
 
-    fn write_usage(&self, version: Version, items: usize, total_bytes: usize) -> Result<()> {
-        self.ledger_db.put::<VersionDataSchema>(
-            &version,
-            &VersionData {
-                state_items: items,
-                total_state_bytes: total_bytes,
-            },
-        )
+    fn write_usage(&self, version: Version, usage: StateStorageUsage) -> Result<()> {
+        self.ledger_db
+            .put::<VersionDataSchema>(&version, &usage.into())
     }
 }
 

--- a/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
+++ b/storage/aptosdb/src/state_store/state_merkle_batch_committer.rs
@@ -14,7 +14,7 @@ use anyhow::{anyhow, ensure, Result};
 use aptos_crypto::HashValue;
 use aptos_jellyfish_merkle::node_type::NodeKey;
 use aptos_logger::{info, trace};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use schemadb::SchemaBatch;
 use std::sync::{mpsc::Receiver, Arc};
 use storage_interface::state_delta::StateDelta;

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -20,6 +20,7 @@ use aptos_infallible::duration_since_epoch;
 use aptos_jellyfish_merkle::{
     restore::StateSnapshotRestore, NodeBatch, StateValueBatch, StateValueWriter, TreeWriter,
 };
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,
@@ -147,7 +148,7 @@ impl StateValueWriter<StateKey, StateValue> for MockStore {
         Ok(())
     }
 
-    fn write_usage(&self, _version: Version, _items: usize, _total_bytes: usize) -> Result<()> {
+    fn write_usage(&self, _version: Version, _usage: StateStorageUsage) -> Result<()> {
         Ok(())
     }
 }

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -18,7 +18,8 @@ use aptos_config::config::{
 use aptos_crypto::HashValue;
 use aptos_infallible::duration_since_epoch;
 use aptos_jellyfish_merkle::{
-    restore::StateSnapshotRestore, NodeBatch, StateValueBatch, StateValueWriter, TreeWriter,
+    restore::StateSnapshotRestore, NodeBatch, StateSnapshotProgress, StateValueBatch,
+    StateValueWriter, TreeWriter,
 };
 use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
@@ -143,13 +144,19 @@ impl TreeWriter<StateKey> for MockStore {
 impl StateValueWriter<StateKey, StateValue> for MockStore {
     fn write_kv_batch(
         &self,
+        _version: Version,
         _kv_batch: &StateValueBatch<StateKey, Option<StateValue>>,
+        _progress: StateSnapshotProgress,
     ) -> Result<()> {
         Ok(())
     }
 
     fn write_usage(&self, _version: Version, _usage: StateStorageUsage) -> Result<()> {
         Ok(())
+    }
+
+    fn get_progress(&self, _version: Version) -> Result<Option<StateSnapshotProgress>> {
+        Ok(None)
     }
 }
 

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -84,6 +84,7 @@ use anyhow::{bail, ensure, format_err, Result};
 use aptos_crypto::hash::SPARSE_MERKLE_PLACEHOLDER_HASH;
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_types::proof::SparseMerkleProofExt;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     nibble::{nibble_path::NibblePath, Nibble, ROOT_NIBBLE_HEIGHT},
     proof::{SparseMerkleProof, SparseMerkleRangeProof},
@@ -148,7 +149,7 @@ pub trait StateValueWriter<K, V>: Send + Sync {
     /// Writes a kv batch into storage.
     fn write_kv_batch(&self, kv_batch: &StateValueBatch<K, Option<V>>) -> Result<()>;
 
-    fn write_usage(&self, version: Version, items: usize, total_bytes: usize) -> Result<()>;
+    fn write_usage(&self, version: Version, usage: StateStorageUsage) -> Result<()>;
 }
 
 pub trait Key: Clone + Serialize + DeserializeOwned + Send + Sync {

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -20,6 +20,7 @@ use aptos_crypto::{
     HashValue,
 };
 use aptos_logger::info;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     nibble::{
         nibble_path::{NibbleIterator, NibblePath},
@@ -746,8 +747,10 @@ impl<K: crate::Key + Hash + Eq, V: crate::Value> StateValueRestore<K, V> {
     }
 
     pub fn finish(self) -> Result<()> {
-        self.db
-            .write_usage(self.version, self.num_items, self.total_bytes)
+        self.db.write_usage(
+            self.version,
+            StateStorageUsage::new(self.num_items, self.total_bytes),
+        )
     }
 }
 

--- a/storage/scratchpad/benches/sparse_merkle.rs
+++ b/storage/scratchpad/benches/sparse_merkle.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::state_store::state_value::StateValue;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use itertools::zip_eq;

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -89,7 +89,7 @@ use aptos_crypto::{
     HashValue,
 };
 use aptos_infallible::Mutex;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{nibble::nibble_path::NibblePath, proof::SparseMerkleProofExt};
 use std::sync::MutexGuard;
 use std::{

--- a/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
+++ b/storage/scratchpad/src/sparse_merkle/test_utils/proptest_helpers.rs
@@ -7,7 +7,7 @@ use crate::{
     SparseMerkleTree,
 };
 use aptos_crypto::{hash::SPARSE_MERKLE_PLACEHOLDER_HASH, HashValue};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::state_store::state_value::StateValue;
 use proptest::{
     collection::{hash_set, vec},

--- a/storage/state-view/src/lib.rs
+++ b/storage/state-view/src/lib.rs
@@ -6,9 +6,9 @@
 //! This crate defines [`trait StateView`](StateView).
 
 use crate::account_with_state_view::{AccountWithStateView, AsAccountWithStateView};
-use crate::state_storage_usage::StateStorageUsage;
 use anyhow::Result;
 use aptos_crypto::HashValue;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     account_address::AccountAddress, state_store::state_key::StateKey, transaction::Version,
 };
@@ -16,7 +16,6 @@ use std::ops::Deref;
 
 pub mod account_with_state_cache;
 pub mod account_with_state_view;
-pub mod state_storage_usage;
 
 /// `StateView` is a trait that defines a read-only snapshot of the global state. It is passed to
 /// the VM for transaction execution, during which the VM is guaranteed to read anything at the

--- a/storage/storage-interface/src/cached_state_view.rs
+++ b/storage/storage-interface/src/cached_state_view.rs
@@ -4,7 +4,8 @@
 use crate::{proof_fetcher::ProofFetcher, state_view::DbStateView, DbReader};
 use anyhow::{format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_state_view::{state_storage_usage::StateStorageUsage, StateView, StateViewId};
+use aptos_state_view::{StateView, StateViewId};
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     proof::SparseMerkleProofExt,
     state_store::{state_key::StateKey, state_value::StateValue},

--- a/storage/storage-interface/src/executed_trees.rs
+++ b/storage/storage-interface/src/executed_trees.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_crypto::{hash::TransactionAccumulatorHasher, HashValue};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::StateViewId;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{proof::accumulator::InMemoryAccumulator, transaction::Version};
 use std::sync::Arc;
 

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -3,8 +3,8 @@
 
 use anyhow::{anyhow, format_err, Result};
 use aptos_crypto::{hash::CryptoHash, HashValue};
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_types::account_config::NewBlockEvent;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::state_store::table::{TableHandle, TableInfo};
 use aptos_types::{
     access_path::AccessPath,

--- a/storage/storage-interface/src/state_delta.rs
+++ b/storage/storage-interface/src/state_delta.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_crypto::HashValue;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{
     state_store::{state_key::StateKey, state_value::StateValue},
     transaction::Version,

--- a/storage/storage-interface/src/state_view.rs
+++ b/storage/storage-interface/src/state_view.rs
@@ -3,8 +3,8 @@
 
 use crate::DbReader;
 use anyhow::Result;
-use aptos_state_view::state_storage_usage::StateStorageUsage;
 use aptos_state_view::StateView;
+use aptos_types::state_store::state_storage_usage::StateStorageUsage;
 use aptos_types::{state_store::state_key::StateKey, transaction::Version};
 use std::sync::Arc;
 

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -3,5 +3,6 @@
 
 pub mod state_key;
 pub mod state_key_prefix;
+pub mod state_storage_usage;
 pub mod state_value;
 pub mod table;

--- a/types/src/state_store/state_storage_usage.rs
+++ b/types/src/state_store/state_storage_usage.rs
@@ -1,7 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+use serde::{Deserialize, Serialize};
+
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(proptest_derive::Arbitrary))]
 pub enum StateStorageUsage {
     Tracked { items: usize, bytes: usize },
     Untracked,

--- a/types/src/state_store/state_storage_usage.rs
+++ b/types/src/state_store/state_storage_usage.rs
@@ -2,21 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-enum UsageInner {
+pub enum StateStorageUsage {
     Tracked { items: usize, bytes: usize },
     Untracked,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub struct StateStorageUsage {
-    inner: UsageInner,
-}
-
 impl StateStorageUsage {
     pub fn new(items: usize, bytes: usize) -> Self {
-        Self {
-            inner: UsageInner::Tracked { items, bytes },
-        }
+        Self::Tracked { items, bytes }
     }
 
     pub fn zero() -> Self {
@@ -24,52 +17,50 @@ impl StateStorageUsage {
     }
 
     pub fn new_untracked() -> Self {
-        Self {
-            inner: UsageInner::Untracked,
-        }
+        Self::Untracked
     }
 
     pub fn is_untracked(&self) -> bool {
-        matches!(self.inner, UsageInner::Untracked)
+        matches!(self, Self::Untracked)
     }
 
     pub fn items(&self) -> usize {
-        match self.inner {
-            UsageInner::Tracked { items, .. } => items,
-            UsageInner::Untracked => 0,
+        match self {
+            Self::Tracked { items, .. } => *items,
+            Self::Untracked => 0,
         }
     }
 
     pub fn bytes(&self) -> usize {
-        match self.inner {
-            UsageInner::Tracked { bytes, .. } => bytes,
-            UsageInner::Untracked => 0,
+        match self {
+            Self::Tracked { bytes, .. } => *bytes,
+            Self::Untracked => 0,
         }
     }
 
     pub fn add_item(&mut self, bytes_delta: usize) {
-        match self.inner {
-            UsageInner::Tracked {
+        match self {
+            Self::Tracked {
                 ref mut items,
                 ref mut bytes,
             } => {
                 *items += 1;
                 *bytes += bytes_delta;
             }
-            UsageInner::Untracked => (),
+            Self::Untracked => (),
         }
     }
 
     pub fn remove_item(&mut self, bytes_delta: usize) {
-        match self.inner {
-            UsageInner::Tracked {
+        match self {
+            Self::Tracked {
                 ref mut items,
                 ref mut bytes,
             } => {
                 *items -= 1;
                 *bytes -= bytes_delta;
             }
-            UsageInner::Untracked => (),
+            Self::Untracked => (),
         }
     }
 }


### PR DESCRIPTION
### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

`cargo test -p aptos-jellyfish-merkle -- test_restore_with_interruption`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3615)
<!-- Reviewable:end -->
