### PR TITLE
Handle when there are invalid network addresses on chain

### DIFF
--- a/ecosystem/node-checker/vfn-check-client/src/main.rs
+++ b/ecosystem/node-checker/vfn-check-client/src/main.rs
@@ -53,9 +53,7 @@ async fn main() -> Result<()> {
         .await
         .context("Failed to get on chain validator info")?;
 
-    let nhc_responses = check_vfns(&nhc_client, &args.check_args, validator_infos)
-        .await
-        .context("Failed to check nodes unexpectedly")?;
+    let nhc_responses = check_vfns(&nhc_client, &args.check_args, validator_infos).await;
 
     info!(
         "Got {} responses from NHC, will now output to {:?}",


### PR DESCRIPTION
### Description
https://aptoslabs.pagerduty.com/incidents/Q2Z1NI1YGFP465. In short, there can be invalid addresses on chain right now. This adds code to handle that case.

### Test Plan
This was failing before:
```
cargo run -p aptos-vfn-check-client -- --node-address https://ait3.aptosdev.com --nhc-address https://node-checker.prod.gcp.aptosdev.com --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json
```

Output snippet:
```
  "86b5e89746c45648735ef61c722debec0c35e051db941c783a82756d77a54f8c": [
    {
      "result": {
        "type": "invalid_network_address"
      },
      "timestamp": {
        "secs": 1661902010,
        "nanos": 37977000
      },
      "vfn_address": null
    }
  ],
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3663)
<!-- Reviewable:end -->
