### PR TITLE
[Community] Add coin::unfreeze_coin_store function to coin module

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -806,11 +806,11 @@ module aptos_framework::coin {
     }
 
     #[test(account = @0x1)]
-    public entry fun deposit_and_widthdraw_unfrozen(account: signer) acquires CoinInfo, CoinStore {
+    public entry fun deposit_widthdraw_unfrozen(account: signer) acquires CoinInfo, CoinStore {
         let account_addr = signer::address_of(&account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
-        
+
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         freeze_coin_store(account_addr, &freeze_cap);
         unfreeze_coin_store(account_addr, &freeze_cap);

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -271,7 +271,16 @@ module aptos_framework::coin {
         _freeze_cap: &FreezeCapability<CoinType>,
     ) acquires CoinStore {
         let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
-        coin_store.frozen = true
+        coin_store.frozen = true;
+    }
+
+    /// Unfreeze a CoinStore to allow transfers
+    public entry fun unfreeze_coin_store<CoinType>(
+        account_addr: address,
+        _freeze_cap: &FreezeCapability<CoinType>,
+    ) acquires CoinStore {
+        let coin_store = borrow_global_mut<CoinStore<CoinType>>(account_addr);
+        coin_store.frozen = false;
     }
 
     /// Upgrade total supply to use a parallelizable implementation if it is
@@ -762,14 +771,14 @@ module aptos_framework::coin {
 
     #[test(account = @0x1)]
     #[expected_failure(abort_code = 0x5000A)]
-    public entry fun withdraw_frozen(account: signer) acquires CoinStore {
+    public entry fun withdraw_frozen(account: signer) acquires CoinInfo, CoinStore {
         let account_addr = signer::address_of(&account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
 
         freeze_coin_store(account_addr, &freeze_cap);
         let coin = withdraw<FakeMoney>(&account, 10);
-        deposit(account_addr, coin);
+        burn(coin, &burn_cap);
 
         move_to(&account, FakeMoneyCapabilities {
             burn_cap,
@@ -788,6 +797,29 @@ module aptos_framework::coin {
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         freeze_coin_store(account_addr, &freeze_cap);
         deposit(account_addr, coins_minted);
+
+        move_to(&account, FakeMoneyCapabilities {
+            burn_cap,
+            freeze_cap,
+            mint_cap,
+        });
+    }
+
+    #[test(account = @0x1)]
+    public entry fun deposit_and_widthdraw_unfrozen(account: signer) acquires CoinInfo, CoinStore {
+        let account_addr = signer::address_of(&account);
+        account::create_account_for_test(account_addr);
+        let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
+        
+        let coins_minted = mint<FakeMoney>(100, &mint_cap);
+        freeze_coin_store(account_addr, &freeze_cap);
+        unfreeze_coin_store(account_addr, &freeze_cap);
+        deposit(account_addr, coins_minted);
+
+        freeze_coin_store(account_addr, &freeze_cap);
+        unfreeze_coin_store(account_addr, &freeze_cap);
+        let coin = withdraw<FakeMoney>(&account, 10);
+        burn(coin, &burn_cap);
 
         move_to(&account, FakeMoneyCapabilities {
             burn_cap,

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -36,7 +36,8 @@ module aptos_framework::reconfiguration {
         events: event::EventHandle<NewEpochEvent>,
     }
 
-    /// Reconfiguration disabled if this resource occurs under LibraRoot.
+    /// Reconfiguration will be disabled if this resource is published under the 
+    /// aptos_framework system address
     struct DisableReconfiguration has key {}
 
     /// The `Configuration` resource is in an invalid state

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -36,7 +36,7 @@ module aptos_framework::reconfiguration {
         events: event::EventHandle<NewEpochEvent>,
     }
 
-    /// Reconfiguration will be disabled if this resource is published under the 
+    /// Reconfiguration will be disabled if this resource is published under the
     /// aptos_framework system address
     struct DisableReconfiguration has key {}
 


### PR DESCRIPTION
### Description
Coin can now be unfrozen. I preferred the term 'unfreeze' to 'thaw' (like on Solana) because I thought it was simpler, but either function name works for me.

### Test Plan
I added a unit test in the coin.move module.

closes #3850

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4065)
<!-- Reviewable:end -->
