### PR TITLE
[forge] Disable panic catching and enable wait for catchup

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -419,7 +419,11 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
         "compat" => config
             .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
             .with_network_tests(&[&SimpleValidatorUpgrade])
-            .with_success_criteria(SuccessCriteria::new(5000, 10000, None)),
+            .with_success_criteria(SuccessCriteria::new(
+                5000,
+                10000,
+                Some(Duration::from_secs(240)),
+            )),
         "config" => config.with_network_tests(&[&ReconfigurationTest]),
         "network_partition" => config.with_network_tests(&[&NetworkPartitionTest]),
         "network_latency" => config.with_network_tests(&[&NetworkLatencyTest]),
@@ -431,7 +435,11 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_initial_validator_count(NonZeroUsize::new(1).unwrap())
             .with_initial_fullnode_count(1)
             .with_network_tests(&[&PerformanceBenchmarkWithFN])
-            .with_success_criteria(SuccessCriteria::new(5000, 10000, None)),
+            .with_success_criteria(SuccessCriteria::new(
+                5000,
+                10000,
+                Some(Duration::from_secs(240)),
+            )),
         _ => return Err(format_err!("Invalid --suite given: {:?}", test_name)),
     };
     Ok(single_test_suite)
@@ -447,13 +455,17 @@ fn land_blocking_test_suite(duration: Duration) -> ForgeConfig<'static> {
             helm_values["chain"]["epoch_duration_secs"] = 300.into();
         }))
         .with_success_criteria(SuccessCriteria::new(
-            if duration > Duration::from_secs(1200) {
+            if duration.as_secs() > 1200 {
                 5000
             } else {
                 6000
             },
             10000,
-            None,
+            Some(Duration::from_secs(if duration.as_secs() > 1200 {
+                240
+            } else {
+                60
+            })),
         ))
 }
 

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -219,10 +219,9 @@ pub trait SwarmExt: Swarm {
             return Err(anyhow!("Fork check failed"));
         }
 
-        runtime.block_on(self.wait_for_all_nodes_to_catchup_to_version(
-            max_version,
-            Instant::now() + Duration::from_secs(10),
-        ))?;
+        runtime.block_on(
+            self.wait_for_all_nodes_to_catchup_to_version(max_version, Duration::from_secs(10)),
+        )?;
 
         if !runtime.block_on(are_root_hashes_equal_at_version(&clients, max_version))? {
             return Err(anyhow!("Fork check failed"));
@@ -235,9 +234,9 @@ pub trait SwarmExt: Swarm {
     async fn wait_for_all_nodes_to_catchup_to_version(
         &self,
         version: u64,
-        deadline: Instant,
+        timeout: Duration,
     ) -> Result<()> {
-        wait_for_all_nodes_to_catchup_to_version(&self.get_clients_with_names(), version, deadline)
+        wait_for_all_nodes_to_catchup_to_version(&self.get_clients_with_names(), version, timeout)
             .await
     }
 
@@ -245,8 +244,8 @@ pub trait SwarmExt: Swarm {
     /// for its current version, selects the max version, then waits for all nodes to catch up to
     /// that version. Once done, we can guarantee that all transactions committed before invocation
     /// of this function are available at all the nodes in the swarm
-    async fn wait_for_all_nodes_to_catchup(&self, deadline: Instant) -> Result<()> {
-        wait_for_all_nodes_to_catchup(&self.get_clients_with_names(), deadline).await
+    async fn wait_for_all_nodes_to_catchup(&self, timeout: Duration) -> Result<()> {
+        wait_for_all_nodes_to_catchup(&self.get_clients_with_names(), timeout).await
     }
 
     fn get_clients_with_names(&self) -> Vec<(String, RestClient)> {
@@ -264,8 +263,9 @@ pub trait SwarmExt: Swarm {
 pub async fn wait_for_all_nodes_to_catchup_to_version(
     clients: &[(String, RestClient)],
     version: u64,
-    deadline: Instant,
+    timeout: Duration,
 ) -> Result<()> {
+    let start_time = Instant::now();
     loop {
         let results: Result<Vec<_>> = try_join_all(clients.iter().map(|(name, node)| async move {
             Ok((
@@ -277,17 +277,21 @@ pub async fn wait_for_all_nodes_to_catchup_to_version(
         let versions = results
             .map(|resps| resps.into_iter().collect::<Vec<_>>())
             .ok();
-        let all_catchup = versions
+        let all_caught_up = versions
             .clone()
             .map(|resps| resps.iter().all(|(_, v)| *v >= version))
             .unwrap_or(false);
-        if all_catchup {
-            break;
+        if all_caught_up {
+            info!(
+                "All nodes caught up successfully in {}s",
+                start_time.elapsed().as_secs()
+            );
+            return Ok(());
         }
 
-        if Instant::now() > deadline {
+        if start_time.elapsed() > timeout {
             return Err(anyhow!(
-                "waiting for nodes to catch up to version {} timed out, current status: {:?}",
+                "Waiting for nodes to catch up to version {} timed out, current status: {:?}",
                 version,
                 versions.unwrap_or_default()
             ));
@@ -295,8 +299,6 @@ pub async fn wait_for_all_nodes_to_catchup_to_version(
 
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-
-    Ok(())
 }
 
 /// Wait for all nodes in the network to be caught up. This is done by first querying each node
@@ -305,7 +307,7 @@ pub async fn wait_for_all_nodes_to_catchup_to_version(
 /// of this function are available at all the nodes in the swarm
 pub async fn wait_for_all_nodes_to_catchup(
     clients: &[(String, RestClient)],
-    deadline: Instant,
+    timeout: Duration,
 ) -> Result<()> {
     if clients.is_empty() {
         bail!("no nodes available")
@@ -320,5 +322,5 @@ pub async fn wait_for_all_nodes_to_catchup(
         );
     }
 
-    wait_for_all_nodes_to_catchup_to_version(clients, latest_version, deadline).await
+    wait_for_all_nodes_to_catchup_to_version(clients, latest_version, timeout).await
 }

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -3,7 +3,7 @@
 
 use anyhow::bail;
 use serde::Serialize;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use transaction_emitter_lib::emitter::stats::TxnStats;
 
 use crate::{Swarm, SwarmExt};
@@ -28,7 +28,7 @@ impl SuccessCriteria {
         }
     }
 
-    pub fn check_for_success(
+    pub async fn check_for_success(
         &self,
         stats: &TxnStats,
         window: &Duration,
@@ -36,26 +36,16 @@ impl SuccessCriteria {
     ) -> anyhow::Result<()> {
         // TODO: Add more success criteria like expired transactions, CPU, memory usage etc
         let avg_tps = stats.committed / window.as_secs();
-        let is_triggerd_by_github_actions =
-            std::env::var("FORGE_TRIGGERED_BY").unwrap_or_default() == "github-actions";
         if avg_tps < self.avg_tps as u64 {
             let error_message = format!(
                 "TPS requirement failed. Average TPS {}, minimum TPS requirement {}",
                 avg_tps, self.avg_tps
             );
-            if is_triggerd_by_github_actions {
-                // ::error:: is github specific syntax to set an error on the job that is highlighted as described here https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
-                println!("::error::{error_message}");
-            }
             bail!(error_message)
         }
 
-        if let Some(duration) = self.wait_for_all_nodes_to_catchup {
-            futures::executor::block_on(async {
-                swarm
-                    .wait_for_all_nodes_to_catchup(Instant::now() + duration)
-                    .await
-            })?;
+        if let Some(timeout) = self.wait_for_all_nodes_to_catchup {
+            swarm.wait_for_all_nodes_to_catchup(timeout).await?;
         }
 
         // TODO(skedia) Add latency success criteria after we have support for querying prometheus

--- a/testsuite/forge/src/test_utils/consensus_utils.rs
+++ b/testsuite/forge/src/test_utils/consensus_utils.rs
@@ -131,13 +131,9 @@ pub async fn test_consensus_fault_tolerance(
     println!("Largest version {}", largest_v);
     let target_v = largest_v + 10;
 
-    wait_for_all_nodes_to_catchup_to_version(
-        &validator_clients,
-        target_v,
-        Instant::now() + Duration::from_secs(30),
-    )
-    .await
-    .unwrap();
+    wait_for_all_nodes_to_catchup_to_version(&validator_clients, target_v, Duration::from_secs(30))
+        .await
+        .unwrap();
 
     let transactions: Vec<_> =
         join_all(validator_clients.iter().cloned().map(move |v| async move {

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -19,7 +19,7 @@ use forge::{reconfig, NodeExt, Swarm, SwarmExt};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 #[tokio::test]
 async fn test_analyze_validators() {
@@ -135,7 +135,7 @@ async fn test_large_total_stake() {
     );
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(20))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(20))
         .await
         .unwrap();
 }

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -52,7 +52,7 @@ async fn test_full_node_basic_flow() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 
@@ -149,7 +149,7 @@ async fn test_vfn_failover() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 
@@ -268,7 +268,7 @@ async fn test_private_full_node() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -578,7 +578,7 @@ async fn execute_transactions_and_wait(
 /// Waits for all nodes to catch up
 async fn wait_for_all_nodes(swarm: &mut LocalSwarm) {
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_CATCH_UP_SECS))
         .await
         .unwrap();
 }

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -46,7 +46,7 @@ async fn test_db_restore() {
     // we need to wait for all nodes to see it, as client_1 is different node from the
     // one creating accounts above
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(30))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(30))
         .await
         .unwrap();
 
@@ -150,7 +150,7 @@ async fn test_db_restore() {
         .unwrap();
     // verify it's caught up
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -52,7 +52,7 @@ async fn test_txn_broadcast() {
     let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
     swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+        .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
 


### PR DESCRIPTION
Identical to #3558, which I merged into a wrong branch, instead of main :/


### Description
previously we were catching panics, and when that happens no info other than that there was a failure was shown.
I don't see any reasons to catch panics, after making this change, we actually see the panic message.

### Test Plan
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3632)
<!-- Reviewable:end -->
