### PR TITLE
feat(ts-sdk): expose API error details

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 
 - Upgraded typescript version from 4.7.4 to 4.8.2, as well as linter package versions.
 - **[Breaking Change]** ModuleBundle transaction support is removed. Instead, SDK users should use `AptosClient.publishPackage` to publish Move packages.
+- Expose detailed API errors.
 
 ## 1.3.10 (2022-08-26)
 

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -56,6 +56,7 @@ export class AptosClient {
    * }
    * ```
    */
+  @parseApiError
   async getAccount(accountAddress: MaybeHexString): Promise<Gen.AccountData> {
     return this.client.accounts.getAccount(HexString.ensure(accountAddress).hex());
   }
@@ -68,6 +69,7 @@ export class AptosClient {
    * @param query?.limit The max number of transactions should be returned for the page. Default is 25.
    * @returns An array of on-chain transactions, sent by account
    */
+  @parseApiError
   async getAccountTransactions(
     accountAddress: MaybeHexString,
     query?: { start?: BigInt | number; limit?: number },
@@ -87,6 +89,7 @@ export class AptosClient {
    * Module is represented by MoveModule interface. It contains module `bytecode` and `abi`,
    * which is JSON representation of a module
    */
+  @parseApiError
   async getAccountModules(
     accountAddress: MaybeHexString,
     query?: { ledgerVersion?: BigInt | number },
@@ -106,6 +109,7 @@ export class AptosClient {
    * Module is represented by MoveModule interface. It contains module `bytecode` and `abi`,
    * which JSON representation of a module
    */
+  @parseApiError
   async getAccountModule(
     accountAddress: MaybeHexString,
     moduleName: string,
@@ -131,6 +135,7 @@ export class AptosClient {
    * }
    * ```
    */
+  @parseApiError
   async getAccountResources(
     accountAddress: MaybeHexString,
     query?: { ledgerVersion?: BigInt | number },
@@ -155,6 +160,7 @@ export class AptosClient {
    * }
    * ```
    */
+  @parseApiError
   async getAccountResource(
     accountAddress: MaybeHexString,
     resourceType: Gen.MoveStructTag,
@@ -255,6 +261,7 @@ export class AptosClient {
    * of `guid` field in the Move struct `EventHandle`
    * @returns Array of events assotiated with given key
    */
+  @parseApiError
   async getEventsByEventKey(eventKey: string): Promise<Gen.Event[]> {
     return this.client.events.getEventsByEventKey(eventKey);
   }
@@ -272,6 +279,7 @@ export class AptosClient {
    * @param query?.limit The number of events to be returned for the page default is 5
    * @returns Array of events
    */
+  @parseApiError
   async getEventsByEventHandle(
     address: MaybeHexString,
     eventHandleStruct: Gen.MoveStructTag,
@@ -342,6 +350,7 @@ export class AptosClient {
    * @param query?.limit The max number of transactions should be returned for the page. Default is 25
    * @returns Array of on-chain transactions
    */
+  @parseApiError
   async getTransactions(query?: { start?: BigInt | number; limit?: number }): Promise<Gen.Transaction[]> {
     return this.client.transactions.getTransactions(query?.start?.toString(), query?.limit);
   }
@@ -351,6 +360,7 @@ export class AptosClient {
    * Transaction version is an uint64 number.
    * @returns Transaction from mempool or on-chain transaction
    */
+  @parseApiError
   async getTransactionByHash(txnHash: string): Promise<Gen.Transaction> {
     return this.client.transactions.getTransactionByHash(txnHash);
   }
@@ -360,6 +370,7 @@ export class AptosClient {
    * Transaction version is an uint64 number.
    * @returns Transaction from mempool or on-chain transaction
    */
+  @parseApiError
   async getTransactionByVersion(txnVersion: BigInt | number): Promise<Gen.Transaction> {
     return this.client.transactions.getTransactionByVersion(txnVersion.toString());
   }
@@ -381,8 +392,8 @@ export class AptosClient {
       const response = await this.client.transactions.getTransactionByHash(txnHash);
       return response.type === "pending_transaction";
     } catch (e) {
-      if (e instanceof Gen.ApiError) {
-        return e.status === 404;
+      if (e?.status === 404) {
+        return true;
       }
       throw e;
     }
@@ -508,6 +519,7 @@ export class AptosClient {
    * }
    * ```
    */
+  @parseApiError
   async getLedgerInfo(): Promise<Gen.IndexResponse> {
     return this.client.general.getLedgerInfo();
   }
@@ -532,6 +544,7 @@ export class AptosClient {
    * @param params Request params
    * @returns Table item value rendered in JSON
    */
+  @parseApiError
   async getTableItem(
     handle: string,
     data: Gen.TableItemRequest,
@@ -657,6 +670,17 @@ export class AptosClient {
   }
 }
 
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly message: string,
+    public readonly errorCode?: string,
+    public readonly vmErrorCode?: string,
+  ) {
+    super(message);
+  }
+}
+
 /**
  * This error is used by `waitForTransactionWithResult` when waiting for a
  * transaction times out.
@@ -681,4 +705,29 @@ export class FailedTransactionError extends Error {
     super(message);
     this.transaction = transaction;
   }
+}
+
+/**
+ * Creates a decorator to parse Gen.ApiError and return a wrapped error that is more developer friendly
+ */
+function parseApiError(target: unknown, propertyKey: string, descriptor: PropertyDescriptor) {
+  const childFunction = descriptor.value;
+  // eslint-disable-next-line no-param-reassign
+  descriptor.value = async function wrapper(...args: any[]) {
+    try {
+      const res = await childFunction.apply(this, [...args]);
+      return res;
+    } catch (e) {
+      if (e instanceof Gen.ApiError) {
+        throw new ApiError(
+          e.status,
+          JSON.stringify({ message: e.message, ...e.body }),
+          e.body?.error_code,
+          e.body?.vm_error_code,
+        );
+      }
+      throw e;
+    }
+  };
+  return descriptor;
 }


### PR DESCRIPTION
### Description
This PR exposes the detailed errors that are returned from APIs. Instead of requiring developers to parse the `error.body`, the `error_code` and `vm_error_code` are directly accessible through a wrapped error class. This PR also makes sure the error thrown carries a meaningful message. Also, in case of errors thrown, the stack trace can now show the correct call stack.

### Test Plan
All tests pass. Manually tested error cases. See pic below
<!-- Please provide us with clear details for verifying that your changes work. -->
![Screen Shot 2022-08-30 at 6 25 49 PM](https://user-images.githubusercontent.com/962285/187572537-ab5637bb-bf4f-4e95-9c8f-e3184db25d3f.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3669)
<!-- Reviewable:end -->
