### PR TITLE
[docs] Use only prebuilt binaries and source to build / install CLI

### DIFF
--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
@@ -17,7 +17,7 @@ The `aptos` tool is a command line interface (CLI) for debugging, development, a
 6. Type `~/bin/aptos help` to read help instructions.
 7. Add `~/bin` to your path in your appropriate `.bashrc` or `.zshrc` for future use.
 
-## Install from Git
+## Step 1: Install from Git
 
 Start by cloning the `aptos-core` GitHub repo from [GitHub](https://github.com/aptos-labs/aptos-core).
 
@@ -32,44 +32,7 @@ Start by cloning the `aptos-core` GitHub repo from [GitHub](https://github.com/a
 6. Build the CLI tool: `cargo build --package aptos --release`
 7. The binary will be available in `target/release/aptos`
 
-## Install with cargo
-
-### Step 1: Install cargo
-
-You will need the `cargo` package manager to install the `aptos` CLI tool.  Follow the below steps.
-
-1. Follow the `cargo` [installation instructions on this page](https://doc.rust-lang.org/cargo/getting-started/installation.html)
-   and install `cargo`.  Proceed only after you successfully install `cargo`.
-2. Execute the below step to ensure that your current shell environment knows where `cargo` is.
-```bash
-source $HOME/.cargo/env
-```
-
-### Step 2: Install the `aptos` CLI
-
-1. Install dependencies before compiling:
-   1. For Debian or Ubuntu: `sudo apt install build-essential pkg-config openssl libssl-dev libclang-dev`.
-   2. For RHEL or Centos: `sudo yum install pkgconfig openssl openssl-devel clang`.
-   3. For others: Manually install `pkg-config` `openssl`, `libssl` and `libclang`:
-      - `pkg-config`:
-         - Download and unzip the source code at https://pkgconfig.freedesktop.org/releases/
-         - `./configure --prefix=/usr/local/pkg_config/0_29_2 --with-internal-glib`
-         - `sudo make && sudo make install`
-      - `openssl` and `libssl`:
-         - Check https://wiki.openssl.org/index.php/Compilation_and_Installation for full instructions.
-      - `libclang`:
-         - Check https://clang.llvm.org/get_started.html for full instructions.
-2. Install the `aptos` CLI tool by running the below command.  **For AIT-3 use `testnet` instead of `devnet`.** You can run this command from any directory.  The `aptos` CLI tool will be installed into your `CARGO_HOME`, usually `~/.cargo`:
-```bash
-cargo install --git https://github.com/aptos-labs/aptos-core.git aptos --branch devnet
-```
-3. Confirm that the `aptos` CLI tool is installed successfully by running the below command.  The terminal will display
-   the path to the `aptos` CLI's location.
-```bash
-which aptos
-```
-
-### Step 3 (optional): Install the dependencies of Move Prover
+### Step 2 (optional): Install the dependencies of Move Prover
 
 Run the following command in the `aptos-core` root directory:
 ```bash

--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
@@ -17,30 +17,55 @@ The `aptos` tool is a command line interface (CLI) for debugging, development, a
 6. Type `~/bin/aptos help` to read help instructions.
 7. Add `~/bin` to your path in your appropriate `.bashrc` or `.zshrc` for future use.
 
-## Step 1: Install from Git
-
-Start by cloning the `aptos-core` GitHub repo from [GitHub](https://github.com/aptos-labs/aptos-core).
-
-1. Clone the Aptos repo:  `git clone https://github.com/aptos-labs/aptos-core.git`
-2. `cd` into `aptos-core` directory: `cd aptos-core`
-3. Run the `scripts/dev_setup.sh` to prepare your environment: `./scripts/dev_setup.sh`
-4. Update your current shell environment: `source ~/.cargo/env`
-5. Checkout the correct branch `git checkout --track origin/branch`, where branch is
-    - `devnet` for building on Devnet
-    - `testnet` for building on Testnet
-    - `main` for the current development branch
-6. Build the CLI tool: `cargo build --package aptos --release`
-7. The binary will be available in `target/release/aptos`
-
 ### Step 2 (optional): Install the dependencies of Move Prover
 
-Run the following command in the `aptos-core` root directory:
-```bash
-./scripts/dev_setup.sh -yp
-. ~/.profile
-```
+1. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+2. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`
+3. Change directory into `aptos-core` directory: `cd aptos-core`
+4. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh -yp`
+5. Source the profile file `source ~/.profile`
+
 This command should work on MacOS and Linux flavors like Ubuntu or CentOS. (Windows is currently not supported).
 
 Notice that you have to include environment variable definitions in `~/.profile` into your shell. Depending on your
 setup, the  `~/.profile` may be already automatically loaded for each login shell, or it may not. If not, you may
 need to add `. ~/.profile` to your `~/.bash_profile` or other shell configuration manually.
+
+6. You should now be able to prove an example
+```bash
+aptos move prove --package-dir aptos-move/move-examples/hello_prover/
+```
+
+## Install from Git
+### Step 1: Install from Git
+
+Start by cloning the `aptos-core` GitHub repo from [GitHub](https://github.com/aptos-labs/aptos-core).
+
+1. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git
+2. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`
+3. Change directory into `aptos-core` directory: `cd aptos-core`
+4. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh`
+5. Update your current shell environment: `source ~/.cargo/env`
+6. Checkout the correct branch `git checkout --track origin/branch`, where branch is
+    - `devnet` for building on Devnet
+    - `testnet` for building on Testnet
+    - `main` for the current development branch
+7. Build the CLI tool: `cargo build --package aptos --release`
+8. The binary will be available in `target/release/aptos`
+9. (Optional) Move this executable to a place on your path e.g. `~/bin/aptos`
+
+### Step 2 (optional): Install the dependencies of Move Prover
+
+1. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh -yp`
+2. Source the profile file `source ~/.profile`
+
+This command should work on MacOS and Linux flavors like Ubuntu or CentOS. (Windows is currently not supported).
+
+Notice that you have to include environment variable definitions in `~/.profile` into your shell. Depending on your
+setup, the  `~/.profile` may be already automatically loaded for each login shell, or it may not. If not, you may
+need to add `. ~/.profile` to your `~/.bash_profile` or other shell configuration manually.
+
+3. You should now be able to prove an example
+```bash
+aptos move prove --package-dir aptos-move/move-examples/hello_prover/
+```

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -956,6 +956,7 @@ if [[ "$INSTALL_PROVER" == "true" ]]; then
     export DOTNET_INSTALL_DIR="/opt/dotnet/"
     mkdir -p "$DOTNET_INSTALL_DIR" || true
   fi
+  install_pkg unzip "$PACKAGE_MANAGER"
   install_z3
   install_cvc5
   install_dotnet
@@ -992,7 +993,13 @@ fi
 
 install_python3
 pip3 install pre-commit
-pre-commit install
+
+# For now best effort install, will need to improve later
+if command -v pre-commit; then
+  pre-commit install
+else
+  ~/.local/bin/pre-commit install
+fi
 
 if [[ "${BATCH_MODE}" == "false" ]]; then
 cat <<EOF


### PR DESCRIPTION
### Description
I've gone through testing multiple platforms, and ensured that the source does build
at least on the installations I can get on Amazon EC2.  Remembering that I'm not really
worried about supporting the CLI on Raspberry PIs or more obscure OS's.

### Test Plan
Architectures and OS's I tested (All with Intel except one graviton):
1. Opensuse x86_64 -> doesn't work because of Zypper
2. Fedora x86_64 -> Works, had to do some tweaks to the dev setup you see here
3. Ubuntu 22.04 (previously also 20.04) x86_64 -> Works
4. Ubuntu 22.04 Arm -> Works (Prover guaranteed doesn't work)
5. Amazon Linux x86_64 -> Works (Prover guaranteed doesn't work)

I also tested the prebuilt binaries on:
1. Mac OSX Arm (I've previously tested on x86_64 without issue)
2. Windows 11 (I haven't tried windows 10, but I'm pretty sure it's built with it)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4031)
<!-- Reviewable:end -->
