### PR TITLE
[DONOTMERGE] Brian/debug futures versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4000,9 +4000,9 @@ checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4015,9 +4015,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4031,9 +4031,9 @@ checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -4063,9 +4063,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -4086,9 +4086,9 @@ checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -18,8 +18,8 @@ bytes = "1.1.0"
 fail = "0.5.0"
 # Previously: Pinning futures to 0.3.21, since release v0.3.23 is causing the network_tests to fail because messages are not received in the channel.
 # Now: Some futures crates were using 0.3.23 as well, which is not a good idea. 0.3.23 has a known issues, so moving to 0.3.24.
-futures = "= 0.3.24"
-futures-channel = "= 0.3.24"
+futures = "= 0.3.23"
+futures-channel = "= 0.3.23"
 itertools = { version = "0.10.3", default-features = false }
 mirai-annotations = { version = "1.12.0", default-features = false }
 num-derive = { version = "0.3.3", default-features = false }

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -102,10 +102,12 @@ impl NetworkSender {
 
         ensure!(from != self.author, "Retrieve block from self");
         let msg = ConsensusMsg::BlockRetrievalRequest(Box::new(retrieval_request.clone()));
+        eprintln!("BCHO DEBUG before send_rpc to {}", from);
         let response_msg = monitor!(
             "block_retrieval",
             self.network_sender.send_rpc(from, msg, timeout).await
         )?;
+        eprintln!("BCHO DEBUG after send_rpc");
         let response = match response_msg {
             ConsensusMsg::BlockRetrievalResponse(resp) => *resp,
             _ => return Err(anyhow!("Invalid response to request")),

--- a/network/src/peer_manager/senders.rs
+++ b/network/src/peer_manager/senders.rs
@@ -100,10 +100,12 @@ impl PeerManagerRequestSender {
             res_tx,
             timeout,
         };
+        eprintln!("BCHO before inner.push");
         self.inner.push(
             (peer_id, protocol_id),
             PeerManagerRequest::SendRpc(peer_id, request),
         )?;
+        eprintln!("BCHO before await");
         res_rx.await?
     }
 }


### PR DESCRIPTION
```
test network_tests::tests::test_rpc has been running for over 60 seconds
test network_tests::tests::test_rpc ... FAILED

failures:

---- network_tests::tests::test_rpc stdout ----
runtime.num_workers: 10
BCHO block retrieval next await from Receiver { shared_state: Mutex(Mutex { data: SharedState { internal_queue: PerKeyQueue { queue_style: LIFO, max_queue_size: 1, num_popped_since_gc: 0 }, waker: None, num_senders: 1, receiver_dropped: false, stream_terminated: false }, poisoned: false, .. }) }
BCHO DEBUG before send_rpc to 8f2f3c6e54f8875fe1aeffc20ab8bfcbd2c05b27888608607df037e9532b9a3c
BCHO before inner.push
BCHO before await
thread 'network_tests::tests::test_rpc' panicked at 'test timed out: Elapsed(())', consensus/src/test_utils/mod.rs:212:10
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
   2: core::result::unwrap_failed
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/result.rs:1805:5
   3: core::result::Result<T,E>::expect
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/result.rs:1055:23
   4: consensus::test_utils::timed_block_on
             at ./src/test_utils/mod.rs:210:5
   5: consensus::network_tests::tests::test_rpc
             at ./src/network_tests.rs:752:9
   6: consensus::network_tests::tests::test_rpc::{{closure}}
             at ./src/network_tests.rs:658:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
   8: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3770)
<!-- Reviewable:end -->
