### PR TITLE
[monitoring] prometheus scrape all cadvisor targets

### DIFF
--- a/terraform/fullnode/aws/main.tf
+++ b/terraform/fullnode/aws/main.tf
@@ -19,8 +19,8 @@ locals {
     ? [for t in data.aws_ecr_image.stable[0].image_tags : t if substr(t, 0, 5) == "main_"][0]
     : "latest"
   )
-  aws_tags = "Terraform=pfn,Workspace=${terraform.workspace}"
-  workspace_name = "${terraform.workspace}"
+  aws_tags       = "Terraform=pfn,Workspace=${terraform.workspace}"
+  workspace_name = terraform.workspace
 }
 
 module "eks" {

--- a/terraform/helm/monitoring/files/prometheus.yml
+++ b/terraform/helm/monitoring/files/prometheus.yml
@@ -89,13 +89,6 @@ scrape_configs:
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 
-  {{ if not .Values.monitoring.prometheus.fullKubernetesScrape }}
-  metric_relabel_configs:
-  - source_labels: [pod]
-    action: keep
-    regex: "{{ .Release.Name }}-.*"
-  {{ end }}
-
 - job_name: "prom-pod-annotation"
 
   kubernetes_sd_configs:


### PR DESCRIPTION
### Description

Still scrape all cadvisor targets even when `.Values.monitoring.prometheus.fullKubernetesScrape = false`, so that we get all container metrics. Previously, it was only scraping the namespace in which prometheus is installed

This makes the monitoring solution work regardless of where the `aptos-node` helm chart is installed

### Test Plan

Apply to cluster.

Before: 
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/12578616/188788156-5a4b3e0b-e733-49bd-8118-99647c088f50.png">


After:
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/12578616/188788210-c812268c-84f5-49ee-800b-c520e09bbc67.png">



<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3922)
<!-- Reviewable:end -->
