### PR TITLE
Print error when unable to find faucet account in minting

### DIFF
--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -468,9 +468,17 @@ mod tests {
             .reply(&filter)
             .await;
 
-        assert_eq!(
-            resp.body(),
-            &format!("faucet account {:?} not found", address)
+        assert!(
+            resp.body().starts_with(
+                format!(
+                    "Faucet account {:?} not found: HTTP error 404 Not Found:",
+                    address
+                )
+                .as_str()
+                .as_bytes()
+            ),
+            "{} did not start with the expected string",
+            std::str::from_utf8(resp.body()).unwrap()
         );
     }
 

--- a/crates/aptos-faucet/src/mint.rs
+++ b/crates/aptos-faucet/src/mint.rs
@@ -215,7 +215,7 @@ async fn sequences(service: &Service, receiver: AccountAddress) -> Result<(u64, 
         .map(|account| account.inner().sequence_number);
     let faucet_seq_num = responses
         .remove(0)
-        .map_err(|_| anyhow::format_err!("faucet account {} not found", faucet_address))?
+        .map_err(|e| anyhow::format_err!("Faucet account {} not found: {:#}", faucet_address, e))?
         .inner()
         .sequence_number;
 

--- a/crates/aptos-rest-client/src/error.rs
+++ b/crates/aptos-rest-client/src/error.rs
@@ -157,8 +157,8 @@ pub enum RestError {
     Timeout(&'static str),
     #[error("Unknown error {0}")]
     Unknown(anyhow::Error),
-    #[error("Http error {0}")]
-    Http(StatusCode),
+    #[error("HTTP error {0}: {1}")]
+    Http(StatusCode, reqwest::Error),
 }
 
 impl From<(AptosError, Option<State>, StatusCode)> for RestError {
@@ -198,7 +198,7 @@ impl From<anyhow::Error> for RestError {
 impl From<reqwest::Error> for RestError {
     fn from(err: reqwest::Error) -> Self {
         if let Some(status) = err.status() {
-            RestError::Http(status)
+            RestError::Http(status, err)
         } else {
             RestError::Unknown(err.into())
         }

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -1088,7 +1088,7 @@ impl Client {
                     RestError::Api(inner) => {
                         should_retry(inner.status_code, Some(inner.error.clone()))
                     }
-                    RestError::Http(inner) => should_retry(*inner, None),
+                    RestError::Http(status_code, _e) => should_retry(*status_code, None),
                     RestError::Bcs(_)
                     | RestError::Json(_)
                     | RestError::Timeout(_)
@@ -1166,6 +1166,6 @@ async fn parse_error(response: reqwest::Response) -> RestError {
     let maybe_state = parse_state_optional(&response);
     match response.json::<AptosError>().await {
         Ok(error) => (error, maybe_state, status_code).into(),
-        Err(_) => RestError::Http(status_code),
+        Err(e) => RestError::Http(status_code, e),
     }
 }

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -287,9 +287,9 @@ impl From<RestError> for ApiError {
             },
             RestError::Bcs(_) => ApiError::DeserializationFailed(None),
             RestError::Json(_) => ApiError::DeserializationFailed(None),
-            RestError::Http(err) => ApiError::InternalError(Some(format!(
-                "Failed internal API call with HTTP code {}",
-                err
+            RestError::Http(status_code, err) => ApiError::InternalError(Some(format!(
+                "Failed internal API call with HTTP code {}: {:#}",
+                status_code, err
             ))),
             RestError::UrlParse(err) => ApiError::InternalError(Some(err.to_string())),
             RestError::Timeout(err) => ApiError::InternalError(Some(err.to_string())),


### PR DESCRIPTION
## Description
Just using printing the error as we do now is not sufficient to get anything useful, since the `Http` error variant only contains the status code. https://github.com/aptos-labs/aptos-core/pull/4044 only made it print that status code, not anything too useful about the error itself. This changes it so it includes the full reqwest error. This is mostly a fix on the REST client moreso than the faucet itself.

## Test Plan
```
cd crates/aptos-faucet
cargo test
```

Old output:
```
Faucet account 8e0d19280063fa870fe4dbb85cc724091a398451c5c11e1e76e64cdc7b588510 not found: Http error 404 Not Found
```

New output:
```
Faucet account 8e0d19280063fa870fe4dbb85cc724091a398451c5c11e1e76e64cdc7b588510 not found: Http error 404 Not Found: error decoding response body: missing field `error_code` at line 1 column 34"
```

This is a contrived example from the tests, which don't return a proper response, hence the deserialization error. This isn't a problem with the actual faucet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4043)
<!-- Reviewable:end -->
