### PR TITLE
Refactor NHC so clients use a single cookie store per NHC run

### DIFF
--- a/ecosystem/node-checker/Cargo.toml
+++ b/ecosystem/node-checker/Cargo.toml
@@ -21,7 +21,7 @@ once_cell = "1.10.0"
 poem = { version = "1.3.40", features = ["anyhow"] }
 poem-openapi = { version = "2.0.10", features = ["swagger-ui", "url"] }
 prometheus-parse = "0.2.2"
-reqwest = "0.11.10"
+reqwest = { version = "0.11.10", features = ["cookies"] }
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"

--- a/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/node_identity.rs
@@ -23,9 +23,17 @@ pub async fn get_node_identity(
     node_address: &NodeAddress,
     timeout: Duration,
 ) -> Result<(ChainId, RoleType)> {
-    let index_response = node_address.get_index_response(timeout)
+    let index_response = node_address
+        .get_index_response(timeout)
         .await
-        .map_err(|e| format_err!("Failed to get response from index (/) of API. Make sure your API port ({}) is open: {}", node_address.api_port, e))?;
+        .map_err(|e| {
+            format_err!(
+                "Failed to get response from index (/) of API. Make sure \
+            your API port ({}) is open: {}",
+                node_address.get_api_port(),
+                e
+            )
+        })?;
     Ok((
         ChainId::new(index_response.chain_id),
         index_response.node_role,

--- a/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/api/transaction_availability.rs
@@ -133,7 +133,9 @@ impl Evaluator for TransactionAvailabilityEvaluator {
         let middle_baseline_accumulator_root_hash =
             Self::unwrap_accumulator_root_hash(&middle_baseline_transaction)?;
 
-        let target_client = AptosRestClient::new(input.target_node_address.get_api_url());
+        let target_client = input
+            .target_node_address
+            .get_api_client(std::time::Duration::from_secs(5));
         let evaluation =
             match Self::get_transaction_by_version(&target_client, middle_shared_version, "latest")
                 .await
@@ -150,8 +152,7 @@ impl Evaluator for TransactionAvailabilityEvaluator {
                                     format!(
                                         "We were able to pull the same transaction (version: {}) \
                                     from both your node and the baseline node. Great! This \
-                                    implies that your node is keeping up with other nodes \
-                                    in the network and returning valid transaction data.",
+                                    implies that your node is returning valid transaction data.",
                                         middle_shared_version,
                                     ),
                                 )

--- a/ecosystem/node-checker/src/evaluators/direct/noise/handshake.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/noise/handshake.rs
@@ -83,7 +83,8 @@ impl Evaluator for HandshakeEvaluator {
                 format!(
                     "{}. This indicates your noise port ({}) is open and the node is \
                     running with the private key matching the provided public key.",
-                    message, input.target_node_address.noise_port
+                    message,
+                    input.target_node_address.get_noise_port()
                 ),
             ),
             Err(e) => self.build_evaluation_result(
@@ -92,7 +93,8 @@ impl Evaluator for HandshakeEvaluator {
                 format!(
                     "{:#}. Either the noise port ({}) is closed or the node is not \
                     running with the private key matching the provided public key.",
-                    e, input.target_node_address.noise_port
+                    e,
+                    input.target_node_address.get_noise_port()
                 ),
             ),
         }])
@@ -117,7 +119,7 @@ impl Evaluator for HandshakeEvaluator {
     }
 
     fn validate_check_node_call(&self, target_node_address: &NodeAddress) -> anyhow::Result<()> {
-        if target_node_address.public_key.is_none() {
+        if target_node_address.get_public_key().is_none() {
             return Err(format_err!(
                 "A public key must be provided to use the handshake evaluator"
             ));

--- a/ecosystem/node-checker/src/evaluators/direct/types.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/types.rs
@@ -1,10 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{configuration::NodeAddress, server::NodeInformation};
 use aptos_rest_client::IndexResponse;
 use aptos_sdk::types::chain_id::ChainId;
-
-use crate::{configuration::NodeAddress, server::NodeInformation};
 
 /// This type of evaluator just takes in the target node address and then
 /// directly fetches whatever information it needs to perform the evaluation.

--- a/ecosystem/node-checker/src/runner/blocking_runner.rs
+++ b/ecosystem/node-checker/src/runner/blocking_runner.rs
@@ -63,7 +63,7 @@ impl<M: MetricCollector> BlockingRunner<M> {
         EvaluationResult {
             headline: "Failed to collect metrics from target node".to_string(),
             score: 0,
-            explanation: format!("Failed to collect metrics from your node, make sure your metrics port ({}) is publicly accessible: {}", address.metrics_port, error),
+            explanation: format!("Failed to collect metrics from your node, make sure your metrics port ({}) is publicly accessible: {}", address.get_metrics_port(), error),
             category: "metrics".to_string(),
             evaluator_name: "metrics_port".to_string(),
             links: vec![],
@@ -216,7 +216,7 @@ impl<M: MetricCollector> Runner for BlockingRunner<M> {
             .await
             .context(format!(
             "Failed to read index response from baseline node. Make sure its API is open (port {})",
-            self.baseline_node_information.node_address.api_port
+            self.baseline_node_information.node_address.get_api_port()
         ))
             .map_err(RunnerError::BaselineMissingDataError)?;
 

--- a/ecosystem/node-checker/src/server/configurations_manager.rs
+++ b/ecosystem/node-checker/src/server/configurations_manager.rs
@@ -40,10 +40,8 @@ fn build_node_configuration_wrapper_with_blocking_runner(
         role_type: node_configuration.get_role_type(),
     };
 
-    let baseline_metric_collector = ReqwestMetricCollector::new(
-        node_configuration.node_address.url.clone(),
-        node_configuration.node_address.metrics_port,
-    );
+    let baseline_metric_collector =
+        ReqwestMetricCollector::new(node_configuration.node_address.clone());
 
     let evaluator_set = build_evaluators(
         &node_configuration.evaluators,

--- a/ecosystem/node-checker/src/server/run.rs
+++ b/ecosystem/node-checker/src/server/run.rs
@@ -81,15 +81,12 @@ pub async fn run(args: Run) -> Result<()> {
 
     let preconfigured_test_node = match args.target_node_url {
         Some(ref url) => {
-            let node_address = NodeAddress {
-                url: url.clone(),
-                api_port: args.target_api_port,
-                metrics_port: args.target_metrics_port,
-                noise_port: args.target_noise_port,
-                public_key: args.target_public_key,
-            };
-            let metric_collector =
-                ReqwestMetricCollector::new(node_address.url.clone(), node_address.metrics_port);
+            let node_address = NodeAddress::new(url.clone())
+                .api_port(args.target_api_port)
+                .metrics_port(args.target_metrics_port)
+                .noise_port(args.target_noise_port)
+                .public_key(args.target_public_key);
+            let metric_collector = ReqwestMetricCollector::new(node_address.clone());
             Some(PreconfiguredNode {
                 node_address,
                 metric_collector,


### PR DESCRIPTION
### Description
This PR helps resolve this problem: https://github.com/aptos-labs/aptos-core/issues/3912. It doesn't address the DNS aspect of the problem, since that isn't relevant at least for our baselines, but instead makes our clients use cookies to leverage the cookie based sticky routing we have enabled on our LBs.

### Test Plan
Run local NHC:
```
cargo run -p aptos-node-checker -- server run --baseline-node-config-paths ~/a/internal-ops/infra/apps/node-checker/configs/* --listen-address 0.0.0.0
```
Query it:
```
curl 'http://127.0.0.1:20121/check_node?node_url=http://34.64.49.220&baseline_configuration_name=ait3_fullnode&metrics_port=9101&api_port=80&noise_port=6182&public_key=0x44fd1324c66371b4788af0b901c9eb8088781acb29e6b8b9c791d5d9838fbe1f' | jq .
```
I tested a metrics evaluator to make sure that still works too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3934)
<!-- Reviewable:end -->
