### PR TITLE
[Consensus] Remove stuck epoch manager check

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -28,8 +28,6 @@ pub struct ConsensusConfig {
     // the period = (poll_count - 1) * 30ms
     pub quorum_store_poll_count: u64,
     pub intra_consensus_channel_buffer_size: usize,
-    // 0 if disbled
-    pub panic_on_stuck_epoch_manager_duration_s: u64,
 }
 
 impl Default for ConsensusConfig {
@@ -49,7 +47,6 @@ impl Default for ConsensusConfig {
             quorum_store_pull_timeout_ms: 1000,
             quorum_store_poll_count: 5,
             intra_consensus_channel_buffer_size: 10,
-            panic_on_stuck_epoch_manager_duration_s: 300,
         }
     }
 }


### PR DESCRIPTION
### Description

Removin this check as we can have false positive in case of epoch change and epoch manager is busy doing state sync. We have been running the chain stably for few days for now, so this check shouldn't be needed. We can plan to bring this back in main after making this robust. 

### Test Plan

Existing tests.
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3948)
<!-- Reviewable:end -->
