### PR TITLE
[aptos-rosetta] Fix deserialization bug of coin info

### DIFF
--- a/types/src/account_config/resources/coin_info.rs
+++ b/types/src/account_config/resources/coin_info.rs
@@ -15,6 +15,7 @@ use move_deps::move_core_types::{
     move_resource::{MoveResource, MoveStructType},
 };
 use serde::{Deserialize, Serialize};
+use std::string::FromUtf8Error;
 
 /// Rust representation of Aggregator Move struct.
 #[derive(Debug, Serialize, Deserialize)]
@@ -71,6 +72,14 @@ impl MoveStructType for CoinInfoResource {
 impl MoveResource for CoinInfoResource {}
 
 impl CoinInfoResource {
+    pub fn symbol(&self) -> Result<String, FromUtf8Error> {
+        String::from_utf8(self.symbol.clone())
+    }
+
+    pub fn decimals(&self) -> u8 {
+        self.decimals
+    }
+
     pub fn supply(&self) -> &Option<OptionalAggregator> {
         &self.supply
     }


### PR DESCRIPTION
### Description
CoinInfo was being deserialized wrong because it was using a custom type.  Now with BCS serialization, it can use the real type.

### Test Plan
I wanted to make a more in depth test, but that requires me to upload a move module in the test for the coin, and I'm going to hold off on that for now.

Here is a successful run against testnet (which failed previously)
```
$ aptos-rosetta-cli account balance --account 0xd945a1c6dd2180bd2e257e427494c1396b195981738227e86efa7cd7e4f4888b --chain-id testnet
{
  "block_identifier": {
    "index": 1056846,
    "hash": "testnet-1056846"
  },
  "balances": [
    {
      "value": "0",
      "currency": {
        "symbol": "455448",
        "decimals": 9,
        "metadata": {
          "move_type": "0xd945a1c6dd2180bd2e257e427494c1396b195981738227e86efa7cd7e4f4888b::Coin::ETH"
        }
      }
    },
    {
      "value": "48619",
      "currency": {
        "symbol": "APT",
        "decimals": 8,
        "metadata": {
          "move_type": "0x1::aptos_coin::AptosCoin"
        }
      }
    },
    {
      "value": "0",
      "currency": {
        "symbol": "425443",
        "decimals": 9,
        "metadata": {
          "move_type": "0xd945a1c6dd2180bd2e257e427494c1396b195981738227e86efa7cd7e4f4888b::Coin::BTC"
        }
      }
    }
  ],
  "metadata": {
    "sequence_number": "13"
  }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4116)
<!-- Reviewable:end -->
