### PR TITLE
[aptos-rosetta] Drop transactions that don't have associated operations

### DIFF
--- a/crates/aptos-rosetta-cli/src/block.rs
+++ b/crates/aptos-rosetta-cli/src/block.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{format_output, BlockArgs, NetworkArgs, UrlArgs};
-use aptos_rosetta::types::{BlockRequest, BlockResponse};
+use aptos_rosetta::types::{BlockRequest, BlockRequestMetadata, BlockResponse};
 use clap::{Parser, Subcommand};
 
 /// Block APIs
@@ -38,9 +38,16 @@ pub struct GetBlockCommand {
 
 impl GetBlockCommand {
     pub async fn execute(self) -> anyhow::Result<BlockResponse> {
+        let metadata = self
+            .block_args
+            .keep_all_transactions
+            .map(|inner| BlockRequestMetadata {
+                keep_empty_transactions: Some(inner),
+            });
         let request = BlockRequest {
             network_identifier: self.network_args.network_identifier(),
             block_identifier: self.block_args.into(),
+            metadata,
         };
         self.url_args.client().block(&request).await
     }

--- a/crates/aptos-rosetta-cli/src/common.rs
+++ b/crates/aptos-rosetta-cli/src/common.rs
@@ -91,6 +91,9 @@ pub struct BlockArgs {
     /// The hash of the block to request
     #[clap(long)]
     block_hash: Option<String>,
+
+    #[clap(long)]
+    pub keep_all_transactions: Option<bool>,
 }
 
 impl From<BlockArgs> for Option<PartialBlockIdentifier> {

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -57,6 +57,14 @@ pub struct BlockRequest {
     /// A set of search parameters (latest, by hash, or by index)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_identifier: Option<PartialBlockIdentifier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<BlockRequestMetadata>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlockRequestMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_empty_transactions: Option<bool>,
 }
 
 impl BlockRequest {
@@ -64,6 +72,7 @@ impl BlockRequest {
         Self {
             network_identifier: chain_id.into(),
             block_identifier,
+            metadata: None,
         }
     }
 
@@ -77,6 +86,13 @@ impl BlockRequest {
 
     pub fn by_index(chain_id: ChainId, index: u64) -> Self {
         Self::new(chain_id, Some(PartialBlockIdentifier::block_index(index)))
+    }
+
+    pub fn with_empty_transactions(mut self) -> Self {
+        self.metadata = Some(BlockRequestMetadata {
+            keep_empty_transactions: Some(true),
+        });
+        self
     }
 }
 


### PR DESCRIPTION
### Description
This should save users who don't want to keep track of transactions without associated operations.  They can be re-enabled by a flag.


### Test Plan
Updated test accordingly.

Note: that it doesn't check specifically which transactions are missing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4138)
<!-- Reviewable:end -->
