### PR TITLE
[Consensus] Tune max block size from 6k -> 3.5k

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -35,7 +35,7 @@ pub struct ConsensusConfig {
 impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
-            max_block_txns: 6000,
+            max_block_txns: 3500,
             max_block_bytes: 5 * 1024 * 1024, // 5MB
             max_pruned_blocks_in_mem: 100,
             mempool_executed_txn_timeout_ms: 1000,


### PR DESCRIPTION
### Description

In AIT3, we are seeing many timeouts under load, the main reason for that being the proposal broadcast time being very high. Reducing the block size, which should help reduce the broadcast time. 

### Test Plan

Run Forge

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4151)
<!-- Reviewable:end -->
