### PR TITLE
[aptos-genesis] Create all accounts upfront, with initial balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.3",
  "toml",
+ "vm-genesis",
  "walkdir",
 ]
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -6,6 +6,7 @@
 mod genesis_context;
 
 use crate::genesis_context::GenesisStateView;
+use anyhow::bail;
 use aptos_crypto::{
     bls12381,
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
@@ -41,6 +42,7 @@ use move_deps::{
 use once_cell::sync::Lazy;
 use rand::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashSet};
 
 // The seed is arbitrarily picked to produce a consistent key. XXX make this more formal?
 const GENESIS_SEED: [u8; 32] = [42; 32];
@@ -82,6 +84,7 @@ pub fn encode_genesis_transaction(
     framework: &ReleaseBundle,
     chain_id: ChainId,
     genesis_config: GenesisConfiguration,
+    initial_balances: &[InitialBalance],
 ) -> Transaction {
     let consensus_config = OnChainConsensusConfig::V1(ConsensusConfigV1::default());
 
@@ -92,6 +95,7 @@ pub fn encode_genesis_transaction(
         consensus_config,
         chain_id,
         &genesis_config,
+        initial_balances,
     )))
 }
 
@@ -102,6 +106,7 @@ pub fn encode_genesis_change_set(
     consensus_config: OnChainConsensusConfig,
     chain_id: ChainId,
     genesis_config: &GenesisConfiguration,
+    initial_balances: &[InitialBalance],
 ) -> ChangeSet {
     validate_genesis_config(genesis_config);
 
@@ -127,7 +132,7 @@ pub fn encode_genesis_change_set(
         initialize_aptos_coin(&mut session);
     }
     initialize_on_chain_governance(&mut session, genesis_config);
-    create_and_initialize_validators(&mut session, validators);
+    create_and_initialize_validators(&mut session, initial_balances, validators);
     if genesis_config.is_test {
         allow_core_resources_to_set_version(&mut session);
     }
@@ -311,6 +316,7 @@ fn initialize_core_resources_and_aptos_coin(
     core_resources_key: &Ed25519PublicKey,
 ) {
     let core_resources_auth_key = AuthenticationKey::ed25519(core_resources_key);
+
     exec_function(
         session,
         GENESIS_MODULE_NAME,
@@ -347,10 +353,20 @@ fn initialize_on_chain_governance(
 /// validator config on-chain.
 fn create_and_initialize_validators(
     session: &mut SessionExt<impl MoveResolver>,
+    initial_balances: &[InitialBalance],
     validators: &[Validator],
 ) {
     let validators_bytes = bcs::to_bytes(validators).expect("Validators can be serialized");
-    let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
+    let mut serialized_values = serialize_values(&vec![
+        MoveValue::Signer(CORE_CODE_ADDRESS),
+        MoveValue::vector_address(initial_balances.iter().map(|inner| inner.address).collect()),
+        MoveValue::Vector(
+            initial_balances
+                .iter()
+                .map(|inner| MoveValue::U64(inner.balance))
+                .collect(),
+        ),
+    ]);
     serialized_values.push(validators_bytes);
     exec_function(
         session,
@@ -518,6 +534,12 @@ pub struct Validator {
     pub full_node_network_addresses: Vec<u8>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct InitialBalance {
+    pub address: AccountAddress,
+    pub balance: u64,
+}
+
 pub struct TestValidator {
     pub key: Ed25519PrivateKey,
     pub consensus_key: bls12381::PrivateKey,
@@ -574,6 +596,8 @@ pub fn generate_test_genesis(
     let test_validators = TestValidator::new_test_set(count, Some(100_000_000));
     let validators_: Vec<Validator> = test_validators.iter().map(|t| t.data.clone()).collect();
     let validators = &validators_;
+    let initial_balances =
+        parse_initial_balances_from_staking_amounts(validators.as_slice()).unwrap();
 
     let genesis = encode_genesis_change_set(
         &GENESIS_KEYPAIR.1,
@@ -595,6 +619,7 @@ pub fn generate_test_genesis(
             voting_duration_secs: 3600,
             voting_power_increase_limit: 50,
         },
+        initial_balances.as_slice(),
     );
     (genesis, test_validators)
 }
@@ -607,6 +632,8 @@ pub fn generate_mainnet_genesis(
     let test_validators = TestValidator::new_test_set(count, Some(1_000_000_000_000_000));
     let validators_: Vec<Validator> = test_validators.iter().map(|t| t.data.clone()).collect();
     let validators = &validators_;
+    let initial_balances =
+        parse_initial_balances_from_staking_amounts(validators.as_slice()).unwrap();
 
     let genesis = encode_genesis_change_set(
         &GENESIS_KEYPAIR.1,
@@ -629,8 +656,44 @@ pub fn generate_mainnet_genesis(
             voting_duration_secs: 7 * 24 * 3600, // 7 days
             voting_power_increase_limit: 30,
         },
+        initial_balances.as_slice(),
     );
     (genesis, test_validators)
+}
+
+/// Uses the staking amounts to determine what the correct initial balances
+/// if there are no other accounts that are initialized with coins
+pub fn parse_initial_balances_from_staking_amounts(
+    validators: &[Validator],
+) -> anyhow::Result<Vec<InitialBalance>> {
+    let mut owners = HashSet::new();
+    let mut initial_balances: BTreeMap<AccountAddress, u64> = BTreeMap::new();
+    for validator in validators {
+        // Ensure that the owner isn't duplicated
+        if owners.contains(&validator.owner_address) {
+            bail!(
+                "Owner showed up twice in validator set {}",
+                validator.owner_address
+            )
+        }
+        owners.insert(validator.owner_address);
+
+        // Add the initial balance for the owner
+        {
+            let entry = initial_balances.entry(validator.owner_address).or_default();
+            *entry = validator.stake_amount;
+        }
+        // Ensure the operator and the voters are present
+        initial_balances
+            .entry(validator.operator_address)
+            .or_default();
+        initial_balances.entry(validator.voter_address).or_default();
+    }
+
+    Ok(initial_balances
+        .into_iter()
+        .map(|(address, balance)| InitialBalance { address, balance })
+        .collect())
 }
 
 #[test]

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -53,6 +53,9 @@ pub struct Layout {
     pub voting_duration_secs: u64,
     /// % of current epoch's total voting power that can be added in this epoch.
     pub voting_power_increase_limit: u64,
+    /// Has initial balances
+    #[serde(default)]
+    pub has_initial_balances: bool,
 }
 
 impl Layout {
@@ -87,6 +90,7 @@ impl Default for Layout {
             rewards_apy_percentage: 10,
             voting_duration_secs: 43_200,
             voting_power_increase_limit: 20,
+            has_initial_balances: false,
         }
     }
 }

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -54,6 +54,7 @@ aptos-temppath = { path = "../aptos-temppath" }
 aptos-transactional-test-harness = { path = "../../aptos-move/aptos-transactional-test-harness" }
 aptos-types = { path = "../../types" }
 aptos-vm = { path = "../../aptos-move/aptos-vm" }
+vm-genesis = { path = "../../aptos-move/vm-genesis" }
 
 backup-cli = { path = "../../storage/backup/backup-cli" }
 cached-packages = { path = '../../aptos-move/framework/cached-packages' }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     CliCommand, CliResult,
 };
 use aptos_crypto::{bls12381, ed25519::Ed25519PublicKey, x25519, ValidCryptoMaterialStringExt};
-use aptos_genesis::builder::GenesisConfiguration;
+use aptos_genesis::builder::{parse_initial_balances_from_staking_amounts, GenesisConfiguration};
 use aptos_genesis::config::{StringOperatorConfiguration, StringOwnerConfiguration};
 use aptos_genesis::{
     config::{Layout, ValidatorConfiguration},
@@ -26,11 +26,14 @@ use aptos_genesis::{
 use aptos_types::account_address::AccountAddress;
 use async_trait::async_trait;
 use clap::Parser;
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::{path::PathBuf, str::FromStr};
+use vm_genesis::InitialBalance;
 
 const WAYPOINT_FILE: &str = "waypoint.txt";
 const GENESIS_FILE: &str = "genesis.blob";
+const BALANCES_FILE: &str = "balances.yaml";
 
 /// Tool for setting up an Aptos chain Genesis transaction
 ///
@@ -144,6 +147,19 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
         ));
     }
 
+    // If there is an initial balances, load them from a file, otherwise do the old way
+    // of building the balances from the staking amounts
+    let initial_balances: Vec<InitialBalance> = if layout.has_initial_balances {
+        parse_initial_balances_from_file(&client, validators.as_slice())?
+    } else {
+        parse_initial_balances_from_staking_amounts(validators.as_slice()).map_err(|err| {
+            CliError::UnexpectedError(format!(
+                "Failed to parse initial balances from validator configurations {}",
+                err
+            ))
+        })?
+    };
+
     let framework = client.get_framework()?;
 
     Ok(GenesisInfo::new(
@@ -164,7 +180,66 @@ pub fn fetch_genesis_info(git_options: GitOptions) -> CliTypedResult<GenesisInfo
             voting_duration_secs: layout.voting_duration_secs,
             voting_power_increase_limit: layout.voting_power_increase_limit,
         },
+        initial_balances.as_slice(),
     )?)
+}
+
+/// Parses initial balances from a file.  This includes erroring out if a known address is supposed
+/// to have exist at genesis.
+fn parse_initial_balances_from_file(
+    client: &Client,
+    validators: &[ValidatorConfiguration],
+) -> CliTypedResult<Vec<InitialBalance>> {
+    let initial_balances: Vec<BTreeMap<AccountAddress, u64>> =
+        client.get(Path::new(BALANCES_FILE))?;
+
+    // Check for duplicate accounts in balances
+    let mut accounts = BTreeMap::new();
+    for balances in initial_balances.into_iter() {
+        for (account, balance) in balances.into_iter() {
+            if accounts.contains_key(&account) {
+                return Err(CliError::CommandArgumentError(format!(
+                    "Duplicate initial balance for {}",
+                    account
+                )));
+            }
+            accounts.insert(account, balance);
+        }
+    }
+
+    // Ensure that at least all of the known addresses are present and follow the basic requirements
+    for validator in validators {
+        // All accounts must be present
+        if !accounts.contains_key(&validator.owner_account_address) {
+            return Err(CliError::CommandArgumentError(format!(
+                "Missing initial balance for owner {}",
+                validator.owner_account_address
+            )));
+        } else if !accounts.contains_key(&validator.operator_account_address) {
+            return Err(CliError::CommandArgumentError(format!(
+                "Missing initial balance for operator {}",
+                validator.operator_account_address
+            )));
+        } else if !accounts.contains_key(&validator.voter_account_address) {
+            return Err(CliError::CommandArgumentError(format!(
+                "Missing initial balance for voter {}",
+                validator.voter_account_address
+            )));
+        }
+
+        // Owner must at least have it's stake amount
+        if *accounts.get(&validator.owner_account_address).unwrap() < validator.stake_amount {
+            return Err(CliError::CommandArgumentError(format!(
+                "Initial balance for {} is below stake amount {}",
+                validator.owner_account_address, validator.stake_amount
+            )));
+        }
+    }
+
+    Ok(accounts
+        .into_iter()
+        .map(|(address, balance)| InitialBalance { address, balance })
+        .collect())
 }
 
 /// Do proper parsing so more information is known about failures

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -29,6 +29,7 @@ use aptos_keygen::KeyGen;
 use aptos_temppath::TempPath;
 use aptos_types::account_address::AccountAddress;
 use aptos_types::chain_id::ChainId;
+use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use std::{
     collections::HashMap,
@@ -297,10 +298,20 @@ fn add_framework_to_dir(git_dir: &Path) {
 
 fn add_balances(git_dir: &Path, initial_balances: &[InitialBalance]) -> CliTypedResult<()> {
     if !initial_balances.is_empty() {
+        // Translate balances to map format
+        let balances: Vec<_> = initial_balances
+            .iter()
+            .map(|initial_balance| {
+                let mut map = BTreeMap::new();
+                map.insert(initial_balance.address, initial_balance.balance);
+                map
+            })
+            .collect();
+
         write_to_file(
             git_dir.join(BALANCES_FILE).as_path(),
             BALANCES_FILE,
-            to_yaml(initial_balances)?.as_bytes(),
+            to_yaml(balances.as_slice())?.as_bytes(),
         )
     } else {
         Ok(())

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -3,9 +3,10 @@
 
 use crate::common::types::OptionalPoolAddressArgs;
 use crate::common::utils::read_from_file;
-use crate::genesis::git::from_yaml;
 use crate::genesis::git::FRAMEWORK_NAME;
+use crate::genesis::git::{from_yaml, to_yaml};
 use crate::genesis::keys::{GenerateLayoutTemplate, PUBLIC_KEYS_FILE};
+use crate::genesis::BALANCES_FILE;
 use crate::{
     common::{
         types::{PromptOptions, RngArgs},
@@ -16,52 +17,58 @@ use crate::{
         keys::{GenerateKeys, SetValidatorConfiguration},
         GenerateGenesis,
     },
-    CliCommand,
+    CliCommand, CliTypedResult,
 };
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     PrivateKey,
 };
 use aptos_genesis::config::{HostAndPort, Layout};
+use aptos_genesis::keys::PublicIdentity;
 use aptos_keygen::KeyGen;
 use aptos_temppath::TempPath;
+use aptos_types::account_address::AccountAddress;
 use aptos_types::chain_id::ChainId;
+use std::fs::read_to_string;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     str::FromStr,
 };
+use vm_genesis::InitialBalance;
 
-/// Test the E2E genesis flow since it doesn't require a node to run
-#[tokio::test]
-async fn test_genesis_e2e_flow() {
-    const NUM_USERS: u8 = 2;
+async fn setup_genesis_test(
+    num_users: u8,
+) -> (
+    ChainId,
+    HashMap<String, PathBuf>,
+    Vec<String>,
+    Ed25519PrivateKey,
+    TempPath,
+) {
     let chain_id = ChainId::test();
     let mut users: HashMap<String, PathBuf> = HashMap::new();
     let dir = TempPath::new();
     dir.create_as_dir().unwrap();
 
     // Create users
-    for i in 0..NUM_USERS {
+    for i in 0..num_users {
         let name = format!("user-{}", i);
         let dir = generate_keys(dir.path(), i).await;
         users.insert(name, dir);
     }
 
+    // Retrieve names of users
     let names: Vec<_> = users.keys().map(|key| key.to_string()).collect();
 
-    let mut keygen = KeyGen::from_seed([NUM_USERS.saturating_add(1); 32]);
-
-    // First step is setup the local git repo
+    // Generate the root key
+    let mut keygen = KeyGen::from_seed([5u8; 32]);
     let root_private_key = keygen.generate_ed25519_private_key();
-    let git_options = setup_git_dir(&root_private_key, names, chain_id).await;
 
-    // Add keys
-    for (name, user_dir) in users.iter() {
-        add_public_keys(name.to_string(), git_options.clone(), user_dir.as_path()).await;
-    }
+    (chain_id, users, names, root_private_key, dir)
+}
 
-    // Now generate genesis
+async fn generate_genesis_in_temp_folder(git_options: GitOptions) -> (PathBuf, PathBuf) {
     let output_dir = TempPath::new();
     output_dir.create_as_dir().unwrap();
     let output_dir = PathBuf::from(output_dir.path());
@@ -72,6 +79,165 @@ async fn test_genesis_e2e_flow() {
     assert!(waypoint_file.exists());
     let genesis_file = output_dir.join("genesis.blob");
     assert!(genesis_file.exists());
+
+    // Return both for more assertions
+    (genesis_file, waypoint_file)
+}
+
+/// Test the E2E genesis flow since it doesn't require a node to run
+#[tokio::test]
+async fn test_genesis_e2e_flow() {
+    const NUM_USERS: u8 = 5;
+    let (chain_id, users, names, root_private_key, _repo_dir) = setup_genesis_test(NUM_USERS).await;
+
+    // First step is setup the local git repo
+    let git_options = setup_git_dir(&root_private_key, names, chain_id, &[]).await;
+
+    // Add keys
+    for (name, user_dir) in users.iter() {
+        add_public_keys(
+            name.to_string(),
+            git_options.clone(),
+            user_dir.as_path(),
+            None,
+            None,
+        )
+        .await;
+    }
+
+    // Now generate genesis
+    generate_genesis_in_temp_folder(git_options).await;
+}
+
+#[tokio::test]
+async fn test_genesis_e2e_flow_with_balances() {
+    const NUM_USERS: u8 = 4;
+    let (chain_id, users, names, root_private_key, _repo_dir) = setup_genesis_test(NUM_USERS).await;
+
+    // Build initial balances
+    let mut initial_balances: Vec<_> = users
+        .iter()
+        .map(|(_, path)| {
+            let public_identity = load_public_identity(path);
+            InitialBalance {
+                address: public_identity.account_address,
+                balance: 100_000_000_000_000,
+            }
+        })
+        .collect();
+
+    // Add one more arbitrary balance, not in the validator set
+    initial_balances.push(InitialBalance {
+        address: AccountAddress::from_str("0x1337").unwrap(),
+        balance: 100,
+    });
+
+    // First step is setup the local git repo
+    let git_options = setup_git_dir(
+        &root_private_key,
+        names,
+        chain_id,
+        initial_balances.as_slice(),
+    )
+    .await;
+
+    // Add keys
+    for (name, user_dir) in users.iter() {
+        add_public_keys(
+            name.to_string(),
+            git_options.clone(),
+            user_dir.as_path(),
+            None,
+            None,
+        )
+        .await;
+    }
+
+    // Now generate genesis
+    generate_genesis_in_temp_folder(git_options).await;
+}
+
+#[tokio::test]
+async fn test_genesis_e2e_flow_with_operators() {
+    const NUM_USERS: u8 = 3;
+    let (chain_id, users, names, root_private_key, dir) = setup_genesis_test(NUM_USERS).await;
+
+    // First step is setup the local git repo
+    let git_options = setup_git_dir(&root_private_key, names, chain_id, &[]).await;
+
+    let operator_dir = generate_keys(dir.path(), 5).await;
+    let voter_dir = generate_keys(dir.path(), 6).await;
+
+    // Add keys
+    for (name, user_dir) in users.iter() {
+        add_public_keys(
+            name.to_string(),
+            git_options.clone(),
+            user_dir.as_path(),
+            Some(operator_dir.join(PUBLIC_KEYS_FILE)),
+            Some(voter_dir.join(PUBLIC_KEYS_FILE)),
+        )
+        .await;
+    }
+
+    // Now generate genesis
+    generate_genesis_in_temp_folder(git_options).await;
+}
+
+#[tokio::test]
+async fn test_genesis_e2e_flow_with_operators_and_balances() {
+    const NUM_USERS: u8 = 3;
+    let (chain_id, users, names, root_private_key, dir) = setup_genesis_test(NUM_USERS).await;
+
+    let operator_dir = generate_keys(dir.path(), 5).await;
+    let operator_address = load_public_identity(operator_dir.as_path()).account_address;
+    let voter_dir = generate_keys(dir.path(), 6).await;
+    let voter_address = load_public_identity(voter_dir.as_path()).account_address;
+    // Build initial balances
+    let mut initial_balances: Vec<_> = users
+        .iter()
+        .map(|(_, path)| {
+            let public_identity = load_public_identity(path);
+            InitialBalance {
+                address: public_identity.account_address,
+                balance: 100_000_000_000_000,
+            }
+        })
+        .collect();
+
+    // Add the operator and voter to balances
+    initial_balances.push(InitialBalance {
+        address: operator_address,
+        balance: 12345,
+    });
+    initial_balances.push(InitialBalance {
+        address: voter_address,
+        balance: 1337,
+    });
+
+    // First step is setup the local git repo
+    let git_options = setup_git_dir(
+        &root_private_key,
+        names,
+        chain_id,
+        initial_balances.as_slice(),
+    )
+    .await;
+
+    // Add keys
+    for (name, user_dir) in users.iter() {
+        add_public_keys(
+            name.to_string(),
+            git_options.clone(),
+            user_dir.as_path(),
+            Some(operator_dir.join(PUBLIC_KEYS_FILE)),
+            Some(voter_dir.join(PUBLIC_KEYS_FILE)),
+        )
+        .await;
+    }
+
+    // Now generate genesis
+    generate_genesis_in_temp_folder(git_options).await;
 }
 
 /// Generate genesis and waypoint
@@ -89,13 +255,21 @@ async fn setup_git_dir(
     root_private_key: &Ed25519PrivateKey,
     users: Vec<String>,
     chain_id: ChainId,
+    initial_balances: &[InitialBalance],
 ) -> GitOptions {
     let git_options = git_options();
     let layout_file = TempPath::new();
     layout_file.create_as_file().unwrap();
     let layout_file = layout_file.path();
 
-    create_layout_file(layout_file, root_private_key.public_key(), users, chain_id).await;
+    create_layout_file(
+        layout_file,
+        root_private_key.public_key(),
+        users,
+        chain_id,
+        !initial_balances.is_empty(),
+    )
+    .await;
     let setup_command = SetupGit {
         git_options: git_options.clone(),
         layout_file: PathBuf::from(layout_file),
@@ -106,8 +280,11 @@ async fn setup_git_dir(
         .await
         .expect("Should not fail creating repo folder");
 
+    let git_dir = git_options.local_repository_dir.as_ref().unwrap();
     // Add framework
-    add_framework_to_dir(git_options.local_repository_dir.as_ref().unwrap().as_path());
+    add_framework_to_dir(git_dir.as_path());
+    // Add balances (if applicable)
+    add_balances(git_dir.as_path(), initial_balances).unwrap();
     git_options
 }
 
@@ -116,6 +293,18 @@ fn add_framework_to_dir(git_dir: &Path) {
     cached_packages::head_release_bundle()
         .write(git_dir.join(FRAMEWORK_NAME))
         .unwrap()
+}
+
+fn add_balances(git_dir: &Path, initial_balances: &[InitialBalance]) -> CliTypedResult<()> {
+    if !initial_balances.is_empty() {
+        write_to_file(
+            git_dir.join(BALANCES_FILE).as_path(),
+            BALANCES_FILE,
+            to_yaml(initial_balances)?.as_bytes(),
+        )
+    } else {
+        Ok(())
+    }
 }
 
 /// Local git options for testing
@@ -134,6 +323,7 @@ async fn create_layout_file(
     root_public_key: Ed25519PublicKey,
     users: Vec<String>,
     chain_id: ChainId,
+    has_initial_balances: bool,
 ) {
     GenerateLayoutTemplate {
         output_file: PathBuf::from(file),
@@ -150,6 +340,7 @@ async fn create_layout_file(
     layout.users = users;
     layout.chain_id = chain_id;
     layout.is_test = true;
+    layout.has_initial_balances = has_initial_balances;
 
     write_to_file(
         file,
@@ -174,7 +365,13 @@ async fn generate_keys(dir: &Path, index: u8) -> PathBuf {
 }
 
 /// Set validator configuration for a user
-async fn add_public_keys(username: String, git_options: GitOptions, keys_dir: &Path) {
+async fn add_public_keys(
+    username: String,
+    git_options: GitOptions,
+    keys_dir: &Path,
+    operator_identity: Option<PathBuf>,
+    voter_identity: Option<PathBuf>,
+) {
     let command = SetValidatorConfiguration {
         username,
         git_options,
@@ -182,9 +379,13 @@ async fn add_public_keys(username: String, git_options: GitOptions, keys_dir: &P
         validator_host: HostAndPort::from_str("localhost:6180").unwrap(),
         stake_amount: 100_000_000_000_000,
         full_node_host: None,
-        operator_public_identity_file: None,
-        voter_public_identity_file: None,
+        operator_public_identity_file: operator_identity,
+        voter_public_identity_file: voter_identity,
     };
 
     command.execute().await.unwrap()
+}
+
+fn load_public_identity(user_dir: &Path) -> PublicIdentity {
+    from_yaml(&read_to_string(user_dir.join(PUBLIC_KEYS_FILE).as_path()).unwrap()).unwrap()
 }

--- a/ecosystem/sf-indexer/firehose-stream/src/tests/proto_converter_tests.rs
+++ b/ecosystem/sf-indexer/firehose-stream/src/tests/proto_converter_tests.rs
@@ -14,12 +14,13 @@ use aptos_protos::extractor::v1::{
     Transaction as TransactionPB,
 };
 
-use aptos_sdk::types::{account_config::aptos_test_root_address, LocalAccount};
+use aptos_sdk::types::LocalAccount;
 use move_deps::{
     move_core_types::{account_address::AccountAddress, value::MoveValue},
     move_package::BuildConfig,
 };
 use serde_json::{json, Value};
+use std::str::FromStr;
 use std::{collections::HashMap, convert::TryInto, path::PathBuf, sync::Arc, time::Duration};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -36,10 +37,8 @@ async fn test_genesis_works() {
     assert_eq!(txn.r#type(), TransactionType::Genesis);
     assert_eq!(txn.block_height, 0);
     if let TxnData::Genesis(txn) = txn.txn_data.unwrap() {
-        assert_eq!(
-            txn.events[0].key.clone().unwrap().account_address,
-            aptos_test_root_address().to_string()
-        );
+        AccountAddress::from_str(&txn.events[0].key.clone().unwrap().account_address)
+            .expect("Valid account address in event");
     }
 }
 


### PR DESCRIPTION
### Description
This allows for a file to create initial balances for any account including both in and out of the validator set.  Additionally, fixes that all accounts will have a coin store at startup.

### Test Plan
E2E tests incoming, but I've also tested this manually.  I expect I will make more correctness checks on Genesis inputs in the coming days

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3939)
<!-- Reviewable:end -->
