### PR TITLE
Add CI to build aptos CLI for Windows

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   build-linux-binary:
     name: "Build Linux binary"
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -50,11 +50,27 @@ jobs:
           name: cli-builds
           path: aptos-cli-*.zip
 
+  build-windows-binary:
+    name: "Build Windows binary"
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - name: Build CLI
+        run: scripts\cli\build_cli_release.ps1
+      - name: Upload Binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cli-builds
+          path: aptos-cli-*.zip
+
   release-binaries:
     name: "Release binaries"
     needs:
       - build-linux-binary
       - build-os-x-binary
+      - build-windows-latest
     runs-on: ubuntu-latest
     permissions:
       contents: "write"

--- a/scripts/cli/build_cli_release.ps1
+++ b/scripts/cli/build_cli_release.ps1
@@ -1,0 +1,25 @@
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+###########################################
+# Build and package a release for the CLI #
+###########################################
+
+# Note: This must be run from the root of the aptos-core repository.
+
+# Set up basic variables.
+$NAME="aptos-cli"
+$CRATE_NAME="aptos"
+$CARGO_PATH="crates\$CRATE_NAME\Cargo.toml"
+
+# Get the version of the CLI from its Cargo.toml.
+$VERSION = Get-Content $CARGO_PATH | Select-String -Pattern '^\w*version = "(\d*\.\d*.\d*)"' | % {"$($_.matches.groups[1])"}
+
+# Build the CLI.
+echo "Building release $VERSION of $NAME for Windows"
+cargo build -p $CRATE_NAME --profile cli
+
+# Compress the CLI.
+$ZIP_NAME="$NAME-$VERSION-Windows-x86_64.zip"
+Compress-Archive -Path targets\cli\$CRATE_NAME -DestinationPath $ZIP_NAME
+

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -4,7 +4,6 @@
 
 ###########################################
 # Build and package a release for the CLI #
-#                                         #
 ###########################################
 
 # Note: This must be run from the root of the aptos-core repository


### PR DESCRIPTION
### Description
Originally I was trying to build on ubuntu-latest with the windows toolchain to avoid writing another script for building the CLI, but I realized that's silly, this is simpler and more native to Windows.

This is only possible now because of https://github.com/aptos-labs/aptos-core/pull/3751.

### Test Plan
On a Windows machine:
```
# Including since I'm a powershell noob, this enables script execution:
Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser

# Execute the script
.\scripts\cli\build_cli_release.ps1
```

Testing the new workflow job from my fork of aptos-core: https://github.com/banool/aptos-core/runs/8160455440?check_suite_focus=true. I confirmed that it's using the correct toolchain: 1.63.0-x86_64-pc-windows-msvc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3767)
<!-- Reviewable:end -->
