### PR TITLE
[mempool] fix sequence number cache

### DIFF
--- a/crates/aptos-infallible/src/lib.rs
+++ b/crates/aptos-infallible/src/lib.rs
@@ -10,4 +10,4 @@ mod time;
 pub use math::ArithmeticError;
 pub use mutex::{Mutex, MutexGuard};
 pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
-pub use time::duration_since_epoch;
+pub use time::{duration_since_epoch, system_time_since_epoch};

--- a/crates/aptos-infallible/src/time.rs
+++ b/crates/aptos-infallible/src/time.rs
@@ -7,7 +7,13 @@ use std::time::{Duration, SystemTime};
 
 /// Gives the duration since the Unix epoch, notice the expect.
 pub fn duration_since_epoch() -> Duration {
-    SystemTime::now()
+    let system_time = SystemTime::now();
+    system_time_since_epoch(&system_time)
+}
+
+/// Gives the duration of the given time since the Unix epoch, notice the expect.
+pub fn system_time_since_epoch(system_time: &SystemTime) -> Duration {
+    system_time
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("System time is before the UNIX_EPOCH")
 }

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -119,16 +119,10 @@ impl TransactionStore {
         }
     }
 
-    /// Fetch mempool transaction by account address + sequence_number.
-    pub(crate) fn get_mempool_txn(
-        &self,
-        address: &AccountAddress,
-        sequence_number: u64,
-    ) -> Option<MempoolTransaction> {
+    pub(crate) fn exists(&self, address: &AccountAddress) -> bool {
         self.transactions
             .get(address)
-            .and_then(|txns| txns.get(&sequence_number))
-            .cloned()
+            .map_or_else(|| false, |transactions| !transactions.is_empty())
     }
 
     /// Insert transaction into TransactionStore. Performs validation checks and updates indexes.
@@ -486,8 +480,9 @@ impl TransactionStore {
     pub(crate) fn gc_by_system_ttl(
         &mut self,
         metrics_cache: &TtlCache<(AccountAddress, u64), SystemTime>,
+        gc_time: SystemTime,
     ) {
-        let now = aptos_infallible::duration_since_epoch();
+        let now = aptos_infallible::system_time_since_epoch(&gc_time);
 
         self.gc(now, true, metrics_cache);
     }

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -578,3 +578,20 @@ fn test_bytes_limit() {
     let hit_limit = pool.get_batch(100, txn_size * limit, HashSet::new());
     assert_eq!(hit_limit.len(), limit as usize);
 }
+
+#[test]
+fn test_sequence_number_cache_at_capacity() {
+    let mut config = NodeConfig::random();
+    config.mempool.capacity = 2;
+    // config.mempool.system_transaction_timeout_secs = 0;
+    let mut pool = CoreMempool::new(&config);
+
+    add_txn(&mut pool, TestTransaction::new(0, 0, 1)).unwrap();
+    add_txn(&mut pool, TestTransaction::new(1, 0, 1)).unwrap();
+    pool.remove_transaction(&TestTransaction::get_address(1), 0, false);
+    add_txn(&mut pool, TestTransaction::new(2, 0, 1)).unwrap();
+    pool.remove_transaction(&TestTransaction::get_address(2), 0, false);
+
+    let batch = pool.get_batch(10, 10240, HashSet::new());
+    assert_eq!(batch.len(), 1);
+}

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -338,7 +338,7 @@ fn test_capacity_bytes() {
             let status = pool.add_txn(
                 txn.txn,
                 txn.ranking_score,
-                txn.sequence_info.account_sequence_number_type,
+                AccountSequenceInfo::Sequential(0),
                 txn.timeline_state,
             );
             assert_eq!(status.code, MempoolStatusCode::Accepted);
@@ -348,7 +348,7 @@ fn test_capacity_bytes() {
             let status = pool.add_txn(
                 txn.txn,
                 txn.ranking_score,
-                txn.sequence_info.account_sequence_number_type,
+                AccountSequenceInfo::Sequential(0),
                 txn.timeline_state,
             );
             assert_eq!(status.code, MempoolStatusCode::MempoolIsFull);


### PR DESCRIPTION
### Description

There were two issues previously:
1. An account's sequence_number_cache could get GC'd before its transactions in mempool were sent to consensus. In this case because a cached sequence number does not exist, the transactions are never sent to consensus (get_batch checks the sequence number).
2. The sequence_number_cache capacity is the same as the mempool, but it could have grown beyond this because sequence_number_cache entries are retained for accounts after transaction removal (until they expire). In this case old sequence_number_cache entries are removed and those transactions may never be sent to consensus (same reason as above).

The fixes are to:
1. Make sequence_number_cache expiration the same as transaction_store.
2. Only retain the sequence_number_cache on transaction removal if there are still transactions for that account in mempool. This ensures that sequence_number_caches <= transaction_store because there is an entry in sequence_number_caches only if there is at least one transaction for that account in transaction_store.

### Test Plan

TODO: need to write some unit tests for the above two issues and confirm they are resolved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3959)
<!-- Reviewable:end -->
