### PR TITLE
[aptos-rosetta] Allow synthetic blocks in Rosetta

### DIFF
--- a/crates/aptos-rosetta-cli/src/block.rs
+++ b/crates/aptos-rosetta-cli/src/block.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{format_output, BlockArgs, NetworkArgs, UrlArgs};
-use aptos_rosetta::types::{BlockRequest, BlockResponse};
+use aptos_rosetta::types::{BlockRequest, BlockRequestMetadata, BlockResponse};
 use clap::{Parser, Subcommand};
 
 /// Block APIs
@@ -38,9 +38,16 @@ pub struct GetBlockCommand {
 
 impl GetBlockCommand {
     pub async fn execute(self) -> anyhow::Result<BlockResponse> {
+        let metadata = self
+            .block_args
+            .keep_all_transactions
+            .map(|inner| BlockRequestMetadata {
+                keep_empty_transactions: Some(inner),
+            });
         let request = BlockRequest {
             network_identifier: self.network_args.network_identifier(),
             block_identifier: self.block_args.into(),
+            metadata,
         };
         self.url_args.client().block(&request).await
     }

--- a/crates/aptos-rosetta-cli/src/common.rs
+++ b/crates/aptos-rosetta-cli/src/common.rs
@@ -91,6 +91,9 @@ pub struct BlockArgs {
     /// The hash of the block to request
     #[clap(long)]
     block_hash: Option<String>,
+
+    #[clap(long)]
+    pub keep_all_transactions: Option<bool>,
 }
 
 impl From<BlockArgs> for Option<PartialBlockIdentifier> {

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -8,9 +8,10 @@ use crate::{
     },
     error::ApiResult,
     types::{Block, BlockIdentifier, BlockRequest, BlockResponse, Transaction},
-    RosettaContext,
+    ApiError, RosettaContext,
 };
 use aptos_logger::{debug, trace};
+use aptos_rest_client::aptos_api_types::BcsBlock;
 use aptos_types::chain_id::ChainId;
 use std::sync::Arc;
 use warp::Filter;
@@ -160,11 +161,15 @@ impl BlockInfo {
 #[derive(Debug)]
 pub struct BlockRetriever {
     rest_client: Arc<aptos_rest_client::Client>,
+    block_size: Option<u16>,
 }
 
 impl BlockRetriever {
-    pub fn new(rest_client: Arc<aptos_rest_client::Client>) -> Self {
-        BlockRetriever { rest_client }
+    pub fn new(rest_client: Arc<aptos_rest_client::Client>, block_size: Option<u16>) -> Self {
+        BlockRetriever {
+            rest_client,
+            block_size,
+        }
     }
 
     pub async fn get_block_info_by_height(
@@ -193,12 +198,40 @@ impl BlockRetriever {
         height: u64,
         with_transactions: bool,
     ) -> ApiResult<aptos_rest_client::aptos_api_types::BcsBlock> {
-        let block = self
-            .rest_client
-            .get_block_by_height_bcs(height, with_transactions)
-            .await?
-            .into_inner();
+        // Let's do some magic if there's a block size
+        if let Some(block_size) = self.block_size {
+            // Synthetic blocks have some problems around block time, and other pieces, but
+            // they are a tradeoff of performance when blocks are mostly empty
+            let first_version = block_size as u64 * height;
+            let last_version = (block_size as u64 * (height + 1)) - 1;
+            let mut block = self
+                .rest_client
+                .get_block_by_version_bcs(last_version, false)
+                .await?
+                .into_inner();
 
-        Ok(block)
+            // We have to hack the block into the correct bounds
+            // Hash doesn't matter and timestamp is the last transaction's block
+            block.first_version = first_version;
+            block.last_version = last_version;
+            block.block_height = height;
+
+            // If we need the transactions, append them to the block info
+            if with_transactions {
+                let transactions = self
+                    .rest_client
+                    .get_transactions_bcs(Some(first_version), Some(block_size))
+                    .await?
+                    .into_inner();
+                block.transactions = Some(transactions);
+            }
+            Ok(block)
+        } else {
+            Ok(self
+                .rest_client
+                .get_block_by_height_bcs(height, with_transactions)
+                .await?
+                .into_inner())
+        }
     }
 }

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -55,6 +55,12 @@ pub struct RosettaContext {
     pub coin_cache: Arc<CoinCache>,
     /// Block index cache
     pub block_cache: Option<Arc<BlockRetriever>>,
+
+    /// In the event that block size is not provided, it will use the actual blocks
+    /// if block size is provided, it will make synthetic blocks based on the transaction
+    /// versions.  Each block will be `block_size` transaction versions
+    pub block_size: Option<u16>,
+
     pub accounts: Arc<Mutex<BTreeMap<AccountAddress, SequenceNumber>>>,
 }
 

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -56,10 +56,8 @@ pub struct RosettaContext {
     /// Block index cache
     pub block_cache: Option<Arc<BlockRetriever>>,
 
-    /// In the event that block size is not provided, it will use the actual blocks
-    /// if block size is provided, it will make synthetic blocks based on the transaction
-    /// versions.  Each block will be `block_size` transaction versions
-    pub block_size: Option<u16>,
+    /// If using synthetic blocks, this will be the block size
+    pub synthetic_block_size: Option<u16>,
 
     pub accounts: Arc<Mutex<BTreeMap<AccountAddress, SequenceNumber>>>,
 }
@@ -87,6 +85,7 @@ pub fn bootstrap(
     chain_id: ChainId,
     api_config: ApiConfig,
     rest_client: Option<aptos_rest_client::Client>,
+    synthetic_block_size: Option<u16>,
 ) -> anyhow::Result<tokio::runtime::Runtime> {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .thread_name_fn(|| {
@@ -101,7 +100,12 @@ pub fn bootstrap(
 
     debug!("Starting up Rosetta server with {:?}", api_config);
 
-    runtime.spawn(bootstrap_async(chain_id, api_config, rest_client));
+    runtime.spawn(bootstrap_async(
+        chain_id,
+        api_config,
+        rest_client,
+        synthetic_block_size,
+    ));
     Ok(runtime)
 }
 
@@ -110,6 +114,7 @@ pub async fn bootstrap_async(
     chain_id: ChainId,
     api_config: ApiConfig,
     rest_client: Option<aptos_rest_client::Client>,
+    synthetic_block_size: Option<u16>,
 ) -> anyhow::Result<JoinHandle<()>> {
     debug!("Starting up Rosetta server with {:?}", api_config);
 
@@ -126,13 +131,20 @@ pub async fn bootstrap_async(
         );
     }
 
+    if matches!(synthetic_block_size, Some(0)) {
+        panic!("Cannot have a synthetic block size of 0");
+    }
+
     let api = WebServer::from(api_config);
     let handle = tokio::spawn(async move {
         // If it's Online mode, add the block cache
         let rest_client = rest_client.map(Arc::new);
-        let block_cache = rest_client
-            .as_ref()
-            .map(|rest_client| Arc::new(BlockRetriever::new(rest_client.clone())));
+        let block_cache = rest_client.as_ref().map(|rest_client| {
+            Arc::new(BlockRetriever::new(
+                rest_client.clone(),
+                synthetic_block_size,
+            ))
+        });
 
         let context = RosettaContext {
             rest_client: rest_client.clone(),
@@ -140,6 +152,7 @@ pub async fn bootstrap_async(
             coin_cache: Arc::new(CoinCache::new(rest_client.clone())),
             block_cache,
             accounts: Arc::new(Mutex::new(BTreeMap::new())),
+            synthetic_block_size,
         };
         api.serve(routes(context)).await;
     });

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::{get_latest_block_height, get_oldest_block_height};
 use crate::{
     common::{check_network, handle_request, with_context, with_empty_request},
     error::ApiError,
@@ -147,15 +148,18 @@ async fn network_status(
     let response = rest_client.get_ledger_information().await?;
     let state = response.state();
 
+    let oldest_block_height = get_oldest_block_height(&server_context, state);
+    let latest_block_height = get_latest_block_height(&server_context, state);
+
     // Get the oldest block
     let oldest_block_identifier = block_cache
-        .get_block_info_by_height(state.oldest_block_height, chain_id)
+        .get_block_info_by_height(oldest_block_height, chain_id)
         .await?
         .block_id;
 
     // Get the latest block
     let current_block = block_cache
-        .get_block_info_by_height(state.block_height, chain_id)
+        .get_block_info_by_height(latest_block_height, chain_id)
         .await?;
     let current_block_identifier = current_block.block_id;
 

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -111,6 +111,15 @@ pub struct Block {
     pub timestamp: u64,
     /// Transactions associated with the version.  In aptos there should only be one transaction
     pub transactions: Vec<Transaction>,
+    /// Metadata for the block
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<BlockMetadata>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlockMetadata {
+    pub first_version: U64,
+    pub last_version: U64,
 }
 
 /// A combination of a transaction and the block associated.  In Aptos, this is just the same

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -57,6 +57,14 @@ pub struct BlockRequest {
     /// A set of search parameters (latest, by hash, or by index)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_identifier: Option<PartialBlockIdentifier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<BlockRequestMetadata>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlockRequestMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_empty_transactions: Option<bool>,
 }
 
 impl BlockRequest {
@@ -64,6 +72,7 @@ impl BlockRequest {
         Self {
             network_identifier: chain_id.into(),
             block_identifier,
+            metadata: None,
         }
     }
 
@@ -77,6 +86,13 @@ impl BlockRequest {
 
     pub fn by_index(chain_id: ChainId, index: u64) -> Self {
         Self::new(chain_id, Some(PartialBlockIdentifier::block_index(index)))
+    }
+
+    pub fn with_empty_transactions(mut self) -> Self {
+        self.metadata = Some(BlockRequestMetadata {
+            keep_empty_transactions: Some(true),
+        });
+        self
     }
 }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -76,6 +76,7 @@ pub async fn setup_test(
         Some(aptos_rest_client::Client::new(
             validator.rest_api_endpoint(),
         )),
+        None,
     )
     .await
     .unwrap();

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -734,20 +734,14 @@ async fn test_block() {
             "Block timestamp should match actual timestamp but in ms"
         );
 
-        // First transaction should be first in block
-        assert_eq!(
-            current_version, actual_block.first_version,
-            "First transaction in block should be the current version"
-        );
+        // TODO: double check that all transactions do show with the flag, and that all expected txns
+        // are shown without the flag
 
         let actual_txns = actual_block
             .transactions
             .as_ref()
             .expect("Every actual block should have transactions");
         parse_block_transactions(&block, &mut balances, actual_txns, &mut current_version).await;
-
-        // The full block must have been processed
-        assert_eq!(current_version - 1, actual_block.last_version);
 
         // Keep track of the previous
         previous_block_index = block_height;
@@ -764,18 +758,33 @@ async fn parse_block_transactions(
     actual_txns: &[TransactionOnChainData],
     current_version: &mut u64,
 ) {
-    for (txn_number, transaction) in block.transactions.iter().enumerate() {
-        let actual_txn = actual_txns
-            .get(txn_number)
-            .expect("There should be the same number of transactions in the actual block");
-        let actual_txn_info = &actual_txn.info;
+    let versions: Vec<_> = block
+        .transactions
+        .iter()
+        .map(|txn| txn.metadata.version.0)
+        .collect();
+    eprintln!(
+        "block: {} txns: {:?}",
+        block.block_identifier.index, versions
+    );
+    for transaction in block.transactions.iter() {
         let txn_metadata = &transaction.metadata;
+        let txn_version = txn_metadata.version.0;
+        let cur_version = *current_version;
+        assert!(
+            txn_version >= cur_version,
+            "Transaction version {} must be greater than previous {}",
+            txn_version,
+            cur_version
+        );
+
+        let actual_txn = actual_txns
+            .iter()
+            .find(|txn| txn.version == txn_version)
+            .expect("There should be the transaction in the actual block");
+        let actual_txn_info = &actual_txn.info;
 
         // Ensure transaction identifier is correct
-        assert_eq!(
-            *current_version, txn_metadata.version.0,
-            "There should be no gaps in transaction versions"
-        );
         assert_eq!(
             format!("{:x}", actual_txn_info.transaction_hash()),
             transaction.transaction_identifier.hash,
@@ -793,7 +802,7 @@ async fn parse_block_transactions(
         match txn_metadata.transaction_type {
             TransactionType::Genesis => {
                 // For this test, there should only be one genesis
-                assert_eq!(0, *current_version);
+                assert_eq!(0, cur_version);
                 assert!(matches!(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::GenesisTransaction(_)
@@ -832,13 +841,13 @@ async fn parse_block_transactions(
         .await;
 
         for (_, account_balance) in balances.iter() {
-            if let Some(amount) = account_balance.get(current_version) {
+            if let Some(amount) = account_balance.get(&cur_version) {
                 assert!(*amount >= 0, "Amount shouldn't be negative!")
             }
         }
 
         // Increment to next version
-        *current_version += 1;
+        *current_version = txn_version + 1;
     }
 }
 
@@ -1184,7 +1193,8 @@ async fn test_invalid_transaction_gas_charged() {
     // Verify failed txn
     let rosetta_txn = block_with_transfer
         .transactions
-        .get(txn_version.saturating_sub(block_info.first_version.0) as usize)
+        .iter()
+        .find(|txn| txn.metadata.version.0 == txn_version)
         .unwrap();
 
     assert_failed_transfer_transaction(


### PR DESCRIPTION
### Description
You can make up blocks based on transactions if you feel that variable block size is not good enough for your current state.

Remembering that the timestamps can be wrong on a block.

Additionally, drops transactions that have no operations by default.

### Test Plan

This is a feature that's not supported in tests.  It has been tested manually to work

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4165)
<!-- Reviewable:end -->
