### PR TITLE
[forge] Fix woopsie in failpoint logic

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -90,10 +90,9 @@ jobs:
         shell: bash
         env:
           FORGE_RUNNER_MODE: pre-forge
-        run: |
-          set +e
-
-          source testsuite/run_forge.sh
+        run: >
+          testsuite/run_forge.sh
+            --verbose
       - name: Post pre-Forge comment
         if: github.event.number != null
         uses: marocchino/sticky-pull-request-comment@v2

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1048,12 +1048,12 @@ class Git:
 
 
 def assert_provided_image_tags_has_profile_or_features(
-    forge_image_tag: Optional[str],
     image_tag: Optional[str],
-    enable_failpoints_feature: bool = False,
-    enable_performance_profile: bool = False,
+    upgrade_image_tag: Optional[str],
+    enable_failpoints_feature: bool,
+    enable_performance_profile: bool,
 ):
-    for tag in [forge_image_tag, image_tag]:
+    for tag in [image_tag, upgrade_image_tag]:
         if not tag:
             continue
         if enable_failpoints_feature:
@@ -1343,7 +1343,7 @@ def test(
 
     assert_provided_image_tags_has_profile_or_features(
         image_tag,
-        forge_image_tag,
+        upgrade_image_tag,
         enable_failpoints_feature=enable_failpoints_feature,
         enable_performance_profile=enable_performance_profile,
     )
@@ -1371,13 +1371,20 @@ def test(
                 shell,
                 git,
                 1,
-                enable_failpoints_feature=enable_performance_profile,
+                enable_failpoints_feature=enable_failpoints_feature,
                 enable_performance_profile=enable_performance_profile,
             )
         )
         image_tag = image_tag or default_latest_image
         forge_image_tag = forge_image_tag or default_latest_image
         upgrade_image_tag = upgrade_image_tag or default_latest_image
+
+    assert_provided_image_tags_has_profile_or_features(
+        image_tag,
+        upgrade_image_tag,
+        enable_failpoints_feature=enable_failpoints_feature,
+        enable_performance_profile=enable_performance_profile,
+    )
 
     assert image_tag is not None, "Image tag is required"
     assert forge_image_tag is not None, "Forge image tag is required"

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -911,7 +911,7 @@ class K8sForgeRunner(ForgeRunner):
                     "wait",
                     "-n",
                     "default",
-                    "--timeout=1m",
+                    "--timeout=5m",
                     "--for=condition=Ready",
                     f"pod/{forge_pod_name}",
                 ]

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -1,3 +1,4 @@
+from cgitb import enable
 from contextlib import ExitStack
 from importlib.metadata import files
 import json
@@ -411,6 +412,7 @@ class TestFindRecentImage(unittest.TestCase):
                 "potato_tomato",
                 "failpoints_performance_potato",
                 enable_failpoints_feature=True,
+                enable_performance_profile=False,
             )
 
     def testFailpointsNoProvidedImageTag(self) -> None:
@@ -418,6 +420,7 @@ class TestFindRecentImage(unittest.TestCase):
             None,
             None,
             enable_failpoints_feature=True,
+            enable_performance_profile=False,
         )
 
 


### PR DESCRIPTION
I accidentally mistyped? a variable name and we didnt check after that the image was correct...

So I added an assertion after modifying the variable name as well and fix the typo

Also removed the optional args, since they really should not be optional

Test Plan: unittests + run forge locally with failopint enabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3947)
<!-- Reviewable:end -->
