### PR TITLE
Fix yarn lint by upgrading TS and linter versions

### DIFF
--- a/ecosystem/typescript/sdk/.eslintrc.js
+++ b/ecosystem/typescript/sdk/.eslintrc.js
@@ -22,7 +22,9 @@ module.exports = {
     "import/prefer-default-export": "off",
     "object-curly-newline": "off",
     "no-use-before-define": "off",
+    "no-unused-vars": "off",
     "@typescript-eslint/no-use-before-define": ["error", { functions: false, classes: false }],
+    "@typescript-eslint/no-unused-vars": ["error"],
   },
   settings: {
     "import/resolver": {

--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
 ## Unreleased
-
-N/A
+- Upgraded typescript version from 4.7.4 to 4.8.2, as well as linter package versions.
 
 ## 1.3.10 (2022-08-26)
 

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -46,8 +46,8 @@
   "devDependencies": {
     "@types/jest": "^28.1.8",
     "@types/node": "^18.6.2",
-    "@typescript-eslint/eslint-plugin": "^5.17.0",
-    "@typescript-eslint/parser": "^5.17.0",
+    "@typescript-eslint/eslint-plugin": "^5.36.0",
+    "@typescript-eslint/parser": "^5.36.0",
     "dotenv": "^16.0.1",
     "eslint": "^8.22.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -62,7 +62,7 @@
     "ts-loader": "^9.3.1",
     "ts-node": "^10.9.1",
     "tsdx": "^0.14.1",
-    "typescript": "4.7.4"
+    "typescript": "4.8.2"
   },
   "version": "1.3.10"
 }


### PR DESCRIPTION
## Description
The newer TS version, linter, and specific lint (as per https://stackoverflow.com/a/61555310/3846032.) seems to fix the previously broken `yarn lint` run.

## Test Plan
```
rm yarn.lock && rm -rf node_modules/
yarn install
yarn lint
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3617)
<!-- Reviewable:end -->
