### PR TITLE
[code publishing] Make package dependency metadata unforgeable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,6 +3385,7 @@ dependencies = [
  "project-root",
  "proptest",
  "rand 0.7.3",
+ "rstest",
  "serde 1.0.144",
  "tempfile",
  "vm-genesis",
@@ -4026,6 +4027,12 @@ name = "futures-task"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -7959,6 +7966,31 @@ source = "git+https://github.com/aptos-labs/rust-rocksdb#3698ab20df2bdc4148efc0f
 dependencies = [
  "libc",
  "librocksdb-sys",
+]
+
+[[package]]
+name = "rstest"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "rustc_version",
+ "syn 1.0.99",
 ]
 
 [[package]]

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -45,6 +45,7 @@ use aptos_types::{
 };
 use fail::fail_point;
 use framework::natives::code::PublishRequest;
+use move_deps::move_binary_format::errors::VMError;
 use move_deps::move_core_types::language_storage::ModuleId;
 use move_deps::{
     move_binary_format::{
@@ -62,7 +63,7 @@ use move_deps::{
 };
 use num_cpus;
 use once_cell::sync::OnceCell;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     cmp::min,
@@ -435,7 +436,7 @@ impl AptosVM {
                         gas_meter,
                     )?;
                 } else {
-                    return Err(PartialVMError::new(StatusCode::VERIFICATION_ERROR)
+                    return Err(PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
                         .finish(Location::Undefined));
                 }
             }
@@ -519,6 +520,7 @@ impl AptosVM {
             destination,
             bundle,
             expected_modules,
+            allowed_deps,
             check_compat,
         }) = session.extract_publish_request()
         {
@@ -529,7 +531,7 @@ impl AptosVM {
             let modules = self.deserialize_module_bundle(&bundle)?;
 
             // Validate the module bundle
-            self.validate_publish_request(&modules, expected_modules)?;
+            self.validate_publish_request(&modules, expected_modules, allowed_deps)?;
 
             // Check what modules exist before publishing.
             let mut exists = BTreeSet::new();
@@ -562,19 +564,45 @@ impl AptosVM {
     fn validate_publish_request(
         &self,
         modules: &[CompiledModule],
-        expected_names: BTreeSet<String>,
+        mut expected_modules: BTreeSet<String>,
+        allowed_deps: Option<BTreeMap<AccountAddress, BTreeSet<String>>>,
     ) -> VMResult<()> {
-        let given_names = modules
-            .iter()
-            .map(|m| m.self_id().name().as_str().to_string())
-            .collect::<BTreeSet<_>>();
-        if given_names != expected_names {
-            Err(PartialVMError::new(StatusCode::VERIFICATION_ERROR)
-                .with_message("metadata and code bundle mismatch".to_owned())
-                .finish(Location::Undefined))
-        } else {
-            Ok(())
+        for m in modules {
+            if !expected_modules.remove(m.self_id().name().as_str()) {
+                return Err(Self::metadata_validation_error(&format!(
+                    "unregistered module: '{}'",
+                    m.self_id().name()
+                )));
+            }
+            if let Some(allowed) = &allowed_deps {
+                for dep in m.immediate_dependencies() {
+                    if !allowed
+                        .get(dep.address())
+                        .map(|modules| {
+                            modules.contains("") || modules.contains(dep.name().as_str())
+                        })
+                        .unwrap_or(false)
+                    {
+                        return Err(Self::metadata_validation_error(&format!(
+                            "unregistered dependency: '{}'",
+                            dep
+                        )));
+                    }
+                }
+            }
         }
+        if !expected_modules.is_empty() {
+            return Err(Self::metadata_validation_error(
+                "not all registered modules published",
+            ));
+        }
+        Ok(())
+    }
+
+    fn metadata_validation_error(msg: &str) -> VMError {
+        PartialVMError::new(StatusCode::CONSTRAINT_NOT_SATISFIED)
+            .with_message(format!("metadata and code bundle mismatch: {}", msg))
+            .finish(Location::Undefined)
     }
 
     pub(crate) fn execute_user_transaction<S: MoveResolverExt + StateView>(

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.10.0"
 project-root = "0.2.2"
 proptest = "1.0.0"
 rand = "0.7.3"
+rstest = "0.15.0"
 serde = { version = "1.0.137", default-features = false }
 tempfile = "3.3.0"
 

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::assert_success;
 use crate::AptosPackageHooks;
 use aptos::move_tool::MemberId;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
@@ -322,15 +321,18 @@ impl MoveHarness {
     /// Enables features
     pub fn enable_features(&mut self, features: Vec<u64>) {
         let acc = self.aptos_framework_account();
-        assert_success!(self.run_entry_function(
-            &acc,
-            str::parse("0x1::features::change_feature_flags").unwrap(),
+        self.executor.exec(
+            "features",
+            "change_feature_flags",
             vec![],
             vec![
+                MoveValue::Signer(*acc.address())
+                    .simple_serialize()
+                    .unwrap(),
                 bcs::to_bytes(&features).unwrap(),
-                bcs::to_bytes(&Vec::<u64>::new()).unwrap()
+                bcs::to_bytes(&Vec::<u64>::new()).unwrap(),
             ],
-        ));
+        );
     }
 
     /// Increase maximal transaction size.

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::assert_success;
 use crate::AptosPackageHooks;
 use aptos::move_tool::MemberId;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
@@ -14,6 +15,7 @@ use aptos_types::{
     transaction::{EntryFunction, SignedTransaction, TransactionPayload, TransactionStatus},
 };
 use cached_packages::aptos_stdlib;
+use framework::natives::code::PackageMetadata;
 use framework::{BuildOptions, BuiltPackage};
 use language_e2e_tests::{
     account::{Account, AccountData},
@@ -69,6 +71,14 @@ impl MoveHarness {
             executor: FakeExecutor::from_testnet_genesis(),
             txn_seq_no: BTreeMap::default(),
         }
+    }
+
+    pub fn new_with_features(features: Vec<u64>) -> Self {
+        let mut h = Self::new();
+        if !features.is_empty() {
+            h.enable_features(features);
+        }
+        h
     }
 
     pub fn new_mainnet() -> Self {
@@ -197,18 +207,22 @@ impl MoveHarness {
 
     /// Creates a transaction which publishes the Move Package found at the given path on behalf
     /// of the given account.
+    ///
+    /// The passed function allows to manipulate the generated metadata for testing purposes.
     pub fn create_publish_package(
         &mut self,
         account: &Account,
         path: &Path,
         options: Option<BuildOptions>,
+        mut patch_metadata: impl FnMut(&mut PackageMetadata),
     ) -> SignedTransaction {
         let package = BuiltPackage::build(path.to_owned(), options.unwrap_or_default())
             .expect("building package must succeed");
         let code = package.extract_code();
-        let metadata = package
+        let mut metadata = package
             .extract_metadata()
             .expect("extracting package metadata must succeed");
+        patch_metadata(&mut metadata);
         self.create_transaction_payload(
             account,
             aptos_stdlib::code_publish_package_txn(
@@ -220,7 +234,7 @@ impl MoveHarness {
 
     /// Runs transaction which publishes the Move Package.
     pub fn publish_package(&mut self, account: &Account, path: &Path) -> TransactionStatus {
-        let txn = self.create_publish_package(account, path, None);
+        let txn = self.create_publish_package(account, path, None, |_| {});
         self.run(txn)
     }
 
@@ -231,7 +245,18 @@ impl MoveHarness {
         path: &Path,
         options: BuildOptions,
     ) -> TransactionStatus {
-        let txn = self.create_publish_package(account, path, Some(options));
+        let txn = self.create_publish_package(account, path, Some(options), |_| {});
+        self.run(txn)
+    }
+
+    /// Runs transaction which publishes the Move Package, and alllows to patch the metadata
+    pub fn publish_package_with_patcher(
+        &mut self,
+        account: &Account,
+        path: &Path,
+        metadata_patcher: impl FnMut(&mut PackageMetadata),
+    ) -> TransactionStatus {
+        let txn = self.create_publish_package(account, path, None, metadata_patcher);
         self.run(txn)
     }
 
@@ -292,6 +317,20 @@ impl MoveHarness {
     /// Checks whether resource exists.
     pub fn exists_resource(&self, addr: &AccountAddress, struct_tag: StructTag) -> bool {
         self.read_resource_raw(addr, struct_tag).is_some()
+    }
+
+    /// Enables features
+    pub fn enable_features(&mut self, features: Vec<u64>) {
+        let acc = self.aptos_framework_account();
+        assert_success!(self.run_entry_function(
+            &acc,
+            str::parse("0x1::features::change_feature_flags").unwrap(),
+            vec![],
+            vec![
+                bcs::to_bytes(&features).unwrap(),
+                bcs::to_bytes(&Vec::<u64>::new()).unwrap()
+            ],
+        ));
     }
 
     /// Increase maximal transaction size.

--- a/aptos-move/e2e-move-tests/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/tests/code_publishing.rs
@@ -15,7 +15,7 @@ mod common;
 
 // Note: this module uses parameterized tests via the
 // [`rstest` crate](https://crates.io/crates/rstest)
-// to test for multiple versions.
+// to test for multiple feature combinations.
 
 /// Mimics `0xcafe::test::State`
 #[derive(Serialize, Deserialize)]
@@ -23,6 +23,8 @@ struct State {
     value: u64,
 }
 
+/// Runs the basic publishing test for all legacy flag combinations. Otherwise we will only
+/// run tests which are expected to make a difference for legacy flag combinations.
 #[rstest]
 #[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
@@ -63,7 +65,6 @@ fn code_publishing_basic(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_upgrade_success_no_compat(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -83,7 +84,6 @@ fn code_publishing_upgrade_success_no_compat(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_upgrade_success_compat(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -103,7 +103,6 @@ fn code_publishing_upgrade_success_compat(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_upgrade_fail_compat(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -124,7 +123,6 @@ fn code_publishing_upgrade_fail_compat(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_upgrade_fail_immutable(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -145,7 +143,6 @@ fn code_publishing_upgrade_fail_immutable(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_upgrade_fail_overlapping_module(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -209,7 +206,6 @@ fn code_publishing_upgrade_loader_cache_consistency() {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_framework_upgrade(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -224,7 +220,6 @@ fn code_publishing_framework_upgrade(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_framework_upgrade_fail(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -240,7 +235,6 @@ fn code_publishing_framework_upgrade_fail(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_weak_dep_fail(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -267,7 +261,6 @@ fn code_publishing_weak_dep_fail(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_arbitray_dep_different_address(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);
@@ -297,7 +290,6 @@ fn code_publishing_arbitray_dep_different_address(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![])]
 #[case(vec![CODE_DEPENDENCY_CHECK])]
 fn code_publishing_using_resource_account(#[case] features: Vec<u64>) {
     let mut h = MoveHarness::new_with_features(features);

--- a/aptos-move/framework/aptos-framework/sources/code.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/code.spec.move
@@ -2,4 +2,8 @@ spec aptos_framework::code {
     spec request_publish { // TODO: temporary mockup.
         pragma opaque;
     }
+
+    spec request_publish_with_allowed_deps { // TODO: temporary mockup.
+        pragma opaque;
+    }
 }

--- a/aptos-move/framework/aptos-framework/sources/configs/features.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/features.move
@@ -1,0 +1,126 @@
+/// Maintains feature flags.
+module aptos_framework::features {
+    use aptos_framework::system_addresses;
+    use std::vector;
+
+    // ============================================================================================
+    // Feature Flag Definitions
+
+    // Each feature flag should come with documentation which justifies the need of the flag.
+    // Introduction of a new feature flag requires approval of framework owners. Be frugal when
+    // introducing new features, as too many features can make it hard to understand the code.
+    //
+    // Each feature flag should come with a specification of a lifetime:
+    //
+    // - a *transient* feature flag is only needed until a related code rollout has happened. This
+    //   is typically associated with the introduction of new native Move functions, and is only used
+    //   from Move code. The owner of this feature is obliged to remove it once this can be done.
+    //
+    // - an *ephemeral* feature flag is required to stay around forever. Typically, those flags guard
+    //   behavior in native code, and the behavior with or without the feature need to be preserved
+    //   for playback.
+    //
+    // Features should be grouped along components. Their name should start with the module or
+    // component name they are associated with.
+
+
+    // --------------------------------------------------------------------------------------------
+    // Code Publishing
+
+    /// Whether validation of package dependencies is enabled, and the related native function is
+    /// available. This is needed because of introduction of a new native function.
+    /// Lifetime: transient
+    const CODE_DEPENDENCY_CHECK: u64 = 1;
+    public fun code_dependency_check_enabled(): bool acquires Features {
+        is_enabled(CODE_DEPENDENCY_CHECK)
+    }
+
+    // ============================================================================================
+    // Feature Flag  Management
+
+    /// The enabled features, represented by a bitset stored on chain.
+    struct Features has key {
+        features: vector<u8>,
+    }
+
+    /// Entry function to enable and disable features. Can only be called by @aptos_framework.
+    public entry fun change_feature_flags(aptos_framework: &signer, enable: vector<u64>, disable: vector<u64>)
+    acquires Features {
+        system_addresses::assert_aptos_framework(aptos_framework);
+        if (!exists<Features>(@aptos_framework)) {
+            move_to<Features>(aptos_framework, Features{features: vector[]})
+        };
+        let features = &mut borrow_global_mut<Features>(@aptos_framework).features;
+        let i = 0;
+        let n = vector::length(&enable);
+        while (i < n) {
+            include_or_exclude(features, *vector::borrow(&enable, i), true);
+            i = i + 1
+        };
+        let i = 0;
+        let n = vector::length(&disable);
+        while (i < n) {
+            include_or_exclude(features, *vector::borrow(&disable, i), false);
+            i = i + 1
+        };
+    }
+
+    /// Check whether the feature is enabled.
+    fun is_enabled(feature: u64): bool acquires Features {
+        exists<Features>(@aptos_framework) &&
+        contains(&borrow_global<Features>(@aptos_framework).features, feature)
+    }
+
+    /// Helper to include or exclude a feature flag.
+    fun include_or_exclude(features: &mut vector<u8>, feature: u64, include: bool) {
+        let byte_index = feature / 8;
+        let bit_mask = 1 << ((feature % 8) as u8);
+        while (vector::length(features) <= byte_index) {
+            vector::push_back(features, 0)
+        };
+        let entry = vector::borrow_mut(features, byte_index);
+        if (include)
+            *entry = *entry | bit_mask
+        else
+            *entry = *entry & (0xff ^ bit_mask)
+    }
+
+    /// Helper to check whether a feature flag is enabled.
+    fun contains(features: &vector<u8>, feature: u64): bool {
+        let byte_index = feature / 8;
+        let bit_mask = 1 << ((feature % 8) as u8);
+        byte_index < vector::length(features) && (*vector::borrow(features, byte_index) & bit_mask) != 0
+    }
+
+    #[test]
+    fun test_feature_sets() {
+        let features = vector[];
+        include_or_exclude(&mut features, 1, true);
+        include_or_exclude(&mut features, 5, true);
+        include_or_exclude(&mut features, 17, true);
+        include_or_exclude(&mut features, 23, true);
+        assert!(contains(&features, 1), 0);
+        assert!(contains(&features, 5), 1);
+        assert!(contains(&features, 17), 2);
+        assert!(contains(&features, 23), 3);
+        include_or_exclude(&mut features, 5, false);
+        include_or_exclude(&mut features, 17, false);
+        assert!(contains(&features, 1), 0);
+        assert!(!contains(&features, 5), 1);
+        assert!(!contains(&features, 17), 2);
+        assert!(contains(&features, 23), 3);
+    }
+
+    #[test(fx = @aptos_framework)]
+    fun test_change_feature_txn(fx: signer) acquires Features {
+        change_feature_flags(&fx, vector[1, 9, 23], vector[]);
+        assert!(is_enabled(1), 1);
+        assert!(is_enabled(9), 2);
+        assert!(is_enabled(23), 3);
+        change_feature_flags(&fx, vector[17], vector[9]);
+        assert!(is_enabled(1), 1);
+        assert!(!is_enabled(9), 2);
+        assert!(is_enabled(17), 3);
+        assert!(is_enabled(23), 4);
+    }
+}

--- a/aptos-move/framework/aptos-framework/sources/configs/features.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/features.move
@@ -8,7 +8,7 @@ module aptos_framework::features {
 
     // Each feature flag should come with documentation which justifies the need of the flag.
     // Introduction of a new feature flag requires approval of framework owners. Be frugal when
-    // introducing new features, as too many features can make it hard to understand the code.
+    // introducing new feature flags, as too many can make it hard to understand the code.
     //
     // Each feature flag should come with a specification of a lifetime:
     //
@@ -43,8 +43,8 @@ module aptos_framework::features {
         features: vector<u8>,
     }
 
-    /// Entry function to enable and disable features. Can only be called by @aptos_framework.
-    public entry fun change_feature_flags(aptos_framework: &signer, enable: vector<u64>, disable: vector<u64>)
+    /// Function to enable and disable features. Can only be called by @aptos_framework.
+    public fun change_feature_flags(aptos_framework: &signer, enable: vector<u64>, disable: vector<u64>)
     acquires Features {
         system_addresses::assert_aptos_framework(aptos_framework);
         if (!exists<Features>(@aptos_framework)) {
@@ -54,13 +54,13 @@ module aptos_framework::features {
         let i = 0;
         let n = vector::length(&enable);
         while (i < n) {
-            include_or_exclude(features, *vector::borrow(&enable, i), true);
+            set(features, *vector::borrow(&enable, i), true);
             i = i + 1
         };
         let i = 0;
         let n = vector::length(&disable);
         while (i < n) {
-            include_or_exclude(features, *vector::borrow(&disable, i), false);
+            set(features, *vector::borrow(&disable, i), false);
             i = i + 1
         };
     }
@@ -72,7 +72,7 @@ module aptos_framework::features {
     }
 
     /// Helper to include or exclude a feature flag.
-    fun include_or_exclude(features: &mut vector<u8>, feature: u64, include: bool) {
+    fun set(features: &mut vector<u8>, feature: u64, include: bool) {
         let byte_index = feature / 8;
         let bit_mask = 1 << ((feature % 8) as u8);
         while (vector::length(features) <= byte_index) {
@@ -95,16 +95,16 @@ module aptos_framework::features {
     #[test]
     fun test_feature_sets() {
         let features = vector[];
-        include_or_exclude(&mut features, 1, true);
-        include_or_exclude(&mut features, 5, true);
-        include_or_exclude(&mut features, 17, true);
-        include_or_exclude(&mut features, 23, true);
+        set(&mut features, 1, true);
+        set(&mut features, 5, true);
+        set(&mut features, 17, true);
+        set(&mut features, 23, true);
         assert!(contains(&features, 1), 0);
         assert!(contains(&features, 5), 1);
         assert!(contains(&features, 17), 2);
         assert!(contains(&features, 23), 3);
-        include_or_exclude(&mut features, 5, false);
-        include_or_exclude(&mut features, 17, false);
+        set(&mut features, 5, false);
+        set(&mut features, 17, false);
         assert!(contains(&features, 1), 0);
         assert!(!contains(&features, 5), 1);
         assert!(!contains(&features, 17), 2);

--- a/aptos-move/framework/aptos-framework/sources/configs/features.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/features.spec.move
@@ -1,0 +1,16 @@
+/// Maintains feature flags.
+spec aptos_framework::features {
+    spec module {
+        pragma verify = false;
+    }
+
+    spec change_feature_flags {
+        pragma opaque = true;
+        modifies global<Features>(@aptos_framework);
+    }
+
+    spec code_dependency_check_enabled {
+        pragma opaque = true;
+    }
+
+}

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -15,6 +15,7 @@ module aptos_framework::reconfiguration {
     friend aptos_framework::aptos_governance;
     friend aptos_framework::block;
     friend aptos_framework::consensus_config;
+    friend aptos_framework::features;
     friend aptos_framework::gas_schedule;
     friend aptos_framework::genesis;
     friend aptos_framework::version;

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -126,6 +126,12 @@ pub enum EntryFunctionCall {
         coin_type: TypeTag,
     },
 
+    /// Entry function to enable and disable features. Can only be called by @aptos_framework.
+    FeaturesChangeFeatureFlags {
+        enable: Vec<u64>,
+        disable: Vec<u64>,
+    },
+
     /// Withdraw an `amount` of coin `CoinType` from `account` and burn it.
     ManagedCoinBurn {
         coin_type: TypeTag,
@@ -334,6 +340,9 @@ impl EntryFunctionCall {
                 amount,
             } => coin_transfer(coin_type, to, amount),
             CoinUpgradeSupply { coin_type } => coin_upgrade_supply(coin_type),
+            FeaturesChangeFeatureFlags { enable, disable } => {
+                features_change_feature_flags(enable, disable)
+            }
             ManagedCoinBurn { coin_type, amount } => managed_coin_burn(coin_type, amount),
             ManagedCoinInitialize {
                 coin_type,
@@ -701,6 +710,25 @@ pub fn coin_upgrade_supply(coin_type: TypeTag) -> TransactionPayload {
         ident_str!("upgrade_supply").to_owned(),
         vec![coin_type],
         vec![],
+    ))
+}
+
+/// Entry function to enable and disable features. Can only be called by @aptos_framework.
+pub fn features_change_feature_flags(enable: Vec<u64>, disable: Vec<u64>) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("features").to_owned(),
+        ),
+        ident_str!("change_feature_flags").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&enable).unwrap(),
+            bcs::to_bytes(&disable).unwrap(),
+        ],
     ))
 }
 
@@ -1293,6 +1321,19 @@ mod decoder {
         }
     }
 
+    pub fn features_change_feature_flags(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::FeaturesChangeFeatureFlags {
+                enable: bcs::from_bytes(script.args().get(0)?).ok()?,
+                disable: bcs::from_bytes(script.args().get(1)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
     pub fn managed_coin_burn(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::ManagedCoinBurn {
@@ -1598,6 +1639,10 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "coin_upgrade_supply".to_string(),
             Box::new(decoder::coin_upgrade_supply),
+        );
+        map.insert(
+            "features_change_feature_flags".to_string(),
+            Box::new(decoder::features_change_feature_flags),
         );
         map.insert(
             "managed_coin_burn".to_string(),

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -126,12 +126,6 @@ pub enum EntryFunctionCall {
         coin_type: TypeTag,
     },
 
-    /// Entry function to enable and disable features. Can only be called by @aptos_framework.
-    FeaturesChangeFeatureFlags {
-        enable: Vec<u64>,
-        disable: Vec<u64>,
-    },
-
     /// Withdraw an `amount` of coin `CoinType` from `account` and burn it.
     ManagedCoinBurn {
         coin_type: TypeTag,
@@ -340,9 +334,6 @@ impl EntryFunctionCall {
                 amount,
             } => coin_transfer(coin_type, to, amount),
             CoinUpgradeSupply { coin_type } => coin_upgrade_supply(coin_type),
-            FeaturesChangeFeatureFlags { enable, disable } => {
-                features_change_feature_flags(enable, disable)
-            }
             ManagedCoinBurn { coin_type, amount } => managed_coin_burn(coin_type, amount),
             ManagedCoinInitialize {
                 coin_type,
@@ -710,25 +701,6 @@ pub fn coin_upgrade_supply(coin_type: TypeTag) -> TransactionPayload {
         ident_str!("upgrade_supply").to_owned(),
         vec![coin_type],
         vec![],
-    ))
-}
-
-/// Entry function to enable and disable features. Can only be called by @aptos_framework.
-pub fn features_change_feature_flags(enable: Vec<u64>, disable: Vec<u64>) -> TransactionPayload {
-    TransactionPayload::EntryFunction(EntryFunction::new(
-        ModuleId::new(
-            AccountAddress::new([
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 1,
-            ]),
-            ident_str!("features").to_owned(),
-        ),
-        ident_str!("change_feature_flags").to_owned(),
-        vec![],
-        vec![
-            bcs::to_bytes(&enable).unwrap(),
-            bcs::to_bytes(&disable).unwrap(),
-        ],
     ))
 }
 
@@ -1321,19 +1293,6 @@ mod decoder {
         }
     }
 
-    pub fn features_change_feature_flags(
-        payload: &TransactionPayload,
-    ) -> Option<EntryFunctionCall> {
-        if let TransactionPayload::EntryFunction(script) = payload {
-            Some(EntryFunctionCall::FeaturesChangeFeatureFlags {
-                enable: bcs::from_bytes(script.args().get(0)?).ok()?,
-                disable: bcs::from_bytes(script.args().get(1)?).ok()?,
-            })
-        } else {
-            None
-        }
-    }
-
     pub fn managed_coin_burn(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::ManagedCoinBurn {
@@ -1639,10 +1598,6 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "coin_upgrade_supply".to_string(),
             Box::new(decoder::coin_upgrade_supply),
-        );
-        map.insert(
-            "features_change_feature_flags".to_string(),
-            Box::new(decoder::features_change_feature_flags),
         );
         map.insert(
             "managed_coin_burn".to_string(),

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -1,0 +1,30 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::on_chain_config::OnChainConfig;
+use serde::{Deserialize, Serialize};
+
+/// Defines the features enabled on-chain.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct Features {
+    #[serde(with = "serde_bytes")]
+    pub features: Vec<u8>,
+}
+
+impl OnChainConfig for Features {
+    const MODULE_IDENTIFIER: &'static str = "features";
+    const TYPE_IDENTIFIER: &'static str = "Features";
+}
+
+impl Features {
+    pub fn is_enabled(&self, flag: u64) -> bool {
+        let byte_index = (flag / 8) as usize;
+        let bit_mask = 1 << (flag % 8);
+        byte_index < self.features.len() && (self.features[byte_index] & bit_mask != 0)
+    }
+}
+
+// --------------------------------------------------------------------------------------------
+// Code Publishing
+
+pub const CODE_DEPENDENCY_CHECK: u64 = 1;

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -17,6 +17,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{collections::HashMap, fmt, sync::Arc};
 
 mod approved_execution_hashes;
+mod aptos_features;
 mod aptos_version;
 mod consensus_config;
 mod gas_schedule;
@@ -24,6 +25,7 @@ mod validator_set;
 
 pub use self::{
     approved_execution_hashes::ApprovedExecutionHashes,
+    aptos_features::*,
     aptos_version::{
         Version, APTOS_MAX_KNOWN_VERSION, APTOS_VERSION_2, APTOS_VERSION_3, APTOS_VERSION_4,
     },


### PR DESCRIPTION
### Description

This PR introduces the new module `aptos-framework/configs/features.move` which manages feature flags for version control and code rollout. 

As a first application, it introduces a new native function in the `code` module to harden package dependency metadata.  If the metadata fakes the dependencies, this will be detected because the module dependencies in the bytecode are not allow-listed. 

It finally shows in the `code_publishing` test case how to generalize tests for multiple feature flag combinations.



### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Generalizing existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3928)
<!-- Reviewable:end -->
