### PR TITLE
[aptos-cli] Support key rotation cli and resource accounts

### DIFF
--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
-
 use crate::common::{
     types::{
         CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, EncodingOptions,
@@ -16,6 +14,8 @@ use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
     PrivateKey, SigningKey,
 };
+use aptos_rest_client::aptos_api_types::{AptosError, AptosErrorCode};
+use aptos_rest_client::error::{AptosErrorResponse, RestError};
 use aptos_rest_client::Client;
 use aptos_types::{
     account_address::AccountAddress, account_config::CORE_CODE_ADDRESS,
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use cached_packages::aptos_stdlib;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, path::PathBuf};
 
 /// Command to rotate an account's authentication key
 ///
@@ -34,10 +35,10 @@ pub struct RotateKey {
     pub(crate) txn_options: TransactionOptions,
 
     /// File name that contains the new private key
-    #[clap(long, group = "private_key_to_rotate_to", parse(from_os_str))]
+    #[clap(long, group = "new_private_key", parse(from_os_str))]
     pub(crate) new_private_key_file: Option<PathBuf>,
     /// New private key encoded in a type as shown in `encoding`
-    #[clap(long, group = "private_key_to_roate_to")]
+    #[clap(long, group = "new_private_key")]
     pub(crate) new_private_key: Option<String>,
 
     /// Name of the profile to save the new private key
@@ -277,41 +278,52 @@ impl CliCommand<AccountAddress> for LookupAddress {
     }
 
     async fn execute(self) -> CliTypedResult<AccountAddress> {
-        let originating_resource = self
-            .rest_client()?
-            .get_account_resource(CORE_CODE_ADDRESS, "0x1::account::OriginatingAddress")
-            .await
-            .map_err(|err| CliError::ApiError(err.to_string()))?
-            .into_inner()
-            .ok_or_else(|| CliError::UnexpectedError("Unable to parse API response.".to_string()))?
-            .data;
+        let rest_client = self.rest_client()?;
 
-        let table_handle = originating_resource["address_map"]["handle"]
-            .as_str()
-            .ok_or_else(|| {
-                CliError::UnexpectedError("Unable to parse table handle.".to_string())
-            })?;
+        let originating_resource: OriginatingResource = rest_client
+            .get_account_resource_bcs(CORE_CODE_ADDRESS, "0x1::account::OriginatingAddress")
+            .await?
+            .into_inner();
+
+        let table_handle = originating_resource.address_map.handle;
 
         // The derived address that can be used to look up the original address
+        // TODO: This command needs to support multi-ed25519
         let address_key = AuthenticationKey::ed25519(&self.public_key()?).derived_address();
-
-        Ok(AccountAddress::from_hex_literal(
-            self.rest_client()?
-                .get_table_item(
-                    AccountAddress::from_str(table_handle)
-                        .map_err(|err| CliError::UnableToParse("table_handle", err.to_string()))?,
-                    "address",
-                    "address",
-                    address_key.to_hex_literal(),
-                )
-                .await
-                .map_err(|err| CliError::ApiError(err.to_string()))?
-                .into_inner()
-                .as_str()
-                .ok_or_else(|| {
-                    CliError::UnexpectedError("Unable to parse API response.".to_string())
-                })?,
-        )
-        .map_err(|err| CliError::UnableToParse("AccountAddress", err.to_string()))?)
+        match rest_client
+            .get_table_item_bcs(
+                table_handle,
+                "address",
+                "address",
+                address_key.to_hex_literal(),
+            )
+            .await
+        {
+            Ok(inner) => Ok(inner.into_inner()),
+            Err(RestError::Api(AptosErrorResponse {
+                error:
+                    AptosError {
+                        error_code: AptosErrorCode::TableItemNotFound,
+                        ..
+                    },
+                ..
+            })) => {
+                // If the table item wasn't found, let's at least check if the account exists
+                // It won't be in the table if it wasn't rotated, then return the derived account address
+                rest_client.get_account_bcs(address_key).await?;
+                Ok(address_key)
+            }
+            Err(err) => Err(err)?,
+        }
     }
+}
+
+#[derive(Deserialize)]
+pub struct OriginatingResource {
+    pub address_map: Table,
+}
+
+#[derive(Deserialize)]
+pub struct Table {
+    pub handle: AccountAddress,
 }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -565,6 +565,15 @@ pub struct PublicKeyInputOptions {
     public_key: Option<String>,
 }
 
+impl PublicKeyInputOptions {
+    pub fn from_key(key: &Ed25519PublicKey) -> PublicKeyInputOptions {
+        PublicKeyInputOptions {
+            public_key: Some(key.to_encoded_string().unwrap()),
+            public_key_file: None,
+        }
+    }
+}
+
 impl ExtractPublicKey for PublicKeyInputOptions {
     fn extract_public_key(
         &self,
@@ -740,20 +749,6 @@ pub trait ExtractPublicKey {
         encoding: EncodingType,
         profile: &str,
     ) -> CliTypedResult<Ed25519PublicKey>;
-
-    fn extract_x25519_public_key(
-        &self,
-        encoding: EncodingType,
-        profile: &str,
-    ) -> CliTypedResult<x25519::PublicKey> {
-        let key = self.extract_public_key(encoding, profile)?;
-        x25519::PublicKey::from_ed25519_public_bytes(&key.to_bytes()).map_err(|err| {
-            CliError::UnexpectedError(format!(
-                "Failed to convert ed25519 key to x25519 key {:?}",
-                err
-            ))
-        })
-    }
 }
 
 pub fn account_address_from_public_key(public_key: &Ed25519PublicKey) -> AccountAddress {

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -646,6 +646,44 @@ impl PrivateKeyInputOptions {
     }
 
     /// Extract private key from CLI args with fallback to config
+    pub fn extract_private_key_and_address(
+        &self,
+        encoding: EncodingType,
+        profile: &str,
+        maybe_address: Option<AccountAddress>,
+    ) -> CliTypedResult<(Ed25519PrivateKey, AccountAddress)> {
+        // Order of operations
+        // 1. CLI inputs
+        // 2. Profile
+        // 3. Derived
+        if let Some(key) = self.extract_private_key_cli(encoding)? {
+            // If we use the CLI inputs, then we should derive or use the address from the input
+            if let Some(address) = maybe_address {
+                Ok((key, address))
+            } else {
+                let address = account_address_from_public_key(&key.public_key());
+                Ok((key, address))
+            }
+        } else if let Some((Some(key), maybe_config_address)) =
+            CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)?
+                .map(|p| (p.private_key, p.account))
+        {
+            match (maybe_address, maybe_config_address) {
+                (Some(address), _) => Ok((key, address)),
+                (_, Some(address)) => Ok((key, address)),
+                (None, None) => {
+                    let address = account_address_from_public_key(&key.public_key());
+                    Ok((key, address))
+                }
+            }
+        } else {
+            Err(CliError::CommandArgumentError(
+                "One of ['--private-key', '--private-key-file'] must be used".to_string(),
+            ))
+        }
+    }
+
+    /// Extract private key from CLI args with fallback to config
     pub fn extract_private_key(
         &self,
         encoding: EncodingType,
@@ -1121,6 +1159,14 @@ pub struct TransactionOptions {
     /// as the max gas
     #[clap(long)]
     pub(crate) estimate_max_gas: bool,
+
+    /// Sender account address
+    ///
+    /// This allows you to override the account address from the derived account address
+    /// in the event that the authentication key was rotated or for a resource account
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) sender_account: Option<AccountAddress>,
+
     #[clap(flatten)]
     pub(crate) private_key_options: PrivateKeyInputOptions,
     #[clap(flatten)]
@@ -1136,31 +1182,23 @@ pub struct TransactionOptions {
 }
 
 impl TransactionOptions {
-    /// Retrieves the private key
-    pub(crate) fn private_key(&self) -> CliTypedResult<Ed25519PrivateKey> {
-        self.private_key_options.extract_private_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )
-    }
-
     /// Builds a rest client
     fn rest_client(&self) -> CliTypedResult<Client> {
         self.rest_options.client(&self.profile_options.profile)
     }
 
+    /// Retrieves the public key and the associated address
+    /// TODO: Cache this information
+    pub fn get_key_and_address(&self) -> CliTypedResult<(Ed25519PrivateKey, AccountAddress)> {
+        self.private_key_options.extract_private_key_and_address(
+            self.encoding_options.encoding,
+            &self.profile_options.profile,
+            self.sender_account,
+        )
+    }
+
     pub fn sender_address(&self) -> CliTypedResult<AccountAddress> {
-        // If private key flags are specified, do not use the profile's account address
-        if self
-            .private_key_options
-            .extract_private_key_cli(self.encoding_options.encoding)?
-            .is_some()
-        {
-            let sender_key = self.private_key()?;
-            Ok(account_address_from_public_key(&sender_key.public_key()))
-        } else {
-            self.profile_options.account_address()
-        }
+        Ok(self.get_key_and_address()?.1)
     }
 
     /// Gets the auth key by account address. We need to fetch the auth key from Rest API rather than creating an
@@ -1184,11 +1222,8 @@ impl TransactionOptions {
         payload: TransactionPayload,
         amount_transfer: Option<u64>,
     ) -> CliTypedResult<Transaction> {
-        let sender_key = self.private_key()?;
         let client = self.rest_client()?;
-
-        // Get sender address
-        let sender_address = self.sender_address()?;
+        let (sender_key, sender_address) = self.get_key_and_address()?;
 
         // Get sequence number for account
         let sequence_number = self.sequence_number(sender_address).await?;
@@ -1249,11 +1284,8 @@ impl TransactionOptions {
         gas_price: Option<u64>,
         amount_transfer: Option<u64>,
     ) -> CliTypedResult<UserTransaction> {
-        let sender_key = self.private_key()?;
         let client = self.rest_client()?;
-
-        // Get sender address
-        let sender_address = self.sender_address()?;
+        let (sender_key, sender_address) = self.get_key_and_address()?;
 
         // Get sequence number for account
         let sequence_number = get_sequence_number(&client, sender_address).await?;

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -538,6 +538,13 @@ impl PromptOptions {
             assume_no: false,
         }
     }
+
+    pub fn no() -> Self {
+        Self {
+            assume_yes: false,
+            assume_no: true,
+        }
+    }
 }
 
 /// An insertable option for use with encodings.

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -15,6 +15,8 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "account", "create-resource-account", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "account", "fund-with-faucet", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "account", "list", "--help"]).await;
+    assert_cmd_not_panic(&["aptos", "account", "lookup-address", "--help"]).await;
+    assert_cmd_not_panic(&["aptos", "account", "rotate-key", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "account", "transfer", "--help"]).await;
 
     assert_cmd_not_panic(&["aptos", "config"]).await;
@@ -60,6 +62,7 @@ async fn ensure_every_command_args_work() {
 
     assert_cmd_not_panic(&["aptos", "node"]).await;
     assert_cmd_not_panic(&["aptos", "node", "analyze-validator-performance", "--help"]).await;
+    assert_cmd_not_panic(&["aptos", "node", "bootstrap-db-from-backup", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "initialize-validator", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "join-validator-set", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "leave-validator-set", "--help"]).await;

--- a/testsuite/smoke-test/src/aptos_cli/account.rs
+++ b/testsuite/smoke-test/src/aptos_cli/account.rs
@@ -6,11 +6,6 @@ use aptos::account::create::DEFAULT_FUNDED_COINS;
 use aptos::common::types::GasOptions;
 use aptos_crypto::{PrivateKey, ValidCryptoMaterialStringExt};
 use aptos_keygen::KeyGen;
-use aptos_types::{
-    account_address::AccountAddress, account_config::CORE_CODE_ADDRESS,
-    transaction::authenticator::AuthenticationKey,
-};
-use forge::NodeExt;
 
 #[tokio::test]
 async fn test_account_flow() {
@@ -91,52 +86,45 @@ async fn test_account_flow() {
 
 #[tokio::test]
 async fn test_account_key_rotation() {
-    let (swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
+    let (_swarm, mut cli, _faucet) = SwarmBuilder::new_local(1)
         .with_aptos()
         .build_with_cli(2)
         .await;
+    let account_id = cli.account_id(0);
+    let original_public_key = cli.private_key(0).public_key();
+    assert_eq!(
+        cli.lookup_address(&original_public_key).await.unwrap(),
+        account_id
+    );
 
-    let mut keygen = KeyGen::from_os_rng();
+    let mut keygen = KeyGen::from_seed([9u8; 32]);
     let new_private_key = keygen.generate_ed25519_private_key();
     cli.rotate_key(0, new_private_key.to_encoded_string().unwrap(), None)
         .await
         .unwrap();
+    // Ensure account id in framework is still the same
+    assert_eq!(account_id, cli.account_id(0));
 
-    let rest_client = swarm.validators().next().unwrap().rest_client();
-
-    let originating_resource = rest_client
-        .get_account_resource(CORE_CODE_ADDRESS, "0x1::account::OriginatingAddress")
-        .await
-        .unwrap()
-        .into_inner()
-        .unwrap()
-        .data;
-
-    let table_handle = originating_resource["address_map"]["handle"]
-        .as_str()
-        .unwrap();
-
-    let new_address = AuthenticationKey::ed25519(&new_private_key.public_key()).derived_address();
-
+    // Original should still work
     assert_eq!(
-        AccountAddress::from_hex_literal(
-            rest_client
-                .get_table_item(
-                    table_handle.parse().unwrap(),
-                    "address",
-                    "address",
-                    new_address.to_hex_literal(),
-                )
-                .await
-                .unwrap()
-                .into_inner()
-                .as_str()
-                .unwrap()
-        )
-        .unwrap(),
-        cli.account_id(0)
+        cli.lookup_address(&original_public_key).await.unwrap(),
+        account_id
+    );
+    // And new one should work
+    assert_eq!(
+        cli.lookup_address(&new_private_key.public_key())
+            .await
+            .unwrap(),
+        account_id
     );
 
+    // And now a transfer with the old key should not work
+    cli.transfer_coins(0, 1, 5, None)
+        .await
+        .expect_err("Old key should not be able to transfer");
+
+    // But the new one should
+    cli.set_private_key(0, new_private_key);
     cli.transfer_coins(0, 1, 5, None)
         .await
         .expect("New key should be able to transfer");


### PR DESCRIPTION
### Description
Currently, the CLI doesn't support having an account address that's different than the one directly derived by the public key.  No longer is that the case!  It will let you sign with different account addresses, and handle it properly.

Additionally, the Rotate key has better testing, and lookup address works with non-rotated accounts.

### Test Plan
Checkout the E2E tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4096)
<!-- Reviewable:end -->
