### PR TITLE
cicd: do not default IMAGE_TAG to GIT_SHA on the workflow level

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -61,7 +61,7 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_REGION: us-west-2
-  IMAGE_TAG: ${{ inputs.IMAGE_TAG || inputs.GIT_SHA }}
+  IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
   FORGE_ENABLED: ${{ secrets.FORGE_ENABLED }}
   FORGE_BLOCKING: ${{ secrets.FORGE_BLOCKING }}
   FORGE_CLUSTER_NAME: ${{ inputs.FORGE_CLUSTER_NAME }}


### PR DESCRIPTION
### Description

We shouldn't default IMAGE_TAG to GIT_SHA on the workflow level. Rather this defaulting logic is already implemented more or less in forge.py itself.  The current defaulting to GIT_SHA is responsible for the issue discussed here https://aptos-org.slack.com/archives/C03EP0XM99D/p1662257852595839?thread_ts=1662238231.302019&cid=C03EP0XM99D which makes the forge.py script think the user set explicitly an image_tag which isn't actually the case.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3846)
<!-- Reviewable:end -->
