### PR TITLE
Test helper for reconfiguration time

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -171,4 +171,17 @@ module aptos_framework::reconfiguration {
     public fun reconfigure_for_test() acquires Configuration {
         reconfigure();
     }
+
+    // This is used together with stake::end_epoch() for testing with last_reconfiguration_time
+    // It must be called each time an epoch changes
+    #[test_only]
+    public fun reconfigure_for_test_custom() acquires Configuration {
+        let config_ref = borrow_global_mut<Configuration>(@aptos_framework);
+        let current_time = timestamp::now_microseconds();
+        if (current_time == config_ref.last_reconfiguration_time) {
+            return
+        };
+        config_ref.last_reconfiguration_time = current_time;
+        config_ref.epoch = config_ref.epoch + 1;        
+    }
 }

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -182,6 +182,6 @@ module aptos_framework::reconfiguration {
             return
         };
         config_ref.last_reconfiguration_time = current_time;
-        config_ref.epoch = config_ref.epoch + 1;        
+        config_ref.epoch = config_ref.epoch + 1;
     }
 }


### PR DESCRIPTION
### Description
This adds a test function that one can use to set reconfiguration time for tests. This is helpful in testing on-chain validator oracles.

### Test Plan
Test only function

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4077)
<!-- Reviewable:end -->
