### PR TITLE
[Aptos Crate] Remove unused (and buggy) crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,6 @@ dependencies = [
  "hex",
  "itertools",
  "move-deps",
- "parse_duration",
  "rand 0.7.3",
  "regex",
  "reqwest",
@@ -5819,7 +5818,7 @@ dependencies = [
  "log",
  "move-compiler",
  "move-model",
- "num 0.4.0",
+ "num",
  "once_cell",
  "regex",
  "serde 1.0.144",
@@ -5936,7 +5935,7 @@ dependencies = [
  "move-disassembler",
  "move-ir-types",
  "move-symbol-pool",
- "num 0.4.0",
+ "num",
  "once_cell",
  "regex",
  "serde 1.0.144",
@@ -6004,7 +6003,7 @@ dependencies = [
  "move-model",
  "move-prover-boogie-backend",
  "move-stackless-bytecode",
- "num 0.4.0",
+ "num",
  "once_cell",
  "pretty",
  "rand 0.8.5",
@@ -6032,7 +6031,7 @@ dependencies = [
  "move-core-types",
  "move-model",
  "move-stackless-bytecode",
- "num 0.4.0",
+ "num",
  "once_cell",
  "pretty",
  "rand 0.8.5",
@@ -6100,7 +6099,7 @@ dependencies = [
  "move-ir-to-bytecode",
  "move-model",
  "move-read-write-set-types",
- "num 0.4.0",
+ "num",
  "once_cell",
  "paste",
  "petgraph 0.5.1",
@@ -6121,7 +6120,7 @@ dependencies = [
  "move-core-types",
  "move-model",
  "move-stackless-bytecode",
- "num 0.4.0",
+ "num",
  "serde 1.0.144",
 ]
 
@@ -6521,29 +6520,15 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
-dependencies = [
- "num-bigint 0.2.6",
- "num-complex 0.2.4",
- "num-integer",
- "num-iter",
- "num-rational 0.2.4",
- "num-traits 0.2.15",
-]
-
-[[package]]
-name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-bigint 0.4.3",
- "num-complex 0.4.2",
+ "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.1",
+ "num-rational",
  "num-traits 0.2.15",
 ]
 
@@ -6566,16 +6551,6 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.15",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
  "num-traits 0.2.15",
 ]
 
@@ -6616,18 +6591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
- "num-integer",
- "num-traits 0.2.15",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
-dependencies = [
- "autocfg",
- "num-bigint 0.2.6",
  "num-integer",
  "num-traits 0.2.15",
 ]
@@ -6905,17 +6868,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c705f256449c60da65e11ff6626e0c16a0a0b96aaa348de61376b249bc340f41"
 dependencies = [
- "regex",
-]
-
-[[package]]
-name = "parse_duration"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
-dependencies = [
- "lazy_static 1.4.0",
- "num 0.2.1",
  "regex",
 ]
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -20,7 +20,6 @@ dirs = "4.0.0"
 futures = "0.3.21"
 hex = "0.4.3"
 itertools = "0.10.3"
-parse_duration = "2.1.1"
 rand = "0.7.3"
 regex = "1.1.5"
 reqwest = { version = "0.11.10", features = ["blocking", "json"] }


### PR DESCRIPTION
### Description

This PR removes a (seemingly unused?) dependency from the Aptos crate. This dependency has a known vulnerability (and no known fix): https://rustsec.org/advisories/RUSTSEC-2021-0041

### Test Plan
Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4003)
<!-- Reviewable:end -->
