### PR TITLE
[txn-emitter] Log and retry improvements

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -111,7 +111,7 @@ pub struct EmitArgs {
 fn parse_target(target: &str) -> Result<Url> {
     let mut url = Url::try_from(target).map_err(|e| {
         format_err!(
-            "Failed to parse listen address, try adding a scheme, e.g. http://: {}",
+            "Failed to parse listen address, try adding a scheme, e.g. http://: {:?}",
             e
         )
     })?;

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -136,7 +136,7 @@ impl Cluster {
 
         let cluster = Cluster::from_host_port(urls, mint_key, args.chain_id, args.reuse_accounts)
             .await
-            .map_err(|e| format_err!("failed to create a cluster from host and port: {}", e))?;
+            .map_err(|e| format_err!("failed to create a cluster from host and port: {:?}", e))?;
 
         Ok(cluster)
     }
@@ -152,7 +152,7 @@ impl Cluster {
     ) -> Result<LocalAccount> {
         let sequence_number = query_sequence_number(client, address).await.map_err(|e| {
             format_err!(
-                "query_sequence_numbers on {:?} for account {} failed: {}",
+                "query_sequence_numbers on {:?} for account {} failed: {:?}",
                 client,
                 address,
                 e

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -174,7 +174,7 @@ impl<'t> AccountMinter<'t> {
             .await
             .into_iter()
             .collect::<Result<Vec<_>>>()
-            .map_err(|e| format_err!("Failed to mint accounts: {}", e))?
+            .map_err(|e| format_err!("Failed to mint accounts: {:?}", e))?
             .into_iter()
             .flatten()
             .collect();
@@ -280,7 +280,7 @@ impl<'t> AccountMinter<'t> {
         let address = account_key.authentication_key().derived_address();
         let sequence_number = query_sequence_number(client, address).await.map_err(|e| {
             format_err!(
-                "query_sequence_number on {:?} for dd account failed: {}",
+                "query_sequence_number on {:?} for dd account failed: {:?}",
                 client,
                 e
             )
@@ -507,7 +507,7 @@ pub async fn execute_and_wait_transactions(
         .await
         .map_err(|e| {
             format_err!(
-                "Failed to submit transactions: {:?}, {}",
+                "Failed to submit transactions: {:?}, {:?}",
                 state
                     .lock()
                     .failures
@@ -551,7 +551,7 @@ pub async fn execute_and_wait_transactions(
         RETRY_POLICY
             .retry(move || client.wait_for_signed_transaction_bcs(txn))
             .await
-            .map_err(|e| format_err!("Failed to wait for transactions: {}", e))?;
+            .map_err(|e| format_err!("Failed to wait for transactions: {:?}", e))?;
     }
 
     debug!(

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -58,7 +58,7 @@ const GAS_AMOUNT: u64 = 1000;
 // account sequence numbers). If these fail, the whole test fails. We do not use
 // this for submitting transactions, as we have a way to handle when that fails.
 // This retry policy means an operation will take 8 seconds at most.
-static RETRY_POLICY: Lazy<RetryPolicy> = Lazy::new(|| {
+pub static RETRY_POLICY: Lazy<RetryPolicy> = Lazy::new(|| {
     RetryPolicy::exponential(Duration::from_millis(125))
         .with_max_retries(6)
         .with_jitter(true)
@@ -713,7 +713,7 @@ where
         addresses.map(|address| RETRY_POLICY.retry(move || client.get_account_bcs(*address))),
     )
     .await
-    .map_err(|e| format_err!("Get accounts failed: {}", e))?
+    .map_err(|e| format_err!("Get accounts failed: {:?}", e))?
     .into_iter()
     .map(|resp| resp.into_inner().sequence_number())
     .collect())

--- a/crates/transaction-emitter-lib/src/transaction_generator/nft_mint.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/nft_mint.rs
@@ -7,8 +7,8 @@ use aptos_sdk::{
     types::{transaction::SignedTransaction, LocalAccount},
 };
 
-use crate::emitter::account_minter::create_and_fund_account_request;
-use aptos_logger::info;
+use crate::emitter::{account_minter::create_and_fund_account_request, RETRY_POLICY};
+use aptos_logger::{info, warn};
 use rand::rngs::StdRng;
 use std::sync::Arc;
 
@@ -57,6 +57,20 @@ impl TransactionGenerator for NFTMint {
     }
 }
 
+async fn submit_retry_and_wait(rest_client: &RestClient, txn: &SignedTransaction) {
+    let submit_result = RETRY_POLICY
+        .retry(move || rest_client.submit_bcs(txn))
+        .await;
+    if let Err(e) = submit_result {
+        warn!("Failed submitting transaction {:?} with {:?}", txn, e);
+    }
+    // if submission timeouts, it might still get committed:
+    RETRY_POLICY
+        .retry(move || rest_client.wait_for_signed_transaction_bcs(txn))
+        .await
+        .unwrap();
+}
+
 pub async fn initialize_nft_collection(
     rest_client: RestClient,
     root_account: &mut LocalAccount,
@@ -72,24 +86,22 @@ pub async fn initialize_nft_collection(
         creator_account.public_key(),
         txn_factory,
     );
-    rest_client
-        .submit_and_wait(&create_account_txn)
-        .await
-        .unwrap();
+
+    submit_retry_and_wait(&rest_client, &create_account_txn).await;
 
     info!("create_account_txn complete");
 
     let collection_txn =
         create_nft_collection_request(creator_account, collection_name, txn_factory);
 
-    rest_client.submit_and_wait(&collection_txn).await.unwrap();
+    submit_retry_and_wait(&rest_client, &collection_txn).await;
 
     info!("collection_txn complete");
 
     let token_txn =
         create_nft_token_request(creator_account, collection_name, token_name, txn_factory);
 
-    rest_client.submit_and_wait(&token_txn).await.unwrap();
+    submit_retry_and_wait(&rest_client, &token_txn).await;
 
     info!("token_txn complete");
 }

--- a/crates/transaction-emitter/src/diag.rs
+++ b/crates/transaction-emitter/src/diag.rs
@@ -32,7 +32,7 @@ pub async fn diag(cluster: &Cluster) -> Result<()> {
                 10,
             )
             .await
-            .map_err(|e| format_err!("Failed to submit txn through {}: {}", instance, e))?;
+            .map_err(|e| format_err!("Failed to submit txn through {}: {:?}", instance, e))?;
         println!("seq={}", faucet_account.sequence_number());
         println!(
             "Waiting all full nodes to get to seq {}",
@@ -51,7 +51,7 @@ pub async fn diag(cluster: &Cluster) -> Result<()> {
             let mut all_good = true;
             for (instance, result) in zip(instances.iter(), results) {
                 let seq = result.map_err(|e| {
-                    format_err!("Failed to query sequence number from {}: {}", instance, e)
+                    format_err!("Failed to query sequence number from {}: {:?}", instance, e)
                 })?[0];
                 let host = instance.api_url().host().unwrap().to_string();
                 let status = if seq != faucet_account.sequence_number() {


### PR DESCRIPTION
{} only prints a message from the last error or context call. {:?} prints errors/contexts beyond the last, and the stack trace if available.

retry logic for nfts initialization, to match account_creation retry logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4143)
<!-- Reviewable:end -->
