### PR TITLE
[aptos-node/cli] Add windows compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2628,7 +2628,6 @@ dependencies = [
  "short-hex-str",
  "storage-interface",
  "tempfile",
- "termion",
  "thiserror",
  "tokio",
  "vm-validator",
@@ -9825,7 +9824,6 @@ dependencies = [
  "itertools",
  "rand 0.7.3",
  "rand_core 0.5.1",
- "termion",
  "tokio",
  "transaction-emitter-lib",
 ]

--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -2,20 +2,49 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use framework::ReleaseTarget;
+use std::env::current_dir;
 use std::path::PathBuf;
 
 fn main() {
     // Set the below variable to skip the building step. This might be useful if the build
     // is broken so it can be debugged with the old outdated artifacts.
     if std::env::var("SKIP_FRAMEWORK_BUILD").is_err() {
-        println!("cargo:rerun-if-changed=../aptos-token/sources");
-        println!("cargo:rerun-if-changed=../aptos-token/Move.toml");
-        println!("cargo:rerun-if-changed=../aptos-framework/sources");
-        println!("cargo:rerun-if-changed=../aptos-framework/Move.toml");
-        println!("cargo:rerun-if-changed=../aptos-stdlib/sources");
-        println!("cargo:rerun-if-changed=../aptos-stdlib/Move.toml");
-        println!("cargo:rerun-if-changed=../move-stdlib/sources");
-        println!("cargo:rerun-if-changed=../move-stdlib/Move.toml");
+        let current_dir = current_dir().expect("Should be able to get current dir");
+        // Get the previous directory
+        let mut prev_dir = current_dir;
+        prev_dir.pop();
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("aptos-token").join("sources").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("aptos-token").join("Move.toml").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("aptos-framework").join("sources").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("aptos-framework").join("Move.toml").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("aptos-stdlib").join("sources").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("aptos-stdlib").join("Move.toml").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("move-stdlib").join("sources").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            prev_dir.join("move-stdlib").join("Move.toml").display()
+        );
         ReleaseTarget::Head
             .create_release(Some(
                 PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR defined")).join("head.mrb"),

--- a/aptos-move/framework/cached-packages/src/lib.rs
+++ b/aptos-move/framework/cached-packages/src/lib.rs
@@ -8,7 +8,10 @@ pub mod aptos_framework_sdk_builder;
 pub mod aptos_stdlib;
 pub mod aptos_token_sdk_builder;
 
+#[cfg(unix)]
 const HEAD_RELEASE_BUNDLE_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/head.mrb"));
+#[cfg(windows)]
+const HEAD_RELEASE_BUNDLE_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "\\head.mrb"));
 
 static HEAD_RELEASE_BUNDLE: Lazy<ReleaseBundle> = Lazy::new(|| {
     bcs::from_bytes::<ReleaseBundle>(HEAD_RELEASE_BUNDLE_BYTES).expect("bcs succeeds")

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -16,7 +16,6 @@ clap = "3.1.8"
 fail = "0.5.0"
 futures = "0.3.21"
 hex = "0.4.3"
-jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 rand = "0.7.3"
 tokio = { version = "1.18.2", features = ["full"] }
 tokio-stream = "0.1.8"
@@ -58,6 +57,9 @@ state-sync-driver = { path = "../state-sync/state-sync-v2/state-sync-driver" }
 storage-interface = { path = "../storage/storage-interface" }
 storage-service-client = { path = "../state-sync/storage-service/client" }
 storage-service-server = { path = "../state-sync/storage-service/server" }
+
+[target.'cfg(unix)'.dependencies]
+jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
 [features]
 default = []

--- a/aptos-node/src/main.rs
+++ b/aptos-node/src/main.rs
@@ -6,6 +6,7 @@
 use aptos_node::AptosNodeArgs;
 use clap::Parser;
 
+#[cfg(unix)]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -27,7 +27,6 @@ once_cell = "1.10.0"
 rand = { version = "0.7.3", default-features = false }
 serde = { version = "1.0.137", default-features = false }
 serde_json = "1.0.81"
-termion = { version = "1.5.6", default-features = false }
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["full"] }
 

--- a/consensus/src/experimental/tests/phase_tester.rs
+++ b/consensus/src/experimental/tests/phase_tester.rs
@@ -59,18 +59,12 @@ impl<T: StatelessPipeline> PhaseTester<T> {
             } in self.cases
             {
                 eprint!(
-                    "{}Unit Test{} - {}:",
-                    termion::color::Fg(termion::color::LightBlue),
-                    termion::style::Reset,
+                    "Unit Test - {}:",
                     prompt.unwrap_or(format!("Test {}", index))
                 );
                 let resp = processor.process(input).await;
                 judge(resp);
-                eprintln!(
-                    " {}OK{}",
-                    termion::color::Fg(termion::color::LightGreen),
-                    termion::style::Reset
-                );
+                eprintln!(" OK",);
             }
         })
     }
@@ -93,9 +87,7 @@ impl<T: StatelessPipeline> PhaseTester<T> {
             } in self.cases
             {
                 eprint!(
-                    "{}E2E Test{} - {}:",
-                    termion::color::Fg(termion::color::LightBlue),
-                    termion::style::Reset,
+                    "E2E Test - {}:",
                     prompt.unwrap_or(format!("Test {}", index))
                 );
                 tx.send(CountedRequest::new(input, Arc::new(AtomicU64::new(0))))
@@ -103,11 +95,7 @@ impl<T: StatelessPipeline> PhaseTester<T> {
                     .ok();
                 let resp = rx.next().await.unwrap();
                 judge(resp);
-                eprintln!(
-                    " {}OK{}",
-                    termion::color::Fg(termion::color::Green),
-                    termion::style::Reset
-                );
+                eprintln!(" OK",);
             }
         })
     }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -48,7 +48,6 @@ use safety_rules::ConsensusState;
 use safety_rules::TSafetyRules;
 use serde::Serialize;
 use std::{mem::Discriminant, sync::Arc, time::Duration};
-use termion::color::*;
 
 #[derive(Serialize, Clone)]
 pub enum UnverifiedEvent {
@@ -585,9 +584,7 @@ impl RoundManager {
             self.block_store.highest_2chain_timeout_cert().as_deref(),
         );
         let vote = vote_result.context(format!(
-            "[RoundManager] SafetyRules {}Rejected{} {}",
-            Fg(Red),
-            Fg(Reset),
+            "[RoundManager] SafetyRules Rejected {}",
             executed_block.block()
         ))?;
         if !executed_block.block().is_nil_block() {

--- a/consensus/src/test_utils/mock_state_computer.rs
+++ b/consensus/src/test_utils/mock_state_computer.rs
@@ -17,7 +17,6 @@ use consensus_types::{block::Block, common::Payload, executed_block::ExecutedBlo
 use executor_types::{Error, StateComputeResult};
 use futures::channel::mpsc;
 use std::{collections::HashMap, sync::Arc};
-use termion::color::*;
 
 pub struct MockStateComputer {
     state_sync_client: mpsc::UnboundedSender<Vec<SignedTransaction>>,
@@ -89,9 +88,7 @@ impl StateComputer for MockStateComputer {
 
     async fn sync_to(&self, commit: LedgerInfoWithSignatures) -> Result<(), StateSyncError> {
         debug!(
-            "{}Fake sync{} to block id {}",
-            Fg(Blue),
-            Fg(Reset),
+            "Fake sync to block id {}",
             commit.ledger_info().consensus_block_id()
         );
         self.consensus_db

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -14,12 +14,13 @@ use itertools::Itertools;
 use move_deps::move_core_types::account_address::AccountAddress;
 use reqwest::Url;
 use serde::Serialize;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 use std::{
     collections::BTreeMap,
     env,
     fs::OpenOptions,
     io::Write,
-    os::unix::fs::OpenOptionsExt,
     path::{Path, PathBuf},
     str::FromStr,
     time::{Duration, Instant},

--- a/crates/transaction-emitter/Cargo.toml
+++ b/crates/transaction-emitter/Cargo.toml
@@ -16,7 +16,6 @@ futures = "0.3.21"
 itertools = "0.10.3"
 rand = "0.7.3"
 rand_core = "0.5.1"
-termion = "1.5.6"
 tokio = { version = "1.18.2", features = ["full"] }
 
 aptos-logger = { path = "../../crates/aptos-logger" }

--- a/crates/transaction-emitter/src/diag.rs
+++ b/crates/transaction-emitter/src/diag.rs
@@ -11,7 +11,6 @@ use std::{
     cmp::min,
     time::{Duration, Instant},
 };
-use termion::color;
 use transaction_emitter_lib::{query_sequence_numbers, Cluster, TxnEmitter};
 
 pub async fn diag(cluster: &Cluster) -> Result<()> {
@@ -58,19 +57,13 @@ pub async fn diag(cluster: &Cluster) -> Result<()> {
                     format_err!("Failed to query sequence number from {}: {}", instance, e)
                 })?[0];
                 let host = instance.api_url().host().unwrap().to_string();
-                let color = if seq != faucet_account.sequence_number() {
+                let status = if seq != faucet_account.sequence_number() {
                     all_good = false;
-                    color::Fg(color::Red).to_string()
+                    "good"
                 } else {
-                    color::Fg(color::Green).to_string()
+                    "bad"
                 };
-                print!(
-                    "[{}{}:{}{}]  ",
-                    color,
-                    &host[..min(host.len(), 10)],
-                    seq,
-                    color::Fg(color::Reset)
-                );
+                print!("[{}:{}:{}]  ", &host[..min(host.len(), 10)], seq, status);
             }
             println!();
             if all_good {

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -14,7 +14,6 @@ chrono = "0.4.19"
 criterion = "0.3.5"
 indicatif = "0.15.0"
 itertools = "0.10.3"
-jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 num_cpus = "1.13.1"
 rand = "0.7.3"
 rayon = "1.5.2"
@@ -40,6 +39,9 @@ executor-types = { path = "../executor-types" }
 schemadb = { path = "../../storage/schemadb" }
 scratchpad = { path = "../../storage/scratchpad" }
 storage-interface = { path = "../../storage/storage-interface" }
+
+[target.'cfg(unix)'.dependencies]
+jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
 [dev-dependencies]
 aptos-temppath = { path = "../../crates/aptos-temppath" }

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -9,6 +9,7 @@ use aptos_vm::AptosVM;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
+#[cfg(unix)]
 #[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 


### PR DESCRIPTION
### Description
We're making the Aptos CLI for everyone, so not everyone has to access the CLI commands via
Linux!  This allows users to run all Aptos CLI commands in Windows.  Note, not all of them are
tested, but it seems a local testnet node runs fine locally on my windows computer.

This removes the colored terminal outputs used in consensus and transaction builder, as well
as puts jemalloc behind a flag for unix since it isn't supported on windows.

Additionally, the move packaging system seemed to put too much on the stack, and the whole program crashed, this just does a little hack for the move packaging to continue to build locally.

### Test Plan
This successfully allows me to run `aptos.exe` to run commands like `account list`, `init`, etc on a windows machine without issue.

```
PS Z:\git\aptos-core> .\target\debug\aptos.exe info
{
  "Result": {
    "build_branch": "windows-compatibility",
    "build_cargo_version": "cargo 1.63.0 (fd9c4297c 2022-07-01)",
    "build_commit_hash": "f1470b97fe06a303f1ebb19847c0cd4778b376b7",
    "build_os": "windows-x86_64",
    "build_pkg_version": "0.3.2",
    "build_rust_channel": "1.63.0-x86_64-pc-windows-msvc",
    "build_rust_version": "rustc 1.63.0 (4b91a6ea7 2022-08-08)",
    "build_tag": "",
    "build_time": "2022-09-01 16:44:42 -07:00"
  }
}


PS Z:\git\aptos-core> .\target\debug\aptos.exe account list
{                  
  "Result": [
    {
      "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>": {
        "coin": {
          "value": "10000"
        },
        "deposit_events": {
          "counter": "1",
          "guid": {
            "id": {
              "addr": "0xaa08c60792e84b2a5f20379d7d1c5e194b040dbe2992e1e444eb66fcbb464450",
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3751)
<!-- Reviewable:end -->
