### PR TITLE
[forge] Add state sync catching up stress tests

### DIFF
--- a/.github/workflows/continuous-e2e-state-sync-failures-catching-up-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-failures-catching-up-test.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E State Sync Failures Catching Up Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  ### Please remember to use different namespace for different tests
+  run-state-sync-failures-catching-up-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-failures-catching-up-test
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: failures_catching_up
+      POST_TO_SLACK: true
+      FORGE_ENABLE_FAILPOINTS: true

--- a/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
+++ b/.github/workflows/continuous-e2e-state-sync-slow-processing-catching-up-test.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E State Sync Slow Processing Catching Up Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  ### Please remember to use different namespace for different tests
+  run-state-sync-slow-processing-catching-up-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-state-sync-slow-processing-catching-up-test
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: slow_processing_catching_up
+      POST_TO_SLACK: true
+      FORGE_ENABLE_FAILPOINTS: true

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -287,31 +287,27 @@ impl Swarm for K8sSwarm {
 
     async fn ensure_no_validator_restart(&self) -> Result<()> {
         for validator in &self.validators {
-            if let Err(e) = check_for_container_restart(
+            check_for_container_restart(
                 &self.kube_client,
                 &self.kube_namespace.clone(),
                 validator.1.stateful_set_name(),
             )
-            .await
-            {
-                return Err(e);
-            }
+            .await?;
         }
+        info!("Found no validator restarts");
         Ok(())
     }
 
     async fn ensure_no_fullnode_restart(&self) -> Result<()> {
         for fullnode in &self.fullnodes {
-            if let Err(e) = check_for_container_restart(
+            check_for_container_restart(
                 &self.kube_client,
                 &self.kube_namespace.clone(),
                 fullnode.1.stateful_set_name(),
             )
-            .await
-            {
-                return Err(e);
-            }
+            .await?;
         }
+        info!("Found no fullnode restarts");
         Ok(())
     }
 
@@ -345,6 +341,7 @@ impl Swarm for K8sSwarm {
             )
             .await?;
             threshold.ensure_threshold(&system_metrics)?;
+            info!("System metrics are healthy");
             Ok(())
         } else {
             bail!("No prom client");

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -20,7 +20,7 @@ pub mod twin_validator_test;
 pub mod validator_join_leave_test;
 pub mod validator_reboot_stress_test;
 
-use anyhow::{anyhow, ensure};
+use anyhow::{anyhow, ensure, Context};
 use aptos_logger::info;
 use aptos_sdk::{transaction_builder::TransactionFactory, types::PeerId};
 use forge::{
@@ -31,6 +31,7 @@ use futures::future::join_all;
 use rand::{rngs::StdRng, SeedableRng};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Builder;
+use tokio::runtime::Runtime;
 
 const WARMUP_DURATION_FRACTION: f32 = 0.07;
 const COOLDOWN_DURATION_FRACTION: f32 = 0.04;
@@ -132,16 +133,14 @@ pub trait NetworkLoadTest: Test {
 
 impl NetworkTest for dyn NetworkLoadTest {
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        let runtime = Runtime::new().unwrap();
         let start_timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
             .as_secs();
-        let one_client = ctx.swarm().aptos_public_info().client().clone();
-        let start_version = ctx
-            .runtime
-            .block_on(one_client.get_ledger_information())?
-            .into_inner()
-            .version;
+        let (start_version, _) = runtime
+            .block_on(ctx.swarm().get_client_with_newest_ledger_version())
+            .context("no clients replied for start version")?;
         let emit_job_request = ctx.emit_job.clone();
         let rng = SeedableRng::from_rng(ctx.core().rng())?;
         let duration = ctx.global_duration;
@@ -160,13 +159,12 @@ impl NetworkTest for dyn NetworkLoadTest {
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
             .as_secs();
-        let end_version = ctx
-            .runtime
-            .block_on(one_client.get_ledger_information())?
-            .into_inner()
-            .version;
+        let (end_version, _) = runtime
+            .block_on(ctx.swarm().get_client_with_newest_ledger_version())
+            .context("no clients replied for end version")?;
 
-        self.finish(ctx.swarm())?;
+        self.finish(ctx.swarm())
+            .context("finish NetworkLoadTest ")?;
 
         ctx.check_for_success(
             &txn_stat,
@@ -175,7 +173,8 @@ impl NetworkTest for dyn NetworkLoadTest {
             end_timestamp as i64,
             start_version,
             end_version,
-        )?;
+        )
+        .context("check for success")?;
 
         Ok(())
     }
@@ -203,7 +202,7 @@ impl dyn NetworkLoadTest {
             .map(|v| v.peer_id())
             .collect::<Vec<_>>();
 
-        let nodes_to_send_load_to = match self.setup(ctx)? {
+        let nodes_to_send_load_to = match self.setup(ctx).context("setup NetworkLoadTest")? {
             LoadDestination::AllNodes => [&all_validators[..], &all_fullnodes[..]].concat(),
             LoadDestination::AllValidators => all_validators,
             LoadDestination::AllFullnodes => all_fullnodes,
@@ -218,7 +217,8 @@ impl dyn NetworkLoadTest {
             &nodes_to_send_load_to,
             aptos_global_constants::GAS_UNIT_PRICE,
             rng,
-        )?;
+        )
+        .context("create emitter")?;
 
         let mut runtime_builder = Builder::new_multi_thread();
         runtime_builder.disable_lifo_slot().enable_all();
@@ -231,23 +231,9 @@ impl dyn NetworkLoadTest {
             .swarm()
             .get_clients_for_peers(&nodes_to_send_load_to, Duration::from_secs(10));
 
-        // Read first
-        for client in &clients {
-            let start = Instant::now();
-            let _v = rt.block_on(client.get_ledger_information())?;
-            let duration = start.elapsed();
-            info!(
-                "Fetch from {:?} took {}ms",
-                client.path_prefix_string(),
-                duration.as_millis(),
-            );
-        }
-
-        let job = rt.block_on(emitter.start_job(
-            ctx.swarm().chain_info().root_account,
-            emit_job_request,
-            3,
-        ))?;
+        let job = rt
+            .block_on(emitter.start_job(ctx.swarm().chain_info().root_account, emit_job_request, 3))
+            .context("start emitter job")?;
 
         let warmup_duration = duration.mul_f32(warmup_duration_fraction);
         let cooldown_duration = duration.mul_f32(cooldown_duration_fraction);
@@ -270,7 +256,8 @@ impl dyn NetworkLoadTest {
         job.start_next_phase();
 
         let test_start = Instant::now();
-        self.test(ctx.swarm(), test_duration)?;
+        self.test(ctx.swarm(), test_duration)
+            .context("test NetworkLoadTest")?;
         let actual_test_duration = test_start.elapsed();
         info!(
             "{}s test finished after {}s",


### PR DESCRIPTION
### Description

Adds two tests, where we send constant TPS, and have nodes get stale, and see that they catchup.

(will separately send a PR to add a check that they participate in the consensus)

- test 1 - cut network on a node for some period of time
- test 2 - make subset of nodes execute blocks slower (by adding sleep in aptos_vm block metadata processing)

### Test Plan
run both on forge to confirm they pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4036)
<!-- Reviewable:end -->
