### PR TITLE
[forge] K8sNode::clear_storage deletes paths directly

### DIFF
--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -245,7 +245,7 @@ impl Node for LocalNode {
         Ok(())
     }
 
-    fn clear_storage(&mut self) -> Result<()> {
+    async fn clear_storage(&mut self) -> Result<()> {
         // Remove all storage files (i.e., blockchain data, consensus data and state sync data)
         let node_config = self.config();
         let ledger_db_path = node_config.storage.dir().join(LEDGER_DB_NAME);
@@ -284,6 +284,9 @@ impl Node for LocalNode {
                 .map_err(anyhow::Error::from)
                 .context("Failed to delete secure_storage_db_path")?;
         }
+
+        // Stop the node to clear buffers
+        self.stop();
 
         Ok(())
     }

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -57,8 +57,8 @@ pub trait Node: Send + Sync {
     /// This should be a noop if the Node isn't running.
     async fn stop(&mut self) -> Result<()>;
 
-    /// Clears this Node's Storage
-    fn clear_storage(&mut self) -> Result<()>;
+    /// Clears this Node's Storage. This stops the node as well
+    async fn clear_storage(&mut self) -> Result<()>;
 
     /// Performs a Health Check on the Node
     async fn health_check(&mut self) -> Result<(), HealthCheckError>;

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -386,7 +386,7 @@ async fn test_validator_sync(swarm: &mut LocalSwarm, validator_index_to_test: us
 
     // Stop the validator and delete the storage
     let validator = validator_peer_ids[validator_index_to_test];
-    stop_validator_and_delete_storage(swarm, validator);
+    stop_validator_and_delete_storage(swarm, validator).await;
 
     // Execute more transactions
     execute_transactions(swarm, &validator_client_0, &mut account_1, &account_0, true).await;
@@ -455,7 +455,7 @@ async fn test_all_validator_failures(mut swarm: LocalSwarm) {
 
     // Go through each validator, stop the node, delete the storage and wait for it to come back
     for validator in validator_peer_ids.clone() {
-        stop_validator_and_delete_storage(&mut swarm, validator);
+        stop_validator_and_delete_storage(&mut swarm, validator).await;
         swarm.validator_mut(validator).unwrap().start().unwrap();
         wait_for_all_nodes(&mut swarm).await;
     }
@@ -472,7 +472,7 @@ async fn test_all_validator_failures(mut swarm: LocalSwarm) {
 
     // Go through each validator, stop the node, delete the storage and wait for it to come back
     for validator in validator_peer_ids.clone() {
-        stop_validator_and_delete_storage(&mut swarm, validator);
+        stop_validator_and_delete_storage(&mut swarm, validator).await;
         swarm.validator_mut(validator).unwrap().start().unwrap();
         wait_for_all_nodes(&mut swarm).await;
     }
@@ -588,8 +588,8 @@ async fn create_test_accounts(swarm: &mut LocalSwarm) -> (LocalAccount, LocalAcc
 }
 
 /// Stops the specified validator and deletes storage
-fn stop_validator_and_delete_storage(swarm: &mut LocalSwarm, validator: AccountAddress) {
+async fn stop_validator_and_delete_storage(swarm: &mut LocalSwarm, validator: AccountAddress) {
     let validator = swarm.validator_mut(validator).unwrap();
-    validator.stop();
-    validator.clear_storage().unwrap();
+    // the validator is stopped during the clear_storage step as well
+    validator.clear_storage().await.unwrap();
 }

--- a/testsuite/testcases/src/forge_setup_test.rs
+++ b/testsuite/testcases/src/forge_setup_test.rs
@@ -4,7 +4,7 @@
 use std::thread;
 
 use aptos_logger::info;
-use forge::{FullNode, NetworkContext, NetworkTest, Result, Test};
+use forge::{NetworkContext, NetworkTest, Result, Test};
 use rand::{
     rngs::{OsRng, StdRng},
     seq::IteratorRandom,
@@ -22,19 +22,6 @@ impl Test for ForgeSetupTest {
     }
 }
 
-async fn wipe_fullnode(fullnode: &mut dyn FullNode) -> Result<()> {
-    fullnode.stop().await?;
-    info!("Clear its storage");
-    fullnode.clear_storage()?;
-    info!("Start it up again");
-    if let Err(e) = fullnode.start().await {
-        info!("Error on fullnode startup: {}", e);
-    } else {
-        info!("Fullnode started successfully");
-    }
-    Ok(())
-}
-
 impl NetworkTest for ForgeSetupTest {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
         let mut rng = StdRng::from_seed(OsRng.gen());
@@ -45,9 +32,9 @@ impl NetworkTest for ForgeSetupTest {
         let all_fullnodes = swarm.full_nodes().map(|v| v.peer_id()).collect::<Vec<_>>();
         let fullnode_id = all_fullnodes.iter().choose(&mut rng).unwrap();
 
-        info!("Pick one fullnode to stop");
+        info!("Pick one fullnode to stop and wipe");
         let fullnode = swarm.full_node_mut(*fullnode_id).unwrap();
-        runtime.block_on(wipe_fullnode(fullnode))?;
+        runtime.block_on(fullnode.clear_storage())?;
 
         let fullnode = swarm.full_node(*fullnode_id).unwrap();
         let fullnode_name = fullnode.name();

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -49,8 +49,7 @@ impl NetworkTest for StateSyncPerformance {
         info!("Deleting all fullnode data!");
         for fullnode_id in &all_fullnodes {
             let fullnode = ctx.swarm().full_node_mut(*fullnode_id).unwrap();
-            runtime.block_on(async { fullnode.stop().await })?;
-            fullnode.clear_storage()?;
+            runtime.block_on(async { fullnode.clear_storage().await })?;
         }
 
         // Fetch the highest synced version from the swarm


### PR DESCRIPTION
### Description

This unbreaks the `state_sync` k8s forge test.

Previously, the `K8sNode::clear_storage` method deleted the underlying storage volume. This was finicky because:
* it requires scaling down the workload, deleting the volume, then spinning the workload back up (and re-create the volume in the case of validators, since the lifecycle of the storage volume is decoupled from that of the validators. This is not the case for fullnodes)
* it's really async

This PR changes the clear_storage logic such that it execs into the running pod and delete its storage via path, the same way `LocalNode::clear_storage` does.

### Test Plan

Run Forge with the `forge_setup` and `state_sync` tests
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3667)
<!-- Reviewable:end -->
