### PR TITLE
[mempool] handle when validate_transaction returns an error

### DIFF
--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -335,6 +335,14 @@ where
                         ));
                     }
                 }
+            } else {
+                statuses.push((
+                    transaction.clone(),
+                    (
+                        MempoolStatus::new(MempoolStatusCode::VmError),
+                        Some(DiscardedVMStatus::UNKNOWN_STATUS),
+                    ),
+                ));
             }
         }
     }


### PR DESCRIPTION
### Description

This was pointed out as a potential problem. Today this only happens on the failpoint; but having one less status in that case is also potentially problematic.

### Test Plan

Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4135)
<!-- Reviewable:end -->
