### PR TITLE
[aptos-rest-client/indexer] Backoff rest client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,6 +1049,7 @@ dependencies = [
  "anyhow",
  "aptos-api-types",
  "aptos-crypto",
+ "aptos-logger",
  "aptos-types",
  "bcs",
  "bytes 1.2.1",

--- a/api/types/src/error.rs
+++ b/api/types/src/error.rs
@@ -8,7 +8,7 @@ use std::fmt::Formatter;
 
 /// This is the generic struct we use for all API errors, it contains a string
 /// message and an Aptos API specific error code.
-#[derive(Debug, Serialize, Deserialize, Object)]
+#[derive(Debug, Clone, Serialize, Deserialize, Object)]
 pub struct AptosError {
     /// A message describing the error
     pub message: String,

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -28,6 +28,7 @@ url = "2.2.2"
 
 aptos-api-types = { path = "../../api/types" }
 aptos-crypto = { path = "../aptos-crypto" }
+aptos-logger = { path = "../aptos-logger" }
 aptos-types = { path = "../../types" }
 
 move-deps = { path = "../../aptos-move/move-deps", features = ["address32"] }

--- a/crates/aptos-rest-client/src/error.rs
+++ b/crates/aptos-rest-client/src/error.rs
@@ -151,14 +151,14 @@ pub enum RestError {
     Bcs(bcs::Error),
     #[error("JSON er/de error {0}")]
     Json(serde_json::Error),
-    #[error("Web client error {0}")]
-    WebClient(reqwest::Error),
     #[error("URL Parse error {0}")]
     UrlParse(url::ParseError),
     #[error("Timeout waiting for transaction {0}")]
     Timeout(&'static str),
     #[error("Unknown error {0}")]
     Unknown(anyhow::Error),
+    #[error("Http error {0}")]
+    Http(u16),
 }
 
 impl From<(AptosError, Option<State>, StatusCode)> for RestError {
@@ -189,15 +189,19 @@ impl From<serde_json::Error> for RestError {
     }
 }
 
-impl From<reqwest::Error> for RestError {
-    fn from(err: reqwest::Error) -> Self {
-        Self::WebClient(err)
-    }
-}
-
 impl From<anyhow::Error> for RestError {
     fn from(err: anyhow::Error) -> Self {
         Self::Unknown(err)
+    }
+}
+
+impl From<reqwest::Error> for RestError {
+    fn from(err: reqwest::Error) -> Self {
+        if let Some(status) = err.status() {
+            RestError::Http(status.as_u16())
+        } else {
+            RestError::Unknown(err.into())
+        }
     }
 }
 

--- a/crates/aptos-rest-client/src/error.rs
+++ b/crates/aptos-rest-client/src/error.rs
@@ -158,7 +158,7 @@ pub enum RestError {
     #[error("Unknown error {0}")]
     Unknown(anyhow::Error),
     #[error("Http error {0}")]
-    Http(u16),
+    Http(StatusCode),
 }
 
 impl From<(AptosError, Option<State>, StatusCode)> for RestError {
@@ -198,7 +198,7 @@ impl From<anyhow::Error> for RestError {
 impl From<reqwest::Error> for RestError {
     fn from(err: reqwest::Error) -> Self {
         if let Some(status) = err.status() {
-            RestError::Http(status.as_u16())
+            RestError::Http(status)
         } else {
             RestError::Unknown(err.into())
         }

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -287,7 +287,10 @@ impl From<RestError> for ApiError {
             },
             RestError::Bcs(_) => ApiError::DeserializationFailed(None),
             RestError::Json(_) => ApiError::DeserializationFailed(None),
-            RestError::WebClient(err) => ApiError::InternalError(Some(err.to_string())),
+            RestError::Http(err) => ApiError::InternalError(Some(format!(
+                "Failed internal API call with HTTP code {}",
+                err
+            ))),
             RestError::UrlParse(err) => ApiError::InternalError(Some(err.to_string())),
             RestError::Timeout(err) => ApiError::InternalError(Some(err.to_string())),
             RestError::Unknown(err) => ApiError::InternalError(Some(err.to_string())),


### PR DESCRIPTION
### Description
The rest client wasn't handling throttles very well, this will now handle throttles.  I suspect we will need to look into this for all of our SDKs.

Additionally, the indexer which caught this issue, will now backoff and go along it's merry way.  Will likely need to tune the numbers later

### Test Plan

Tested locally on the indexer
```
2022-08-30T08:11:09.535200Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 1000ms: Http(429)
2022-08-30T08:11:10.563343Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 2000ms: Http(429)
2022-08-30T08:11:12.590567Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 4000ms: Http(429)
2022-08-30T08:11:16.618698Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 8000ms: Http(429)
2022-08-30T08:11:34.319581Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 325457 as the new highest known version
2022-08-30T08:11:44.941695Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 325534 as the new highest known version
2022-08-30T08:11:55.576643Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 325619 as the new highest known version
2022-08-30T08:12:06.188914Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 325694 as the new highest known version
2022-08-30T08:12:07.253522Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 1000ms: Http(429)
2022-08-30T08:12:08.306916Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 1000ms: Http(429)
2022-08-30T08:12:09.334997Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 2000ms: Http(429)
2022-08-30T08:12:11.364715Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 4000ms: Http(429)
2022-08-30T08:12:15.391320Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 8000ms: Http(429)
2022-08-30T08:12:23.585548Z [main] INFO ecosystem/indexer/src/main.rs:126 Indexer has processed version 326090. Overall average TPS: 8
2022-08-30T08:12:33.037707Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 325884 as the new highest known version
2022-08-30T08:12:43.663845Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 325960 as the new highest known version
2022-08-30T08:12:54.288560Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 326040 as the new highest known version
2022-08-30T08:13:04.880380Z [tokio-runtime-worker] INFO ecosystem/indexer/src/indexer/fetcher.rs:67 Found 326104 as the new highest known version
2022-08-30T08:13:08.069121Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 1000ms: Http(429)
2022-08-30T08:13:09.095824Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 2000ms: Http(429)
2022-08-30T08:13:11.122735Z [tokio-runtime-worker] INFO crates/aptos-rest-client/src/lib.rs:1040 Failed to call API, retrying in 4000ms: Http(429)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3633)
<!-- Reviewable:end -->
