### PR TITLE
[move] bump move dependencies to fix the SignatureToken deserialization bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,7 +2201,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -5473,7 +5473,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5490,7 +5490,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -5505,12 +5505,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5537,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5612,7 +5612,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "difference",
@@ -5629,7 +5629,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5658,7 +5658,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5675,7 +5675,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5729,7 +5729,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5747,7 +5747,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5765,7 +5765,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5810,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5829,7 +5829,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "hex",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "hex",
@@ -5856,7 +5856,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5882,7 +5882,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5918,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5955,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5983,7 +5983,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -5994,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6005,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6020,7 +6020,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6047,7 +6047,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6065,7 +6065,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "log",
@@ -6087,7 +6087,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6096,7 +6096,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6175,7 +6175,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6192,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6206,7 +6206,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7719,7 +7719,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7734,7 +7734,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=4bdf8d3e76ffaab5c83eda2fa55dfe136c380675#4bdf8d3e76ffaab5c83eda2fa55dfe136c380675"
+source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/aptos-move/aptos-gas/Cargo.toml
+++ b/aptos-move/aptos-gas/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2021"
 
 [dependencies]
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
 
 aptos-types = { path = "../../types" }
 framework = { path = "../framework" }

--- a/aptos-move/gas-algebra-ext/Cargo.toml
+++ b/aptos-move/gas-algebra-ext/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-move-core-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -21,34 +21,34 @@ edition = "2021"
 #   actively looking for solutions.
 #
 ##########################################################################################
-move-abigen = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-cli = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-model = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-package = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-prover = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "4bdf8d3e76ffaab5c83eda2fa55dfe136c380675" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-cli = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-model = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-package = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-prover = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
 
 [features]
 default = []


### PR DESCRIPTION
For the bug fix, see https://github.com/move-language/move/pull/472 for details.

I've manually checked the commits between this and the one we currently depend on and there should be no breaking changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4122)
<!-- Reviewable:end -->
