### PR TITLE
[community] Relax wallet uniqueness constraint to include wallet name.

### DIFF
--- a/ecosystem/platform/server/app/components/claim_nft_button_component.html.erb
+++ b/ecosystem/platform/server/app/components/claim_nft_button_component.html.erb
@@ -2,7 +2,7 @@
   <p class="text-red-400 hidden mb-8" data-claim-nft-target="transactionFailedError">
   NFT minting failed. Please ensure that your account has sufficient tokens to perform the transaction and try again.
   </p>
-  <%= render ButtonComponent.new(href: nft_offer_path(@nft_offer, wallet: @wallet.public_key), data: { action: 'claim-nft#handleClick' }, **@rest) do %>
+  <%= render ButtonComponent.new(href: nft_offer_path(@nft_offer, wallet: @wallet.public_key, wallet_name: @wallet.wallet_name), data: { action: 'claim-nft#handleClick' }, **@rest) do %>
     <% if content %>
       <%= content %>
     <% else %>

--- a/ecosystem/platform/server/app/controllers/nft_offers_controller.rb
+++ b/ecosystem/platform/server/app/controllers/nft_offers_controller.rb
@@ -43,7 +43,13 @@ class NftOffersController < ApplicationController
 
   def update
     @nft_offer = NftOffer.find_by(slug: params[:slug])
-    @wallet = current_user.wallets.find_by(network: @nft_offer.network, public_key: params[:wallet])
+    @wallet = current_user.wallets.find_by(
+      network: @nft_offer.network,
+      public_key: params[:wallet],
+      wallet_name: params[:wallet_name]
+    )
+
+    return render json: { error: 'wallet_not_found' } if @wallet.nil?
 
     result = NftClaimer.new.claim_nft(
       nft_offer: @nft_offer,

--- a/ecosystem/platform/server/app/models/wallet.rb
+++ b/ecosystem/platform/server/app/models/wallet.rb
@@ -13,7 +13,8 @@ class Wallet < ApplicationRecord
 
   validates :network, presence: true, inclusion: { in: VALID_NETWORKS }
   validates :wallet_name, presence: true, inclusion: { in: VALID_WALLET_NAMES }
-  validates :public_key, presence: true, uniqueness: { scope: :network }, format: { with: /\A0x[a-f0-9]{64}\z/ }
+  validates :public_key, presence: true, uniqueness: { scope: %i[network wallet_name] },
+                         format: { with: /\A0x[a-f0-9]{64}\z/ }
 
   validates :challenge, presence: true, format: { with: /\A[0-9]{24}\z/ }
   validates :signed_challenge, presence: true, format: { with: /\A0x[a-f0-9]{128}\z/ }

--- a/ecosystem/platform/server/db/migrate/20220910032621_adjust_wallet_uniqueness.rb
+++ b/ecosystem/platform/server/db/migrate/20220910032621_adjust_wallet_uniqueness.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+class AdjustWalletUniqueness < ActiveRecord::Migration[7.0]
+  def change
+    add_index :wallets, %i[public_key network wallet_name], unique: true
+    remove_index :wallets, name: 'index_wallets_on_public_key_and_network'
+  end
+end

--- a/ecosystem/platform/server/db/schema.rb
+++ b/ecosystem/platform/server/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_06_031531) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_10_032621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -415,7 +415,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_06_031531) do
     t.string "address", null: false, comment: "The account address."
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["public_key", "network"], name: "index_wallets_on_public_key_and_network", unique: true
+    t.index ["public_key", "network", "wallet_name"], name: "index_wallets_on_public_key_and_network_and_wallet_name", unique: true
     t.index ["user_id"], name: "index_wallets_on_user_id"
     t.check_constraint "public_key::text ~ '^0x[0-9a-f]{64}$'::text"
   end

--- a/ecosystem/platform/server/test/services/wallet_creator_test.rb
+++ b/ecosystem/platform/server/test/services/wallet_creator_test.rb
@@ -34,4 +34,25 @@ class WalletCreatorTest < ActiveSupport::TestCase
       refute result.created?
     end
   end
+
+  test 'wallets with the same address but different wallet_name can be created' do
+    signing_key = Ed25519::SigningKey.generate
+
+    verify_key = signing_key.verify_key
+    public_key = "0x#{verify_key.to_bytes.unpack1('H*')}"
+    challenge = '1' * 24
+    message = WalletCreator.new.send(:verify_wallet_message, challenge)
+    signed_challenge = "0x#{signing_key.sign(message).unpack1('H*')}"
+
+    petra_wallet = FactoryBot.build(:wallet, wallet_name: 'petra', public_key:, challenge:, signed_challenge:)
+    martian_wallet = FactoryBot.build(:wallet, wallet_name: 'martian', public_key:, challenge:, signed_challenge:)
+
+    assert_difference('Wallet.count', 2) do
+      result = WalletCreator.new.create_wallet(wallet: petra_wallet)
+      assert result.created?
+
+      result = WalletCreator.new.create_wallet(wallet: martian_wallet)
+      assert result.created?
+    end
+  end
 end


### PR DESCRIPTION
### Description

Makes it possible to have the same account in multiple wallets.

### Test Plan
Manual + automated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4064)
<!-- Reviewable:end -->
