### PR TITLE
[mempool] remove sequence_number_cache and instead store directly in transaction_store

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -23,7 +23,6 @@ use aptos_types::{
     transaction::SignedTransaction,
 };
 use std::{
-    cmp::max,
     collections::HashSet,
     time::{Duration, SystemTime},
 };
@@ -32,7 +31,6 @@ pub struct Mempool {
     // Stores the metadata of all transactions in mempool (of all states).
     transactions: TransactionStore,
 
-    sequence_number_cache: TtlCache<AccountAddress, u64>,
     // For each transaction, an entry with a timestamp is added when the transaction enters mempool.
     // This is used to measure e2e latency of transactions in the system, as well as the time it
     // takes to pick it up by consensus.
@@ -44,8 +42,7 @@ impl Mempool {
     pub fn new(config: &NodeConfig) -> Self {
         Mempool {
             transactions: TransactionStore::new(&config.mempool),
-            sequence_number_cache: TtlCache::new(config.mempool.capacity, Duration::from_secs(100)),
-            metrics_cache: TtlCache::new(config.mempool.capacity, Duration::from_secs(100)),
+            metrics_cache: TtlCache::new(config.mempool.capacity),
             system_transaction_timeout: Duration::from_secs(
                 config.mempool.system_transaction_timeout_secs,
             ),
@@ -71,39 +68,8 @@ impl Mempool {
         self.log_latency(*sender, sequence_number, metric_label);
         self.metrics_cache.remove(&(*sender, sequence_number));
 
-        let current_seq_number = self
-            .sequence_number_cache
-            .remove(sender)
-            .unwrap_or_default();
-
-        if is_rejected {
-            if sequence_number >= current_seq_number {
-                self.transactions
-                    .reject_transaction(sender, sequence_number);
-            }
-        } else {
-            let new_seq_number = max(current_seq_number, sequence_number + 1);
-            self.sequence_number_cache.insert(*sender, new_seq_number);
-
-            let new_seq_number = if let Some(mempool_transaction) =
-                self.transactions.get_mempool_txn(sender, sequence_number)
-            {
-                match mempool_transaction
-                    .sequence_info
-                    .account_sequence_number_type
-                {
-                    AccountSequenceInfo::Sequential(_) => {
-                        AccountSequenceInfo::Sequential(new_seq_number)
-                    }
-                }
-            } else {
-                AccountSequenceInfo::Sequential(new_seq_number)
-            };
-            // update current cached sequence number for account
-            self.sequence_number_cache
-                .insert(*sender, new_seq_number.min_seq());
-            self.transactions.commit_transaction(sender, new_seq_number);
-        }
+        self.transactions
+            .remove(sender, sequence_number, is_rejected);
     }
 
     fn log_latency(&self, account: AccountAddress, sequence_number: u64, metric: &str) {
@@ -135,29 +101,25 @@ impl Mempool {
                 .txns(TxnsLog::new_txn(txn.sender(), txn.sequence_number())),
             committed_seq_number = db_sequence_number
         );
-        let cached_value = self.sequence_number_cache.get(&txn.sender());
-        let sequence_number = match sequence_info {
-            AccountSequenceInfo::Sequential(_) => AccountSequenceInfo::Sequential(
-                cached_value.map_or(db_sequence_number, |value| max(*value, db_sequence_number)),
-            ),
-        };
-        self.sequence_number_cache
-            .insert(txn.sender(), sequence_number.min_seq());
 
         // don't accept old transactions (e.g. seq is less than account's current seq_number)
-        if txn.sequence_number() < sequence_number.min_seq() {
+        if txn.sequence_number() < db_sequence_number {
             return MempoolStatus::new(MempoolStatusCode::InvalidSeqNumber).with_message(format!(
                 "transaction sequence number is {}, current sequence number is  {}",
                 txn.sequence_number(),
-                sequence_number.min_seq(),
+                db_sequence_number,
             ));
         }
 
         let expiration_time =
             aptos_infallible::duration_since_epoch() + self.system_transaction_timeout;
+
         if timeline_state != TimelineState::NonQualified {
-            self.metrics_cache
-                .insert((txn.sender(), txn.sequence_number()), SystemTime::now());
+            self.metrics_cache.insert(
+                (txn.sender(), txn.sequence_number()),
+                SystemTime::now(),
+                expiration_time,
+            );
         }
 
         let txn_info = MempoolTransaction::new(
@@ -165,7 +127,7 @@ impl Mempool {
             expiration_time,
             ranking_score,
             timeline_state,
-            sequence_number,
+            AccountSequenceInfo::Sequential(db_sequence_number),
         );
 
         self.transactions.insert(txn_info)
@@ -200,7 +162,7 @@ impl Mempool {
                 continue;
             }
             let tx_seq = txn.sequence_number.transaction_sequence_number;
-            let account_sequence_number = self.sequence_number_cache.get(&txn.address);
+            let account_sequence_number = self.transactions.get_sequence_number(&txn.address);
             let seen_previous = tx_seq > 0 && seen.contains(&(txn.address, tx_seq - 1));
             // include transaction if it's "next" for given account or
             // we've already sent its ancestor to Consensus.
@@ -263,10 +225,9 @@ impl Mempool {
     /// Removes all expired transactions and clears expired entries in metrics
     /// cache and sequence number cache.
     pub(crate) fn gc(&mut self) {
-        let now = SystemTime::now();
-        self.transactions.gc_by_system_ttl(&self.metrics_cache);
+        let now = aptos_infallible::duration_since_epoch();
+        self.transactions.gc_by_system_ttl(&self.metrics_cache, now);
         self.metrics_cache.gc(now);
-        self.sequence_number_cache.gc(now);
     }
 
     /// Garbage collection based on client-specified expiration time.

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -128,7 +128,7 @@ impl TransactionStore {
         sequence_number: u64,
         is_rejected: bool,
     ) {
-        let current_seq_number = self.sequence_numbers.get(sender).map_or(0, |v| *v);
+        let current_seq_number = self.get_sequence_number(sender).map_or(0, |v| *v);
         if is_rejected {
             if sequence_number >= current_seq_number {
                 self.reject_transaction(sender, sequence_number);


### PR DESCRIPTION
### Description

There were two issues previously:
1. An account's sequence_number_cache could get GC'd before its transactions in mempool were sent to consensus. In this case because a cached sequence number does not exist, the transactions are never sent to consensus (get_batch checks the sequence number).
2. The sequence_number_cache capacity is the same as the mempool, but it could have grown beyond this because sequence_number_cache entries are retained for accounts after transaction removal (until they expire). In this case old sequence_number_cache entries are removed and those transactions may never be sent to consensus (same reason as above).

There doesn't seem to be a need for a separate sequence_number_cache at all. When transactions are submitted to mempool, the latest account sequence number from state db is passed in. The argument is that this sequence number should never be stale compared to notifications coming in to  mempool, as state db will be updated before notifications.

Thus we remove the problematic cache and simply store in the transaction_store. If there are no more transactions, the value is removed (same as the main transaction hashmap after #4041

### Test Plan

Add test for case 2 that would fail in main. Otherwise rely on existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4053)
<!-- Reviewable:end -->
