### PR TITLE
[consensus] avoid broadcasting commit vote in happy path

### DIFF
--- a/consensus/src/block_storage/tracing.rs
+++ b/consensus/src/block_storage/tracing.rs
@@ -19,6 +19,7 @@ impl BlockStage {
     pub const QC_ADDED: &'static str = "qc_added";
     pub const ORDERED: &'static str = "ordered";
     pub const EXECUTED: &'static str = "executed";
+    pub const COMMIT_CERTIFIED: &'static str = "commit_certified";
     pub const COMMITTED: &'static str = "committed";
 }
 

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -218,6 +218,12 @@ impl NetworkSender {
         self.broadcast(msg).await
     }
 
+    pub async fn send_commit_vote(&mut self, commit_vote: CommitVote, recipient: Author) {
+        fail_point!("consensus::send::commit_vote", |_| ());
+        let msg = ConsensusMsg::CommitVoteMsg(Box::new(commit_vote));
+        self.send(msg, vec![recipient]).await
+    }
+
     /// Sends the vote to the chosen recipients (typically that would be the recipients that
     /// we believe could serve as proposers in the next round). The recipients on the receiving
     /// end are going to be notified about a new vote in the vote queue.
@@ -256,6 +262,12 @@ impl NetworkSender {
 
     pub fn author(&self) -> Author {
         self.author
+    }
+
+    pub async fn broadcast_commit_proof(&mut self, ledger_info: LedgerInfoWithSignatures) {
+        fail_point!("consensus::send::broadcast_commit_proof", |_| ());
+        let msg = ConsensusMsg::CommitDecisionMsg(Box::new(CommitDecision::new(ledger_info)));
+        self.broadcast(msg).await
     }
 }
 


### PR DESCRIPTION
In happy path, we now only send the commit vote to the block proposer (still broadcast if it's a NIL block).
On receiver side, if the node aggregates the decision and is the block proposer, it'll broadcast the decision.

We still rebroadcast if there's no progress within a time frame.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4076)
<!-- Reviewable:end -->
