### PR TITLE
feat: fetching data over BCS

### DIFF
--- a/ecosystem/typescript/sdk/.eslintrc.js
+++ b/ecosystem/typescript/sdk/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
     "no-unused-vars": "off",
     "@typescript-eslint/no-use-before-define": ["error", { functions: false, classes: false }],
     "@typescript-eslint/no-unused-vars": ["error"],
+    "class-methods-use-this": "off",
   },
   settings: {
     "import/resolver": {

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -61,7 +61,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.25.4",
     "jest": "^28.1.3",
-    "openapi-typescript-codegen": "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p2/openapi-typescript-codegen-v0.23.0-p2.tgz",
+    "openapi-typescript-codegen": "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p3/openapi-typescript-codegen-v0.23.0-p3.tgz",
     "prettier": "^2.6.2",
     "standard-version": "^9.5.0",
     "ts-jest": "^28.0.7",

--- a/ecosystem/typescript/sdk/src/generated/core/request.ts
+++ b/ecosystem/typescript/sdk/src/generated/core/request.ts
@@ -206,6 +206,14 @@ const sendRequest = async <T>(
         cancelToken: source.token,
     };
 
+    const isBCS = Object.keys(config.HEADERS || {})
+    .filter((k) => k.toLowerCase() === "accept")
+    .map((k) => (config.HEADERS as Record<string, string>)[k])
+    .includes("application/x-bcs");
+  if (isBCS) {
+    requestConfig.responseType = "arraybuffer";
+  }
+
     onCancel(() => source.cancel('The user aborted a request.'));
 
     try {

--- a/ecosystem/typescript/sdk/src/util.ts
+++ b/ecosystem/typescript/sdk/src/util.ts
@@ -13,13 +13,13 @@ export async function sleep(timeMs: number): Promise<null> {
 
 export const DEFAULT_VERSION_PATH_BASE = "/v1";
 
-export function fixNodeUrl(nodeUrl: string): string {
+export function fixNodeUrl(nodeUrl: string, version = DEFAULT_VERSION_PATH_BASE): string {
   let out = `${nodeUrl}`;
   if (out.endsWith("/")) {
     out = out.substring(0, out.length - 1);
   }
-  if (!out.endsWith(DEFAULT_VERSION_PATH_BASE)) {
-    out = `${out}${DEFAULT_VERSION_PATH_BASE}`;
+  if (!out.endsWith(version)) {
+    out = `${out}${version}`;
   }
   return out;
 }

--- a/ecosystem/typescript/sdk/yarn.lock
+++ b/ecosystem/typescript/sdk/yarn.lock
@@ -3605,9 +3605,9 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-"openapi-typescript-codegen@https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p2/openapi-typescript-codegen-v0.23.0-p2.tgz":
-  version "0.23.0-p2"
-  resolved "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p2/openapi-typescript-codegen-v0.23.0-p2.tgz#273123a28737f2e099fcddf2d76f1011374e6855"
+"openapi-typescript-codegen@https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p3/openapi-typescript-codegen-v0.23.0-p3.tgz":
+  version "0.23.0-p3"
+  resolved "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p3/openapi-typescript-codegen-v0.23.0-p3.tgz#7e46fd506c2d717c43ba43155325fcea21d27a99"
   dependencies:
     camelcase "^6.3.0"
     commander "^9.3.0"


### PR DESCRIPTION
### Description
Experimenting with data reads over BCS rather than JSON for TS SDK. Make `getAccountResource` read data through BCS by default. Developers can override this behavior by setting the flag `enableBCSRead` to false.

### Test Plan
Added a Jest test to compare the read result for all resources under 0x1 except a few.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4099)
<!-- Reviewable:end -->
