### PR TITLE
[gha] run compat forge test alongside e2e

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -157,7 +157,30 @@ jobs:
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
-      FORGE_NAMESPACE: forge-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
+      FORGE_NAMESPACE: forge-e2e-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
+
+  # Run e2e compat test against testnet branch
+  forge-compat-test:
+    needs: [rust-images, rust-images-testing, rust-images-performance, determine-docker-build-metadata]
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+        (github.event_name == 'push' && github.ref_name != 'main') ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null ||
+        contains(github.event.pull_request.body, '#e2e')
+      )
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: compat
+      IMAGE_TAG: testnet
+      FORGE_RUNNER_DURATION_SECS: 300
+      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
+      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
+      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
+      FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   community-platform:
     needs: [permission-check]


### PR DESCRIPTION
### Description

Run forge-compat test alongside forge-e2e (performance) test. Both of these should be land-blocking. Few things should happen before this lands though:
* ~Fix or roll back the current backwards breaking change (move native function https://aptos-org.slack.com/archives/C03PKBQM2RY/p1662053271975889)~
* Add this new job as a check to the `main` branch protection rules

This should increase our cluster usage by ~17%, since compat test uses only 5 nodes.

### Test Plan

Run Forge with label to check things still work. It won't run compat test yet though

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3793)
<!-- Reviewable:end -->
