### PR TITLE
[telemetry-service] Allowlist for PFNs

### DIFF
--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -9,12 +9,11 @@ use crate::{
     error::ServiceError,
     types::{
         auth::Claims,
-        common::EventIdentity,
+        common::{EventIdentity, NodeType},
         telemetry::{BigQueryRow, TelemetryDump},
     },
 };
 use anyhow::anyhow;
-use aptos_config::config::PeerRole;
 use aptos_logger::{debug, error};
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
 use serde_json::json;
@@ -27,9 +26,10 @@ pub fn custom_event(context: Context) -> BoxedFilter<(impl Reply,)> {
         .and(with_auth(
             context,
             vec![
-                PeerRole::Validator,
-                PeerRole::ValidatorFullNode,
-                PeerRole::Unknown,
+                NodeType::Validator,
+                NodeType::ValidatorFullNode,
+                NodeType::PublicFullNode,
+                NodeType::Unknown,
             ],
         ))
         .and(warp::body::json())

--- a/crates/aptos-telemetry-service/src/error.rs
+++ b/crates/aptos-telemetry-service/src/error.rs
@@ -35,6 +35,10 @@ impl ServiceError {
         Self::new(StatusCode::UNAUTHORIZED, msg.to_string())
     }
 
+    pub fn forbidden<S: Display>(msg: S) -> Self {
+        Self::new(StatusCode::FORBIDDEN, msg.to_string())
+    }
+
     pub fn internal(err: anyhow::Error) -> Self {
         Self::from_anyhow_error(StatusCode::INTERNAL_SERVER_ERROR, err)
     }

--- a/crates/aptos-telemetry-service/src/tests/auth_test.rs
+++ b/crates/aptos-telemetry-service/src/tests/auth_test.rs
@@ -14,6 +14,7 @@ use aptos_types::{
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use serde_json::json;
 
+use crate::types::common::NodeType;
 use crate::{
     tests::test_context::new_test_context,
     types::auth::{AuthResponse, Claims},
@@ -134,7 +135,7 @@ async fn test_auth_validator() {
         Claims {
             chain_id,
             peer_id,
-            peer_role: PeerRole::Validator,
+            node_type: NodeType::Validator,
             epoch: 1,
             exp: decoded.claims.exp,
             iat: decoded.claims.iat
@@ -174,7 +175,7 @@ async fn test_auth_validatorfullnode() {
         Claims {
             chain_id,
             peer_id,
-            peer_role: PeerRole::ValidatorFullNode,
+            node_type: NodeType::ValidatorFullNode,
             epoch: 1,
             exp: decoded.claims.exp,
             iat: decoded.claims.iat

--- a/crates/aptos-telemetry-service/src/tests/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/tests/custom_event.rs
@@ -3,14 +3,17 @@
 
 use std::collections::BTreeMap;
 
-use aptos_config::config::{PeerRole, PeerSet};
+use aptos_config::config::PeerSet;
 use aptos_types::{chain_id::ChainId, PeerId};
 use chrono::Utc;
 use serde_json::json;
 
 use crate::{
     jwt_auth::create_jwt_token,
-    types::telemetry::{TelemetryDump, TelemetryEvent},
+    types::{
+        common::NodeType,
+        telemetry::{TelemetryDump, TelemetryEvent},
+    },
 };
 
 use super::test_context::new_test_context;
@@ -20,7 +23,7 @@ async fn test_custom_event() {
     let test_context = new_test_context().await;
     let chain_id = ChainId::new(28);
     let peer_id = PeerId::random();
-    let peer_role = PeerRole::Validator;
+    let node_type = NodeType::Validator;
     let epoch = 10;
 
     test_context
@@ -33,7 +36,7 @@ async fn test_custom_event() {
         test_context.inner.clone(),
         chain_id,
         peer_id,
-        peer_role,
+        node_type,
         epoch,
     )
     .unwrap();

--- a/crates/aptos-telemetry-service/src/tests/mod.rs
+++ b/crates/aptos-telemetry-service/src/tests/mod.rs
@@ -3,4 +3,4 @@
 
 mod auth_test;
 mod custom_event;
-mod test_context;
+pub(crate) mod test_context;

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::clients::humio;
 use crate::GCPBigQueryConfig;
@@ -38,6 +39,7 @@ pub async fn new_test_context() -> TestContext {
         victoria_metrics_token: "".into(),
         humio_url: "".into(),
         humio_auth_token: "".into(),
+        pfn_allowlist: HashMap::new(),
     };
     let humio_client = humio::IngestClient::new(
         Url::parse("http://localhost/").unwrap(),
@@ -48,11 +50,13 @@ pub async fn new_test_context() -> TestContext {
         .unwrap();
     let validator_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
     let vfn_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
+    let pfn_cache = Arc::new(aptos_infallible::RwLock::new(HashMap::new()));
 
     TestContext::new(Context::new(
         config,
         validator_cache,
         vfn_cache,
+        pfn_cache,
         Some(gcp_bigquery_client),
         None,
         humio_client,

--- a/crates/aptos-telemetry-service/src/types/auth.rs
+++ b/crates/aptos-telemetry-service/src/types/auth.rs
@@ -1,10 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_config::config::{PeerRole, RoleType};
+use aptos_config::config::RoleType;
 use aptos_crypto::x25519;
 use aptos_types::{chain_id::ChainId, PeerId};
 use serde::{Deserialize, Serialize};
+
+use super::common::NodeType;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AuthRequest {
@@ -25,7 +27,7 @@ pub struct AuthResponse {
 pub struct Claims {
     pub chain_id: ChainId,
     pub peer_id: PeerId,
-    pub peer_role: PeerRole,
+    pub node_type: NodeType,
     pub epoch: u64,
     pub exp: usize,
     pub iat: usize,

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -7,8 +7,9 @@ pub mod validator_set;
 
 pub mod common {
 
+    use std::fmt;
+
     use crate::types::auth::Claims;
-    use aptos_config::config::PeerRole;
     use aptos_types::chain_id::ChainId;
     use aptos_types::PeerId;
     use serde::{Deserialize, Serialize};
@@ -17,7 +18,7 @@ pub mod common {
     pub struct EventIdentity {
         pub peer_id: PeerId,
         pub chain_id: ChainId,
-        pub role_type: PeerRole,
+        pub role_type: NodeType,
         pub epoch: u64,
     }
 
@@ -26,9 +27,40 @@ pub mod common {
             Self {
                 peer_id: claims.peer_id,
                 chain_id: claims.chain_id,
-                role_type: claims.peer_role,
+                role_type: claims.node_type,
                 epoch: claims.epoch,
             }
+        }
+    }
+
+    #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+    pub enum NodeType {
+        Validator,
+        ValidatorFullNode,
+        PublicFullNode,
+        Unknown,
+    }
+
+    impl NodeType {
+        pub fn as_str(self) -> &'static str {
+            match self {
+                NodeType::Validator => "validator",
+                NodeType::ValidatorFullNode => "validator_fullnode",
+                NodeType::PublicFullNode => "public_fullnode",
+                NodeType::Unknown => "unknown_peer",
+            }
+        }
+    }
+
+    impl fmt::Debug for NodeType {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}", self)
+        }
+    }
+
+    impl fmt::Display for NodeType {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "{}", self.as_str())
         }
     }
 }


### PR DESCRIPTION
### Description

This PR adds support for telemetry service to accept metrics and logs from PFNs via an allow list. The allow list (map of peer ID to public keys per chain ID) is defined in the config file and is read during start-up.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Ran a devnet public fullnode locally and was able to send metrics successfully to telemetry service.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3887)
<!-- Reviewable:end -->
