### PR TITLE
[forge] assert image tags have prefix if profile or feature

### DIFF
--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1090,6 +1090,23 @@ class Git:
             yield self.run(["rev-parse", f"HEAD~{i}"]).unwrap().decode().strip()
 
 
+def assert_provided_image_tags_has_profile_or_features(
+    forge_image_tag,
+    image_tag,
+    enable_failpoints_feature: bool = False,
+    enable_performance_profile: bool = False,
+):
+    for tag in [forge_image_tag, image_tag]:
+        if enable_failpoints_feature:
+            assert tag.startswith(
+                "failpoints"
+            ), f"Missing failpoints_ feature prefix in {tag}"
+        if enable_performance_profile:
+            assert tag.startswith(
+                "performance"
+            ), f"Missing performance_ profile prefix in {tag}"
+
+
 def find_recent_images_by_profile_or_features(
     shell: Shell,
     git: Git,
@@ -1312,6 +1329,13 @@ def test(
     # These features and profile flags are set as strings
     forge_enable_failpoints = forge_enable_failpoints == "true"
     forge_enable_performance = forge_enable_performance == "true"
+
+    assert_provided_image_tags_has_profile_or_features(
+        image_tag,
+        forge_image_tag,
+        enable_failpoints_feature=forge_enable_failpoints,
+        enable_performance_profile=forge_enable_performance,
+    )
 
     if forge_test_suite == "compat":
         # Compat uses 2 image tags

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -27,6 +27,7 @@ from .forge import (
     SystemContext,
     assert_aws_token_expiration,
     find_recent_images_by_profile_or_features,
+    assert_provided_image_tags_has_profile_or_features,
     format_comment,
     format_pre_comment,
     format_report,
@@ -375,6 +376,14 @@ class TestFindRecentImage(unittest.TestCase):
                 find_recent_images_by_profile_or_features(
                     shell, git, 1, commit_threshold=1
                 )
+            )
+
+    def testFailpointsProvidedImageTag(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_provided_image_tags_has_profile_or_features(
+                "potato_tomato",
+                "failpoints_performance_potato",
+                enable_failpoints_feature=True,
             )
 
 


### PR DESCRIPTION
### Description

Assert that if we're trying to use failpoints via `FORGE_ENABLE_FAILPOINTS` env var, that the image tags are correct, if we're manually specifying image tags

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3890)
<!-- Reviewable:end -->
