### PR TITLE
[cherry-pick] remote logs as log level warn

### DIFF
--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -225,7 +225,7 @@ impl AptosDataBuilder {
             enable_backtrace: false,
             level: Level::Info,
             remote_level: Level::Info,
-            telemetry_level: Level::Error,
+            telemetry_level: Level::Warn,
             address: None,
             printer: Some(Box::new(StdoutWriter::new())),
             remote_log_tx: None,


### PR DESCRIPTION
Cherry-pick logging level warn for remote logs into testnet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3812)
<!-- Reviewable:end -->
