### PR TITLE
[framework] improve resource account

### DIFF
--- a/aptos-move/e2e-move-tests/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/tests/code_publishing.rs
@@ -24,9 +24,7 @@ struct State {
 
 #[test]
 fn code_publishing_basic() {
-    // Parallel execution and code publishing don't work well yet, hence all test harness created
-    // here have this off
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     assert_success!(h.publish_package(
         &acc,
@@ -63,7 +61,7 @@ fn code_publishing_basic() {
 
 #[test]
 fn code_publishing_upgrade_success_no_compat() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
     // Install the initial version with no compat requirements
@@ -81,7 +79,7 @@ fn code_publishing_upgrade_success_no_compat() {
 
 #[test]
 fn code_publishing_upgrade_success_compat() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
     // Install the initial version with compat requirements
@@ -99,7 +97,7 @@ fn code_publishing_upgrade_success_compat() {
 
 #[test]
 fn code_publishing_upgrade_fail_compat() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
     // Install the initial version with compat requirements
@@ -118,7 +116,7 @@ fn code_publishing_upgrade_fail_compat() {
 
 #[test]
 fn code_publishing_upgrade_fail_immutable() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
     // Install the initial version with immutable requirements
@@ -137,7 +135,7 @@ fn code_publishing_upgrade_fail_immutable() {
 
 #[test]
 fn code_publishing_upgrade_fail_overlapping_module() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
     // Install the initial version
@@ -163,7 +161,7 @@ fn code_publishing_upgrade_fail_overlapping_module() {
 /// TODO: for some reason this test did not capture a serious bug in `code::check_coexistence`.
 #[test]
 fn code_publishing_upgrade_loader_cache_consistency() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
     // Create a sequence of package upgrades
@@ -196,7 +194,7 @@ fn code_publishing_upgrade_loader_cache_consistency() {
 
 #[test]
 fn code_publishing_framework_upgrade() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.aptos_framework_account();
 
     // We should be able to upgrade move-stdlib, as our local package has only
@@ -209,7 +207,7 @@ fn code_publishing_framework_upgrade() {
 
 #[test]
 fn code_publishing_framework_upgrade_fail() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.aptos_framework_account();
 
     // We should not be able to upgrade move-stdlib because we removed a function
@@ -223,7 +221,7 @@ fn code_publishing_framework_upgrade_fail() {
 
 #[test]
 fn code_publishing_weak_dep_fail() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
     let mut weak = PackageBuilder::new("WeakPackage").with_policy(UpgradePolicy::arbitrary());
@@ -248,7 +246,7 @@ fn code_publishing_weak_dep_fail() {
 
 #[test]
 fn code_publishing_arbitray_dep_different_address() {
-    let mut h = MoveHarness::new_no_parallel();
+    let mut h = MoveHarness::new();
     let acc1 = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     let acc2 = h.new_account_at(AccountAddress::from_hex_literal("0xdeaf").unwrap());
 

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -308,12 +308,17 @@ module aptos_framework::account {
     /// Basic account creation methods.
     ///////////////////////////////////////////////////////////////////////////
 
+    /// This is a helper function to compute resource addresses. Computation of the address
+    /// involves the use of a cryptographic hash operation and should be use thoughtfully.
+    public fun create_resource_address(source: &address, seed: vector<u8>): address {
+        let bytes = bcs::to_bytes(source);
+        vector::append(&mut bytes, seed);
+        from_bcs::to_address(hash::sha3_256(bytes))
+    }
+
     /// A resource account is used to manage resources independent of an account managed by a user.
     public fun create_resource_account(source: &signer, seed: vector<u8>): (signer, SignerCapability) {
-        let bytes = bcs::to_bytes(&signer::address_of(source));
-        vector::append(&mut bytes, seed);
-        let addr = from_bcs::to_address(hash::sha3_256(bytes));
-
+        let addr = create_resource_address(&signer::address_of(source), seed);
         let signer = create_account_unchecked(copy addr);
         let signer_cap = SignerCapability { account: addr };
         (signer, signer_cap)

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -385,10 +385,16 @@ module aptos_framework::account {
         create_signer(*addr)
     }
 
+    public fun get_signer_capability_address(capability: &SignerCapability): address {
+        capability.account
+    }
+
     #[test(user = @0x1)]
     public entry fun test_create_resource_account(user: signer) {
-        let (resource_account, _) = create_resource_account(&user, x"01");
-        assert!(signer::address_of(&resource_account) != signer::address_of(&user), 0);
+        let (resource_account, resource_account_cap) = create_resource_account(&user, x"01");
+        let resource_addr = signer::address_of(&resource_account);
+        assert!(resource_addr != signer::address_of(&user), 0);
+        assert!(resource_addr == get_signer_capability_address(&resource_account_cap), 1);
     }
 
     #[test_only]


### PR DESCRIPTION
* add create_resource_address due to 1) popular demand and 2) improved testability. I don't think anyone should use this in production to compute an address of an already created account, that seems bad, but it can serve some purposes.
* support the ability to create a resource account and fund it (for the legacy flow)
* support the ability to create a resource account and publish modules to it -- note this one explicitly does not support funding because that should be something that can be done when transferring over the ownership cap if that is desirable

I'd like to get this in the cut for Wednesday devnet if possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3622)
<!-- Reviewable:end -->
