### PR TITLE
Correct coin decimal datatype in your-coin.py Python example

### DIFF
--- a/ecosystem/python/sdk/examples/your-coin.py
+++ b/ecosystem/python/sdk/examples/your-coin.py
@@ -42,7 +42,7 @@ class CoinClient(RestClient):
             [
                 TransactionArgument("Moon Coin", Serializer.str),
                 TransactionArgument("MOON", Serializer.str),
-                TransactionArgument(6, Serializer.u64),
+                TransactionArgument(6, Serializer.u8),
                 TransactionArgument(False, Serializer.bool),
             ],
         )


### PR DESCRIPTION
### Description
At present, this example fails because the coin decimals are given as a u64 instead of a u8.

See https://github.com/aptos-labs/aptos-core/blob/49b2991b341e96060aa310c8090e4ee469817697/aptos-move/framework/aptos-framework/sources/managed_coin.move#L54-L60 for reference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3752)
<!-- Reviewable:end -->
