### PR TITLE
Include additional build info: release vs debug, tokio unstable usage, build profile

### DIFF
--- a/crates/aptos-build-info/build.rs
+++ b/crates/aptos-build-info/build.rs
@@ -2,5 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() -> shadow_rs::SdResult<()> {
+    // CARGO_CFG env vars don't make it to the program at runtime, so we
+    // propagate it here by adding a new env var via this cargo directive.
+    println!(
+        "cargo:rustc-env=USING_TOKIO_UNSTABLE={}",
+        std::env::var("CARGO_CFG_TOKIO_UNSTABLE").is_ok()
+    );
     shadow_rs::new()
 }

--- a/crates/aptos-build-info/src/lib.rs
+++ b/crates/aptos-build-info/src/lib.rs
@@ -3,7 +3,7 @@
 
 use std::collections::BTreeMap;
 
-use shadow_rs::shadow;
+use shadow_rs::{is_release, shadow};
 
 /// Build information keys
 pub const BUILD_BRANCH: &str = "build_branch";
@@ -15,6 +15,9 @@ pub const BUILD_OS: &str = "build_os";
 pub const BUILD_PKG_VERSION: &str = "build_pkg_version";
 pub const BUILD_RUST_CHANNEL: &str = "build_rust_channel";
 pub const BUILD_RUST_VERSION: &str = "build_rust_version";
+pub const BUILD_IS_RELEASE_BUILD: &str = "build_is_release_build";
+pub const BUILD_PROFILE_NAME: &str = "build_profile_name";
+pub const BUILD_USING_TOKIO_UNSTABLE: &str = "build_using_tokio_unstable";
 
 /// This macro returns the build information as visible during build-time.
 /// Use of this macro is recommended over the `get_build_information`
@@ -32,6 +35,22 @@ macro_rules! build_information {
 
         build_information
     }};
+}
+
+/// The only known way to get the build profile name is to look at the path
+/// in the OUT_DIR env var: https://stackoverflow.com/a/73603419/3846032.
+/// This env var is set during compilation, hence the use of `std::env!`.
+///
+/// WARNING: This does not return the expected value for the `dev`, `test`,
+/// and `bench` profiles. See the SO link above for more details.
+fn get_build_profile_name() -> String {
+    // The profile name is always the 3rd last part of the path (with 1 based indexing).
+    // e.g. /code/core/target/debug/build/aptos-build-info-9f91ba6f99d7a061/out
+    std::env!("OUT_DIR")
+        .split(std::path::MAIN_SEPARATOR)
+        .nth_back(3)
+        .unwrap_or("unknown")
+        .to_string()
 }
 
 /// This method returns the build information as visible during build-time.
@@ -53,6 +72,14 @@ pub fn get_build_information() -> BTreeMap<String, String> {
     build_information.insert(BUILD_OS.into(), build::BUILD_OS.into());
     build_information.insert(BUILD_RUST_CHANNEL.into(), build::RUST_CHANNEL.into());
     build_information.insert(BUILD_RUST_VERSION.into(), build::RUST_VERSION.into());
+
+    // Compilation information
+    build_information.insert(BUILD_IS_RELEASE_BUILD.into(), is_release().to_string());
+    build_information.insert(BUILD_PROFILE_NAME.into(), get_build_profile_name());
+    build_information.insert(
+        BUILD_USING_TOKIO_UNSTABLE.into(),
+        std::env!("USING_TOKIO_UNSTABLE").to_string(),
+    );
 
     // Get Git metadata from environment variables set during build-time.
     // This is applicable for docker based builds  where the cargo cannot


### PR DESCRIPTION
### Description
The shadow rs docs misleadingly imply that `BUILD_RUST_CHANNEL` has this information, but in reality it's the Rust channel (like the name implies). This PR adds a key to the build info showing whether the build is a release or debug build.

### Test Plan
```
cargo run -p aptos-node --features failpoints -- --test
```
```
cat /private/var/folders/w_/0mh2yzrs5fx2hknmdqxpz40w0000gn/T/514ea5cfb3783e98e7eea9cef2c3af26/validator.log | grep -o -E 'is_release_build": "false"'
is_release_build": "false"
```

```
cargo run -p aptos-node --release --features failpoints -- --test
```
```
cat /private/var/folders/w_/0mh2yzrs5fx2hknmdqxpz40w0000gn/T/514ea5cfb3783e98e7eea9cef2c3af26/validator.log | grep -o -E 'is_release_build": "true"'
is_release_build": "true"
```

### Testing the profile name determination
```
$ cargo run -p aptos-node --features failpoints -- --test
...
    "build_profile_name": "debug",
```
```
$ cargo run -p aptos-node --features failpoints --profile cli -- --test
...
    "build_profile_name": "cli",
```
```
$ cargo run -p aptos-node --features failpoints --profile performance -- --test
...
    "build_profile_name": "performance",
```
```
$ cargo run -p aptos-node --features failpoints --profile release -- --test
...
    "build_profile_name": "release",
```

Note: As you can see below, this method does not work specifically for the `dev`, `test`, and `bench` pre-included build profiles:
```
$ cargo run -p aptos-node --features bench --profile bench -- --test
...
    "build_profile_name": "release",
```
The reason is this, [described here](https://doc.rust-lang.org/cargo/guide/build-cache.html):

> For historical reasons, the dev and test profiles are stored in the debug directory, and the release and bench profiles are stored in the release directory. User-defined profiles are stored in a directory with the same name as the profile.

Read more about this in my [SO question + answer](https://stackoverflow.com/questions/73595435/how-to-get-profile-from-cargo-toml-in-build-rs-or-at-runtime/73603419#73603419).

I opened a couple of issues in the cargo repo related to this:
- https://github.com/rust-lang/cargo/issues/11053
- https://github.com/rust-lang/cargo/issues/11054

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3832)
<!-- Reviewable:end -->
