### PR TITLE
[cli] Fix analyze-validators when pruning deletes oldest events

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -855,6 +855,7 @@ impl Client {
                     serde_json::from_value::<NewBlockEventResponse>(event.data)
                         .map_err(|e| anyhow!(e))
                         .and_then(|e| {
+                            assert_eq!(e.height, sequence_number);
                             Ok(VersionedNewBlockEvent {
                                 event: NewBlockEvent::new(
                                     AccountAddress::from_hex_literal(&e.hash)


### PR DESCRIPTION
### Description

fixing #3871 issue

### Test Plan
```
% cargo run -p aptos -- node analyze-validator-performance --analyze-mode=network-health-over-time --url=http://34.176.214.8 --start-epoch=0 --end-epoch=36 

Oldest full epoch that can be retreived is 35 
Fetching 535419 to 886531 sequence number, wanting epochs [35, 36), last version: 224127645 and epoch: 127
Network health over epochs [35, 35]:
epoch    | reliable   | r low vote | unreliable | only vote  | down(cons) | rounds   | failure rate
35       | 135        | 23         | 14         | 1          | 59         | 9306     | 0.58027077

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3874)
<!-- Reviewable:end -->
