### PR TITLE
[aptos-rosetta] Cleanup rosetta with BCS

### DIFF
--- a/api/types/src/block.rs
+++ b/api/types/src/block.rs
@@ -43,6 +43,5 @@ pub struct BcsBlock {
     /// The last ledger version of the block inclusive
     pub last_version: u64,
     /// The transactions in the block in sequential order
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub transactions: Option<Vec<TransactionOnChainData>>,
 }

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -28,7 +28,7 @@ use aptos_api_types::{
     UserTransaction, VersionedEvent,
 };
 use aptos_crypto::HashValue;
-use aptos_types::account_config::AccountResource;
+use aptos_types::account_config::{AccountResource, CoinStoreResource};
 use aptos_types::contract_event::EventWithVersion;
 use aptos_types::transaction::ExecutionStatus;
 use aptos_types::{
@@ -188,6 +188,20 @@ impl Client {
                 Err(anyhow!("No data returned").into())
             }
         })
+    }
+
+    pub async fn get_account_balance_bcs(
+        &self,
+        address: AccountAddress,
+        coin_type: &str,
+    ) -> AptosResult<Response<u64>> {
+        let resp = self
+            .get_account_resource_bcs::<CoinStoreResource>(
+                address,
+                &format!("0x1::coin::CoinStore<{}>", coin_type),
+            )
+            .await?;
+        resp.and_then(|resource| Ok(resource.coin()))
     }
 
     pub async fn get_account_balance_at_version(

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -675,6 +675,19 @@ impl Client {
         self.json(response).await
     }
 
+    pub async fn get_account_resources_at_version_bcs(
+        &self,
+        address: AccountAddress,
+        version: u64,
+    ) -> AptosResult<Response<BTreeMap<StructTag, Vec<u8>>>> {
+        let url = self.build_path(&format!(
+            "accounts/{}/resources?ledger_version={}",
+            address, version
+        ))?;
+        let response = self.get_bcs(url).await?;
+        Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)
+    }
+
     pub async fn get_resource<T: DeserializeOwned>(
         &self,
         address: AccountAddress,

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -19,11 +19,6 @@ use crate::{
     RosettaContext,
 };
 use aptos_logger::{debug, trace};
-use aptos_rest_client::aptos_api_types::AccountData;
-use aptos_rest_client::{
-    aptos::{AptosCoin, Balance},
-    aptos_api_types::U64,
-};
 use aptos_sdk::move_types::language_storage::TypeTag;
 use aptos_types::account_address::AccountAddress;
 use aptos_types::account_config::{AccountResource, CoinStoreResource};

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -60,11 +60,11 @@ async fn block(request: BlockRequest, server_context: RosettaContext) -> ApiResu
 /// Build up the transaction, which should contain the `operations` as the change set
 async fn build_block(
     parent_block_identifier: BlockIdentifier,
-    block: aptos_rest_client::aptos_api_types::Block,
+    block: aptos_rest_client::aptos_api_types::BcsBlock,
     chain_id: ChainId,
 ) -> ApiResult<Block> {
     // note: timestamps are in microseconds, so we convert to milliseconds
-    let timestamp = get_timestamp(block.block_timestamp.0);
+    let timestamp = get_timestamp(block.block_timestamp);
     let block_identifier = BlockIdentifier::from_block(&block, chain_id);
 
     // Convert the transactions and build the block
@@ -88,7 +88,10 @@ async fn get_block_by_index(
     block_cache: &BlockRetriever,
     block_height: u64,
     chain_id: ChainId,
-) -> ApiResult<(BlockIdentifier, aptos_rest_client::aptos_api_types::Block)> {
+) -> ApiResult<(
+    BlockIdentifier,
+    aptos_rest_client::aptos_api_types::BcsBlock,
+)> {
     let block = block_cache.get_block_by_height(block_height, true).await?;
 
     // For the genesis block, we populate parent_block_identifier with the
@@ -120,13 +123,13 @@ pub struct BlockInfo {
 
 impl BlockInfo {
     pub fn from_block(
-        block: &aptos_rest_client::aptos_api_types::Block,
+        block: &aptos_rest_client::aptos_api_types::BcsBlock,
         chain_id: ChainId,
     ) -> BlockInfo {
         BlockInfo {
             block_id: BlockIdentifier::from_block(block, chain_id),
-            timestamp: get_timestamp(block.block_timestamp.0),
-            last_version: block.last_version.0,
+            timestamp: get_timestamp(block.block_timestamp),
+            last_version: block.last_version,
         }
     }
 }
@@ -167,10 +170,10 @@ impl BlockRetriever {
         &self,
         height: u64,
         with_transactions: bool,
-    ) -> ApiResult<aptos_rest_client::aptos_api_types::Block> {
+    ) -> ApiResult<aptos_rest_client::aptos_api_types::BcsBlock> {
         let block = self
             .rest_client
-            .get_block_by_height(height, with_transactions)
+            .get_block_by_height_bcs(height, with_transactions)
             .await?
             .into_inner();
 

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -735,8 +735,9 @@ async fn construction_submit(
     let rest_client = server_context.rest_client()?;
 
     let txn: SignedTransaction = decode_bcs(&request.signed_transaction, "SignedTransaction")?;
-    let response = rest_client.submit(&txn).await?;
+    let hash = txn.clone().committed_hash();
+    rest_client.submit_bcs(&txn).await?;
     Ok(ConstructionSubmitResponse {
-        transaction_identifier: response.inner().hash.into(),
+        transaction_identifier: hash.into(),
     })
 }

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -52,7 +52,7 @@ async fn main() {
         let total_wait_duration = Duration::from_secs(TOTAL_REST_API_WAIT_DURATION_S);
         let start = Instant::now();
         while start.elapsed() < total_wait_duration {
-            if client.get_index().await.is_ok() {
+            if client.get_index_bcs().await.is_ok() {
                 successful = true;
                 break;
             }

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -10,7 +10,7 @@ use crate::{
     common::{to_hex_lower, BLOCKCHAIN},
     error::{ApiError, ApiResult},
 };
-use aptos_rest_client::aptos_api_types::{HashValue, TransactionInfo};
+use aptos_types::transaction::TransactionInfo;
 use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -70,12 +70,12 @@ pub struct BlockIdentifier {
 
 impl BlockIdentifier {
     pub fn from_block(
-        block: &aptos_rest_client::aptos_api_types::Block,
+        block: &aptos_rest_client::aptos_api_types::BcsBlock,
         chain_id: ChainId,
     ) -> BlockIdentifier {
         BlockIdentifier {
-            index: block.block_height.0,
-            hash: BlockHash::new(chain_id, block.block_height.0).to_string(),
+            index: block.block_height,
+            hash: BlockHash::new(chain_id, block.block_height).to_string(),
         }
     }
 }
@@ -175,15 +175,7 @@ pub struct TransactionIdentifier {
 impl From<&TransactionInfo> for TransactionIdentifier {
     fn from(txn: &TransactionInfo) -> Self {
         TransactionIdentifier {
-            hash: to_hex_lower(&txn.hash),
-        }
-    }
-}
-
-impl From<HashValue> for TransactionIdentifier {
-    fn from(hash: HashValue) -> Self {
-        TransactionIdentifier {
-            hash: to_hex_lower(&hash),
+            hash: to_hex_lower(&txn.transaction_hash()),
         }
     }
 }

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -8,9 +8,8 @@
 use crate::common::parse_currency;
 use crate::types::{
     ACCOUNT_MODULE, ACCOUNT_RESOURCE, APTOS_ACCOUNT_MODULE, COIN_MODULE, COIN_STORE_RESOURCE,
-    CREATE_ACCOUNT_FUNCTION, DEPOSIT_EVENTS_FIELD, SEQUENCE_NUMBER_FIELD,
-    SET_OPERATOR_EVENTS_FIELD, SET_OPERATOR_FUNCTION, STAKE_MODULE, STAKE_POOL_RESOURCE,
-    TRANSFER_FUNCTION, WITHDRAW_EVENTS_FIELD,
+    CREATE_ACCOUNT_FUNCTION, SET_OPERATOR_FUNCTION, STAKE_MODULE, STAKE_POOL_RESOURCE,
+    TRANSFER_FUNCTION,
 };
 use crate::{
     common::{is_native_coin, native_coin},
@@ -23,17 +22,18 @@ use crate::{
 };
 use anyhow::anyhow;
 use aptos_crypto::{ed25519::Ed25519PublicKey, ValidCryptoMaterialStringExt};
-use aptos_rest_client::aptos_api_types::{
-    Address, EntryFunctionPayload, Event, MoveResource, MoveStructTag, MoveType,
-    TransactionPayload, UserTransactionRequest, WriteResource,
-};
-use aptos_rest_client::{
-    aptos::Balance,
-    aptos_api_types::{WriteSetChange, U64},
-};
+use aptos_rest_client::aptos_api_types::TransactionOnChainData;
+use aptos_rest_client::{aptos::Balance, aptos_api_types::U64};
+use aptos_sdk::move_types::language_storage::{StructTag, TypeTag};
+use aptos_types::account_config::{AccountResource, CoinStoreResource, WithdrawEvent};
+use aptos_types::contract_event::ContractEvent;
+use aptos_types::stake_pool::StakePool;
+use aptos_types::state_store::state_key::StateKey;
+use aptos_types::transaction::{EntryFunction, TransactionPayload};
+use aptos_types::write_set::WriteOp;
 use aptos_types::{account_address::AccountAddress, event::EventKey};
 use cached_packages::aptos_stdlib;
-use serde::{de::Error as SerdeError, Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::{
     collections::HashMap,
@@ -453,37 +453,30 @@ impl Display for TransactionType {
 }
 
 impl Transaction {
-    pub async fn from_transaction(txn: aptos_rest_client::Transaction) -> ApiResult<Transaction> {
-        use aptos_rest_client::Transaction::*;
-        let (txn_type, maybe_user_transaction_request, txn_info, events) = match txn {
-            // Pending transactions aren't supported by Rosetta (for now)
-            PendingTransaction(_) => return Err(ApiError::TransactionIsPending),
-            UserTransaction(txn) => (
-                TransactionType::User,
-                Some(txn.request),
-                txn.info,
-                txn.events,
-            ),
-            GenesisTransaction(txn) => (TransactionType::Genesis, None, txn.info, txn.events),
-            BlockMetadataTransaction(txn) => {
-                (TransactionType::BlockMetadata, None, txn.info, txn.events)
+    pub async fn from_transaction(txn: TransactionOnChainData) -> ApiResult<Transaction> {
+        use aptos_types::transaction::Transaction::*;
+        let (txn_type, maybe_user_txn, txn_info, events) = match &txn.transaction {
+            UserTransaction(user_txn) => {
+                (TransactionType::User, Some(user_txn), txn.info, txn.events)
             }
-            StateCheckpointTransaction(txn) => {
-                (TransactionType::StateCheckpoint, None, txn.info, vec![])
-            }
+            GenesisTransaction(_) => (TransactionType::Genesis, None, txn.info, txn.events),
+            BlockMetadata(_) => (TransactionType::BlockMetadata, None, txn.info, txn.events),
+            StateCheckpoint(_) => (TransactionType::StateCheckpoint, None, txn.info, vec![]),
         };
 
         // Operations must be sequential and operation index must always be in the same order
         // with no gaps
+        let successful = txn_info.status().is_success();
         let mut operations = vec![];
         let mut operation_index: u64 = 0;
-        if txn_info.success {
+        if successful {
             // Parse all operations from the writeset changes in a success
-            for change in &txn_info.changes {
+            for (state_key, write_op) in &txn.changes {
                 let mut ops = parse_operations_from_write_set(
-                    change,
+                    state_key,
+                    write_op,
                     &events,
-                    &maybe_user_transaction_request,
+                    maybe_user_txn.map(|inner| inner.sender()),
                     operation_index,
                 );
                 operation_index += ops.len() as u64;
@@ -491,11 +484,11 @@ impl Transaction {
             }
         } else {
             // Parse all failed operations from the payload
-            if let Some(ref request) = maybe_user_transaction_request {
+            if let Some(user_txn) = maybe_user_txn {
                 let mut ops = parse_operations_from_txn_payload(
                     operation_index,
-                    *request.sender.inner(),
-                    &request.payload,
+                    user_txn.sender(),
+                    user_txn.payload(),
                 );
                 operation_index += ops.len() as u64;
                 operations.append(&mut ops);
@@ -510,12 +503,12 @@ impl Transaction {
         }
 
         // Everything committed costs gas
-        if let Some(ref request) = maybe_user_transaction_request {
+        if let Some(txn) = maybe_user_txn {
             operations.push(Operation::gas_fee(
                 operation_index,
-                *request.sender.inner(),
-                txn_info.gas_used.0,
-                request.gas_unit_price.0,
+                txn.sender(),
+                txn_info.gas_used(),
+                txn.gas_unit_price(),
             ));
         }
 
@@ -524,9 +517,9 @@ impl Transaction {
             operations,
             metadata: TransactionMetadata {
                 transaction_type: txn_type,
-                version: txn_info.version,
-                failed: !txn_info.success,
-                vm_status: txn_info.vm_status,
+                version: txn.version.into(),
+                failed: !successful,
+                vm_status: format!("{:?}", txn_info.status()),
             },
         })
     }
@@ -542,24 +535,22 @@ fn parse_operations_from_txn_payload(
     payload: &TransactionPayload,
 ) -> Vec<Operation> {
     let mut operations = vec![];
-    if let TransactionPayload::EntryFunctionPayload(inner) = payload {
+    if let TransactionPayload::EntryFunction(inner) = payload {
         match (
-            *inner.function.module.address.inner(),
-            inner.function.module.name.0.as_str(),
-            inner.function.name.0.as_str(),
+            *inner.module().address(),
+            inner.module().name().as_str(),
+            inner.function().as_str(),
         ) {
             (AccountAddress::ONE, COIN_MODULE, TRANSFER_FUNCTION) => {
-                if let Some(MoveType::Struct(MoveStructTag {
+                if let Some(TypeTag::Struct(StructTag {
                     address,
                     module,
                     name,
                     ..
-                })) = inner.type_arguments.first()
+                })) = inner.ty_args().first()
                 {
                     // If we don't know the currency, we can't parse any operations, skip it
-                    if let Ok(currency) =
-                        parse_currency(*address.inner(), module.0.as_str(), name.0.as_str())
-                    {
+                    if let Ok(currency) = parse_currency(*address, module.as_str(), name.as_str()) {
                         operations = parse_transfer_from_txn_payload(
                             inner,
                             currency,
@@ -575,24 +566,23 @@ fn parse_operations_from_txn_payload(
                     parse_transfer_from_txn_payload(inner, native_coin(), sender, operation_index)
             }
             (AccountAddress::ONE, ACCOUNT_MODULE, CREATE_ACCOUNT_FUNCTION) => {
-                let address =
-                    serde_json::from_value::<Address>(inner.arguments.first().cloned().unwrap())
-                        .unwrap();
+                // TODO: Fix unwrap
+                let address: AccountAddress =
+                    bcs::from_bytes(inner.args().first().unwrap()).unwrap();
                 operations.push(Operation::create_account(
                     operation_index,
                     Some(OperationStatusType::Failure),
-                    address.into(),
+                    address,
                     sender,
                 ));
             }
             (AccountAddress::ONE, STAKE_MODULE, SET_OPERATOR_FUNCTION) => {
-                let operator =
-                    serde_json::from_value::<Address>(inner.arguments.first().cloned().unwrap())
-                        .unwrap();
+                let operator: AccountAddress =
+                    bcs::from_bytes(inner.args().first().unwrap()).unwrap();
                 operations.push(Operation::set_operator(
                     operation_index,
                     Some(OperationStatusType::Failure),
-                    operator.into(),
+                    operator,
                     sender,
                 ));
             }
@@ -605,17 +595,14 @@ fn parse_operations_from_txn_payload(
 }
 
 fn parse_transfer_from_txn_payload(
-    payload: &EntryFunctionPayload,
+    payload: &EntryFunction,
     currency: Currency,
     sender: AccountAddress,
     operation_index: u64,
 ) -> Vec<Operation> {
     let mut operations = vec![];
-    let receiver =
-        serde_json::from_value::<Address>(payload.arguments.first().cloned().unwrap()).unwrap();
-    let amount = serde_json::from_value::<U64>(payload.arguments.get(1).cloned().unwrap())
-        .unwrap()
-        .0;
+    let receiver: AccountAddress = bcs::from_bytes(payload.args().first().unwrap()).unwrap();
+    let amount: u64 = bcs::from_bytes(payload.args().get(1).unwrap()).unwrap();
     operations.push(Operation::withdraw(
         operation_index,
         Some(OperationStatusType::Failure),
@@ -626,7 +613,7 @@ fn parse_transfer_from_txn_payload(
     operations.push(Operation::deposit(
         operation_index + 1,
         Some(OperationStatusType::Failure),
-        receiver.into(),
+        receiver,
         currency,
         amount,
     ));
@@ -639,94 +626,98 @@ fn parse_transfer_from_txn_payload(
 /// This can only be done during a successful transaction because there are actual state changes.
 /// It is more accurate because untracked scripts are included in balance operations
 fn parse_operations_from_write_set(
-    change: &WriteSetChange,
-    events: &[Event],
-    maybe_request: &Option<UserTransactionRequest>,
+    state_key: &StateKey,
+    write_op: &WriteOp,
+    events: &[ContractEvent],
+    maybe_sender: Option<AccountAddress>,
     operation_index: u64,
 ) -> Vec<Operation> {
     let operations = vec![];
-    if let WriteSetChange::WriteResource(WriteResource { address, data, .. }) = change {
-        let address = *address.inner();
 
-        // Determine operation
-        match (
-            *data.typ.address.inner(),
-            data.typ.module.0.as_str(),
-            data.typ.name.as_str(),
-        ) {
-            (AccountAddress::ONE, ACCOUNT_MODULE, ACCOUNT_RESOURCE) => {
-                parse_account_changes(address, data, maybe_request, operations, operation_index)
-            }
-            (AccountAddress::ONE, STAKE_MODULE, STAKE_POOL_RESOURCE) => {
-                parse_stakepool_changes(address, data, events, operations, operation_index)
-            }
-            (AccountAddress::ONE, COIN_MODULE, COIN_STORE_RESOURCE) => {
-                parse_coinstore_changes(address, data, events, operations, operation_index)
-            }
-            _ => {
-                // Any unknown type will just skip the operations
-                operations
+    let (struct_tag, address) = match state_key {
+        StateKey::AccessPath(path) => {
+            if let Some(struct_tag) = path.get_struct_tag() {
+                (struct_tag, path.address)
+            } else {
+                return vec![];
             }
         }
-    } else {
-        operations
+        _ => {
+            // Ignore all but access path
+            return vec![];
+        }
+    };
+
+    let data = match write_op {
+        WriteOp::Creation(inner) => inner,
+        WriteOp::Modification(inner) => inner,
+        WriteOp::Deletion => return vec![],
+    };
+
+    // Determine operation
+    match (
+        struct_tag.address,
+        struct_tag.module.as_str(),
+        struct_tag.name.as_str(),
+    ) {
+        (AccountAddress::ONE, ACCOUNT_MODULE, ACCOUNT_RESOURCE) => {
+            parse_account_changes(address, data, maybe_sender, operation_index)
+        }
+        (AccountAddress::ONE, STAKE_MODULE, STAKE_POOL_RESOURCE) => {
+            parse_stakepool_changes(address, data, events, operation_index)
+        }
+        (AccountAddress::ONE, COIN_MODULE, COIN_STORE_RESOURCE) => {
+            parse_coinstore_changes(address, data, events, operation_index)
+        }
+        _ => {
+            // Any unknown type will just skip the operations
+            operations
+        }
     }
 }
 
 fn parse_account_changes(
     address: AccountAddress,
-    move_resource: &MoveResource,
-    maybe_request: &Option<UserTransactionRequest>,
-    mut operations: Vec<Operation>,
-    mut operation_index: u64,
+    data: &[u8],
+    maybe_sender: Option<AccountAddress>,
+    operation_index: u64,
 ) -> Vec<Operation> {
     // TODO: Handle key rotation
-    for (id, value) in move_resource.data.0.iter() {
-        if id.0.as_str() == SEQUENCE_NUMBER_FIELD {
-            // Account sequence number increase (possibly creation)
-            // Find out if it's the 0th sequence number (creation)
-            if let Ok(U64(0)) = serde_json::from_value::<U64>(value.clone()) {
-                operations.push(Operation::create_account(
-                    operation_index,
-                    Some(OperationStatusType::Success),
-                    address,
-                    maybe_request
-                        .as_ref()
-                        .map(|inner| *inner.sender.inner())
-                        .unwrap_or(AccountAddress::ONE),
-                ));
-                operation_index += 1;
-            }
-        }
+    // TODO: Handle unwrap
+    let mut operations = Vec::new();
+    let account: AccountResource = bcs::from_bytes(data).unwrap();
+    // Account sequence number increase (possibly creation)
+    // Find out if it's the 0th sequence number (creation)
+    if 0 == account.sequence_number() {
+        operations.push(Operation::create_account(
+            operation_index,
+            Some(OperationStatusType::Success),
+            address,
+            maybe_sender.unwrap_or(AccountAddress::ONE),
+        ));
     }
     operations
 }
 
 fn parse_stakepool_changes(
     address: AccountAddress,
-    move_resource: &MoveResource,
-    events: &[Event],
-    mut operations: Vec<Operation>,
-    mut operation_index: u64,
+    data: &[u8],
+    events: &[ContractEvent],
+    operation_index: u64,
 ) -> Vec<Operation> {
-    for (id, value) in move_resource.data.0.iter() {
-        if id.0.as_str() == SET_OPERATOR_EVENTS_FIELD {
-            // Parse set operator events
-            serde_json::from_value::<EventId>(value.clone()).unwrap();
-            if let Ok(event) = serde_json::from_value::<EventId>(value.clone()) {
-                let set_operator_event =
-                    EventKey::new(event.guid.id.creation_num.0, event.guid.id.addr);
-                if let Some(operator) = get_set_operator_from_event(events, set_operator_event) {
-                    operations.push(Operation::set_operator(
-                        operation_index,
-                        Some(OperationStatusType::Success),
-                        address,
-                        operator,
-                    ));
-                    operation_index += 1;
-                }
-            }
-        }
+    let mut operations = Vec::new();
+    // TODO: handle unwrap
+    let stakepool: StakePool = bcs::from_bytes(data).unwrap();
+
+    stakepool.set_operator_events.key();
+    if let Some(operator) = get_set_operator_from_event(events, stakepool.set_operator_events.key())
+    {
+        operations.push(Operation::set_operator(
+            operation_index,
+            Some(OperationStatusType::Success),
+            address,
+            operator,
+        ));
     }
 
     operations
@@ -734,82 +725,60 @@ fn parse_stakepool_changes(
 
 fn parse_coinstore_changes(
     address: AccountAddress,
-    move_resource: &MoveResource,
-    events: &[Event],
-    mut operations: Vec<Operation>,
+    data: &[u8],
+    events: &[ContractEvent],
     mut operation_index: u64,
 ) -> Vec<Operation> {
-    for (id, value) in move_resource.data.0.iter() {
-        match id.0.as_str() {
-            WITHDRAW_EVENTS_FIELD => {
-                serde_json::from_value::<EventId>(value.clone()).unwrap();
-                if let Ok(event) = serde_json::from_value::<EventId>(value.clone()) {
-                    let withdraw_event =
-                        EventKey::new(event.guid.id.creation_num.0, event.guid.id.addr);
-                    if let Some(amount) = get_amount_from_event(events, withdraw_event) {
-                        operations.push(Operation::withdraw(
-                            operation_index,
-                            Some(OperationStatusType::Success),
-                            address,
-                            native_coin(),
-                            amount,
-                        ));
-                        operation_index += 1;
-                    }
-                }
-            }
-            DEPOSIT_EVENTS_FIELD => {
-                serde_json::from_value::<EventId>(value.clone()).unwrap();
-                if let Ok(event) = serde_json::from_value::<EventId>(value.clone()) {
-                    let deposit_event =
-                        EventKey::new(event.guid.id.creation_num.0, event.guid.id.addr);
-                    if let Some(amount) = get_amount_from_event(events, deposit_event) {
-                        operations.push(Operation::deposit(
-                            operation_index,
-                            Some(OperationStatusType::Success),
-                            address,
-                            native_coin(),
-                            amount,
-                        ));
-                        operation_index += 1;
-                    }
-                }
-            }
-            _ => {
-                // Ignore other fields
-            }
-        }
+    let coin_store: CoinStoreResource = bcs::from_bytes(data).unwrap();
+    let mut operations = vec![];
+
+    // TODO: Handle other coins
+    if let Some(amount) = get_amount_from_event(events, coin_store.withdraw_events().key()) {
+        operations.push(Operation::withdraw(
+            operation_index,
+            Some(OperationStatusType::Success),
+            address,
+            native_coin(),
+            amount,
+        ));
+        operation_index += 1;
+    }
+
+    if let Some(amount) = get_amount_from_event(events, coin_store.deposit_events().key()) {
+        operations.push(Operation::deposit(
+            operation_index,
+            Some(OperationStatusType::Success),
+            address,
+            native_coin(),
+            amount,
+        ));
     }
     operations
 }
 
 /// Pulls the balance change from a withdraw or deposit event
-fn get_amount_from_event(events: &[Event], event_key: EventKey) -> Option<u64> {
-    if let Some(event) = events
-        .iter()
-        .find(|event| EventKey::from(event.key) == event_key)
-    {
-        if let Ok(CoinEvent { amount }) = serde_json::from_value::<CoinEvent>(event.data.clone()) {
-            return Some(amount.0);
-        }
+fn get_amount_from_event(events: &[ContractEvent], event_key: &EventKey) -> Option<u64> {
+    if let Some(event) = events.iter().find(|event| event.key() == event_key) {
+        // TODO: Separate for deposit
+        // TODO: Handle unwrap
+        let event: WithdrawEvent = bcs::from_bytes(event.event_data()).unwrap();
+        Some(event.amount())
+    } else {
+        None
     }
-
-    None
 }
 
-fn get_set_operator_from_event(events: &[Event], event_key: EventKey) -> Option<AccountAddress> {
-    if let Some(event) = events
-        .iter()
-        .find(|event| EventKey::from(event.key) == event_key)
-    {
-        if let Ok(SetOperatorEvent { new_operator, .. }) =
-            serde_json::from_value::<SetOperatorEvent>(event.data.clone())
-        {
-            return Some(*new_operator.inner());
-        }
+fn get_set_operator_from_event(
+    events: &[ContractEvent],
+    event_key: &EventKey,
+) -> Option<AccountAddress> {
+    if let Some(event) = events.iter().find(|event| event.key() == event_key) {
+        // TODO: Handle unwrap
+        let event: SetOperatorEvent = bcs::from_bytes(event.event_data()).unwrap();
+        Some(event.new_operator)
+    } else {
+        None
     }
-
-    None
 }
 
 /// An enum for processing which operation is in a transaction
@@ -1032,51 +1001,9 @@ pub struct SetOperator {
     pub operator: AccountAddress,
 }
 
-#[derive(Clone, Debug, Deserialize)]
-pub struct CoinEvent {
-    amount: U64,
-}
-
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 pub struct SetOperatorEvent {
-    new_operator: Address,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct EventId {
-    guid: Id,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct Id {
-    id: EventKeyId,
-}
-
-#[derive(Clone, Debug, Deserialize)]
-pub struct EventKeyId {
-    #[serde(deserialize_with = "deserialize_account_address")]
-    addr: AccountAddress,
-    creation_num: U64,
-}
-
-fn deserialize_account_address<'de, D>(
-    deserializer: D,
-) -> std::result::Result<AccountAddress, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    if deserializer.is_human_readable() {
-        let s = <String>::deserialize(deserializer)?;
-        AccountAddress::from_hex_literal(&s).map_err(D::Error::custom)
-    } else {
-        // In order to preserve the Serde data model and help analysis tools,
-        // make sure to wrap our value in a container with the same name
-        // as the original type.
-        #[derive(::serde::Deserialize)]
-        #[serde(rename = "AccountAddress")]
-        struct Value([u8; AccountAddress::LENGTH]);
-
-        let value = Value::deserialize(deserializer)?;
-        Ok(AccountAddress::new(value.0))
-    }
+    pub pool_address: AccountAddress,
+    pub old_operator: AccountAddress,
+    pub new_operator: AccountAddress,
 }

--- a/types/src/stake_pool.rs
+++ b/types/src/stake_pool.rs
@@ -15,7 +15,7 @@ pub struct StakePool {
     pub delegated_voter: AccountAddress,
 
     initialize_validator_events: EventHandle,
-    set_operator_events: EventHandle,
+    pub set_operator_events: EventHandle,
     add_stake_events: EventHandle,
     reactivate_stake_events: EventHandle,
     rotate_consensus_key_events: EventHandle,


### PR DESCRIPTION
### Description
This migrates all old JSON calls to BCS for Rosetta.  This should improve its performance and simplify the code significantly.

This additionally fixes the BCS output of the block APIs.

### Test Plan
Currently E2E tests fail on the last commit.  I suspect there's something wrong with the BCS serialization and the Block by height API.  Will need more debugging

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3967)
<!-- Reviewable:end -->
