### PR TITLE
[Mempool] Small consistency fix.

### DIFF
--- a/mempool/src/core_mempool/ttl_cache.rs
+++ b/mempool/src/core_mempool/ttl_cache.rs
@@ -36,16 +36,15 @@ where
     }
 
     pub fn insert(&mut self, key: K, value: V) {
-        // Remove old entry if it exists.
-        match self.data.get(&key) {
+        // Remove the old entry from data and ttl_index (if it exists)
+        match self.data.remove(&key) {
             Some(info) => {
                 self.ttl_index.remove(&info.ttl);
             }
             None => {
-                // Remove oldest entry if cache is still full.
+                // Remove the oldest entry if the cache is still full
                 if self.data.len() == self.capacity {
-                    let first_entry = self.ttl_index.keys().next().cloned();
-                    if let Some(tst) = first_entry {
+                    if let Some(tst) = self.ttl_index.keys().next().cloned() {
                         if let Some(key) = self.ttl_index.remove(&tst) {
                             self.data.remove(&key);
                         }
@@ -54,13 +53,13 @@ where
             }
         }
 
-        // Insert the new transaction.
+        // Insert the new transaction
         if let Some(expiration_time) = SystemTime::now().checked_add(self.default_timeout) {
-            self.ttl_index.insert(expiration_time, key.clone());
             let value_info = ValueInfo {
                 value,
                 ttl: expiration_time,
             };
+            self.ttl_index.insert(expiration_time, key.clone());
             self.data.insert(key, value_info);
         }
     }


### PR DESCRIPTION
### Description
There is an extreme (and rare) edge case whereby if the expiration time is too large, we might not be able to insert a new transaction into the `ttl_index` but it could still exist in `data` (as it was never removed). To avoid this, we remove from `ttl_index` and `data` together, and insert into them together. This is a very rare case (and unlikely in practice), but better safe than sorry 😄 

### Test Plan
Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3671)
<!-- Reviewable:end -->
