### PR TITLE
[Consensus] Debug tokio loop using progress check timers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2616,6 +2616,7 @@ dependencies = [
  "termion",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "vm-validator",
 ]
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -31,6 +31,7 @@ serde_json = "1.0.81"
 termion = { version = "1.5.6", default-features = false }
 thiserror = "1.0.31"
 tokio = { version = "1.18.2", features = ["full"] }
+tokio-stream = "0.1.8"
 
 aptos-bitvec = { path = "../crates/aptos-bitvec" }
 aptos-config = { path = "../config" }

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -62,6 +62,15 @@ pub static COMMITTED_TXNS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Counts the total number of progress checks called
+pub static PROGRESS_CHECK_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_progress_check",
+        "Total number of progress checks in main loop"
+    )
+    .unwrap()
+});
+
 //////////////////////
 // PROPOSAL ELECTION
 //////////////////////

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -75,6 +75,8 @@ use std::{
     sync::Arc,
     time::Duration,
 };
+use tokio::time::interval;
+use tokio_stream::wrappers::IntervalStream;
 
 /// Range of rounds (window) that we might be calling proposer election
 /// functions with at any given time, in addition to the proposer history length.
@@ -820,6 +822,9 @@ impl EpochManager {
         mut round_timeout_sender_rx: channel::Receiver<Round>,
         mut network_receivers: NetworkReceivers,
     ) {
+        let mut progress_check_interval =
+            IntervalStream::new(interval(Duration::from_secs(1))).fuse();
+
         // initial start of the processor
         self.await_reconfig_notification().await;
         loop {
@@ -827,18 +832,23 @@ impl EpochManager {
                 "main_loop",
                 ::futures::select! {
                     (peer, msg) = network_receivers.consensus_messages.select_next_some() => {
-                        if let Err(e) = monitor!("process_message", self.process_message(peer, msg).await) {
+                        monitor!("process_message", if let Err(e) = self.process_message(peer, msg).await {
                             error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));
-                        }
+                        });
                     },
                     (peer, request) = network_receivers.block_retrieval.select_next_some() => {
-                        if let Err(e) = monitor!("send_block_retrieval", self.process_block_retrieval(peer, request).await) {
+                        monitor!("send_block_retrieval",
+                        if let Err(e) = self.process_block_retrieval(peer, request).await {
                             error!(epoch = self.epoch(), error = ?e, kind = error_kind(&e));
-                        }
+                        });
                     },
                     round = round_timeout_sender_rx.select_next_some() => {
                         monitor!("send_timeout", self.process_local_timeout(round));
                     },
+                    _ = progress_check_interval.select_next_some() => {
+                        debug!("We're in the progress check interval branch!");
+                        counters::PROGRESS_CHECK_COUNT.inc();
+                    }
                 }
             );
             // Continually capture the time of consensus process to ensure that clock skew between


### PR DESCRIPTION
### Description
This PR adds a simple interval stream to the problematic tokio::select loop. We can see if it ever get's hit at the grind.

### Test Plan
Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3792)
<!-- Reviewable:end -->
