### PR TITLE
[docs] Make it a build error if there are broken links

### DIFF
--- a/developer-docs-site/docs/guides/interacting-with-the-blockchain.md
+++ b/developer-docs-site/docs/guides/interacting-with-the-blockchain.md
@@ -9,7 +9,7 @@ The Aptos Blockchain uses the [Move][move_url] virtual machine (VM) for executin
 native operations, Aptos delegates all operations to Move, including: account creation, fund transfer and publishing Move modules.
 To support these operations, blockchains built on top of Move must provide a framework (akin to
 an operating system for a computer or a minimal viable set of functions) for interacting with the blockchain. In this section, we discuss
-these functions, exposed via the Aptos Framework's `script` functions. 
+these functions, exposed via the Aptos Framework's `script` functions.
 
 This guide (in concert with the [Move module tutorial][your-first-move-module]) will unlock the minimal amount of information required to start building rich applications on top of the Aptos Blockchain. Note: the Aptos Framework is under heavy development and this document may not
 be up to date. The most recent framework can be found in the source code, [here][aptos_framework].
@@ -77,7 +77,7 @@ It is important to note that the Move bytecode must specify the same address as 
 
 [accounts]: /concepts/basics-accounts
 [your-first-coin]: /tutorials/your-first-coin
-[your-first-move-module]: /tutorials/your-first-move-module
+[your-first-move-module]: /tutorials/first-move-module
 [your-first-transaction]: /tutorials/your-first-transaction
 [move_url]: https://diem.github.io/move/
 [aptos_framework]: https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/framework/aptos-framework/sources

--- a/developer-docs-site/docs/nodes/local-testnet/run-a-local-testnet.md
+++ b/developer-docs-site/docs/nodes/local-testnet/run-a-local-testnet.md
@@ -186,5 +186,5 @@ Use the [Aptos CLI tool](https://github.com/aptos-labs/aptos-core/blob/main/crat
 At this point, you will have a special root account at `0x1` that can perform the mint operation. Follow up with:
 
 * [Your first transaction](/tutorials/your-first-transaction) to learn how to submit transactions.
-* [Your first Move module](/tutorials/your-first-move-module) to learn how to create Move modules.
+* [Your first Move module](/tutorials/first-move-module) to learn how to create Move modules.
 * [Interacting with the Aptos Blockchain](/guides/interacting-with-the-aptos-blockchain) to learn how to mint coins.

--- a/developer-docs-site/docs/whats-new-in-docs.md
+++ b/developer-docs-site/docs/whats-new-in-docs.md
@@ -7,7 +7,7 @@ slug: "whats-new-in-docs"
 
 ## 25 August 2022
 
-- A new guide describing [Upgrading the Move Code](/guides/move-guides/upgrading-move-code.md) is posted. 
+- A new guide describing [Upgrading the Move Code](/guides/move-guides/upgrading-move-code.md) is posted.
 
 
 ## 24 August 2022
@@ -36,4 +36,4 @@ slug: "whats-new-in-docs"
 
 ## 02 August 2022
 
-- A new [Guide for System Integrators](/guides/guide-for-system-integrators) is posted.
+- A new [Guide for System Integrators](/guides/system-integrators-guide) is posted.

--- a/developer-docs-site/docusaurus.config.js
+++ b/developer-docs-site/docusaurus.config.js
@@ -12,8 +12,8 @@ const config = {
   tagline: "Developer Documentation",
   url: "https://aptos.dev",
   baseUrl: "/",
-  onBrokenLinks: "warn",
-  onBrokenMarkdownLinks: "warn",
+  onBrokenLinks: "throw",
+  onBrokenMarkdownLinks: "throw",
   favicon: "img/favicon.ico",
   organizationName: "aptos-labs", // Usually your GitHub org/user name.
   projectName: "aptos-core", // Usually your repo name.


### PR DESCRIPTION
### Description
Addresses https://github.com/aptos-labs/aptos-core/issues/3646. As part of this I fix the broken links.

Docs: https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks.

### Test Plan
```
cd developer-docs-site
yarn build
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3657)
<!-- Reviewable:end -->
