### PR TITLE
[backup] second try fixing routing_and_error_codes

### DIFF
--- a/storage/backup/backup-service/src/lib.rs
+++ b/storage/backup/backup-service/src/lib.rs
@@ -95,11 +95,13 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(resp.status(), 500);
-        let resp = get(&format!("http://127.0.0.1:{}/state_root_proof/0", port,)).unwrap();
+        let resp = get(&format!("http://127.0.0.1:{}/state_root_proof/0", port)).unwrap();
         assert_eq!(resp.status(), 500);
 
         // In an endpoint handled by `reply_with_async_channel_writer', connection terminates
-        // prematurely when the channel writer errors.
-        assert!(get(&format!("http://127.0.0.1:{}/state_snapshot/1", port,)).is_err());
+        // prematurely when the channel writer errors. However a 200 is either returned or not
+        // before the termination of the connection, resulting in slightly different behavior:
+        let res = get(&format!("http://127.0.0.1:{}/state_snapshot/1", port));
+        assert!(res.is_err() || res.unwrap().bytes().is_err());
     }
 }


### PR DESCRIPTION
Looks like the behavior swings between the original and #3993

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4000)
<!-- Reviewable:end -->
