### PR TITLE
[CP] Create hidden dummy address to allow for Ctrl+F full string

### DIFF
--- a/ecosystem/platform/server/app/components/icon_tooltip_component.html.erb
+++ b/ecosystem/platform/server/app/components/icon_tooltip_component.html.erb
@@ -1,6 +1,6 @@
 <button class="relative group text-left normal-case font-sans text-xs cursor-pointer">
   <%= render IconComponent.new(:info, size: @size, class: 'text-neutral-700 group-focus:text-neutral-600 group-hover:text-neutral-600') %>
-  <div class="absolute min-w-max right-0 top-4 scale-0 opacity-0 group-focus:scale-100 group-focus-within:scale-100 group-hover:scale-100 group-focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 origin-top-right transition-opacity duration-150 cursor-default">
+  <div class="z-10 absolute min-w-max right-0 top-4 scale-0 opacity-0 group-focus:scale-100 group-focus-within:scale-100 group-hover:scale-100 group-focus:opacity-100 group-focus-within:opacity-100 group-hover:opacity-100 origin-top-right transition-opacity duration-150 cursor-default">
     <div class="pointer-events-auto mt-4 bg-neutral-700 rounded-md flex flex-col flex-1 max-w-xs">
       <h3 class="bg-neutral-600 p-4 rounded-t-md"><%= header %></h3>
       <div class="p-4 flex flex-col flex-1">

--- a/ecosystem/platform/server/app/helpers/leaderboard_helper.rb
+++ b/ecosystem/platform/server/app/helpers/leaderboard_helper.rb
@@ -39,11 +39,11 @@ module LeaderboardHelper
 
   def liveness_icon(liveness)
     if liveness >= 97
-      render IconComponent.new(:check_circle, class: 'text-teal-400 w-5 h-5')
+      render IconComponent.new(:check_circle, class: 'text-teal-400 w-4 h-4')
     elsif liveness >= 95
-      render IconComponent.new(:check_circle, class: 'text-yellow-500 w-5 h-5')
+      render IconComponent.new(:check_circle, class: 'text-yellow-500 w-4 h-4')
     else
-      render IconComponent.new(:x_circle, class: 'text-red-500 w-5 h-5')
+      render IconComponent.new(:x_circle, class: 'text-red-500 w-4 h-4')
     end
   end
 end

--- a/ecosystem/platform/server/app/views/leaderboard/it1.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it1.html.erb
@@ -106,7 +106,10 @@
                   <%= metric.rank %>
                 <% end %>
                 <%= tr.with_column(align: 'left', title: "0x#{metric.validator}") do %>
-                  <%= truncate_address("0x#{metric.validator}") %>
+                  <div class="relative">
+                    <%= truncate_address("0x#{metric.validator}") %>
+                    <span class="absolute w-100 overflow-visible inline-block text-transparent bottom-0 left-0 pointer-events-none">0x<%= metric.validator %></span>
+                  </div>
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">
@@ -116,7 +119,7 @@
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">
-                    <div class="<%= availability_color(metric.participation) %> block w-5 h-5 rounded-full"></div>
+                    <div class="<%= availability_color(metric.participation) %> block w-4 h-4 rounded-full"></div>
                     <%= number_to_percentage(metric.participation, precision: 2) %>
                   </div>
                 <% end %>

--- a/ecosystem/platform/server/app/views/leaderboard/it2.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it2.html.erb
@@ -107,7 +107,10 @@
                   <%= metric.rank %>
                 <% end %>
                 <%= tr.with_column(align: 'left', title: "0x#{metric.validator}") do %>
-                  <%= truncate_address("0x#{metric.validator}") %>
+                  <div class="relative">
+                    <%= truncate_address("0x#{metric.validator}") %>
+                    <span class="absolute w-100 overflow-visible inline-block text-transparent bottom-0 left-0 pointer-events-none">0x<%= metric.validator %></span>
+                  </div>
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">
@@ -117,7 +120,7 @@
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">
-                    <div class="<%= availability_color(metric.participation) %> block w-5 h-5 rounded-full"></div>
+                    <div class="<%= availability_color(metric.participation) %> block w-4 h-4 rounded-full"></div>
                     <%= number_to_percentage(metric.participation, precision: 2) %>
                   </div>
                 <% end %>

--- a/ecosystem/platform/server/app/views/leaderboard/it3.html.erb
+++ b/ecosystem/platform/server/app/views/leaderboard/it3.html.erb
@@ -102,13 +102,14 @@
 
           <%= t.with_body do %>
             <% @metrics.each_with_index do |metric, i| %>
-              <%= render TableRowComponent.new(class: 'cursor-pointer select-none active:translate-y-0.5') do |tr| %>
+              <%= render TableRowComponent.new(class: 'cursor-pointer select-none active:translate-y-0.5', title: 'Click to view account on Explorer') do |tr| %>
                 <%= tr.with_column(align: 'left') do %>
                   <%= metric.rank %>
                 <% end %>
-                <%= tr.with_column(align: 'left', title: metric.owner_address) do %>
-                  <a href="https://explorer.devnet.aptos.dev/account/<%= metric.owner_address %>?network=ait3" target="_blank" title="<%= metric.owner_address %>">
+                <%= tr.with_column(align: 'left') do %>
+                  <a class="relative" href="https://explorer.devnet.aptos.dev/account/<%= metric.owner_address %>?network=ait3" target="_blank" title="<%= metric.owner_address %>">
                     <%= truncate_address(metric.owner_address) %>
+                    <span class="absolute w-100 overflow-visible inline-block text-transparent left-0 pointer-events-none"><%= metric.owner_address %></span>
                   </a>
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
@@ -119,7 +120,7 @@
                 <% end %>
                 <%= tr.with_column(align: 'left') do %>
                   <div class="flex items-center gap-2">
-                    <div class="<%= rewards_growth_color(metric.rewards_growth) %> block w-5 h-5 rounded-full"></div>
+                    <div class="<%= rewards_growth_color(metric.rewards_growth) %> block w-4 h-4 rounded-full"></div>
                     <%= number_to_percentage(metric.rewards_growth, precision: 2) %>
                   </div>
                 <% end %>


### PR DESCRIPTION
### Description

Creates a hidden dummy element containing full address to allow for users to Ctrl+F the full address and land on the appropriate row. 

### Test Plan
`Ctrl+F` / browser search for full address and ensure it reveals the appropriate row with truncated address. 

<img width="1993" alt="image" src="https://user-images.githubusercontent.com/98909677/187564022-9bb8854c-a6d7-4497-84b1-46edfc295bd3.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3666)
<!-- Reviewable:end -->
