### PR TITLE
[cli] Add `Raw` type to support passing BCS-encoded parameters directly

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -804,7 +804,8 @@ impl FunctionArgType {
                     .map_err(|err| CliError::UnableToParse("u128", err.to_string()))?,
             ),
             FunctionArgType::Raw => {
-                let raw = hex::decode(arg).map_err(|err| CliError::UnableToParse("raw", err.to_string()))?;
+                let raw = hex::decode(arg)
+                    .map_err(|err| CliError::UnableToParse("raw", err.to_string()))?;
                 Ok(raw)
             }
         }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -713,7 +713,7 @@ pub struct RunFunction {
 
     /// Arguments combined with their type separated by spaces.
     ///
-    /// Supported types [u8, u64, u128, bool, hex, string, address]
+    /// Supported types [u8, u64, u128, bool, hex, string, address, raw]
     ///
     /// Example: `address:0x1 bool:true u8:0`
     #[clap(long, multiple_values = true)]
@@ -774,6 +774,7 @@ pub(crate) enum FunctionArgType {
     U8,
     U64,
     U128,
+    Raw,
 }
 
 impl FunctionArgType {
@@ -802,6 +803,10 @@ impl FunctionArgType {
                 &u128::from_str(arg)
                     .map_err(|err| CliError::UnableToParse("u128", err.to_string()))?,
             ),
+            FunctionArgType::Raw => {
+                let raw = hex::decode(arg).map_err(|err| CliError::UnableToParse("raw", err.to_string()))?;
+                Ok(raw)
+            }
         }
         .map_err(|err| CliError::BCS("arg", err))
     }
@@ -818,6 +823,7 @@ impl FromStr for FunctionArgType {
             "u8" => Ok(FunctionArgType::U8),
             "u64" => Ok(FunctionArgType::U64),
             "u128" => Ok(FunctionArgType::U128),
+            "raw" => Ok(FunctionArgType::Raw),
             str => Err(CliError::CommandArgumentError(format!("Invalid arg type '{}'.  Must be one of: ['address','bool','hex','string','u8','u64','u128']", str))),
         }
     }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -825,7 +825,7 @@ impl FromStr for FunctionArgType {
             "u64" => Ok(FunctionArgType::U64),
             "u128" => Ok(FunctionArgType::U128),
             "raw" => Ok(FunctionArgType::Raw),
-            str => Err(CliError::CommandArgumentError(format!("Invalid arg type '{}'.  Must be one of: ['address','bool','hex','string','u8','u64','u128']", str))),
+            str => Err(CliError::CommandArgumentError(format!("Invalid arg type '{}'.  Must be one of: ['address','bool','hex','string','u8','u64','u128','raw']", str))),
         }
     }
 }


### PR DESCRIPTION
### Description
After `u8, u64, u128, bool, hex, string, address`  are passed in cmd, they are encoded again by BCS.
### Test Plan
Add `Raw` type which is encoded by BCS, and passed in with Hex format.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3872)
<!-- Reviewable:end -->
