### PR TITLE
[mempool] remove per-account data structure when no more transactions

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -297,4 +297,9 @@ impl Mempool {
     pub fn get_parking_lot_size(&self) -> usize {
         self.transactions.get_parking_lot_size()
     }
+
+    #[cfg(test)]
+    pub fn get_transaction_store(&self) -> &TransactionStore {
+        &self.transactions
+    }
 }

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -440,9 +440,9 @@ impl TransactionStore {
 
     /// Removes account datastructures if there are no more transactions for the account
     fn account_remove(&mut self, address: &AccountAddress) {
-        if let Some(txns) = self.transactions.get(&address) {
+        if let Some(txns) = self.transactions.get(address) {
             if txns.is_empty() {
-                self.transactions.remove(&address);
+                self.transactions.remove(address);
             }
         }
     }

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -165,7 +165,7 @@ impl TransactionStore {
                     // Update txn if gas unit price is a larger value than before
                     if let Some(txn) = txns.remove(&sequence_number.transaction_sequence_number) {
                         self.index_remove(&txn);
-                        self.account_remove(&txn.get_sender());
+                        self.remove_account_if_empty(&txn.get_sender());
                     };
                 } else if current_version.get_gas_price() > txn.get_gas_price() {
                     return MempoolStatus::new(MempoolStatusCode::InvalidUpdate).with_message(
@@ -282,7 +282,7 @@ impl TransactionStore {
                         ))
                     );
                     self.index_remove(&txn);
-                    self.account_remove(&address);
+                    self.remove_account_if_empty(&address);
                 }
             }
         }
@@ -394,7 +394,7 @@ impl TransactionStore {
                 address,
                 sequence_number
             );
-            self.account_remove(address);
+            self.remove_account_if_empty(address);
         }
     }
 
@@ -421,7 +421,7 @@ impl TransactionStore {
                 self.index_remove(transaction);
             }
             debug!(LogSchema::new(LogEntry::CleanRejectedTxn).txns(txns_log));
-            self.account_remove(account);
+            self.remove_account_if_empty(account);
         }
     }
 
@@ -439,7 +439,7 @@ impl TransactionStore {
     }
 
     /// Removes account datastructures if there are no more transactions for the account
-    fn account_remove(&mut self, address: &AccountAddress) {
+    fn remove_account_if_empty(&mut self, address: &AccountAddress) {
         if let Some(txns) = self.transactions.get(address) {
             if txns.is_empty() {
                 self.transactions.remove(address);
@@ -583,7 +583,7 @@ impl TransactionStore {
                     // remove txn
                     self.index_remove(&txn);
                 }
-                self.account_remove(&key.address);
+                self.remove_account_if_empty(&key.address);
             }
         }
 


### PR DESCRIPTION
### Description

The hashmap entry with no transactions is 56 bytes (32 account address + 24 empty btree).
Since it's never cleaned up this can grow to the number of accounts ever seen in the mempool. E.g., 330M (twitter MAU) * hashmap entry = 18GB

After the change, the number of hashmap entries is bounded by the total mempool size.

### Test Plan

Add unit test that checks the transaction store no longer has an entry for the account after transaction removal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4041)
<!-- Reviewable:end -->
