### PR TITLE
txn emitter followup

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -8,7 +8,7 @@ use aptos::common::types::EncodingType;
 use aptos_config::keys::ConfigKey;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_sdk::types::chain_id::ChainId;
-use clap::{ArgEnum, Parser};
+use clap::{ArgEnum, ArgGroup, Parser};
 
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -68,17 +68,22 @@ impl Default for TransactionType {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Parser, Serialize)]
+#[clap(group(
+    ArgGroup::new("mode")
+        .required(true)
+        .args(&["mempool-backlog", "target-tps"]),
+))]
 pub struct EmitArgs {
-    #[clap(long, default_value = "0")]
+    #[clap(long)]
     /// Number of transactions outstanding in mempool - this is needed to ensure that the emitter
     /// is producing enough load to get the highest TPS in the system. Typically this should be
     /// configured to be ~4x of the max achievable TPS.
     /// 0 if target_tps used.
-    pub mempool_backlog: usize,
+    pub mempool_backlog: Option<usize>,
 
     /// Target constant TPS, 0 if mempool_backlog used
-    #[clap(long, default_value = "0")]
-    pub target_tps: usize,
+    #[clap(long)]
+    pub target_tps: Option<usize>,
 
     #[clap(long, default_value = "30")]
     pub txn_expiration_time_secs: u64,

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -3,10 +3,10 @@
 
 use crate::emitter::wait_for_single_account_sequence;
 use crate::{
-    emitter::{MAX_TXNS, RETRY_POLICY, SEND_AMOUNT},
+    emitter::{GAS_AMOUNT, MAX_TXNS, RETRY_POLICY, SEND_AMOUNT},
     query_sequence_numbers, EmitJobRequest, EmitModeParams,
 };
-use anyhow::{format_err, Context, Result};
+use anyhow::{anyhow, format_err, Context, Result};
 use aptos::common::types::EncodingType;
 use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use aptos_infallible::Mutex;
@@ -77,16 +77,39 @@ impl<'t> AccountMinter<'t> {
                 (total_requested_accounts / 50).max(1)
             };
         let num_accounts = total_requested_accounts - accounts.len(); // Only minting extra accounts
-        let coins_per_account = MAX_TXNS * (SEND_AMOUNT + 10); // extra coins for secure to pay none zero gas price
+        let coins_per_account = (MAX_TXNS / total_requested_accounts as u64)
+            .checked_mul(SEND_AMOUNT + GAS_AMOUNT)
+            .unwrap(); // extra coins for secure to pay none zero gas price
         let txn_factory = self.txn_factory.clone();
-
-        let coins_per_seed_account = num_accounts as u64 * (coins_per_account + 1_000_000);
+        let coins_per_seed_account = (num_accounts as u64)
+            .checked_mul(coins_per_account + 1_000_000)
+            .unwrap();
+        let coins_for_root = coins_per_seed_account
+            .checked_mul(expected_num_seed_accounts as u64)
+            .unwrap()
+            .checked_add(1_000_000)
+            .unwrap();
         if req.mint_to_root {
-            self.mint_to_root(
-                &req.rest_clients,
-                coins_per_seed_account * expected_num_seed_accounts as u64 + 1_000_000,
-            )
-            .await?;
+            self.mint_to_root(&req.rest_clients, coins_for_root).await?;
+        } else {
+            let balance = &self
+                .pick_mint_client(&req.rest_clients)
+                .get_account_balance(self.root_account.address())
+                .await?
+                .into_inner();
+            info!(
+                "Root account current balance is {}, needed {} coins",
+                balance.get(),
+                coins_for_root
+            );
+            if balance.get() < coins_for_root {
+                return Err(anyhow!(
+                    "Root ({}) doesn't have enough coins, balance {} < needed {}",
+                    self.root_account.address(),
+                    balance.get(),
+                    coins_for_root
+                ));
+            }
         }
 
         let failed_requests = AtomicUsize::new(0);

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -44,9 +44,10 @@ use aptos_sdk::transaction_builder::aptos_stdlib;
 use rand::rngs::StdRng;
 use stats::{StatsAccumulator, TxnStats};
 
-// Max is 10k TPS for a full day.
-const MAX_TXNS: u64 = 10_000_000_000;
+// Max is 100k TPS for a full day.
+const MAX_TXNS: u64 = 100_000_000_000;
 const SEND_AMOUNT: u64 = 1;
+const GAS_AMOUNT: u64 = 1000;
 
 // This retry policy is used for important client calls necessary for setting
 // up the test (e.g. account creation) and collecting its results (e.g. checking
@@ -82,19 +83,19 @@ pub enum EmitJobMode {
 }
 
 impl EmitJobMode {
-    pub fn create(mempool_backlog: usize, target_tps: usize) -> Self {
-        if mempool_backlog > 0 {
+    pub fn create(mempool_backlog: Option<usize>, target_tps: Option<usize>) -> Self {
+        if let Some(mempool_backlog_val) = mempool_backlog {
             assert!(
-                target_tps == 0,
+                target_tps.is_none(),
                 "Cannot set both mempool_backlog and target_tps"
             );
-            Self::MaxLoad { mempool_backlog }
+            Self::MaxLoad {
+                mempool_backlog: mempool_backlog_val,
+            }
         } else {
-            assert!(
-                target_tps > 0,
-                "Need to set either mempool_backlog or target_tps"
-            );
-            Self::ConstTps { tps: target_tps }
+            Self::ConstTps {
+                tps: target_tps.expect("Need to set either mempool_backlog or target_tps"),
+            }
         }
     }
 }

--- a/testsuite/smoke-test/src/txn_emitter.rs
+++ b/testsuite/smoke-test/src/txn_emitter.rs
@@ -51,6 +51,7 @@ pub async fn generate_traffic(
         .await
 }
 
+#[ignore]
 #[tokio::test]
 async fn test_txn_emmitter() {
     let mut swarm = new_local_swarm_with_aptos(1).await;


### PR DESCRIPTION
Addressing comments left after I landed the PR.

- flags --mempool-backlog and --target-tps are now exclusive
- better accounting of how much coins we create, and whether we have enough
- turned off txn-emitter smoke test, I think it might be that one that is causing flakiness to others (as it is probably creating some connections)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3693)
<!-- Reviewable:end -->
