### PR TITLE
[community] sort Job Departments alphabetically on Careers

### DIFF
--- a/ecosystem/platform/server/app/views/static_page/careers.html.erb
+++ b/ecosystem/platform/server/app/views/static_page/careers.html.erb
@@ -9,7 +9,7 @@
       </h2>
       <%= render DividerComponent.new(scheme: :primary, class: 'mt-6 mb-16') %>
       <div class="mb-20">
-        <% @job_departments.each do |department, jobs| %>
+        <% @job_departments.sort.each do |department, jobs| %>
           <div class="mb-12">
             <h2 class="text-4xl mb-4 block font-display font-light"><%= department %></h2>
             <% jobs.each do |job| %>


### PR DESCRIPTION
### Description
Display Job Departments in alphabetical order on Careers page.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Before:
<img width="1743" alt="image" src="https://user-images.githubusercontent.com/98909677/189794787-4364044e-e14b-42d9-92d8-3022c7433d32.png">

After:
<img width="1734" alt="image" src="https://user-images.githubusercontent.com/98909677/189794747-5b837fb9-575b-43df-98ce-8f7d120b5a55.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4140)
<!-- Reviewable:end -->
