### PR TITLE
[consensus] dedicate channel to shutdown round manager

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -121,6 +121,7 @@ pub struct EpochManager {
     round_manager_tx: Option<
         aptos_channel::Sender<(Author, Discriminant<VerifiedEvent>), (Author, VerifiedEvent)>,
     >,
+    round_manager_close_tx: Option<oneshot::Sender<oneshot::Sender<()>>>,
     epoch_state: Option<EpochState>,
     block_retrieval_tx:
         Option<aptos_channel::Sender<AccountAddress, IncomingBlockRetrievalRequest>>,
@@ -159,6 +160,7 @@ impl EpochManager {
             buffer_manager_msg_tx: None,
             buffer_manager_reset_tx: None,
             round_manager_tx: None,
+            round_manager_close_tx: None,
             epoch_state: None,
             block_retrieval_tx: None,
         }
@@ -486,11 +488,12 @@ impl EpochManager {
     }
 
     async fn shutdown_current_processor(&mut self) {
-        if self.round_manager_tx.is_some() {
+        if let Some(close_tx) = self.round_manager_close_tx.take() {
             // Release the previous RoundManager, especially the SafetyRule client
             let (ack_tx, ack_rx) = oneshot::channel();
-            let event = VerifiedEvent::Shutdown(ack_tx);
-            self.forward_to_round_manager(self.author, event);
+            close_tx
+                .send(ack_tx)
+                .expect("[EpochManager] Fail to drop round manager");
             ack_rx
                 .await
                 .expect("[EpochManager] Fail to drop round manager");
@@ -624,7 +627,9 @@ impl EpochManager {
             Some(&counters::ROUND_MANAGER_CHANNEL_MSGS),
         );
         self.round_manager_tx = Some(round_manager_tx);
-        tokio::spawn(round_manager.start(round_manager_rx));
+        let (close_tx, close_rx) = oneshot::channel();
+        self.round_manager_close_tx = Some(close_tx);
+        tokio::spawn(round_manager.start(round_manager_rx, close_rx));
 
         self.spawn_block_retrieval_task(epoch, block_store);
     }

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -116,7 +116,6 @@ pub enum VerifiedEvent {
     CommitDecision(Box<CommitDecision>),
     // local messages
     LocalTimeout(Round),
-    Shutdown(oneshot::Sender<()>),
 }
 
 #[cfg(test)]
@@ -759,45 +758,51 @@ impl RoundManager {
             (Author, Discriminant<VerifiedEvent>),
             (Author, VerifiedEvent),
         >,
+        close_rx: oneshot::Receiver<oneshot::Sender<()>>,
     ) {
         info!(epoch = self.epoch_state().epoch, "RoundManager started");
-        while let Some((peer_id, event)) = event_rx.next().await {
-            let result = match event {
-                VerifiedEvent::ProposalMsg(proposal_msg) => {
-                    monitor!(
-                        "process_proposal",
-                        self.process_proposal_msg(*proposal_msg).await
-                    )
-                }
-                VerifiedEvent::VoteMsg(vote_msg) => {
-                    monitor!("process_vote", self.process_vote_msg(*vote_msg).await)
-                }
-                VerifiedEvent::UnverifiedSyncInfo(sync_info) => {
-                    monitor!(
-                        "process_sync_info",
-                        self.process_sync_info_msg(*sync_info, peer_id).await
-                    )
-                }
-                VerifiedEvent::LocalTimeout(round) => monitor!(
-                    "process_local_timeout",
-                    self.process_local_timeout(round).await
-                ),
-                VerifiedEvent::Shutdown(ack_sender) => {
-                    ack_sender
-                        .send(())
-                        .expect("[RoundManager] Fail to ack shutdown");
-                    break;
-                }
-                unexpected_event => unreachable!("Unexpected event: {:?}", unexpected_event),
-            }
-            .with_context(|| format!("from peer {}", peer_id));
+        let mut close_rx = close_rx.into_stream();
+        loop {
+            futures::select! {
+                (peer_id, event) = event_rx.select_next_some() => {
+                    let result = match event {
+                        VerifiedEvent::ProposalMsg(proposal_msg) => {
+                            monitor!(
+                                "process_proposal",
+                                self.process_proposal_msg(*proposal_msg).await
+                            )
+                        }
+                        VerifiedEvent::VoteMsg(vote_msg) => {
+                            monitor!("process_vote", self.process_vote_msg(*vote_msg).await)
+                        }
+                        VerifiedEvent::UnverifiedSyncInfo(sync_info) => {
+                            monitor!(
+                                "process_sync_info",
+                                self.process_sync_info_msg(*sync_info, peer_id).await
+                            )
+                        }
+                        VerifiedEvent::LocalTimeout(round) => monitor!(
+                            "process_local_timeout",
+                            self.process_local_timeout(round).await
+                        ),
+                        unexpected_event => unreachable!("Unexpected event: {:?}", unexpected_event),
+                    }
+                    .with_context(|| format!("from peer {}", peer_id));
 
-            let round_state = self.round_state();
-            match result {
-                Ok(_) => trace!(RoundStateLogSchema::new(round_state)),
-                Err(e) => {
-                    counters::ERROR_COUNT.inc();
-                    error!(error = ?e, kind = error_kind(&e), RoundStateLogSchema::new(round_state));
+                    let round_state = self.round_state();
+                    match result {
+                        Ok(_) => trace!(RoundStateLogSchema::new(round_state)),
+                        Err(e) => {
+                            counters::ERROR_COUNT.inc();
+                            error!(error = ?e, kind = error_kind(&e), RoundStateLogSchema::new(round_state));
+                        }
+                    }
+                }
+                close_req = close_rx.select_next_some() => {
+                    if let Ok(ack_sender) = close_req {
+                        ack_sender.send(()).expect("[RoundManager] Fail to ack shutdown");
+                    }
+                    break;
                 }
             }
         }


### PR DESCRIPTION
The close message can be in the end of the event queue and not get polled for significant time, although if we receive the
close message, any message in the current epoch is useless. Split it out can help shut down the round manager much faster under load.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3860)
<!-- Reviewable:end -->
