### PR TITLE
[Indexer] Export prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,6 +1230,8 @@ dependencies = [
  "field_count",
  "futures",
  "http",
+ "hyper",
+ "inspection-service",
  "once_cell",
  "pbjson",
  "prost 0.10.4",

--- a/crates/inspection-service/src/inspection_service.rs
+++ b/crates/inspection-service/src/inspection_service.rs
@@ -24,7 +24,7 @@ use tokio::runtime;
 const DISABLED_ENDPOINT_MESSAGE: &str =
     "This endpoint is disabled! Enable it in the InspectionServiceConfig.";
 
-fn encode_metrics(encoder: impl Encoder) -> Vec<u8> {
+pub fn encode_metrics(encoder: impl Encoder) -> Vec<u8> {
     let metric_families = gather_metrics();
     let mut buffer = vec![];
     encoder.encode(&metric_families, &mut buffer).unwrap();

--- a/ecosystem/sf-indexer/aptos-sf-indexer/Cargo.toml
+++ b/ecosystem/sf-indexer/aptos-sf-indexer/Cargo.toml
@@ -18,6 +18,7 @@ aptos-metrics-core = { path = "../../../crates/aptos-metrics-core" }
 aptos-protos = { path = "../../../crates/aptos-protos" }
 aptos-rest-client = { path = "../../../crates/aptos-rest-client" }
 aptos-types = { path = "../../../types" }
+inspection-service = { path = "../../../crates/inspection-service" }
 async-stream = "0.3"
 async-trait = "0.1.53"
 bigdecimal = { version = "0.1.2", features = ["serde"] }
@@ -29,6 +30,7 @@ diesel_migrations = { version = "1.4.0", features = ["postgres"] }
 field_count = "0.1.1"
 futures = "0.3.21"
 http = "0.2.3"
+hyper = { version = "0.14.18", features = ["full"] }
 once_cell = "1.10.0"
 pbjson = "0.4.0"
 prost = "0.10.4"

--- a/ecosystem/sf-indexer/aptos-sf-indexer/src/counters.rs
+++ b/ecosystem/sf-indexer/aptos-sf-indexer/src/counters.rs
@@ -3,9 +3,21 @@
 
 use aptos_metrics_core::{
     register_int_counter, register_int_counter_vec, register_int_gauge_vec, IntCounter,
-    IntCounterVec, IntGaugeVec,
+    IntCounterVec, IntGaugeVec, TextEncoder,
 };
+use http::StatusCode;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Method, Request, Response, Server,
+};
+use inspection_service::inspection_service::encode_metrics;
 use once_cell::sync::Lazy;
+use std::{
+    convert::Infallible,
+    net::{SocketAddr, ToSocketAddrs},
+    thread,
+};
+use tokio::runtime;
 
 /// Number of times a given processor has been invoked
 pub static PROCESSOR_INVOCATIONS: Lazy<IntCounterVec> = Lazy::new(|| {
@@ -64,3 +76,93 @@ pub static LATEST_PROCESSED_BLOCK: Lazy<IntGaugeVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+/// Max version processed
+pub static LATEST_PROCESSED_VERSION: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "indexer_processor_latest_version",
+        "Latest version a processor has fully consumed",
+        &["processor_name"]
+    )
+    .unwrap()
+});
+
+pub fn start_inspection_service(service_address: &str, service_port: u16) {
+    // Only called from places that guarantee that host is parsable, but this must be assumed.
+    let addr: SocketAddr = (service_address, service_port)
+        .to_socket_addrs()
+        .unwrap_or_else(|_| {
+            unreachable!(
+                "Failed to parse {}:{} as address",
+                service_address, service_port
+            )
+        })
+        .next()
+        .unwrap();
+
+    // Spawn the server
+    thread::spawn(move || {
+        let make_service =
+            make_service_fn(
+                move |_conn| async move { Ok::<_, Infallible>(service_fn(serve_requests)) },
+            );
+
+        let runtime = runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+        runtime
+            .block_on(async {
+                let server = Server::bind(&addr).serve(make_service);
+                server.await
+            })
+            .unwrap();
+    });
+}
+
+async fn serve_requests(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    let mut resp = Response::new(Body::empty());
+    match (req.method(), req.uri().path()) {
+        // Exposes text encoded metrics
+        (&Method::GET, "/metrics") => {
+            let encoder = TextEncoder::new();
+            let buffer = encode_metrics(encoder);
+            *resp.body_mut() = Body::from(buffer);
+        }
+        _ => {
+            *resp.status_mut() = StatusCode::NOT_FOUND;
+        }
+    };
+    Ok(resp)
+}
+
+// pub fn encode_metrics(encoder: impl Encoder) -> Vec<u8> {
+//     let metric_families = gather_metrics();
+//     let mut buffer = vec![];
+//     encoder.encode(&metric_families, &mut buffer).unwrap();
+//     buffer
+// }
+
+// pub fn gather_metrics() -> Vec<prometheus::proto::MetricFamily> {
+//     let metric_families = aptos_metrics_core::gather();
+//     let mut total: u64 = 0;
+//     let mut families_over_1000: u64 = 0;
+
+//     // Take metrics of metric gathering so we know possible overhead of this process
+//     for metric_family in &metric_families {
+//         let family_count = metric_family.get_metric().len();
+//         if family_count > 1000 {
+//             families_over_1000 = families_over_1000.saturating_add(1);
+//             let name = metric_family.get_name();
+//             aptos_logger::warn!(
+//                 count = family_count,
+//                 metric_family = name,
+//                 "Metric Family '{}' over 1000 dimensions '{}'",
+//                 name,
+//                 family_count
+//             );
+//         }
+//         total = total.saturating_add(family_count as u64);
+//     }
+//     metric_families
+// }

--- a/ecosystem/sf-indexer/aptos-sf-indexer/src/main.rs
+++ b/ecosystem/sf-indexer/aptos-sf-indexer/src/main.rs
@@ -11,8 +11,9 @@ use aptos_sf_indexer::indexer::substream_processor::{
 use aptos_sf_indexer::proto;
 
 use anyhow::{format_err, Context, Error};
-use aptos_sf_indexer::database::new_db_pool;
 use aptos_sf_indexer::{
+    counters::start_inspection_service,
+    database::new_db_pool,
     substream_processors::block_output_processor::BlockOutputSubstreamProcessor,
     substreams::SubstreamsEndpoint,
     substreams_stream::{BlockResponse, SubstreamsStream},
@@ -58,6 +59,11 @@ async fn main() -> Result<(), Error> {
     let substream_module_name = &args.module_name;
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let inspection_url = env::var("INSPECTION_URL").unwrap_or_else(|_| "localhost".to_string());
+    let inspection_port = env::var("INSPECTION_PORT")
+        .map(|v| v.parse::<u16>().unwrap_or(9105))
+        .unwrap_or(9105);
+    start_inspection_service(inspection_url.as_str(), inspection_port);
     let conn_pool = new_db_pool(&database_url).unwrap();
     info!("Created the connection pool");
 

--- a/ecosystem/sf-indexer/aptos-sf-indexer/src/schema.rs
+++ b/ecosystem/sf-indexer/aptos-sf-indexer/src/schema.rs
@@ -1,6 +1,3 @@
-// Copyright (c) Aptos
-// SPDX-License-Identifier: Apache-2.0
-
 table! {
     block_metadata_transactions (version) {
         version -> Int8,

--- a/ecosystem/sf-indexer/aptos-sf-indexer/src/substream_processors/block_output_processor.rs
+++ b/ecosystem/sf-indexer/aptos-sf-indexer/src/substream_processors/block_output_processor.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    counters::LATEST_PROCESSED_VERSION,
     database::{execute_with_better_error, get_chunks, PgDbPool, PgPoolConnection},
     indexer::{
         errors::BlockProcessingError, processing_result::ProcessingResult,
@@ -441,8 +442,9 @@ impl SubstreamProcessor for BlockOutputSubstreamProcessor {
 
         let (txns, txn_details, events, wscs, wsc_details) =
             TransactionModel::from_transactions(&block_output.transactions);
-        let conn = Self::get_conn(self.connection_pool());
+        let last_version = txns.last().unwrap().version;
 
+        let conn = Self::get_conn(self.connection_pool());
         let tx_result = insert_block(
             &conn,
             self.substream_module_name(),
@@ -455,10 +457,15 @@ impl SubstreamProcessor for BlockOutputSubstreamProcessor {
         );
 
         match tx_result {
-            Ok(_) => Ok(ProcessingResult::new(
-                self.substream_module_name(),
-                block_height,
-            )),
+            Ok(_) => {
+                LATEST_PROCESSED_VERSION
+                    .with_label_values(&[self.substream_module_name()])
+                    .set(last_version);
+                Ok(ProcessingResult::new(
+                    self.substream_module_name(),
+                    block_height,
+                ))
+            }
             Err(err) => Err(BlockProcessingError::BlockCommitError((
                 anyhow::Error::from(err),
                 block_height,


### PR DESCRIPTION
### Description
Reusing inspection-service crate used to export metrics for aptos node. 

### Test Plan
Same command to start server
```
DATABASE_URL=postgres://postgres@localhost:5432/aptos_indexer_local  cargo run -- --endpoint-url http://localhost:18015 --package-file ../aptos-substreams/aptos-substreams-v0.0.1.spkg --module-name block_to_block_output --emit-every 50
```

Go to `http://localhost:9105/metrics`
```
# HELP aptos_metrics Number of metrics in certain states
# TYPE aptos_metrics counter
aptos_metrics{type="families_over_1000"} 0
aptos_metrics{type="total"} 594
aptos_metrics{type="total_bytes"} 50586
# HELP aptos_struct_log_count Count of the struct logs.
# TYPE aptos_struct_log_count counter
aptos_struct_log_count 13
# HELP indexer_connection_pool_ok Number of times the connection pool got a connection
# TYPE indexer_connection_pool_ok counter
indexer_connection_pool_ok 421
# HELP indexer_processor_invocation_count Number of times a given processor has been invoked
# TYPE indexer_processor_invocation_count counter
indexer_processor_invocation_count{processor_name="block_to_block_output"} 141
# HELP indexer_processor_latest_block Latest block a processor has fully consumed
# TYPE indexer_processor_latest_block gauge
indexer_processor_latest_block{processor_name="block_to_block_output"} 2239
# HELP indexer_processor_latest_version Latest version a processor has fully consumed
# TYPE indexer_processor_latest_version gauge
indexer_processor_latest_version{processor_name="block_to_block_output"} 4502
# HELP indexer_processor_success_count Number of times a given processor has completed successfully
# TYPE indexer_processor_success_count counter
indexer_processor_success_count{processor_name="block_to_block_output"} 140
```