### PR TITLE
Correct doc comment typo in `BigVector`

### DIFF
--- a/aptos-move/move-examples/data_structures/sources/big_vector.move
+++ b/aptos-move/move-examples/data_structures/sources/big_vector.move
@@ -190,7 +190,7 @@ module aptos_std::big_vector {
         }
     }
 
-    /// Reserver `additional_buckets` more buckets.
+    /// Reserve `additional_buckets` more buckets.
     public fun reserve<T>(v: &mut BigVector<T>, additional_buckets: u64) {
         while (additional_buckets > 0) {
             table_with_length::add(&mut v.buckets, v.num_buckets, vector::empty());


### PR DESCRIPTION
Tagging @davidiw who added this file in its previous commit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4051)
<!-- Reviewable:end -->
