### PR TITLE
Fixes for not having wallet installed and switching accounts

### DIFF
--- a/ecosystem/platform/server/app/javascript/controllers/claim_nft_controller.ts
+++ b/ecosystem/platform/server/app/javascript/controllers/claim_nft_controller.ts
@@ -128,7 +128,13 @@ export default class extends Controller<HTMLAnchorElement> {
         ) {
           return this.redirectToTransaction(pendingTransaction.hash);
         }
-      } catch (error) {
+      } catch (error: any) {
+        if (error.name === "Unauthorized") {
+          // if unauthorized, we need to connect to wallet
+          const url = new URL(location.href);
+          url.search = `connect-wallet`;
+          location.href = url.toString();
+        }
         Sentry.captureException(error);
       }
     } else if (claimDetails.wallet_name === "martian") {

--- a/ecosystem/platform/server/app/javascript/controllers/connect_wallet_controller.ts
+++ b/ecosystem/platform/server/app/javascript/controllers/connect_wallet_controller.ts
@@ -73,8 +73,16 @@ export default class extends Controller<HTMLElement> {
 
   async getPublicKey() {
     if (this.walletName === "petra") {
-      const { publicKey } = await window.aptos!.connect();
-      return publicKey;
+      if (window.aptos) {
+        const { publicKey } = await window.aptos.connect();
+        return publicKey;
+      } else {
+        window.open(
+          "https://chrome.google.com/webstore/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci",
+          "_blank"
+        );
+        throw "Petra wallet not installed. Install from the Chrome Web Store and refresh the page.";
+      }
     } else if (this.walletName === "martian") {
       const { publicKey } = await window.martian!.connect();
       return publicKey;

--- a/ecosystem/platform/server/app/views/nft_offers/show.html.erb
+++ b/ecosystem/platform/server/app/views/nft_offers/show.html.erb
@@ -52,7 +52,7 @@
                 <% elsif step.name == :connect_wallet %>
                   Connect your wallet. You will need
                   an Aptos Wallet, such as <%= render(LinkComponent.new(href: 'https://chrome.google.com/webstore/detail/petra-aptos-wallet/ejjladinnckdgjemekebdpeokbikhfci')) { 'Petra Wallet' } %>,
-                  with a funded account and the network set to <%= @nft_offer.network.capitalize %>.
+                  with a funded account and the network set to <%= @nft_offer.network.capitalize %>. <br>Refresh the page after installing.
                 <% elsif step.name == :claim_nft %>
                   Your NFT is ready to mint!
                 <% end %>


### PR DESCRIPTION
### Description
The top errors are
1. Petra Wallet Not being installed (redirect to chrome store)
2. No accounts found
3. Petra Wallet Not being installed (redirect to chrome store)
4. User is not connected to a wallet in the last step because they switch wallets or some other reason. (redirect to connect)

### Test Plan
 

https://user-images.githubusercontent.com/19931667/189506026-edb94da8-c971-4a45-8822-f10c2db33753.mov

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4082)
<!-- Reviewable:end -->
