### PR TITLE
[forge] Add warmup and cooldown to measuring performance

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -5,10 +5,11 @@ pub mod account_minter;
 pub mod stats;
 pub mod submission_worker;
 
-use ::aptos_logger::*;
 use again::RetryPolicy;
 use anyhow::{anyhow, format_err, Result};
 use aptos_infallible::RwLock;
+use aptos_logger::sample::Sampling;
+use aptos_logger::{info, sample, sample::SampleRate, warn};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     move_types::account_address::AccountAddress,
@@ -33,7 +34,11 @@ use tokio::{runtime::Handle, task::JoinHandle, time};
 
 use crate::{
     args::TransactionType,
-    emitter::{account_minter::AccountMinter, submission_worker::SubmissionWorker},
+    emitter::{
+        account_minter::AccountMinter,
+        stats::{DynamicStatsTracking, TxnStats},
+        submission_worker::SubmissionWorker,
+    },
     transaction_generator::{
         account_generator::AccountGeneratorCreator, nft_mint::NFTMintGeneratorCreator,
         p2p_transaction_generator::P2PTransactionGeneratorCreator,
@@ -42,7 +47,6 @@ use crate::{
 };
 use aptos_sdk::transaction_builder::aptos_stdlib;
 use rand::rngs::StdRng;
-use stats::{StatsAccumulator, TxnStats};
 
 // Max is 100k TPS for a full day.
 const MAX_TXNS: u64 = 100_000_000_000;
@@ -74,6 +78,7 @@ pub struct EmitModeParams {
     pub start_jitter_millis: u64,
     pub wait_millis: u64,
     pub check_account_sequence_only_once_fraction: f32,
+    pub check_account_sequence_sleep_millis: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -200,7 +205,7 @@ impl EmitJobRequest {
                 // The target mempool backlog is set to be 3x of the target TPS because of the on an average,
                 // we can ~3 blocks in consensus queue. As long as we have 3x the target TPS as backlog,
                 // it should be enough to produce the target TPS.
-                let transactions_per_account = 5;
+                let transactions_per_account = 20;
                 let num_workers_per_endpoint = max(
                     mempool_backlog / (clients_count * transactions_per_account),
                     1,
@@ -226,6 +231,7 @@ impl EmitJobRequest {
                     accounts_per_worker: 1,
                     workers_per_endpoint: num_workers_per_endpoint,
                     check_account_sequence_only_once_fraction: 0.0,
+                    check_account_sequence_sleep_millis: 300,
                 }
             }
             EmitJobMode::ConstTps { tps } => {
@@ -276,9 +282,16 @@ impl EmitJobRequest {
                     transactions_per_account, wait_seconds
                 );
 
+                // sample latency on 2% of requests, or at least once every 5s.
+                let sample_latency_fraction = 1.0_f32.min(0.02_f32.max(
+                    wait_seconds as f32
+                        / (clients_count * num_workers_per_endpoint) as f32
+                        / 5.0_f32,
+                ));
+
                 info!(
-                    " Will use {} clients and {} workers per client",
-                    clients_count, num_workers_per_endpoint
+                    " Will use {} clients and {} workers per client, sampling latency on {}",
+                    clients_count, num_workers_per_endpoint, sample_latency_fraction
                 );
 
                 EmitModeParams {
@@ -293,8 +306,8 @@ impl EmitJobRequest {
                     start_jitter_millis: 0,
                     accounts_per_worker: 1,
                     workers_per_endpoint: num_workers_per_endpoint,
-                    // sample latency on 2% of requests.
-                    check_account_sequence_only_once_fraction: 1.0 - 0.02,
+                    check_account_sequence_only_once_fraction: 1.0 - sample_latency_fraction,
+                    check_account_sequence_sleep_millis: 300,
                 }
             }
         }
@@ -310,7 +323,17 @@ struct Worker {
 pub struct EmitJob {
     workers: Vec<Worker>,
     stop: Arc<AtomicBool>,
-    stats: Arc<StatsAccumulator>,
+    stats: Arc<DynamicStatsTracking>,
+}
+
+impl EmitJob {
+    pub fn start_next_phase(&self) {
+        self.stats.start_next_phase();
+    }
+
+    pub fn get_cur_phase(&self) -> usize {
+        self.stats.get_cur_phase()
+    }
 }
 
 #[derive(Debug)]
@@ -349,6 +372,7 @@ impl TxnEmitter {
         &mut self,
         root_account: &mut LocalAccount,
         req: EmitJobRequest,
+        stats_tracking_phases: usize,
     ) -> Result<EmitJob> {
         let mode_params = req.calculate_mode_params();
         let workers_per_endpoint = mode_params.workers_per_endpoint;
@@ -369,7 +393,7 @@ impl TxnEmitter {
         let all_addresses = Arc::new(RwLock::new(all_addresses));
         let mut all_accounts = all_accounts.into_iter();
         let stop = Arc::new(AtomicBool::new(false));
-        let stats = Arc::new(StatsAccumulator::default());
+        let stats = Arc::new(DynamicStatsTracking::new(stats_tracking_phases));
         let tokio_handle = Handle::current();
         let txn_factory = self
             .txn_factory
@@ -463,7 +487,7 @@ impl TxnEmitter {
         })
     }
 
-    pub async fn stop_job(&mut self, job: EmitJob) -> TxnStats {
+    pub async fn stop_job(&mut self, job: EmitJob) -> Vec<TxnStats> {
         job.stop.store(true, Ordering::Relaxed);
         for worker in job.workers {
             let mut accounts = worker
@@ -472,23 +496,30 @@ impl TxnEmitter {
                 .expect("TxnEmitter worker thread failed");
             self.accounts.append(&mut accounts);
         }
+
         job.stats.accumulate()
     }
 
-    pub fn peek_job_stats(&self, job: &EmitJob) -> TxnStats {
+    pub fn peek_job_stats(&self, job: &EmitJob) -> Vec<TxnStats> {
         job.stats.accumulate()
     }
 
     pub async fn periodic_stat(&mut self, job: &EmitJob, duration: Duration, interval_secs: u64) {
         let deadline = Instant::now() + duration;
-        let mut prev_stats: Option<TxnStats> = None;
+        let mut prev_stats: Option<Vec<TxnStats>> = None;
+        let default_stats = TxnStats::default();
         let window = Duration::from_secs(max(interval_secs, 1));
         while Instant::now() < deadline {
             tokio::time::sleep(window).await;
+            let cur_phase = job.stats.get_cur_phase();
             let stats = self.peek_job_stats(job);
-            let delta = &stats - &prev_stats.unwrap_or_default();
+            let delta = &stats[cur_phase]
+                - prev_stats
+                    .as_ref()
+                    .map(|p| &p[cur_phase])
+                    .unwrap_or(&default_stats);
             prev_stats = Some(stats);
-            info!("{}", delta.rate(window));
+            info!("phase {}: {}", cur_phase, delta.rate(window));
         }
     }
 
@@ -498,13 +529,13 @@ impl TxnEmitter {
         emit_job_request: EmitJobRequest,
         duration: Duration,
     ) -> Result<TxnStats> {
-        let job = self.start_job(root_account, emit_job_request).await?;
+        let job = self.start_job(root_account, emit_job_request, 1).await?;
         info!("Starting emitting txns for {} secs", duration.as_secs());
         time::sleep(duration).await;
         info!("Ran for {} secs, stopping job...", duration.as_secs());
         let stats = self.stop_job(job).await;
         info!("Stopped job");
-        Ok(stats)
+        Ok(stats.into_iter().next().unwrap())
     }
 
     pub async fn emit_txn_for_with_stats(
@@ -515,12 +546,12 @@ impl TxnEmitter {
         interval_secs: u64,
     ) -> Result<TxnStats> {
         info!("Starting emitting txns for {} secs", duration.as_secs());
-        let job = self.start_job(root_account, emit_job_request).await?;
+        let job = self.start_job(root_account, emit_job_request, 1).await?;
         self.periodic_stat(&job, duration, interval_secs).await;
         info!("Ran for {} secs, stopping job...", duration.as_secs());
         let stats = self.stop_job(job).await;
         info!("Stopped job");
-        Ok(stats)
+        Ok(stats.into_iter().next().unwrap())
     }
 
     pub async fn submit_single_transaction(
@@ -553,9 +584,12 @@ async fn wait_for_single_account_sequence(
                 }
             }
             Err(e) => {
-                info!(
-                    "Failed to query sequence number for account {:?} for instance {:?} : {:?}",
-                    account, client, e
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(60)),
+                    warn!(
+                        "Failed to query sequence number for account {:?} for instance {:?} : {:?}",
+                        account, client, e
+                    )
                 );
             }
         }
@@ -568,7 +602,7 @@ async fn wait_for_single_account_sequence(
 }
 
 /// This function waits for the submitted transactions to be committed, up to
-/// a deadline.
+/// a wait_timeout (counted from the start_time passed in, not from the function call).
 /// It returns number of transactions that expired without being committed,
 /// and sum of completion timestamps for those that have.
 ///
@@ -581,8 +615,8 @@ async fn wait_for_accounts_sequence(
     transactions_per_account: usize,
     wait_timeout: Duration,
     fetch_only_once: bool,
+    sleep_between_cycles: Duration,
 ) -> (usize, u128) {
-    let deadline = start_time + wait_timeout;
     let mut pending_addresses: HashSet<_> = accounts.iter().map(|d| d.address()).collect();
     let mut latest_fetched_counts = HashMap::new();
 
@@ -610,18 +644,21 @@ async fn wait_for_accounts_sequence(
                 }
             }
             Err(e) => {
-                info!(
-                    "Failed to query ledger info on accounts {:?} for instance {:?} : {:?}",
-                    pending_addresses, client, e
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(60)),
+                    warn!(
+                        "Failed to query ledger info on accounts {:?} for instance {:?} : {:?}",
+                        pending_addresses, client, e
+                    )
                 );
             }
         }
 
-        if Instant::now() >= deadline {
+        if start_time.elapsed() >= wait_timeout {
             break;
         }
 
-        time::sleep(Duration::from_millis(1000)).await;
+        time::sleep(sleep_between_cycles).await;
     }
 
     (

--- a/crates/transaction-emitter-lib/src/emitter/stats.rs
+++ b/crates/transaction-emitter-lib/src/emitter/stats.rs
@@ -5,7 +5,7 @@ use std::{
     fmt,
     ops::Sub,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -29,6 +29,9 @@ pub struct TxnStatsRate {
     pub expired: u64,
     pub failed_submission: u64,
     pub latency: u64,
+    pub latency_samples: u64,
+    pub p50_latency: u64,
+    pub p90_latency: u64,
     pub p99_latency: u64,
 }
 
@@ -36,8 +39,8 @@ impl fmt::Display for TxnStatsRate {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "submitted: {} txn/s, committed: {} txn/s, expired: {} txn/s, failed submission: {} tnx/s, latency: {} ms, p99 latency: {} ms",
-            self.submitted, self.committed, self.expired, self.failed_submission, self.latency, self.p99_latency,
+            "submitted: {} txn/s, committed: {} txn/s, expired: {} txn/s, failed submission: {} tnx/s, latency: {} ms, (p50: {} ms, p90: {} ms, p99: {} ms), latency samples: {}",
+            self.submitted, self.committed, self.expired, self.failed_submission, self.latency, self.p50_latency, self.p90_latency, self.p99_latency, self.latency_samples,
         )
     }
 }
@@ -58,6 +61,9 @@ impl TxnStats {
             } else {
                 self.latency / self.latency_samples
             },
+            latency_samples: self.latency_samples,
+            p50_latency: self.latency_buckets.percentile(50, 100),
+            p90_latency: self.latency_buckets.percentile(90, 100),
             p99_latency: self.latency_buckets.percentile(99, 100),
         }
     }
@@ -114,8 +120,10 @@ impl StatsAccumulator {
     }
 }
 
-const DEFAULT_HISTOGRAM_CAPACITY: usize = 1024;
-const DEFAULT_HISTOGRAM_STEP_WIDTH: u64 = 50;
+// have more slots than generally used txn expiration. (240s)
+const DEFAULT_HISTOGRAM_CAPACITY: usize = 2400;
+// we don't have better precision than ~300 ms anyways.
+const DEFAULT_HISTOGRAM_STEP_WIDTH: u64 = 100;
 
 #[derive(Debug)]
 pub struct AtomicHistogramAccumulator {
@@ -155,17 +163,17 @@ impl AtomicHistogramAccumulator {
         }
     }
 
-    fn get_bucket_num(&self, data_value: u64) -> u64 {
+    fn get_bucket_num(&self, data_value: u64) -> usize {
         let bucket_num = data_value / self.step_width;
         if bucket_num >= self.capacity as u64 - 2 {
-            return self.capacity as u64 - 1;
+            return self.capacity - 1;
         }
-        bucket_num
+        bucket_num as usize
     }
 
     pub fn record_data_point(&self, data_value: u64, data_num: u64) {
         let bucket_num = self.get_bucket_num(data_value);
-        self.buckets[bucket_num as usize].fetch_add(data_num as u64, Ordering::Relaxed);
+        self.buckets[bucket_num].fetch_add(data_num as u64, Ordering::Relaxed);
     }
 }
 
@@ -220,6 +228,42 @@ impl AtomicHistogramSnapshot {
     }
 }
 
+#[derive(Debug)]
+pub struct DynamicStatsTracking {
+    num_phases: usize,
+    cur_phase: AtomicUsize,
+    stats: Vec<StatsAccumulator>,
+}
+
+impl DynamicStatsTracking {
+    pub fn new(num_phases: usize) -> DynamicStatsTracking {
+        assert!(num_phases >= 1);
+        Self {
+            num_phases,
+            cur_phase: AtomicUsize::new(0),
+            stats: (0..num_phases)
+                .map(|_| StatsAccumulator::default())
+                .collect(),
+        }
+    }
+
+    pub fn start_next_phase(&self) {
+        assert!(self.cur_phase.fetch_add(1, Ordering::Relaxed) + 1 < self.num_phases);
+    }
+
+    pub fn get_cur_phase(&self) -> usize {
+        self.cur_phase.load(Ordering::Relaxed)
+    }
+
+    pub fn get_cur(&self) -> &StatsAccumulator {
+        self.stats.get(self.get_cur_phase()).unwrap()
+    }
+
+    pub fn accumulate(&self) -> Vec<TxnStats> {
+        self.stats.iter().map(|s| s.accumulate()).collect()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::emitter::stats::{
@@ -238,10 +282,19 @@ mod test {
     pub fn test_get_bucket_num() {
         let histogram = AtomicHistogramAccumulator::default();
         assert_eq!(histogram.get_bucket_num(0), 0);
-        assert_eq!(histogram.get_bucket_num(49), 0);
-        assert_eq!(histogram.get_bucket_num(50), 1);
-        assert_eq!(histogram.get_bucket_num(51), 1);
-        assert_eq!(histogram.get_bucket_num(200_000), 1023);
+        assert_eq!(
+            histogram.get_bucket_num(DEFAULT_HISTOGRAM_STEP_WIDTH - 1),
+            0
+        );
+        assert_eq!(histogram.get_bucket_num(DEFAULT_HISTOGRAM_STEP_WIDTH), 1);
+        assert_eq!(
+            histogram.get_bucket_num(DEFAULT_HISTOGRAM_STEP_WIDTH + 1),
+            1
+        );
+        assert_eq!(
+            histogram.get_bucket_num(500_000),
+            DEFAULT_HISTOGRAM_CAPACITY - 1
+        );
     }
 
     #[test]

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -22,9 +22,12 @@ use forge::{
     EmitJobRequest, NetworkContext, NetworkTest, NodeExt, Result, Swarm, Test, TxnEmitter,
     TxnStats, Version,
 };
-use rand::SeedableRng;
+use rand::{rngs::StdRng, SeedableRng};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Builder;
+
+const WARMUP_DURATION_FRACTION: f32 = 0.05;
+const COOLDOWN_DURATION_FRACTION: f32 = 0.05;
 
 async fn batch_update(
     ctx: &mut NetworkContext<'_>,
@@ -49,31 +52,29 @@ async fn batch_update(
 }
 
 pub fn create_emitter_and_request(
-    ctx: &mut NetworkContext<'_>,
+    swarm: &mut dyn Swarm,
+    mut emit_job_request: EmitJobRequest,
     nodes: &[PeerId],
     gas_price: u64,
+    rng: StdRng,
 ) -> Result<(TxnEmitter, EmitJobRequest)> {
     ensure!(gas_price > 0, "gas_price is required to be non zero");
-    let rng = SeedableRng::from_rng(ctx.core().rng())?;
 
     // as we are loading nodes, use higher client timeout
     let client_timeout = Duration::from_secs(30);
-    let validator_clients = ctx
-        .swarm()
+    let validator_clients = swarm
         .validators()
         .filter(|v| nodes.contains(&v.peer_id()))
         .map(|n| n.rest_client_with_timeout(client_timeout))
         .collect::<Vec<_>>();
-    let fullnode_clients = ctx
-        .swarm()
+    let fullnode_clients = swarm
         .full_nodes()
         .filter(|v| nodes.contains(&v.peer_id()))
         .map(|n| n.rest_client_with_timeout(client_timeout))
         .collect::<Vec<_>>();
     let all_node_clients = [&fullnode_clients[..], &validator_clients[..]].concat();
 
-    let mut emit_job_request = ctx.emit_job.clone();
-    let chain_info = ctx.swarm().chain_info();
+    let chain_info = swarm.chain_info();
     let transaction_factory = TransactionFactory::new(chain_info.chain_id).with_gas_unit_price(1);
     let emitter = TxnEmitter::new(transaction_factory, rng);
 
@@ -89,7 +90,10 @@ pub fn generate_traffic(
     duration: Duration,
     gas_price: u64,
 ) -> Result<TxnStats> {
-    let (mut emitter, emit_job_request) = create_emitter_and_request(ctx, nodes, gas_price)?;
+    let emit_job_request = ctx.emit_job.clone();
+    let rng = SeedableRng::from_rng(ctx.core().rng())?;
+    let (mut emitter, emit_job_request) =
+        create_emitter_and_request(ctx.swarm(), emit_job_request, nodes, gas_price, rng)?;
 
     let mut runtime_builder = Builder::new_multi_thread();
     runtime_builder.disable_lifo_slot().enable_all();
@@ -135,21 +139,50 @@ impl NetworkTest for dyn NetworkLoadTest {
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
             .as_secs();
+        let emit_job_request = ctx.emit_job.clone();
+        let rng = SeedableRng::from_rng(ctx.core().rng())?;
         let duration = ctx.global_duration;
+        let (txn_stat, actual_test_duration) = self.network_load_test(
+            ctx.swarm(),
+            emit_job_request,
+            duration,
+            WARMUP_DURATION_FRACTION,
+            COOLDOWN_DURATION_FRACTION,
+            rng,
+        )?;
+        ctx.report
+            .report_txn_stats(self.name().to_string(), &txn_stat, actual_test_duration);
 
-        let all_validators = ctx
-            .swarm()
-            .validators()
-            .map(|v| v.peer_id())
-            .collect::<Vec<_>>();
+        ctx.check_for_success(&txn_stat, &actual_test_duration)?;
 
-        let all_fullnodes = ctx
-            .swarm()
-            .full_nodes()
-            .map(|v| v.peer_id())
-            .collect::<Vec<_>>();
+        let end_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs();
 
-        let nodes_to_send_load_to = match self.setup(ctx.swarm())? {
+        ctx.check_for_success(&txn_stat, &actual_test_duration)?;
+
+        self.finish(ctx.swarm(), start_timestamp, end_timestamp)?;
+
+        Ok(())
+    }
+}
+
+impl dyn NetworkLoadTest {
+    pub fn network_load_test(
+        &self,
+        swarm: &mut dyn Swarm,
+        emit_job_request: EmitJobRequest,
+        duration: Duration,
+        warmup_duration_fraction: f32,
+        cooldown_duration_fraction: f32,
+        rng: StdRng,
+    ) -> Result<(TxnStats, Duration)> {
+        let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+
+        let all_fullnodes = swarm.full_nodes().map(|v| v.peer_id()).collect::<Vec<_>>();
+
+        let nodes_to_send_load_to = match self.setup(swarm)? {
             LoadDestination::AllNodes => [&all_validators[..], &all_fullnodes[..]].concat(),
             LoadDestination::AllValidators => all_validators,
             LoadDestination::AllFullnodes => all_fullnodes,
@@ -159,7 +192,7 @@ impl NetworkTest for dyn NetworkLoadTest {
         // Generate some traffic
 
         let (mut emitter, emit_job_request) =
-            create_emitter_and_request(ctx, &nodes_to_send_load_to, 1)?;
+            create_emitter_and_request(swarm, emit_job_request, &nodes_to_send_load_to, 1, rng)?;
 
         let mut runtime_builder = Builder::new_multi_thread();
         runtime_builder.disable_lifo_slot().enable_all();
@@ -168,28 +201,44 @@ impl NetworkTest for dyn NetworkLoadTest {
             .build()
             .map_err(|err| anyhow!("Failed to start runtime for transaction emitter. {}", err))?;
 
-        let job = rt
-            .block_on(emitter.start_job(ctx.swarm().chain_info().root_account, emit_job_request))?;
-        info!("Starting emitting txns for {} secs", duration.as_secs());
+        let job =
+            rt.block_on(emitter.start_job(swarm.chain_info().root_account, emit_job_request, 3))?;
 
-        self.test(ctx.swarm(), duration)?;
+        let warmup_duration = duration.mul_f32(warmup_duration_fraction);
+        let cooldown_duration = duration.mul_f32(cooldown_duration_fraction);
+        let test_duration = duration - warmup_duration - cooldown_duration;
+        info!("Starting emitting txns for {}s", duration.as_secs());
 
-        info!("Ran for {} secs, stopping job...", duration.as_secs());
-        let txn_stat = rt.block_on(emitter.stop_job(job));
+        std::thread::sleep(warmup_duration);
+        info!("{}s warmup finished", warmup_duration.as_secs());
+
+        job.start_next_phase();
+
+        let test_start = Instant::now();
+        self.test(swarm, test_duration)?;
+        let actual_test_duration = test_start.elapsed();
+        info!(
+            "{}s test finished after {}s",
+            test_duration.as_secs(),
+            actual_test_duration.as_secs()
+        );
+
+        job.start_next_phase();
+
+        std::thread::sleep(cooldown_duration);
+        info!("{}s cooldown finished", cooldown_duration.as_secs());
+
+        info!(
+            "Emitting txns ran for {} secs, stopping job...",
+            duration.as_secs()
+        );
+        let txn_stats = rt.block_on(emitter.stop_job(job));
+
         info!("Stopped job");
+        info!("Warmup stats: {}", txn_stats[0].rate(warmup_duration));
+        info!("Test stats: {}", txn_stats[1].rate(actual_test_duration));
+        info!("Cooldown stats: {}", txn_stats[2].rate(cooldown_duration));
 
-        ctx.report
-            .report_txn_stats(self.name().to_string(), &txn_stat, duration);
-
-        let end_timestamp = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_secs();
-
-        ctx.check_for_success(&txn_stat, &duration)?;
-
-        self.finish(ctx.swarm(), start_timestamp, end_timestamp)?;
-
-        Ok(())
+        Ok((txn_stats.into_iter().nth(1).unwrap(), actual_test_duration))
     }
 }


### PR DESCRIPTION
### Description

As metrics can differ during that period. I think keeping 5% on each end shouldn't reduce the test much, but might give useful stability to it.

### Test Plan
CI landblocking forge

Warmup stats: submitted: 7160 txn/s, committed: 7160 txn/s, expired: 0 txn/s, failed submission: 0 tnx/s, latency: 4082 ms, p99 latency: 6000 ms"}
Test stats: submitted: 6827 txn/s, committed: 6827 txn/s, expired: 0 txn/s, failed submission: 0 tnx/s, latency: 4380 ms, p99 latency: 6000 ms"}
Cooldown stats: submitted: 7042 txn/s, committed: 7042 txn/s, expired: 0 txn/s, failed submission: 0 tnx/s, latency: 4324 ms, p99 latency: 6000 ms"}

Bigger difference can be seen with ConstTps (3000):

Warmup stats: submitted: 2970 txn/s, committed: 2970 txn/s, expired: 0 txn/s, failed submission: 0 tnx/s, latency: 1381 ms, p99 latency: 2200 ms
Test stats: submitted: 2998 txn/s, committed: 2998 txn/s, expired: 0 txn/s, failed submission: 0 tnx/s, latency: 2284 ms, p99 latency: 5350 ms
Cooldown stats: submitted: 2995 txn/s, committed: 2979 txn/s, expired: 16 txn/s, failed submission: 0 tnx/s, latency: 1208 ms, p99 latency: 1650 ms

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3938)
<!-- Reviewable:end -->
