### PR TITLE
[gas] allow gas parameters to be optional

### DIFF
--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -71,8 +71,8 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     [.hash.sip_hash.base, "hash.sip_hash.base", 1],
     [.hash.sip_hash.per_byte, "hash.sip_hash.per_byte", 1],
 
-    [.hash.keccak256.base, "hash.keccak256.base", 1],
-    [.hash.keccak256.per_byte, "hash.keccak256.per_byte", 1],
+    [.hash.keccak256.base, optional "hash.keccak256.base", 1],
+    [.hash.keccak256.per_byte, optional "hash.keccak256.per_byte", 1],
 
     [.type_info.type_of.base, "type_info.type_of.base", 1],
     [.type_info.type_of.per_byte_in_str, "type_info.type_of.per_abstract_memory_unit", 1],


### PR DESCRIPTION
This allows one to designate gas parameters as being optional in the gas macros by putting the `optional` keyword before the key for the on-chain entry. Such parameters will default to 0 if their corresponding entry cannot be found on-chain.

Also fixes the issue introduced by https://github.com/aptos-labs/aptos-core/pull/3755 so it doesn't need to be reverted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3816)
<!-- Reviewable:end -->
