### PR TITLE
Ensure .cargo is included in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@
 !docker/build-rust-all.sh
 !docker/tools/boto.cfg
 
+!.cargo/
 !**/Cargo.toml
 !**/Cargo.lock
 !**/*.mv

--- a/docker/build-rust-all.sh
+++ b/docker/build-rust-all.sh
@@ -7,7 +7,7 @@ PROFILE=${PROFILE:-release}
 FEATURES=${FEATURES:-""}
 
 # Build all the rust binaries
-RUSTFLAGS="--cfg tokio_unstable" cargo build --profile=$PROFILE \
+cargo build --profile=$PROFILE \
         -p aptos \
         -p aptos-faucet \
         -p aptos-indexer \


### PR DESCRIPTION
### Description
This just ensures that the build flags we set there are included in the Docker build. This means we don't need to set `RUSTFLAGS` explicitly like we were doing.

### Test Plan
CI, it'll fail if the tokio unstable cfg flag isn't included, so we'll know if it's working that way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3831)
<!-- Reviewable:end -->
