### PR TITLE
[aptos-cli] Add a command to generate writeset for fire events

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -29,10 +29,9 @@ use aptos_gas::AptosGasMeter;
 use aptos_logger::prelude::*;
 use aptos_module_verifier::module_init::verify_module_init_function;
 use aptos_state_view::StateView;
-use aptos_types::account_config::new_block_event_key;
-use aptos_types::vm_status::AbortLocation;
 use aptos_types::{
     account_config,
+    account_config::new_block_event_key,
     block_metadata::BlockMetadata,
     on_chain_config::new_epoch_event_key,
     transaction::{
@@ -40,22 +39,21 @@ use aptos_types::{
         Transaction, TransactionOutput, TransactionPayload, TransactionStatus, VMValidatorResult,
         WriteSetPayload,
     },
-    vm_status::{StatusCode, VMStatus},
+    vm_status::{AbortLocation, StatusCode, VMStatus},
     write_set::WriteSet,
 };
 use fail::fail_point;
 use framework::natives::code::PublishRequest;
-use move_deps::move_binary_format::errors::VMError;
-use move_deps::move_core_types::language_storage::ModuleId;
 use move_deps::{
     move_binary_format::{
         access::ModuleAccess,
-        errors::{verification_error, Location, PartialVMError, VMResult},
+        errors::{verification_error, Location, PartialVMError, VMError, VMResult},
         CompiledModule, IndexKind,
     },
     move_core_types::{
         account_address::AccountAddress,
         ident_str,
+        language_storage::ModuleId,
         transaction_argument::convert_txn_args,
         value::{serialize_values, MoveValue},
     },
@@ -63,12 +61,14 @@ use move_deps::{
 };
 use num_cpus;
 use once_cell::sync::OnceCell;
-use std::collections::{BTreeMap, BTreeSet};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     cmp::min,
+    collections::{BTreeMap, BTreeSet},
     convert::{AsMut, AsRef},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 static EXECUTION_CONCURRENCY_LEVEL: OnceCell<usize> = OnceCell::new();
@@ -788,7 +788,7 @@ impl AptosVM {
         let change_set_ext = match self.execute_writeset(
             storage,
             &writeset_payload,
-            None,
+            Some(aptos_types::account_config::reserved_vm_address()),
             SessionId::genesis(genesis_id),
         ) {
             Ok(cse) => cse,

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -4,6 +4,7 @@
 use crate::common::types::OptionalPoolAddressArgs;
 use crate::common::utils::{create_dir_if_not_exist, current_dir, dir_default_to_current};
 use crate::genesis::git::{LAYOUT_FILE, OPERATOR_FILE, OWNER_FILE};
+use crate::governance::CompileScriptFunction;
 use crate::{
     common::{
         types::{CliError, CliTypedResult, PromptOptions, RngArgs},
@@ -15,6 +16,8 @@ use crate::{
 use aptos_genesis::config::{Layout, OperatorConfiguration, OwnerConfiguration};
 use aptos_genesis::keys::PublicIdentity;
 use aptos_genesis::{config::HostAndPort, keys::generate_key_objects};
+use aptos_types::account_address::AccountAddress;
+use aptos_types::transaction::{Script, Transaction, WriteSetPayload};
 use async_trait::async_trait;
 use clap::Parser;
 use std::path::{Path, PathBuf};
@@ -278,6 +281,49 @@ impl CliCommand<()> for GenerateLayoutTemplate {
             self.output_file.as_path(),
             &self.output_file.display().to_string(),
             to_yaml(&layout)?.as_bytes(),
+        )
+    }
+}
+
+/// Generate a WriteSet genesis compiled from a script file.
+///
+/// This will compile a piece of Move script and generate a writeset from that script.
+#[derive(Parser)]
+pub struct GenerateAdminWriteSet {
+    /// Path of the output genesis file
+    #[clap(long, parse(from_os_str))]
+    pub(crate) output_file: PathBuf,
+
+    /// Address of the account which execute this script.
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) execute_as: AccountAddress,
+
+    #[clap(flatten)]
+    pub(crate) compile_proposal_args: CompileScriptFunction,
+
+    #[clap(flatten)]
+    pub(crate) prompt_options: PromptOptions,
+}
+
+#[async_trait]
+impl CliCommand<()> for GenerateAdminWriteSet {
+    fn command_name(&self) -> &'static str {
+        "GenerateAdminWriteSet"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        check_if_file_exists(self.output_file.as_path(), self.prompt_options)?;
+        let (bytecode, _script_hash) = self.compile_proposal_args.compile(self.prompt_options)?;
+
+        let txn = Transaction::GenesisTransaction(WriteSetPayload::Script {
+            execute_as: self.execute_as,
+            script: Script::new(bytecode, vec![], vec![]),
+        });
+
+        write_to_user_only_file(
+            self.output_file.as_path(),
+            &self.output_file.display().to_string(),
+            &bcs::to_bytes(&txn).map_err(CliError::from)?,
         )
     }
 }

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -45,6 +45,7 @@ pub enum GenesisTool {
     GenerateGenesis(GenerateGenesis),
     GenerateKeys(keys::GenerateKeys),
     GenerateLayoutTemplate(keys::GenerateLayoutTemplate),
+    GenerateAdminWriteSet(keys::GenerateAdminWriteSet),
     SetupGit(git::SetupGit),
     SetValidatorConfiguration(keys::SetValidatorConfiguration),
 }
@@ -55,6 +56,7 @@ impl GenesisTool {
             GenesisTool::GenerateGenesis(tool) => tool.execute_serialized().await,
             GenesisTool::GenerateKeys(tool) => tool.execute_serialized().await,
             GenesisTool::GenerateLayoutTemplate(tool) => tool.execute_serialized_success().await,
+            GenesisTool::GenerateAdminWriteSet(tool) => tool.execute_serialized_success().await,
             GenesisTool::SetupGit(tool) => tool.execute_serialized_success().await,
             GenesisTool::SetValidatorConfiguration(tool) => tool.execute_serialized_success().await,
         }

--- a/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
+++ b/execution/db-bootstrapper/src/bin/db-bootstrapper.rs
@@ -58,13 +58,14 @@ fn main() -> Result<()> {
         TARGET_SNAPSHOT_SIZE,
         DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
     )
-    .with_context(|| format_err!("Failed to open DB."))?;
+    .expect("Failed to open DB.");
     let db = DbReaderWriter::new(db);
 
     let executed_trees = db
         .reader
         .get_latest_executed_trees()
         .with_context(|| format_err!("Failed to get latest tree state."))?;
+    println!("Db has {} transactions", executed_trees.num_transactions());
     if let Some(waypoint) = opt.waypoint_to_verify {
         ensure!(
             waypoint.version() == executed_trees.num_transactions(),

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::interface::system_metrics::{query_prometheus_system_metrics, SystemMetricsThreshold};
 use crate::{
     check_for_container_restart, create_k8s_client, delete_all_chaos, get_free_port,
     get_stateful_set_image,
+    interface::system_metrics::{query_prometheus_system_metrics, SystemMetricsThreshold},
     node::K8sNode,
     prometheus::{self, query_with_metadata},
     query_sequence_numbers, set_stateful_set_image_tag, uninstall_testnet_resources, ChainInfo,
@@ -103,10 +103,10 @@ impl K8sSwarm {
         })
     }
 
-    fn get_rest_api_url(&self) -> String {
+    fn get_rest_api_url(&self, idx: usize) -> String {
         self.validators
             .values()
-            .next()
+            .nth(idx)
             .unwrap()
             .rest_api_endpoint()
             .to_string()
@@ -240,7 +240,7 @@ impl Swarm for K8sSwarm {
     }
 
     fn chain_info(&mut self) -> ChainInfo<'_> {
-        let rest_api_url = self.get_rest_api_url();
+        let rest_api_url = self.get_rest_api_url(0);
         ChainInfo::new(&mut self.root_account, rest_api_url, self.chain_id)
     }
 
@@ -341,6 +341,11 @@ impl Swarm for K8sSwarm {
         } else {
             bail!("No prom client");
         }
+    }
+
+    fn chain_info_for_node(&mut self, idx: usize) -> ChainInfo<'_> {
+        let rest_api_url = self.get_rest_api_url(idx);
+        ChainInfo::new(&mut self.root_account, rest_api_url, self.chain_id)
     }
 }
 

--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -1,15 +1,16 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::interface::system_metrics::SystemMetricsThreshold;
 use crate::{
-    ChainInfo, FullNode, HealthCheckError, LocalNode, LocalVersion, Node, Swarm, SwarmChaos,
-    SwarmExt, Validator, Version,
+    interface::system_metrics::SystemMetricsThreshold, ChainInfo, FullNode, HealthCheckError,
+    LocalNode, LocalVersion, Node, Swarm, SwarmChaos, SwarmExt, Validator, Version,
 };
 use anyhow::{anyhow, bail, Result};
-use aptos_config::config::NetworkConfig;
-use aptos_config::network_id::NetworkId;
-use aptos_config::{config::NodeConfig, keys::ConfigKey};
+use aptos_config::{
+    config::{NetworkConfig, NodeConfig},
+    keys::ConfigKey,
+    network_id::NetworkId,
+};
 use aptos_genesis::builder::{FullnodeNodeConfig, InitConfigFn, InitGenesisConfigFn};
 use aptos_infallible::Mutex;
 use aptos_logger::{info, warn};
@@ -264,7 +265,7 @@ impl LocalSwarm {
         Ok(())
     }
 
-    async fn wait_for_startup(&mut self) -> Result<()> {
+    pub async fn wait_for_startup(&mut self) -> Result<()> {
         let num_attempts = 30;
         let mut done = vec![false; self.validators.len()];
         for i in 0..num_attempts {
@@ -543,15 +544,14 @@ impl Swarm for LocalSwarm {
     }
 
     fn chain_info(&mut self) -> ChainInfo<'_> {
-        ChainInfo::new(
-            &mut self.root_account,
-            self.validators
-                .values()
-                .map(|v| v.rest_api_endpoint().to_string())
-                .next()
-                .unwrap(),
-            self.chain_id,
-        )
+        let rest_api_url = self
+            .validators()
+            .next()
+            .unwrap()
+            .rest_api_endpoint()
+            .to_string();
+
+        ChainInfo::new(&mut self.root_account, rest_api_url, self.chain_id)
     }
 
     fn logs_location(&mut self) -> String {
@@ -595,6 +595,17 @@ impl Swarm for LocalSwarm {
         _threshold: SystemMetricsThreshold,
     ) -> Result<()> {
         todo!()
+    }
+
+    fn chain_info_for_node(&mut self, idx: usize) -> ChainInfo<'_> {
+        let rest_api_url = self
+            .validators()
+            .nth(idx)
+            .unwrap()
+            .rest_api_endpoint()
+            .to_string();
+
+        ChainInfo::new(&mut self.root_account, rest_api_url, self.chain_id)
     }
 }
 

--- a/testsuite/forge/src/interface/swarm.rs
+++ b/testsuite/forge/src/interface/swarm.rs
@@ -1,9 +1,9 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::interface::system_metrics::SystemMetricsThreshold;
 use crate::{
-    AptosPublicInfo, ChainInfo, FullNode, NodeExt, Result, SwarmChaos, Validator, Version,
+    interface::system_metrics::SystemMetricsThreshold, AptosPublicInfo, ChainInfo, FullNode,
+    NodeExt, Result, SwarmChaos, Validator, Version,
 };
 use anyhow::{anyhow, bail};
 use aptos_config::config::NodeConfig;
@@ -101,6 +101,12 @@ pub trait Swarm: Sync {
 
     fn aptos_public_info(&mut self) -> AptosPublicInfo<'_> {
         self.chain_info().into_aptos_public_info()
+    }
+
+    fn chain_info_for_node(&mut self, idx: usize) -> ChainInfo<'_>;
+
+    fn aptos_public_info_for_node(&mut self, idx: usize) -> AptosPublicInfo<'_> {
+        self.chain_info_for_node(idx).into_aptos_public_info()
     }
 }
 

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -1,0 +1,242 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    smoke_test_environment::SwarmBuilder,
+    storage::{db_backup, db_restore},
+    test_utils::{check_create_mint_transfer_node, swarm_utils::insert_waypoint},
+    workspace_builder,
+    workspace_builder::workspace_root,
+};
+use anyhow::anyhow;
+use aptos_config::config::NodeConfig;
+use aptos_temppath::TempPath;
+use aptos_types::{transaction::Transaction, waypoint::Waypoint};
+use forge::{get_highest_synced_version, LocalNode, Node, NodeExt, SwarmExt};
+use move_deps::move_core_types::language_storage::CORE_CODE_ADDRESS;
+use regex::Regex;
+use std::{fs, process::Command, str::FromStr, time::Duration};
+
+fn update_node_config_restart(validator: &mut LocalNode, mut config: NodeConfig) {
+    validator.stop();
+    let node_path = validator.config_path();
+    config.save(node_path).unwrap();
+    validator.start().unwrap();
+}
+
+#[tokio::test]
+/// This test verifies the flow of a genesis transaction after the chain starts.
+/// 1. Test the consensus sync_only mode, every node should stop at the same version.
+/// 2. Test the db-bootstrapper applying a manual genesis transaction (remove validator 0) on diemdb directly
+/// 3. Test the nodes and clients resume working after updating waypoint
+/// 4. Test a node lagging behind can sync to the waypoint
+async fn test_genesis_transaction_flow() {
+    let db_bootstrapper = workspace_builder::get_bin("db-bootstrapper");
+    let aptos_cli = workspace_builder::get_bin("aptos");
+
+    // prebuild tools.
+    workspace_builder::get_bin("db-backup");
+    workspace_builder::get_bin("db-restore");
+    workspace_builder::get_bin("db-backup-verify");
+
+    let num_nodes = 5;
+    let (mut env, cli, _) = SwarmBuilder::new_local(num_nodes)
+        .with_aptos()
+        .build_with_cli(0)
+        .await;
+
+    println!("1. Set sync_only = true for the last node and check it can sync to others");
+    let node = env.validators_mut().nth(4).unwrap();
+    let mut new_config = node.config().clone();
+    new_config.consensus.sync_only = true;
+    update_node_config_restart(node, new_config.clone());
+    // wait for some versions
+    env.wait_for_all_nodes_to_catchup_to_version(10, Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    println!("2. Set sync_only = true for all nodes and restart");
+    for node in env.validators_mut() {
+        let mut node_config = node.config().clone();
+        node_config.consensus.sync_only = true;
+        update_node_config_restart(node, node_config)
+    }
+
+    println!("3. delete one node's db and test they can still sync when sync_only is true for every nodes");
+    let node = env.validators_mut().nth(3).unwrap();
+    node.stop();
+    node.clear_storage().await.unwrap();
+    node.start().unwrap();
+
+    println!("4. verify all nodes are at the same round and no progress being made");
+    env.wait_for_all_nodes_to_catchup(Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    println!("5. kill nodes and prepare a genesis txn to remove the last validator");
+    for node in env.validators_mut().take(3) {
+        node.stop();
+    }
+
+    let first_validator_address = env.validators().nth(4).unwrap().config().peer_id().unwrap();
+
+    let script = format!(
+        r#"
+        script {{
+            use aptos_framework::stake;
+            use aptos_framework::aptos_governance;
+            use aptos_framework::block;
+
+            fun main(vm_signer: &signer, framework_signer: &signer) {{
+                stake::remove_validators(framework_signer, &vector[@0x{:?}]);
+                block::emit_writeset_block_event(vm_signer, @0x1);
+                aptos_governance::reconfigure(framework_signer);
+            }}
+    }}
+    "#,
+        first_validator_address
+    );
+
+    let temp_script_path = TempPath::new();
+    let mut move_script_path = temp_script_path.path().to_path_buf();
+    move_script_path.set_extension("move");
+
+    fs::write(move_script_path.as_path(), script).unwrap();
+
+    let genesis_blob_path = TempPath::new();
+    genesis_blob_path.create_as_file().unwrap();
+
+    Command::new(aptos_cli.as_path())
+        .current_dir(workspace_root())
+        .args(&vec![
+            "genesis",
+            "generate-admin-write-set",
+            "--output-file",
+            genesis_blob_path.path().to_str().unwrap(),
+            "--execute-as",
+            CORE_CODE_ADDRESS.clone().to_hex().as_str(),
+            "--script-path",
+            move_script_path.as_path().to_str().unwrap(),
+            "--framework-git-rev",
+            "HEAD",
+            "--assume-yes",
+        ])
+        .output()
+        .unwrap();
+
+    let genesis_transaction = {
+        let buf = fs::read(genesis_blob_path.as_ref()).unwrap();
+        bcs::from_bytes::<Transaction>(&buf).unwrap()
+    };
+
+    println!("6. prepare the waypoint with the transaction");
+    let waypoint_command = Command::new(db_bootstrapper.as_path())
+        .current_dir(workspace_root())
+        .args(&vec![
+            env.validators()
+                .next()
+                .unwrap()
+                .config()
+                .storage
+                .dir()
+                .to_str()
+                .unwrap(),
+            "--genesis-txn-file",
+            genesis_blob_path.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    println!("Db bootstrapper output: {:?}", waypoint_command);
+    let output = std::str::from_utf8(&waypoint_command.stdout).unwrap();
+    let waypoint = parse_waypoint(output);
+
+    println!("7. apply genesis transaction for nodes 0, 1, 2");
+    for node in env.validators_mut().take(3) {
+        let mut node_config = node.config().clone();
+        insert_waypoint(&mut node_config, waypoint);
+        node_config.execution.genesis = Some(genesis_transaction.clone());
+        // reset the sync_only flag to false
+        node_config.consensus.sync_only = false;
+        update_node_config_restart(node, node_config);
+    }
+
+    println!("8. verify it's able to mint after the waypoint");
+    env.wait_for_startup().await.unwrap();
+    check_create_mint_transfer_node(&mut env, 0).await;
+
+    let (epoch, version) = {
+        let response = env
+            .validators()
+            .next()
+            .unwrap()
+            .rest_client()
+            .get_ledger_information()
+            .await
+            .unwrap();
+        (response.inner().epoch, response.inner().version)
+    };
+
+    let backup_path = db_backup(
+        env.validators()
+            .next()
+            .unwrap()
+            .config()
+            .storage
+            .backup_service_address
+            .port(),
+        epoch.checked_sub(1).unwrap(), // target epoch: most recently closed epoch
+        version,                       // target version
+        version as usize,              // txn batch size (version 0 is in its own batch)
+        epoch.checked_sub(1).unwrap() as usize, // state snapshot interval
+        &[waypoint],
+    );
+
+    println!("9. verify node 4 is out from the validator set");
+    assert_eq!(
+        cli.show_validator_set()
+            .await
+            .unwrap()
+            .active_validators
+            .len(),
+        4
+    );
+
+    println!("10. nuke DB on node 3, and run db-restore, test if it rejoins the network okay.");
+    let node = env.validators_mut().nth(3).unwrap();
+    node.stop();
+    let mut node_config = node.config().clone();
+    node_config.consensus.sync_only = false;
+    node_config.save(node.config_path()).unwrap();
+
+    let db_dir = node.config().storage.dir();
+    fs::remove_dir_all(&db_dir).unwrap();
+    db_restore(backup_path.path(), db_dir.as_path(), &[waypoint]);
+
+    node.start().unwrap();
+    let client = node.rest_client();
+    // wait for it to catch up
+    {
+        let version = get_highest_synced_version(&env.get_all_nodes_clients_with_names())
+            .await
+            .unwrap();
+        loop {
+            if let Ok(resp) = client.get_ledger_information().await {
+                if resp.into_inner().version > version {
+                    println!("Node 3 catches up on {}", version);
+                    break;
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    check_create_mint_transfer_node(&mut env, 3).await;
+}
+
+fn parse_waypoint(db_bootstrapper_output: &str) -> Waypoint {
+    let waypoint = Regex::new(r"Got waypoint: (\d+:\w+)")
+        .unwrap()
+        .captures(db_bootstrapper_output)
+        .ok_or_else(|| anyhow!("Failed to parse db-bootstrapper output."));
+    Waypoint::from_str(waypoint.unwrap()[1].into()).unwrap()
+}

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -16,6 +16,8 @@ mod full_nodes;
 #[cfg(test)]
 mod fullnode;
 #[cfg(test)]
+mod genesis;
+#[cfg(test)]
 mod indexer;
 #[cfg(test)]
 mod network;

--- a/testsuite/smoke-test/src/test_utils.rs
+++ b/testsuite/smoke-test/src/test_utils.rs
@@ -80,38 +80,58 @@ pub async fn assert_balance(client: &RestClient, account: &LocalAccount, balance
 /// node swarm, or a public full node swarm.
 #[cfg(test)]
 pub mod swarm_utils {
-    use aptos_config::config::{NodeConfig, WaypointConfig};
+    use aptos_config::config::{
+        InitialSafetyRulesConfig, NodeConfig, SecureBackend, WaypointConfig,
+    };
+    use aptos_secure_storage::{KVStorage, Storage};
     use aptos_types::waypoint::Waypoint;
 
     pub fn insert_waypoint(node_config: &mut NodeConfig, waypoint: Waypoint) {
         node_config.base.waypoint = WaypointConfig::FromConfig(waypoint);
+        node_config
+            .consensus
+            .safety_rules
+            .initial_safety_rules_config = InitialSafetyRulesConfig::None;
+
+        let f = |backend: &SecureBackend| {
+            let mut storage: Storage = backend.into();
+            storage
+                .set(aptos_global_constants::WAYPOINT, waypoint)
+                .expect("Unable to write waypoint");
+            storage
+                .set(aptos_global_constants::GENESIS_WAYPOINT, waypoint)
+                .expect("Unable to write waypoint");
+        };
+        let backend = &node_config.consensus.safety_rules.backend;
+        f(backend);
     }
 }
 
 /// This helper function creates 3 new accounts, mints funds, transfers funds
 /// between the accounts and verifies that these operations succeed.
 pub async fn check_create_mint_transfer(swarm: &mut LocalSwarm) {
-    let client = swarm.validators().next().unwrap().rest_client();
+    check_create_mint_transfer_node(swarm, 0).await;
+}
+
+/// This helper function creates 3 new accounts, mints funds, transfers funds
+/// between the accounts and verifies that these operations succeed on one specific validator.
+pub async fn check_create_mint_transfer_node(swarm: &mut LocalSwarm, idx: usize) {
+    let client = swarm.validators().nth(idx).unwrap().rest_client();
 
     // Create account 0, mint 10 coins and check balance
-    let mut account_0 = create_and_fund_account(swarm, 10).await;
+    let transaction_factory = TransactionFactory::new(swarm.chain_id());
+    let mut info = swarm.aptos_public_info_for_node(idx);
+    let mut account_0 = info.create_and_fund_user_account(10).await.unwrap();
     assert_balance(&client, &account_0, 10).await;
 
     // Create account 1, mint 1 coin, transfer 3 coins from account 0 to 1, check balances
-    let account_1 = create_and_fund_account(swarm, 1).await;
-    transfer_coins(
-        &client,
-        &swarm.chain_info().transaction_factory(),
-        &mut account_0,
-        &account_1,
-        3,
-    )
-    .await;
+    let account_1 = info.create_and_fund_user_account(1).await.unwrap();
+    transfer_coins(&client, &transaction_factory, &mut account_0, &account_1, 3).await;
 
     assert_balance(&client, &account_0, 7).await;
     assert_balance(&client, &account_1, 4).await;
 
     // Create account 2, mint 15 coins and check balance
-    let account_2 = create_and_fund_account(swarm, 15).await;
+    let account_2 = info.create_and_fund_user_account(15).await.unwrap();
     assert_balance(&client, &account_2, 15).await;
 }


### PR DESCRIPTION
### Description

Resurrect the writeset generator tool to generate the genesis writeset need to apply to nodes manually in case of network outages. 

### Test Plan
`cargo test --package smoke-test --lib -- genesis::test_genesis_transaction_flow --exact --nocapture`
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4037)
<!-- Reviewable:end -->
