### PR TITLE
[aptos-rosetta] Add failed & vm status to transactions

### DIFF
--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -427,10 +427,12 @@ pub struct Transaction {
     pub metadata: TransactionMetadata,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TransactionMetadata {
     pub transaction_type: TransactionType,
     pub version: U64,
+    pub failed: bool,
+    pub vm_status: String,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -526,6 +528,8 @@ impl Transaction {
             metadata: TransactionMetadata {
                 transaction_type: txn_type,
                 version: txn_info.version,
+                failed: !txn_info.success,
+                vm_status: txn_info.vm_status,
             },
         })
     }


### PR DESCRIPTION
### Description
This adds the transaction status to the transaction.  It also adds the VM status for good measure to tell what happened to the transaction

### Test Plan
See smoke test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3737)
<!-- Reviewable:end -->
