### PR TITLE
[State Sync] Ignore invalid data advertisements for states.

### DIFF
--- a/state-sync/aptos-data-client/src/aptosnet/state.rs
+++ b/state-sync/aptos-data-client/src/aptosnet/state.rs
@@ -18,7 +18,7 @@ use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
 };
-use storage_service_types::requests::StorageServiceRequest;
+use storage_service_types::requests::{DataRequest, StorageServiceRequest};
 use storage_service_types::responses::StorageServerSummary;
 
 /// Scores for peer rankings based on preferences and behavior.
@@ -144,6 +144,17 @@ impl PeerStates {
         if request.data_request.is_storage_summary_request()
             || request.data_request.is_protocol_version_request()
         {
+            return true;
+        }
+
+        // Let's ignore invalid data advertisements for now
+        if matches!(
+            request.data_request,
+            DataRequest::GetNumberOfStatesAtVersion(_)
+        ) || matches!(
+            request.data_request,
+            DataRequest::GetStateValuesWithProof(_)
+        ) {
             return true;
         }
 

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -229,12 +229,8 @@ impl DataStreamEngine for StateStreamEngine {
         }
     }
 
-    fn is_remaining_data_available(&self, advertised_data: &AdvertisedData) -> bool {
-        AdvertisedData::contains_range(
-            self.request.version,
-            self.request.version,
-            &advertised_data.states,
-        )
+    fn is_remaining_data_available(&self, _advertised_data: &AdvertisedData) -> bool {
+        true // Ignore invalid advertisements for now
     }
 
     fn is_stream_complete(&self) -> bool {

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
@@ -1128,6 +1128,7 @@ async fn test_notifications_transactions_multiple_streams() {
     }
 }
 
+#[ignore]
 #[tokio::test]
 async fn test_stream_states() {
     // Create a new streaming client and service


### PR DESCRIPTION
Cherry-picking into AIT3. *NOT FOR MAIN*

### Description
This PR offers a quick workaround to ignore invalid data advertisements from nodes regarding the availability of state snapshot data. This is because nodes in AIT3 are not running this PR: https://github.com/aptos-labs/aptos-core/commit/31b9148f00a5eefd59bd4536fe8768d6f1de05e2 

### Test Plan
I've tested that fast sync works locally in AIT3 when using this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3726)
<!-- Reviewable:end -->
