### PR TITLE
[fn-check-client] Explicitly include noise port in NHC requests

### DIFF
--- a/ecosystem/node-checker/fn-check-client/src/check.rs
+++ b/ecosystem/node-checker/fn-check-client/src/check.rs
@@ -48,7 +48,7 @@ pub struct NodeHealthCheckerArgs {
     pub nhc_timeout_secs: u64,
 
     /// Max number of requests to NHC we can have running concurrently.
-    #[clap(long, default_value_t = 64)]
+    #[clap(long, default_value_t = 32)]
     pub max_concurrent_nhc_requests: u16,
 }
 
@@ -146,6 +146,7 @@ impl NodeHealthCheckerArgs {
                     nhc_address,
                     &node_info.node_url,
                     api_port,
+                    node_info.noise_port,
                     node_info.public_key,
                 )
                 .await
@@ -159,6 +160,7 @@ impl NodeHealthCheckerArgs {
                             nhc_address,
                             &node_info.node_url,
                             API_PORTS[index],
+                            node_info.noise_port,
                             node_info.public_key,
                         )
                         .await;
@@ -191,12 +193,14 @@ impl NodeHealthCheckerArgs {
         nhc_address: &Url,
         node_url: &Url,
         api_port: u16,
+        noise_port: u16,
         public_key: Option<x25519::PublicKey>,
     ) -> SingleCheckResult {
         // Build up query params.
         let mut params = HashMap::new();
         params.insert("node_url", node_url.to_string());
         params.insert("api_port", api_port.to_string());
+        params.insert("noise_port", noise_port.to_string());
         params.insert(
             "baseline_configuration_name",
             self.nhc_baseline_config_name.clone(),
@@ -281,6 +285,9 @@ pub struct NodeInfo {
 
     /// If given, we will use this. If not, we'll try each of API_PORTS.
     pub api_port: Option<u16>,
+
+    /// This will be included in the request to NHC.
+    pub noise_port: u16,
 
     /// If this is included, we'll include this in the NHC request.
     pub public_key: Option<x25519::PublicKey>,

--- a/ecosystem/node-checker/fn-check-client/src/get_pfns.rs
+++ b/ecosystem/node-checker/fn-check-client/src/get_pfns.rs
@@ -82,7 +82,7 @@ pub struct Entry {
     api_port: u16,
 
     /// The noise port.
-    pub noise_port: u16,
+    noise_port: u16,
 
     /// The port the metrics server is running on.
     pub metrics_port: u16,
@@ -98,6 +98,7 @@ impl TryInto<NodeInfo> for Entry {
         Ok(NodeInfo {
             node_url: Url::parse(&self.url).context("Failed to parse URL")?,
             api_port: Some(self.api_port),
+            noise_port: self.noise_port,
             public_key: Some(
                 x25519::PublicKey::from_encoded_string(&self.public_key)
                     .context("Failed to parse public key")?,

--- a/ecosystem/node-checker/fn-check-client/src/get_vfns.rs
+++ b/ecosystem/node-checker/fn-check-client/src/get_vfns.rs
@@ -113,8 +113,8 @@ impl GetValidatorFullNodes {
             }
 
             for vfn_address in vfn_addresses.into_iter() {
-                let node_url = match extract_network_address(&vfn_address) {
-                    Ok(node_url) => node_url,
+                let (node_url, noise_port) = match extract_network_address(&vfn_address) {
+                    Ok(result) => result,
                     Err(e) => {
                         invalid_node_address_results
                             .entry(*account_address)
@@ -136,6 +136,7 @@ impl GetValidatorFullNodes {
                     .push(NodeInfo {
                         node_url,
                         api_port: None,
+                        noise_port,
                         public_key: vfn_address.find_noise_proto(),
                     });
             }

--- a/ecosystem/node-checker/fn-check-client/src/helpers.rs
+++ b/ecosystem/node-checker/fn-check-client/src/helpers.rs
@@ -8,7 +8,8 @@ use std::net::{SocketAddr, ToSocketAddrs};
 
 // This function takes a NetworkAddress and returns a string representation
 // of it if it is a format we can send to NHC. Otherwise we return an error.
-pub fn extract_network_address(network_address: &NetworkAddress) -> Result<Url> {
+// We also return the noise port.
+pub fn extract_network_address(network_address: &NetworkAddress) -> Result<(Url, u16)> {
     let mut socket_addrs = network_address
         .to_socket_addrs()
         .with_context(|| format!("Failed to parse network address as SocketAddr, this might imply that the domain name doesn't resolve to an IP: {}", network_address))?;
@@ -16,8 +17,11 @@ pub fn extract_network_address(network_address: &NetworkAddress) -> Result<Url> 
         .next()
         .ok_or_else(|| anyhow::anyhow!("No socket address found"))?;
     match socket_addr {
-        SocketAddr::V4(addr) => Ok(Url::parse(&format!("http://{}", addr.ip()))
-            .context("Failed to parse address as URL")?),
+        SocketAddr::V4(addr) => Ok((
+            Url::parse(&format!("http://{}", addr.ip()))
+                .context("Failed to parse address as URL")?,
+            addr.port(),
+        )),
         SocketAddr::V6(addr) => Err(anyhow::anyhow!(
             "We do not not support IPv6 addresses: {}",
             addr


### PR DESCRIPTION
## Description
The tool was erroneously not including the noise port in the NHC requests, meaning NHC was just using the default. This doesn't matter for the existing data, since we're only checking VFNs and for those we're not doing the handshake check, but it does matter for PFNs.

## Test Plan
### VFNs
```
cargo run -p aptos-fn-check-client -- --nhc-address https://node-checker.prod.gcp.aptosdev.com --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json --big-query-dry-run check-validator-full-nodes --node-address https://ait3.aptosdev.com 
```

### PFNs
```
cargo run -p aptos-fn-check-client -- --nhc-address https://node-checker.prod.gcp.aptosdev.com --nhc-baseline-config-name ait3_vfn --big-query-key-path ~/a/internal-ops/helm/observability-center/files/bigquery-cron-key.json --big-query-dry-run check-public-full-nodes --input-file ~/test_data.json
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/3988)
<!-- Reviewable:end -->
