### PR TITLE
[State Sync] Add a new alert for state sync lag and tweak a config.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -81,7 +81,7 @@ impl Default for StateSyncDriverConfig {
             max_consecutive_stream_notifications: 10,
             max_pending_data_chunks: 100,
             max_stream_wait_time_ms: 5000,
-            num_versions_to_skip_snapshot_sync: 10_000_000, // At 1k TPS, this allows a node to fail for about 3 hours.
+            num_versions_to_skip_snapshot_sync: 100_000_000, // At 5k TPS, this allows a node to fail for about 6 hours.
         }
     }
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -516,7 +516,7 @@ impl<
                 // validator, consensus will take control and sync depending on how it sees fit.
                 self.bootstrapping_complete().await
             } else {
-                panic!("Snapshot syncing is currently unsupported for nodes with existing state! \
+                panic!("Fast syncing is currently unsupported for nodes with existing state! \
                         You are currently {:?} versions behind the latest snapshot version ({:?}). Either \
                         select a different syncing mode, or delete your storage and restart your node.",
                        num_versions_behind, highest_known_ledger_version);

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
@@ -768,9 +768,7 @@ async fn test_snapshot_sync_lag() {
 }
 
 #[tokio::test]
-#[should_panic(
-    expected = "Snapshot syncing is currently unsupported for nodes with existing state!"
-)]
+#[should_panic(expected = "Fast syncing is currently unsupported for nodes with existing state!")]
 async fn test_snapshot_sync_lag_panic() {
     // Create test data
     let num_versions_behind = 10000;

--- a/terraform/helm/monitoring/files/rules/alerts.yml
+++ b/terraform/helm/monitoring/files/rules/alerts.yml
@@ -30,7 +30,14 @@ groups:
     for: 5m
     labels:
       severity: error
-      summary: "State sync is not making progress (i.e., it is not keeping up with the head of the blockchain)"
+      summary: "State sync is not making progress (i.e., the synced version is not increasing!)"
+    annotations:
+  - alert: State sync is lagging significantly
+    expr: (aptos_data_client_highest_advertised_data{data_type="transactions"} - on(kubernetes_pod_name, role) aptos_state_sync_version{type="synced"}) > 1000000
+    for: 5m
+    labels:
+      severity: error
+      summary: "State sync is lagging significantly (i.e., the lag is greater than 1 million versions)"
     annotations:
 
     # Mempool alerts


### PR DESCRIPTION
### Description
This PR makes two small tweaks to state sync:
1. It adds an alert for state sync when the node is lagging more than 1 million versions behind head. We might want to tweak this in the future based on how often it fires, but let's start here.
2. It increases the `num_versions_to_skip_snapshot_sync` in the state sync config.

### Test Plan
Existing infrastructure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4178)
<!-- Reviewable:end -->
