### PR TITLE
[cli] Use bcs when fetching events from API for analyze_validators

### DIFF
--- a/crates/aptos/src/node/analyze/fetch_metadata.rs
+++ b/crates/aptos/src/node/analyze/fetch_metadata.rs
@@ -127,7 +127,7 @@ impl FetchMetadata {
         end_epoch: Option<i64>,
     ) -> Result<Vec<EpochInfo>> {
         let (last_events, state) = client
-            .get_new_block_events(None, Some(1))
+            .get_new_block_events_bcs(None, Some(1))
             .await?
             .into_parts();
         let mut start_seq_num = state.oldest_block_height;
@@ -142,7 +142,7 @@ impl FetchMetadata {
             }
 
             let oldest_event = client
-                .get_new_block_events(Some(start_seq_num), Some(1))
+                .get_new_block_events_bcs(Some(start_seq_num), Some(1))
                 .await?
                 .into_inner()
                 .into_iter()
@@ -181,7 +181,7 @@ impl FetchMetadata {
                 let mid = (start_seq_num + search_end) / 2;
 
                 let mid_epoch = client
-                    .get_new_block_events(Some(mid), Some(1))
+                    .get_new_block_events_bcs(Some(mid), Some(1))
                     .await?
                     .into_inner()
                     .first()
@@ -215,7 +215,9 @@ impl FetchMetadata {
 
         let mut cursor = start_seq_num;
         loop {
-            let events = client.get_new_block_events(Some(cursor), Some(batch)).await;
+            let events = client
+                .get_new_block_events_bcs(Some(cursor), Some(batch))
+                .await;
 
             if events.is_err() {
                 println!(

--- a/testsuite/forge/src/test_utils/consensus_utils.rs
+++ b/testsuite/forge/src/test_utils/consensus_utils.rs
@@ -23,7 +23,7 @@ pub struct NodeState {
 // TODO: check if we can fetch consensus round, not just committed round.
 async fn get_node_state(validator_client: &RestClient) -> NodeState {
     let (events, state) = validator_client
-        .get_new_block_events(None, Some(1))
+        .get_new_block_events_bcs(None, Some(1))
         .await
         .unwrap()
         .into_parts();

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -113,7 +113,7 @@ async fn test_latest_events_and_transactions() {
     let mut swarm = new_local_swarm_with_aptos(1).await;
     let client = swarm.validators().next().unwrap().rest_client();
     let start_events = client
-        .get_new_block_events(None, Some(2))
+        .get_new_block_events_bcs(None, Some(2))
         .await
         .unwrap()
         .into_inner();
@@ -125,7 +125,7 @@ async fn test_latest_events_and_transactions() {
 
     create_and_fund_account(&mut swarm, 100).await;
     let cur_events = client
-        .get_new_block_events(None, Some(2))
+        .get_new_block_events_bcs(None, Some(2))
         .await
         .unwrap()
         .into_inner();


### PR DESCRIPTION
### Description

### Test Plan
Improves 3x the speed of this command:

cargo run -p aptos -- node analyze-validator-performance --analyze-mode=all --url=https://ait3.aptosdev.com  --start-epoch=190 --end-epoch=195

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4166)
<!-- Reviewable:end -->
