### PR TITLE
[doc] Remove the extra 'a' in first transaction TS snippet

### DIFF
--- a/developer-docs-site/docs/tutorials/first-transaction.md
+++ b/developer-docs-site/docs/tutorials/first-transaction.md
@@ -371,7 +371,7 @@ In Typescript, just calling `coinClient.transfer` is sufficient to wait for the 
 
 You can set `checkSuccess` to true when calling `transfer` if you'd like it to throw if the transaction was not committed successfully:
 ```ts
-:!: static/sdks/typescript/examples/typescript/transfer_coin.ts section_6
+:!: static/sdks/typescript/examples/typescript/transfer_coin.ts section_6a
 ```
 
   </TabItem>


### PR DESCRIPTION
### Description
Remove the extra 'a'. See pic:
![Screen Shot 2022-08-29 at 9 53 21 PM](https://user-images.githubusercontent.com/962285/187352447-091ac841-8d6d-4324-bd35-28d4a9b57d00.png)


### Test Plan
yarn start and verified in browser

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3624)
<!-- Reviewable:end -->
