### PR TITLE
[aptos-api-types] Allow Event to be forwards and backwards compatible

### DIFF
--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -23,7 +23,8 @@ use aptos_types::{
 };
 
 use poem_openapi::{Object, Union};
-use serde::{Deserialize, Serialize};
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize};
 use std::{
     boxed::Box,
     convert::{From, Into, TryFrom, TryInto},
@@ -477,10 +478,11 @@ pub struct BlockMetadataTransaction {
 }
 
 /// An event from a transaction
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Object)]
 pub struct Event {
     pub key: EventKey,
-    // The globally unique identifer of this event stream.
+    // The globally unique identifier of this event stream.
+    #[serde(default)]
     pub guid: EventGuid,
     // The sequence number of the event
     pub sequence_number: U64,
@@ -489,6 +491,44 @@ pub struct Event {
     pub typ: MoveType,
     /// The JSON representation of the event
     pub data: serde_json::Value,
+}
+
+// Convert old format where EventGuid isn't shown
+#[derive(Serialize, Deserialize)]
+pub struct CompatibleEvent {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key: Option<EventKey>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub guid: Option<EventGuid>,
+    // The sequence number of the event
+    pub sequence_number: U64,
+    #[serde(rename = "type")]
+    pub typ: MoveType,
+    /// The JSON representation of the event
+    pub data: serde_json::Value,
+}
+
+impl<'de> Deserialize<'de> for Event {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let event = CompatibleEvent::deserialize(deserializer)?;
+        let (key, guid) = match (event.key, event.guid) {
+            (Some(key), Some(guid)) => (key, guid),
+            (Some(key), _) => (key, EventGuid::from(key)),
+            (_, Some(guid)) => (guid.into(), guid),
+            _ => return Err(D::Error::missing_field("key and guid")),
+        };
+
+        Ok(Event {
+            key,
+            guid,
+            sequence_number: event.sequence_number,
+            typ: event.typ,
+            data: event.data,
+        })
+    }
 }
 
 impl From<(&ContractEvent, serde_json::Value)> for Event {
@@ -1086,4 +1126,81 @@ impl TransactionSigningMessage {
 pub struct GasEstimation {
     /// The current estimate for the gas unit price
     pub gas_estimate: u64,
+}
+
+#[cfg(test)]
+mod test {
+    use crate::transaction::CompatibleEvent;
+    use crate::{Event, EventGuid, MoveType, U64};
+    use aptos_types::account_address::AccountAddress;
+
+    #[test]
+    fn check_event_compatibility() {
+        let creation_number = 42.into();
+        let account_address = AccountAddress::ONE.into();
+        let guid = EventGuid {
+            creation_number,
+            account_address,
+        };
+        let key: crate::EventKey = guid.into();
+        let sequence_number: U64 = 1.into();
+        let move_type = MoveType::Bool;
+        let data = serde_json::json!("{\"key\":\"value\"");
+
+        let both = serde_json::to_string(&CompatibleEvent {
+            key: Some(key),
+            guid: Some(guid),
+            sequence_number,
+            typ: move_type.clone(),
+            data: data.clone(),
+        })
+        .unwrap();
+        let no_key = serde_json::to_string(&CompatibleEvent {
+            key: None,
+            guid: Some(guid),
+            sequence_number,
+            typ: move_type.clone(),
+            data: data.clone(),
+        })
+        .unwrap();
+        let no_guid = serde_json::to_string(&CompatibleEvent {
+            key: Some(key),
+            guid: None,
+            sequence_number,
+            typ: move_type.clone(),
+            data: data.clone(),
+        })
+        .unwrap();
+        let neither = serde_json::to_string(&CompatibleEvent {
+            key: None,
+            guid: None,
+            sequence_number,
+            typ: move_type.clone(),
+            data: data.clone(),
+        })
+        .unwrap();
+
+        let expected = Event {
+            key,
+            guid,
+            sequence_number,
+            typ: move_type,
+            data,
+        };
+
+        assert_eq!(
+            expected,
+            serde_json::from_str(&both).expect("Should parse both fields")
+        );
+        assert_eq!(
+            expected,
+            serde_json::from_str(&no_key).expect("Should parse guid only")
+        );
+        assert_eq!(
+            expected,
+            serde_json::from_str(&no_guid).expect("Should parse key only")
+        );
+        serde_json::from_str::<Event>(&neither)
+            .expect_err("Should not parse missing both key and guid");
+    }
 }

--- a/api/types/src/wrappers.rs
+++ b/api/types/src/wrappers.rs
@@ -89,11 +89,30 @@ impl From<EventKey> for EventGuid {
     }
 }
 
+impl From<crate::EventKey> for EventGuid {
+    fn from(event_key: crate::EventKey) -> Self {
+        Self {
+            creation_number: U64(event_key.0.get_creation_number()),
+            account_address: Address::from(event_key.0.get_creator_address()),
+        }
+    }
+}
+
 impl From<EventGuid> for EventKey {
     fn from(event_key_wrapper: EventGuid) -> EventKey {
         EventKey::new(
             event_key_wrapper.creation_number.0,
             event_key_wrapper.account_address.into(),
         )
+    }
+}
+
+impl From<EventGuid> for crate::EventKey {
+    fn from(event_key_wrapper: EventGuid) -> crate::EventKey {
+        EventKey::new(
+            event_key_wrapper.creation_number.0,
+            event_key_wrapper.account_address.into(),
+        )
+        .into()
     }
 }


### PR DESCRIPTION
### Description
This should allow Events to be parsed forwards and backwards.  Note we'll need to deprecate the original event key

### Test Plan
Unit tests, and ran the validator checker

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4170)
<!-- Reviewable:end -->
