### PR TITLE
[Forge] Add instructions for running a faucet and minting inside local swarms.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ dependencies = [
  "aptos-crypto",
  "aptos-global-constants",
  "aptos-keygen",
+ "aptos-logger",
  "aptos-secure-storage",
  "aptos-state-view",
  "aptos-temppath",

--- a/crates/aptos-genesis/Cargo.toml
+++ b/crates/aptos-genesis/Cargo.toml
@@ -22,6 +22,7 @@ aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../aptos-crypto" }
 aptos-global-constants = { path = "../../config/global-constants" }
 aptos-keygen = { path = "../aptos-keygen" }
+aptos-logger = { path = "../aptos-logger" }
 aptos-secure-storage = { path = "../../secure/storage" }
 aptos-state-view =  { path = "../../storage/state-view" }
 aptos-temppath = { path = "../aptos-temppath" }

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -24,6 +24,7 @@ use aptos_crypto::{
     PrivateKey,
 };
 use aptos_keygen::KeyGen;
+use aptos_logger::prelude::*;
 use aptos_types::{chain_id::ChainId, transaction::Transaction, waypoint::Waypoint};
 use framework::ReleaseBundle;
 use rand::Rng;
@@ -457,18 +458,19 @@ impl Builder {
     where
         R: rand::RngCore + rand::CryptoRng,
     {
-        println!(
+        // We use this print statement to allow debugging of local deployments
+        info!(
             "Building genesis with {:?} validators. Directory of output: {:?}",
             self.num_validators.get(),
             self.config_dir
         );
-        let mut keygen = KeyGen::from_seed(rng.gen());
 
         // Generate root key
+        let mut keygen = KeyGen::from_seed(rng.gen());
         let root_key = keygen.generate_ed25519_private_key();
 
-        let template = NodeConfig::default_for_validator();
         // Generate validator configs
+        let template = NodeConfig::default_for_validator();
         let mut validators: Vec<ValidatorNodeConfig> = (0..self.num_validators.get())
             .map(|i| self.generate_validator_config(i, &mut rng, &template))
             .collect::<anyhow::Result<Vec<ValidatorNodeConfig>>>()?;

--- a/testsuite/forge-cli/src/README.md
+++ b/testsuite/forge-cli/src/README.md
@@ -7,37 +7,71 @@ custom_edit_url: https://github.com/aptos-labs/aptos-core/edit/main/testsuite/fo
 # Forge CLI
 
 This crate contains the Forge command line interface (CLI) tool. This enables users to
-run local and remote forge swarms (i.e., networks of validator nodes). For example, to
-deploy a local validator swarm, run:
+run local and remote Aptos swarms (i.e., networks of validators and validator fullnodes). For
+example, to deploy a local validator swarm, run:
 
 ```
-cargo run -p forge-cli -- --suite "run_forever" --num-validators 3 test local-swarm
+cargo run -p forge-cli -- --suite "run_forever" --num-validators 4 test local-swarm
 ```
 
-This will start a local swarm of 3 validators, each running in their own process. The
-swarm will run forever, unless manually killed. The output will display the locations
-of the swarm files (e.g., the genesis files, logs, node configurations, etc.) and the
-commands that were run to start each node. The process id (PID) of each node is also
-displayed when it starts.
-
-Using the information from the above command, you could stop a single node and restart
-it, e.g., run:
+This will start a local network of 4 validators, each running in their own process. The
+network will run forever, unless manually killed. The output will display the locations
+of the validator files (e.g., the genesis files, logs, node configurations, etc.) and the
+commands that were run to start each node. The process id (PID) of each node and
+server addresses (e.g., REST APIs) are also displayed when it starts. For example, if you
+run the above command you should see:
 
 ```
-kill -9 <Node PID>
-cargo run -p aptos-node -- -f <Location to the node configuration file outputted above>
+...
+2022-09-01T15:41:27.228289Z [main] INFO crates/aptos-genesis/src/builder.rs:462 Building genesis with 4 validators. Directory of output: "/private/var/folders/dx/c0l2rrkn0656gfx6v5_dy_p80000gn/T/.tmpq9uPMJ"
+...
+2022-09-01T15:41:28.090606Z [main] INFO testsuite/forge/src/backend/local/swarm.rs:207 The root (or mint) key for the swarm is: 0xf9f...
+...
+2022-09-01T15:41:28.094800Z [main] INFO testsuite/forge/src/backend/local/node.rs:129 Started node 0 (PID: 78939) with command: ".../aptos-core/target/debug/aptos-node" "-f" "/private/var/folders/dx/c0l2rrkn0656gfx6v5_dy_p80000gn/T/.tmpq9uPMJ/0/node.yaml"
+2022-09-01T15:41:28.094825Z [main] INFO testsuite/forge/src/backend/local/node.rs:137 Node 0: REST API is listening at: http://127.0.0.1:64566
+2022-09-01T15:41:28.094838Z [main] INFO testsuite/forge/src/backend/local/node.rs:142 Node 0: Inspection service is listening at http://127.0.0.1:64568
+...
 ```
+
+Using the information from this output, you could stop a single node and restart
+it, e.g., stop and restart node `0`:
+
+```
+kill -9 <Node 0 PID>
+cargo run -p aptos-node -- -f <Location to the node 0 configuration file displayed above>
+```
+
+## Faucet and Minting
+
+In addition, the swarm output also displays the root (or mint) key for the network. This allows
+you to run a local faucet and start minting test tokens in the network. For this, simply run the
+faucet command using the mint key and point it to the REST API of one of the nodes, e.g. node `0`:
+
+```
+cargo run --bin aptos-faucet -- -c TESTING --mint-key <Root/mint key displayed above> -s <URL for node 0 REST API> -p 8081   
+```
+
+The above command will run a faucet locally, listening on port `8081`. Using this faucet, you could
+then mint tokens to your test accounts, e.g.,:
+
+```
+curl -X POST http://127.0.0.1:8081/mint\?amount\=<amount to mint>\&pub_key\=<public key to mint tokens to>\&return_txns\=true
+01000000000000000000000000000000dd05a600000000000001e001a11ceb0b01000...
+```
+
+See more about how the faucet works in the [README](https://github.com/aptos-labs/aptos-core/tree/main/crates/aptos-faucet).
+Likewise, see the documentation about how to use the [Aptos CLI](https://aptos.dev/cli-tools/aptos-cli-tool/use-aptos-cli) with an existing faucet.
+
+## Validator fullnodes
+
+To also run validator fullnodes inside the network, use the `--num-validator-fullnodes` flag, e.g.,:
+```
+cargo run -p forge-cli -- --suite "run_forever" --num-validators 3 --num-validator-fullnodes 1 test local-swarm
+```
+
+## Additional usage
 
 To see all tool usage options, run:
 ```
 cargo run -p forge-cli --help
 ```
-
-To also run fullnodes inside the swarm, use the `--num-validator-fullnodes` flag, e.g.,:
-```
-cargo run -p forge-cli -- --suite "run_forever" --num-validators 3 --num-validator-fullnodes 1 test local-swarm
-```
-
-
-
-// TODO: add more detailed usage information. There's a lot more that users can do!

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -4,7 +4,7 @@
 use crate::{FullNode, HealthCheckError, LocalVersion, Node, NodeExt, Validator, Version};
 use anyhow::{anyhow, ensure, Context, Result};
 use aptos_config::{config::NodeConfig, keys::ConfigKey};
-use aptos_logger::debug;
+use aptos_logger::{debug, info};
 use aptos_sdk::{
     crypto::ed25519::Ed25519PrivateKey,
     types::{account_address::AccountAddress, PeerId},
@@ -125,12 +125,25 @@ impl LocalNode {
             )
         })?;
 
-        println!(
-            "Started node {:?} (PID: {:?}) with command: {:?}",
+        // We print out the commands and PIDs for debugging of local swarms
+        info!(
+            "Started node {} (PID: {}) with command: {:?}",
             self.name,
             process.id(),
             node_command
         );
+
+        // We print out the API endpoints of each node for local debugging
+        info!(
+            "Node {}: REST API is listening at: http://127.0.0.1:{}",
+            self.name,
+            self.config.api.address.port()
+        );
+        info!(
+            "Node {}: Inspection service is listening at http://127.0.0.1:{}",
+            self.name, self.config.inspection_service.port
+        );
+
         self.process = Some(Process(process));
 
         Ok(())

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -201,6 +201,14 @@ impl LocalSwarm {
                 Ok((validator.peer_id(), public_network))
             })
             .collect::<Result<HashMap<_, _>>>()?;
+
+        // We print out the root key to make it easy for users to deploy a local faucet
+        let encoded_root_key = hex::encode(&root_key.to_bytes());
+        info!(
+            "The root (or mint) key for the swarm is: 0x{}",
+            encoded_root_key
+        );
+
         let root_key = ConfigKey::new(root_key);
         let root_account = LocalAccount::new(
             aptos_sdk::types::account_config::aptos_test_root_address(),


### PR DESCRIPTION
### Description
This PR adds additional logs and instructions for running a faucet inside local swarms and minting test tokens. This is useful for developers who wish to build, test and deploy local networks and develop on top of them. The README now also contains instructions for doing these things (e.g., running a faucet and minting tokens).

### Test Plan
Tested manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3730)
<!-- Reviewable:end -->
