### PR TITLE
[NHC] Add evaluator that uses `aptos-network-checker`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,6 +937,7 @@ dependencies = [
  "aptos-config",
  "aptos-crypto",
  "aptos-logger",
+ "aptos-network-checker",
  "aptos-rest-client",
  "aptos-sdk",
  "async-trait",

--- a/ecosystem/node-checker/Cargo.toml
+++ b/ecosystem/node-checker/Cargo.toml
@@ -33,6 +33,7 @@ aptos-api = { path = "../../api" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-network-checker = { path = "../../crates/aptos-network-checker" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-sdk = { path = "../../sdk" }
 

--- a/ecosystem/node-checker/doc/spec.json
+++ b/ecosystem/node-checker/doc/spec.json
@@ -73,6 +73,17 @@
             "required": false,
             "deprecated": false,
             "explode": true
+          },
+          {
+            "name": "public_key",
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "description": "A public key for the node, e.g. 0x44fd1324c66371b4788af0b901c9eb8088781acb29e6b8b9c791d5d9838fbe1f.\nThis is only necessary for certain evaluators, e.g. HandshakeEvaluator.",
+            "required": false,
+            "deprecated": false,
+            "explode": true
           }
         ],
         "responses": {
@@ -289,6 +300,7 @@
           "consensus_proposals_args",
           "consensus_round_args",
           "consensus_timeouts_args",
+          "handshake_args",
           "hardware_args",
           "latency_args",
           "network_minimum_peers_args",
@@ -309,6 +321,9 @@
           },
           "consensus_timeouts_args": {
             "$ref": "#/components/schemas/ConsensusTimeoutsEvaluatorArgs"
+          },
+          "handshake_args": {
+            "$ref": "#/components/schemas/HandshakeEvaluatorArgs"
           },
           "hardware_args": {
             "$ref": "#/components/schemas/HardwareEvaluatorArgs"
@@ -332,6 +347,9 @@
             "$ref": "#/components/schemas/TransactionAvailabilityEvaluatorArgs"
           }
         }
+      },
+      "HandshakeEvaluatorArgs": {
+        "type": "object"
       },
       "HardwareEvaluatorArgs": {
         "type": "object",

--- a/ecosystem/node-checker/doc/spec.yaml
+++ b/ecosystem/node-checker/doc/spec.yaml
@@ -59,6 +59,16 @@ paths:
         required: false
         deprecated: false
         explode: true
+      - name: public_key
+        schema:
+          type: string
+        in: query
+        description: |-
+          A public key for the node, e.g. 0x44fd1324c66371b4788af0b901c9eb8088781acb29e6b8b9c791d5d9838fbe1f.
+          This is only necessary for certain evaluators, e.g. HandshakeEvaluator.
+        required: false
+        deprecated: false
+        explode: true
       responses:
         '200':
           description: ''
@@ -219,6 +229,7 @@ components:
       - consensus_proposals_args
       - consensus_round_args
       - consensus_timeouts_args
+      - handshake_args
       - hardware_args
       - latency_args
       - network_minimum_peers_args
@@ -235,6 +246,8 @@ components:
           $ref: '#/components/schemas/ConsensusRoundEvaluatorArgs'
         consensus_timeouts_args:
           $ref: '#/components/schemas/ConsensusTimeoutsEvaluatorArgs'
+        handshake_args:
+          $ref: '#/components/schemas/HandshakeEvaluatorArgs'
         hardware_args:
           $ref: '#/components/schemas/HardwareEvaluatorArgs'
         latency_args:
@@ -249,6 +262,8 @@ components:
           $ref: '#/components/schemas/StateSyncVersionEvaluatorArgs'
         transaction_availability_args:
           $ref: '#/components/schemas/TransactionAvailabilityEvaluatorArgs'
+    HandshakeEvaluatorArgs:
+      type: object
     HardwareEvaluatorArgs:
       type: object
       required:

--- a/ecosystem/node-checker/src/configuration/mod.rs
+++ b/ecosystem/node-checker/src/configuration/mod.rs
@@ -26,10 +26,10 @@ pub struct Configuration {
 
 #[derive(Clone, Debug, Subcommand)]
 enum Command {
-    /// todo
+    /// Create a new baseline configuration.
     Create(Create),
 
-    /// todo
+    /// Validate an existing baseline configuration.
     Validate(Validate),
 }
 

--- a/ecosystem/node-checker/src/evaluator/traits.rs
+++ b/ecosystem/node-checker/src/evaluator/traits.rs
@@ -1,7 +1,11 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{configuration::EvaluatorArgs, evaluator::EvaluationResult, evaluators::EvaluatorType};
+use crate::{
+    configuration::{EvaluatorArgs, NodeAddress},
+    evaluator::EvaluationResult,
+    evaluators::EvaluatorType,
+};
 use log::info;
 use std::{collections::HashSet, error::Error, fmt::Debug};
 
@@ -56,6 +60,13 @@ pub trait Evaluator: Debug + Sync + Send {
             Self::get_category_name(),
             Self::get_evaluator_name()
         )
+    }
+
+    /// Before the evaluation is run, this function is called for all evaluators
+    /// configured for the given baseline configuration. This gives those evaluators
+    /// an opportunity to error out early if a necessary argument is not provided.
+    fn validate_check_node_call(&self, _target_node_address: &NodeAddress) -> anyhow::Result<()> {
+        Ok(())
     }
 
     // It would be better to require From<&EvaluatorArgs> on the trait

--- a/ecosystem/node-checker/src/evaluators/build_evaluators.rs
+++ b/ecosystem/node-checker/src/evaluators/build_evaluators.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    configuration::EvaluatorArgs,
+    configuration::{EvaluatorArgs, NodeAddress},
     evaluator::Evaluator,
     evaluators::{
         direct::{
-            ApiEvaluatorError, DirectEvaluatorInput, LatencyEvaluator, TpsEvaluator,
-            TpsEvaluatorError, TransactionAvailabilityEvaluator,
+            ApiEvaluatorError, DirectEvaluatorInput, HandshakeEvaluator, LatencyEvaluator,
+            NoiseEvaluatorError, TpsEvaluator, TpsEvaluatorError, TransactionAvailabilityEvaluator,
         },
         metrics::{
             ConsensusProposalsEvaluator, ConsensusRoundEvaluator, ConsensusTimeoutsEvaluator,
@@ -15,18 +15,19 @@ use crate::{
             NetworkPeersWithinToleranceEvaluator, StateSyncVersionEvaluator,
         },
         system_information::{
-            BuildVersionEvaluator, SystemInformationEvaluatorError, SystemInformationEvaluatorInput,
+            BuildVersionEvaluator, HardwareEvaluator, SystemInformationEvaluatorError,
+            SystemInformationEvaluatorInput,
         },
     },
 };
 use anyhow::{bail, Result};
 use std::collections::HashSet;
 
-use super::system_information::HardwareEvaluator;
-
 type ApiEvaluatorType = Box<dyn Evaluator<Input = DirectEvaluatorInput, Error = ApiEvaluatorError>>;
 type MetricsEvaluatorType =
     Box<dyn Evaluator<Input = MetricsEvaluatorInput, Error = MetricsEvaluatorError>>;
+type NoiseEvaluatorType =
+    Box<dyn Evaluator<Input = DirectEvaluatorInput, Error = NoiseEvaluatorError>>;
 type SystemInformationEvaluatorType = Box<
     dyn Evaluator<Input = SystemInformationEvaluatorInput, Error = SystemInformationEvaluatorError>,
 >;
@@ -46,8 +47,38 @@ type TpsEvaluatorType = Box<dyn Evaluator<Input = DirectEvaluatorInput, Error = 
 pub enum EvaluatorType {
     Api(ApiEvaluatorType),
     Metrics(MetricsEvaluatorType),
+    Noise(NoiseEvaluatorType),
     SystemInformation(SystemInformationEvaluatorType),
     Tps(TpsEvaluatorType),
+}
+
+// Consider using something like ambassador for this. But if you do, consider
+// a wholesale re-evaluation of the trait structure instead. For example, this
+// struct should itself implement the trait with the common functions and there
+// should be another way to build up the dependency tree of evaluators.
+impl EvaluatorType {
+    pub fn validate_check_node_call(
+        &self,
+        target_node_address: &NodeAddress,
+    ) -> anyhow::Result<()> {
+        match self {
+            EvaluatorType::Api(evaluator) => {
+                evaluator.validate_check_node_call(target_node_address)
+            }
+            EvaluatorType::Metrics(evaluator) => {
+                evaluator.validate_check_node_call(target_node_address)
+            }
+            EvaluatorType::Noise(evaluator) => {
+                evaluator.validate_check_node_call(target_node_address)
+            }
+            EvaluatorType::SystemInformation(evaluator) => {
+                evaluator.validate_check_node_call(target_node_address)
+            }
+            EvaluatorType::Tps(evaluator) => {
+                evaluator.validate_check_node_call(target_node_address)
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -87,7 +118,12 @@ impl EvaluatorSet {
     pub fn get_direct_evaluators(&self) -> Vec<&EvaluatorType> {
         self.evaluators
             .iter()
-            .filter(|evaluator| matches!(evaluator, EvaluatorType::Api(_) | EvaluatorType::Tps(_)))
+            .filter(|evaluator| {
+                matches!(
+                    evaluator,
+                    EvaluatorType::Api(_) | EvaluatorType::Noise(_) | EvaluatorType::Tps(_)
+                )
+            })
             .collect()
     }
 }
@@ -116,6 +152,11 @@ pub fn build_evaluators(
         evaluator_args,
     )?;
     ConsensusTimeoutsEvaluator::add_from_evaluator_args(
+        &mut evaluators,
+        &mut evaluator_identifiers,
+        evaluator_args,
+    )?;
+    HandshakeEvaluator::add_from_evaluator_args(
         &mut evaluators,
         &mut evaluator_identifiers,
         evaluator_args,

--- a/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
@@ -62,7 +62,7 @@ impl NodeIdentityEvaluator {
                 100,
                 format!(
                     "The node under investigation reported the same {} {} \
-                as is reported by the baseline node",
+                as is reported by the baseline node.",
                     attribute_str, target_value
                 ),
             )

--- a/ecosystem/node-checker/src/evaluators/direct/mod.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/mod.rs
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod api;
+mod noise;
 mod tps;
 mod types;
 
 pub use api::*;
+pub use noise::*;
 
 pub use tps::{TpsEvaluator, TpsEvaluatorArgs, TpsEvaluatorError};
 pub use types::DirectEvaluatorInput;

--- a/ecosystem/node-checker/src/evaluators/direct/noise/handshake.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/noise/handshake.rs
@@ -1,0 +1,127 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    configuration::{EvaluatorArgs, NodeAddress},
+    evaluator::{EvaluationResult, Evaluator},
+    evaluators::EvaluatorType,
+};
+use anyhow::{format_err, Result};
+use aptos_network_checker::{
+    args::{CheckEndpointArgs, HandshakeArgs, NodeAddressArgs},
+    check_endpoint::check_endpoint,
+};
+use clap::Parser;
+use poem_openapi::Object as PoemObject;
+use serde::{Deserialize, Serialize};
+
+use super::super::DirectEvaluatorInput;
+use super::{NoiseEvaluatorError, NOISE_CATEGORY};
+
+#[derive(Clone, Debug, Default, Deserialize, Parser, PoemObject, Serialize)]
+pub struct HandshakeEvaluatorArgs {
+    #[clap(flatten)]
+    #[oai(skip)]
+    pub handshake_args: HandshakeArgs,
+}
+
+#[derive(Debug)]
+pub struct HandshakeEvaluator {
+    args: HandshakeEvaluatorArgs,
+}
+
+impl HandshakeEvaluator {
+    pub fn new(args: HandshakeEvaluatorArgs) -> Self {
+        Self { args }
+    }
+}
+
+#[async_trait::async_trait]
+impl Evaluator for HandshakeEvaluator {
+    type Input = DirectEvaluatorInput;
+    type Error = NoiseEvaluatorError;
+
+    /// Assert that we can establish a noise connection with the target node
+    /// with the given public key. If we cannot, it implies that either the
+    /// node is not listening on that port, or the node is not running with
+    /// the private key matching the public key provided as part of the request
+    /// to NHC.
+    async fn evaluate(&self, input: &Self::Input) -> Result<Vec<EvaluationResult>, Self::Error> {
+        // Confirm that we can build the target node into a NetworkAddress.
+        // TODO: Given that at this point we've already confirmed that the target
+        // node is there, how else could this possibly fail? I figure it can't,
+        // because all that could fail is DNS lookup, which should've already worked.
+        let target_network_address = match input.target_node_address.as_noise_network_address() {
+            Ok(network_address) => network_address,
+            Err(e) => {
+                return Ok(vec![self.build_evaluation_result(
+                    "Invalid node address".to_string(),
+                    0,
+                    format!(
+                        "Failed to resolve given address as noise NetworkAddress, \
+                        ensure your address is valid: {:#}",
+                        e
+                    ),
+                )]);
+            }
+        };
+        Ok(vec![match check_endpoint(
+            &CheckEndpointArgs {
+                node_address_args: NodeAddressArgs {
+                    address: target_network_address,
+                    chain_id: input.get_target_chain_id(),
+                },
+                handshake_args: self.args.handshake_args.clone(),
+            },
+            None,
+        )
+        .await
+        {
+            Ok(message) => self.build_evaluation_result(
+                "Noise connection established successfully".to_string(),
+                100,
+                format!(
+                    "{}. This indicates your noise port ({}) is open and the node is \
+                    running with the private key matching the provided public key.",
+                    message, input.target_node_address.noise_port
+                ),
+            ),
+            Err(e) => self.build_evaluation_result(
+                "Failed to establish noise connection".to_string(),
+                0,
+                format!(
+                    "{:#}. Either the noise port ({}) is closed or the node is not \
+                    running with the private key matching the provided public key.",
+                    e, input.target_node_address.noise_port
+                ),
+            ),
+        }])
+    }
+
+    fn get_category_name() -> String {
+        NOISE_CATEGORY.to_string()
+    }
+
+    fn get_evaluator_name() -> String {
+        "handshake".to_string()
+    }
+
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        Ok(Self::new(evaluator_args.handshake_args.clone()))
+    }
+
+    fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {
+        Ok(EvaluatorType::Noise(Box::new(Self::from_evaluator_args(
+            evaluator_args,
+        )?)))
+    }
+
+    fn validate_check_node_call(&self, target_node_address: &NodeAddress) -> anyhow::Result<()> {
+        if target_node_address.public_key.is_none() {
+            return Err(format_err!(
+                "A public key must be provided to use the handshake evaluator"
+            ));
+        }
+        Ok(())
+    }
+}

--- a/ecosystem/node-checker/src/evaluators/direct/noise/mod.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/noise/mod.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+mod handshake;
+
+pub use handshake::{HandshakeEvaluator, HandshakeEvaluatorArgs};
+use thiserror::Error as ThisError;
+
+pub const NOISE_CATEGORY: &str = "noise";
+
+#[derive(Debug, ThisError)]
+pub enum NoiseEvaluatorError {}

--- a/ecosystem/node-checker/src/metric_collector/traits.rs
+++ b/ecosystem/node-checker/src/metric_collector/traits.rs
@@ -6,8 +6,6 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use thiserror::Error as ThisError;
 
-// TODO: Consider using thiserror.
-
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SystemInformation(pub HashMap<String, String>);
 

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -180,6 +180,11 @@ impl<M: MetricCollector> BlockingRunner<M> {
                         .evaluate(direct_evaluator_input)
                         .err_into::<RunnerError>(),
                 ),
+                EvaluatorType::Noise(evaluator) => Box::pin(
+                    evaluator
+                        .evaluate(direct_evaluator_input)
+                        .err_into::<RunnerError>(),
+                ),
                 _ => continue,
             });
         }
@@ -266,5 +271,9 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
         let complete_evaluation = EvaluationSummary::from(evaluation_results);
 
         Ok(complete_evaluation)
+    }
+
+    fn get_evaluator_set(&self) -> &EvaluatorSet {
+        &self.evaluator_set
     }
 }

--- a/ecosystem/node-checker/src/runner/traits.rs
+++ b/ecosystem/node-checker/src/runner/traits.rs
@@ -9,9 +9,12 @@ use crate::{
     configuration::NodeAddress,
     evaluator::EvaluationSummary,
     evaluators::{
-        direct::{ApiEvaluatorError, NodeIdentityEvaluatorError, TpsEvaluatorError},
+        direct::{
+            ApiEvaluatorError, NodeIdentityEvaluatorError, NoiseEvaluatorError, TpsEvaluatorError,
+        },
         metrics::MetricsEvaluatorError,
         system_information::SystemInformationEvaluatorError,
+        EvaluatorSet,
     },
     metric_collector::{MetricCollector, MetricCollectorError},
 };
@@ -36,6 +39,9 @@ pub enum RunnerError {
     /// We failed to get the node identity.
     #[error("Failed to check identity of node: {0}")]
     NodeIdentityEvaluatorError(#[from] NodeIdentityEvaluatorError),
+
+    #[error("Failed to evaluate over noise port: {0}")]
+    NoiseEvaluatorError(#[from] NoiseEvaluatorError),
 
     /// We couldn't parse the metrics.
     #[error("Failed to parse metrics: {0}")]
@@ -71,4 +77,6 @@ pub trait Runner: Sync + Send + 'static {
         target_node_address: &NodeAddress,
         target_metric_collector: &M,
     ) -> Result<EvaluationSummary, RunnerError>;
+
+    fn get_evaluator_set(&self) -> &EvaluatorSet;
 }

--- a/ecosystem/node-checker/ts-client/CHANGELOG.md
+++ b/ecosystem/node-checker/ts-client/CHANGELOG.md
@@ -4,5 +4,8 @@ All notable changes to the client will be captured in this file. This changelog 
 
 **Note:** The client does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
+## 0.0.2 (2022-09-01)
+- Added `public_key` as an optional field to `check_node`. If an evaluator that needs it, e.g. the `HandshakeEvaluator`, is configured as part of the baseline config, it will return an error indicating as such if it is not provided.
+
 ## 0.0.1 (2022-08-31)
 - Initial release.

--- a/ecosystem/node-checker/ts-client/package.json
+++ b/ecosystem/node-checker/ts-client/package.json
@@ -46,5 +46,5 @@
     "tsdx": "^0.14.1",
     "typescript": "4.8.2"
   },
-  "version": "0.0.1"
+  "version": "0.0.2"
 }

--- a/ecosystem/node-checker/ts-client/src/index.ts
+++ b/ecosystem/node-checker/ts-client/src/index.ts
@@ -18,6 +18,7 @@ export type { ConsensusTimeoutsEvaluatorArgs } from './models/ConsensusTimeoutsE
 export type { EvaluationResult } from './models/EvaluationResult';
 export type { EvaluationSummary } from './models/EvaluationSummary';
 export type { EvaluatorArgs } from './models/EvaluatorArgs';
+export type { HandshakeEvaluatorArgs } from './models/HandshakeEvaluatorArgs';
 export type { HardwareEvaluatorArgs } from './models/HardwareEvaluatorArgs';
 export type { LatencyEvaluatorArgs } from './models/LatencyEvaluatorArgs';
 export type { NetworkMinimumPeersEvaluatorArgs } from './models/NetworkMinimumPeersEvaluatorArgs';
@@ -38,6 +39,7 @@ export { $ConsensusTimeoutsEvaluatorArgs } from './schemas/$ConsensusTimeoutsEva
 export { $EvaluationResult } from './schemas/$EvaluationResult';
 export { $EvaluationSummary } from './schemas/$EvaluationSummary';
 export { $EvaluatorArgs } from './schemas/$EvaluatorArgs';
+export { $HandshakeEvaluatorArgs } from './schemas/$HandshakeEvaluatorArgs';
 export { $HardwareEvaluatorArgs } from './schemas/$HardwareEvaluatorArgs';
 export { $LatencyEvaluatorArgs } from './schemas/$LatencyEvaluatorArgs';
 export { $NetworkMinimumPeersEvaluatorArgs } from './schemas/$NetworkMinimumPeersEvaluatorArgs';

--- a/ecosystem/node-checker/ts-client/src/models/EvaluatorArgs.ts
+++ b/ecosystem/node-checker/ts-client/src/models/EvaluatorArgs.ts
@@ -6,6 +6,7 @@ import type { BuildVersionEvaluatorArgs } from './BuildVersionEvaluatorArgs';
 import type { ConsensusProposalsEvaluatorArgs } from './ConsensusProposalsEvaluatorArgs';
 import type { ConsensusRoundEvaluatorArgs } from './ConsensusRoundEvaluatorArgs';
 import type { ConsensusTimeoutsEvaluatorArgs } from './ConsensusTimeoutsEvaluatorArgs';
+import type { HandshakeEvaluatorArgs } from './HandshakeEvaluatorArgs';
 import type { HardwareEvaluatorArgs } from './HardwareEvaluatorArgs';
 import type { LatencyEvaluatorArgs } from './LatencyEvaluatorArgs';
 import type { NetworkMinimumPeersEvaluatorArgs } from './NetworkMinimumPeersEvaluatorArgs';
@@ -19,6 +20,7 @@ export type EvaluatorArgs = {
     consensus_proposals_args: ConsensusProposalsEvaluatorArgs;
     consensus_round_args: ConsensusRoundEvaluatorArgs;
     consensus_timeouts_args: ConsensusTimeoutsEvaluatorArgs;
+    handshake_args: HandshakeEvaluatorArgs;
     hardware_args: HardwareEvaluatorArgs;
     latency_args: LatencyEvaluatorArgs;
     network_minimum_peers_args: NetworkMinimumPeersEvaluatorArgs;

--- a/ecosystem/node-checker/ts-client/src/models/HandshakeEvaluatorArgs.ts
+++ b/ecosystem/node-checker/ts-client/src/models/HandshakeEvaluatorArgs.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type HandshakeEvaluatorArgs = {
+};
+

--- a/ecosystem/node-checker/ts-client/src/schemas/$EvaluatorArgs.ts
+++ b/ecosystem/node-checker/ts-client/src/schemas/$EvaluatorArgs.ts
@@ -19,6 +19,10 @@ export const $EvaluatorArgs = {
             type: 'ConsensusTimeoutsEvaluatorArgs',
             isRequired: true,
         },
+        handshake_args: {
+            type: 'HandshakeEvaluatorArgs',
+            isRequired: true,
+        },
         hardware_args: {
             type: 'HardwareEvaluatorArgs',
             isRequired: true,

--- a/ecosystem/node-checker/ts-client/src/schemas/$HandshakeEvaluatorArgs.ts
+++ b/ecosystem/node-checker/ts-client/src/schemas/$HandshakeEvaluatorArgs.ts
@@ -1,0 +1,7 @@
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export const $HandshakeEvaluatorArgs = {
+    properties: {
+    },
+} as const;

--- a/ecosystem/node-checker/ts-client/src/services/DefaultService.ts
+++ b/ecosystem/node-checker/ts-client/src/services/DefaultService.ts
@@ -26,6 +26,7 @@ export class DefaultService {
         metricsPort = 9101,
         apiPort = 8080,
         noisePort = 6180,
+        publicKey,
     }: {
         /**
          * The URL of the node to check. e.g. http://44.238.19.217 or http://fullnode.mysite.com
@@ -38,6 +39,11 @@ export class DefaultService {
         metricsPort?: number,
         apiPort?: number,
         noisePort?: number,
+        /**
+         * A public key for the node, e.g. 0x44fd1324c66371b4788af0b901c9eb8088781acb29e6b8b9c791d5d9838fbe1f.
+         * This is only necessary for certain evaluators, e.g. HandshakeEvaluator.
+         */
+        publicKey?: string,
     }): CancelablePromise<EvaluationSummary> {
         return this.httpRequest.request({
             method: 'GET',
@@ -48,6 +54,7 @@ export class DefaultService {
                 'metrics_port': metricsPort,
                 'api_port': apiPort,
                 'noise_port': noisePort,
+                'public_key': publicKey,
             },
         });
     }


### PR DESCRIPTION
### Description
This PR adds an evaluator to NHC that uses aptos-network-checker. As part of this, I've added support to NHC for optionally providing a public key to check node. Accordingly, I've added support for evaluators to validate the input args, e.g. so the handshake evaluator can ensure that public key was provided.

Some questions:
- In `src/configuration/types.rs` I have a function that takes the regular address + noise port + public key and turns it into a `NetworkAddress`. This function can fail in a few ways, but I think the main way it could fail is if the DNS look up fails. At this point however I've already checked that. How else could this realistically fail?

### Test Plan
Generate appropriate config:
```
cargo run -p aptos-node-checker -- configuration create --configuration-name ait3_fullnode --configuration-name-pretty "AIT3 FullNode Checker" --url http://34.64.49.220 --api-port 80 --evaluators api_latency api_transaction_availability noise_handshake > ~/a/internal-ops/infra/apps/node-checker/configs/ait3_fullnode.yaml
```

Run local NHC:
```
cargo run -p aptos-node-checker -- server run --baseline-node-config-paths ~/a/internal-ops/infra/apps/node-checker/configs/ait3_fullnode.yaml --listen-address 0.0.0.0
```

Check a fullnode:
```
curl 'http://127.0.0.1:20121/check_node?node_url=http://192.168.86.2&baseline_configuration_name=ait3_fullnode&metrics_port=9101&api_port=80&noise_port=6180&public_key=0x44fd1324c66371b4788af0b901c9eb8088781acb29e6b8b9c791d5d9838fbe1f'
```

Output:
```
{
  "evaluation_results": [
    {
      "headline": "Chain ID reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Chain ID 47 as is reported by the baseline node.",
      "evaluator_name": "node_identity",
      "category": "api",
      "links": []
    },
    {
      "headline": "Role Type reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Role Type full_node as is reported by the baseline node.",
      "evaluator_name": "node_identity",
      "category": "api",
      "links": []
    },
    {
      "headline": "Noise connection established successfully",
      "score": 100,
      "explanation": "Successfully connected to /ip4/34.64.49.220/tcp/6182/noise-ik/0x44fd1324c66371b4788af0b901c9eb8088781acb29e6b8b9c791d5d9838fbe1f/handshake/0. This indicates your noise port (6182) is open and the node is running with the private key matching the provided public key.",
      "evaluator_name": "handshake",
      "category": "noise",
      "links": []
    },
    {
      "headline": "Average API latency is good",
      "score": 100,
      "explanation": "The average API latency was 290ms, which is below the maximum allowed latency of 1000ms. Note, this latency is not the same as standard ping latency, see the attached link.",
      "evaluator_name": "latency",
      "category": "api",
      "links": [
        "https://aptos.dev/nodes/node-health-checker-faq#how-does-the-latency-evaluator-work"
      ]
    },
    {
      "headline": "Target node produced valid recent transaction",
      "score": 100,
      "explanation": "We were able to pull the same transaction (version: 99349086) from both your node and the baseline node. Great! This implies that your node is keeping up with other nodes in the network.",
      "evaluator_name": "transaction_availability",
      "category": "api",
      "links": []
    }
  ],
  "summary_score": 100,
  "summary_explanation": "100: Awesome!"
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3746)
<!-- Reviewable:end -->
