### PR TITLE
[Forge] Pre-release test to run for 5 hours for now

### DIFF
--- a/.github/workflows/continuous-e2e-release-test.yaml
+++ b/.github/workflows/continuous-e2e-release-test.yaml
@@ -18,7 +18,7 @@ jobs:
     with:
       FORGE_NAMESPACE: forge-release-blocking
       # Run for 10 hours
-      FORGE_RUNNER_DURATION_SECS: 36000
+      FORGE_RUNNER_DURATION_SECS: 18000
       FORGE_TEST_SUITE: land_blocking
       USE_NEW_WRAPPER: true
       # Give us 12 hour timeout

--- a/.github/workflows/continuous-e2e-release-test.yaml
+++ b/.github/workflows/continuous-e2e-release-test.yaml
@@ -17,7 +17,7 @@ jobs:
     secrets: inherit
     with:
       FORGE_NAMESPACE: forge-release-blocking
-      # Run for 10 hours
+      # Run for 5 hours
       FORGE_RUNNER_DURATION_SECS: 18000
       FORGE_TEST_SUITE: land_blocking
       USE_NEW_WRAPPER: true


### PR DESCRIPTION
### Description

Pre-release tests are failing with GH timeout. We need to figure out a way to increase the GH workflow timeout but running it for 5 hours for now to make it stable.

### Test Plan
N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3637)
<!-- Reviewable:end -->
