### PR TITLE
[Forge] Add new state sync performance tests.

### DIFF
--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-apply-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-apply-test.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E State Sync Performance Test For Fullnode Transaction Output Application
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  # Performance test in an optimal setting
+  run-forge-state-sync-perf-fullnode-apply-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-apply
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_apply_outputs
+      POST_TO_SLACK: true

--- a/.github/workflows/continuous-e2e-state-sync-perf-fullnode-execute-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-fullnode-execute-test.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E State Sync Performance Test For Fullnode Transaction Execution
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  # Performance test in an optimal setting
+  run-forge-state-sync-perf-fullnode-execute-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-perf-fullnode-execute
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_fullnodes_execute_transactions
+      POST_TO_SLACK: true

--- a/.github/workflows/continuous-e2e-state-sync-perf-validator-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-perf-validator-test.yaml
@@ -1,4 +1,4 @@
-name: Continuous E2E State Sync Performance Test
+name: Continuous E2E State Sync Performance Test For Validators
 
 permissions:
   issues: write
@@ -11,13 +11,13 @@ on:
 
 jobs:
   # Performance test in an optimal setting
-  run-forge-state-sync-performance:
+  run-forge-state-sync-perf-validator-test:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-state-sync-perf
+      FORGE_NAMESPACE: forge-state-sync-perf-validator
       FORGE_CLUSTER_NAME: aptos-forge-big-1
-      # Run for 30 minutes
-      FORGE_RUNNER_DURATION_SECS: 1800
-      FORGE_TEST_SUITE: state_sync
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 2400
+      FORGE_TEST_SUITE: state_sync_perf_validators
       POST_TO_SLACK: true

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -8,40 +8,61 @@ use forge::{get_highest_synced_version, NetworkContext, NetworkTest, Result, Swa
 use std::time::Instant;
 use tokio::{runtime::Runtime, time::Duration};
 
-const MAX_FULLNODE_LAG_SECS: u64 = 10; // Max amount of lag (in seconds) that fullnodes should adhere to
+const MAX_NODE_LAG_SECS: u64 = 10; // Max amount of lag (in seconds) that nodes should adhere to
 
-pub struct StateSyncPerformance;
+/// A state sync performance test that measures fullnode sync performance.
+/// In the test, all fullnodes are wiped, restarted and timed to synchronize.
+pub struct StateSyncFullnodePerformance;
 
-impl Test for StateSyncPerformance {
+impl Test for StateSyncFullnodePerformance {
     fn name(&self) -> &'static str {
-        "StateSyncPerformance"
+        "StateSyncFullnodePerformance"
     }
 }
 
-impl NetworkTest for StateSyncPerformance {
+impl NetworkTest for StateSyncFullnodePerformance {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
-        let emit_txn_duration = ctx.global_duration; // How long we'll emit txns for
-        let fullnode_sync_duration = emit_txn_duration.saturating_mul(2); // Limits state sync to half txn throughput
-
-        // Generate some traffic through the fullnodes
-        info!(
-            "Generating the initial traffic for {:?} seconds.",
-            emit_txn_duration.as_secs()
-        );
+        // Verify we have at least 1 fullnode
         let all_fullnodes = ctx
             .swarm()
             .full_nodes()
             .map(|v| v.peer_id())
             .collect::<Vec<_>>();
+        if all_fullnodes.is_empty() {
+            return Err(anyhow::format_err!(
+                "Fullnode performance tests require at least 1 fullnode!"
+            ));
+        }
+
+        // Log the test setup
+        let all_validators = ctx
+            .swarm()
+            .validators()
+            .map(|v| v.peer_id())
+            .collect::<Vec<_>>();
+        info!(
+            "Running state sync test {:?} with {:?} validators and {:?} fullnodes.",
+            self.name(),
+            all_validators.len(),
+            all_fullnodes.len()
+        );
+
+        // Generate some traffic through the fullnodes.
+        // We do this for half the test time.
+        let emit_txn_duration = ctx.global_duration.checked_div(2).unwrap();
+        info!(
+            "Generating the initial traffic for {:?} seconds.",
+            emit_txn_duration.as_secs()
+        );
         let _txn_stat = generate_traffic(ctx, &all_fullnodes, emit_txn_duration, 1)?;
 
-        // Wait for all nodes to catch up. We time bound this to ensure
+        // Wait for all nodes to synchronize. We time bound this to ensure
         // fullnodes don't fall too far behind the validators.
         info!("Waiting for the validators and fullnodes to be synchronized.");
         let runtime = Runtime::new().unwrap();
         runtime.block_on(async {
             ctx.swarm()
-                .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_FULLNODE_LAG_SECS))
+                .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_NODE_LAG_SECS))
                 .await
         })?;
 
@@ -52,70 +73,154 @@ impl NetworkTest for StateSyncPerformance {
             runtime.block_on(async { fullnode.clear_storage().await })?;
         }
 
-        // Fetch the highest synced version from the swarm
-        let highest_synced_version = runtime.block_on(async {
-            get_highest_synced_version(&ctx.swarm().get_all_nodes_clients_with_names())
-                .await
-                .unwrap_or(0)
-        });
-        if highest_synced_version == 0 {
-            return Err(anyhow::format_err!(
-                "The swarm has synced 0 versions! Something has gone wrong!"
-            ));
-        }
-        info!("Syncing to target version at: {:?}", highest_synced_version);
-
-        // Restart the fullnodes so they start syncing from a fresh state
+        // Restart the nodes so they start syncing from a fresh state
+        // and start the timer.
         for fullnode_id in &all_fullnodes {
             let fullnode = ctx.swarm().full_node_mut(*fullnode_id).unwrap();
             runtime.block_on(async { fullnode.start().await })?;
         }
-
-        // Wait for all fullnodes to catch up to the highest synced version
-        info!("Restarting all the fullnodes and waiting for them to catchup.");
         let timer = Instant::now();
-        runtime.block_on(async {
-            ctx.swarm()
-                .wait_for_all_nodes_to_catchup(fullnode_sync_duration)
-                .await
-        })?;
-        let duration_to_state_sync = timer.elapsed();
-        let seconds_to_state_sync = duration_to_state_sync.as_secs();
 
-        // Calculate the state sync throughput
-        if seconds_to_state_sync == 0 {
+        // Wait for all nodes to catch up to the highest synced version
+        // then calculate and display the throughput results.
+        ensure_state_sync_throughput(ctx, timer, self.name())
+    }
+}
+
+/// A state sync performance test that measures validator sync performance.
+/// In the test, 2 validators are wiped, restarted and timed to synchronize.
+pub struct StateSyncValidatorPerformance;
+
+impl Test for StateSyncValidatorPerformance {
+    fn name(&self) -> &'static str {
+        "StateSyncValidatorPerformance"
+    }
+}
+
+impl NetworkTest for StateSyncValidatorPerformance {
+    fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        // Verify we have at least 7 validators (i.e., 3f+1, where f is 2)
+        // so we can kill 2 validators but still make progress.
+        let all_validators = ctx
+            .swarm()
+            .validators()
+            .map(|v| v.peer_id())
+            .collect::<Vec<_>>();
+        let num_validators = all_validators.len();
+        if num_validators < 7 {
             return Err(anyhow::format_err!(
-                "The time taken to state sync was 0 seconds! Something has gone wrong!"
+                "State sync validator performance tests require at least 7 validators! Given: {:?} \
+                 This is to ensure the chain can still make progress when 2 validators are killed.",
+                num_validators
             ));
         }
-        let state_sync_throughput = highest_synced_version as u64 / seconds_to_state_sync;
 
-        // Report the state sync results
-        let state_sync_throughput_message =
-            format!("State sync throughput : {} txn/sec", state_sync_throughput);
+        // Log the test setup
         info!(
-            "Measured state sync throughput: {:?}",
-            state_sync_throughput_message
-        );
-        ctx.report.report_text(state_sync_throughput_message);
-        ctx.report.report_metric(
+            "Running state sync test {:?} with {:?} validators.",
             self.name(),
-            "state_sync_throughput",
-            state_sync_throughput as f64,
+            num_validators,
         );
 
-        // TODO: we fetch the TPS requirement from the given success criteria.
-        // But, we should probably make it more generic to avoid this.
-        // Ensure we meet the success criteria.
-        let min_expected_tps = ctx.success_criteria.avg_tps as u64;
-        if state_sync_throughput < min_expected_tps {
-            let error_message = format!(
-                "State sync TPS requirement failed. Average TPS: {}, minimum required TPS: {}",
-                state_sync_throughput, min_expected_tps
-            );
-            bail!(error_message)
+        // Generate some traffic through the validators.
+        // We do this for half the test time.
+        let emit_txn_duration = ctx.global_duration.checked_div(2).unwrap();
+        info!(
+            "Generating the initial traffic for {:?} seconds.",
+            emit_txn_duration.as_secs()
+        );
+        let _txn_stat = generate_traffic(ctx, &all_validators, emit_txn_duration, 1)?;
+
+        // Wait for all nodes to synchronize and stabilize.
+        info!("Waiting for the validators to be synchronized.");
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async {
+            ctx.swarm()
+                .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_NODE_LAG_SECS))
+                .await
+        })?;
+
+        // Stop and reset two validators
+        info!("Deleting data for two validators!");
+        let validators_to_restart = &all_validators[0..2];
+        for validator_id in validators_to_restart {
+            let validator = ctx.swarm().validator_mut(*validator_id).unwrap();
+            runtime.block_on(async { validator.clear_storage().await })?;
         }
 
-        Ok(())
+        // Restart the validators so they start syncing from a fresh state
+        // and start the timer.
+        for validator_id in validators_to_restart {
+            let validator = ctx.swarm().validator_mut(*validator_id).unwrap();
+            runtime.block_on(async { validator.start().await })?;
+        }
+        let timer = Instant::now();
+
+        // Wait for all nodes to catch up to the highest synced version
+        // then calculate and display the throughput results.
+        ensure_state_sync_throughput(ctx, timer, self.name())
     }
+}
+
+/// Calculates, enforces and displays the state sync throughput using
+/// the synced version and sync duration.
+fn ensure_state_sync_throughput(
+    ctx: &mut NetworkContext<'_>,
+    timer: Instant,
+    test_name: &str,
+) -> Result<()> {
+    // Get the highest synced version for the chain
+    let runtime = Runtime::new().unwrap();
+    let highest_synced_version = runtime.block_on(async {
+        get_highest_synced_version(&ctx.swarm().get_all_nodes_clients_with_names())
+            .await
+            .unwrap_or(0)
+    });
+    if highest_synced_version == 0 {
+        return Err(anyhow::format_err!(
+            "The swarm has synced 0 versions! Something has gone wrong!"
+        ));
+    }
+
+    // Wait for all nodes to catch up to the same synced version.
+    // We allow up to half the test time to do this.
+    let node_sync_duration = ctx.global_duration.checked_div(2).unwrap();
+    runtime.block_on(async {
+        ctx.swarm()
+            .wait_for_all_nodes_to_catchup(node_sync_duration)
+            .await
+    })?;
+
+    // Calculate the state sync throughput
+    let seconds_to_sync = timer.elapsed().as_secs();
+    if seconds_to_sync == 0 {
+        return Err(anyhow::format_err!(
+            "The time taken to state sync was 0 seconds! Something has gone wrong!"
+        ));
+    }
+    let state_sync_throughput = highest_synced_version as u64 / seconds_to_sync;
+
+    // Report the state sync results
+    let throughput_message = format!("State sync throughput : {} txn/sec", state_sync_throughput);
+    info!("Measured state sync throughput: {:?}", throughput_message);
+    ctx.report.report_text(throughput_message);
+    ctx.report.report_metric(
+        test_name,
+        "state_sync_throughput",
+        state_sync_throughput as f64,
+    );
+
+    // TODO: we fetch the TPS requirement from the given success criteria.
+    // But, we should probably make it more generic to avoid this.
+    // Ensure we meet the success criteria.
+    let min_expected_tps = ctx.success_criteria.avg_tps as u64;
+    if state_sync_throughput < min_expected_tps {
+        let error_message = format!(
+            "State sync TPS requirement failed. Average TPS: {}, minimum required TPS: {}",
+            state_sync_throughput, min_expected_tps
+        );
+        bail!(error_message)
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
### Description
This PR expands the single state sync performance test into three separate tests:
1. A fullnode syncing test for transaction output application.
2. A fullnode syncing test for transaction execution.
3. A validator syncing test for validators that have fallen behind.

Each of the above tests will measure and report state sync throughput.

### Test Plan
Manual verification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3919)
<!-- Reviewable:end -->
