### PR TITLE
[community] Update copy, integrate login Dialog, utilize css grid

### DIFF
--- a/ecosystem/platform/server/app/controllers/nft_offers_controller.rb
+++ b/ecosystem/platform/server/app/controllers/nft_offers_controller.rb
@@ -46,6 +46,7 @@ class NftOffersController < ApplicationController
   private
 
   def sign_in_step
+    @login_dialog = DialogComponent.new(id: 'login_dialog')
     completed = user_signed_in?
     {
       name: :sign_in,

--- a/ecosystem/platform/server/app/views/nft_offers/show.html.erb
+++ b/ecosystem/platform/server/app/views/nft_offers/show.html.erb
@@ -1,74 +1,84 @@
-<% content_for(:page_title, 'APTOS : ZERO - Official Commemorative Testnet NFT') %>
-<% content_for(:page_description, 'Aptos Community - A worldwide movement of developers, node operators, educators, and other contributors') %>
+<% content_for(:page_title, 'APTOS : ZERO - Testnet NFT') %>
+<% content_for(:page_description, 'Claim your commemorative Aptos Testnet NFT and help us test the network.') %>
 <div class="bg-neutral-900 text-neutral-100 h-full">
   <div class="max-w-screen-2xl mx-auto px-6 pb-24">
     <section class="py-12 lg:py-32">
       <h3 class="text-base uppercase text-teal-400 mb-4 font-mono">Community</h3>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-12 xl:gap-12">
-        <h1 class="font-display text-5xl lg:text-6xl">
-          APTOS : ZERO<br>
-          Official Commemorative Testnet NFT
+      <div class="grid grid-cols-1 md:grid-cols-12 gap-12 md:gap-0">
+        <h1 class="font-display text-5xl lg:text-6xl md:col-span-5">
+          <span class="whitespace-nowrap">APTOS <span class="inline-block align-text-top">:</span> ZERO</span><br>
+          <span>Testnet NFT</span>
         </h1>
-        <div class="flex items-center">
+        <div class="flex items-center md:col-start-7 md:col-end-13">
           <p class="text-xl xl:text-2xl text-neutral-400">
-          <%= Faker::Lorem.paragraph %>
-          <%= Faker::Lorem.paragraph %>
+            Claim your commemorative Aptos Testnet NFT and help us test the&nbsp;network.
           </p>
         </div>
       </div>
     </section>
-    <section class="flex flex-col gap-16 md:flex-row max-w-screen-xl mx-auto">
-      <%= turbo_frame_tag dom_id(@nft_offer) do %>
-        <div class="flex-1">
-          <%= render 'layouts/flash' %>
-          <h2 class="font-display text-3xl mb-8">Claim your Aptos NFT</h2>
-          <ol class="pl-4">
-            <% @steps.each_with_index do |step, i| %>
-              <%= content_tag :li, class: ['pl-10 relative border-dotted', step.completed ? 'pb-4 border-teal-400' : 'pb-8 border-neutral-400', i + 1 == @steps.length ? '' : 'border-l-2'] do %>
-                <%= content_tag :div, class: ['absolute w-10 h-10 text-sm font-mono top-0 left-0 -translate-x-1/2 -translate-y-1 bg-neutral-900 rounded-full border-2 flex justify-center items-center', step.disabled ? 'border-neutral-400 text-neutral-400' : 'border-teal-400 text-teal-400'] do %>
-                  <% if step.completed %>
-                    <%= render IconComponent.new(:check, size: :small) %>
-                  <% else %>
-                    <%= i + 1 %>
-                  <% end %>
+    <section class="max-w-screen-xl mx-auto py-12 lg:py-18 grid grid-cols-1 md:grid-cols-12 gap-8 md:gap-0">
+      <%= turbo_frame_tag dom_id(@nft_offer), class: 'md:col-span-6 lg:col-span-4' do %>
+        <%= render 'layouts/flash' %>
+        <h2 class="font-display text-3xl mb-8">Claim your NFT</h2>
+        <ol class="pl-4">
+          <% @steps.each_with_index do |step, i| %>
+            <%= content_tag :li, class: ['pl-10 relative border-dotted', !step.disabled && !step.completed ? 'pb-16' : 'pb-4', step.completed ? 'border-teal-400 opacity-50' : 'border-neutral-400', i + 1 == @steps.length ? '' : 'border-l-2'] do %>
+              <%= content_tag :div, class: ['absolute w-10 h-10 text-sm font-mono top-0 left-0 -translate-x-1/2 -translate-y-1 bg-neutral-900 rounded-full border-2 flex justify-center items-center', step.disabled ? 'border-neutral-400 text-neutral-400' : 'border-teal-400 text-teal-400'] do %>
+                <% if step.completed %>
+                  <%= render IconComponent.new(:check, size: :small, class: 'stroke-2') %>
+                <% else %>
+                  <%= i + 1 %>
                 <% end %>
-                <%= content_tag :h3, class: ['uppercase text-2xl font-mono mb-4', step.disabled ? 'text-neutral-400' : 'text-teal-400'] do %>
-                  <% if step.name == :sign_in %>
-                    Sign In
-                  <% elsif step.name == :connect_wallet %>
-                    Connect Wallet
-                  <% elsif step.name == :claim_nft %>
-                    Claim NFT
-                  <% end %>
+              <% end %>
+              <%= content_tag :h3, class: ['uppercase text-2xl font-mono mb-4', step.disabled ? 'text-neutral-400' : 'text-teal-400'] do %>
+                <% if step.name == :sign_in %>
+                  Sign In
+                <% elsif step.name == :connect_wallet %>
+                  Connect Wallet
+                <% elsif step.name == :claim_nft %>
+                  Claim NFT
                 <% end %>
-                <% if !step.disabled && !step.completed %>
-                  <p class="text-lg text-neutral-400 mb-4">
-                  <% if step.name == :sign_in %>
-                    To begin, sign in to Aptos.
-                  <% elsif step.name == :connect_wallet %>
-                    Connect your wallet.
-                  <% elsif step.name == :claim_nft %>
-                    Claim your NFT.
+              <% end %>
+              <% if !step.disabled && !step.completed %>
+                <p class="text-lg text-neutral-400 mb-4">
+                <% if step.name == :sign_in %>
+                  To begin, sign in to Aptos.
+                <% elsif step.name == :connect_wallet %>
+                  Connect your wallet.
+                <% elsif step.name == :claim_nft %>
+                  Your NFT is ready to mint!
+                <% end %>
+                </p>
+                <% if step.name == :sign_in %>
+                  <%= render ButtonComponent.new(dialog: @login_dialog, size: :large) do %>
+                    Sign in
                   <% end %>
-                  <%= Faker::Lorem.paragraph %>
-                  </p>
-                  <% if step.name == :sign_in %>
-                    <%= render(ButtonComponent.new(href: new_user_session_path, scheme: :primary, class: 'w-64')) { 'Sign In' } %>
-                  <% elsif step.name == :connect_wallet %>
-                    <%= render(ConnectWalletButtonComponent.new(wallet: @wallet, scheme: :primary, class: 'w-64', turbo_frame: dom_id(@nft_offer))) %>
-                  <% elsif step.name == :claim_nft %>
-                    <%= render(ClaimNftButtonComponent.new(nft_offer: @nft_offer, wallet: @wallet, scheme: :primary, class: 'w-64')) %>
+                  <%= render @login_dialog do |dialog| %>
+                    <%= dialog.with_title do %>
+                      Sign in with
+                    <% end %>
+                    <%= dialog.with_body do %>
+                      <div class="flex flex-col gap-3 outline-none" autofocus tabindex="-1">
+                        <%= render LoginButtonComponent.new(provider: :discord, size: :large, class: 'w-full') %>
+                        <%= render LoginButtonComponent.new(provider: :google, size: :large, class: 'w-full') %>
+                        <%= render LoginButtonComponent.new(provider: :github, size: :large, class: 'w-full') %>
+                      </div>
+                    <% end %>
                   <% end %>
+                <% elsif step.name == :connect_wallet %>
+                  <%= render(ConnectWalletButtonComponent.new(wallet: @wallet, scheme: :primary, size: :large, class: 'inline-flex', turbo_frame: dom_id(@nft_offer))) %>
+                <% elsif step.name == :claim_nft %>
+                  <%= render(ClaimNftButtonComponent.new(nft_offer: @nft_offer, wallet: @wallet, scheme: :primary, size: :large, class: 'inline-flex')) %>
                 <% end %>
               <% end %>
             <% end %>
-          </ol>
-        </div>
+          <% end %>
+        </ol>
       <% end %>
-      <div class="self-start">
+      <div class="md:col-start-8 md:col-end-13 lg:col-span-6 lg:col-start-7">
         <%= render CardOutlineComponent.new(scheme: :filled) do %>
-          <div class="flex w-64 h-64 lg:w-96 lg:h-96 xl:w-[600px] xl:h-[600px] items-center justify-center border-2 border-neutral-900 text-neutral-900">
-            <%= render IconComponent.new(:aptos, class: 'w-32 h-32 lg:w-64 lg:h-96') %>
+          <div class="flex w-full items-center justify-center border-2 border-neutral-900 text-neutral-900 aspect-square">
+            <%= render IconComponent.new(:aptos, class: 'w-1/2') %>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
### Description

- Update copy
- Integrate Sign in dialog / modal
- Increase button size to large
- Conditional bottom padding on steps only if is currently active step `!step.disabled && !step.completed`
- Fluid container for NFT with `aspect-ratio: 1/1;`
- Muted completed steps by reducing opacity
- Utilize CSS Grid
- Vertically center colon within APTOS:ZERO heading
- Non-breaking space added to end of hero lead-in copy to prevent widow

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<img width="1464" alt="image" src="https://user-images.githubusercontent.com/98909677/188380414-24bd6f8a-3d93-4f18-9f4f-0265460f52d0.png">

<img width="454" alt="image" src="https://user-images.githubusercontent.com/98909677/188381909-640cbe3b-9d66-48bd-8f08-b0d72d655e85.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3862)
<!-- Reviewable:end -->
