### PR TITLE
[Aptos Framework][Genesis] Register operator/voter accounts to receive Aptos coin during Genesis

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -73,7 +73,6 @@ module aptos_framework::genesis {
             i = i+1;
         };
 
-
         consensus_config::initialize(&aptos_framework_account, consensus_config);
         version::initialize(&aptos_framework_account, initial_version);
         stake::initialize(&aptos_framework_account);
@@ -145,11 +144,13 @@ module aptos_framework::genesis {
             // Create the operator account if it's different from owner.
             if (validator.operator_address != validator.owner_address) {
                 operator = &account::create_account(validator.operator_address);
+                coin::register<AptosCoin>(operator);
             };
             // Create the voter account if it's different from owner and operator.
             if (validator.voter_address != validator.owner_address &&
                 validator.voter_address != validator.operator_address) {
-                account::create_account(validator.voter_address);
+                let voter = &account::create_account(validator.voter_address);
+                coin::register<AptosCoin>(voter);
             };
 
             // Mint the initial staking amount to the validator.
@@ -175,7 +176,7 @@ module aptos_framework::genesis {
                 validator.network_addresses,
                 validator.full_node_network_addresses,
             );
-            stake::join_validator_set_internal(operator, validator.owner_address);
+            stake::join_validator_set(operator, validator.owner_address);
 
             i = i + 1;
         };


### PR DESCRIPTION
### Description

After a recent refactoring, account::create_account no longer registers an account for AptosCoin by default. register needs to called separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3620)
<!-- Reviewable:end -->
