### PR TITLE
[Forge] Fix network partition test

### DIFF
--- a/.github/workflows/continuous-e2e-network-partition-test.yaml
+++ b/.github/workflows/continuous-e2e-network-partition-test.yaml
@@ -1,0 +1,22 @@
+name: Continuous E2E Network Partition Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  run-forge-network-partition-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-network-partition
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      # Run for 15 minutes
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: network_partition
+      POST_TO_SLACK: true

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -451,7 +451,16 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                 helm_values["chain"]["epoch_duration_secs"] = 30.into();
             })),
         "config" => config.with_network_tests(vec![&ReconfigurationTest]),
-        "network_partition" => config.with_network_tests(vec![&NetworkPartitionTest]),
+        "network_partition" => config
+            .with_initial_validator_count(NonZeroUsize::new(10).unwrap())
+            .with_network_tests(vec![&NetworkPartitionTest])
+            .with_success_criteria(SuccessCriteria::new(
+                3000,
+                10000,
+                true,
+                Some(Duration::from_secs(240)),
+                None,
+            )),
         "network_latency" => config
             .with_network_tests(vec![&NetworkLatencyTest])
             .with_success_criteria(SuccessCriteria::new(4000, 10000, true, None, None)),

--- a/testsuite/forge/src/backend/k8s/chaos/network_partition.yaml
+++ b/testsuite/forge/src/backend/k8s/chaos/network_partition.yaml
@@ -16,7 +16,7 @@ spec:
     selector:
       namespaces:
         - {namespace}
-      labelSelectors:
-        app.kubernetes.io/name: validator
+      expressionSelectors:
+        - {{ key: app.kubernetes.io/instance, operator: In, values: [validator-0, validator-1, validator-2] }}
     mode: fixed-percent
     value: "{partition_percentage}"

--- a/testsuite/testcases/src/network_partition_test.rs
+++ b/testsuite/testcases/src/network_partition_test.rs
@@ -28,7 +28,13 @@ impl NetworkLoadTest for NetworkPartitionTest {
         );
         println!("{}", msg);
         ctx.report.report_text(msg);
-        Ok(LoadDestination::AllNodes)
+        // Just send the load to last validator which is not included in the partition
+        Ok(LoadDestination::Peers(vec![ctx
+            .swarm()
+            .validators()
+            .last()
+            .map(|v| v.peer_id())
+            .unwrap()]))
     }
 
     fn finish(&self, swarm: &mut dyn Swarm) -> anyhow::Result<()> {


### PR DESCRIPTION
### Description

Fixed the existing network partition test to be more stable. Instead of randomly partitioning the network, it partitions the first 3 nodes and ensures that we don't send transactions there. 

### Test Plan

Ran the test locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4146)
<!-- Reviewable:end -->
