### PR TITLE
[Network] Ensure mutual_authentication is enabled for all validators.

### DIFF
--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -325,6 +325,7 @@ impl NodeConfig {
         let mut network_ids = HashSet::new();
         if let Some(network) = &mut self.validator_network {
             network.load_validator_network()?;
+            network.mutual_authentication = true; // This should always be the default for validators
             network_ids.insert(network.network_id);
         }
         for network in &mut self.full_node_networks {

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -115,12 +115,13 @@ impl Default for NetworkConfig {
 
 impl NetworkConfig {
     pub fn network_with_id(network_id: NetworkId) -> NetworkConfig {
+        let mutual_authentication = network_id.is_validator_network();
         let mut config = Self {
             discovery_method: DiscoveryMethod::None,
             discovery_methods: Vec::new(),
             identity: Identity::None,
             listen_address: "/ip4/0.0.0.0/tcp/6180".parse().unwrap(),
-            mutual_authentication: false,
+            mutual_authentication,
             network_id,
             runtime_threads: None,
             seed_addrs: HashMap::new(),


### PR DESCRIPTION
### Description
This PR ensures that `mutual_authentication` is always enabled for validators on startup. If this isn't set, it's possible that `AntiReplayTimestamps` won't be enforced. I'm not sure if it's practically exploitable, but let's avoid the issue entirely and panic if a validator starts without `mutual_authentication`.

### Test Plan
Existing and new tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3782)
<!-- Reviewable:end -->
