### PR TITLE
[Forge] Add Validator and FullNodes reboot stress tests

### DIFF
--- a/.github/workflows/continuous-e2e-full-node-reboot-stress-test.yaml
+++ b/.github/workflows/continuous-e2e-full-node-reboot-stress-test.yaml
@@ -1,0 +1,22 @@
+name: Continuous E2E Full Node Reboot Stress Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  run-forge-fullnode-reboot-stress-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-fullnode-reboot-stress
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 1800
+      FORGE_TEST_SUITE: fullnode_reboot_stress_test
+      POST_TO_SLACK: true

--- a/.github/workflows/continuous-e2e-validator-reboot-stress-test.yaml
+++ b/.github/workflows/continuous-e2e-validator-reboot-stress-test.yaml
@@ -1,0 +1,22 @@
+name: Continuous E2E Validator Reboot Stress Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  run-forge-validator-reboot-stress-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-validator-reboot-stress
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      # Run for 40 minutes
+      FORGE_RUNNER_DURATION_SECS: 1800
+      FORGE_TEST_SUITE: validator_reboot_stress_test
+      POST_TO_SLACK: true

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -13,12 +13,14 @@ use std::{env, num::NonZeroUsize, process, thread, time::Duration};
 use structopt::StructOpt;
 use testcases::consensus_reliability_tests::ChangingWorkingQuorumTest;
 use testcases::continuous_progress_test::ContinuousProgressTest;
+use testcases::fullnode_reboot_stress_test::FullNodeRebootStressTest;
 use testcases::load_vs_perf_benchmark::LoadVsPerfBenchmark;
 use testcases::network_bandwidth_test::NetworkBandwidthTest;
 use testcases::network_latency_test::NetworkLatencyTest;
 use testcases::network_loss_test::NetworkLossTest;
 use testcases::performance_with_fullnode_test::PerformanceBenchmarkWithFN;
 use testcases::state_sync_performance::StateSyncValidatorPerformance;
+use testcases::validator_reboot_stress_test::ValidatorRebootStressTest;
 use testcases::{
     compatibility_test::SimpleValidatorUpgrade, forge_setup_test::ForgeSetupTest, generate_traffic,
     network_partition_test::NetworkPartitionTest, performance_test::PerformanceBenchmark,
@@ -461,6 +463,26 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_network_tests(vec![&PerformanceBenchmarkWithFN])
             .with_success_criteria(SuccessCriteria::new(
                 5000,
+                10000,
+                true,
+                Some(Duration::from_secs(240)),
+            )),
+        "validator_reboot_stress_test" => config
+            .with_initial_validator_count(NonZeroUsize::new(15).unwrap())
+            .with_initial_fullnode_count(1)
+            .with_network_tests(vec![&ValidatorRebootStressTest])
+            .with_success_criteria(SuccessCriteria::new(
+                5000,
+                10000,
+                true,
+                Some(Duration::from_secs(240)),
+            )),
+        "fullnode_reboot_stress_test" => config
+            .with_initial_validator_count(NonZeroUsize::new(10).unwrap())
+            .with_initial_fullnode_count(10)
+            .with_network_tests(vec![&FullNodeRebootStressTest])
+            .with_success_criteria(SuccessCriteria::new(
+                4000,
                 10000,
                 true,
                 Some(Duration::from_secs(240)),

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1260,7 +1260,7 @@ def create_forge_command(
 @envoption("FORGE_ENABLE_HAPROXY")
 @envoption("FORGE_ENABLE_FAILPOINTS")
 @envoption("FORGE_ENABLE_PERFORMANCE")
-@envoption("FORGE_TEST_SUITE", "land_blocking")
+@envoption("FORGE_TEST_SUITE", "validator_reboot_stress_test")
 @envoption("FORGE_RUNNER_DURATION_SECS", "300")
 @envoption("FORGE_IMAGE_TAG")
 @envoption("IMAGE_TAG")

--- a/testsuite/testcases/src/fullnode_reboot_stress_test.rs
+++ b/testsuite/testcases/src/fullnode_reboot_stress_test.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{LoadDestination, NetworkLoadTest};
+use forge::{NetworkContext, NetworkTest, Result, Swarm, Test};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::time::Instant;
+
+pub struct FullNodeRebootStressTest;
+
+impl Test for FullNodeRebootStressTest {
+    fn name(&self) -> &'static str {
+        "fullnode reboot stress test"
+    }
+}
+
+impl NetworkLoadTest for FullNodeRebootStressTest {
+    fn setup(&self, _swarm: &mut dyn Swarm) -> Result<LoadDestination> {
+        Ok(LoadDestination::AllFullnodes)
+    }
+
+    fn test(&self, swarm: &mut dyn Swarm, duration: Duration) -> Result<()> {
+        let start = Instant::now();
+        let runtime = Runtime::new().unwrap();
+
+        let all_fullnodes = swarm.full_nodes().map(|v| v.peer_id()).collect::<Vec<_>>();
+
+        let mut rng = thread_rng();
+
+        while start.elapsed() < duration {
+            let fullnode_to_reboot = swarm
+                .full_node_mut(*all_fullnodes.choose(&mut rng).unwrap())
+                .unwrap();
+            runtime.block_on(async { fullnode_to_reboot.stop().await })?;
+            runtime.block_on(async { fullnode_to_reboot.start().await })?;
+            std::thread::sleep(Duration::from_secs(5));
+        }
+
+        Ok(())
+    }
+}
+
+impl NetworkTest for FullNodeRebootStressTest {
+    fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        <dyn NetworkLoadTest>::run(self, ctx)
+    }
+}

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -5,6 +5,7 @@ pub mod compatibility_test;
 pub mod consensus_reliability_tests;
 pub mod continuous_progress_test;
 pub mod forge_setup_test;
+pub mod fullnode_reboot_stress_test;
 pub mod gas_price_test;
 pub mod load_vs_perf_benchmark;
 pub mod network_bandwidth_test;
@@ -16,6 +17,7 @@ pub mod performance_test;
 pub mod performance_with_fullnode_test;
 pub mod reconfiguration_test;
 pub mod state_sync_performance;
+pub mod validator_reboot_stress_test;
 
 use anyhow::{anyhow, ensure};
 use aptos_logger::info;

--- a/testsuite/testcases/src/validator_reboot_stress_test.rs
+++ b/testsuite/testcases/src/validator_reboot_stress_test.rs
@@ -1,0 +1,50 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{LoadDestination, NetworkLoadTest};
+use forge::{NetworkContext, NetworkTest, Result, Swarm, Test};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::time::Instant;
+
+pub struct ValidatorRebootStressTest;
+
+impl Test for ValidatorRebootStressTest {
+    fn name(&self) -> &'static str {
+        "validator reboot stress test"
+    }
+}
+
+impl NetworkLoadTest for ValidatorRebootStressTest {
+    fn setup(&self, _swarm: &mut dyn Swarm) -> Result<LoadDestination> {
+        Ok(LoadDestination::AllFullnodes)
+    }
+
+    fn test(&self, swarm: &mut dyn Swarm, duration: Duration) -> Result<()> {
+        let start = Instant::now();
+        let runtime = Runtime::new().unwrap();
+
+        let all_validators = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+
+        let mut rng = thread_rng();
+
+        while start.elapsed() < duration {
+            let validator_to_reboot = swarm
+                .validator_mut(*all_validators.choose(&mut rng).unwrap())
+                .unwrap();
+            runtime.block_on(async { validator_to_reboot.stop().await })?;
+            runtime.block_on(async { validator_to_reboot.start().await })?;
+            std::thread::sleep(Duration::from_secs(5));
+        }
+
+        Ok(())
+    }
+}
+
+impl NetworkTest for ValidatorRebootStressTest {
+    fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        <dyn NetworkLoadTest>::run(self, ctx)
+    }
+}


### PR DESCRIPTION
### Description

Stress tests which reboots nodes randomly every 5 seconds and ensures that all nodes are able to catch up to the network at the end. This will help detect various node stuck issue during restart.

### Test Plan

Run newly added tests