### PR TITLE
[API] Return 404 if given event stream doesn't exist on account

### DIFF
--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -332,6 +332,7 @@ impl Account {
                     &self.latest_ledger_info,
                 )
             })?;
+
         // Deserialization may fail because the bytes are not EventHandle struct type.
         let event_handle: EventHandle = bcs::from_bytes(&event_handle_bytes)
             .context(format!(
@@ -345,6 +346,7 @@ impl Account {
                     &self.latest_ledger_info,
                 )
             })?;
+
         Ok(*event_handle.key())
     }
 

--- a/api/types/src/error.rs
+++ b/api/types/src/error.rs
@@ -80,6 +80,12 @@ pub enum AptosErrorCode {
     /// Usually means the block is fully or partially pruned or the height / version is ahead
     /// of the latest version
     BlockNotFound = 108,
+    /// Event stream not found at the requested version
+    ///
+    /// This implies either that the event stream exists, but not within the
+    /// requested ledger version range, or that the event stream does not exist
+    /// at all.
+    EventStreamNotFound = 109,
 
     /// Ledger version is pruned
     VersionPruned = 200,

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -41,6 +41,7 @@ pub enum ApiError {
     TransactionNotFound(Option<String>),
     TableItemNotFound(Option<String>),
     BlockNotFound(Option<String>),
+    EventStreamNotFound(Option<String>),
     VersionPruned(Option<String>),
     BlockPruned(Option<String>),
     InvalidInput(Option<String>),
@@ -87,6 +88,7 @@ impl ApiError {
             TransactionNotFound(None),
             TableItemNotFound(None),
             BlockNotFound(None),
+            EventStreamNotFound(None),
             VersionPruned(None),
             BlockPruned(None),
             InvalidInput(None),
@@ -125,6 +127,7 @@ impl ApiError {
             TransactionNotFound(_) => 23,
             TableItemNotFound(_) => 24,
             BlockNotFound(_) => 25,
+            EventStreamNotFound(_) => 33,
             VersionPruned(_) => 26,
             BlockPruned(_) => 27,
             InvalidInput(_) => 28,
@@ -139,7 +142,11 @@ impl ApiError {
         use ApiError::*;
         matches!(
             self,
-            AccountNotFound(_) | BlockNotFound(_) | MempoolIsFull(_) | GasEstimationFailed(_)
+            AccountNotFound(_)
+                | BlockNotFound(_)
+                | EventStreamNotFound(_)
+                | MempoolIsFull(_)
+                | GasEstimationFailed(_)
         )
     }
 
@@ -167,6 +174,7 @@ impl ApiError {
             ApiError::UnsupportedSignatureCount(_) => "Number of signatures is not supported",
             ApiError::NodeIsOffline => "This API is unavailable for the node because he's offline",
             ApiError::BlockNotFound(_) => "Block is missing events",
+            ApiError::EventStreamNotFound(_) => "Event stream could not be found",
             ApiError::TransactionParseError(_) => "Transaction failed to parse",
             ApiError::InternalError(_) => "Internal error",
             ApiError::ResourceNotFound(_) => "Resource not found",
@@ -203,6 +211,7 @@ impl ApiError {
             ApiError::TransactionNotFound(inner) => inner,
             ApiError::TableItemNotFound(inner) => inner,
             ApiError::BlockNotFound(inner) => inner,
+            ApiError::EventStreamNotFound(inner) => inner,
             ApiError::VersionPruned(inner) => inner,
             ApiError::BlockPruned(inner) => inner,
             ApiError::InvalidInput(inner) => inner,
@@ -264,6 +273,9 @@ impl From<RestError> for ApiError {
                     ApiError::TableItemNotFound(Some(err.error.message))
                 }
                 AptosErrorCode::BlockNotFound => ApiError::BlockNotFound(Some(err.error.message)),
+                AptosErrorCode::EventStreamNotFound => {
+                    ApiError::EventStreamNotFound(Some(err.error.message))
+                }
                 AptosErrorCode::VersionPruned => ApiError::VersionPruned(Some(err.error.message)),
                 AptosErrorCode::BlockPruned => ApiError::BlockPruned(Some(err.error.message)),
                 AptosErrorCode::InvalidInput => ApiError::InvalidInput(Some(err.error.message)),


### PR DESCRIPTION
### Description
If the event stream exists, but there are no events in it, it should return a 200 with `[]` as the response. If the event stream doesn't exist, it should return a 404. This PR makes that change. Previously it returned 200 in both of these cases.

I still need to check with the storage folks about this PR, I'm not confident that the check is targeted enough, I don't want to accidentally throw errors unintentionally, we should only be throwing errors if the event stream (as keyed by creation number) doesn't exist in the given ledger version range.

I'm not 100% sure whether this should be considered retriable for Rosetta either.

I'm also not 100% sure if with this change, a 200 with an empty list is even possible anymore. As in, I'm not sure if an empty stream is possible. To-be-investigated.

### Test Plan
Run local testnet:
```
cargo run -p aptos -- node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
```

Request an event by key that doesn't exist:
```
$ curl http://127.0.0.1:8080/v1/events/0x90000000000000050000000000000000000000000000000000000000000000000000000000000001
{"message":"Failed to find events by key 0x90000000000000050000000000000000000000000000000000000000000000000000000000000001, there is no event stream with the given creation number in the DB","error_code":"event_stream_not_found","vm_error_code":null}
```

Request an event by key that _does_ exist (I ran the TS SDK tests to "seed" the blockchain with events):
```
# Get a random event key
$ curl http://127.0.0.1:8080/v1/transactions?limit=1000  | jq -r .[].events[0].key | grep -v null | grep -v '0000000000000000000000000000000000000000000000000000000' | head -n 1
0x00000000000000009f7a0496f7e68eb556cb56f9b731da7051a23dc89e61d63d3c28fe9768bab5c3

# Get the event 
curl http://127.0.0.1:8080/v1/events/0x00000000000000009f7a0496f7e68eb556cb56f9b731da7051a23dc89e61d63d3c28fe9768bab5c3
[
  {
    "version": "947",
    "key": "0x00000000000000009f7a0496f7e68eb556cb56f9b731da7051a23dc89e61d63d3c28fe9768bab5c3",
    "sequence_number": "0",
    "type": "0x1::account::CoinRegisterEvent",
    "data": {
      "type_info": {
        "account_address": "0x1",
        "module_name": "0x6170746f735f636f696e",
        "struct_name": "0x4170746f73436f696e"
      }
    }
  }
]
```

API tests (from `api/`):
```
cargo test
```
**Note**: Some tests are failing right now, I won't fix them until we figure out the exact semantics we want. I figure these tests _should_ be failing, because they expect success even though they're querying (as far as I can tell) an event stream that doesn't exist. At the least, there are no tests that test the case where there _are_ events. We should add tests that add events and ensure we can actually retrieve them.

TS SDK tests (from `ecosystem/typescript/sdk`):
```
yarn test
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3815)
<!-- Reviewable:end -->
