### PR TITLE
[mempool] fix issue where gaps in seq no can cause txn to not be broadcast

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -558,10 +558,11 @@ impl TransactionStore {
                         Bound::Excluded(next_key.sequence_number)
                     });
                 // mark all following txns as non-ready, i.e. park them
-                for (_, t) in txns.range((park_range_start, park_range_end)) {
+                for (_, t) in txns.range_mut((park_range_start, park_range_end)) {
                     self.parking_lot_index.insert(t);
                     self.priority_index.remove(t);
                     self.timeline_index.remove(t);
+                    t.timeline_state = TimelineState::NotReady;
                 }
                 if let Some(txn) = txns.remove(&key.sequence_number) {
                     let is_active = self.priority_index.contains(&txn);

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -562,7 +562,9 @@ impl TransactionStore {
                     self.parking_lot_index.insert(t);
                     self.priority_index.remove(t);
                     self.timeline_index.remove(t);
-                    t.timeline_state = TimelineState::NotReady;
+                    if let TimelineState::Ready(_) = t.timeline_state {
+                        t.timeline_state = TimelineState::NotReady;
+                    }
                 }
                 if let Some(txn) = txns.remove(&key.sequence_number) {
                     let is_active = self.priority_index.contains(&txn);

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -675,6 +675,13 @@ fn test_gc_ready_transaction() {
     let (timeline, _) = pool.read_timeline(0, 10);
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline[0].sequence_number(), 0);
+
+    // Resubmit txn 1
+    add_txn(&mut pool, TestTransaction::new(1, 1, 1)).unwrap();
+
+    // Make sure txns 2 and 3 can be broadcast after txn 1 is resubmitted
+    let (timeline, _) = pool.read_timeline(0, 10);
+    assert_eq!(timeline.len(), 4);
 }
 
 #[test]


### PR DESCRIPTION
### Description

An example of the issue:
1. txn0 and txn1 are added to mempool.
2. GC removes txn0. txn1 is sent to parking lot and removed from timeline_index. But timeline_state is still Ready!
3. txn0 is resubmitted by the user. txn1 is removed from the parking lot, but only NonReady transactions are added to the timeline_index, so txn1 is not added to timeline_index.
4. (txn1 never gets broadcast)

The fix is to reset Ready to NotReady in (2).

### Test Plan
Added this case to the existing gc test case. Failed before the fix and now passes after the fix.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3895)
<!-- Reviewable:end -->
