### PR TITLE
[NHC] Add state sync evaluator that leverages the API

### DIFF
--- a/ecosystem/node-checker/src/evaluators/build_evaluators.rs
+++ b/ecosystem/node-checker/src/evaluators/build_evaluators.rs
@@ -7,12 +7,13 @@ use crate::{
     evaluators::{
         direct::{
             ApiEvaluatorError, DirectEvaluatorInput, HandshakeEvaluator, LatencyEvaluator,
-            NoiseEvaluatorError, TpsEvaluator, TpsEvaluatorError, TransactionAvailabilityEvaluator,
+            NoiseEvaluatorError, StateSyncVersionEvaluator, TpsEvaluator, TpsEvaluatorError,
+            TransactionAvailabilityEvaluator,
         },
         metrics::{
             ConsensusProposalsEvaluator, ConsensusRoundEvaluator, ConsensusTimeoutsEvaluator,
             MetricsEvaluatorError, MetricsEvaluatorInput, NetworkMinimumPeersEvaluator,
-            NetworkPeersWithinToleranceEvaluator, StateSyncVersionEvaluator,
+            NetworkPeersWithinToleranceEvaluator, StateSyncVersionMetricsEvaluator,
         },
         system_information::{
             BuildVersionEvaluator, HardwareEvaluator, SystemInformationEvaluatorError,
@@ -182,6 +183,11 @@ pub fn build_evaluators(
         evaluator_args,
     )?;
     StateSyncVersionEvaluator::add_from_evaluator_args(
+        &mut evaluators,
+        &mut evaluator_identifiers,
+        evaluator_args,
+    )?;
+    StateSyncVersionMetricsEvaluator::add_from_evaluator_args(
         &mut evaluators,
         &mut evaluator_identifiers,
         evaluator_args,

--- a/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::{fmt::Display, time::Duration};
 use thiserror::Error as ThisError;
 
-use super::{super::DirectEvaluatorInput, get_index_response, API_CATEGORY};
+use super::{super::DirectEvaluatorInput, API_CATEGORY};
 
 /// This function hits the `/` endpoint of the API and returns the chain ID
 /// and role type, extracted from the IndexResponse.
@@ -23,7 +23,7 @@ pub async fn get_node_identity(
     node_address: &NodeAddress,
     timeout: Duration,
 ) -> Result<(ChainId, RoleType)> {
-    let index_response = get_index_response(node_address, timeout)
+    let index_response = node_address.get_index_response(timeout)
         .await
         .map_err(|e| format_err!("Failed to get response from index (/) of API. Make sure your API port ({}) is open: {}", node_address.api_port, e))?;
     Ok((

--- a/ecosystem/node-checker/src/evaluators/direct/api/state_sync.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/state_sync.rs
@@ -1,0 +1,176 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use super::super::DirectEvaluatorInput;
+use super::ApiEvaluatorError;
+use crate::{
+    configuration::EvaluatorArgs,
+    evaluator::{EvaluationResult, Evaluator},
+    evaluators::EvaluatorType,
+};
+use anyhow::Result;
+use clap::Parser;
+use poem_openapi::Object as PoemObject;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Clone, Debug, Deserialize, Parser, PoemObject, Serialize)]
+pub struct StateSyncVersionEvaluatorArgs {
+    #[clap(long, default_value_t = 10000)]
+    pub version_delta_tolerance: u64,
+
+    #[clap(long, default_value_t = 5)]
+    pub version_fetch_delay_secs: u64,
+
+    #[clap(long, default_value_t = 4)]
+    pub api_call_timeout_secs: u64,
+}
+
+#[derive(Debug)]
+pub struct StateSyncVersionEvaluator {
+    args: StateSyncVersionEvaluatorArgs,
+}
+
+impl StateSyncVersionEvaluator {
+    pub fn new(args: StateSyncVersionEvaluatorArgs) -> Self {
+        Self { args }
+    }
+
+    fn build_state_sync_version_evaluation(
+        &self,
+        previous_target_version: u64,
+        latest_target_version: u64,
+        latest_baseline_version: u64,
+    ) -> EvaluationResult {
+        // We convert to i64 to avoid potential overflow if somehow the ledger version went backwards.
+        let target_progress = latest_target_version as i64 - previous_target_version as i64;
+        match target_progress {
+            target_progress if (target_progress == 0) => self.build_evaluation_result(
+                "Ledger version is not increasing".to_string(),
+                25,
+                format!(
+                    "Successfully pulled ledger version from your node \
+                        twice, but the ledger version isnt't increasing ({} both times).",
+                    latest_target_version
+                ),
+            ),
+            target_progress if (target_progress < 0) => self.build_evaluation_result(
+                "Ledger version went backwards!".to_string(),
+                0,
+                format!(
+                    "Successfully pulled ledger version from your node twice, \
+                    but the second time the ledger version went backwards! \
+                    First datapoint: {}, second datapoint: {}",
+                    previous_target_version, latest_target_version
+                ),
+            ),
+            _wildcard => {
+                // We convert to i64 to avoid potential overflow if the target is ahead of the baseline.
+                let delta_from_baseline =
+                    latest_baseline_version as i64 - latest_target_version as i64;
+                if delta_from_baseline > self.args.version_delta_tolerance as i64 {
+                    self.build_evaluation_result(
+                        "Ledger version is lagging".to_string(),
+                        50,
+                        format!(
+                            "Successfully pulled ledger version from your node twice \
+                            and saw the version was increasing, but it is lagging {} versions \
+                            behind the baseline node, more than the allowed lag of {}. \
+                            Target version: {}. Baseline version: {}.",
+                            delta_from_baseline,
+                            self.args.version_delta_tolerance,
+                            latest_target_version,
+                            latest_baseline_version,
+                        ),
+                    )
+                } else {
+                    self.build_evaluation_result(
+                        "Ledger version is increasing".to_string(),
+                        100,
+                        format!(
+                            "NHC pulled ledger version from your node twice, \
+                            saw that the version is increasing (it increased by {} over \
+                            {} seconds), and saw that it is within tolerance of the the \
+                            baseline node. The baseline ledger version is {} and your node's \
+                            ledger version is {}, which is within the allowed lag of {} versions.",
+                            target_progress,
+                            self.args.version_fetch_delay_secs,
+                            latest_baseline_version,
+                            latest_target_version,
+                            self.args.version_delta_tolerance
+                        ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Evaluator for StateSyncVersionEvaluator {
+    type Input = DirectEvaluatorInput;
+    type Error = ApiEvaluatorError;
+
+    /// Assert that the ledger version is increasing on the target node
+    /// and that we're within tolerance of the baseline node's latest version.
+    async fn evaluate(&self, input: &Self::Input) -> Result<Vec<EvaluationResult>, Self::Error> {
+        let api_call_timeout = Duration::from_secs(self.args.api_call_timeout_secs);
+
+        // We already have one ledger version from the target.
+        let previous_target_version = input.target_index_response.ledger_version;
+
+        // Now wait.
+        tokio::time::sleep(Duration::from_secs(self.args.version_fetch_delay_secs)).await;
+
+        // Get the target ledger version again after the delay. If this fails,
+        // return an evaluation result indicating as such.
+        let latest_target_version = match input
+            .target_node_address
+            .get_index_response_or_evaluation_result(api_call_timeout)
+            .await
+        {
+            Ok(response) => response.ledger_version,
+            Err(evaluation_result) => return Ok(vec![evaluation_result]),
+        };
+
+        // Get the latest version from the baseline node. In this case, if we
+        // cannot find the value, we return an error instead of a negative evalution,
+        // since this implies some issue with the baseline node / this code.
+        let latest_baseline_version = match input
+            .baseline_node_information
+            .node_address
+            .get_index_response(api_call_timeout)
+            .await
+        {
+            Ok(response) => response.ledger_version,
+            Err(e) => {
+                return Err(ApiEvaluatorError::EndpointError("/".to_string(), e));
+            }
+        };
+
+        // Evaluate the data, returning an evaluation.
+        Ok(vec![self.build_state_sync_version_evaluation(
+            previous_target_version.0,
+            latest_target_version.0,
+            latest_baseline_version.0,
+        )])
+    }
+
+    fn get_category_name() -> String {
+        "state_sync".to_string()
+    }
+
+    fn get_evaluator_name() -> String {
+        "version".to_string()
+    }
+
+    fn from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<Self> {
+        Ok(Self::new(evaluator_args.state_sync_version_args.clone()))
+    }
+
+    fn evaluator_type_from_evaluator_args(evaluator_args: &EvaluatorArgs) -> Result<EvaluatorType> {
+        Ok(EvaluatorType::Api(Box::new(Self::from_evaluator_args(
+            evaluator_args,
+        )?)))
+    }
+}

--- a/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
@@ -143,7 +143,7 @@ impl Evaluator for TransactionAvailabilityEvaluator {
                                         "We were able to pull the same transaction (version: {}) \
                                     from both your node and the baseline node. Great! This \
                                     implies that your node is keeping up with other nodes \
-                                    in the network.",
+                                    in the network and returning valid transaction data.",
                                         latest_shared_version,
                                     ),
                                 )

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -6,10 +6,7 @@ use crate::{
     configuration::NodeAddress,
     evaluator::{EvaluationResult, EvaluationSummary, Evaluator},
     evaluators::{
-        direct::{
-            get_index_response, get_index_response_or_evaluation_result, DirectEvaluatorInput,
-            NodeIdentityEvaluator,
-        },
+        direct::{DirectEvaluatorInput, NodeIdentityEvaluator},
         metrics::{parse_metrics, MetricsEvaluatorInput},
         system_information::SystemInformationEvaluatorInput,
         EvaluatorSet, EvaluatorType,
@@ -212,26 +209,24 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
 
         let api_client_timeout = Duration::from_secs(self.args.api_client_timeout_secs);
 
-        let baseline_index_response = get_index_response(
-            &self.baseline_node_information.node_address,
-            api_client_timeout,
-        )
-        .await
-        .context(format!(
+        let baseline_index_response = self
+            .baseline_node_information
+            .node_address
+            .get_index_response(api_client_timeout)
+            .await
+            .context(format!(
             "Failed to read index response from baseline node. Make sure its API is open (port {})",
             self.baseline_node_information.node_address.api_port
         ))
-        .map_err(RunnerError::BaselineMissingDataError)?;
+            .map_err(RunnerError::BaselineMissingDataError)?;
 
-        let target_index_response =
-            match get_index_response_or_evaluation_result(target_node_address, api_client_timeout)
-                .await
-            {
-                Ok(response) => response,
-                Err(evaluation_result) => {
-                    return Ok(EvaluationSummary::from(vec![evaluation_result]))
-                }
-            };
+        let target_index_response = match target_node_address
+            .get_index_response_or_evaluation_result(api_client_timeout)
+            .await
+        {
+            Ok(response) => response,
+            Err(evaluation_result) => return Ok(EvaluationSummary::from(vec![evaluation_result])),
+        };
 
         let direct_evaluator_input = DirectEvaluatorInput {
             baseline_node_information: self.baseline_node_information.clone(),


### PR DESCRIPTION
### Description
This PR adds a version of the state sync evaluator that uses the API, vs the data from the metrics port.

I chose to keep the metrics based version of this evaluator, just in case there are setups where the metrics port is open but not the API port. Though I don't think it'll see as much use, so I rename it and steal its name for the new API based version. We can delete it later if we decide it's not useful.

### Test Plan
Generate appropriate config:
```
cargo run -p aptos-node-checker -- configuration create --configuration-name devnet_fullnode --configuration-name-pretty "Devnet Fullnode Checker" --url http://fullnode.devnet.aptoslabs.com --api-port 80 --evaluators api_latency api_transaction_availability state_sync_version --target-tps 1200 > ~/a/internal-ops/infra/apps/node-checker/configs/devnet_fullnode.yaml
```

Run local NHC:
```
cargo run -p aptos-node-checker -- server run --baseline-node-config-paths ~/a/internal-ops/infra/apps/node-checker/configs/devnet_fullnode.yaml --listen-address 0.0.0.0
```

Check a fullnode:
```
curl 'http://127.0.0.1:20121/check_node?node_url=http://fullnode.devnet.aptoslabs.com/&baseline_configuration_name=devnet_fullnode&metrics_port=9101&api_port=80&noise_port=6182&public_key=0x44fd1324c66371b4788af0b901c9eb8088781acb29e6b8b9c791d5d9838fbe1f' | jq .
```

Output:
```
{
  "evaluation_results": [
    {
      "headline": "Chain ID reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Chain ID 25 as is reported by the baseline node.",
      "evaluator_name": "node_identity",
      "category": "api",
      "links": []
    },
    {
      "headline": "Role Type reported by baseline and target match",
      "score": 100,
      "explanation": "The node under investigation reported the same Role Type full_node as is reported by the baseline node.",
      "evaluator_name": "node_identity",
      "category": "api",
      "links": []
    },
    {
      "headline": "Average API latency is good",
      "score": 100,
      "explanation": "The average API latency was 162ms, which is below the maximum allowed latency of 1000ms. Note, this latency is not the same as standard ping latency, see the attached link.",
      "evaluator_name": "latency",
      "category": "api",
      "links": [
        "https://aptos.dev/nodes/node-health-checker-faq#how-does-the-latency-evaluator-work"
      ]
    },
    {
      "headline": "Ledger version is increasing",
      "score": 100,
      "explanation": "NHC pulled ledger version from your node twice, saw that the version is increasing (it increased by 360 over 5 seconds), and saw that it is within tolerance of the the baseline node. The baseline ledger version is 45945651 and your node's ledger version is 45945645, which is within the allowed lag of 10000 versions.",
      "evaluator_name": "version",
      "category": "state_sync",
      "links": []
    },
    {
      "headline": "Target node produced valid recent transaction",
      "score": 100,
      "explanation": "We were able to pull the same transaction (version: 45945282) from both your node and the baseline node. Great! This implies that your node is keeping up with other nodes in the network and returning valid transaction data.",
      "evaluator_name": "transaction_availability",
      "category": "api",
      "links": []
    }
  ],
  "summary_score": 100,
  "summary_explanation": "100: Awesome!"
}
```

Output from web UI:
![image](https://user-images.githubusercontent.com/7816187/188234389-fc9d1534-3758-4857-a0df-84de1f5bdbb5.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3799)
<!-- Reviewable:end -->
