### PR TITLE
Add rust_lint.sh, use it in CI

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -127,10 +127,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/rust-setup
       - uses: pre-commit/action@v3.0.0
-      - run: cargo xclippy
-      - run: cargo fmt --check
       - run: cargo install cargo-sort
-      - run: cargo sort --grouped --check --workspace
+      - run: scripts/rust_lint.sh --check
 
   rust-doc-test:
     runs-on: high-perf-docker

--- a/scripts/rust_lint.sh
+++ b/scripts/rust_lint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# This assumes you have already installed cargo-sort:
+# cargo install cargo-sort
+#
+# The best way to do this however is to run scripts/dev_setup.sh
+#
+# If you want to run this from anywhere in aptos-core, try adding this wrapepr
+# script to your path:
+# https://gist.github.com/banool/e6a2b85e2fff067d3a215cbfaf808032
+
+# Make sure we're in the root of the repo.
+if [ ! -d ".github" ] 
+then
+    echo "Please run this from the root of aptos-core" 
+    exit 1
+fi
+
+# Run in check mode if requested.
+CHECK_ARG=""
+if [ "$1" = "--check" ]; then
+    CHECK_ARG="--check"
+fi
+
+set -x
+
+cargo xclippy
+cargo fmt $CHECK_ARG
+cargo sort --grouped --workspace $CHECK_ARG


### PR DESCRIPTION
### Description
Long requested, much desired, finally here. Running this script will ensure that your PR passes the `rust-lint` step in CI.

### Test Plan
```
scripts/rust_lint.sh
```
```
scripts/rust_lint.sh --check
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4175)
<!-- Reviewable:end -->
