### PR TITLE
[crypto+move] add support for Keccak-256 hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3964,6 +3964,7 @@ dependencies = [
  "smallvec",
  "structopt 0.3.26",
  "tempfile",
+ "tiny-keccak",
 ]
 
 [[package]]

--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -71,6 +71,9 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     [.hash.sip_hash.base, "hash.sip_hash.base", 1],
     [.hash.sip_hash.per_byte, "hash.sip_hash.per_byte", 1],
 
+    [.hash.keccak256.base, "hash.keccak256.base", 1],
+    [.hash.keccak256.per_byte, "hash.keccak256.per_byte", 1],
+
     [.type_info.type_of.base, "type_info.type_of.base", 1],
     [.type_info.type_of.per_byte_in_str, "type_info.type_of.per_abstract_memory_unit", 1],
     [.type_info.type_name.base, "type_info.type_name.base", 1],

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -35,6 +35,7 @@ siphasher = "0.3.10"
 smallvec = "1.8.0"
 structopt = "0.3.21"
 tempfile = "3.3.0"
+tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 
 aptos-aggregator = { path = "../../aptos-move/aptos-aggregator" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -1,4 +1,11 @@
-/// Non-cryptographic hashes
+/// Cryptographic hashes:
+/// - Keccak-256: see https://keccak.team/keccak.html
+///
+/// In addition, SHA2-256 and SHA3-256 are available in `std::hash`. Note that SHA3-256 is a variant of Keccak: it is
+/// NOT the same as Keccak-256.
+///
+/// Non-cryptograhic hashes:
+/// - SipHash: an add-rotate-xor (ARX) based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012
 module aptos_std::aptos_hash {
     use std::bcs;
 
@@ -8,5 +15,39 @@ module aptos_std::aptos_hash {
         let bytes = bcs::to_bytes(v);
 
         sip_hash(bytes)
+    }
+
+    //
+    // Native functions
+    //
+
+    native public fun keccak256(bytes: vector<u8>): vector<u8>;
+
+    //
+    // Testing
+    //
+
+    #[test]
+    fun keccak256_test() {
+        let inputs = vector[
+            b"testing",
+            b"",
+        ];
+
+        let outputs = vector[
+            x"5f16f4c7f149ac4f9510d9cf8cf384038ad348b3bcdc01915f95de12df9d1b02",
+            x"c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+        ];
+
+        let i = 0;
+        while (i < std::vector::length(&inputs)) {
+            let input = *std::vector::borrow(&inputs, i);
+            let hash_expected = *std::vector::borrow(&outputs, i);
+            let hash = keccak256(input);
+
+            assert!(hash_expected == hash, 1);
+
+            i = i + 1;
+        };
     }
 }

--- a/aptos-move/framework/src/natives/hash.rs
+++ b/aptos-move/framework/src/natives/hash.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::natives::util::make_native_from_func;
 use move_deps::{
     move_binary_format::errors::PartialVMResult,
     move_core_types::gas_algebra::{InternalGas, InternalGasPerByte, NumBytes},
@@ -10,7 +11,8 @@ use move_deps::{
     },
 };
 use smallvec::smallvec;
-use std::{collections::VecDeque, hash::Hasher, sync::Arc};
+use std::{collections::VecDeque, hash::Hasher};
+use tiny_keccak::{Hasher as KeccakHasher, Keccak};
 
 /***************************************************************************************************
  * native fun sip_hash
@@ -24,7 +26,7 @@ pub struct SipHashGasParameters {
     pub per_byte: InternalGasPerByte,
 }
 
-/// Feed thes bytes into SipHasher. This is not cryptographically secure.
+/// Feed these bytes into SipHasher. This is not cryptographically secure.
 fn native_sip_hash(
     gas_params: &SipHashGasParameters,
     _context: &mut NativeContext,
@@ -46,8 +48,31 @@ fn native_sip_hash(
     Ok(NativeResult::ok(cost, smallvec![Value::u64(hash)]))
 }
 
-pub fn make_native_sip_hash(gas_params: SipHashGasParameters) -> NativeFunction {
-    Arc::new(move |context, ty_args, args| native_sip_hash(&gas_params, context, ty_args, args))
+#[derive(Debug, Clone)]
+pub struct Keccak256HashGasParameters {
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
+}
+
+fn native_keccak256(
+    gas_params: &Keccak256HashGasParameters,
+    _context: &mut NativeContext,
+    mut _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let bytes = pop_arg!(args, Vec<u8>);
+
+    let cost = gas_params.base + gas_params.per_byte * NumBytes::new(bytes.len() as u64);
+
+    let mut hasher = Keccak::v256();
+    hasher.update(&bytes);
+    let mut output = [0u8; 32];
+    hasher.finalize(&mut output);
+
+    Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(output)]))
 }
 
 /***************************************************************************************************
@@ -57,10 +82,20 @@ pub fn make_native_sip_hash(gas_params: SipHashGasParameters) -> NativeFunction 
 #[derive(Debug, Clone)]
 pub struct GasParameters {
     pub sip_hash: SipHashGasParameters,
+    pub keccak256: Keccak256HashGasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
-    let natives = [("sip_hash", make_native_sip_hash(gas_params.sip_hash))];
+    let natives = [
+        (
+            "sip_hash",
+            make_native_from_func(gas_params.sip_hash, native_sip_hash),
+        ),
+        (
+            "keccak256",
+            make_native_from_func(gas_params.keccak256, native_keccak256),
+        ),
+    ];
 
     crate::natives::helpers::make_module_natives(natives)
 }

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -115,6 +115,10 @@ impl GasParameters {
                     base: 0.into(),
                     per_byte: 0.into(),
                 },
+                keccak256: hash::Keccak256HashGasParameters {
+                    base: 0.into(),
+                    per_byte: 0.into(),
+                },
             },
             type_info: type_info::GasParameters {
                 type_of: type_info::TypeOfGasParameters {


### PR DESCRIPTION
### Description

Added Keccak-256 in exchange for a Mountain Dew Zero tomorrow from @davidiw.

### Test Plan

Tested the output on two hashes. Can always add more.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3755)
<!-- Reviewable:end -->
