### PR TITLE
Fix token client functions, simple-nft in Python SDK

### DIFF
--- a/developer-docs-site/docs/tutorials/first-dapp.md
+++ b/developer-docs-site/docs/tutorials/first-dapp.md
@@ -11,9 +11,9 @@ For this tutorial, we will use the Move Module `HelloBlockchain` described in [Y
 
 We will use:
 
-- The [Aptos SDK](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/typescript/sdk).
-- The [Aptos Wallet](https://github.com/aptos-labs/aptos-core/tree/main/ecosystem/web-wallet), and
-- The [Aptos CLI](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos) to interact with blockchain.
+- The [Aptos Typescript SDK][ts_sdk],
+- The [Aptos Wallet][building_wallet], and
+- The [Aptos CLI][installing_cli] to interact with blockchain.
 
 The end result is a dapp that lets users publish and share snippets of text on the Aptos Blockchain.
 
@@ -38,7 +38,7 @@ Ensure that your account has sufficient funds to perform transactions by clickin
 
 ### Aptos CLI
 
-1. Install the [Aptos CLI](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos).
+1. Install the [Aptos CLI][install_cli].
 
 2. Run `aptos init`, and when it asks for your private key, paste the private key from the Aptos Wallet that you copied earlier. This will initialize the Aptos CLI to use the same account as used by the Aptos Wallet.
 
@@ -548,3 +548,7 @@ function App() {
 ```
 
 That concludes this tutorial.
+
+[building_wallet]: /guides/building-wallet-extension
+[installing_cli]: /cli-tools/aptos-cli-tool/install-aptos-cli
+[ts_sdk]: /sdks/typescript-sdk

--- a/developer-docs-site/docs/tutorials/your-first-nft.md
+++ b/developer-docs-site/docs/tutorials/your-first-nft.md
@@ -261,7 +261,7 @@ Coming soon!
 
 Now begins the process of creating tokens. First, the creator must create a collection to store tokens. A collection can contain zero, one, or many distinct tokens within it. The collection does not restrict the attributes of the tokens, as it is only a container.
 
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
 Your application will call `createCollection`:
@@ -296,7 +296,7 @@ Coming soon!
 
 To create a token, the creator must specify an associated collection. A token must be associated with a collection and that collection must have remaining tokens that can be minted. There are many attributes associated with a token, but the helper API only exposes the minimal amount required to create static content.
 
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
 Your application will call `createToken`:
@@ -331,7 +331,7 @@ Coming soon!
 
 Both the collection and token metadata are stored on the creator's account within their `Collections` in a table. The SDKs provide convenience wrappers around querying these specific tables:
 
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
 To read a collection's metadata:
@@ -378,7 +378,7 @@ Coming soon!
 
 Each token within Aptos is a distinct asset, the assets owned by the user are stored within their `TokenStore`. To get the balance:
 
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
 ```ts
@@ -403,7 +403,7 @@ Many users have received unwanted tokens that may cause minimally embarrassment 
 
 To offer a token:
 
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
 ```ts
@@ -424,7 +424,7 @@ Coming soon!
 
 To claim a token:
 
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
 ```ts
@@ -446,7 +446,7 @@ Coming soon!
 ### Step 4.9: Safe unilateral transferring of a token
 
 To support safe unilateral transfers of a token, the sender may first ask the recipient to acknowledge off-chain about a pending transfer. This comes in the form of a multiagent transaction request. Multiagent transactions contain multiple signatures, one for each on-chain account. Move then can leverage this to give `signer` level permissions to all that signed. For token transfers, this ensures that the receiving party does indeed desire to receive this token without requiring the use of the token transfer framework described above.
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
 ```ts
@@ -469,7 +469,7 @@ Coming soon!
 
 Coming soon!
 
-<Tabs>
+<Tabs groupId="sdk-examples">
   <TabItem value="python" label="Python">
 
 Coming soon!

--- a/ecosystem/python/sdk/Makefile
+++ b/ecosystem/python/sdk/Makefile
@@ -5,9 +5,9 @@ test:
 	- poetry run python -m unittest discover -s aptos_sdk/ -p '*.py' -t ..
 
 fmt:
-	- find aptos_sdk -type f -name "*.py" | xargs poetry run autoflake -i -r --remove-all-unused-imports --remove-unused-variables --ignore-init-module-imports
-	- find aptos_sdk -type f -name "*.py" | xargs poetry run isort
-	- find aptos_sdk -type f -name "*.py" | xargs poetry run black
+	- find . -type f -name "*.py" | xargs poetry run autoflake -i -r --remove-all-unused-imports --remove-unused-variables --ignore-init-module-imports
+	- find . -type f -name "*.py" | xargs poetry run isort
+	- find . -type f -name "*.py" | xargs poetry run black
 
 examples:
 	- poetry run python -m examples.transfer-coin

--- a/ecosystem/python/sdk/aptos_sdk/client.py
+++ b/ecosystem/python/sdk/aptos_sdk/client.py
@@ -46,7 +46,8 @@ class RestClient:
         """Returns the sequence number and authentication key for an account"""
 
         response = self.client.get(f"{self.base_url}/accounts/{account_address}")
-        assert response.status_code == 200, f"{response.text} - {account_address}"
+        if response.status_code >= 400:
+            raise ApiError(f"{response.text} - {account_address}", response.status_code)
         return response.json()
 
     def account_balance(self, account_address: str) -> int:
@@ -67,7 +68,8 @@ class RestClient:
         )
         if response.status_code == 404:
             return None
-        assert response.status_code == 200, response.text
+        if response.status_code >= 400:
+            raise ApiError(f"{response.text} - {account_address}", response.status_code)
         return response.json()
 
     def get_table_item(
@@ -81,7 +83,8 @@ class RestClient:
                 "key": key,
             },
         )
-        assert response.status_code == 200, response.text
+        if response.status_code >= 400:
+            raise ApiError(response.text, response.status_code)
         return response.json()
 
     #
@@ -90,7 +93,8 @@ class RestClient:
 
     def info(self) -> Dict[str, str]:
         response = self.client.get(self.base_url)
-        assert response.status_code == 200, f"{response.text}"
+        if response.status_code >= 400:
+            raise ApiError(response.text, response.status_code)
         return response.json()
 
     #
@@ -104,7 +108,8 @@ class RestClient:
             headers=headers,
             content=signed_transaction.bytes(),
         )
-        assert response.status_code == 202, f"{response.text} - {signed_transaction}"
+        if response.status_code >= 400:
+            raise ApiError(response.text, response.status_code)
         return response.json()["hash"]
 
     def submit_transaction(self, sender: Account, payload: Dict[str, Any]) -> str:
@@ -124,12 +129,13 @@ class RestClient:
             "payload": payload,
         }
 
-        res = self.client.post(
+        response = self.client.post(
             f"{self.base_url}/transactions/encode_submission", json=txn_request
         )
-        assert res.status_code == 200, res.text
+        if response.status_code >= 400:
+            raise ApiError(response.text, response.status_code)
 
-        to_sign = bytes.fromhex(res.json()[2:])
+        to_sign = bytes.fromhex(response.json()[2:])
         signature = sender.sign(to_sign)
         txn_request["signature"] = {
             "type": "ed25519_signature",
@@ -141,14 +147,16 @@ class RestClient:
         response = self.client.post(
             f"{self.base_url}/transactions", headers=headers, json=txn_request
         )
-        assert response.status_code == 202, f"{response.text} - {txn_request}"
+        if response.status_code >= 400:
+            raise ApiError(response.text, response.status_code)
         return response.json()["hash"]
 
     def transaction_pending(self, txn_hash: str) -> bool:
         response = self.client.get(f"{self.base_url}/transactions/by_hash/{txn_hash}")
         if response.status_code == 404:
             return True
-        assert response.status_code == 200, f"{response.text} - {txn_hash}"
+        if response.status_code >= 400:
+            raise ApiError(response.text, response.status_code)
         return response.json()["type"] == "pending_transaction"
 
     def wait_for_transaction(self, txn_hash: str) -> None:
@@ -265,18 +273,16 @@ class RestClient:
         signed_transaction = self.create_single_signer_bcs_transaction(
             sender, TransactionPayload(payload)
         )
-        return self.submit_bcs_transaction(signed_transaction)
-# <:!:bcs_transfer
+        return self.submit_bcs_transaction(signed_transaction)  # <:!:bcs_transfer
 
     #
     # Token transaction wrappers
     #
 
-#:!:>create_collection
+    #:!:>create_collection
     def create_collection(
         self, account: Account, name: str, description: str, uri: str
-    ) -> str:
-#<:!:create_collection
+    ) -> str:  # <:!:create_collection
         """Creates a new collection within the specified account"""
 
         transaction_arguments = [
@@ -301,7 +307,7 @@ class RestClient:
         )
         return self.submit_bcs_transaction(signed_transaction)
 
-#:!:>create_token
+    #:!:>create_token
     def create_token(
         self,
         account: Account,
@@ -311,8 +317,7 @@ class RestClient:
         supply: int,
         uri: str,
         royalty_points_per_million: int,
-    ) -> str:
-#<:!:create_token
+    ) -> str:  # <:!:create_token
         transaction_arguments = [
             TransactionArgument(collection_name, Serializer.str),
             TransactionArgument(name, Serializer.str),
@@ -437,7 +442,7 @@ class RestClient:
     # Token accessors
     #
 
-    def get_token_balance(
+    def get_token(
         self,
         owner: AccountAddress,
         creator: AccountAddress,
@@ -445,9 +450,9 @@ class RestClient:
         token_name: str,
         property_version: int,
     ) -> Any:
-        token_store = self.account_resource(owner, "0x3::token::TokenStore")["data"][
-            "tokens"
-        ]["handle"]
+        token_store_handle = self.account_resource(owner, "0x3::token::TokenStore")[
+            "data"
+        ]["tokens"]["handle"]
 
         token_id = {
             "token_data_id": {
@@ -458,14 +463,34 @@ class RestClient:
             "property_version": str(property_version),
         }
 
-        return self.get_table_item(
-            token_store,
-            "0x3::token::TokenId",
-            "0x3::token::Token",
-            token_id,
+        try:
+            return self.get_table_item(
+                token_store_handle,
+                "0x3::token::TokenId",
+                "0x3::token::Token",
+                token_id,
+            )
+        except ApiError as e:
+            if e.status_code == 404:
+                return {
+                    "id": token_id,
+                    "amount": "0",
+                }
+            raise
+
+    def get_token_balance(
+        self,
+        owner: AccountAddress,
+        creator: AccountAddress,
+        collection_name: str,
+        token_name: str,
+        property_version: int,
+    ) -> str:
+        return self.get_token(
+            owner, creator, collection_name, token_name, property_version
         )["amount"]
 
-        #:!:>read_token_data_table
+    #:!:>read_token_data_table
     def get_token_data(
         self,
         creator: AccountAddress,
@@ -473,9 +498,9 @@ class RestClient:
         token_name: str,
         property_version: int,
     ) -> Any:
-        token_data = self.account_resource(creator, "0x3::token::Collections")["data"][
-            "token_data"
-        ]["handle"]
+        token_data_handle = self.account_resource(creator, "0x3::token::Collections")[
+            "data"
+        ]["token_data"]["handle"]
 
         token_data_id = {
             "creator": creator.hex(),
@@ -484,12 +509,11 @@ class RestClient:
         }
 
         return self.get_table_item(
-            token_data,
+            token_data_handle,
             "0x3::token::TokenDataId",
             "0x3::token::TokenData",
             token_data_id,
-        )
-        #<:!:read_token_data_table
+        )  # <:!:read_token_data_table
 
     def get_collection(self, creator: AccountAddress, collection_name: str) -> Any:
         token_data = self.account_resource(creator, "0x3::token::Collections")["data"][
@@ -520,9 +544,19 @@ class FaucetClient:
     def fund_account(self, address: str, amount: int):
         """This creates an account if it does not exist and mints the specified amount of
         coins into that account."""
-        txns = self.rest_client.client.post(
+        response = self.rest_client.client.post(
             f"{self.base_url}/mint?amount={amount}&address={address}"
         )
-        assert txns.status_code == 200, txns.text
-        for txn_hash in txns.json():
+        if response.status_code >= 400:
+            raise ApiError(response.text, response.status_code)
+        for txn_hash in response.json():
             self.rest_client.wait_for_transaction(txn_hash)
+
+
+class ApiError(Exception):
+    """Error thrown when the API returns >= 400"""
+
+    def __init__(self, message, status_code):
+        # Call the base class constructor with the parameters it needs
+        super().__init__(message)
+        self.status_code = status_code

--- a/ecosystem/python/sdk/examples/common.py
+++ b/ecosystem/python/sdk/examples/common.py
@@ -5,5 +5,6 @@ import os
 
 #:!:>section_1
 NODE_URL = os.getenv("APTOS_NODE_URL", "https://fullnode.devnet.aptoslabs.com/v1")
-FAUCET_URL = os.getenv("APTOS_FAUCET_URL", "https://faucet.devnet.aptoslabs.com")
-#<:!:section_1
+FAUCET_URL = os.getenv(
+    "APTOS_FAUCET_URL", "https://faucet.devnet.aptoslabs.com"
+)  # <:!:section_1

--- a/ecosystem/python/sdk/examples/simple-nft.py
+++ b/ecosystem/python/sdk/examples/simple-nft.py
@@ -9,28 +9,25 @@ from aptos_sdk.client import FaucetClient, RestClient
 from .common import FAUCET_URL, NODE_URL
 
 if __name__ == "__main__":
-#:!:>section_1
+    #:!:>section_1
     rest_client = RestClient(NODE_URL)
-    faucet_client = FaucetClient(FAUCET_URL, rest_client)
-#<:!:section_1
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)  # <:!:section_1
 
-#:!:>section_2
+    #:!:>section_2
     alice = Account.generate()
-    bob = Account.generate()
-#<:!:section_2
-
+    bob = Account.generate()  # <:!:section_2
 
     collection_name = "Alice's"
     token_name = "Alice's first token"
+    property_version = 0
 
     print("\n=== Addresses ===")
     print(f"Alice: {alice.address()}")
     print(f"Bob: {bob.address()}")
 
-#:!:>section_3
+    #:!:>section_3
     faucet_client.fund_account(alice.address(), 20_000)
-    faucet_client.fund_account(bob.address(), 20_000)
-#<:!:section_3
+    faucet_client.fund_account(bob.address(), 20_000)  # <:!:section_3
 
     print("\n=== Initial Coin Balances ===")
     print(f"Alice: {rest_client.account_balance(alice.address())}")
@@ -38,14 +35,13 @@ if __name__ == "__main__":
 
     print("\n=== Creating Collection and Token ===")
 
-#:!:>section_4
+    #:!:>section_4
     txn_hash = rest_client.create_collection(
         alice, collection_name, "Alice's simple collection", "https://aptos.dev"
-    )
-#<:!:section_4
+    )  # <:!:section_4
     rest_client.wait_for_transaction(txn_hash)
 
-#:!:>section_5
+    #:!:>section_5
     txn_hash = rest_client.create_token(
         alice,
         collection_name,
@@ -54,65 +50,74 @@ if __name__ == "__main__":
         1,
         "https://aptos.dev/img/nyan.jpeg",
         0,
-    )
-#<:!:section_5
+    )  # <:!:section_5
     rest_client.wait_for_transaction(txn_hash)
 
-#:!:>section_6
+    #:!:>section_6
     collection_data = rest_client.get_collection(alice.address(), collection_name)
-    print(f"Alice's collection: {json.dumps(collection_data, indent=4, sort_keys=True)}")
-#<:!:section_6
-#:!:>section_7
-    balance = rest_client.get_token_balance(alice.address(), alice.address(), collection_name, token_name, 0)
-    print(f"Alice's token balance: {balance}")
-#<:!:section_7
-#:!:>section_8
-    token_data = rest_client.get_token_data(alice.address(), collection_name, token_name, 0)
-    print(f"Alice's token data: {json.dumps(token_data, indent=4, sort_keys=True)}")
-#<:!:section_8
+    print(
+        f"Alice's collection: {json.dumps(collection_data, indent=4, sort_keys=True)}"
+    )  # <:!:section_6
+    #:!:>section_7
+    balance = rest_client.get_token_balance(
+        alice.address(), alice.address(), collection_name, token_name, property_version
+    )
+    print(f"Alice's token balance: {balance}")  # <:!:section_7
+    #:!:>section_8
+    token_data = rest_client.get_token_data(
+        alice.address(), collection_name, token_name, property_version
+    )
+    print(
+        f"Alice's token data: {json.dumps(token_data, indent=4, sort_keys=True)}"
+    )  # <:!:section_8
 
     print("\n=== Transferring the token to Bob ===")
-#:!:>section_9
+    #:!:>section_9
     txn_hash = rest_client.offer_token(
         alice,
         bob.address(),
         alice.address(),
         collection_name,
         token_name,
-        0,
+        property_version,
         1,
-    )
-#<:!:section_9
+    )  # <:!:section_9
     rest_client.wait_for_transaction(txn_hash)
 
-#:!:>section_10
+    #:!:>section_10
     txn_hash = rest_client.claim_token(
         bob,
         alice.address(),
         alice.address(),
         collection_name,
         token_name,
-        0,
-    )
-#<:!:section_10
+        property_version,
+    )  # <:!:section_10
     rest_client.wait_for_transaction(txn_hash)
 
-    balance = rest_client.get_token_balance(alice.address(), alice.address(), collection_name, token_name, 0)
+    balance = rest_client.get_token_balance(
+        alice.address(), alice.address(), collection_name, token_name, property_version
+    )
     print(f"Alice's token balance: {balance}")
-    balance = rest_client.get_token_balance(bob.address(), alice.address(), collection_name, token_name, 0)
+    balance = rest_client.get_token_balance(
+        bob.address(), alice.address(), collection_name, token_name, property_version
+    )
     print(f"Bob's token balance: {balance}")
 
     print("\n=== Transferring the token back to Alice using MultiAgent ===")
-#:!:>section_11
+    #:!:>section_11
     txn_hash = rest_client.direct_transfer_token(
         bob, alice, alice.address(), collection_name, token_name, 0, 1
-    )
-#<:!:section_11
+    )  # <:!:section_11
     rest_client.wait_for_transaction(txn_hash)
 
-    balance = rest_client.get_token_balance(alice.address(), alice.address(), collection_name, token_name, 0)
+    balance = rest_client.get_token_balance(
+        alice.address(), alice.address(), collection_name, token_name, property_version
+    )
     print(f"Alice's token balance: {balance}")
-    balance = rest_client.get_token_balance(bob.address(), alice.address(), collection_name, token_name, 0)
+    balance = rest_client.get_token_balance(
+        bob.address(), alice.address(), collection_name, token_name, property_version
+    )
     print(f"Bob's token balance: {balance}")
 
     rest_client.close()

--- a/ecosystem/python/sdk/examples/transfer-coin.py
+++ b/ecosystem/python/sdk/examples/transfer-coin.py
@@ -7,38 +7,32 @@ from aptos_sdk.client import FaucetClient, RestClient
 from .common import FAUCET_URL, NODE_URL
 
 if __name__ == "__main__":
-#:!:>section_1
+    #:!:>section_1
     rest_client = RestClient(NODE_URL)
-    faucet_client = FaucetClient(FAUCET_URL, rest_client)
-#<:!:section_1
+    faucet_client = FaucetClient(FAUCET_URL, rest_client)  # <:!:section_1
 
-#:!:>section_2
+    #:!:>section_2
     alice = Account.generate()
-    bob = Account.generate()
-#<:!:section_2
+    bob = Account.generate()  # <:!:section_2
 
     print("\n=== Addresses ===")
     print(f"Alice: {alice.address()}")
     print(f"Bob: {bob.address()}")
 
-#:!:>section_3
+    #:!:>section_3
     faucet_client.fund_account(alice.address(), 20_000)
-    faucet_client.fund_account(bob.address(), 0)
-#<:!:section_3
+    faucet_client.fund_account(bob.address(), 0)  # <:!:section_3
 
     print("\n=== Initial Balances ===")
-#:!:>section_4
+    #:!:>section_4
     print(f"Alice: {rest_client.account_balance(alice.address())}")
-    print(f"Bob: {rest_client.account_balance(bob.address())}")
-#<:!:section_4
+    print(f"Bob: {rest_client.account_balance(bob.address())}")  # <:!:section_4
 
     # Have Alice give Bob 1_000 coins
-#:!:>section_5
-    txn_hash = rest_client.transfer(alice, bob.address(), 1_000)
-#<:!:section_5
-#:!:>section_6
-    rest_client.wait_for_transaction(txn_hash)
-#<:!:section_6
+    #:!:>section_5
+    txn_hash = rest_client.transfer(alice, bob.address(), 1_000)  # <:!:section_5
+    #:!:>section_6
+    rest_client.wait_for_transaction(txn_hash)  # <:!:section_6
 
     print("\n=== Intermediate Balances ===")
     print(f"Alice: {rest_client.account_balance(alice.address())}")

--- a/ecosystem/python/sdk/poetry.lock
+++ b/ecosystem/python/sdk/poetry.lock
@@ -18,14 +18,15 @@ trio = ["trio (>=0.16)"]
 
 [[package]]
 name = "autoflake"
-version = "1.4"
+version = "1.5.2"
 description = "Removes unused imports and unused variables"
 category = "dev"
 optional = false
-python-versions = "*"
+python-versions = ">=3.7"
 
 [package.dependencies]
 pyflakes = ">=1.1.0"
+toml = ">=0.10.2"
 
 [[package]]
 name = "black"
@@ -184,11 +185,11 @@ python-versions = "*"
 
 [[package]]
 name = "pathspec"
-version = "0.9.0"
+version = "0.10.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "dev"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.7"
 
 [[package]]
 name = "platformdirs"
@@ -256,6 +257,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -302,7 +311,8 @@ anyio = [
     {file = "anyio-3.6.1.tar.gz", hash = "sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b"},
 ]
 autoflake = [
-    {file = "autoflake-1.4.tar.gz", hash = "sha256:61a353012cff6ab94ca062823d1fb2f692c4acda51c76ff83a8d77915fba51ea"},
+    {file = "autoflake-1.5.2-py2.py3-none-any.whl", hash = "sha256:3a57716fdaa6c21273b901e62a8d1682b266a2ad43f7a64e5f16663c9cdfd73c"},
+    {file = "autoflake-1.5.2.tar.gz", hash = "sha256:79c27c11efba4c7f35ca9747cdc2da0f5862fb0e0813c168fd781c0c572b9b01"},
 ]
 black = [
     {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
@@ -436,8 +446,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 pathspec = [
-    {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
-    {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
+    {file = "pathspec-0.10.0-py3-none-any.whl", hash = "sha256:aefa80ac32d5bf1f96139dca67cefb69a431beff4e6bf1168468f37d7ab87015"},
+    {file = "pathspec-0.10.0.tar.gz", hash = "sha256:01eecd304ba0e6eeed188ae5fa568e99ef10265af7fd9ab737d6412b4ee0ab85"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -470,6 +480,10 @@ rfc3986 = [
 sniffio = [
     {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
     {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},


### PR DESCRIPTION
### Description
- Make the token functions in the Python SDK work the same as the TS SDK, namely return something on 404 instead of throwing.
- Change the Python SDK to raise an exception instead of assert when response >= 400.
- Format the examples as well.
- Fix tab stuff in the first NFT example.

I have made sure the docs still look good since the section tags moved around.

### Test Plan
```
cd ecosystem/python/sdk
curl -sSL https://install.python-poetry.org/ | python3
poetry update
poetry run python -m examples.simple-nft
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3710)
<!-- Reviewable:end -->
