### PR TITLE
[tf/helm][fullnode] add back alb ingress and external-dns

### DIFF
--- a/terraform/fullnode/aws/addons.tf
+++ b/terraform/fullnode/aws/addons.tf
@@ -1,0 +1,55 @@
+resource "kubernetes_service_account" "k8s-aws-integrations" {
+  metadata {
+    name      = "k8s-aws-integrations"
+    namespace = "kube-system"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.k8s-aws-integrations.arn
+    }
+  }
+}
+
+# when upgrading the AWS ALB ingress controller, update the CRDs as well using:
+# kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds?ref=master"
+resource "helm_release" "aws-load-balancer-controller" {
+  name        = "aws-load-balancer-controller"
+  repository  = "https://aws.github.io/eks-charts"
+  chart       = "aws-load-balancer-controller"
+  version     = "1.4.3"
+  namespace   = "kube-system"
+  max_history = 5
+  wait        = false
+
+  values = [
+    jsonencode({
+      serviceAccount = {
+        create = false
+        name   = kubernetes_service_account.k8s-aws-integrations.metadata[0].name
+      }
+      clusterName = data.aws_eks_cluster.aptos.name
+      region      = var.region
+      vpcId       = module.eks.vpc_id
+    })
+  ]
+}
+
+resource "helm_release" "external-dns" {
+  count       = var.zone_id != "" ? 1 : 0
+  name        = "external-dns"
+  repository  = "https://kubernetes-sigs.github.io/external-dns"
+  chart       = "external-dns"
+  version     = "1.11.0"
+  namespace   = "kube-system"
+  max_history = 5
+  wait        = false
+
+  values = [
+    jsonencode({
+      serviceAccount = {
+        create = false
+        name   = kubernetes_service_account.k8s-aws-integrations.metadata[0].name
+      }
+      domainFilters = var.zone_id != "" ? [data.aws_route53_zone.pfn[0].name] : []
+      txtOwnerId    = var.zone_id
+    })
+  ]
+}

--- a/terraform/fullnode/aws/auth.tf
+++ b/terraform/fullnode/aws/auth.tf
@@ -37,7 +37,9 @@ data "aws_iam_policy_document" "alb-ingress" {
       "ec2:DeleteTags",
       "ec2:DeleteSecurityGroup",
       "ec2:DescribeAccountAttributes",
+      # https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/2525
       "ec2:DescribeAddresses",
+      "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInstances",
       "ec2:DescribeInstanceStatus",
       "ec2:DescribeInternetGateways",

--- a/terraform/fullnode/aws/fullnode/values.yaml
+++ b/terraform/fullnode/aws/fullnode/values.yaml
@@ -84,13 +84,3 @@ monitoring:
         memory: 128Mi
     googleAuth:
     config:
-
-
-
-aws:
-  region:
-  cluster_name:
-  vpc_id:
-  role_arn:
-  zone_name:
-

--- a/terraform/fullnode/aws/main.tf
+++ b/terraform/fullnode/aws/main.tf
@@ -95,13 +95,6 @@ resource "helm_release" "pfn" {
           }
         }
       }
-      aws = {
-        region       = var.region
-        cluster_name = data.aws_eks_cluster.aptos.name
-        vpc_id       = module.eks.vpc_id
-        role_arn     = aws_iam_role.k8s-aws-integrations.arn
-        zone_name    = var.zone_id != "" ? data.aws_route53_zone.pfn[0].name : null
-      }
     }),
     jsonencode(var.pfn_helm_values),
   ]


### PR DESCRIPTION
### Description

Add back ALB ingress controller as its own helm chart. It was previously removed

External-DNS is its own helm chart as well now. This makes things easier to manage and upgradable if they are not bundled into the same helm chart like before.

Also we should consider merging all these special charts together, or removing them. AWS fullnode TF invokes two helm charts both named `fullnode`, but the one embedded in AWS folder is actually just special AWS addons, including external-dns, alb ingress controller, monitoring. The first two can be standalone helm charts invoked as they are in this PR. Monitoring chart we have our own separate chart for that as well

### Test Plan

Apply to fullnode cluster

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3732)
<!-- Reviewable:end -->
