### PR TITLE
[vfn-check-client] Output address of node in success case

### DIFF
--- a/ecosystem/node-checker/vfn-check-client/src/check.rs
+++ b/ecosystem/node-checker/vfn-check-client/src/check.rs
@@ -88,13 +88,39 @@ pub enum SingleCheckResult {
     /// The node was successfully checked. Note: The evaulation itself could
     /// indicate, a problem with the node, this just states that we were able
     /// to check the node sucessfully with NHC.
-    Success(EvaluationSummary),
+    Success(SingleCheckSuccess),
 
     /// Something went wrong with checking the node.
     Failure(SingleCheckFailure),
 
     /// The account does not have a VFN registered on chain.
     NoVfnRegistered(NoVfnRegistered),
+}
+
+#[derive(Debug, Serialize)]
+pub struct SingleCheckSuccess {
+    /// The evaluation summary returned by NHC. This doesn't necessarily imply
+    /// that the node passed the evaluation, just that an evaluation was returned
+    /// successfully and it passed the API available check.
+    pub evaluation_summary: EvaluationSummary,
+
+    /// This is the address that we used to get this successful evaluation.
+    /// This is presented in a normal URL format, not the NetworkAddress
+    /// representation. Example value for this field: http://65.109.17.29:8080.
+    /// Note, sometimes the address we started with was a DNS name, and we resolved
+    /// it to an IP address. As such, this IP address may become incorrect down
+    /// the line. In that case, refer to vfn_address in SingleCheck, or just
+    /// run this tool again.
+    pub vfn_address_url: String,
+}
+
+impl SingleCheckSuccess {
+    pub fn new(evaluation_summary: EvaluationSummary, vfn_address_url: String) -> Self {
+        Self {
+            evaluation_summary,
+            vfn_address_url,
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -307,10 +333,8 @@ async fn check_single_vfn_one_api_port(
     params.insert("api_port", &api_port_string);
     params.insert("baseline_configuration_name", nhc_baseline_config_name);
 
-    debug!(
-        "Querying NHC at address: {}:{}",
-        vfn_url_string, api_port_string
-    );
+    let address_single_string = format!("{}:{}", vfn_url_string, api_port_string);
+    debug!("Querying NHC at address: {}", address_single_string);
 
     // Send the request and parse the response.
     let response = match nhc_client
@@ -365,5 +389,8 @@ async fn check_single_vfn_one_api_port(
         ));
     }
 
-    SingleCheckResult::Success(evaluation_summary)
+    SingleCheckResult::Success(SingleCheckSuccess::new(
+        evaluation_summary,
+        address_single_string,
+    ))
 }


### PR DESCRIPTION
### Description
This will be helpful for further processing / testing, e.g. for continuous txn emission.

### Test Plan
```
cargo run -p aptos-vfn-check-client -- --node-address https://ait3.aptosdev.com --nhc-address https://node-checker.prod.gcp.aptosdev.com --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json | jq .
```
Sample of output:
```json
  "17e6eeec824c4ebe71f276aeb2115b63defcd8b5898663074d02c6db6494991b": [
    {
      "result": {
        "type": "success",
        "evaluation_summary": {
          "evaluation_results": [
            {
              "headline": "Chain ID reported by baseline and target match",
              "score": 100,
              "explanation": "The node under investigation reported the same Chain ID 47 as is reported by the baseline node",
              "evaluator_name": "node_identity",
              "category": "api",
              "links": []
            },
            {
              "headline": "Role Type reported by baseline and target match",
              "score": 100,
              "explanation": "The node under investigation reported the same Role Type full_node as is reported by the baseline node",
              "evaluator_name": "node_identity",
              "category": "api",
              "links": []
            },
            {
              "headline": "Average API latency is good",
              "score": 100,
              "explanation": "The average API latency was 318ms, which is below the maximum allowed latency of 750ms. Note, this latency is not the same as standard ping latency, see the attached link.",
              "evaluator_name": "latency",
              "category": "api",
              "links": [
                "https://aptos.dev/nodes/node-health-checker-faq#how-does-the-latency-evaluator-work"
              ]
            },
            {
              "headline": "Target node produced valid recent transaction",
              "score": 100,
              "explanation": "We were able to pull the same transaction (version: 608627) from both your node and the baseline node. Great! This implies that your node is keeping up with other nodes in the network.",
              "evaluator_name": "transaction_availability",
              "category": "api",
              "links": []
            }
          ],
          "summary_score": 100,
          "summary_explanation": "100: Awesome!"
        },
        "vfn_address_url": "http://65.109.17.29:8080"
      },
      "timestamp": {
        "secs": 1661892310,
        "nanos": 677036000
      },
      "vfn_address": "/dns/ait3full.aptos.rhinostake.com/tcp/6182/noise-ik/0xa164f14348186bd6f027998c3504bd5bb63e7e472e7dc03ea882adf319e1cb0d/handshake/0"
    }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3652)
<!-- Reviewable:end -->
