### PR TITLE
[forge] Enable different genesis validator stake in forge

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -49,6 +49,7 @@ const GENESIS_BLOB: &str = "genesis.blob";
 #[derive(Debug, Clone)]
 pub struct ValidatorNodeConfig {
     pub name: String,
+    pub index: usize,
     pub config: NodeConfig,
     pub dir: PathBuf,
     pub account_private_key: Option<ConfigKey<Ed25519PrivateKey>>,
@@ -59,6 +60,7 @@ impl ValidatorNodeConfig {
     /// Create a new validator and initialize keys appropriately
     pub fn new(
         name: String,
+        index: usize,
         base_dir: &Path,
         mut config: NodeConfig,
         genesis_stake_amount: u64,
@@ -70,6 +72,7 @@ impl ValidatorNodeConfig {
 
         Ok(ValidatorNodeConfig {
             name,
+            index,
             config,
             dir,
             account_private_key: None,
@@ -506,6 +509,7 @@ impl Builder {
 
         let mut validator = ValidatorNodeConfig::new(
             name,
+            index,
             self.config_dir.as_path(),
             config,
             genesis_stake_amount,

--- a/terraform/helm/genesis/README.md
+++ b/terraform/helm/genesis/README.md
@@ -40,6 +40,8 @@ Aptos blockchain automated genesis ceremony for testnets
 | genesis.validator.enable_onchain_discovery | bool | `false` | Use External DNS as created by aptos-node helm chart for validator host in genesis |
 | genesis.validator.internal_host_suffix | string | `"validator-lb"` | If `enable_onchain_discovery` is false, use this host suffix for internal kubernetes service name |
 | genesis.validator.stake_amount | string | `"100000000000000"` | Stake amount for each validator in this testnet. Defaults to 1M APTOS coins with 8 decimals |
+| genesis.validator.num_validators_with_larger_stake | string | `"0"` | Stake amount for each validator in this testnet. Defaults to 1M APTOS coins with 8 decimals |
+| genesis.validator.larger_stake_amount | string | `"1000000000000000"` | Stake amount for each validator in this testnet. Defaults to 1M APTOS coins with 8 decimals |
 | imageTag | string | `"testnet"` | Default image tag to use for all tools images |
 | labels | string | `nil` |  |
 | podSecurityPolicy | bool | `true` | LEGACY: create PodSecurityPolicy, which exists at the cluster-level |

--- a/terraform/helm/genesis/files/genesis.sh
+++ b/terraform/helm/genesis/files/genesis.sh
@@ -18,6 +18,8 @@ VALIDATOR_INTERNAL_HOST_SUFFIX=${VALIDATOR_INTERNAL_HOST_SUFFIX:-validator-lb}
 FULLNODE_INTERNAL_HOST_SUFFIX=${FULLNODE_INTERNAL_HOST_SUFFIX:-fullnode-lb}
 MOVE_FRAMEWORK_DIR=${MOVE_FRAMEWORK_DIR:-"/aptos-framework/move"}
 STAKE_AMOUNT=${STAKE_AMOUNT:-1}
+NUM_VALIDATORS_WITH_LARGER_STAKE=${NUM_VALIDATORS_WITH_LARGER_STAKE:0}
+LARGER_STAKE_AMOUNT=${LARGER_STAKE_AMOUNT:-1}
 
 if [ -z ${ERA} ] || [ -z ${NUM_VALIDATORS} ]; then
     echo "ERA (${ERA:-null}) and NUM_VALIDATORS (${NUM_VALIDATORS:-null}) must be set"
@@ -37,32 +39,41 @@ echo "USERNAME_PREFIX=${USERNAME_PREFIX}"
 echo "VALIDATOR_INTERNAL_HOST_SUFFIX=${VALIDATOR_INTERNAL_HOST_SUFFIX}"
 echo "FULLNODE_INTERNAL_HOST_SUFFIX=${FULLNODE_INTERNAL_HOST_SUFFIX}"
 echo "STAKE_AMOUNT=${STAKE_AMOUNT}"
+echo "NUM_VALIDATORS_WITH_LARGER_STAKE=${NUM_VALIDATORS_WITH_LARGER_STAKE}"
+echo "LARGER_STAKE_AMOUNT=${LARGER_STAKE_AMOUNT}"
 
 # generate all validator configurations
 for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
-username="${USERNAME_PREFIX}-${i}"
-user_dir="${WORKSPACE}/${username}"
-mkdir $user_dir
+    username="${USERNAME_PREFIX}-${i}"
+    user_dir="${WORKSPACE}/${username}"
+    mkdir $user_dir
 
-if [ "${FULLNODE_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
-    fullnode_host="fullnode${i}.${DOMAIN}:6182"
-else
-    fullnode_host="${username}-${FULLNODE_INTERNAL_HOST_SUFFIX}:6182"
-fi
+    if [ "${FULLNODE_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
+        fullnode_host="fullnode${i}.${DOMAIN}:6182"
+    else
+        fullnode_host="${username}-${FULLNODE_INTERNAL_HOST_SUFFIX}:6182"
+    fi
 
-if [ "${VALIDATOR_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
-    validator_host="val${i}.${DOMAIN}:6180"
-else
-    validator_host="${username}-${VALIDATOR_INTERNAL_HOST_SUFFIX}:6180"
-fi
+    if [ "${VALIDATOR_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
+        validator_host="val${i}.${DOMAIN}:6180"
+    else
+        validator_host="${username}-${VALIDATOR_INTERNAL_HOST_SUFFIX}:6180"
+    fi
 
+    if [ $i -lt $NUM_VALIDATORS_WITH_LARGER_STAKE ]; then
+        CUR_STAKE_AMOUNT=$LARGER_STAKE_AMOUNT
+    else
+        CUR_STAKE_AMOUNT=$STAKE_AMOUNT
+    fi
 
-aptos genesis generate-keys --output-dir $user_dir
-aptos genesis set-validator-configuration --owner-public-identity-file $user_dir/public-keys.yaml --local-repository-dir $WORKSPACE \
-    --username $username \
-    --validator-host $validator_host \
-    --full-node-host $fullnode_host \
-    --stake-amount $STAKE_AMOUNT
+    echo "CUR_STAKE_AMOUNT=${CUR_STAKE_AMOUNT} for ${i} validator"
+
+    aptos genesis generate-keys --output-dir $user_dir
+    aptos genesis set-validator-configuration --owner-public-identity-file $user_dir/public-keys.yaml --local-repository-dir $WORKSPACE \
+        --username $username \
+        --validator-host $validator_host \
+        --full-node-host $fullnode_host \
+        --stake-amount $CUR_STAKE_AMOUNT
 done
 
 # get the framework

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -124,6 +124,10 @@ spec:
           value: {{ .Values.genesis.fullnode.internal_host_suffix | quote }}
         - name: STAKE_AMOUNT
           value: {{ .Values.genesis.validator.stake_amount | quote }}
+        - name: NUM_VALIDATORS_WITH_LARGER_STAKE
+          value: {{ .Values.genesis.validator.num_validators_with_larger_stake | quote }}
+        - name: LARGER_STAKE_AMOUNT
+          value: {{ .Values.genesis.validator.larger_stake_amount | quote }}
         volumeMounts:
         - name: layout
           mountPath: /tmp/layout.yaml

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -56,6 +56,10 @@ genesis:
     internal_host_suffix: validator-lb
     # -- Stake amount for each validator in this testnet. Defaults to 1M APTOS coins with 8 decimals
     stake_amount: "100000000000000"
+    # -- Number of validators to give larger stake in genesis to.
+    num_validators_with_larger_stake: 0
+    # -- Stake amount for nodes we are giving larger state to. Defaults to 10M APTOS coins with 8 decimals
+    larger_stake_amount: "1000000000000000"
   fullnode:
     # -- Use External DNS as created by aptos-node helm chart for fullnode host in genesis
     enable_onchain_discovery: true

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -50,11 +50,6 @@ impl K8sNode {
         self.service_name.clone()
     }
 
-    #[allow(dead_code)]
-    fn index(&self) -> usize {
-        self.index
-    }
-
     pub(crate) fn rest_client(&self) -> RestClient {
         RestClient::new(self.rest_api_endpoint())
     }
@@ -128,6 +123,10 @@ impl K8sNode {
 impl Node for K8sNode {
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn index(&self) -> usize {
+        self.index
     }
 
     fn peer_id(&self) -> PeerId {

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -130,15 +130,23 @@ impl Swarm for K8sSwarm {
     }
 
     fn validators<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a> {
-        Box::new(self.validators.values().map(|v| v as &'a dyn Validator))
+        let mut validators: Vec<_> = self
+            .validators
+            .values()
+            .map(|v| v as &'a dyn Validator)
+            .collect();
+        validators.sort_by_key(|v| v.index());
+        Box::new(validators.into_iter())
     }
 
     fn validators_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn Validator> + 'a> {
-        Box::new(
-            self.validators
-                .values_mut()
-                .map(|v| v as &'a mut dyn Validator),
-        )
+        let mut validators: Vec<_> = self
+            .validators
+            .values_mut()
+            .map(|v| v as &'a mut dyn Validator)
+            .collect();
+        validators.sort_by_key(|v| v.index());
+        Box::new(validators.into_iter())
     }
 
     fn validator(&self, id: PeerId) -> Option<&dyn Validator> {

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -46,6 +46,7 @@ pub struct LocalNode {
     version: LocalVersion,
     process: Option<Process>,
     name: String,
+    index: usize,
     account_private_key: Option<ConfigKey<Ed25519PrivateKey>>,
     peer_id: AccountAddress,
     directory: PathBuf,
@@ -56,6 +57,7 @@ impl LocalNode {
     pub fn new(
         version: LocalVersion,
         name: String,
+        index: usize,
         directory: PathBuf,
         account_private_key: Option<ConfigKey<Ed25519PrivateKey>>,
     ) -> Result<Self> {
@@ -70,6 +72,7 @@ impl LocalNode {
             version,
             process: None,
             name,
+            index,
             account_private_key,
             peer_id,
             directory,
@@ -221,6 +224,10 @@ impl LocalNode {
 impl Node for LocalNode {
     fn peer_id(&self) -> PeerId {
         self.peer_id()
+    }
+
+    fn index(&self) -> usize {
+        self.index
     }
 
     fn name(&self) -> &str {

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -81,7 +81,7 @@ impl AsRef<Path> for SwarmDirectory {
 
 #[derive(Debug)]
 pub struct LocalSwarm {
-    node_name_counter: u64,
+    node_name_counter: usize,
     genesis: Transaction,
     genesis_waypoint: Waypoint,
     versions: Arc<HashMap<Version, LocalVersion>>,
@@ -169,8 +169,13 @@ impl LocalSwarm {
         let mut validators = validators
             .into_iter()
             .map(|v| {
-                let node =
-                    LocalNode::new(version.to_owned(), v.name, v.dir, v.account_private_key)?;
+                let node = LocalNode::new(
+                    version.to_owned(),
+                    v.name,
+                    v.index,
+                    v.dir,
+                    v.account_private_key,
+                )?;
                 Ok((node.peer_id(), node))
             })
             .collect::<Result<HashMap<_, _>>>()?;
@@ -217,7 +222,7 @@ impl LocalSwarm {
         );
 
         Ok(LocalSwarm {
-            node_name_counter: validators.len() as u64,
+            node_name_counter: validators.len(),
             genesis,
             genesis_waypoint,
             versions,
@@ -324,6 +329,7 @@ impl LocalSwarm {
         }
 
         let name = self.node_name_counter.to_string();
+        let index = self.node_name_counter;
         self.node_name_counter += 1;
         let fullnode_config = FullnodeNodeConfig::validator_fullnode(
             name,
@@ -339,6 +345,7 @@ impl LocalSwarm {
         let mut fullnode = LocalNode::new(
             version.to_owned(),
             fullnode_config.name,
+            index,
             fullnode_config.dir,
             None,
         )?;
@@ -354,6 +361,7 @@ impl LocalSwarm {
 
     fn add_fullnode(&mut self, version: &Version, template: NodeConfig) -> Result<PeerId> {
         let name = self.node_name_counter.to_string();
+        let index = self.node_name_counter;
         self.node_name_counter += 1;
         let fullnode_config = FullnodeNodeConfig::public_fullnode(
             name,
@@ -367,6 +375,7 @@ impl LocalSwarm {
         let mut fullnode = LocalNode::new(
             version.to_owned(),
             fullnode_config.name,
+            index,
             fullnode_config.dir,
             None,
         )?;
@@ -398,14 +407,14 @@ impl LocalSwarm {
     pub fn validators(&self) -> impl Iterator<Item = &LocalNode> {
         // sort by id to keep the order consistent:
         let mut validators: Vec<&LocalNode> = self.validators.values().collect();
-        validators.sort_by_key(|v| v.name().parse::<i32>().unwrap());
+        validators.sort_by_key(|v| v.index());
         validators.into_iter()
     }
 
     pub fn validators_mut(&mut self) -> impl Iterator<Item = &mut LocalNode> {
         // sort by id to keep the order consistent:
         let mut validators: Vec<&mut LocalNode> = self.validators.values_mut().collect();
-        validators.sort_by_key(|v| v.name().parse::<i32>().unwrap());
+        validators.sort_by_key(|v| v.index());
         validators.into_iter()
     }
 
@@ -438,15 +447,23 @@ impl Swarm for LocalSwarm {
     }
 
     fn validators<'a>(&'a self) -> Box<dyn Iterator<Item = &'a dyn Validator> + 'a> {
-        Box::new(self.validators.values().map(|v| v as &'a dyn Validator))
+        let mut validators: Vec<_> = self
+            .validators
+            .values()
+            .map(|v| v as &'a dyn Validator)
+            .collect();
+        validators.sort_by_key(|v| v.index());
+        Box::new(validators.into_iter())
     }
 
     fn validators_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut dyn Validator> + 'a> {
-        Box::new(
-            self.validators
-                .values_mut()
-                .map(|v| v as &'a mut dyn Validator),
-        )
+        let mut validators: Vec<_> = self
+            .validators
+            .values_mut()
+            .map(|v| v as &'a mut dyn Validator)
+            .collect();
+        validators.sort_by_key(|v| v.index());
+        Box::new(validators.into_iter())
     }
 
     fn validator(&self, id: PeerId) -> Option<&dyn Validator> {

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -34,6 +34,9 @@ pub trait Node: Send + Sync {
     /// Return the PeerId of this Node
     fn peer_id(&self) -> PeerId;
 
+    /// Return index of the node
+    fn index(&self) -> usize;
+
     /// Return the human readable name of this Node
     fn name(&self) -> &str;
 

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -236,8 +236,12 @@ pub trait SwarmExt: Swarm {
         version: u64,
         timeout: Duration,
     ) -> Result<()> {
-        wait_for_all_nodes_to_catchup_to_version(&self.get_clients_with_names(), version, timeout)
-            .await
+        wait_for_all_nodes_to_catchup_to_version(
+            &self.get_all_nodes_clients_with_names(),
+            version,
+            timeout,
+        )
+        .await
     }
 
     /// Wait for all nodes in the network to be caught up. This is done by first querying each node
@@ -245,10 +249,16 @@ pub trait SwarmExt: Swarm {
     /// that version. Once done, we can guarantee that all transactions committed before invocation
     /// of this function are available at all the nodes in the swarm
     async fn wait_for_all_nodes_to_catchup(&self, timeout: Duration) -> Result<()> {
-        wait_for_all_nodes_to_catchup(&self.get_clients_with_names(), timeout).await
+        wait_for_all_nodes_to_catchup(&self.get_all_nodes_clients_with_names(), timeout).await
     }
 
-    fn get_clients_with_names(&self) -> Vec<(String, RestClient)> {
+    fn get_validator_clients_with_names(&self) -> Vec<(String, RestClient)> {
+        self.validators()
+            .map(|node| (node.name().to_string(), node.rest_client()))
+            .collect()
+    }
+
+    fn get_all_nodes_clients_with_names(&self) -> Vec<(String, RestClient)> {
         self.validators()
             .map(|node| (node.name().to_string(), node.rest_client()))
             .chain(

--- a/testsuite/testcases/src/continuous_progress_test.rs
+++ b/testsuite/testcases/src/continuous_progress_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::NetworkLoadTest;
+use anyhow::bail;
 use forge::test_utils::consensus_utils::{no_failure_injection, test_consensus_fault_tolerance};
 use forge::{NetworkContext, NetworkTest, Result, Swarm, Test};
 use std::time::Duration;
@@ -47,19 +48,21 @@ impl NetworkLoadTest for ContinuousProgressTest {
                 let transactions = cur.iter().map(|s| s.version).min().unwrap()
                     - previous.iter().map(|s| s.version).max().unwrap();
 
-                assert!(
-                    transactions >= (target_tps * check_period_s / 2) as u64,
-                    "no progress with active consensus, only {} transactions, expected >= {}",
-                    transactions,
-                    (target_tps * check_period_s / 2),
-                );
-                assert!(
-                    epochs > 0 || rounds >= (check_period_s / 2) as u64,
-                    "no progress with active consensus, only {} epochs and {} rounds, expectd >= {}",
-                    epochs,
-                    rounds,
-                    (check_period_s / 2),
-                );
+                if transactions < (target_tps * check_period_s / 2) as u64 {
+                    bail!(
+                        "no progress with active consensus, only {} transactions, expected >= {}",
+                        transactions,
+                        (target_tps * check_period_s / 2),
+                    );
+                }
+                if epochs == 0 && rounds < (check_period_s / 2) as u64 {
+                    bail!("no progress with active consensus, only {} epochs and {} rounds, expectd >= {}",
+                        epochs,
+                        rounds,
+                        (check_period_s / 2),
+                    );
+                }
+                Ok(())
             }),
             false,
         ))?;

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -54,7 +54,7 @@ impl NetworkTest for StateSyncPerformance {
 
         // Fetch the highest synced version from the swarm
         let highest_synced_version = runtime.block_on(async {
-            get_highest_synced_version(&ctx.swarm().get_clients_with_names())
+            get_highest_synced_version(&ctx.swarm().get_all_nodes_clients_with_names())
                 .await
                 .unwrap_or(0)
         });


### PR DESCRIPTION
- through passing genesis configuration (same way as epoch change)
- with that, surface validator indices, and have iterators on validators
  be consistent with what they return
  (so that we can properly know which nodes were set with larger stake)
- additionally, make continuous_progress_test return Err on checks,
  instead of panicing.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3896)
<!-- Reviewable:end -->
