### PR TITLE
fix(ts-sdk): get rid of spread operator for Uint8Array

### DIFF
--- a/ecosystem/typescript/sdk/src/bytes_to_hex.ts
+++ b/ecosystem/typescript/sdk/src/bytes_to_hex.ts
@@ -4,7 +4,9 @@
  * @returns
  */
 export const bytesToHex = (buffer: Uint8Array): string =>
-  [...buffer].map((x) => x.toString(16).padStart(2, "0")).join("");
+  Array.from(buffer)
+    .map((x) => x.toString(16).padStart(2, "0"))
+    .join("");
 
 /**
  * Checks if a string is a valid string of hex characters.


### PR DESCRIPTION
### Description
The spread operator of Uint8Array doesn't work well with tsdx. This PR gets rid of the spread operator. Will replace tsdx in another PR.

### Test Plan
Make sure all tests pass
Packed a local package and make sure examples pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3806)
<!-- Reviewable:end -->
