### PR TITLE
[community] Only send email notifications if email confirmed.

### DIFF
--- a/ecosystem/platform/server/test/notifications/governance_proposal_notification_test.rb
+++ b/ecosystem/platform/server/test/notifications/governance_proposal_notification_test.rb
@@ -34,6 +34,20 @@ class GovernanceProposalNotificationTest < ActiveSupport::TestCase
     end
   end
 
+  test 'is not delivered by email if preference is true but user does not have a confirmed email' do
+    user = FactoryBot.create(:user, email: nil, unconfirmed_email: Faker::Internet.email)
+    NotificationPreference.create(user:, delivery_method: :database, governance_proposal_notification: true)
+    NotificationPreference.create(user:, delivery_method: :email, governance_proposal_notification: true)
+    network_operation = NetworkOperation.create(title: 'foo', content: 'bar')
+    notification = GovernanceProposalNotification.with(network_operation:)
+
+    assert_difference('Notification.count') do
+      assert_emails 0 do
+        notification.deliver(user)
+      end
+    end
+  end
+
   test 'is not delivered if preference is false' do
     user = FactoryBot.create(:user)
     NotificationPreference.create(user:, delivery_method: :database, governance_proposal_notification: false)


### PR DESCRIPTION
### Description

Fixes this error:

```
Error:
GovernanceProposalNotificationTest#test_is_not_delivered_by_email_if_preference_is_true_but_user_does_not_have_a_confirmed_email:
ArgumentError: SMTP To address may not be blank: []
    app/jobs/application_job.rb:19:in `block (2 levels) in <class:ApplicationJob>'
    app/jobs/application_job.rb:14:in `block in <class:ApplicationJob>'
    test/notifications/governance_proposal_notification_test.rb:46:in `block (3 levels) in <class:GovernanceProposalNotificationTest>'
    test/notifications/governance_proposal_notification_test.rb:45:in `block (2 levels) in <class:GovernanceProposalNotificationTest>'
    test/notifications/governance_proposal_notification_test.rb:44:in `block in <class:GovernanceProposalNotificationTest>'
```

### Test Plan
I wrote automated tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3823)
<!-- Reviewable:end -->
