### PR TITLE
[TS SDK] Simplify parseApiError, fix NFT test, add comment for retry behavior

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -458,6 +458,7 @@ export class AptosClient {
           break;
         }
       } catch (e) {
+        // In short, this means we will retry if it was an ApiError and the code was 404 or 5xx.
         const isApiError = e instanceof Gen.ApiError;
         const isRequestError = isApiError && e.status !== 404 && e.status >= 400 && e.status < 500;
         if (!isApiError || isRequestError) {
@@ -708,6 +709,9 @@ function parseApiError(target: unknown, propertyKey: string, descriptor: Propert
   // eslint-disable-next-line no-param-reassign
   descriptor.value = async function wrapper(...args: any[]) {
     try {
+      // We need to explicitly await here so that the function is called and
+      // potentially throws an error. If we just return without awaiting, the
+      // promise is returned directly and the catch block cannot trigger.
       const res = await childFunction.apply(this, [...args]);
       return res;
     } catch (e) {

--- a/ecosystem/typescript/sdk/src/token_client.test.ts
+++ b/ecosystem/typescript/sdk/src/token_client.test.ts
@@ -95,5 +95,5 @@ test(
     const bobBalance = await tokenClient.getTokenForAccount(bob.address().hex(), tokenId);
     expect(bobBalance.amount).toBe("1");
   },
-  30 * 1000,
+  60 * 1000,
 );


### PR DESCRIPTION
### Description
Just a few small changes.

### Test Plan
```
yarn test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3807)
<!-- Reviewable:end -->
