### PR TITLE
[storage] get_rightmost_leaf take a version

### DIFF
--- a/storage/aptosdb/src/state_restore/restore_test.rs
+++ b/storage/aptosdb/src/state_restore/restore_test.rs
@@ -108,8 +108,8 @@ where
         self.tree_store.get_node_option(node_key)
     }
 
-    fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode<K>)>> {
-        self.tree_store.get_rightmost_leaf()
+    fn get_rightmost_leaf(&self, version: Version) -> Result<Option<(NodeKey, LeafNode<K>)>> {
+        self.tree_store.get_rightmost_leaf(version)
     }
 }
 

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -710,6 +710,8 @@ impl StateStore {
         })
     }
 
+    // state sync doesn't query for the progress, but keeps its record by itself.
+    // TODO: change to async comment once it does like https://github.com/aptos-labs/aptos-core/blob/159b00f3d53e4327523052c1b99dd9889bf13b03/storage/backup/backup-cli/src/backup_types/state_snapshot/restore.rs#L147 or overlap at least two chunks.
     pub fn get_snapshot_receiver(
         self: &Arc<Self>,
         version: Version,
@@ -720,7 +722,7 @@ impl StateStore {
             self,
             version,
             expected_root_hash,
-            true, /* async_commit */
+            false, /* async_commit */
         )?))
     }
 

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -715,11 +715,12 @@ impl StateStore {
         version: Version,
         expected_root_hash: HashValue,
     ) -> Result<Box<dyn StateSnapshotReceiver<StateKey, StateValue>>> {
-        Ok(Box::new(StateSnapshotRestore::new_overwrite(
+        Ok(Box::new(StateSnapshotRestore::new(
             &self.state_merkle_db,
             self,
             version,
             expected_root_hash,
+            true, /* async_commit */
         )?))
     }
 

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -410,9 +410,14 @@ proptest! {
         let tmp_dir2 = TempPath::new();
         let db2 = AptosDB::new_for_test(&tmp_dir2);
         let store2 = &db2.state_store;
-
+        let max_hash = HashValue::new([0xff; HashValue::LENGTH]);
         let mut restore =
             StateSnapshotRestore::new(&store2.state_merkle_db, store2, version, expected_root_hash, false, /* async_commit */).unwrap();
+
+        let dummy_state_key = StateKey::Raw(vec![]);
+        let (batch, _) = store2.state_merkle_db.merklize_value_set(vec![(max_hash, Some(&(HashValue::random(), dummy_state_key)))], None, 0, None, None).unwrap();
+        store2.state_merkle_db.db.write_schemas(batch).unwrap();
+        assert!(store2.state_merkle_db.get_rightmost_leaf(version).unwrap().is_none());
 
         let mut ordered_input: Vec<_> = input
             .into_iter()
@@ -431,8 +436,8 @@ proptest! {
         restore.add_chunk(batch1, proof_of_batch1).unwrap();
         restore.wait_for_async_commit().unwrap();
 
-        let expected = store2.state_merkle_db.get_rightmost_leaf_naive().unwrap();
-        let actual = store2.state_merkle_db.get_rightmost_leaf().unwrap();
+        let expected = store2.state_merkle_db.get_rightmost_leaf_naive(version).unwrap();
+        let actual = store2.state_merkle_db.get_rightmost_leaf(version).unwrap();
         prop_assert_eq!(actual, expected);
     }
 

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -136,9 +136,9 @@ pub trait TreeReader<K> {
     /// Gets node given a node key. Returns `None` if the node does not exist.
     fn get_node_option(&self, node_key: &NodeKey) -> Result<Option<Node<K>>>;
 
-    /// Gets the rightmost leaf. Note that this assumes we are in the process of restoring the tree
-    /// and all nodes are at the same version.
-    fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode<K>)>>;
+    /// Gets the rightmost leaf at a version. Note that this assumes we are in the process of
+    /// restoring the tree and all nodes are at the same version.
+    fn get_rightmost_leaf(&self, version: Version) -> Result<Option<(NodeKey, LeafNode<K>)>>;
 }
 
 pub trait TreeWriter<K>: Send + Sync {

--- a/storage/jellyfish-merkle/src/mock_tree_store.rs
+++ b/storage/jellyfish-merkle/src/mock_tree_store.rs
@@ -32,14 +32,16 @@ where
         Ok(self.data.read().0.get(node_key).cloned())
     }
 
-    fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode<K>)>> {
+    fn get_rightmost_leaf(&self, version: Version) -> Result<Option<(NodeKey, LeafNode<K>)>> {
         let locked = self.data.read();
         let mut node_key_and_node: Option<(NodeKey, LeafNode<K>)> = None;
 
         for (key, value) in locked.0.iter() {
             if let Node::Leaf(leaf_node) = value {
-                if node_key_and_node.is_none()
-                    || leaf_node.account_key() > node_key_and_node.as_ref().unwrap().1.account_key()
+                if key.version() == version
+                    && (node_key_and_node.is_none()
+                        || leaf_node.account_key()
+                            > node_key_and_node.as_ref().unwrap().1.account_key())
                 {
                     node_key_and_node.replace((key.clone(), leaf_node.clone()));
                 }

--- a/storage/jellyfish-merkle/src/node_type/node_type_test.rs
+++ b/storage/jellyfish-merkle/src/node_type/node_type_test.rs
@@ -30,7 +30,10 @@ impl TreeReader<StateKey> for DummyReader {
         unimplemented!()
     }
 
-    fn get_rightmost_leaf(&self) -> anyhow::Result<Option<(NodeKey, LeafNode<StateKey>)>> {
+    fn get_rightmost_leaf(
+        &self,
+        _version: Version,
+    ) -> anyhow::Result<Option<(NodeKey, LeafNode<StateKey>)>> {
         unimplemented!()
     }
 }

--- a/storage/jellyfish-merkle/src/restore/mod.rs
+++ b/storage/jellyfish-merkle/src/restore/mod.rs
@@ -186,7 +186,7 @@ where
                 expected_root_hash,
             );
             (true, vec![], None)
-        } else if let Some((node_key, leaf_node)) = tree_reader.get_rightmost_leaf()? {
+        } else if let Some((node_key, leaf_node)) = tree_reader.get_rightmost_leaf(version)? {
             // If the system crashed in the middle of the previous restoration attempt, we need
             // to recover the partial nodes to the state right before the crash.
             (


### PR DESCRIPTION
### Description

Take a version now so fast sync wouldn't take a wrong leaf node at a different version in any case.

### Test Plan
ut

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4123)
<!-- Reviewable:end -->
