### PR TITLE
[backup] simplify restore coordinator

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -317,11 +317,7 @@ impl EpochHistoryRestoreController {
 
     pub async fn run(self) -> Result<EpochHistory> {
         let name = self.name();
-        info!(
-            "{} started. Trying epoch endings starting from epoch 0, {} in total.",
-            name,
-            self.manifest_handles.len(),
-        );
+        info!("{} started.", name,);
         let res = self
             .run_impl()
             .await

--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -15,7 +15,7 @@ use crate::{
     storage::BackupStorage,
     utils::{unix_timestamp_sec, GlobalRestoreOptions},
 };
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use aptos_logger::prelude::*;
 use aptos_types::transaction::Version;
 use clap::Parser;
@@ -87,6 +87,22 @@ impl RestoreCoordinator {
     }
 
     async fn run_impl(self) -> Result<()> {
+        // N.b.
+        // The coordinator now focuses on doing one procedure, ignoring the combination of options
+        // supported before:
+        //   1. a most recent state snapshot
+        //   2. a only transaction and its output, at the state snapshot version
+        //   3. the epoch history from 0 up until the latest closed epoch preceding the state
+        //      snapshot version.
+        // And it does so in a resume-able way.
+
+        if self.replay_all {
+            bail!("--replay--all not supported in this version.");
+        }
+        if self.ledger_history_start_version.is_some() {
+            bail!("--ledger-history-start-version not supported in this version.");
+        }
+
         let metadata_view = metadata::cache::sync_and_load(
             &self.metadata_cache_opt,
             Arc::clone(&self.storage),
@@ -94,67 +110,46 @@ impl RestoreCoordinator {
         )
         .await?;
 
-        let mut transactions =
-            metadata_view.select_transaction_backups(0, self.target_version())?;
-        let actual_target_version = self.get_actual_target_version(&transactions)?;
-        let epoch_endings = metadata_view.select_epoch_ending_backups(actual_target_version)?;
-        let txn_resume_point = self
+        let next_txn_version = self
             .global_opt
             .run_mode
             .get_next_expected_transaction_version()?;
-
-        let state_snapshot = if self.replay_all || txn_resume_point != 0 {
-            None
-        } else if let Some(version) = self.global_opt.run_mode.get_in_progress_state_snapshot()? {
-            info!("Found in progress state snapshot restore, at version {}, looking for matching backup.", version);
-            Some(metadata_view.expect_state_snapshot(version)?)
-        } else {
-            metadata_view.select_state_snapshot(actual_target_version)?
-        };
-        let replay_transactions_from_version = match &state_snapshot {
-            Some(b) => b.version + 1,
-            None => txn_resume_point,
-        };
-        COORDINATOR_TARGET_VERSION.set(actual_target_version as i64);
-        info!("Planned to restore to version {}.", actual_target_version);
-        let mut start_version = state_snapshot.as_ref().map(|s| s.version + 1).unwrap_or(0);
-        if let Some(v) = self.ledger_history_start_version {
-            if v < start_version {
-                start_version = v;
-            }
+        if next_txn_version != 0 {
+            // DB is already in workable state
+            info!(
+                next_txn_version = next_txn_version,
+                "DB is ready to accept transactions, start the node to catch up with the chain. \
+                If the node is unable to catch up because the DB is too old, delete the data folder \
+                and bootstrap again.",
+            );
+            return Ok(());
         }
-        transactions = transactions
-            .into_iter()
-            .skip_while(|p| p.last_version < start_version)
-            .collect();
-        if let Some(actual_start_version) = transactions.first().map(|t| t.first_version) {
-            if txn_resume_point > 0 {
-                if actual_start_version > txn_resume_point {
-                    panic!(
-                        "DB has transactions till {}, requesting to add transactions from {:?}, might \
-                    result in non-continuous ledger history, aborting. Try to adjust the \
-                    --ledger_history_start_version flag.",
-                        txn_resume_point,
-                        self.ledger_history_start_version,
-                    );
-                }
-                warn!(
-                    "DB has existing transactions, will skip transaction backups before version {}",
-                    txn_resume_point
+
+        let state_snapshot_backup =
+            if let Some(version) = self.global_opt.run_mode.get_in_progress_state_snapshot()? {
+                info!(
+                    version = version,
+                    "Found in progress state snapshot restore",
                 );
-                transactions = transactions
-                    .into_iter()
-                    .skip_while(|p| p.last_version < txn_resume_point)
-                    .collect();
-            }
-        }
+                metadata_view.expect_state_snapshot(version)?
+            } else {
+                metadata_view
+                    .select_state_snapshot(self.target_version())?
+                    .ok_or_else(|| anyhow!("No usable state snapshot."))?
+            };
+        let version = state_snapshot_backup.version;
+        let epoch_ending_backups = metadata_view.select_epoch_ending_backups(version)?;
+        let transaction_backup = metadata_view
+            .select_transaction_backups(version, version)?
+            .pop()
+            .unwrap();
+        COORDINATOR_TARGET_VERSION.set(version as i64);
+        info!(version = version, "Restore target decided.");
 
-        let epoch_history = if self.skip_epoch_endings {
-            None
-        } else {
+        let epoch_history = if !self.skip_epoch_endings {
             Some(Arc::new(
                 EpochHistoryRestoreController::new(
-                    epoch_endings
+                    epoch_ending_backups
                         .into_iter()
                         .map(|backup| backup.manifest)
                         .collect(),
@@ -164,28 +159,28 @@ impl RestoreCoordinator {
                 .run()
                 .await?,
             ))
+        } else {
+            None
         };
 
-        if let Some(backup) = state_snapshot {
-            StateSnapshotRestoreController::new(
-                StateSnapshotRestoreOpt {
-                    manifest_handle: backup.manifest,
-                    version: backup.version,
-                },
-                self.global_opt.clone(),
-                Arc::clone(&self.storage),
-                epoch_history.clone(),
-            )
-            .run()
-            .await?;
-        }
+        StateSnapshotRestoreController::new(
+            StateSnapshotRestoreOpt {
+                manifest_handle: state_snapshot_backup.manifest,
+                version,
+            },
+            self.global_opt.clone(),
+            Arc::clone(&self.storage),
+            epoch_history.clone(),
+        )
+        .run()
+        .await?;
 
-        let txn_manifests = transactions.into_iter().map(|b| b.manifest).collect();
+        let txn_manifests = vec![transaction_backup.manifest];
         TransactionRestoreBatchController::new(
             self.global_opt,
             self.storage,
             txn_manifests,
-            Some(replay_transactions_from_version),
+            Some(version + 1),
             epoch_history,
         )
         .run()
@@ -200,6 +195,7 @@ impl RestoreCoordinator {
         self.global_opt.target_version
     }
 
+    #[allow(dead_code)]
     fn get_actual_target_version(
         &self,
         transaction_backups: &[TransactionBackupMeta],

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -313,8 +313,6 @@ pub(crate) fn db_restore(backup_path: &Path, db_path: &Path, trusted_waypoints: 
             "auto",
             "--metadata-cache-dir",
             metadata_cache_path.path().to_str().unwrap(),
-            "--ledger-history-start-version",
-            "0",
             "local-fs",
             "--dir",
             backup_path.to_str().unwrap(),


### PR DESCRIPTION
### Description

make the logic straightforward -- all it tries to do is to get the latest snapshot

because State Sync catches up faster, there's no point at this point for the db-restore to replay txns.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4095)
<!-- Reviewable:end -->
