### PR TITLE
[SDK] Handle bcs Vecbytes primitive in golang generation

### DIFF
--- a/aptos-move/aptos-sdk-builder/src/golang.rs
+++ b/aptos-move/aptos-sdk-builder/src/golang.rs
@@ -771,6 +771,11 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
             Address => None,
             Vector(type_tag) => match type_tag.as_ref() {
                 U8 => Some("Bytes"),
+                Vector(type_tag) => match type_tag.as_ref() {
+                    U8 => Some("VecBytes"),
+                    type_tag => Self::bcs_primitive_type_name(type_tag).and(None),
+                    // _ => common::type_not_allowed(type_tag),
+                },
                 type_tag => Self::bcs_primitive_type_name(type_tag).and(None),
                 // _ => common::type_not_allowed(type_tag),
             },

--- a/aptos-move/aptos-sdk-builder/src/golang.rs
+++ b/aptos-move/aptos-sdk-builder/src/golang.rs
@@ -774,10 +774,8 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
                 Vector(type_tag) => match type_tag.as_ref() {
                     U8 => Some("VecBytes"),
                     type_tag => Self::bcs_primitive_type_name(type_tag).and(None),
-                    // _ => common::type_not_allowed(type_tag),
                 },
                 type_tag => Self::bcs_primitive_type_name(type_tag).and(None),
-                // _ => common::type_not_allowed(type_tag),
             },
             Struct(struct_tag) => match struct_tag {
                 tag if tag == Lazy::force(&str_tag) => Some("Bytes"),


### PR DESCRIPTION
### Description

Added `VecBytes` (`vec<vec<U8>>`) into bcs primitive generation.
There are probably missed places that should handle this too.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

* Ran against latest and go compiles.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4018)
<!-- Reviewable:end -->
