### PR TITLE
[forge] cargo run with failpoints with local test runner

### DIFF
--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -178,6 +178,7 @@ def fake_context(
         filesystem=filesystem if filesystem else FakeFilesystem(),
         processes=processes if processes else FakeProcesses(),
         time=time if time else FakeTime(),
+        forge_enable_failpoints=False,
         forge_test_suite="banana",
         forge_runner_duration_secs="123",
         reuse_args=[],


### PR DESCRIPTION
### Description

To use failpoints with the local test runner against the k8s backend, we need to `cargo run --features failpoints`

### Test Plan

Run it and the command looks right

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3814)
<!-- Reviewable:end -->
