### PR TITLE
[aptos-cli] Add ability to run move script from CLI

### DIFF
--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -72,7 +72,7 @@ pub struct SubmitProposal {
     #[clap(flatten)]
     pub(crate) pool_address_args: PoolAddressArgs,
     #[clap(flatten)]
-    pub(crate) compile_proposal_args: CompileProposalArgs,
+    pub(crate) compile_proposal_args: CompileScriptFunction,
 }
 
 #[async_trait]
@@ -370,7 +370,7 @@ pub struct ExecuteProposal {
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
     #[clap(flatten)]
-    pub(crate) compile_proposal_args: CompileProposalArgs,
+    pub(crate) compile_proposal_args: CompileScriptFunction,
 }
 
 #[async_trait]
@@ -397,7 +397,7 @@ impl CliCommand<TransactionSummary> for ExecuteProposal {
 
 /// Execute a proposal that has passed voting requirements
 #[derive(Parser)]
-pub struct CompileProposalArgs {
+pub struct CompileScriptFunction {
     /// Path to the Move script for the proposal
     #[clap(long, parse(from_os_str))]
     pub script_path: PathBuf,
@@ -411,8 +411,11 @@ pub struct CompileProposalArgs {
     pub(crate) framework_git_rev: Option<String>,
 }
 
-impl CompileProposalArgs {
-    fn compile(&self, prompt_options: PromptOptions) -> CliTypedResult<(Vec<u8>, HashValue)> {
+impl CompileScriptFunction {
+    pub(crate) fn compile(
+        &self,
+        prompt_options: PromptOptions,
+    ) -> CliTypedResult<(Vec<u8>, HashValue)> {
         // Check script file
         let script_path = self.script_path.as_path();
         if !self.script_path.exists() {

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -15,6 +15,7 @@ use crate::common::types::{ProfileOptions, RestOptions};
 use crate::common::utils::{
     create_dir_if_not_exist, dir_default_to_current, prompt_yes_with_override, write_to_file,
 };
+use crate::governance::CompileScriptFunction;
 use crate::move_tool::manifest::{
     Dependency, ManifestNamedAddress, MovePackageManifest, PackageInfo,
 };
@@ -33,7 +34,7 @@ use aptos_module_verifier::module_init::verify_module_init_function;
 use aptos_rest_client::aptos_api_types::MoveType;
 use aptos_transactional_test_harness::run_aptos_test;
 use aptos_types::account_address::AccountAddress;
-use aptos_types::transaction::{EntryFunction, ModuleBundle, TransactionPayload};
+use aptos_types::transaction::{EntryFunction, ModuleBundle, Script, TransactionPayload};
 use async_trait::async_trait;
 use clap::{ArgEnum, Parser, Subcommand};
 use framework::natives::code::UpgradePolicy;
@@ -75,6 +76,7 @@ pub enum MoveTool {
     List(ListPackage),
     Clean(CleanPackage),
     Run(RunFunction),
+    RunScript(RunScript),
     Test(TestPackage),
     Prove(ProvePackage),
     TransactionalTest(TransactionalTestOpts),
@@ -90,6 +92,7 @@ impl MoveTool {
             MoveTool::List(tool) => tool.execute_serialized().await,
             MoveTool::Clean(tool) => tool.execute_serialized().await,
             MoveTool::Run(tool) => tool.execute_serialized().await,
+            MoveTool::RunScript(tool) => tool.execute_serialized().await,
             MoveTool::Test(tool) => tool.execute_serialized().await,
             MoveTool::Prove(tool) => tool.execute_serialized().await,
             MoveTool::TransactionalTest(tool) => tool.execute_serialized_success().await,
@@ -762,6 +765,37 @@ impl CliCommand<TransactionSummary> for RunFunction {
             )
             .await
             .map(TransactionSummary::from)
+    }
+}
+
+/// Run a Move script
+#[derive(Parser)]
+pub struct RunScript {
+    #[clap(flatten)]
+    pub(crate) txn_options: TransactionOptions,
+    #[clap(flatten)]
+    pub(crate) compile_proposal_args: CompileScriptFunction,
+}
+
+#[async_trait]
+impl CliCommand<TransactionSummary> for RunScript {
+    fn command_name(&self) -> &'static str {
+        "RunScript"
+    }
+
+    async fn execute(self) -> CliTypedResult<TransactionSummary> {
+        let (bytecode, _script_hash) = self
+            .compile_proposal_args
+            .compile(self.txn_options.prompt_options)?;
+
+        let txn = self
+            .txn_options
+            .submit_transaction(
+                TransactionPayload::Script(Script::new(bytecode, vec![], vec![])),
+                None,
+            )
+            .await?;
+        Ok(TransactionSummary::from(&txn))
     }
 }
 

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -54,6 +54,7 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "move", "prove", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "publish", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "run", "--help"]).await;
+    assert_cmd_not_panic(&["aptos", "move", "run-script", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "test", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "move", "transactional-test", "--help"]).await;
 


### PR DESCRIPTION
### Description
Run arbitrary script files from the CLI

Note, no arguments are supported at this moment.

### Test Plan
```
aptos move run-script --script-path /Users/greg/aptos-core/test_script.move --framework-git-rev testnet-stable --profile local
{
  "Result": {
    "transaction_hash": "0xd865716879f7e0a875ce82b6c06da4ed60db2eab019f6560108d10579860c734",
    "gas_used": 1,
    "gas_unit_price": 1,
    "sender": "5ddf80d85bcd7bd8b833a2589def64ca0cf7df18b8b5ed0d7bdd067658fc49e3",
    "sequence_number": 0,
    "success": true,
    "timestamp_us": 1662689728636741,
    "version": 8537,
    "vm_status": "Executed successfully"
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4016)
<!-- Reviewable:end -->
