### PR TITLE
[community] Fix DoubleRenderError.

### DIFF
--- a/ecosystem/platform/server/app/controllers/it3_profiles_controller.rb
+++ b/ecosystem/platform/server/app/controllers/it3_profiles_controller.rb
@@ -171,9 +171,9 @@ class It3ProfilesController < ApplicationController
   end
 
   def ensure_registration_enabled!
-    redirect_to root_path unless Flipper.enabled?(:it3_registration_open)
-    redirect_to it3_path unless Flipper.enabled?(:it3_node_registration_enabled, current_user)
-    redirect_to it3_path if Flipper.enabled?(:it3_registration_closed) && !Flipper.enabled?(:it3_registration_override,
-                                                                                            current_user)
+    return redirect_to root_path unless Flipper.enabled?(:it3_registration_open)
+    return redirect_to it3_path unless Flipper.enabled?(:it3_node_registration_enabled, current_user)
+    return redirect_to it3_path if Flipper.enabled?(:it3_registration_closed) && !Flipper.enabled?(:it3_registration_override,
+                                                                                                   current_user)
   end
 end


### PR DESCRIPTION
### Description

Fixes this issue:

```
AbstractController::DoubleRenderError
Render and/or redirect were called multiple times in this action. Please note that you may only call render OR redirect, and at most once per action. Also note that neither redirect nor render terminate execution of the action, so if you want to exit an action after redirecting, you need to do something like "redirect_to(...) and return".
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3643)
<!-- Reviewable:end -->
