### PR TITLE
[aptos-vm] disable modules during prologue

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -861,6 +861,9 @@ impl AptosVM {
                 self.0.run_script_prologue(session, txn_data, log_context)
             }
             TransactionPayload::ModuleBundle(_module) => {
+                if MODULE_BUNDLE_DISALLOWED.load(Ordering::Relaxed) {
+                    return Err(VMStatus::Error(StatusCode::FEATURE_UNDER_GATING));
+                }
                 self.0.check_gas(storage, txn_data, log_context)?;
                 self.0.run_module_prologue(session, txn_data, log_context)
             }

--- a/vm-validator/src/unit_tests/vm_validator_test.rs
+++ b/vm-validator/src/unit_tests/vm_validator_test.rs
@@ -8,7 +8,7 @@ use aptos_types::{
     account_address, account_config,
     chain_id::ChainId,
     test_helpers::transaction_test_helpers,
-    transaction::{Module, Script, TransactionPayload},
+    transaction::{Script, TransactionPayload},
     vm_status::StatusCode,
 };
 use aptos_vm::AptosVM;
@@ -273,40 +273,6 @@ fn test_validate_max_gas_price_below_bounds() {
     //    ret.status().unwrap().major_status,
     //    StatusCode::GAS_UNIT_PRICE_BELOW_MIN_BOUND
     //);
-}
-
-// Make sure that we can publish non-allowlisted modules from the association address
-#[test]
-fn test_validate_module_publishing() {
-    let vm_validator = TestValidator::new();
-
-    let address = account_config::aptos_test_root_address();
-    let transaction = transaction_test_helpers::get_test_signed_module_publishing_transaction(
-        address,
-        1,
-        &vm_genesis::GENESIS_KEYPAIR.0,
-        vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Module::new(vec![]),
-    );
-    let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert_eq!(ret.status(), None);
-}
-
-#[test]
-fn test_validate_module_publishing_non_association() {
-    let vm_validator = TestValidator::new();
-
-    let address = account_config::aptos_test_root_address();
-    let transaction = transaction_test_helpers::get_test_signed_module_publishing_transaction(
-        address,
-        1,
-        &vm_genesis::GENESIS_KEYPAIR.0,
-        vm_genesis::GENESIS_KEYPAIR.1.clone(),
-        Module::new(vec![]),
-    );
-    // open publishing is enabled
-    let ret = vm_validator.validate_transaction(transaction).unwrap();
-    assert!(ret.status().is_none());
 }
 
 #[test]


### PR DESCRIPTION
since we want to delete this as much as possible, we need to prevent them from getting into mempool and hitting a committed but aborted state. To that end, we need protect further upstream. We already added an abort call in the VM for testnet to protect it, but that's a hack considering the code situation. Moving this in here simplifies testnet, makes sure weird behavior cannot happen on devnet (e.g., committed but aborted ModuleBundle), and makes it so we don't have to think about it for mainnet.

I would have deleted the ModuleBundle code, but it looks like @wrwg is using it to validate module upgrades work as expected for now.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4083)
<!-- Reviewable:end -->
