### PR TITLE
[API] Adds api types to testsuite serde yaml generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4119,6 +4119,7 @@ dependencies = [
 name = "generate-format"
 version = "0.1.0"
 dependencies = [
+ "aptos-api-types",
  "aptos-config",
  "aptos-crypto",
  "aptos-crypto-derive",

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -17,6 +17,7 @@ serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev
 serde_yaml = "0.8.24"
 structopt = "0.3.21"
 
+aptos-api-types = { path = "../../api/types", package = "aptos-api-types" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto", features = ["fuzzing"] }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }

--- a/testsuite/generate-format/src/api.rs
+++ b/testsuite/generate-format/src/api.rs
@@ -1,0 +1,95 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
+    hash::{CryptoHasher as _, TestOnlyHasher},
+    multi_ed25519::{MultiEd25519PublicKey, MultiEd25519Signature},
+    traits::{SigningKey, Uniform},
+};
+use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
+use aptos_types::{
+    access_path::{AccessPath, Path},
+    account_config::{CoinStoreResource, DepositEvent, WithdrawEvent},
+    contract_event, event,
+    state_store::state_key::StateKey,
+    transaction,
+    transaction::authenticator::{AccountAuthenticator, TransactionAuthenticator},
+    vm_status::AbortLocation,
+    write_set,
+};
+use move_deps::move_core_types::language_storage;
+use rand::{rngs::StdRng, SeedableRng};
+use serde::{Deserialize, Serialize};
+use serde_reflection::{Registry, Result, Samples, Tracer, TracerConfig};
+
+/// Default output file.
+pub fn output_file() -> Option<&'static str> {
+    Some("tests/staged/api.yaml")
+}
+
+/// This aims at signing canonically serializable BCS data
+#[derive(CryptoHasher, BCSCryptoHash, Serialize, Deserialize)]
+struct TestAptosCrypto(String);
+
+/// Record sample values for crypto types used by transactions.
+fn trace_crypto_values(tracer: &mut Tracer, samples: &mut Samples) -> Result<()> {
+    let mut hasher = TestOnlyHasher::default();
+    hasher.update(b"Test message");
+    let hashed_message = hasher.finish();
+
+    let message = TestAptosCrypto("Hello, World".to_string());
+
+    let mut rng: StdRng = SeedableRng::from_seed([0; 32]);
+    let private_key = Ed25519PrivateKey::generate(&mut rng);
+    let public_key: Ed25519PublicKey = (&private_key).into();
+    let signature = private_key.sign(&message);
+
+    tracer.trace_value(samples, &hashed_message)?;
+    tracer.trace_value(samples, &public_key)?;
+    tracer.trace_value::<MultiEd25519PublicKey>(samples, &public_key.into())?;
+    tracer.trace_value(samples, &signature)?;
+    tracer.trace_value::<MultiEd25519Signature>(samples, &signature.into())?;
+    Ok(())
+}
+
+pub fn get_registry() -> Result<Registry> {
+    let mut tracer =
+        Tracer::new(TracerConfig::default().is_human_readable(bcs::is_human_readable()));
+    let mut samples = Samples::new();
+    // 1. Record samples for types with custom deserializers.
+    trace_crypto_values(&mut tracer, &mut samples)?;
+    tracer.trace_value(&mut samples, &event::EventKey::random())?;
+
+    // 2. Trace the main entry point(s) + every enum separately.
+    // stdlib types
+    tracer.trace_type::<contract_event::ContractEvent>(&samples)?;
+    tracer.trace_type::<language_storage::TypeTag>(&samples)?;
+    tracer.trace_type::<transaction::Transaction>(&samples)?;
+    tracer.trace_type::<transaction::TransactionArgument>(&samples)?;
+    tracer.trace_type::<transaction::TransactionPayload>(&samples)?;
+    tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
+    tracer.trace_type::<StateKey>(&samples)?;
+    tracer.trace_type::<transaction::ExecutionStatus>(&samples)?;
+    tracer.trace_type::<TransactionAuthenticator>(&samples)?;
+    tracer.trace_type::<write_set::WriteOp>(&samples)?;
+    tracer.trace_type::<AccountAuthenticator>(&samples)?;
+    tracer.trace_type::<AbortLocation>(&samples)?;
+
+    // events
+    tracer.trace_type::<WithdrawEvent>(&samples)?;
+    tracer.trace_type::<DepositEvent>(&samples)?;
+
+    // writeset
+    tracer.trace_type::<AccessPath>(&samples)?;
+    tracer.trace_type::<Path>(&samples)?;
+
+    // api types
+    tracer.trace_type::<aptos_api_types::TransactionData>(&samples)?;
+    tracer.trace_type::<aptos_api_types::TransactionOnChainData>(&samples)?;
+
+    // output types
+    tracer.trace_type::<CoinStoreResource>(&samples)?;
+
+    tracer.registry()
+}

--- a/testsuite/generate-format/src/lib.rs
+++ b/testsuite/generate-format/src/lib.rs
@@ -8,6 +8,8 @@ use serde_reflection::Registry;
 use std::str::FromStr;
 use structopt::{clap::arg_enum, StructOpt};
 
+/// Rest API types
+mod api;
 /// Aptos transactions.
 mod aptos;
 /// Consensus messages.
@@ -25,6 +27,7 @@ arg_enum! {
 #[derive(Debug, StructOpt, Clone, Copy)]
 /// A corpus of Rust types to trace, and optionally record on disk.
 pub enum Corpus {
+    API,
     Aptos,
     Consensus,
     Network,
@@ -44,6 +47,7 @@ impl Corpus {
     /// Compute the registry of formats.
     pub fn get_registry(self) -> Registry {
         let result = match self {
+            Corpus::API => api::get_registry(),
             Corpus::Aptos => aptos::get_registry(),
             Corpus::Consensus => consensus::get_registry(),
             Corpus::Network => network::get_registry(),
@@ -60,6 +64,7 @@ impl Corpus {
     /// Where to record this corpus on disk.
     pub fn output_file(self) -> Option<&'static str> {
         match self {
+            Corpus::API => api::output_file(),
             Corpus::Aptos => aptos::output_file(),
             Corpus::Consensus => consensus::output_file(),
             Corpus::Network => network::output_file(),

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -1,0 +1,420 @@
+---
+AbortInfo:
+  STRUCT:
+    - reason_name: STR
+    - description: STR
+AbortLocation:
+  ENUM:
+    0:
+      Module:
+        NEWTYPE:
+          TYPENAME: ModuleId
+    1:
+      Script: UNIT
+AccessPath:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - path: BYTES
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 32
+AccountAuthenticator:
+  ENUM:
+    0:
+      Ed25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: Ed25519PublicKey
+          - signature:
+              TYPENAME: Ed25519Signature
+    1:
+      MultiEd25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: MultiEd25519PublicKey
+          - signature:
+              TYPENAME: MultiEd25519Signature
+BlockMetadata:
+  STRUCT:
+    - id:
+        TYPENAME: HashValue
+    - epoch: U64
+    - round: U64
+    - proposer:
+        TYPENAME: AccountAddress
+    - previous_block_votes_bitvec: BYTES
+    - failed_proposer_indices:
+        SEQ: U32
+    - timestamp_usecs: U64
+ChainId:
+  NEWTYPESTRUCT: U8
+ChangeSet:
+  STRUCT:
+    - write_set:
+        TYPENAME: WriteSet
+    - events:
+        SEQ:
+          TYPENAME: ContractEvent
+CoinStoreResource:
+  STRUCT:
+    - coin: U64
+    - frozen: BOOL
+    - deposit_events:
+        TYPENAME: EventHandle
+    - withdraw_events:
+        TYPENAME: EventHandle
+ContractEvent:
+  ENUM:
+    0:
+      V0:
+        NEWTYPE:
+          TYPENAME: ContractEventV0
+ContractEventV0:
+  STRUCT:
+    - key:
+        TYPENAME: EventKey
+    - sequence_number: U64
+    - type_tag:
+        TYPENAME: TypeTag
+    - event_data: BYTES
+DepositEvent:
+  STRUCT:
+    - amount: U64
+Ed25519PublicKey:
+  NEWTYPESTRUCT: BYTES
+Ed25519Signature:
+  NEWTYPESTRUCT: BYTES
+EntryFunction:
+  STRUCT:
+    - module:
+        TYPENAME: ModuleId
+    - function:
+        TYPENAME: Identifier
+    - ty_args:
+        SEQ:
+          TYPENAME: TypeTag
+    - args:
+        SEQ: BYTES
+EventHandle:
+  STRUCT:
+    - count: U64
+    - key:
+        TYPENAME: EventKey
+EventKey:
+  STRUCT:
+    - creation_number: U64
+    - account_address:
+        TYPENAME: AccountAddress
+ExecutionStatus:
+  ENUM:
+    0:
+      Success: UNIT
+    1:
+      OutOfGas: UNIT
+    2:
+      MoveAbort:
+        STRUCT:
+          - location:
+              TYPENAME: AbortLocation
+          - code: U64
+          - info:
+              OPTION:
+                TYPENAME: AbortInfo
+    3:
+      ExecutionFailure:
+        STRUCT:
+          - location:
+              TYPENAME: AbortLocation
+          - function: U16
+          - code_offset: U16
+    4:
+      MiscellaneousError:
+        NEWTYPE:
+          OPTION: U64
+HashValue:
+  STRUCT:
+    - hash:
+        TUPLEARRAY:
+          CONTENT: U8
+          SIZE: 32
+Identifier:
+  NEWTYPESTRUCT: STR
+Module:
+  STRUCT:
+    - code: BYTES
+ModuleBundle:
+  STRUCT:
+    - codes:
+        SEQ:
+          TYPENAME: Module
+ModuleId:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - name:
+        TYPENAME: Identifier
+MultiEd25519PublicKey:
+  NEWTYPESTRUCT: BYTES
+MultiEd25519Signature:
+  NEWTYPESTRUCT: BYTES
+Path:
+  ENUM:
+    0:
+      Code:
+        NEWTYPE:
+          TYPENAME: ModuleId
+    1:
+      Resource:
+        NEWTYPE:
+          TYPENAME: StructTag
+RawTransaction:
+  STRUCT:
+    - sender:
+        TYPENAME: AccountAddress
+    - sequence_number: U64
+    - payload:
+        TYPENAME: TransactionPayload
+    - max_gas_amount: U64
+    - gas_unit_price: U64
+    - expiration_timestamp_secs: U64
+    - chain_id:
+        TYPENAME: ChainId
+Script:
+  STRUCT:
+    - code: BYTES
+    - ty_args:
+        SEQ:
+          TYPENAME: TypeTag
+    - args:
+        SEQ:
+          TYPENAME: TransactionArgument
+SignedTransaction:
+  STRUCT:
+    - raw_txn:
+        TYPENAME: RawTransaction
+    - authenticator:
+        TYPENAME: TransactionAuthenticator
+StateKey:
+  ENUM:
+    0:
+      AccessPath:
+        NEWTYPE:
+          TYPENAME: AccessPath
+    1:
+      TableItem:
+        STRUCT:
+          - handle:
+              TYPENAME: TableHandle
+          - key: BYTES
+    2:
+      Raw:
+        NEWTYPE: BYTES
+StructTag:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - module:
+        TYPENAME: Identifier
+    - name:
+        TYPENAME: Identifier
+    - type_args:
+        SEQ:
+          TYPENAME: TypeTag
+TableHandle:
+  NEWTYPESTRUCT:
+    TYPENAME: AccountAddress
+Transaction:
+  ENUM:
+    0:
+      UserTransaction:
+        NEWTYPE:
+          TYPENAME: SignedTransaction
+    1:
+      GenesisTransaction:
+        NEWTYPE:
+          TYPENAME: WriteSetPayload
+    2:
+      BlockMetadata:
+        NEWTYPE:
+          TYPENAME: BlockMetadata
+    3:
+      StateCheckpoint:
+        NEWTYPE:
+          TYPENAME: HashValue
+TransactionArgument:
+  ENUM:
+    0:
+      U8:
+        NEWTYPE: U8
+    1:
+      U64:
+        NEWTYPE: U64
+    2:
+      U128:
+        NEWTYPE: U128
+    3:
+      Address:
+        NEWTYPE:
+          TYPENAME: AccountAddress
+    4:
+      U8Vector:
+        NEWTYPE: BYTES
+    5:
+      Bool:
+        NEWTYPE: BOOL
+TransactionAuthenticator:
+  ENUM:
+    0:
+      Ed25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: Ed25519PublicKey
+          - signature:
+              TYPENAME: Ed25519Signature
+    1:
+      MultiEd25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: MultiEd25519PublicKey
+          - signature:
+              TYPENAME: MultiEd25519Signature
+    2:
+      MultiAgent:
+        STRUCT:
+          - sender:
+              TYPENAME: AccountAuthenticator
+          - secondary_signer_addresses:
+              SEQ:
+                TYPENAME: AccountAddress
+          - secondary_signers:
+              SEQ:
+                TYPENAME: AccountAuthenticator
+TransactionData:
+  ENUM:
+    0:
+      OnChain:
+        NEWTYPE:
+          TYPENAME: TransactionOnChainData
+    1:
+      Pending:
+        NEWTYPE:
+          TYPENAME: SignedTransaction
+TransactionInfo:
+  ENUM:
+    0:
+      V0:
+        NEWTYPE:
+          TYPENAME: TransactionInfoV0
+TransactionInfoV0:
+  STRUCT:
+    - gas_used: U64
+    - status:
+        TYPENAME: ExecutionStatus
+    - transaction_hash:
+        TYPENAME: HashValue
+    - event_root_hash:
+        TYPENAME: HashValue
+    - state_change_hash:
+        TYPENAME: HashValue
+    - state_checkpoint_hash:
+        OPTION:
+          TYPENAME: HashValue
+    - state_cemetery_hash:
+        OPTION:
+          TYPENAME: HashValue
+TransactionOnChainData:
+  STRUCT:
+    - version: U64
+    - transaction:
+        TYPENAME: Transaction
+    - info:
+        TYPENAME: TransactionInfo
+    - events:
+        SEQ:
+          TYPENAME: ContractEvent
+    - accumulator_root_hash:
+        TYPENAME: HashValue
+    - changes:
+        TYPENAME: WriteSet
+TransactionPayload:
+  ENUM:
+    0:
+      Script:
+        NEWTYPE:
+          TYPENAME: Script
+    1:
+      ModuleBundle:
+        NEWTYPE:
+          TYPENAME: ModuleBundle
+    2:
+      EntryFunction:
+        NEWTYPE:
+          TYPENAME: EntryFunction
+TypeTag:
+  ENUM:
+    0:
+      bool: UNIT
+    1:
+      u8: UNIT
+    2:
+      u64: UNIT
+    3:
+      u128: UNIT
+    4:
+      address: UNIT
+    5:
+      signer: UNIT
+    6:
+      vector:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    7:
+      struct:
+        NEWTYPE:
+          TYPENAME: StructTag
+WithdrawEvent:
+  STRUCT:
+    - amount: U64
+WriteOp:
+  ENUM:
+    0:
+      Creation:
+        NEWTYPE: BYTES
+    1:
+      Modification:
+        NEWTYPE: BYTES
+    2:
+      Deletion: UNIT
+WriteSet:
+  ENUM:
+    0:
+      V0:
+        NEWTYPE:
+          TYPENAME: WriteSetV0
+WriteSetMut:
+  STRUCT:
+    - write_set:
+        MAP:
+          KEY:
+            TYPENAME: StateKey
+          VALUE:
+            TYPENAME: WriteOp
+WriteSetPayload:
+  ENUM:
+    0:
+      Direct:
+        NEWTYPE:
+          TYPENAME: ChangeSet
+    1:
+      Script:
+        STRUCT:
+          - execute_as:
+              TYPENAME: AccountAddress
+          - script:
+              TYPENAME: Script
+WriteSetV0:
+  NEWTYPESTRUCT:
+    TYPENAME: WriteSetMut


### PR DESCRIPTION
### Description

The API requires slightly different types for generating a valid bcs payload.
To solve this poorly, added all the API types to a new file the be generated by serde-reflection.

### Considerations

* Not all api types will be able to use the serde-reflection library
* The serde-reflection library does not accept two types of the same name.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Use these types in the go sdk generator, hit `/v1/transactions` `Accept`: `application/x-bcs` and parse the transaction

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3713)
<!-- Reviewable:end -->
