### PR TITLE
[forge] Set random-seed parameter for key generation

### DIFF
--- a/terraform/helm/genesis/files/genesis.sh
+++ b/terraform/helm/genesis/files/genesis.sh
@@ -41,11 +41,17 @@ echo "FULLNODE_INTERNAL_HOST_SUFFIX=${FULLNODE_INTERNAL_HOST_SUFFIX}"
 echo "STAKE_AMOUNT=${STAKE_AMOUNT}"
 echo "NUM_VALIDATORS_WITH_LARGER_STAKE=${NUM_VALIDATORS_WITH_LARGER_STAKE}"
 echo "LARGER_STAKE_AMOUNT=${LARGER_STAKE_AMOUNT}"
+echo "RANDOM_SEED=${RANDOM_SEED}"
+
+RANDOM_SEED_IN_DECIMAL=$(printf "%d" 0x${RANDOM_SEED})
 
 # generate all validator configurations
 for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
     username="${USERNAME_PREFIX}-${i}"
     user_dir="${WORKSPACE}/${username}"
+    seed=$(printf "%064x" "$((${RANDOM_SEED_IN_DECIMAL}+i))")
+    echo "seed=$seed for ${i}th validator"
+
     mkdir $user_dir
 
     if [ "${FULLNODE_ENABLE_ONCHAIN_DISCOVERY}" = "true" ]; then
@@ -68,7 +74,12 @@ for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
 
     echo "CUR_STAKE_AMOUNT=${CUR_STAKE_AMOUNT} for ${i} validator"
 
-    aptos genesis generate-keys --output-dir $user_dir
+    if [[ -z "${RANDOM_SEED}" ]]; then
+      aptos genesis generate-keys --output-dir $user_dir
+    else
+      aptos genesis generate-keys --random-seed $seed --output-dir $user_dir
+    fi
+
     aptos genesis set-validator-configuration --owner-public-identity-file $user_dir/public-keys.yaml --local-repository-dir $WORKSPACE \
         --username $username \
         --validator-host $validator_host \

--- a/terraform/helm/genesis/templates/genesis.yaml
+++ b/terraform/helm/genesis/templates/genesis.yaml
@@ -116,6 +116,8 @@ spec:
           value: {{ .Values.genesis.domain | quote }}
         - name: VALIDATOR_ENABLE_ONCHAIN_DISCOVERY
           value: {{ .Values.genesis.validator.enable_onchain_discovery | quote }}
+        - name: RANDOM_SEED
+          value: {{ .Values.genesis.validator.key_seed | quote }}
         - name: FULLNODE_ENABLE_ONCHAIN_DISCOVERY
           value: {{ .Values.genesis.fullnode.enable_onchain_discovery | quote }}
         - name: VALIDATOR_INTERNAL_HOST_SUFFIX

--- a/terraform/helm/genesis/values.yaml
+++ b/terraform/helm/genesis/values.yaml
@@ -60,6 +60,8 @@ genesis:
     num_validators_with_larger_stake: 0
     # -- Stake amount for nodes we are giving larger state to. Defaults to 10M APTOS coins with 8 decimals
     larger_stake_amount: "1000000000000000"
+    # -- Random seed to generate validator keys in order to make the key generation deterministic
+    key_seed:
   fullnode:
     # -- Use External DNS as created by aptos-node helm chart for fullnode host in genesis
     enable_onchain_discovery: true

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -5,10 +5,10 @@ use crate::{
     get_fullnodes, get_validators, k8s_wait_genesis_strategy, k8s_wait_nodes_strategy,
     nodes_healthcheck, wait_stateful_set, Create, GenesisConfigFn, K8sApi, K8sNode, NodeConfigFn,
     Result, APTOS_NODE_HELM_CHART_PATH, APTOS_NODE_HELM_RELEASE_NAME, DEFAULT_ROOT_KEY,
-    FULLNODE_HAPROXY_SERVICE_SUFFIX, FULLNODE_SERVICE_SUFFIX, GENESIS_HELM_CHART_PATH,
-    GENESIS_HELM_RELEASE_NAME, HELM_BIN, KUBECTL_BIN, MANAGEMENT_CONFIGMAP_PREFIX,
-    NAMESPACE_CLEANUP_THRESHOLD_SECS, POD_CLEANUP_THRESHOLD_SECS, VALIDATOR_HAPROXY_SERVICE_SUFFIX,
-    VALIDATOR_SERVICE_SUFFIX,
+    FORGE_KEY_SEED, FULLNODE_HAPROXY_SERVICE_SUFFIX, FULLNODE_SERVICE_SUFFIX,
+    GENESIS_HELM_CHART_PATH, GENESIS_HELM_RELEASE_NAME, HELM_BIN, KUBECTL_BIN,
+    MANAGEMENT_CONFIGMAP_PREFIX, NAMESPACE_CLEANUP_THRESHOLD_SECS, POD_CLEANUP_THRESHOLD_SECS,
+    VALIDATOR_HAPROXY_SERVICE_SUFFIX, VALIDATOR_SERVICE_SUFFIX,
 };
 use again::RetryPolicy;
 use anyhow::{bail, format_err};
@@ -539,6 +539,7 @@ pub fn construct_genesis_helm_values(
     value["chain"]["root_key"] = DEFAULT_ROOT_KEY.into();
     value["genesis"]["numValidators"] = num_validators.into();
     value["genesis"]["validator"]["internal_host_suffix"] = validator_internal_host_suffix.into();
+    value["genesis"]["validator"]["key_seed"] = FORGE_KEY_SEED.into();
     value["genesis"]["fullnode"]["internal_host_suffix"] = fullnode_internal_host_suffix.into();
     value["labels"]["forge-namespace"] = kube_namespace.into();
     value["labels"]["forge-image-tag"] = genesis_image_tag.into();
@@ -989,6 +990,7 @@ genesis:
   numValidators: 5
   validator:
     internal_host_suffix: validator-lb
+    key_seed: \"80000\"
   fullnode:
     internal_host_suffix: fullnode-lb
 labels:

--- a/testsuite/forge/src/backend/k8s/constants.rs
+++ b/testsuite/forge/src/backend/k8s/constants.rs
@@ -9,6 +9,9 @@ pub const DEFAULT_ROOT_KEY: &str =
 pub const DEFAULT_ROOT_PRIV_KEY: &str =
     "E25708D90C72A53B400B27FC7602C4D546C7B7469FA6E12544F0EBFB2F16AE19";
 
+// Seed to generate keys for forge tests.
+pub const FORGE_KEY_SEED: &str = "80000";
+
 // binaries expected to be present on test runner
 pub const HELM_BIN: &str = "helm";
 pub const KUBECTL_BIN: &str = "kubectl";


### PR DESCRIPTION
### Description
- Add a seed parameter for keys generation so that the keys generation will be deterministic and can be accessed from forge tests.
- The i th validator will use the `passed in paremeter + i` as seed to generate keys.
### Test Plan
Apply the label CICD:run-e2e-tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4042)
<!-- Reviewable:end -->
