### PR TITLE
✨ add individual labels to fullnode/validator `sts/svc/pod`

### DIFF
--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -8,9 +8,11 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
+    {{- .service.labels | nindent 4 }}
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
+    {{- .pod.labels | nindent 4 }}
     app.kubernetes.io/name: fullnode
     app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
@@ -30,6 +32,7 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}-e{{ $.Values.chain.era }}
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
+    {{- .statefulset.labels | nindent 4 }}
     app.kubernetes.io/name: fullnode
     app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
@@ -40,6 +43,7 @@ spec:
   selector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
+      {{- .pod.labels | nindent 6 }}
       app.kubernetes.io/name: fullnode
       app.kubernetes.io/instance: fullnode-{{$i}}
       group: {{ .name }}
@@ -57,6 +61,7 @@ spec:
     metadata:
       labels:
         {{- include "aptos-validator.selectorLabels" $ | nindent 8 }}
+        {{- .pod.labels | nindent 8 }}
         app.kubernetes.io/name: fullnode
         app.kubernetes.io/instance: fullnode-{{$i}}
         group: {{ .name }}

--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -8,11 +8,12 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    {{- .service.labels | nindent 4 }}
+    {{- with $.Values.fullnode.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
-    {{- .pod.labels | nindent 4 }}
     app.kubernetes.io/name: fullnode
     app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
@@ -32,7 +33,12 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-{{ .name }}-e{{ $.Values.chain.era }}
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    {{- .statefulset.labels | nindent 4 }}
+    {{- with $.Values.fullnode.statefulset.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $.Values.fullnode.pod.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/name: fullnode
     app.kubernetes.io/instance: fullnode-{{$i}}
     group: {{ .name }}
@@ -43,7 +49,9 @@ spec:
   selector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
-      {{- .pod.labels | nindent 6 }}
+      {{- with $.Values.fullnode.pod.labels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       app.kubernetes.io/name: fullnode
       app.kubernetes.io/instance: fullnode-{{$i}}
       group: {{ .name }}
@@ -61,7 +69,9 @@ spec:
     metadata:
       labels:
         {{- include "aptos-validator.selectorLabels" $ | nindent 8 }}
-        {{- .pod.labels | nindent 8 }}
+        {{- with $.Values.fullnode.pod.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/name: fullnode
         app.kubernetes.io/instance: fullnode-{{$i}}
         group: {{ .name }}

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -6,9 +6,11 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
+    {{- .service.labels | nindent 4 }}
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
+    {{- .pod.labels | nindent 4 }}
     app.kubernetes.io/name: validator
     app.kubernetes.io/instance: validator-{{$i}}
   ports:
@@ -47,6 +49,7 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
+    {{- .statefulset.labels | nindent 4 }}
     app.kubernetes.io/name: validator
     app.kubernetes.io/instance: validator-{{$i}}
 spec:
@@ -56,12 +59,14 @@ spec:
   selector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
+      {{- .pod.labels | nindent 6 }}
       app.kubernetes.io/name: validator
       app.kubernetes.io/instance: validator-{{$i}}
   template:
     metadata:
       labels:
         {{- include "aptos-validator.selectorLabels" $ | nindent 8 }}
+        {{- .pod.labels | nindent 8 }}
         app.kubernetes.io/name: validator
         app.kubernetes.io/instance: validator-{{$i}}
       annotations:

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -6,11 +6,15 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    {{- .service.labels | nindent 4 }}
+    {{- with $.Values.validator.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     {{- include "aptos-validator.selectorLabels" $ | nindent 4 }}
-    {{- .pod.labels | nindent 4 }}
+    {{- with $.Values.validator.pod.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/name: validator
     app.kubernetes.io/instance: validator-{{$i}}
   ports:
@@ -49,7 +53,12 @@ metadata:
   name: {{ include "aptos-validator.fullname" $ }}-{{$i}}-validator
   labels:
     {{- include "aptos-validator.labels" $ | nindent 4 }}
-    {{- .statefulset.labels | nindent 4 }}
+    {{- with $.Values.validator.statefulset.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with $.Values.validator.pod.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/name: validator
     app.kubernetes.io/instance: validator-{{$i}}
 spec:
@@ -59,14 +68,18 @@ spec:
   selector:
     matchLabels:
       {{- include "aptos-validator.selectorLabels" $ | nindent 6 }}
-      {{- .pod.labels | nindent 6 }}
+      {{- with $.Values.validator.pod.labels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       app.kubernetes.io/name: validator
       app.kubernetes.io/instance: validator-{{$i}}
   template:
     metadata:
       labels:
         {{- include "aptos-validator.selectorLabels" $ | nindent 8 }}
-        {{- .pod.labels | nindent 8 }}
+        {{- with $.Values.validator.pod.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         app.kubernetes.io/name: validator
         app.kubernetes.io/instance: validator-{{$i}}
       annotations:

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -109,13 +109,10 @@ validator:
   # -- Lock down network ingress and egress with Kubernetes NetworkPolicy
   enableNetworkPolicy: true
   statefulset:
-    # To do: validator statefulset related property should be pulled here
     labels: {}
   service:
-    # To do: validator service related property should be pulled here
     labels: {}
   pod:
-    # To do: validator pod related property should be pulled here
     labels: {}
 
 fullnode:
@@ -177,13 +174,10 @@ fullnode:
     validator_network: {}
     failpoints: {}
   statefulset:
-    # -- To do: fullnode statefulset related property should be pulled here
     labels: {}
   service:
-    # -- To do: fullnode service related property should be pulled here
     labels: {}
   pod:
-    # To do: fullnode pod related property should be pulled here
     labels: {}
 
 service:

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -109,13 +109,13 @@ validator:
   # -- Lock down network ingress and egress with Kubernetes NetworkPolicy
   enableNetworkPolicy: true
   statefulset:
-    # To do: statefulset related property should be pulled here
+    # To do: validator statefulset related property should be pulled here
     labels: {}
   service:
-    # To do: service related property should be pulled here
+    # To do: validator service related property should be pulled here
     labels: {}
   pod:
-    # To do: pod related property should be pulled here
+    # To do: validator pod related property should be pulled here
     labels: {}
 
 fullnode:
@@ -177,13 +177,13 @@ fullnode:
     validator_network: {}
     failpoints: {}
   statefulset:
-    # -- To do: statefulset related property should be pulled here
+    # -- To do: fullnode statefulset related property should be pulled here
     labels: {}
   service:
-    # -- To do: service related property should be pulled here
+    # -- To do: fullnode service related property should be pulled here
     labels: {}
   pod:
-    # To do: pod related property should be pulled here
+    # To do: fullnode pod related property should be pulled here
     labels: {}
 
 service:

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -108,6 +108,15 @@ validator:
     failpoints: {}
   # -- Lock down network ingress and egress with Kubernetes NetworkPolicy
   enableNetworkPolicy: true
+  statefulset:
+    # To do: statefulset related property should be pulled here
+    labels: {}
+  service:
+    # To do: service related property should be pulled here
+    labels: {}
+  pod:
+    # To do: pod related property should be pulled here
+    labels: {}
 
 fullnode:
   # -- Specify fullnode groups by `name` and number of `replicas`
@@ -167,6 +176,15 @@ fullnode:
     test: {}
     validator_network: {}
     failpoints: {}
+  statefulset:
+    # -- To do: statefulset related property should be pulled here
+    labels: {}
+  service:
+    # -- To do: service related property should be pulled here
+    labels: {}
+  pod:
+    # To do: pod related property should be pulled here
+    labels: {}
 
 service:
   # -- If set, the base domain name to use for External DNS


### PR DESCRIPTION
### Description
✨ add individual labels to fullnode/validator `service/statefulset/pod` to finer control the labels - the current helm chart only support global wide `labels`, hard to change this, as it's referenced in `deploy/sts` `selector.matchLabels`, which is `immutable`, with this change user can add `labels` to target resource without the need to modify global `labels`

useful under situation when user only want to add a label to service (e.g `chain: testnet`),so the `ServiceMonitor` can reference the `chain: testnet` label in `selector.matchLabels` (and `chain` in `targetLabels`)

### Test Plan
```bash
# checkout source code, and make sure under root level of the repo
helm template --debug terraform/helm/aptos-node
```
check above default renders correctly

```bash
# checkout source code, and make sure under root level of the repo
helm template --debug terraform/helm/aptos-node $(echo service pod statefulset | tr -s ' ' '\n' | xargs -I {} echo --set validator.{}.labels.chain=testnet --set validator.{}.labels.foo=bar --set fullnode.{}.labels.chain=testnet --set fullnode.{}.labels.foo=bar | tr -s '\n' ' ') | less
```
look for `chain: testnet` and `foo: bar`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3817)
<!-- Reviewable:end -->
