### PR TITLE
fix broken link: "Chain ID" to chain_id.rs

### DIFF
--- a/developer-docs-site/docs/guides/basics-life-of-txn.md
+++ b/developer-docs-site/docs/guides/basics-life-of-txn.md
@@ -36,7 +36,7 @@ The raw transaction includes the following fields:
 | [Gas price](/reference/glossary#gas-price) | The amount (in Aptos Coins) Alice is willing to pay per unit of gas, to execute the transaction. |
 | [Expiration time](/reference/glossary#expiration-time) | Expiration time of the transaction. |
 | [Sequence number](/reference/glossary#sequence-number)  | The sequence number (5, in this example) for an account indicates the number of transactions that have been submitted and commited on-chain from that account. In this case, 5 transactions have been submitted from Alice’s account, including Traw<sub>5</sub>. Note: a transaction with sequence number 5 can only be committed on-chain if the account sequence number is 5. |
-| [Chain ID](https://github.com/aptos/aptos/blob/main/types/src/chain_id.rs) | An identifier that distinguishes the Aptos network deployments (to prevent cross-network attacks). |
+| [Chain ID](https://github.com/aptos-labs/aptos-core/blob/main/types/src/chain_id.rs) | An identifier that distinguishes the Aptos network deployments (to prevent cross-network attacks). |
 
 # Lifecycle of the transaction
 


### PR DESCRIPTION
under "Client submits a transaction" on [this page](https://aptos.dev/guides/basics-life-of-txn), in the table of raw transaction fields, "Chain ID" links to /aptos/aptos/... instead of /aptos-core/aptos-labs/...

thanks to egormajj, who reported this on Discord ☺️

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3729)
<!-- Reviewable:end -->
