### PR TITLE
[fix] prune stale state value index

### DIFF
--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -741,6 +741,8 @@ impl StateStore {
             if index.stale_since_version > end {
                 break;
             }
+            // Prune the stale state value index itself first.
+            db_batch.delete::<StaleStateValueIndexSchema>(&index)?;
             db_batch.delete::<StateValueSchema>(&(index.state_key, index.version))?;
         }
         for version in begin..end {


### PR DESCRIPTION
### Description
We forget to delete stale_value_index itself when delete stale value. it will incur lots of garbage/deprecated stale value indices data.

### Test Plan
reinforced unit test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3942)
<!-- Reviewable:end -->
