### PR TITLE
[Token] add public methods to get data from token module and do type conversion 

### DIFF
--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -174,18 +174,16 @@ module aptos_token::property_map {
 
     /// create a property value from generic type data
     public fun create_property_value<T: copy>(data: &T): PropertyValue {
-        if (type_name<T>() == string::utf8(b"bool")) {
-            create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"bool"))
-        } else if (type_name<T>() == string::utf8(b"u8")) {
-            create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"u8"))
-        } else if (type_name<T>() == string::utf8(b"u64")) {
-            create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"u64"))
-        } else if (type_name<T>() == string::utf8(b"u128")) {
-            create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"u128"))
-        } else if (type_name<T>() == string::utf8(b"address")) {
-            create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"address"))
-        } else if (type_name<T>() == string::utf8(b"0x1::string::String")) {
-            create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"0x1::string::String"))
+        let name = type_name<T>();
+        if (
+            name == string::utf8(b"bool") ||
+            name == string::utf8(b"u8") ||
+            name == string::utf8(b"u64") ||
+            name == string::utf8(b"u128") ||
+            name == string::utf8(b"address") ||
+            name == string::utf8(b"0x1::string::String")
+        ) {
+            create_property_value_raw(bcs::to_bytes<T>(data), name)
         } else {
             create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"vector<u8>"))
         }
@@ -255,5 +253,14 @@ module aptos_token::property_map {
         let plist = new(keys, values, types);
         assert!(!read_bool(&plist, &utf8(b"mutable")), 1);
         assert!(read_u8(&plist, &utf8(b"attack")) == 10, 1);
+    }
+
+    #[test]
+    fun test_generate_property_value_convert_back() {
+        let data: address = @0xcafe;
+        let pv = create_property_value(&data);
+        let pm = create_property_list();
+        add(&mut pm, string::utf8(b"addr"), pv);
+        assert!(read_address(&pm, &string::utf8(b"addr")) == data, 1)
     }
 }

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -302,7 +302,51 @@ module aptos_token::token {
         *opt_in_flag = opt_in;
     }
 
+    public fun  mutate_one_token(
+        account: &signer,
+        token_owner: address,
+        token_id: TokenId,
+        keys: vector<String>,
+        values: vector<vector<u8>>,
+        types: vector<String>,
+    ): TokenId acquires Collections, TokenStore {
+        let creator = token_id.token_data_id.creator;
+        assert!(signer::address_of(account) == creator, ENO_MUTATE_CAPABILITY);
+        // validate if the properties is mutable
+        assert!(exists<Collections>(creator), ECOLLECTIONS_NOT_PUBLISHED);
+        let all_token_data = &mut borrow_global_mut<Collections>(
+            creator
+        ).token_data;
 
+        assert!(table::contains(all_token_data, token_id.token_data_id), ETOKEN_NOT_PUBLISHED);
+        let token_data = table::borrow_mut(all_token_data, token_id.token_data_id);
+
+        assert!(token_data.mutability_config.properties, EFIELD_NOT_MUTABLE);
+        // check if the property_version is 0 to determine if we need to update the property_version
+        if (token_id.property_version == 0) {
+            let token = withdraw_with_event_internal(token_owner, token_id, 1);
+            let largest_property_version = token_data.largest_property_version;
+            // give a new property_version for each token
+            let cur_property_version = largest_property_version + 1;
+            let new_token_id = create_token_id(token_id.token_data_id, cur_property_version);
+            let new_token = Token {
+                id: new_token_id,
+                amount: 1,
+                token_properties: *&token_data.default_properties,
+            };
+            direct_deposit(token_owner, new_token);
+            update_token_property_internal(token_owner, new_token_id, keys, values, types);
+
+            token_data.largest_property_version = cur_property_version;
+            // burn the orignial property_version 0 token after mutation
+            let Token {id: _, amount: _, token_properties: _} = token;
+            new_token_id
+        } else {
+            // only 1 copy for the token with property verion bigger than 0
+            update_token_property_internal(token_owner, token_id, keys, values, types);
+            token_id
+        }
+    }
 
     /// mutate the token property and save the new property in TokenStore
     /// if the token property_version is 0, we will create a new property_version per token and store the properties
@@ -331,30 +375,11 @@ module aptos_token::token {
         let token_data = table::borrow_mut(all_token_data, token_id.token_data_id);
         assert!(token_data.mutability_config.properties, error::permission_denied(EFIELD_NOT_MUTABLE));
         // check if the property_version is 0 to determine if we need to update the property_version
-        if (token_id.property_version == 0) {
-            let token = withdraw_with_event_internal(token_owner, token_id, amount);
-            let i = 0;
-            let largest_property_version = token_data.largest_property_version;
-            // give a new property_version for each token
-            while (i < token.amount) {
-                let cur_property_version = largest_property_version + i + 1;
-                let new_token_id = create_token_id(token_id.token_data_id, cur_property_version);
-                let new_token = Token {
-                    id: new_token_id,
-                    amount: 1,
-                    token_properties: *&token_data.default_properties,
-                };
-                // update the token largest property_version
-                direct_deposit(token_owner, new_token);
-                update_token_property_internal(token_owner, new_token_id, keys, values, types);
-                i = i + 1;
-            };
-            token_data.largest_property_version = largest_property_version + token.amount;
-            // burn the orignial property_version 0 token after mutation
-            let Token {id: _, amount: _, token_properties: _} = token;
-        } else {
-            assert!(amount == 1,  error::invalid_state(ENON_ZERO_PROPERTY_VERSION_ONLY_ONE_INSTANCE));
-            update_token_property_internal(token_owner, token_id, keys, values, types);
+        let i = 0;
+        // give a new property_version for each token
+        while (i < amount) {
+            mutate_one_token(account, token_owner, token_id, keys, values, types);
+            i = i + 1;
         };
     }
 
@@ -811,6 +836,48 @@ module aptos_token::token {
         token_id
     }
 
+
+    /// create tokens and directly deposite to receiver's address. The receiver should opt-in direct transfer
+    public fun mint_token_to(
+        account: &signer,
+        receiver: address,
+        token_data_id: TokenDataId,
+        amount: u64,
+    ) acquires Collections, TokenStore {
+        assert!(exists<TokenStore>(receiver), error::not_found(ETOKEN_STORE_NOT_PUBLISHED));
+        let opt_in_transfer = borrow_global<TokenStore>(receiver).direct_transfer;
+        assert!(opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER));
+
+        assert!(token_data_id.creator == signer::address_of(account), error::permission_denied(ENO_MINT_CAPABILITY));
+        let creator_addr = token_data_id.creator;
+        let all_token_data = &mut borrow_global_mut<Collections>(creator_addr).token_data;
+        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_NOT_PUBLISHED));
+        let token_data = table::borrow_mut(all_token_data, token_data_id);
+
+        if (token_data.maximum > 0 ) {
+            assert!(token_data.supply + amount <= token_data.maximum, error::invalid_argument(EMINT_WOULD_EXCEED_TOKEN_MAXIMUM));
+            token_data.supply = token_data.supply + amount;
+        };
+
+        // we add more tokens with property_version 0
+        let token_id = create_token_id(token_data_id, 0);
+        direct_deposit(receiver,
+            Token{
+                id: token_id,
+                amount,
+                token_properties: property_map::empty(), // same as default properties no need to store
+            }
+        );
+
+        event::emit_event<MintTokenEvent>(
+            &mut borrow_global_mut<Collections>(creator_addr).mint_token_events,
+            MintTokenEvent {
+                id: token_data_id,
+                amount,
+            }
+        );
+    }
+
     public entry fun burn(
         owner: &signer,
         creators_address: address,
@@ -926,6 +993,42 @@ module aptos_token::token {
         token.amount
     }
 
+    /// return the creator address, collection name, token name and property_version
+    public fun get_token_id_fields(token_id: &TokenId): (address, String, String, u64) {
+        (
+            token_id.token_data_id.creator,
+            token_id.token_data_id.collection,
+            token_id.token_data_id.name,
+            token_id.property_version,
+        )
+    }
+
+    public fun get_token_data_id_fields(token_data_id: &TokenDataId): (address, String, String) {
+        (
+            token_data_id.creator,
+            token_data_id.collection,
+            token_data_id.name,
+        )
+    }
+
+    /// return a copy of the token property map.
+    /// if property_version = 0, return the default property map
+    /// if property_version > 0, return the property value stored at owner's token store
+    public fun get_property_map(owner: address, token_id: TokenId): PropertyMap acquires Collections, TokenStore {
+        assert!(balance_of(owner, token_id) > 0, error::not_found(EINSUFFICIENT_BALANCE));
+        // if property_version = 0, return default property map
+        if (token_id.property_version == 0) {
+            let creator_addr = token_id.token_data_id.creator;
+            let all_token_data = &borrow_global<Collections>(creator_addr).token_data;
+            assert!(table::contains(all_token_data, token_id.token_data_id), error::not_found(ETOKEN_NOT_PUBLISHED));
+            let token_data = table::borrow(all_token_data, token_id.token_data_id);
+            *&token_data.default_properties
+        } else {
+            let tokens = &borrow_global<TokenStore>(owner).tokens;
+            *&table::borrow(tokens, token_id).token_properties
+        }
+    }
+
     // ****************** TEST-ONLY FUNCTIONS **************
 
     #[test_only]
@@ -964,11 +1067,12 @@ module aptos_token::token {
     #[test(creator = @0x1)]
     #[expected_failure] // (abort_code = 5)]
     public entry fun test_collection_maximum(creator: signer) acquires Collections, TokenStore {
+        use std::bcs;
         account::create_account_for_test(signer::address_of(&creator));
         let token_id = create_collection_and_token(&creator, 2, 2, 1);
         let default_keys = vector<String>[ string::utf8(b"attack"), string::utf8(b"num_of_use") ];
-        let default_vals = vector<vector<u8>>[ b"10", b"5" ];
-        let default_types = vector<String>[ string::utf8(b"integer"), string::utf8(b"integer") ];
+        let default_vals = vector<vector<u8>>[ bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5) ];
+        let default_types = vector<String>[ string::utf8(b"u64"), string::utf8(b"u64") ];
         let mutate_setting = vector<bool>[ false, false, false, false, false, false ];
 
         create_token_script(
@@ -1022,6 +1126,7 @@ module aptos_token::token {
         token_max: u64
     ): TokenId acquires Collections, TokenStore {
         use std::string;
+        use std::bcs;
         let mutate_setting = vector<bool>[false, false, false];
 
         create_collection(
@@ -1034,8 +1139,8 @@ module aptos_token::token {
         );
 
         let default_keys = vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")];
-        let default_vals = vector<vector<u8>>[b"10", b"5"];
-        let default_types = vector<String>[string::utf8(b"integer"), string::utf8(b"integer")];
+        let default_vals = vector<vector<u8>>[bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5)];
+        let default_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64")];
         let mutate_setting = vector<bool>[false, false, false, false, true];
         create_token_script(
             creator,
@@ -1085,6 +1190,7 @@ module aptos_token::token {
 
     #[test(creator = @0xAF, owner = @0xBB)]
     fun test_mutate_token_property(creator: &signer, owner: &signer) acquires Collections, TokenStore {
+        use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
 
@@ -1095,10 +1201,10 @@ module aptos_token::token {
             string::utf8(b"attack"), string::utf8(b"num_of_use")
         ];
         let new_vals = vector<vector<u8>>[
-            b"1", b"1"
+            bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
         ];
         let new_types = vector<String>[
-            string::utf8(b"integer"), string::utf8(b"integer")
+            string::utf8(b"u64"), string::utf8(b"u64")
         ];
 
         mutate_token_properties(
@@ -1154,6 +1260,7 @@ module aptos_token::token {
     #[test(creator = @0xAF, owner = @0xBB)]
     #[expected_failure(abort_code = 393219)]
     fun test_mutate_token_property_fail(creator: &signer) acquires Collections, TokenStore {
+        use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
 
         // token owner mutate the token property
@@ -1164,10 +1271,10 @@ module aptos_token::token {
             string::utf8(b"attack"), string::utf8(b"num_of_use"), string::utf8(b"wrong_attribute")
         ];
         let new_vals = vector<vector<u8>>[
-            b"1", b"1", b"1"
+            bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
         ];
         let new_types = vector<String>[
-            string::utf8(b"integer"), string::utf8(b"integer"), string::utf8(b"integer")
+            string::utf8(b"u64"), string::utf8(b"u64"), string::utf8(b"u64")
         ];
 
         mutate_token_properties(
@@ -1182,5 +1289,46 @@ module aptos_token::token {
             new_vals,
             new_types,
         );
+    }
+
+    #[test(creator = @0xAF, owner = @0xBB)]
+    fun test_get_property_map_should_not_update_source_value(creator: &signer) acquires Collections, TokenStore {
+        use std::bcs;
+        account::create_account_for_test(signer::address_of(creator));
+
+        // token owner mutate the token property
+        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        assert!(token_id.property_version == 0, 1);
+        // only be able to mutate the attributed defined when creating the token
+        let new_keys = vector<String>[
+            string::utf8(b"attack"), string::utf8(b"num_of_use")
+        ];
+        let new_vals = vector<vector<u8>>[
+            bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
+        ];
+        let new_types = vector<String>[
+            string::utf8(b"u64"), string::utf8(b"u64")
+        ];
+        let pm = get_property_map(signer::address_of(creator), token_id);
+        assert!(property_map::length(&pm) == 2, 1);
+        let new_token_id = mutate_one_token(
+            creator,
+            signer::address_of(creator),
+            token_id,
+            new_keys,
+            new_vals,
+            new_types,
+        );
+        let updated_pm = get_property_map(signer::address_of(creator), new_token_id);
+        assert!(property_map::length(&updated_pm) == 2, 1);
+        property_map::update_property_value(
+            &mut updated_pm,
+            &string::utf8(b"attack"),
+            property_map::create_property_value<u64>(&2),
+        );
+
+        assert!(property_map::read_u64(&updated_pm, &string::utf8(b"attack")) == 2, 1);
+        let og_pm = get_property_map(signer::address_of(creator), new_token_id);
+        assert!(property_map::read_u64(&og_pm, &string::utf8(b"attack")) == 1, 1);
     }
 }

--- a/aptos-move/framework/aptos-token/sources/token_coin_swap.move
+++ b/aptos-move/framework/aptos-token/sources/token_coin_swap.move
@@ -235,7 +235,16 @@ module aptos_token::token_coin_swap {
         assert!(table::contains(tokens_in_escrow, token_id), ETOKEN_NOT_IN_ESCROW);
         let token_escrow = table::borrow_mut(tokens_in_escrow, token_id);
         assert!(timestamp::now_seconds() > token_escrow.locked_until_secs, ETOKEN_CANNOT_MOVE_OUT_OF_ESCROW_BEFORE_LOCKUP_TIME);
-        split(&mut token_escrow.token, amount)
+        if (amount == token::get_token_amount(&token_escrow.token)) {
+            // destruct the token escrow to reclaim storage
+            let TokenEscrow {
+                token: tokens,
+                locked_until_secs: _
+            } = table::remove(tokens_in_escrow, token_id);
+            tokens
+        } else {
+            split(&mut token_escrow.token, amount)
+        }
     }
 
     /// Withdraw tokens from the token escrow. It needs a signer to authorize


### PR DESCRIPTION
### Description

Based on recent NFT airdrop feedbacks and observation, make the following improvement over token module to make it easy to use

1. add read methods for PropertyMap with type conversion
2. add a mutate one token method that can be directly used by community contracts
3. add a set of public get method for getting token data. 
4. add a mint_to method reduce the number of resource touched for lazy_mint

### Test Plan
add new unit test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4118)
<!-- Reviewable:end -->
