### PR TITLE
[aptos-cli] Fix extract key command

### DIFF
--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -183,6 +183,8 @@ impl TryFrom<ValidatorConfiguration> for Validator {
     }
 }
 
+const LOCALHOST: &str = "localhost";
+
 /// Combined Host (DnsName or IP) and port
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HostAndPort {
@@ -191,6 +193,13 @@ pub struct HostAndPort {
 }
 
 impl HostAndPort {
+    pub fn local(port: u16) -> anyhow::Result<HostAndPort> {
+        Ok(HostAndPort {
+            host: DnsName::try_from(LOCALHOST.to_string())?,
+            port,
+        })
+    }
+
     pub fn as_network_address(&self, key: x25519::PublicKey) -> anyhow::Result<NetworkAddress> {
         let host = self.host.to_string();
 

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -25,7 +25,7 @@ use crate::node::{
     ShowValidatorStake, UpdateConsensusKey, UpdateValidatorNetworkAddresses,
     ValidatorConsensusKeyArgs, ValidatorNetworkAddressesArgs,
 };
-use crate::op::key::{ExtractPeer, GenerateKey, SaveKey};
+use crate::op::key::{ExtractPeer, GenerateKey, NetworkKeyInputOptions, SaveKey};
 use crate::stake::{
     AddStake, IncreaseLockup, InitializeStakeOwner, SetDelegatedVoter, SetOperator, UnlockStake,
     WithdrawStake,
@@ -569,17 +569,20 @@ impl CliTestFramework {
 
     pub async fn extract_peer(
         &self,
+        host: HostAndPort,
         private_key_file: PathBuf,
         output_file: PathBuf,
     ) -> CliTypedResult<HashMap<AccountAddress, Peer>> {
         ExtractPeer {
-            private_key_input_options: PrivateKeyInputOptions::from_file(private_key_file),
+            host,
+            network_key_input_options: NetworkKeyInputOptions::from_private_key_file(
+                private_key_file,
+            ),
             output_file_options: SaveFile {
                 output_file,
                 prompt_options: PromptOptions::yes(),
             },
             encoding_options: Default::default(),
-            profile_options: Default::default(),
         }
         .execute()
         .await


### PR DESCRIPTION
### Description
Extract key command wasn't loading the network key, and was
trying to load Ed25519 keys, which was wrong

The extracted value should be the same exact as the public key.

Additionally, requires a host to be added to build a network address

Resolves https://github.com/aptos-labs/aptos-core/issues/2372

### Test Plan
```
$ cat private-key.txt.pub
6638222DA2225F4E72F2C57775BCF040A20E635CC885B64E3D17AA05C39E1325%
$ aptos key extract-peer --host example.com:6180 --public-network-key-file private-key.txt.pub --output-file extracted-peer
"extracted-peer" already exists, are you sure you want to overwrite it? [yes/no] >
yes
{
  "Result": {
    "6638222da2225f4e72f2c57775bcf040a20e635cc885b64e3d17aa05c39e1325": {
      "addresses": [
        "/dns/example.com/tcp/6180/noise-ik/0x6638222da2225f4e72f2c57775bcf040a20e635cc885b64e3d17aa05c39e1325/handshake/0"
      ],
      "keys": [
        "0x6638222da2225f4e72f2c57775bcf040a20e635cc885b64e3d17aa05c39e1325"
      ],
      "role": "Upstream"
    }
  }
}
$ aptos key extract-peer --host 1.1.1.1:6180 --public-network-key-file private-key.txt.pub --output-file extracted-peer
"extracted-peer" already exists, are you sure you want to overwrite it? [yes/no] >
yes
{
  "Result": {
    "6638222da2225f4e72f2c57775bcf040a20e635cc885b64e3d17aa05c39e1325": {
      "addresses": [
        "/ip4/1.1.1.1/tcp/6180/noise-ik/0x6638222da2225f4e72f2c57775bcf040a20e635cc885b64e3d17aa05c39e1325/handshake/0"
      ],
      "keys": [
        "0x6638222da2225f4e72f2c57775bcf040a20e635cc885b64e3d17aa05c39e1325"
      ],
      "role": "Upstream"
    }
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3885)
<!-- Reviewable:end -->
