### PR TITLE
Proved an invariant and the non-aborting property in the `stake` module

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -612,4 +612,14 @@ module aptos_framework::aptos_governance {
         initialize(&account, 1, 2, 3);
         update_governance_config(&account, 10, 20, 30);
     }
+
+    #[verify_only]
+    public fun initialize_for_verification(
+        aptos_framework: &signer,
+        min_voting_threshold: u128,
+        required_proposer_stake: u64,
+        voting_duration_secs: u64,
+    ) {
+        initialize(aptos_framework, min_voting_threshold, required_proposer_stake, voting_duration_secs);
+    }
 }

--- a/aptos-move/framework/aptos-framework/sources/block.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/block.spec.move
@@ -1,0 +1,6 @@
+spec aptos_framework::block {
+    spec block_prologue {
+        use aptos_framework::chain_status;
+        requires chain_status::is_operating();
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/chain_status.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/chain_status.spec.move
@@ -1,0 +1,5 @@
+spec aptos_framework::chain_status {
+    spec set_genesis_end {
+        pragma verify=false;
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -361,6 +361,9 @@ module aptos_framework::coin {
     /// "Merges" the two given coins.  The coin passed in as `dst_coin` will have a value equal
     /// to the sum of the two tokens (`dst_coin` and `source_coin`).
     public fun merge<CoinType>(dst_coin: &mut Coin<CoinType>, source_coin: Coin<CoinType>) {
+        spec {
+            assume dst_coin.value + source_coin.value <= MAX_U64;
+        };
         dst_coin.value = dst_coin.value + source_coin.value;
         let Coin { value: _ } = source_coin;
     }

--- a/aptos-move/framework/aptos-framework/sources/coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.spec.move
@@ -1,0 +1,20 @@
+spec aptos_framework::coin {
+    spec mint {
+        pragma opaque;
+        let addr = spec_coin_address<CoinType>();
+        modifies global<CoinInfo<CoinType>>(addr);
+        ensures [abstract] global<CoinInfo<CoinType>>(addr) == old(global<CoinInfo<CoinType>>(addr));
+        aborts_if [abstract] false;
+        ensures [abstract] result.value == amount;
+    }
+
+    spec coin_address {
+        pragma opaque;
+        ensures [abstract] result == spec_coin_address<CoinType>();
+    }
+
+    spec fun spec_coin_address<CoinType>(): address {
+        // TODO: abstracted due to the lack of support for `type_info` in Prover.
+        @0x0
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.move
@@ -6,14 +6,17 @@ module aptos_framework::staking_config {
 
     friend aptos_framework::genesis;
 
-    /// Stake lockup duration cannot be zero
+    /// Stake lockup duration cannot be zero.
     const EZERO_LOCKUP_DURATION: u64 = 1;
-    /// Reward rate denominator cannot be zero
+    /// Reward rate denominator cannot be zero.
     const EZERO_REWARDS_RATE_DENOMINATOR: u64 = 2;
-    /// Specified stake range is invalid. Max must be greater than min
+    /// Specified stake range is invalid. Max must be greater than min.
     const EINVALID_STAKE_RANGE: u64 = 3;
-    /// The voting power increase limit percentage must be within (0, 50]
+    /// The voting power increase limit percentage must be within (0, 50].
     const EINVALID_VOTING_POWER_INCREASE_LIMIT: u64 = 4;
+    /// Specified rewards rate is invalid, which must be within [0, 100).
+    const EINVALID_REWARDS_RATE: u64 = 5;
+
 
     /// Validator set configurations that will be stored with the @aptos_framework account.
     struct StakingConfig has copy, drop, key {
@@ -146,7 +149,6 @@ module aptos_framework::staking_config {
             new_rewards_rate_denominator > 0,
             error::invalid_argument(EZERO_REWARDS_RATE_DENOMINATOR),
         );
-
         let staking_config = borrow_global_mut<StakingConfig>(@aptos_framework);
         staking_config.rewards_rate = new_rewards_rate;
         staking_config.rewards_rate_denominator = new_rewards_rate_denominator;

--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -1,0 +1,6 @@
+spec aptos_framework::staking_config {
+    spec module {
+        use aptos_framework::chain_status;
+        invariant chain_status::is_operating() ==> exists<StakingConfig>(@aptos_framework);
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/event.move
+++ b/aptos-move/framework/aptos-framework/sources/event.move
@@ -30,6 +30,9 @@ module aptos_std::event {
     /// Emit an event with payload `msg` by using `handle_ref`'s key and counter.
     public fun emit_event<T: drop + store>(handle_ref: &mut EventHandle<T>, msg: T) {
         write_to_event_store<T>(bcs::to_bytes(&handle_ref.guid), handle_ref.counter, msg);
+        spec {
+            assume handle_ref.counter + 1 <= MAX_U64;
+        };
         handle_ref.counter = handle_ref.counter + 1;
     }
 

--- a/aptos-move/framework/aptos-framework/sources/event.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/event.spec.move
@@ -1,6 +1,10 @@
 spec aptos_std::event {
-    spec write_to_event_store {
-        // TODO: temporary mockup.
+    spec emit_event {
         pragma opaque;
+        aborts_if [abstract] false;
+    }
+
+    spec module {
+        pragma verify=false;
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/genesis.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.spec.move
@@ -1,0 +1,14 @@
+spec aptos_framework::genesis {
+    spec module {
+        // We are not proving each genesis step indivisually. Instead, we construct
+        // and prove `initialize_for_verification` which is a "#[verify_only]" function that
+        // simulates the genesis encoding process in `vm-genesis` (written in Rust).
+        // So, we turn off the verification at the module level, but turn it on for
+        // the verification-only function `initialize_for_verification`.
+        pragma verify=false;
+    }
+
+    spec initialize_for_verification {
+        pragma verify=true;
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -1,0 +1,168 @@
+spec aptos_framework::stake {
+
+    // -----------------
+    // Global invariants
+    // -----------------
+
+    spec module {
+        // The validator set should satisfy its desired invariant.
+        invariant [suspendable] validator_set_is_valid();
+        // After genesis, `AptosCoinCapabilities`, `ValidatorPerformance` and `ValidatorSet` exist.
+        invariant [suspendable] chain_status::is_operating() ==> exists<AptosCoinCapabilities>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==> exists<ValidatorPerformance>(@aptos_framework);
+        invariant [suspendable] chain_status::is_operating() ==> exists<ValidatorSet>(@aptos_framework);
+    }
+
+    // A desired invariant for the validator set.
+    spec fun validator_set_is_valid(): bool {
+        let validator_set = global<ValidatorSet>(@aptos_framework);
+        spec_validators_are_initialized(validator_set.active_validators) &&
+            spec_validators_are_initialized(validator_set.pending_inactive) &&
+            spec_validators_are_initialized(validator_set.pending_active) &&
+            spec_validator_indices_are_valid(validator_set.active_validators) &&
+            spec_validator_indices_are_valid(validator_set.pending_inactive)
+    }
+
+
+    // -----------------------
+    // Function specifications
+    // -----------------------
+
+    spec on_new_epoch {
+        pragma disable_invariants_in_body;
+        // The following resource requirement cannot be discharged by the global
+        // invariants because this function is called during genesis.
+        include ResourceRequirement;
+        // This function should never abort.
+        aborts_if false;
+    }
+
+    spec update_performance_statistics {
+        // This function is expected to be used after genesis.
+        requires chain_status::is_operating();
+        // This function should never abort.
+        aborts_if false;
+    }
+
+    spec update_stake_pool {
+        include ResourceRequirement;
+        aborts_if !exists<StakePool>(pool_address);
+        aborts_if !exists<ValidatorConfig>(pool_address);
+        aborts_if global<ValidatorConfig>(pool_address).validator_index >= len(validator_perf.validators);
+    }
+
+    spec distribute_rewards {
+        include ResourceRequirement;
+        aborts_if false;
+        ensures old(stake.value) > 0 ==>
+                result == spec_rewards_amount(
+                    old(stake.value),
+                    num_successful_proposals,
+                    num_total_proposals,
+                    rewards_rate,
+                    rewards_rate_denominator);
+        ensures old(stake.value) > 0 ==>
+                stake.value == old(stake.value) + spec_rewards_amount(
+                    old(stake.value),
+                    num_successful_proposals,
+                    num_total_proposals,
+                    rewards_rate,
+                    rewards_rate_denominator);
+        ensures old(stake.value) == 0 ==> result == 0;
+        ensures old(stake.value) == 0 ==> stake.value == old(stake.value);
+    }
+
+    spec calculate_rewards_amount {
+        pragma opaque;
+        ensures [concrete] (rewards_rate_denominator * num_total_proposals == 0) ==> result == 0;
+        ensures [concrete] (rewards_rate_denominator * num_total_proposals > 0) ==>
+            result == ((stake_amount * rewards_rate * num_successful_proposals) /
+                (rewards_rate_denominator * num_total_proposals));
+        // We assume that rewards_rate < 100 and num_successful_proposals < 86400 (1 proposal per second in a day).
+        // So, the multiplication in the reward formula should not overflow.
+        aborts_if [abstract] false;
+        // Used an uninterpreted spec function to avoid dealing with the arithmetic overflow and non-linear arithmetic.
+        ensures [abstract] result == spec_rewards_amount(
+            stake_amount,
+            num_successful_proposals,
+            num_total_proposals,
+            rewards_rate,
+            rewards_rate_denominator);
+    }
+
+    spec find_validator {
+        pragma opaque;
+        ensures option::is_none(result) ==> (forall i in 0..len(v): v[i].addr != addr);
+        ensures option::is_some(result) ==> v[option::borrow(result)].addr == addr;
+    }
+
+    spec append {
+        pragma opaque, verify=false;
+        aborts_if false;
+        ensures len(v1) == old(len(v1) + len(v2));
+        ensures len(v2) == 0;
+        // The prefix of the new `v1` is the same as the old `v1`.
+        ensures (forall i in 0..old(len(v1)): v1[i] == old(v1[i]));
+        // The suffix of the new `v1` is the same as the reverse of the old `v2`.
+        ensures (forall i in old(len(v1))..len(v1): v1[i] == old(v2[len(v2) - (i - len(v1)) - 1]));
+    }
+
+    spec remove_validators {
+        pragma disable_invariants_in_body;
+    }
+
+    spec remove_validators_internal {
+        requires spec_validators_are_initialized(active_validators);
+        requires spec_validator_indices_are_valid(active_validators);
+    }
+
+
+    // ---------------------------------
+    // Spec helper functions and schemas
+    // ---------------------------------
+
+    // A predicate that all given validators have been initialized.
+    spec fun spec_validators_are_initialized(validators: vector<ValidatorInfo>): bool {
+        forall i in 0..len(validators):
+            spec_has_stake_pool(validators[i].addr) &&
+                spec_has_validator_config(validators[i].addr)
+    }
+
+    // A predicate that the validator index of each given validator in-range.
+    spec fun spec_validator_indices_are_valid(validators: vector<ValidatorInfo>): bool {
+        forall i in 0..len(validators):
+            global<ValidatorConfig>(validators[i].addr).validator_index < spec_validator_index_upper_bound()
+    }
+
+    // The upper bound of validator indices.
+    spec fun spec_validator_index_upper_bound(): u64 {
+        len(global<ValidatorPerformance>(@aptos_framework).validators)
+    }
+
+    spec fun spec_has_stake_pool(a: address): bool {
+        exists<StakePool>(a)
+    }
+
+    spec fun spec_has_validator_config(a: address): bool {
+        exists<ValidatorConfig>(a)
+    }
+
+    // An uninterpreted spec function to represent the stake reward formula.
+    spec fun spec_rewards_amount(
+        stake_amount: u64,
+        num_successful_proposals: u64,
+        num_total_proposals: u64,
+        rewards_rate: u64,
+        rewards_rate_denominator: u64,
+    ): u64;
+
+    // These resources are required to successfully execute `on_new_epoch`, which cannot
+    // be discharged by the global invariants because `on_new_epoch` is called in genesis.
+    spec schema ResourceRequirement {
+        requires exists<AptosCoinCapabilities>(@aptos_framework);
+        requires exists<ValidatorPerformance>(@aptos_framework);
+        requires exists<ValidatorSet>(@aptos_framework);
+        requires exists<StakingConfig>(@aptos_framework);
+        requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/timestamp.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/timestamp.spec.move
@@ -1,2 +1,14 @@
 spec aptos_framework::timestamp {
+    spec fun spec_now_microseconds(): u64 {
+        global<CurrentTimeMicroseconds>(@aptos_framework).microseconds
+    }
+
+    spec fun spec_now_seconds(): u64 {
+        spec_now_microseconds() / MICRO_CONVERSION_FACTOR
+    }
+
+    spec module {
+        use aptos_framework::chain_status;
+        invariant chain_status::is_operating() ==> exists<CurrentTimeMicroseconds>(@aptos_framework);
+    }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/table.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/table.spec.move
@@ -1,10 +1,21 @@
-/// Specifications of the `Table` module.
+/// Specifications of the `table` module.
 spec aptos_std::table {
 
     // Make most of the public API intrinsic. Those functions have custom specifications in the prover.
 
     spec Table {
-        pragma intrinsic;
+        pragma intrinsic = map,
+            map_new = new,
+            map_destroy_empty = destroy,
+            map_has_key = contains,
+            map_add_no_override = add,
+            map_del_must_exist = remove,
+            map_borrow = borrow,
+            map_borrow_mut = borrow_mut,
+            map_spec_get = spec_get,
+            map_spec_set = spec_add,
+            map_spec_del = spec_remove,
+            map_spec_has_key = spec_contains;
     }
 
     spec new {
@@ -36,9 +47,6 @@ spec aptos_std::table {
     }
 
     // Specification functions for tables
-
-    spec native fun spec_table<K, V>(): Table<K, V>;
-    spec native fun spec_len<K, V>(t: Table<K, V>): num;
     spec native fun spec_contains<K, V>(t: Table<K, V>, k: K): bool;
     spec native fun spec_add<K, V>(t: Table<K, V>, k: K, v: V): Table<K, V>;
     spec native fun spec_remove<K, V>(t: Table<K, V>, k: K): Table<K, V>;


### PR DESCRIPTION
### Description
- defined and proved an invariant for `validator_set`
  - validators in the validator sets have been initialized
  - validator indices are valid (in-range)
- proved `update_performance_statistics` and `on_new_epoch` does not abort unexpectedly.
- proved the genesis steps partially 
  - only the parts that the `stake` module depends on

- Note that there was some changes in the Move code
  - a `while` was split into two for loop invariant writing
  - `remove_validators` uses a help function (e.g., `..._internal`) for the global invariant verification
  - also a few minor changes

- TOOD:
  - add the comments for the specs so that they are better auditable.
  - completely verify the genesis steps

### Test Plan
aptos move prove

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3661)
<!-- Reviewable:end -->
