### PR TITLE
Update values.yaml

### DIFF
--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -42,7 +42,7 @@ resources:
     cpu: 7
     memory: 14Gi
   requests:
-    cpu: 7
+    cpu: 6.5
     memory: 12Gi
 
 nodeSelector: {}


### PR DESCRIPTION
Cannot schedule pods: Insufficient cpu. when deploying on GCP. 

need to adjust the resource request down

agreed with Rustie to change request down from 7 to 6.5. Keep limit at 7. Tested deployment and this resolved the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3722)
<!-- Reviewable:end -->
