### PR TITLE
[clippy] Remove clippy warning about deprecated name

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,7 +7,7 @@ xclippy = [
   "-Dwarnings",
   "-Wclippy::all",
   "-Aclippy::unit_arg",
-  "-Aclippy::eval-order-dependence",
+  "-Aclippy::mixed_read_write_in_expression",
   "-Aclippy::new-without-default",
   "-Aclippy::rc_buffer",
   "-Aclippy::upper_case_acronyms",


### PR DESCRIPTION
### Description
Fixing this bug
```
warning: lint `clippy::eval_order_dependence` has been renamed to `clippy::mixed_read_write_in_expression`
  |
  = note: requested on the command line with `-A clippy::eval_order_dependence`
```
### Test Plan
`cargo xclippy`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3714)
<!-- Reviewable:end -->
