### PR TITLE
refactor(ts-sdk): get rid of bigint literals

### DIFF
--- a/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/bcs_transaction.ts
@@ -75,9 +75,9 @@ const {
     BigInt(sequenceNumber),
     entryFunctionPayload,
     // Max gas unit to spend
-    2000n,
+    BigInt(2000),
     // Gas price per unit
-    1n,
+    BigInt(1),
     // Expiration timestamp. Transaction is discarded if it is not executed within 10 seconds from now.
     BigInt(Math.floor(Date.now() / 1000) + 10),
     new ChainId(chainId),

--- a/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
+++ b/ecosystem/typescript/sdk/examples/typescript/multisig_transaction.ts
@@ -89,9 +89,9 @@ const FAUCET_URL = process.env.APTOS_FAUCET_URL || "https://faucet.devnet.aptosl
     BigInt(sequenceNumber),
     entryFunctionPayload,
     // Max gas unit to spend
-    2000n,
+    BigInt(2000),
     // Gas price per unit
-    1n,
+    BigInt(1),
     // Expiration timestamp. Transaction is discarded if it is not executed within 10 seconds from now.
     BigInt(Math.floor(Date.now() / 1000) + 10),
     new TxnBuilderTypes.ChainId(chainId),

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -561,8 +561,8 @@ export class AptosClient {
     extraArgs?: { maxGasAmount?: BCS.Uint64; gasUnitPrice?: BCS.Uint64; expireTimestamp?: BCS.Uint64 },
   ): Promise<TxnBuilderTypes.RawTransaction> {
     const { maxGasAmount, gasUnitPrice, expireTimestamp } = {
-      maxGasAmount: 2000n,
-      gasUnitPrice: 1n,
+      maxGasAmount: BigInt(2000),
+      gasUnitPrice: BigInt(1),
       expireTimestamp: BigInt(Math.floor(Date.now() / 1000) + 20),
       ...extraArgs,
     };

--- a/ecosystem/typescript/sdk/src/coin_client.test.ts
+++ b/ecosystem/typescript/sdk/src/coin_client.test.ts
@@ -21,7 +21,7 @@ test(
 
     await client.waitForTransaction(await coinClient.transfer(alice, bob, 42), { checkSuccess: true });
 
-    expect(await coinClient.checkBalance(bob)).toBe(42n);
+    expect(await coinClient.checkBalance(bob)).toBe(BigInt(42));
   },
   30 * 1000,
 );

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/consts.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/consts.ts
@@ -7,5 +7,5 @@ import { Uint128, Uint16, Uint32, Uint64, Uint8 } from "./types";
 export const MAX_U8_NUMBER: Uint8 = 2 ** 8 - 1;
 export const MAX_U16_NUMBER: Uint16 = 2 ** 16 - 1;
 export const MAX_U32_NUMBER: Uint32 = 2 ** 32 - 1;
-export const MAX_U64_BIG_INT: Uint64 = BigInt(2 ** 64) - 1n;
-export const MAX_U128_BIG_INT: Uint128 = BigInt(2 ** 128) - 1n;
+export const MAX_U64_BIG_INT: Uint64 = BigInt(2 ** 64) - BigInt(1);
+export const MAX_U128_BIG_INT: Uint128 = BigInt(2 ** 128) - BigInt(1);

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/deserializer.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/deserializer.test.ts
@@ -74,20 +74,20 @@ describe("BCS Deserializer", () => {
 
   it("deserializes a uint64", () => {
     let deserializer = new Deserializer(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
-    expect(deserializer.deserializeU64()).toEqual(18446744073709551615n);
+    expect(deserializer.deserializeU64()).toEqual(BigInt("18446744073709551615"));
     deserializer = new Deserializer(new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12]));
-    expect(deserializer.deserializeU64()).toEqual(1311768467750121216n);
+    expect(deserializer.deserializeU64()).toEqual(BigInt("1311768467750121216"));
   });
 
   it("deserializes a uint128", () => {
     let deserializer = new Deserializer(
       new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
     );
-    expect(deserializer.deserializeU128()).toEqual(340282366920938463463374607431768211455n);
+    expect(deserializer.deserializeU128()).toEqual(BigInt("340282366920938463463374607431768211455"));
     deserializer = new Deserializer(
       new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
     );
-    expect(deserializer.deserializeU128()).toEqual(1311768467750121216n);
+    expect(deserializer.deserializeU128()).toEqual(BigInt("1311768467750121216"));
   });
 
   it("deserializes a uleb128", () => {

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/deserializer.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/deserializer.ts
@@ -153,7 +153,7 @@ export class Deserializer {
    * BCS use uleb128 encoding in two cases: (1) lengths of variable-length sequences and (2) tags of enum values
    */
   deserializeUleb128AsU32(): Uint32 {
-    let value: bigint = 0n;
+    let value: bigint = BigInt(0);
     let shift = 0;
 
     while (value < MAX_U32_NUMBER) {

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/helper.test.ts
@@ -55,13 +55,13 @@ test("bcsSerializeU32", () => {
 });
 
 test("bcsSerializeU64", () => {
-  expect(bcsSerializeUint64(18446744073709551615n)).toEqual(
+  expect(bcsSerializeUint64(BigInt("18446744073709551615"))).toEqual(
     new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
   );
 });
 
 test("bcsSerializeU128", () => {
-  expect(bcsSerializeU128(340282366920938463463374607431768211455n)).toEqual(
+  expect(bcsSerializeU128(BigInt("340282366920938463463374607431768211455"))).toEqual(
     new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
   );
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/serializer.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/serializer.test.ts
@@ -118,17 +118,17 @@ describe("BCS Serializer", () => {
   });
 
   it("serializes a uint64", () => {
-    serializer.serializeU64(18446744073709551615n);
+    serializer.serializeU64(BigInt("18446744073709551615"));
     expect(serializer.getBytes()).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
 
     serializer = new Serializer();
-    serializer.serializeU64(1311768467750121216n);
+    serializer.serializeU64(BigInt("1311768467750121216"));
     expect(serializer.getBytes()).toEqual(new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12]));
   });
 
   it("throws when serializing uint64 with out of range value", () => {
     expect(() => {
-      serializer.serializeU64(18446744073709551616n);
+      serializer.serializeU64(BigInt("18446744073709551616"));
     }).toThrow("Value is out of range");
 
     expect(() => {
@@ -138,13 +138,13 @@ describe("BCS Serializer", () => {
   });
 
   it("serializes a uint128", () => {
-    serializer.serializeU128(340282366920938463463374607431768211455n);
+    serializer.serializeU128(BigInt("340282366920938463463374607431768211455"));
     expect(serializer.getBytes()).toEqual(
       new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
     );
 
     serializer = new Serializer();
-    serializer.serializeU128(1311768467750121216n);
+    serializer.serializeU128(BigInt("1311768467750121216"));
     expect(serializer.getBytes()).toEqual(
       new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
     );
@@ -152,7 +152,7 @@ describe("BCS Serializer", () => {
 
   it("throws when serializing uint128 with out of range value", () => {
     expect(() => {
-      serializer.serializeU128(340282366920938463463374607431768211456n);
+      serializer.serializeU128(BigInt("340282366920938463463374607431768211456"));
     }).toThrow("Value is out of range");
 
     expect(() => {

--- a/ecosystem/typescript/sdk/src/transaction_builder/bcs/serializer.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/bcs/serializer.ts
@@ -146,7 +146,7 @@ export class Serializer {
    * assert(serializer.getBytes() === new Uint8Array([0x00, 0xEF, 0xCD, 0xAB, 0x78, 0x56, 0x34, 0x12]));
    * ```
    */
-  @checkNumberRange(0n, MAX_U64_BIG_INT)
+  @checkNumberRange(BigInt(0), MAX_U64_BIG_INT)
   serializeU64(value: AnyNumber): void {
     const low = BigInt(value.toString()) & BigInt(MAX_U32_NUMBER);
     const high = BigInt(value.toString()) >> BigInt(32);
@@ -161,7 +161,7 @@ export class Serializer {
    *
    * BCS layout for "uint128": Sixteen bytes. Binary format in little-endian representation.
    */
-  @checkNumberRange(0n, MAX_U128_BIG_INT)
+  @checkNumberRange(BigInt(0), MAX_U128_BIG_INT)
   serializeU128(value: AnyNumber): void {
     const low = BigInt(value.toString()) & MAX_U64_BIG_INT;
     const high = BigInt(value.toString()) >> BigInt(64);

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -192,8 +192,8 @@ export class TransactionBuilderABI {
     });
 
     this.builderConfig = {
-      gasUnitPrice: 1n,
-      maxGasAmount: 2000n,
+      gasUnitPrice: BigInt(1),
+      maxGasAmount: BigInt(2000),
       expSecFromNow: 20,
       ...builderConfig,
     };

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.test.ts
@@ -170,7 +170,7 @@ describe("BuilderUtils", () => {
 
   it("serializes a u64 arg", async () => {
     let serializer = new Serializer();
-    serializeArg(18446744073709551615n, new TypeTagU64(), serializer);
+    serializeArg(BigInt("18446744073709551615"), new TypeTagU64(), serializer);
     expect(serializer.getBytes()).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
 
     serializer = new Serializer();
@@ -181,7 +181,7 @@ describe("BuilderUtils", () => {
 
   it("serializes a u128 arg", async () => {
     let serializer = new Serializer();
-    serializeArg(340282366920938463463374607431768211455n, new TypeTagU128(), serializer);
+    serializeArg(BigInt("340282366920938463463374607431768211455"), new TypeTagU128(), serializer);
     expect(serializer.getBytes()).toEqual(
       new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
     );
@@ -275,7 +275,7 @@ describe("BuilderUtils", () => {
 
   it("converts a u64 TransactionArgument", async () => {
     const res = argToTransactionArgument(123, new TypeTagU64());
-    expect((res as TransactionArgumentU64).value).toEqual(123n);
+    expect((res as TransactionArgumentU64).value).toEqual(BigInt(123));
     expect(() => {
       argToTransactionArgument("u64", new TypeTagU64());
     }).toThrow(/Cannot convert/);
@@ -283,7 +283,7 @@ describe("BuilderUtils", () => {
 
   it("converts a u128 TransactionArgument", async () => {
     const res = argToTransactionArgument(123, new TypeTagU128());
-    expect((res as TransactionArgumentU128).value).toEqual(123n);
+    expect((res as TransactionArgumentU128).value).toEqual(BigInt(123));
     expect(() => {
       argToTransactionArgument("u128", new TypeTagU128());
     }).toThrow(/Cannot convert/);
@@ -335,8 +335,8 @@ describe("BuilderUtils", () => {
   });
 
   it("ensures a bigint", async () => {
-    expect(ensureBigInt(10)).toBe(10n);
-    expect(ensureBigInt("123")).toBe(123n);
+    expect(ensureBigInt(10)).toBe(BigInt(10));
+    expect(ensureBigInt("123")).toBe(BigInt(123));
     expect(() => ensureBigInt("True")).toThrow(/^Cannot convert/);
   });
 });

--- a/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/transaction_builder.test.ts
@@ -71,10 +71,10 @@ test("serialize entry function payload with no type args", () => {
 
   const rawTxn = new RawTransaction(
     AccountAddress.fromHex(new HexString(ADDRESS_3)),
-    0n,
+    BigInt(0),
     entryFunctionPayload,
-    2000n,
-    0n,
+    BigInt(2000),
+    BigInt(0),
     BigInt(TXN_EXPIRE),
     new ChainId(4),
   );
@@ -100,10 +100,10 @@ test("serialize entry function payload with type args", () => {
 
   const rawTxn = new RawTransaction(
     AccountAddress.fromHex(ADDRESS_3),
-    0n,
+    BigInt(0),
     entryFunctionPayload,
-    2000n,
-    0n,
+    BigInt(2000),
+    BigInt(0),
     BigInt(TXN_EXPIRE),
     new ChainId(4),
   );
@@ -124,10 +124,10 @@ test("serialize entry function payload with type args but no function args", () 
 
   const rawTxn = new RawTransaction(
     AccountAddress.fromHex(ADDRESS_3),
-    0n,
+    BigInt(0),
     entryFunctionPayload,
-    2000n,
-    0n,
+    BigInt(2000),
+    BigInt(0),
     BigInt(TXN_EXPIRE),
     new ChainId(4),
   );
@@ -146,10 +146,10 @@ test("serialize script payload with no type args and no function args", () => {
 
   const rawTxn = new RawTransaction(
     AccountAddress.fromHex(ADDRESS_3),
-    0n,
+    BigInt(0),
     scriptPayload,
-    2000n,
-    0n,
+    BigInt(2000),
+    BigInt(0),
     BigInt(TXN_EXPIRE),
     new ChainId(4),
   );
@@ -170,10 +170,10 @@ test("serialize script payload with type args but no function args", () => {
 
   const rawTxn = new RawTransaction(
     AccountAddress.fromHex(ADDRESS_3),
-    0n,
+    BigInt(0),
     scriptPayload,
-    2000n,
-    0n,
+    BigInt(2000),
+    BigInt(0),
     BigInt(TXN_EXPIRE),
     new ChainId(4),
   );
@@ -195,10 +195,10 @@ test("serialize script payload with type arg and function arg", () => {
   const scriptPayload = new TransactionPayloadScript(new Script(script, [token], [argU8]));
   const rawTxn = new RawTransaction(
     AccountAddress.fromHex(ADDRESS_3),
-    0n,
+    BigInt(0),
     scriptPayload,
-    2000n,
-    0n,
+    BigInt(2000),
+    BigInt(0),
     BigInt(TXN_EXPIRE),
     new ChainId(4),
   );
@@ -222,10 +222,10 @@ test("serialize script payload with one type arg and two function args", () => {
 
   const rawTxn = new RawTransaction(
     AccountAddress.fromHex(ADDRESS_3),
-    0n,
+    BigInt(0),
     scriptPayload,
-    2000n,
-    0n,
+    BigInt(2000),
+    BigInt(0),
     BigInt(TXN_EXPIRE),
     new ChainId(4),
   );


### PR DESCRIPTION
### Description
BigInt literals require ES2020 or above as `target` in TS `compilerOptions`. This PR gets rid of the bigint literals.

### Test Plan
Make sure tests still pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3943)
<!-- Reviewable:end -->
