### PR TITLE
[CP] Adjust tables to prevent horizontal scrollbar on large screens

### DIFF
--- a/ecosystem/platform/server/app/components/icon_tooltip_component.html.erb
+++ b/ecosystem/platform/server/app/components/icon_tooltip_component.html.erb
@@ -1,6 +1,6 @@
 <button class="relative group text-left normal-case font-sans text-xs cursor-pointer">
   <%= render IconComponent.new(:info, size: @size, class: 'text-neutral-700 group-focus:text-neutral-600 group-hover:text-neutral-600') %>
-  <div class="absolute right-0 top-4 scale-0 opacity-0 group-focus:scale-100 group-focus-within:scale-100 group-hover:scale-100 group-focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 origin-top-right transition-opacity duration-150 cursor-default">
+  <div class="absolute min-w-max right-0 top-4 scale-0 opacity-0 group-focus:scale-100 group-focus-within:scale-100 group-hover:scale-100 group-focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 origin-top-right transition-opacity duration-150 cursor-default">
     <div class="pointer-events-auto mt-4 bg-neutral-700 rounded-md flex flex-col flex-1 max-w-xs">
       <h3 class="bg-neutral-600 p-4 rounded-t-md"><%= header %></h3>
       <div class="p-4 flex flex-col flex-1">

--- a/ecosystem/platform/server/app/components/table_header_column_component.rb
+++ b/ecosystem/platform/server/app/components/table_header_column_component.rb
@@ -19,7 +19,8 @@ class TableHeaderColumnComponent < ViewComponent::Base
 
     @rest = rest
     @rest[:class] = [
-      'py-4 pr-8 pl-2 first:rounded-l-lg last:rounded-r-lg uppercase text-base font-normal whitespace-nowrap',
+      'py-4 pr-16 first:pl-8 last:pr-8 first:rounded-l-lg last:rounded-r-lg ' \
+      'uppercase text-sm font-mono whitespace-nowrap',
       @rest[:class]
     ]
   end

--- a/ecosystem/platform/server/app/components/table_row_column_component.rb
+++ b/ecosystem/platform/server/app/components/table_row_column_component.rb
@@ -5,7 +5,8 @@
 class TableRowColumnComponent < ViewComponent::Base
   def initialize(**rest)
     rest[:class] = [
-      'py-4 pr-8 pl-2 text-neutral-100 first-of-type:rounded-l-lg last-of-type:rounded-r-lg',
+      'py-4 pr-16 first-of-type:pl-8 last-of-type:pr-8 text-neutral-100 ' \
+      'first-of-type:rounded-l-lg last-of-type:rounded-r-lg',
       rest[:class]
     ]
     @rest = rest

--- a/ecosystem/platform/server/app/helpers/leaderboard_helper.rb
+++ b/ecosystem/platform/server/app/helpers/leaderboard_helper.rb
@@ -3,6 +3,12 @@
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
 module LeaderboardHelper
+  def truncate_address(string, separator: '…')
+    string.truncate(
+      (4 * 2) + separator.size, omission: "#{separator}#{string.last(4)}"
+    )
+  end
+
   def availability_color(availability)
     if availability >= 97
       'bg-teal-400'

--- a/ecosystem/platform/server/app/views/leaderboard/it1.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it1.html.erb
@@ -31,7 +31,7 @@
     <%= turbo_frame_tag 'metrics', data: { controller: 'refresh', refresh_interval_value: 1.minute, refresh_src_value: request.path, turbo_action: 'advance' } do %>
       <%= content_tag :div, class: 'overflow-x-auto' do %>
         <%= render TableComponent.new(class: 'w-full table-auto border-separate border-spacing-y-2') do |t| %>
-          <%= t.with_column(:rank, '#', align: 'right') %>
+          <%= t.with_column(:rank, '#', align: 'left') %>
           <%= t.with_column('Account Address', align: 'left') %>
           <%= t.with_column(:liveness, 'Liveness', align: 'left') do |column| %>
             <%= column.with_tooltip(:info) do |tooltip| %>
@@ -102,11 +102,11 @@
           <%= t.with_body do %>
             <% @metrics.each_with_index do |metric, i| %>
               <%= render TableRowComponent.new do |tr| %>
-                <%= tr.with_column(align: 'right') do %>
+                <%= tr.with_column(align: 'left') do %>
                   <%= metric.rank %>
                 <% end %>
-                <%= tr.with_column(class: 'max-w-0 2xl:max-w-full w-full 2xl:w-auto truncate', title: metric.validator) do %>
-                  <%= metric.validator %>
+                <%= tr.with_column(align: 'left', title: "0x#{metric.validator}") do %>
+                  <%= truncate_address("0x#{metric.validator}") %>
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">

--- a/ecosystem/platform/server/app/views/leaderboard/it2.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it2.html.erb
@@ -31,7 +31,7 @@
     <%= turbo_frame_tag 'metrics', data: { controller: 'refresh', refresh_interval_value: 1.minute, refresh_src_value: request.path, turbo_action: 'advance' } do %>
       <%= content_tag :div, class: 'overflow-x-auto' do %>
         <%= render TableComponent.new(class: 'w-full table-auto border-separate border-spacing-y-2') do |t| %>
-          <%= t.with_column(:rank, '#', align: 'right') %>
+          <%= t.with_column(:rank, '#', align: 'left') %>
           <%= t.with_column('Account Address', align: 'left') %>
           <%= t.with_column(:liveness, 'Liveness', align: 'left') do |column| %>
             <%= column.with_tooltip(:info) do |tooltip| %>
@@ -103,11 +103,11 @@
           <%= t.with_body do %>
             <% @metrics.each_with_index do |metric, i| %>
               <%= render TableRowComponent.new do |tr| %>
-                <%= tr.with_column(align: 'right') do %>
+                <%= tr.with_column(align: 'left') do %>
                   <%= metric.rank %>
                 <% end %>
-                <%= tr.with_column(class: 'max-w-0 2xl:max-w-full w-full 2xl:w-auto truncate', title: metric.validator) do %>
-                  <%= "0x#{metric.validator}" %>
+                <%= tr.with_column(align: 'left', title: "0x#{metric.validator}") do %>
+                  <%= truncate_address("0x#{metric.validator}") %>
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">

--- a/ecosystem/platform/server/app/views/leaderboard/it3.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it3.html.erb
@@ -31,7 +31,7 @@
     <%= turbo_frame_tag 'metrics', data: { controller: 'refresh', refresh_interval_value: 1.minute, refresh_src_value: request.path, turbo_action: 'advance' } do %>
       <%= content_tag :div, class: 'overflow-x-auto' do %>
         <%= render TableComponent.new(class: 'w-full table-auto border-separate border-spacing-y-2') do |t| %>
-          <%= t.with_column(:rank, '#', align: 'right') %>
+          <%= t.with_column(:rank, '#', align: 'left') %>
           <%= t.with_column('Owner Address', align: 'left') %>
           <%= t.with_column(:liveness, 'Liveness', align: 'left') do |column| %>
             <%= column.with_tooltip(:info) do |tooltip| %>
@@ -98,16 +98,18 @@
             <% end %>
           <% end %>
           <%= t.with_column(:last_epoch_performance, 'Last Epoch Performance', align: 'left') %>
-          <%= t.with_column(:governance_voting_record, 'Governance Votes', align: 'left') %>
+          <%= t.with_column(:governance_voting_record, 'Governance Votes', align: 'right') %>
 
           <%= t.with_body do %>
             <% @metrics.each_with_index do |metric, i| %>
               <%= render TableRowComponent.new(class: 'cursor-pointer select-none active:translate-y-0.5') do |tr| %>
-                <%= tr.with_column(align: 'right') do %>
+                <%= tr.with_column(align: 'left') do %>
                   <%= metric.rank %>
                 <% end %>
-                <%= tr.with_column(class: 'max-w-0 2xl:max-w-full w-full 2xl:w-auto truncate', title: metric.owner_address) do %>
-                  <a href="https://explorer.devnet.aptos.dev/account/<%= metric.owner_address %>?network=ait3" target="_blank" title="View Account Address on Explorer"><%= metric.owner_address %></a>
+                <%= tr.with_column(align: 'left', title: metric.owner_address) do %>
+                  <a href="https://explorer.devnet.aptos.dev/account/<%= metric.owner_address %>?network=ait3" target="_blank" title="<%= metric.owner_address %>">
+                    <%= truncate_address(metric.owner_address) %>
+                  </a>
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">
@@ -126,7 +128,7 @@
                     <span class="<%= last_epoch_performance_color(metric.last_epoch_performance) %>" title="Last epoch: <%= metric.last_epoch %>"><%= metric.last_epoch_performance %></span>
                   <% end %>
                 <% end %>
-                <%= tr.with_column(align: 'left') do %>
+                <%= tr.with_column(align: 'right') do %>
                   <% if metric.governance_voting_record.present? %>
                     <%= metric.governance_voting_record %>
                   <% end %>


### PR DESCRIPTION
### Description
Make adjustments to AIT tables to prevent horizontal scrollbar from appearing on large screens:

- Font sizing, padding adjustments
- Integrate new `truncate_address` function which splits a string down the middle with an ellipsis, leaving 4 characters on each side (see Explorer). 

### Test Plan

- Verify tables on large screens do not show horizontal scrollbars at full width 
- Check truncated ellipsis formatting for addresses

<img width="1993" alt="image" src="https://user-images.githubusercontent.com/98909677/187540455-0b52a2b4-33b8-4566-8d24-0f1ae867e1d5.png">


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3648)
<!-- Reviewable:end -->
