### PR TITLE
[forge] fix assert image tags have prefix if profile or feature

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -19,6 +19,7 @@ on:
       FORGE_CLUSTER_NAME:
         required: false
         type: string
+        default: aptos-forge-big-0
         description: The Forge k8s cluster to be used for test
       FORGE_RUNNER_DURATION_SECS:
         required: false

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -992,7 +992,7 @@ def list_eks_clusters(shell: Shell) -> List[str]:
         return [
             cluster_name
             for cluster_name in cluster_result["clusters"]
-            if cluster_name.startswith("aptos-forge-")
+            if cluster_name.startswith("aptos-forge-big-")
         ]
     except Exception as e:
         raise AwsError("Failed to list eks clusters") from e

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1044,12 +1044,14 @@ class Git:
 
 
 def assert_provided_image_tags_has_profile_or_features(
-    forge_image_tag,
-    image_tag,
+    forge_image_tag: Optional[str],
+    image_tag: Optional[str],
     enable_failpoints_feature: bool = False,
     enable_performance_profile: bool = False,
 ):
     for tag in [forge_image_tag, image_tag]:
+        if not tag:
+            continue
         if enable_failpoints_feature:
             assert tag.startswith(
                 "failpoints"

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -413,6 +413,13 @@ class TestFindRecentImage(unittest.TestCase):
                 enable_failpoints_feature=True,
             )
 
+    def testFailpointsNoProvidedImageTag(self) -> None:
+        assert_provided_image_tags_has_profile_or_features(
+            None,
+            None,
+            enable_failpoints_feature=True,
+        )
+
 
 class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
     maxDiff = None


### PR DESCRIPTION
### Description

When no image tags are provided, make sure we do not assert

Also, only autoselect from forge-big clusters, so we can start to phase out the original (small) forge clusters

### Test Plan

Unit test

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3937)
<!-- Reviewable:end -->
