### PR TITLE
[community] global announcement banner update - Aptos:Zero NFT

### DIFF
--- a/ecosystem/platform/server/app/components/global_announcement_component.html.erb
+++ b/ecosystem/platform/server/app/components/global_announcement_component.html.erb
@@ -1,14 +1,14 @@
 <%= content_tag :div, **@rest do %>
     <div class="flex items-center mx-auto">
       <div class="flex items-center gap-2 md:gap-4 text-xs sm:text-sm md:text-medium text-teal-900">
-        <%= render ButtonComponent.new(href: it3_path, title: 'Register Node for AIT-3', size: :tiny, scheme: :primary, class: 'hidden md:block bg-neutral-900 hover:bg-teal-800 text-teal-400') do %>
-          AIT-3
+        <%= render ButtonComponent.new(href: nft_offer_path('aptos-zero'), title: 'Claim your Aptos Testnet NFT', size: :tiny, scheme: :primary, class: 'hidden md:block bg-neutral-900 hover:bg-teal-800 text-teal-400') do %>
+          APTOS:ZERO
         <% end %>
         <p class="block">
-          Aptos Incentivized Testnet 3 is Live!
+          Claim your Aptos Testnet NFT
         </p>
-        <%= render ButtonComponent.new(href: incentivized_testnet_path, title: 'Learn more about Aptos Incentivized Testnet', scheme: :tertiary, class: '!p-0 flex items-center gap-1 capitalize text-teal-900 font-sans hover:text-teal-900/75 text-xs sm:text-sm md:text-medium', size: :small) do %>
-          Learn More
+        <%= render ButtonComponent.new(href: nft_offer_path('aptos-zero'), title: 'Claim your Aptos Testnet NFT', scheme: :tertiary, class: '!p-0 flex items-center gap-1 capitalize text-teal-900 font-sans hover:text-teal-900/75 text-xs sm:text-sm md:text-medium', size: :small) do %>
+          Go
           <span class="text-sm sm:text-lg leading-none">&rarr;</span>
         <% end %>
       </div>

--- a/ecosystem/platform/server/app/views/nft_offers/show.html.erb
+++ b/ecosystem/platform/server/app/views/nft_offers/show.html.erb
@@ -3,6 +3,9 @@
 <% content_for(:meta) do %>
   <meta property="og:image" content="<%= image_url('meta/aptos_meta_og_nft-aptos-zero.jpg') %>">
 <% end %>
+
+<style type="text/css">#global-announcement { display: none }</style>
+
 <div class="bg-neutral-900 text-neutral-100 h-full">
   <div class="max-w-screen-2xl mx-auto px-6 pb-24">
     <section class="py-12 lg:py-32">

--- a/ecosystem/platform/server/app/views/static_page/incentivized_testnet.html.erb
+++ b/ecosystem/platform/server/app/views/static_page/incentivized_testnet.html.erb
@@ -4,8 +4,6 @@
   <meta property="og:image" content="https://aptoslabs.com/images/meta/aptos_meta_og_ait3.jpg">
 <% end %>
 
-<style type="text/css">#global-announcement { display: none }</style>
-
 <div class="bg-neutral-900 text-neutral-50 h-full">
   <div class="max-w-screen-2xl mx-auto px-6 pb-24">
     <section class="py-12 lg:py-32">


### PR DESCRIPTION
### Description

Global announcement banner for Aptos:Zero NFT

### Test Plan

Ensure global announcement banner is displayed on pages other than Aptos:Zero NFT
<img width="1770" alt="image" src="https://user-images.githubusercontent.com/98909677/189438852-70280417-f891-4e97-a76f-efe743978bc0.png">



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4047)
<!-- Reviewable:end -->
