### PR TITLE
Add optimized big vector functionality, helpers

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -28,7 +28,7 @@ module aptos_std::type_info {
     /// reference to a quasi-null instance of fixed-size `T`,
     /// `fixed_size_type_null_ref`.
     ///
-    /// Analagous to `sizeof()` in C.
+    /// Analogous to `sizeof()` in C.
     ///
     /// Ideally this function would be implemented as a native function
     /// of the form `public native fun size_of<T>(): u64;`, such that

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -1,5 +1,7 @@
 module aptos_std::type_info {
+    use std::bcs;
     use std::string;
+    use std::vector;
 
     struct TypeInfo has copy, drop, store {
         account_address: address,
@@ -21,6 +23,32 @@ module aptos_std::type_info {
 
     public native fun type_of<T>(): TypeInfo;
     public native fun type_name<T>(): string::String;
+
+    /// Return the size, in bytes, of a `T`, provided an immutable
+    /// reference to a quasi-null instance of fixed-size `T`,
+    /// `fixed_size_type_null_ref`.
+    ///
+    /// Analagous to `sizeof()` in C.
+    ///
+    /// Ideally this function would be implemented as a native function
+    /// of the form `public native fun size_of<T>(): u64;`, such that
+    /// callers do not need to concoct quasi-null instances, e.g.
+    /// `false` for `T` as a `bool`, `0` for `T` as a `u8`, or `@0x0`
+    /// for `T` as an `address`.
+    ///
+    /// Does not actually enfore that `T` is a fixed-size type, which
+    /// would require determining whether or not vectors are nested
+    /// within, for example.
+    ///
+    /// See `test_size_of()` for an analysis of common types and nesting
+    /// patterns, as well as `test_size_of_vectors()` for an analysis of
+    /// vector base size dynamism.
+    public fun size_of<T>(
+        fixed_size_type_null_ref: &T
+    ): u64 {
+        // Return vector length of vectorized bytes representation
+        vector::length(&bcs::to_bytes(fixed_size_type_null_ref))
+    }
 
     #[test]
     fun test() {
@@ -56,4 +84,173 @@ module aptos_std::type_info {
             >
         >() == string::utf8(b"0x1::table::Table<0x1::type_info::TypeInfo, 0x1::table::Table<u8, vector<0x1::type_info::TypeInfo>>>"), 10);
     }
+
+    #[test_only]
+    struct CustomType has drop {}
+
+    #[test_only]
+    struct SimpleStruct has copy, drop {
+        field: u8
+    }
+
+    #[test_only]
+    struct ComplexStruct<T> has copy, drop {
+        field_1: bool,
+        field_2: u8,
+        field_3: u64,
+        field_4: u128,
+        field_5: SimpleStruct,
+        field_6: T
+    }
+
+    #[test_only]
+    struct TwoBools has drop {
+        bool_1: bool,
+        bool_2: bool
+    }
+
+    #[test_only]
+    use std::option;
+
+    #[test(account = @0x0)]
+    /// Ensure valid returns across native types and nesting schemas
+    fun test_size_of(
+        account: &signer
+    ) {
+        assert!(size_of(&false) == 1, 0); // Bool takes 1 byte
+        assert!(size_of<u8>(&0) == 1, 0); // u8 takes 1 byte
+        assert!(size_of<u64>(&0) == 8, 0); // u64 takes 8 bytes
+        assert!(size_of<u128>(&0) == 16, 0); // u128 takes 16 bytes
+        // Address is stored as a u256
+        assert!(size_of(&@0x0) == 32, 0);
+        assert!(size_of(account) == 32, 0); // Signer is an address
+        // Assert custom type without fields has size 1
+        assert!(size_of(&CustomType{}) == 1, 0);
+        // Declare a simple struct with a 1-byte field
+        let simple_struct = SimpleStruct{field: 0};
+        // Assert size is indicated as 1 byte
+        assert!(size_of(&simple_struct) == 1, 0);
+        let complex_struct = ComplexStruct<u128>{
+            field_1: false,
+            field_2: 0,
+            field_3: 0,
+            field_4: 0,
+            field_5: simple_struct,
+            field_6: 0
+        }; // Declare a complex struct with another nested inside
+        // Assert size is bytewise sum of components
+        assert!(size_of(&complex_struct) == (1 + 1 + 8 + 16 + 1 + 16), 0);
+        // Declare a struct with two boolean values
+        let two_bools = TwoBools{bool_1: false, bool_2: false};
+        // Assert size is two bytes
+        assert!(size_of(&two_bools) == 2, 0);
+        // Declare an empty vector of element type u64
+        let empty_vector_u64 = vector::empty<u64>();
+        // Declare an empty vector of element type u128
+        let empty_vector_u128 = vector::empty<u128>();
+        // Assert size is 1 byte regardless of underlying element type
+        assert!(size_of(&empty_vector_u64) == 1, 0);
+        // Assert size is 1 byte regardless of underlying element type
+        assert!(size_of(&empty_vector_u128) == 1, 0);
+        // Declare a bool in a vector
+        let bool_vector = vector::singleton(false);
+        // Push back another bool
+        vector::push_back(&mut bool_vector, false);
+        // Assert size is 3 bytes (1 per element, 1 for the base vector)
+        assert!(size_of(&bool_vector) == 3, 0);
+        // Get a some option, which is implemented as a vector
+        let u64_option = option::some(0);
+        // Assert size is 9 bytes (8 per element, 1 for the base vector)
+        assert!(size_of(&u64_option) == 9, 0);
+        option::extract(&mut u64_option); // Remove the value inside
+        // Assert size reduces to 1 byte
+        assert!(size_of(&u64_option) == 1, 0);
+    }
+
+    #[test]
+    /// Verify returns for base vector size at different lengths, with
+    /// different underlying fixed-size elements.
+    ///
+    /// For a vector of length n containing fixed-size elements, the
+    /// size of the vector is b + n * s bytes, where s is the size of an
+    /// element in bytes, and b is a "base size" in bytes that varies
+    /// with n. Per below, b is established as follows:
+    /// * b = 1, n < 128
+    /// * b = 2, 128 <= n < 16384
+    /// * b = 3, 16384 <= n < ?
+    /// ...
+    fun test_size_of_vectors() {
+        let vector_u64 = vector::empty<u64>(); // Declare empty vector
+        let null_element = 0; // Declare a null element
+        let element_size = size_of(&null_element); // Get element size
+        // Vector size is 1 byte when length is 0
+        assert!(size_of(&vector_u64) == 1, 0);
+        let i = 0; // Declare loop counter
+        while (i < 127) { // For 127 iterations
+            // Add an element
+            vector::push_back(&mut vector_u64, null_element);
+            i = i + 1; // Increment counter
+        };
+        // Vector base size is still 1 byte (127 elements)
+        assert!(size_of(&vector_u64) - element_size * i == 1, 0);
+        // Add a 128th element
+        vector::push_back(&mut vector_u64, null_element);
+        i = i + 1; // Increment counter
+        // Vector base size is now 2 bytes
+        assert!(size_of(&vector_u64) - element_size * i == 2, 0);
+        // Repeat until (2 ^ 16 / 4 - 1) elements in vector
+        while (i < 16383) {
+            // Add an element
+            vector::push_back(&mut vector_u64, null_element);
+            i = i + 1; // Increment counter
+        };
+        // Vector base size is still 2 bytes
+        assert!(size_of(&vector_u64) - element_size * i == 2, 0);
+        // Add 16384th element
+        vector::push_back(&mut vector_u64, null_element);
+        i = i + 1; // Increment counter
+        // Vector base size is now 3 bytes
+        assert!(size_of(&vector_u64) - element_size * i == 3, 0);
+        // Repeat for custom struct
+        let vector_complex = vector::empty<ComplexStruct<address>>();
+        // Declare a null element
+        let null_element = ComplexStruct{
+            field_1: false,
+            field_2: 0,
+            field_3: 0,
+            field_4: 0,
+            field_5: SimpleStruct{field: 0},
+            field_6: @0x0
+        };
+        element_size = size_of(&null_element); // Get element size
+        // Vector size is 1 byte when length is 0
+        assert!(size_of(&vector_complex) == 1, 0);
+        i = 0; // Re-initialize loop counter
+        while (i < 127) { // For 127 iterations
+            // Add an element
+            vector::push_back(&mut vector_complex, copy null_element);
+            i = i + 1; // Increment counter
+        };
+        // Vector base size is still 1 byte (127 elements)
+        assert!(size_of(&vector_complex) - element_size * i == 1, 0);
+        // Add a 128th element
+        vector::push_back(&mut vector_complex, null_element);
+        i = i + 1; // Increment counter
+        // Vector base size is now 2 bytes
+        assert!(size_of(&vector_complex) - element_size * i == 2, 0);
+        // Repeat until (2 ^ 16 / 4 - 1) elements in vector
+        while (i < 16383) {
+            // Add an element
+            vector::push_back(&mut vector_complex, copy null_element);
+            i = i + 1; // Increment counter
+        };
+        // Vector base size is still 2 bytes
+        assert!(size_of(&vector_complex) - element_size * i == 2, 0);
+        // Add 16384th element
+        vector::push_back(&mut vector_complex, null_element);
+        i = i + 1; // Increment counter
+        // Vector base size is now 3 bytes
+        assert!(size_of(&vector_complex) - element_size * i == 3, 0);
+    }
+
 }

--- a/aptos-move/move-examples/data_structures/sources/big_vector.move
+++ b/aptos-move/move-examples/data_structures/sources/big_vector.move
@@ -2,6 +2,7 @@ module aptos_std::big_vector {
     use std::error;
     use std::vector;
     use aptos_std::table_with_length::{Self, TableWithLength};
+    use aptos_std::type_info;
 
     /// Vector index is out of bounds
     const EINDEX_OUT_OF_BOUNDS: u64 = 1;
@@ -9,6 +10,28 @@ module aptos_std::big_vector {
     const EOUT_OF_CAPACITY: u64 = 2;
     /// Cannot destroy a non-empty vector
     const EVECTOR_NOT_EMPTY: u64 = 3;
+    /// The given fixed-size type can not fit in an optimized vector
+    const E_TOO_BIG_TO_OPTIMIZE: u64 = 4;
+
+    /// Optimal sector size, in bytes. Each bucket is stored as a
+    /// vector, which is serialized and stored on disk as a binary large
+    /// object (BLOB). Per the International Disk Drive Equipment and
+    /// Materials Association (IDEMA) Advanced Format (AF) standard
+    /// instituted circa 2010, newer machines are likely to implement a
+    /// 4096-byte (4K) disk sector size. Hence buckets size is matched
+    /// to this figure for optimized read/write performance.
+    const OPTIMAL_BLOB_SIZE: u64 = 4096;
+    /// Per `aptos_std::type_info`, a vector containing n fixed-width
+    /// elements, each of size s, has a size of n * s + 1 bytes, when
+    /// n is less than 128.
+    const VECTOR_BASE_SIZE_SMALL: u64 = 1;
+    /// Per `aptos_std::type_info`, a vector containing n fixed-width
+    /// elements, each of size s, has a size of n * s + 2 bytes, when
+    /// 128 <= n < 16384
+    const VECTOR_BASE_SIZE_LARGE: u64 = 2;
+    /// Per `aptos_std::type_info`, the base size of a vector
+    /// increases to 2 bytes when the 127th element is added
+    const VECTOR_BASE_SIZE_LENGTH_CUTOFF: u64 = 127;
 
     /// Index of the value in the buckets.
     struct BigVectorIndex has copy, drop, store {
@@ -45,6 +68,53 @@ module aptos_std::big_vector {
         let v = new(bucket_size);
         reserve(&mut v, num_buckets);
         v
+    }
+
+    /// Create a new optimized vector, provided a reference to a
+    /// quasi-null instance of fixed-size element type `T`. See inner
+    /// function `get_optimized_bucket_size()`.
+    public fun new_optimized<T: store>(
+        fixed_size_type_null_ref: &T
+    ): BigVector<T> {
+        // Return optimized vector
+        new(get_optimal_bucket_size(fixed_size_type_null_ref))
+    }
+
+    /// Create an empty optimized vector with `num_buckets`, provided a
+    /// reference to a quasi-null instance of fixed-size element type
+    /// `T`. See inner function `get_optimized_bucket_size()`.
+    public fun new_with_capacity_optimized<T: store>(
+        fixed_size_type_null_ref: &T,
+        num_buckets: u64
+    ): BigVector<T> {
+        // Return new optimized vector with specified number of buckets
+        new_with_capacity(
+            get_optimal_bucket_size(fixed_size_type_null_ref), num_buckets)
+    }
+
+    /// Return a singleton optimized vector containing `element`.
+    public fun singleton_optimized<T: store>(
+        element: T
+    ): BigVector<T> {
+        // Create new empty optimized vector
+        let vector_optimized = new_optimized(&element);
+        // Insert element
+        push_back(&mut vector_optimized, element);
+        vector_optimized // Return optimized singleton
+    }
+
+    /// Return a singleton optimized vector containing `element`, with
+    /// `num_buckets` reserved.
+    public fun singleton_with_capacity_optimized<T: store>(
+        element: T,
+        num_buckets: u64
+    ): BigVector<T> {
+        // Create new empty optimized vector with reserved buckets
+        let vector_optimized =
+            new_with_capacity_optimized(&element, num_buckets);
+        // Insert element
+        push_back(&mut vector_optimized, element);
+        vector_optimized // Return optimized singleton
     }
 
     /// Destroy the vector `v`.
@@ -93,10 +163,45 @@ module aptos_std::big_vector {
         vector::borrow(table_with_length::borrow(&v.buckets, index.bucket_index), index.vec_index)
     }
 
+    /// Like `borrow()`, but accepts a `simple_index` corresponding the
+    /// `i`th element of the entire `BigVector` indicated by `v`.
+    ///
+    /// Ideally a reference to the internally calculated
+    /// `BigVectorIndex` would be simply passed to `borrow()`, but this
+    /// approach violates the borrow checker. Hence the corresponding
+    /// internal vector borrow is re-implemented per below.
+    public fun borrow_simple<T>(
+        v: &BigVector<T>,
+        simple_index: u64
+    ): &T {
+        // Get big vector index
+        let big_vector_index = bucket_index(v, simple_index);
+        vector::borrow( // Immutably borrow corresponding element
+            table_with_length::borrow(
+                &v.buckets,
+                big_vector_index.bucket_index
+            ),
+            big_vector_index.vec_index
+        )
+    }
+
     /// Return a mutable reference to the `i`th element in the vector `v`.
     /// Aborts if `i` is out of bounds.
     public fun borrow_mut<T>(v: &mut BigVector<T>, index: &BigVectorIndex): &mut T {
         vector::borrow_mut(table_with_length::borrow_mut(&mut v.buckets, index.bucket_index), index.vec_index)
+    }
+
+    /// Wrapped version of `borrow_mut()`, accepting a `simple_index`
+    /// corresponding to the `i`th element of the entire `BigVector`
+    /// indicated by `v`.
+    public fun borrow_simple_mut<T>(
+        v: &mut BigVector<T>,
+        simple_index: u64
+    ): &mut T {
+        // Get big vector index
+        let big_vector_index = bucket_index(v, simple_index);
+        // Mutably borrow corresponding element
+        borrow_mut(v, &big_vector_index)
     }
 
     /// Return the length of the vector.
@@ -126,6 +231,19 @@ module aptos_std::big_vector {
         vector::push_back(bucket, last_val);
         vector::swap(bucket, index.vec_index, bucket_len - 1);
         val
+    }
+
+    /// Wrapped version of `swap_remove()`, accepting a `simple_index`
+    /// corresponding to the `i`th element of the entire `BigVector`
+    /// indicated by `v`.
+    public fun swap_remove_simple<T>(
+        v: &mut BigVector<T>,
+        simple_index: u64
+    ): T {
+        // Get big vector index
+        let big_vector_index = bucket_index(v, simple_index);
+        // Swap remove corresponding element
+        swap_remove(v, &big_vector_index)
     }
 
     /// Return true if `val` is in the vector `v`.
@@ -190,7 +308,7 @@ module aptos_std::big_vector {
         }
     }
 
-    /// Reserver `additional_buckets` more buckets.
+    /// Reserve `additional_buckets` more buckets.
     public fun reserve<T>(v: &mut BigVector<T>, additional_buckets: u64) {
         while (additional_buckets > 0) {
             table_with_length::add(&mut v.buckets, v.num_buckets, vector::empty());
@@ -211,6 +329,56 @@ module aptos_std::big_vector {
     fun buckets_required(end_index: &BigVectorIndex): u64 {
         let additional = if (end_index.vec_index == 0) { 0 } else { 1 };
         end_index.bucket_index + additional
+    }
+
+    /// Return the number of elements of fixed-size type `T` that can
+    /// fit into the optimal BLOB size, after allocating the necessary
+    /// base size for a bucket vector.
+    ///
+    /// The underlying value indicated by `fixed_size_type_null_ref` is
+    /// not required for calculations, and so it can be passed as a
+    /// quasi-null value, e.g. `&false` for `T` as a `bool`, `&0` for
+    /// `T` as a `u8`, and `&@0x0` for `T` as an `address`.
+    ///
+    /// Does not enforce that `T` actually has a fixed size, as the
+    /// underlying `type_info::size_of()` implementation is incapable of
+    /// such enforcement.
+    ///
+    /// See `test_get_optimal_bucket_size()` for examples.
+    fun get_optimal_bucket_size<T: store>(
+        fixed_size_type_null_ref: &T
+    ): u64 {
+        // Get element size, in bytes
+        let element_size = type_info::size_of(fixed_size_type_null_ref);
+        // Return optimal bucket size
+        get_optimal_bucket_size_from_element_size(element_size)
+    }
+
+    /// Inner function for `get_optimal_bucket_size()`, isolated for
+    /// simpler expected-failure unit testing. `element_size` is in
+    /// bytes.
+    fun get_optimal_bucket_size_from_element_size(
+        element_size: u64
+    ): u64 {
+        // Calculate the maximum element size for an optimized bucket
+        // when the underlying bucket vector only takes up one byte
+        // beyond the total size of the fixed-size elements within
+        let max_element_size_base_small =
+            (OPTIMAL_BLOB_SIZE - VECTOR_BASE_SIZE_SMALL) /
+                VECTOR_BASE_SIZE_LENGTH_CUTOFF;
+        // The base size of the bucket vector is the smaller base size
+        // when elements are larger than the cutoff, and the larger
+        // base size when elements are smaller than the cutoff
+        let vector_base_size = if (element_size > max_element_size_base_small)
+            VECTOR_BASE_SIZE_SMALL else VECTOR_BASE_SIZE_LARGE;
+        // Optimal bucket size is the number of elements that can fit
+        // into the optimal BLOB size, after allocating the necessary
+        // base size for the bucket vector
+        let bucket_size =
+            (OPTIMAL_BLOB_SIZE - vector_base_size) / element_size;
+        // Assert that at least one element can fit in an optimal bucket
+        assert!(bucket_size > 0, E_TOO_BIG_TO_OPTIMIZE);
+        bucket_size // Return optimal bucket size
     }
 
     #[test]
@@ -308,4 +476,139 @@ module aptos_std::big_vector {
         assert!(!contains<u64>(&v, &(1 as u64)), 0);
         destroy_empty(v);
     }
+
+    #[test]
+    #[expected_failure(abort_code = 4)]
+    /// Verify failure for an element that is too large
+    fun test_get_optimal_bucket_size_from_element_size() {
+        // Attempt invalid invocation with element that is 1 byte too
+        // large
+        get_optimal_bucket_size_from_element_size(OPTIMAL_BLOB_SIZE);
+    }
+
+    #[test]
+    /// Verify expected returns for assorted sizes
+    fun test_get_optimal_bucket_size() {
+        assert!(get_optimal_bucket_size_from_element_size(4095) == 1, 0);
+        assert!(get_optimal_bucket_size_from_element_size(1) == 4094, 0);
+        assert!(get_optimal_bucket_size(&false) == 4094, 0);
+        assert!(get_optimal_bucket_size<u8>(&0) == 4094, 0);
+        assert!(get_optimal_bucket_size_from_element_size(8) == 511, 0);
+        assert!(get_optimal_bucket_size<u64>(&0) == 511, 0);
+        assert!(get_optimal_bucket_size_from_element_size(16) == 255, 0);
+        assert!(get_optimal_bucket_size<u128>(&0) == 255, 0);
+        assert!(get_optimal_bucket_size_from_element_size(32) == 127, 0);
+        assert!(get_optimal_bucket_size(&@0x0) == 127, 0);
+        // Below cases exercise logic associated with the size length
+        // cutoff: at a vector base size of 1 byte, 4095 bytes are
+        // reserved for elements. 13 is a prime factor of 4095, such
+        // that 105 elements of size 39 can fit perfectly:
+        assert!(get_optimal_bucket_size_from_element_size(39) == 105, 0);
+        // The max element size while still having a vector base size of
+        // 1 byte is 32 bytes (after truncating division), hence
+        // elements with a size of 33 result in the lower vector base
+        // size
+        assert!(get_optimal_bucket_size_from_element_size(33) == 124, 0);
+        // An element size of 32 is the cutoff.
+        assert!(get_optimal_bucket_size_from_element_size(32) == 127, 0);
+        // An element size of 31 is just under the cutoff, hence there
+        // are only 4094 bytes reserved for elements, in which 132 may
+        // fit
+        assert!(get_optimal_bucket_size_from_element_size(31) == 132, 0);
+        // Here, 4094 bytes are reserved for elements, and 23 is a prime
+        // factor of 23. Hence 178 elements fit perfectly
+        assert!(get_optimal_bucket_size_from_element_size(23) == 178, 0);
+    }
+
+    #[test]
+    /// Verify expected initialization
+    fun test_new_optimized() {
+        // Declare empty vector for u128 elements
+        let empty_vector = new_optimized<u128>(&0);
+        // Assert expected bucket size
+        assert!(empty_vector.bucket_size == 255, 0);
+        destroy_empty(empty_vector); // Destroy empty vector
+    }
+
+    #[test_only]
+    struct TestStruct<T> has copy, drop, store {
+        field_1: u64,
+        field_2: T
+    }
+
+    #[test]
+    /// Verify expected initialization
+    fun test_new_with_capacity_optimized() {
+        let num_buckets = 25; // Declare number of buckets to init
+        // Declare empty vector for address elements
+        let empty_vector = new_with_capacity_optimized(&TestStruct{
+            field_1: 0, field_2: @0x0}, num_buckets);
+        // Calculate expected bucket size
+        let bucket_size_expected = (OPTIMAL_BLOB_SIZE - VECTOR_BASE_SIZE_SMALL)
+            / (8 + 32); // u64 is 8 bytes, address is 32
+        // Assert expected bucket size
+        assert!(empty_vector.bucket_size == bucket_size_expected, 0);
+        destroy_empty(empty_vector); // Destroy empty vector
+    }
+
+    #[test]
+    /// Verify expected initialization
+    fun test_singleton_optimized():
+    BigVector<u64> {
+        let element = 25; // Declare singleton element
+        // Declare empty vector for u128 elements
+        let singleton = singleton_optimized(element);
+        // Assert expected bucket size
+        assert!(singleton.bucket_size == 511, 0);
+        // Assert first element is as expected
+        assert!(*borrow_simple(&singleton, 0) == element, 0);
+        singleton // Return rather than unpack
+    }
+
+    #[test]
+    /// Verify expected initialization
+    fun test_singleton_with_capacity_optimized():
+    BigVector<TestStruct<bool>> {
+        // Declare singleton element
+        let element = TestStruct{field_1: 0, field_2: false};
+        let num_buckets = 35; // Declare number of buckets to init
+        // Declare empty vector with TestStruct of type bool
+        let singleton =
+            singleton_with_capacity_optimized(element, num_buckets);
+        // Calculate expected bucket size
+        let bucket_size_expected =
+            // u64 is 8 bytes, bool takes 1
+            (OPTIMAL_BLOB_SIZE - VECTOR_BASE_SIZE_LARGE) / (8 + 1);
+        // Assert expected bucket size
+        assert!(singleton.bucket_size == bucket_size_expected, 0);
+        // Assert first element is as expected
+        //assert!(*borrow_simple(&singleton, 0) == element, 0);
+        singleton // Return rather than unpack
+    }
+
+    #[test]
+    /// Verify expected mutations, state lookups, for functions that
+    /// accept simple indices
+    fun test_simple_index_operations() {
+        // Define element values
+        let (e_0, e_1, e_1_prime, e_2) = (1, 2, 3, 4);
+        // Create a singleton vector, then append additional elements
+        let big_vector = singleton_optimized<u8>(e_0);
+        push_back(&mut big_vector, e_1);
+        push_back(&mut big_vector, e_2);
+        // Assert element at index 1 pre-mutation
+        assert!(*borrow_simple(&big_vector, 1) == e_1, 0);
+        // Mutate element at index 1
+        *borrow_simple_mut(&mut big_vector, 1) = e_1_prime;
+        // Assert element at index 1 post-mutation
+        assert!(*borrow_simple(&big_vector, 1) == e_1_prime, 0);
+        // Swap remove element at index 0
+        assert!(swap_remove_simple(&mut big_vector, 0) == e_0, 0);
+        // Swap remove new element at index 0
+        assert!(swap_remove_simple(&mut big_vector, 0) == e_2, 0);
+        // Swap remove only remaining element
+        assert!(swap_remove_simple(&mut big_vector, 0) == e_1_prime, 0);
+        destroy_empty(big_vector) // Destroy empty vector
+    }
+
 }


### PR DESCRIPTION
* Adds a `size_of()` function analogous to `sizeof()` in C.
* Adds a 4K disk sector optimized implementation of `BigVector`.
* Adds simple index-based borrowers/swap remove for `BigVector`.
* Adds tests for all of the above, byte size analysis
* Addresses #3695 

Tagging @davidiw per #4051 , @gregnazario per recent discussion on vector size, @CapCap per recent discussion on struct field byte size, and @hariria , @lightmark , @wrwg , @zekun000, @runtian-zhou per #3695

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4067)
<!-- Reviewable:end -->
