### PR TITLE
[forge] correctly apply genesis config for state_sync tests

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -619,8 +619,10 @@ fn state_sync_perf_fullnodes_apply_outputs(
     forge_config: ForgeConfig<'static>,
 ) -> ForgeConfig<'static> {
     state_sync_perf_fullnodes_config(forge_config)
-        .with_node_helm_config_fn(Arc::new(|helm_values| {
+        .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = 600.into();
+        }))
+        .with_node_helm_config_fn(Arc::new(|helm_values| {
             helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
                 ["bootstrapping_mode"] = "ApplyTransactionOutputsFromGenesis".into();
             helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
@@ -635,8 +637,10 @@ fn state_sync_perf_fullnodes_execute_transactions(
     forge_config: ForgeConfig<'static>,
 ) -> ForgeConfig<'static> {
     state_sync_perf_fullnodes_config(forge_config)
-        .with_node_helm_config_fn(Arc::new(|helm_values| {
+        .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = 600.into();
+        }))
+        .with_node_helm_config_fn(Arc::new(|helm_values| {
             helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
                 ["bootstrapping_mode"] = "ExecuteTransactionsFromGenesis".into();
             helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
@@ -650,8 +654,10 @@ fn state_sync_perf_fullnodes_execute_transactions(
 fn state_sync_perf_validators(forge_config: ForgeConfig<'static>) -> ForgeConfig<'static> {
     forge_config
         .with_initial_validator_count(NonZeroUsize::new(7).unwrap())
-        .with_node_helm_config_fn(Arc::new(|helm_values| {
+        .with_genesis_helm_config_fn(Arc::new(|helm_values| {
             helm_values["chain"]["epoch_duration_secs"] = 600.into();
+        }))
+        .with_node_helm_config_fn(Arc::new(|helm_values| {
             helm_values["validator"]["config"]["state_sync"]["state_sync_driver"]
                 ["bootstrapping_mode"] = "ApplyTransactionOutputsFromGenesis".into();
             helm_values["validator"]["config"]["state_sync"]["state_sync_driver"]


### PR DESCRIPTION
### Description

Genesis helm values were not getting set in the correct place

After this lands, we should really change the interface to change the aptos-node and genesis configuration. Editing helm values directly breaks a few abstraction barriers and isn't too friendly

### Test Plan

Canary in Forge
* run1: https://github.com/aptos-labs/aptos-core/runs/8299083397?check_suite_focus=true 
  * FORGE_RUNNER_DURATION_SECS: 300
  * `State sync throughput : 13586 txn/sec`
* run2: https://github.com/aptos-labs/aptos-core/runs/8299083256?check_suite_focus=true
  * FORGE_RUNNER_DURATION_SECS: 480
  * `State sync throughput : 14045 txn/sec`

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4098)
<!-- Reviewable:end -->
