### PR TITLE
[backup] ignore "History until epoch X can't verify" error

### DIFF
--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -280,7 +280,8 @@ impl EpochHistory {
             warn!(
                 epoch = epoch,
                 epoch_history_until = self.epoch_endings.len(),
-                "Epoch too new, can't verify. Don't worry, node won't be able to start if data is not compatible.",
+                "Epoch too new, can't verify, letting it pass. Don't worry, previous chunks are \
+                verified, and node won't be able to start if this piece of data is indeed malicious.",
             );
             return Ok(());
         }

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -275,12 +275,15 @@ impl EpochHistory {
     pub fn verify_ledger_info(&self, li_with_sigs: &LedgerInfoWithSignatures) -> Result<()> {
         let epoch = li_with_sigs.ledger_info().epoch();
         ensure!(!self.epoch_endings.is_empty(), "Empty epoch history.",);
-        ensure!(
-            epoch <= self.epoch_endings.len() as u64,
-            "History until epoch {} can't verify epoch {}",
-            self.epoch_endings.len(),
-            epoch,
-        );
+        if epoch > self.epoch_endings.len() as u64 {
+            // TODO(aldenhu): fix this from upper level
+            warn!(
+                epoch = epoch,
+                epoch_history_until = self.epoch_endings.len(),
+                "Epoch too new, can't verify. Don't worry, node won't be able to start if data is not compatible.",
+            );
+            return Ok(());
+        }
         if epoch == 0 {
             ensure!(
                 li_with_sigs.ledger_info() == &self.epoch_endings[0],

--- a/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/epoch_ending/restore.rs
@@ -280,8 +280,8 @@ impl EpochHistory {
             warn!(
                 epoch = epoch,
                 epoch_history_until = self.epoch_endings.len(),
-                "Epoch too new, can't verify, letting it pass. Don't worry, previous chunks are \
-                verified, and node won't be able to start if this piece of data is indeed malicious.",
+                "Epoch is too new and can't be verified. Previous chunks are verified and node \
+                won't be able to start if this data is malicious."
             );
             return Ok(());
         }


### PR DESCRIPTION


### Description
Edge case where the last txn chunk containing the target version carries a proof from the next epoch -- we can't write that epoch ending info to the DB so we didn't load it.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4108)
<!-- Reviewable:end -->
