### PR TITLE
Log build + feature information at startup in aptos node

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 
+mod log_build_information;
+
 use anyhow::anyhow;
 use aptos_api::bootstrap as bootstrap_api;
 use aptos_build_info::build_information;
@@ -40,6 +42,7 @@ use executor::{chunk_executor::ChunkExecutor, db_bootstrapper::maybe_bootstrap};
 use framework::ReleaseBundle;
 use futures::channel::mpsc;
 use hex::FromHex;
+use log_build_information::log_build_information;
 use mempool_notifications::MempoolNotificationSender;
 use network::application::storage::PeerMetadataStorage;
 use network_builder::builder::NetworkBuilder;
@@ -196,6 +199,9 @@ pub fn start(config: NodeConfig, log_file: Option<PathBuf>) -> anyhow::Result<()
         remote_log_rx = Some(rx);
     }
     let _logger = logger.build();
+
+    // Print out build information.
+    log_build_information();
 
     // Let's now log some important information, since the logger is set up
     info!(config = config, "Loaded AptosNode config");

--- a/aptos-node/src/log_build_information.rs
+++ b/aptos-node/src/log_build_information.rs
@@ -1,0 +1,28 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_build_info::build_information;
+use aptos_logger::info;
+
+macro_rules! log_feature_info {
+    ($($feature:literal),*) => {
+        $(
+        if cfg!(feature = $feature) {
+            info!("Running with {} feature enabled", $feature);
+        } else {
+            info!("Running with {} feature disabled", $feature);
+        }
+        )*
+    }
+}
+
+// Naturally this should only be called after a logger has been set up.
+pub fn log_build_information() {
+    info!("Build information:");
+    let build_info = build_information!();
+    for (key, value) in build_info {
+        info!("{}: {}", key, value);
+    }
+    info!("Feature information:");
+    log_feature_info!("failpoints", "assert-private-keys-not-cloneable");
+}


### PR DESCRIPTION
### Description
This should make it easier to know what we're running. The telemetry crate debug logs the build information as it sends it already, but printing it at startup at info level ensures we get it when debug logs are disabled. The feature information previously wasn't logged anywhere.

### Test Plan
Without a feature enabled:
```
cargo run -p aptos-node -- --test
```
```
2022-09-03T18:26:33.890264Z [main] INFO aptos-node/src/print_build_information.rs:21 Build information:
2022-09-03T18:26:33.890493Z [main] INFO aptos-node/src/print_build_information.rs:24 build_branch:
2022-09-03T18:26:33.890509Z [main] INFO aptos-node/src/print_build_information.rs:24 build_cargo_version: cargo 1.63.0 (fd9c4297c 2022-07-01)
2022-09-03T18:26:33.890609Z [main] INFO aptos-node/src/print_build_information.rs:24 build_commit_hash: 7cc52b419a766cfa568df63c4ea0469d180435b0
2022-09-03T18:26:33.890619Z [main] INFO aptos-node/src/print_build_information.rs:24 build_os: macos-aarch64
2022-09-03T18:26:33.890628Z [main] INFO aptos-node/src/print_build_information.rs:24 build_pkg_version: 0.1.0
2022-09-03T18:26:33.890646Z [main] INFO aptos-node/src/print_build_information.rs:24 build_rust_channel: 1.63.0-aarch64-apple-darwin
2022-09-03T18:26:33.890669Z [main] INFO aptos-node/src/print_build_information.rs:24 build_rust_version: rustc 1.63.0 (4b91a6ea7 2022-08-08)
2022-09-03T18:26:33.890682Z [main] INFO aptos-node/src/print_build_information.rs:24 build_tag:
2022-09-03T18:26:33.890695Z [main] INFO aptos-node/src/print_build_information.rs:24 build_time: 2022-09-02 16:53:45 -07:00
2022-09-03T18:26:33.890710Z [main] INFO aptos-node/src/print_build_information.rs:26 Feature information:
2022-09-03T18:26:33.890717Z [main] INFO aptos-node/src/print_build_information.rs:27 Running with failpoints feature disabled
2022-09-03T18:26:33.890725Z [main] INFO aptos-node/src/print_build_information.rs:27 Running with assert-private-keys-not-cloneable feature disabled
```

With a feature enabled:
```
cargo run -p aptos-node --features failpoints -- --test
```
```
2022-09-03T18:29:51.485454Z [main] INFO aptos-node/src/print_build_information.rs:27 Running with failpoints feature enabled
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3830)
<!-- Reviewable:end -->
