### PR TITLE
feat(ts-sdk): accept string payload params

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 - Upgraded typescript version from 4.7.4 to 4.8.2, as well as linter package versions.
 - **[Breaking Change]** ModuleBundle transaction support is removed. Instead, SDK users should use `AptosClient.publishPackage` to publish Move packages.
 - Expose detailed API errors.
+- Accept stringified values as transaction payload parameters.
 
 ## 1.3.10 (2022-08-26)
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
@@ -21,7 +21,14 @@ import {
   TypeTagVector,
 } from "./aptos_types";
 import { Serializer } from "./bcs";
-import { argToTransactionArgument, TypeTagParser, serializeArg } from "./builder_utils";
+import {
+  argToTransactionArgument,
+  TypeTagParser,
+  serializeArg,
+  ensureBoolean,
+  ensureNumber,
+  ensureBigInt,
+} from "./builder_utils";
 
 describe("BuilderUtils", () => {
   it("parses a bool TypeTag", async () => {
@@ -158,7 +165,7 @@ describe("BuilderUtils", () => {
     serializer = new Serializer();
     expect(() => {
       serializeArg("u8", new TypeTagU8(), serializer);
-    }).toThrow(/Invalid arg/);
+    }).toThrow(/Invalid number string/);
   });
 
   it("serializes a u64 arg", async () => {
@@ -169,7 +176,7 @@ describe("BuilderUtils", () => {
     serializer = new Serializer();
     expect(() => {
       serializeArg("u64", new TypeTagU64(), serializer);
-    }).toThrow(/Invalid arg/);
+    }).toThrow(/^Cannot convert/);
   });
 
   it("serializes a u128 arg", async () => {
@@ -182,7 +189,7 @@ describe("BuilderUtils", () => {
     serializer = new Serializer();
     expect(() => {
       serializeArg("u128", new TypeTagU128(), serializer);
-    }).toThrow(/Invalid arg/);
+    }).toThrow(/^Cannot convert/);
   });
 
   it("serializes an AccountAddress arg", async () => {
@@ -263,23 +270,23 @@ describe("BuilderUtils", () => {
     expect((res as TransactionArgumentU8).value).toEqual(123);
     expect(() => {
       argToTransactionArgument("u8", new TypeTagBool());
-    }).toThrow(/Invalid arg/);
+    }).toThrow(/Invalid boolean string/);
   });
 
   it("converts a u64 TransactionArgument", async () => {
     const res = argToTransactionArgument(123, new TypeTagU64());
-    expect((res as TransactionArgumentU64).value).toEqual(123);
+    expect((res as TransactionArgumentU64).value).toEqual(123n);
     expect(() => {
       argToTransactionArgument("u64", new TypeTagU64());
-    }).toThrow(/Invalid arg/);
+    }).toThrow(/Cannot convert/);
   });
 
   it("converts a u128 TransactionArgument", async () => {
     const res = argToTransactionArgument(123, new TypeTagU128());
-    expect((res as TransactionArgumentU128).value).toEqual(123);
+    expect((res as TransactionArgumentU128).value).toEqual(123n);
     expect(() => {
       argToTransactionArgument("u128", new TypeTagU128());
-    }).toThrow(/Invalid arg/);
+    }).toThrow(/Cannot convert/);
   });
 
   it("converts an AccountAddress TransactionArgument", async () => {
@@ -311,5 +318,25 @@ describe("BuilderUtils", () => {
       // @ts-ignore
       argToTransactionArgument(123456, "unknown_type");
     }).toThrow("Unknown type for TransactionArgument.");
+  });
+
+  it("ensures a boolean", async () => {
+    expect(ensureBoolean(false)).toBe(false);
+    expect(ensureBoolean(true)).toBe(true);
+    expect(ensureBoolean("true")).toBe(true);
+    expect(ensureBoolean("false")).toBe(false);
+    expect(() => ensureBoolean("True")).toThrow("Invalid boolean string.");
+  });
+
+  it("ensures a number", async () => {
+    expect(ensureNumber(10)).toBe(10);
+    expect(ensureNumber("123")).toBe(123);
+    expect(() => ensureNumber("True")).toThrow("Invalid number string.");
+  });
+
+  it("ensures a bigint", async () => {
+    expect(ensureBigInt(10)).toBe(10n);
+    expect(ensureBigInt("123")).toBe(123n);
+    expect(() => ensureBigInt("True")).toThrow(/^Cannot convert/);
   });
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts
@@ -212,25 +212,56 @@ export class TypeTagParser {
   }
 }
 
+export function ensureBoolean(val: boolean | string): boolean {
+  assertType(val, ["boolean", "string"]);
+  if (typeof val === "boolean") {
+    return val;
+  }
+
+  if (val === "true") {
+    return true;
+  }
+  if (val === "false") {
+    return false;
+  }
+
+  throw new Error("Invalid boolean string.");
+}
+
+export function ensureNumber(val: number | string): number {
+  assertType(val, ["number", "string"]);
+  if (typeof val === "number") {
+    return val;
+  }
+
+  const res = Number.parseInt(val, 10);
+  if (Number.isNaN(res)) {
+    throw new Error("Invalid number string.");
+  }
+
+  return res;
+}
+
+export function ensureBigInt(val: number | bigint | string): bigint {
+  assertType(val, ["number", "bigint", "string"]);
+  return BigInt(val);
+}
+
 export function serializeArg(argVal: any, argType: TypeTag, serializer: Serializer) {
   if (argType instanceof TypeTagBool) {
-    assertType(argVal, "boolean");
-    serializer.serializeBool(argVal);
+    serializer.serializeBool(ensureBoolean(argVal));
     return;
   }
   if (argType instanceof TypeTagU8) {
-    assertType(argVal, "number");
-    serializer.serializeU8(argVal);
+    serializer.serializeU8(ensureNumber(argVal));
     return;
   }
   if (argType instanceof TypeTagU64) {
-    assertType(argVal, ["number", "bigint"]);
-    serializer.serializeU64(argVal);
+    serializer.serializeU64(ensureBigInt(argVal));
     return;
   }
   if (argType instanceof TypeTagU128) {
-    assertType(argVal, ["number", "bigint"]);
-    serializer.serializeU128(argVal);
+    serializer.serializeU128(ensureBigInt(argVal));
     return;
   }
   if (argType instanceof TypeTagAddress) {
@@ -287,24 +318,20 @@ export function serializeArg(argVal: any, argType: TypeTag, serializer: Serializ
 
 export function argToTransactionArgument(argVal: any, argType: TypeTag): TransactionArgument {
   if (argType instanceof TypeTagBool) {
-    assertType(argVal, "boolean");
-    return new TransactionArgumentBool(argVal);
+    return new TransactionArgumentBool(ensureBoolean(argVal));
   }
   if (argType instanceof TypeTagU8) {
-    assertType(argVal, "number");
-    return new TransactionArgumentU8(argVal);
+    return new TransactionArgumentU8(ensureNumber(argVal));
   }
   if (argType instanceof TypeTagU64) {
-    assertType(argVal, ["number", "bigint"]);
-    return new TransactionArgumentU64(argVal);
+    return new TransactionArgumentU64(ensureBigInt(argVal));
   }
   if (argType instanceof TypeTagU128) {
-    assertType(argVal, ["number", "bigint"]);
-    return new TransactionArgumentU128(argVal);
+    return new TransactionArgumentU128(ensureBigInt(argVal));
   }
   if (argType instanceof TypeTagAddress) {
     let addr: AccountAddress;
-    if (typeof argVal === "string") {
+    if (typeof argVal === "string" || argVal instanceof HexString) {
       addr = AccountAddress.fromHex(argVal);
     } else if (argVal instanceof AccountAddress) {
       addr = argVal;


### PR DESCRIPTION
### Description
Currently, TS SDK requires users to pass in parameter values in the corresponding types defined in smart contracts. This PR allows users to pass in stringified parameter values.

### Test Plan
Jest test
