### PR TITLE
[consensus] spawn block retrieval to a dedicated task

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -334,6 +334,16 @@ pub static BLOCK_RETRIEVAL_CHANNEL_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counters(queued,dequeued,dropped) related to block retrieval task
+pub static BLOCK_RETRIEVAL_TASK_MSGS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "aptos_consensus_block_retrieval_task_msgs_count",
+        "Counters(queued,dequeued,dropped) related to block retrieval task",
+        &["state"]
+    )
+    .unwrap()
+});
+
 /// Count of the buffer manager retry requests since last restart.
 pub static BUFFER_MANAGER_RETRY_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -122,7 +122,8 @@ pub struct EpochManager {
         aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
     >,
     epoch_state: Option<EpochState>,
-    block_store: Option<Arc<BlockStore>>,
+    block_retrieval_tx:
+        Option<aptos_channel::Sender<AccountAddress, IncomingBlockRetrievalRequest>>,
 }
 
 impl EpochManager {
@@ -159,7 +160,7 @@ impl EpochManager {
             buffer_manager_reset_tx: None,
             round_manager_tx: None,
             epoch_state: None,
-            block_store: None,
+            block_retrieval_tx: None,
         }
     }
 
@@ -417,6 +418,28 @@ impl EpochManager {
         spawn_named!("Quorum Store", quorum_store.start());
     }
 
+    fn spawn_block_retrieval_task(&mut self, epoch: u64, block_store: Arc<BlockStore>) {
+        let (request_tx, mut request_rx) = aptos_channel::new(
+            QueueStyle::LIFO,
+            1,
+            Some(&counters::BLOCK_RETRIEVAL_TASK_MSGS),
+        );
+        let task = async move {
+            info!(epoch = epoch, "Block retrieval task starts");
+            while let Some(request) = request_rx.next().await {
+                if let Err(e) = monitor!(
+                    "process_block_retrieval",
+                    block_store.process_block_retrieval(request).await
+                ) {
+                    error!(epoch = epoch, error = ?e, kind = error_kind(&e));
+                }
+            }
+            info!(epoch = epoch, "Block retrieval task stops");
+        };
+        self.block_retrieval_tx = Some(request_tx);
+        tokio::spawn(task);
+    }
+
     /// this function spawns the phases and a buffer manager
     /// it sets `self.commit_msg_tx` to a new aptos_channel::Sender and returns an OrderingStateComputer
     fn spawn_decoupled_execution(
@@ -490,6 +513,9 @@ impl EpochManager {
                 .await
                 .expect("[EpochManager] Fail to drop buffer manager");
         }
+
+        // Shutdown the block retrieval task by dropping the sender
+        self.block_retrieval_tx = None;
     }
 
     async fn start_round_manager(
@@ -600,8 +626,9 @@ impl EpochManager {
             Some(&counters::ROUND_MANAGER_CHANNEL_MSGS),
         );
         self.round_manager_tx = Some(round_manager_tx);
-        self.block_store = Some(block_store);
         tokio::spawn(round_manager.start(round_manager_rx));
+
+        self.spawn_block_retrieval_task(epoch, block_store);
     }
 
     async fn start_new_epoch(&mut self, payload: OnChainConfigPayload) {
@@ -757,16 +784,14 @@ impl EpochManager {
 
     async fn process_block_retrieval(
         &self,
+        peer_id: Author,
         request: IncomingBlockRetrievalRequest,
     ) -> anyhow::Result<()> {
         fail_point!("consensus::process::any", |_| {
             Err(anyhow::anyhow!("Injected error in process_block_retrieval"))
         });
-        if let Some(block_store) = &self.block_store {
-            monitor!(
-                "process_block_retrieval",
-                block_store.process_block_retrieval(request).await
-            )
+        if let Some(tx) = &self.block_retrieval_tx {
+            tx.push(peer_id, request)
         } else {
             Err(anyhow::anyhow!("Round manager not started"))
         }
@@ -800,8 +825,8 @@ impl EpochManager {
                         error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));
                     }
                 }
-                Some(request) = network_receivers.block_retrieval.next() => {
-                    if let Err(e) = self.process_block_retrieval(request).await {
+                Some((peer, request)) = network_receivers.block_retrieval.next() => {
+                    if let Err(e) = self.process_block_retrieval(peer, request).await {
                         error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));
                     }
                 }

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -725,7 +725,7 @@ mod tests {
         // verify request block rpc
         let mut block_retrieval = receiver_1.block_retrieval;
         let on_request_block = async move {
-            while let Some(request) = block_retrieval.next().await {
+            while let Some((_, request)) = block_retrieval.next().await {
                 // make sure the network task is not blocked during RPC
                 // we limit the network notification queue size to 1 so if it's blocked,
                 // we can not process 2 votes and the test will timeout


### PR DESCRIPTION
Spawn block retrieval to a dedicated task to not block the epoch manager

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3745)
<!-- Reviewable:end -->
