### PR TITLE
[aptos-vm] Enable lazy_natives feature and add test case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,7 +2262,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -5533,7 +5533,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5550,7 +5550,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -5565,12 +5565,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5585,7 +5585,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5597,7 +5597,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5609,7 +5609,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5626,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "difference",
@@ -5689,7 +5689,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5718,7 +5718,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5735,7 +5735,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5789,7 +5789,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5807,7 +5807,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5825,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5851,7 +5851,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5870,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5889,7 +5889,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "hex",
@@ -5902,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "hex",
@@ -5916,7 +5916,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5942,7 +5942,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5978,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6015,7 +6015,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6043,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -6054,7 +6054,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6080,7 +6080,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6107,7 +6107,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6125,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "log",
@@ -6147,7 +6147,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6156,7 +6156,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6173,7 +6173,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6204,7 +6204,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6235,7 +6235,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6252,7 +6252,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6266,7 +6266,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7832,7 +7832,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7847,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4cd47108661a5717486e4e90821a4a10f2710ea7#4cd47108661a5717486e4e90821a4a10f2710ea7"
+source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/aptos-move/aptos-gas/Cargo.toml
+++ b/aptos-move/aptos-gas/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2021"
 
 [dependencies]
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
 
 aptos-types = { path = "../../types" }
 framework = { path = "../framework" }

--- a/aptos-move/e2e-move-tests/tests/lazy_natives.rs
+++ b/aptos-move/e2e-move-tests/tests/lazy_natives.rs
@@ -1,0 +1,47 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_types::account_address::AccountAddress;
+use e2e_move_tests::package_builder::PackageBuilder;
+use e2e_move_tests::{assert_success, assert_vm_status, MoveHarness};
+use move_deps::move_core_types::vm_status::StatusCode;
+
+#[test]
+fn lazy_natives() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    let mut builder = PackageBuilder::new("LazyNatives");
+    builder.add_source(
+        "test",
+        "
+module 0xcafe::test {
+    native fun undefined();
+
+    public entry fun nothing() {}
+    public entry fun something() { undefined() }
+}
+    ",
+    );
+    let dir = builder.write_to_temp().unwrap();
+
+    // Should be able to publish with unbound native.
+    assert_success!(h.publish_package(&acc, dir.path()));
+
+    // Should be able to call nothing entry
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test::nothing").unwrap(),
+        vec![],
+        vec![]
+    ));
+
+    // Should not be able to call something entry
+    let status = h.run_entry_function(
+        &acc,
+        str::parse("0xcafe::test::something").unwrap(),
+        vec![],
+        vec![],
+    );
+    assert_vm_status!(status, StatusCode::MISSING_DEPENDENCY)
+}

--- a/aptos-move/gas-algebra-ext/Cargo.toml
+++ b/aptos-move/gas-algebra-ext/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-move-core-types = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -21,34 +21,34 @@ edition = "2018"
 #   actively looking for solutions.
 #
 ##########################################################################################
-move-abigen = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-cli = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-model = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-package = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-prover = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "4cd47108661a5717486e4e90821a4a10f2710ea7" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-cli = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-model = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-package = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-prover = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
 
 [features]
 default = []


### PR DESCRIPTION
### Description

This enables the new `lazy_natives` feature for the Aptos VM. With this landed, we should be able to avoid staged rollout for adding new native Move functions.



### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Add a test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3868)
<!-- Reviewable:end -->
