### PR TITLE
[crypto+move] added support for SHA2-512, SHA3-512 and RIPEMD-160 in Move

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,6 +14,7 @@
 /aptos-move/framework/aptos-framework/sources/account.move @alinush
 /aptos-move/framework/aptos-stdlib/sources/cryptography/ @alinush
 /aptos-move/framework/**/*.spec.move @junkil-park
+/aptos-move/framework/aptos-stdlib/sources/hash.move @alinush
 
 # Owner for aptos-token, cryptography natives, parallel-executor and vm-genesis.
 /aptos-move/framework/aptos-token @areshand

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3994,11 +3994,13 @@ dependencies = [
  "proptest-derive",
  "rand_core 0.5.1",
  "rayon",
+ "ripemd",
  "serde 1.0.144",
  "serde_bytes",
  "serde_json",
  "serde_yaml 0.8.26",
  "sha2 0.9.9",
+ "sha3",
  "siphasher",
  "smallvec",
  "tempfile",
@@ -8000,6 +8002,15 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1facec54cb5e0dc08553501fa740091086d0259ad0067e0d4103448e4cb22ed3"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]

--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -82,6 +82,16 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     // TODO(Gas): the on-chain name is wrong...
     [.type_info.type_name.per_byte_in_str, "type_info.type_name.per_abstract_memory_unit", 5 * MUL],
 
+    // Reusing SHA2-512's cost from Ristretto
+    [.hash.sha2_512.base, optional "hash.sha2_512.base", 3_240],
+    [.hash.sha2_512.per_byte, optional "hash.sha2_512.per_byte", 60],
+    // Back-of-the-envelop approximation from SHA3-256's (4000 base, 45 per-byte) costs
+    [.hash.sha3_512.base, optional "hash.sha3_512.base", 4_500],
+    [.hash.sha3_512.per_byte, optional "hash.sha3_512.per_byte", 50],
+    // Using SHA2-256's cost
+    [.hash.ripemd160.base, optional "hash.ripemd160.base", 3000],
+    [.hash.ripemd160.per_byte, optional "hash.ripemd160.per_byte", 50],
+
     [.util.from_bytes.base, "util.from_bytes.base", 300 * MUL],
     [.util.from_bytes.per_byte, "util.from_bytes.per_byte", 5 * MUL],
 

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -39,7 +39,7 @@ use std::collections::BTreeMap;
 //       global operations.
 // - V1
 //   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = 3;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = 4;
 
 pub(crate) const EXECUTION_GAS_MULTIPLIER: u64 = 20;
 

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
@@ -47,6 +47,17 @@ module std::features {
         is_enabled(TREAT_FRIEND_AS_PRIVATE)
     }
 
+    /// Whether the new SHA2-512, SHA3-512 and RIPEMD-160 hash function natives are enabled.
+    /// This is needed because of the introduction of new native functions.
+    /// Lifetime: transient
+    const SHA_512_AND_RIPEMD_160_NATIVES: u64 = 3;
+
+    public fun get_sha_512_and_ripemd_160_feature(): u64 { SHA_512_AND_RIPEMD_160_NATIVES }
+
+    public fun sha_512_and_ripemd_160_enabled(): bool acquires Features {
+        is_enabled(SHA_512_AND_RIPEMD_160_NATIVES)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -37,11 +37,13 @@ once_cell = "1.10.0"
 proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 rayon = "1.5.2"
+ripemd = "0.1.1"
 serde = { version = "1.0.137", default-features = false }
 serde_bytes = "0.11.6"
 serde_json = "1.0.81"
 serde_yaml = "0.8.24"
 sha2 = "0.9.3"
+sha3 = "0.9.1"
 siphasher = "0.3.10"
 smallvec = "1.8.0"
 tempfile = "3.3.0"

--- a/aptos-move/framework/aptos-stdlib/doc/hash.md
+++ b/aptos-move/framework/aptos-stdlib/doc/hash.md
@@ -13,15 +13,43 @@ Non-cryptograhic hashes:
 - SipHash: an add-rotate-xor (ARX) based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012
 
 
+-  [Constants](#@Constants_0)
 -  [Function `sip_hash`](#0x1_aptos_hash_sip_hash)
 -  [Function `sip_hash_from_value`](#0x1_aptos_hash_sip_hash_from_value)
 -  [Function `keccak256`](#0x1_aptos_hash_keccak256)
--  [Specification](#@Specification_0)
-    -  [Function `sip_hash`](#@Specification_0_sip_hash)
-    -  [Function `sip_hash_from_value`](#@Specification_0_sip_hash_from_value)
+-  [Function `sha2_512`](#0x1_aptos_hash_sha2_512)
+-  [Function `sha3_512`](#0x1_aptos_hash_sha3_512)
+-  [Function `ripemd160`](#0x1_aptos_hash_ripemd160)
+-  [Function `sha2_512_internal`](#0x1_aptos_hash_sha2_512_internal)
+-  [Function `sha3_512_internal`](#0x1_aptos_hash_sha3_512_internal)
+-  [Function `ripemd160_internal`](#0x1_aptos_hash_ripemd160_internal)
+-  [Specification](#@Specification_1)
+    -  [Function `sip_hash`](#@Specification_1_sip_hash)
+    -  [Function `sip_hash_from_value`](#@Specification_1_sip_hash_from_value)
+    -  [Function `keccak256`](#@Specification_1_keccak256)
+    -  [Function `sha2_512`](#@Specification_1_sha2_512)
+    -  [Function `sha3_512`](#@Specification_1_sha3_512)
+    -  [Function `ripemd160`](#@Specification_1_ripemd160)
 
 
 <pre><code><b>use</b> <a href="../../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
+<b>use</b> <a href="../../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+</code></pre>
+
+
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_aptos_hash_E_NATIVE_FUN_NOT_AVAILABLE"></a>
+
+A newly-added native function is not yet enabled.
+
+
+<pre><code><b>const</b> <a href="hash.md#0x1_aptos_hash_E_NATIVE_FUN_NOT_AVAILABLE">E_NATIVE_FUN_NOT_AVAILABLE</a>: u64 = 1;
 </code></pre>
 
 
@@ -30,6 +58,7 @@ Non-cryptograhic hashes:
 
 ## Function `sip_hash`
 
+Returns the (non-cryptographic) SipHash of <code>bytes</code>. See https://en.wikipedia.org/wiki/SipHash.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sip_hash">sip_hash</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): u64
@@ -52,6 +81,7 @@ Non-cryptograhic hashes:
 
 ## Function `sip_hash_from_value`
 
+Returns the (non-cryptographic) SipHash of the BCS serialization of <code>v</code>. See https://en.wikipedia.org/wiki/SipHash.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sip_hash_from_value">sip_hash_from_value</a>&lt;MoveValue&gt;(v: &MoveValue): u64
@@ -78,6 +108,7 @@ Non-cryptograhic hashes:
 
 ## Function `keccak256`
 
+Returns the Keccak-256 hash of <code>bytes</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_keccak256">keccak256</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
@@ -96,12 +127,174 @@ Non-cryptograhic hashes:
 
 </details>
 
-<a name="@Specification_0"></a>
+<a name="0x1_aptos_hash_sha2_512"></a>
+
+## Function `sha2_512`
+
+Returns the SHA2-512 hash of <code>bytes</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha2_512">sha2_512</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha2_512">sha2_512</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>if</b>(!<a href="../../move-stdlib/doc/features.md#0x1_features_sha_512_and_ripemd_160_enabled">features::sha_512_and_ripemd_160_enabled</a>()) {
+        <b>abort</b>(std::error::invalid_state(<a href="hash.md#0x1_aptos_hash_E_NATIVE_FUN_NOT_AVAILABLE">E_NATIVE_FUN_NOT_AVAILABLE</a>))
+    };
+
+    <a href="hash.md#0x1_aptos_hash_sha2_512_internal">sha2_512_internal</a>(bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aptos_hash_sha3_512"></a>
+
+## Function `sha3_512`
+
+Returns the SHA3-512 hash of <code>bytes</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha3_512">sha3_512</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha3_512">sha3_512</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>if</b>(!<a href="../../move-stdlib/doc/features.md#0x1_features_sha_512_and_ripemd_160_enabled">features::sha_512_and_ripemd_160_enabled</a>()) {
+        <b>abort</b>(std::error::invalid_state(<a href="hash.md#0x1_aptos_hash_E_NATIVE_FUN_NOT_AVAILABLE">E_NATIVE_FUN_NOT_AVAILABLE</a>))
+    };
+
+    <a href="hash.md#0x1_aptos_hash_sha3_512_internal">sha3_512_internal</a>(bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aptos_hash_ripemd160"></a>
+
+## Function `ripemd160`
+
+Returns the RIPEMD-160 hash of <code>bytes</code>.
+
+WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
+hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_ripemd160">ripemd160</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_ripemd160">ripemd160</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>if</b>(!<a href="../../move-stdlib/doc/features.md#0x1_features_sha_512_and_ripemd_160_enabled">features::sha_512_and_ripemd_160_enabled</a>()) {
+        <b>abort</b>(std::error::invalid_state(<a href="hash.md#0x1_aptos_hash_E_NATIVE_FUN_NOT_AVAILABLE">E_NATIVE_FUN_NOT_AVAILABLE</a>))
+    };
+
+    <a href="hash.md#0x1_aptos_hash_ripemd160_internal">ripemd160_internal</a>(bytes)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aptos_hash_sha2_512_internal"></a>
+
+## Function `sha2_512_internal`
+
+Returns the SHA2-512 hash of <code>bytes</code>.
+
+
+<pre><code><b>fun</b> <a href="hash.md#0x1_aptos_hash_sha2_512_internal">sha2_512_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha2_512_internal">sha2_512_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aptos_hash_sha3_512_internal"></a>
+
+## Function `sha3_512_internal`
+
+Returns the SHA3-512 hash of <code>bytes</code>.
+
+
+<pre><code><b>fun</b> <a href="hash.md#0x1_aptos_hash_sha3_512_internal">sha3_512_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha3_512_internal">sha3_512_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_aptos_hash_ripemd160_internal"></a>
+
+## Function `ripemd160_internal`
+
+Returns the RIPEMD-160 hash of <code>bytes</code>.
+
+WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
+hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
+
+
+<pre><code><b>fun</b> <a href="hash.md#0x1_aptos_hash_ripemd160_internal">ripemd160_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_ripemd160_internal">ripemd160_internal</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;;
+</code></pre>
+
+
+
+</details>
+
+<a name="@Specification_1"></a>
 
 ## Specification
 
 
-<a name="@Specification_0_sip_hash"></a>
+<a name="@Specification_1_sip_hash"></a>
 
 ### Function `sip_hash`
 
@@ -117,12 +310,76 @@ Non-cryptograhic hashes:
 
 
 
-<a name="@Specification_0_sip_hash_from_value"></a>
+<a name="@Specification_1_sip_hash_from_value"></a>
 
 ### Function `sip_hash_from_value`
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sip_hash_from_value">sip_hash_from_value</a>&lt;MoveValue&gt;(v: &MoveValue): u64
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_keccak256"></a>
+
+### Function `keccak256`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_keccak256">keccak256</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_sha2_512"></a>
+
+### Function `sha2_512`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha2_512">sha2_512</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_sha3_512"></a>
+
+### Function `sha3_512`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_sha3_512">sha3_512</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a name="@Specification_1_ripemd160"></a>
+
+### Function `ripemd160`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_ripemd160">ripemd160</a>(bytes: <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -23,6 +23,14 @@ module aptos_std::aptos_hash {
 
     native public fun keccak256(bytes: vector<u8>): vector<u8>;
 
+    native public fun sha2_512(bytes: vector<u8>): vector<u8>;
+
+    native public fun sha3_512(bytes: vector<u8>): vector<u8>;
+
+    /// WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
+    /// hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
+    native public fun ripemd160(bytes: vector<u8>): vector<u8>;
+
     //
     // Testing
     //
@@ -44,6 +52,82 @@ module aptos_std::aptos_hash {
             let input = *std::vector::borrow(&inputs, i);
             let hash_expected = *std::vector::borrow(&outputs, i);
             let hash = keccak256(input);
+
+            assert!(hash_expected == hash, 1);
+
+            i = i + 1;
+        };
+    }
+
+    #[test]
+    fun sha2_512_test() {
+        let inputs = vector[
+        b"testing",
+        b"",
+        ];
+
+        // From https://emn178.github.io/online-tools/sha512.html
+        let outputs = vector[
+        x"521b9ccefbcd14d179e7a1bb877752870a6d620938b28a66a107eac6e6805b9d0989f45b5730508041aa5e710847d439ea74cd312c9355f1f2dae08d40e41d50",
+        x"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+        ];
+
+        let i = 0;
+        while (i < std::vector::length(&inputs)) {
+            let input = *std::vector::borrow(&inputs, i);
+            let hash_expected = *std::vector::borrow(&outputs, i);
+            let hash = sha2_512(input);
+
+            assert!(hash_expected == hash, 1);
+
+            i = i + 1;
+        };
+    }
+
+    #[test]
+    fun sha3_512_test() {
+        let inputs = vector[
+        b"testing",
+        b"",
+        ];
+
+        // From https://emn178.github.io/online-tools/sha3_512.html
+        let outputs = vector[
+        x"881c7d6ba98678bcd96e253086c4048c3ea15306d0d13ff48341c6285ee71102a47b6f16e20e4d65c0c3d677be689dfda6d326695609cbadfafa1800e9eb7fc1",
+        x"a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
+        ];
+
+        let i = 0;
+        while (i < std::vector::length(&inputs)) {
+            let input = *std::vector::borrow(&inputs, i);
+            let hash_expected = *std::vector::borrow(&outputs, i);
+            let hash = sha3_512(input);
+
+            assert!(hash_expected == hash, 1);
+
+            i = i + 1;
+        };
+    }
+
+
+    #[test]
+    fun ripemd160_test() {
+        let inputs = vector[
+        b"testing",
+        b"",
+        ];
+
+        // From https://www.browserling.com/tools/ripemd160-hash
+        let outputs = vector[
+        x"b89ba156b40bed29a5965684b7d244c49a3a769b",
+        x"9c1185a5c5e9fc54612808977ee8f548b2258d31",
+        ];
+
+        let i = 0;
+        while (i < std::vector::length(&inputs)) {
+            let input = *std::vector::borrow(&inputs, i);
+            let hash_expected = *std::vector::borrow(&outputs, i);
+            let hash = ripemd160(input);
 
             assert!(hash_expected == hash, 1);
 

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -8,28 +8,79 @@
 /// - SipHash: an add-rotate-xor (ARX) based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012
 module aptos_std::aptos_hash {
     use std::bcs;
+    use std::features;
 
+    //
+    // Constants
+    //
+
+    /// A newly-added native function is not yet enabled.
+    const E_NATIVE_FUN_NOT_AVAILABLE: u64 = 1;
+
+    //
+    // Functions
+    //
+
+    /// Returns the (non-cryptographic) SipHash of `bytes`. See https://en.wikipedia.org/wiki/SipHash.
     native public fun sip_hash(bytes: vector<u8>): u64;
 
+    /// Returns the (non-cryptographic) SipHash of the BCS serialization of `v`. See https://en.wikipedia.org/wiki/SipHash.
     public fun sip_hash_from_value<MoveValue>(v: &MoveValue): u64 {
         let bytes = bcs::to_bytes(v);
 
         sip_hash(bytes)
     }
 
-    //
-    // Native functions
-    //
-
+    /// Returns the Keccak-256 hash of `bytes`.
     native public fun keccak256(bytes: vector<u8>): vector<u8>;
 
-    native public fun sha2_512(bytes: vector<u8>): vector<u8>;
+    /// Returns the SHA2-512 hash of `bytes`.
+    public fun sha2_512(bytes: vector<u8>): vector<u8> {
+        if(!features::sha_512_and_ripemd_160_enabled()) {
+            abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
+        };
 
-    native public fun sha3_512(bytes: vector<u8>): vector<u8>;
+        sha2_512_internal(bytes)
+    }
 
+    /// Returns the SHA3-512 hash of `bytes`.
+    public fun sha3_512(bytes: vector<u8>): vector<u8> {
+        if(!features::sha_512_and_ripemd_160_enabled()) {
+            abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
+        };
+
+        sha3_512_internal(bytes)
+    }
+
+
+    /// Returns the RIPEMD-160 hash of `bytes`.
+    ///
     /// WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
     /// hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
-    native public fun ripemd160(bytes: vector<u8>): vector<u8>;
+    public fun ripemd160(bytes: vector<u8>): vector<u8> {
+        if(!features::sha_512_and_ripemd_160_enabled()) {
+            abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
+        };
+
+        ripemd160_internal(bytes)
+    }
+
+    //
+    // Private native functions
+    //
+
+    /// Returns the SHA2-512 hash of `bytes`.
+    native fun sha2_512_internal(bytes: vector<u8>): vector<u8>;
+
+
+    /// Returns the SHA3-512 hash of `bytes`.
+    native fun sha3_512_internal(bytes: vector<u8>): vector<u8>;
+
+    /// Returns the RIPEMD-160 hash of `bytes`.
+    ///
+    /// WARNING: Only 80-bit security is provided by this function. This means an adversary who can compute roughly 2^80
+    /// hashes will, with high probability, find a collision x_1 != x_2 such that RIPEMD-160(x_1) = RIPEMD-160(x_2).
+    native fun ripemd160_internal(bytes: vector<u8>): vector<u8>;
 
     //
     // Testing
@@ -59,8 +110,11 @@ module aptos_std::aptos_hash {
         };
     }
 
-    #[test]
-    fun sha2_512_test() {
+    #[test(fx = @aptos_std)]
+    fun sha2_512_test(fx: signer) {
+        // We need to enable the feature in order for the native call to be allowed.
+        features::change_feature_flags(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
+
         let inputs = vector[
         b"testing",
         b"",
@@ -84,8 +138,10 @@ module aptos_std::aptos_hash {
         };
     }
 
-    #[test]
-    fun sha3_512_test() {
+    #[test(fx = @aptos_std)]
+    fun sha3_512_test(fx: signer) {
+        // We need to enable the feature in order for the native call to be allowed.
+        features::change_feature_flags(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
         let inputs = vector[
         b"testing",
         b"",
@@ -109,9 +165,10 @@ module aptos_std::aptos_hash {
         };
     }
 
-
-    #[test]
-    fun ripemd160_test() {
+    #[test(fx = @aptos_std)]
+    fun ripemd160_test(fx: signer) {
+        // We need to enable the feature in order for the native call to be allowed.
+        features::change_feature_flags(&fx, vector[features::get_sha_512_and_ripemd_160_feature()], vector[]);
         let inputs = vector[
         b"testing",
         b"",

--- a/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.spec.move
@@ -8,4 +8,25 @@ spec aptos_std::aptos_hash {
         // TODO: temporary mockup.
         pragma opaque;
     }
+
+    spec keccak256 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec sha2_512 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec sha3_512 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
+    spec ripemd160 {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
+
 }

--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -1791,6 +1791,7 @@ The token is owned at address owner
 
     <b>let</b> burn_by_creator_flag = <a href="property_map.md#0x3_property_map_read_bool">property_map::read_bool</a>(&token_data.default_properties, &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(<a href="token.md#0x3_token_BURNABLE_BY_CREATOR">BURNABLE_BY_CREATOR</a>));
     <b>assert</b>!(burn_by_creator_flag, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_ECREATOR_CANNOT_BURN_TOKEN">ECREATOR_CANNOT_BURN_TOKEN</a>));
+
     // Burn the tokens.
     <b>let</b> <a href="token.md#0x3_token_Token">Token</a> { id: _, amount: burned_amount, token_properties: _ } = <a href="token.md#0x3_token_withdraw_with_event_internal">withdraw_with_event_internal</a>(owner, token_id, amount);
     <b>let</b> token_store = <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_TokenStore">TokenStore</a>&gt;(owner);
@@ -2147,7 +2148,7 @@ Burn a token by the token owner
     <a href="token.md#0x3_token_assert_collection_exists">assert_collection_exists</a>(creator_address, collection_name);
     <b>let</b> collection_data = <a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(creator_address).collection_data, collection_name);
     // cannot change maximum from 0 and cannot change maximum <b>to</b> 0
-    <b>assert</b>!(collection_data.maximum != 0 && maximum !=0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
+    <b>assert</b>!(collection_data.maximum != 0 && maximum != 0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(maximum &gt;= collection_data.supply, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(collection_data.mutability_config.maximum, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>));
     collection_data.maximum = maximum;
@@ -2205,7 +2206,7 @@ Burn a token by the token owner
     <a href="token.md#0x3_token_assert_tokendata_exists">assert_tokendata_exists</a>(creator, token_data_id);
     <b>let</b> all_token_data = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(token_data_id.creator).token_data;
     <b>let</b> token_data = <a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(all_token_data, token_data_id);
-    <b>assert</b>!(token_data.supply &lt;= maximum, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
+    <b>assert</b>!(maximum &gt;= token_data.supply, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(token_data.mutability_config.maximum, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>));
     token_data.maximum = maximum;
 }

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -11,6 +11,8 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Constants](#@Constants_0)
 -  [Function `code_dependency_check_enabled`](#0x1_features_code_dependency_check_enabled)
 -  [Function `treat_friend_as_private`](#0x1_features_treat_friend_as_private)
+-  [Function `get_sha_512_and_ripemd_160_feature`](#0x1_features_get_sha_512_and_ripemd_160_feature)
+-  [Function `sha_512_and_ripemd_160_enabled`](#0x1_features_sha_512_and_ripemd_160_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -81,6 +83,18 @@ The provided signer has not a framework address.
 
 
 
+<a name="0x1_features_SHA_512_AND_RIPEMD_160_NATIVES"></a>
+
+Whether the new SHA2-512, SHA3-512 and RIPEMD-160 hash function natives are enabled.
+This is needed because of the introduction of new native functions.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_SHA_512_AND_RIPEMD_160_NATIVES">SHA_512_AND_RIPEMD_160_NATIVES</a>: u64 = 3;
+</code></pre>
+
+
+
 <a name="0x1_features_TREAT_FRIEND_AS_PRIVATE"></a>
 
 Whether during upgrade compatibility checking, friend functions should be treated similar like
@@ -134,6 +148,52 @@ Lifetime: ephemeral
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_treat_friend_as_private">treat_friend_as_private</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_TREAT_FRIEND_AS_PRIVATE">TREAT_FRIEND_AS_PRIVATE</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_get_sha_512_and_ripemd_160_feature"></a>
+
+## Function `get_sha_512_and_ripemd_160_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_sha_512_and_ripemd_160_feature">get_sha_512_and_ripemd_160_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_sha_512_and_ripemd_160_feature">get_sha_512_and_ripemd_160_feature</a>(): u64 { <a href="features.md#0x1_features_SHA_512_AND_RIPEMD_160_NATIVES">SHA_512_AND_RIPEMD_160_NATIVES</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_sha_512_and_ripemd_160_enabled"></a>
+
+## Function `sha_512_and_ripemd_160_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_sha_512_and_ripemd_160_enabled">sha_512_and_ripemd_160_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_sha_512_and_ripemd_160_enabled">sha_512_and_ripemd_160_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SHA_512_AND_RIPEMD_160_NATIVES">SHA_512_AND_RIPEMD_160_NATIVES</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -47,6 +47,18 @@ module std::features {
         is_enabled(TREAT_FRIEND_AS_PRIVATE)
     }
 
+    /// Whether the new SHA2-512, SHA3-512 and RIPEMD-160 hash function natives are enabled.
+    /// This is needed because of the introduction of new native functions.
+    /// Lifetime: transient
+    const SHA_512_AND_RIPEMD_160_NATIVES: u64 = 3;
+
+    public fun get_sha_512_and_ripemd_160_feature(): u64 { SHA_512_AND_RIPEMD_160_NATIVES }
+
+    public fun sha_512_and_ripemd_160_enabled(): bool acquires Features {
+        is_enabled(SHA_512_AND_RIPEMD_160_NATIVES)
+    }
+
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/framework/src/natives/hash.rs
+++ b/aptos-move/framework/src/natives/hash.rs
@@ -178,15 +178,15 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
             make_native_from_func(gas_params.keccak256, native_keccak256),
         ),
         (
-            "sha2_512",
+            "sha2_512_internal",
             make_native_from_func(gas_params.sha2_512, native_sha2_512),
         ),
         (
-            "sha3_512",
+            "sha3_512_internal",
             make_native_from_func(gas_params.sha3_512, native_sha3_512),
         ),
         (
-            "ripemd160",
+            "ripemd160_internal",
             make_native_from_func(gas_params.ripemd160, native_ripemd160),
         ),
     ];

--- a/aptos-move/framework/src/natives/hash.rs
+++ b/aptos-move/framework/src/natives/hash.rs
@@ -9,7 +9,8 @@ use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
     loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
 };
-
+use ripemd::Digest as OtherDigest;
+use sha2::Digest;
 use smallvec::smallvec;
 use std::{collections::VecDeque, hash::Hasher};
 use tiny_keccak::{Hasher as KeccakHasher, Keccak};
@@ -75,6 +76,84 @@ fn native_keccak256(
     Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(output)]))
 }
 
+#[derive(Debug, Clone)]
+pub struct Sha2_512HashGasParameters {
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
+}
+
+fn native_sha2_512(
+    gas_params: &Sha2_512HashGasParameters,
+    _context: &mut NativeContext,
+    mut _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let bytes = pop_arg!(args, Vec<u8>);
+
+    let cost = gas_params.base + gas_params.per_byte * NumBytes::new(bytes.len() as u64);
+
+    let mut hasher = sha2::Sha512::new();
+    hasher.update(&bytes);
+    let output = hasher.finalize().to_vec();
+
+    Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(output)]))
+}
+
+#[derive(Debug, Clone)]
+pub struct Sha3_512HashGasParameters {
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
+}
+
+fn native_sha3_512(
+    gas_params: &Sha3_512HashGasParameters,
+    _context: &mut NativeContext,
+    mut _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let bytes = pop_arg!(args, Vec<u8>);
+
+    let cost = gas_params.base + gas_params.per_byte * NumBytes::new(bytes.len() as u64);
+
+    let mut hasher = sha3::Sha3_512::new();
+    hasher.update(&bytes);
+    let output = hasher.finalize().to_vec();
+
+    Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(output)]))
+}
+
+#[derive(Debug, Clone)]
+pub struct Ripemd160HashGasParameters {
+    pub base: InternalGas,
+    pub per_byte: InternalGasPerByte,
+}
+
+fn native_ripemd160(
+    gas_params: &Ripemd160HashGasParameters,
+    _context: &mut NativeContext,
+    mut _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    let bytes = pop_arg!(args, Vec<u8>);
+
+    let cost = gas_params.base + gas_params.per_byte * NumBytes::new(bytes.len() as u64);
+
+    let mut hasher = ripemd::Ripemd160::new();
+    hasher.update(&bytes);
+    let output = hasher.finalize().to_vec();
+
+    Ok(NativeResult::ok(cost, smallvec![Value::vector_u8(output)]))
+}
+
 /***************************************************************************************************
  * module
  *
@@ -83,6 +162,9 @@ fn native_keccak256(
 pub struct GasParameters {
     pub sip_hash: SipHashGasParameters,
     pub keccak256: Keccak256HashGasParameters,
+    pub sha2_512: Sha2_512HashGasParameters,
+    pub sha3_512: Sha3_512HashGasParameters,
+    pub ripemd160: Ripemd160HashGasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
@@ -94,6 +176,18 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
         (
             "keccak256",
             make_native_from_func(gas_params.keccak256, native_keccak256),
+        ),
+        (
+            "sha2_512",
+            make_native_from_func(gas_params.sha2_512, native_sha2_512),
+        ),
+        (
+            "sha3_512",
+            make_native_from_func(gas_params.sha3_512, native_sha3_512),
+        ),
+        (
+            "ripemd160",
+            make_native_from_func(gas_params.ripemd160, native_ripemd160),
         ),
     ];
 

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -118,6 +118,18 @@ impl GasParameters {
                     base: 0.into(),
                     per_byte: 0.into(),
                 },
+                sha2_512: hash::Sha2_512HashGasParameters {
+                    base: 0.into(),
+                    per_byte: 0.into(),
+                },
+                sha3_512: hash::Sha3_512HashGasParameters {
+                    base: 0.into(),
+                    per_byte: 0.into(),
+                },
+                ripemd160: hash::Ripemd160HashGasParameters {
+                    base: 0.into(),
+                    per_byte: 0.into(),
+                },
             },
             type_info: type_info::GasParameters {
                 type_of: type_info::TypeOfGasParameters {


### PR DESCRIPTION
### Description

Added support for SHA2-512, SHA3-512 and RIPEMD-160, to support folks write bridge contracts to other platforms, as per conversations with @JoshLind.

This PR should be good to go:

 - it is feature-gated
 - it has (reasonable) gas costs for the new hash functions, marked with `optional`
 - it bumps up the gas feature version

### Test Plan

This PR merely exports existing hash function crates, which are either already used throughout `aptos-core/` or are believed to be trustworthy implementations. Therefore, we only made sure the native implementation give the expected hash values for the empty string "" and for `b"testing"`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4181)
<!-- Reviewable:end -->
