### PR TITLE
[CP] Remove Network Status from main nav

### DIFF
--- a/ecosystem/platform/server/app/components/header_component.rb
+++ b/ecosystem/platform/server/app/components/header_component.rb
@@ -26,8 +26,7 @@ class HeaderComponent < ViewComponent::Base
     NavGroup.new(
       NavItem.new('#', 'Network', 'Aptos Network'),
       [
-        NavItem.new('https://explorer.devnet.aptos.dev/', 'Explorer', 'Aptos Explorer'),
-        NavItem.new('https://status.devnet.aptos.dev/', 'Network Status', 'Aptos Network Status')
+        NavItem.new('https://explorer.devnet.aptos.dev/', 'Explorer', 'Aptos Explorer')
       ]
     ),
     NavGroup.new(


### PR DESCRIPTION
### Description
Removes "Network Status" from main navigation as this URL is currently not maintained. Will restore once the new Status Page is ready. 

### Test Plan
Ensure "Network Status" no longer exists within main navigation "Network" dropdown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3689)
<!-- Reviewable:end -->
