### PR TITLE
[aptos-cli] Add flag to turn on max gas estimation

### DIFF
--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -802,6 +802,7 @@ impl CliTestFramework {
             rest_options: self.rest_options(),
             gas_options: gas_options.unwrap_or_default(),
             prompt_options: PromptOptions::yes(),
+            estimate_max_gas: true,
             ..Default::default()
         }
     }


### PR DESCRIPTION
### Description
Now you need to pass --estimate-max-gas, otherwise, it defaults to 50k for now.

We'll need to get rid of this before mainnet, as we should not be defaulting gas, because it hides how much it'll cost.

### Test Plan
CI, has it enabled

```
$ aptos account transfer --profile other --account testnet --amount 1000000000
{
  "Error": "API error: API error Error(VmError): Invalid transaction: Type: Validation Code: INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE"
}

$ aptos account transfer --profile other --account testnet --amount 1000000000 --estimate-max-gas
{
  "Error": "API error: Simulated transaction failed with status Transaction Executed and Committed with Error MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS"
}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3961)
<!-- Reviewable:end -->
