### PR TITLE
fix broken link

### DIFF
--- a/developer-docs-site/docs/guides/system-integrators-guide.md
+++ b/developer-docs-site/docs/guides/system-integrators-guide.md
@@ -169,7 +169,7 @@ See the following documentation for generating valid transactions:
 - [Python example of BCS encoded coin transfers](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/python/sdk/aptos_sdk/client.py#L240).
 - [Typescript example of BCS encoded coin transfers](https://github.com/aptos-labs/aptos-core/blob/9b85d41ed8ef4a61a9cd64f9de511654fcc02024/ecosystem/typescript/sdk/src/aptos_client.test.ts#L122).
 - [CLI-based transaction publishing](http://aptos.dev/cli-tools/aptos-cli-tool/use-aptos-cli#publishing-a-move-package-with-a-named-address).
-- [Publish your first Move module](https://aptos.dev/tutorials/your-first-move-module) via Typescript, Python, and Rust.
+- [Publish your first Move module](https://aptos.dev/tutorials/first-move-module) via Typescript, Python, and Rust.
 
 :::
 


### PR DESCRIPTION
on [this page](https://aptos.dev/guides/system-integrators-guide), clicking "Publish your first Move module" gives a 404 error

/your-first-move-module => /first-move-module

reported by egormajj on Discord

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3798)
<!-- Reviewable:end -->
