### PR TITLE
[mempool] fix broadcast retry fails if retry is empty

### DIFF
--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -148,6 +148,14 @@ impl MempoolNode {
         }
     }
 
+    pub async fn commit_txns(&mut self, txns: &[TestTransaction]) {
+        for txn in sign_transactions(txns) {
+            self.mempool
+                .lock()
+                .remove_transaction(&txn.sender(), txn.sequence_number(), false);
+        }
+    }
+
     /// Asynchronously waits for up to 1 second for txns to appear in mempool
     pub async fn wait_on_txns_in_mempool(&self, txns: &[TestTransaction]) {
         for _ in 0..10 {


### PR DESCRIPTION
### Description

On broadcast error (e.g., receiver mempool is full) the broadcast is retried later. If this retry was empty (e.g., all transactions were since notified as committed) `determine_broadcast_batch` would continuously return `BroadcastError::NoTransactions` without removing the (now-empty) retry.

### Test Plan

Add an integration test that would stall because of this issue in main.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4129)
<!-- Reviewable:end -->
