### PR TITLE
fix `waitForTransaction` bug in `transfer_coin` example

### DIFF
--- a/ecosystem/typescript/sdk/examples/typescript/transfer_coin.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/transfer_coin.ts
@@ -44,7 +44,7 @@ import { NODE_URL, FAUCET_URL } from "./common";
 
   // Have Alice send Bob some AptosCoins.
   // :!:>section_5
-  const txnHash = await coinClient.transfer(alice, bob, 1_000); // <:!:section_5
+  let txnHash = await coinClient.transfer(alice, bob, 1_000); // <:!:section_5
   // :!:>section_6a
   await client.waitForTransaction(txnHash); // <:!:section_6a
 
@@ -55,7 +55,7 @@ import { NODE_URL, FAUCET_URL } from "./common";
   console.log("");
 
   // Have Alice send Bob some more AptosCoins.
-  await coinClient.transfer(alice, bob, 1_000);
+  txnHash = await coinClient.transfer(alice, bob, 1_000);
   // :!:>section_6b
   await client.waitForTransaction(txnHash, { checkSuccess: true }); // <:!:section_6b
 


### PR DESCRIPTION
### Description
The second `waitForTransaction` wrongly waits on the first transaction as the `txnHash` has not been re-assigned.
This leads to a potential race condition where the wrong balances are printed at the end of the script.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3642)
<!-- Reviewable:end -->
