### PR TITLE
[Aptos Framework] Add a few governance powers

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -55,6 +55,10 @@ module aptos_framework::aptos_coin {
         (burn_cap, mint_cap)
     }
 
+    public fun has_mint_capability(account: &signer): bool {
+        exists<MintCapStore>(signer::address_of(account))
+    }
+
     /// Only called during genesis to destroy the aptos framework account's mint capability once all initial validators
     /// and accounts have been initialized during genesis.
     public(friend) fun destroy_mint_cap(aptos_framework: &signer) acquires MintCapStore {


### PR DESCRIPTION
### Description

1. Add the ability for on chain governance to remove validators from the active validator set.
2. Allow the core resources account to get framework signers in tests and testnets.

### Test Plan
Unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4084)
<!-- Reviewable:end -->
