### PR TITLE
Add CI to build aptos CLI for Windows

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   build-linux-binary:
     name: "Build Linux binary"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,6 +38,21 @@ jobs:
   build-os-x-binary:
     name: "Build OS X binary"
     runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh
+      - name: Upload Binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cli-builds
+          path: aptos-cli-*.zip
+
+  build-windows-binary:
+    name: "Build Windows binary"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### Description
Originally I was trying to build on ubuntu-latest with the windows toolchain to avoid writing another script for building the CLI, but I realized that's silly, this is simpler and more native to Windows.

This is only possible now because of https://github.com/aptos-labs/aptos-core/pull/3751.

### Test Plan
On a Windows machine:
```
todo
```

todo: test the CI itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3765)
<!-- Reviewable:end -->
