### PR TITLE
Prepare for mainnet genesis

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -194,6 +194,8 @@ module aptos_framework::genesis {
         chain_status::set_genesis_end(aptos_framework);
     }
 
+    native fun create_signer(addr: address): signer;
+
     #[verify_only]
     fun initialize_for_verification(
         gas_schedule: vector<u8>,

--- a/aptos-move/framework/aptos-framework/sources/genesis.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.spec.move
@@ -11,4 +11,8 @@ spec aptos_framework::genesis {
     spec initialize_for_verification {
         pragma verify=true;
     }
+
+    spec create_signer { // TODO: temporary mockup.
+        pragma opaque;
+    }
 }

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -184,8 +184,9 @@ pub fn all_natives(
         };
     }
 
-    add_natives_from_module!("account", account::make_all(gas_params.account));
+    add_natives_from_module!("account", account::make_all(gas_params.account.clone()));
     add_natives_from_module!("ed25519", ed25519::make_all(gas_params.ed25519.clone()));
+    add_natives_from_module!("genesis", account::make_all(gas_params.account));
     add_natives_from_module!("multi_ed25519", multi_ed25519::make_all(gas_params.ed25519));
     add_natives_from_module!(
         "bls12381",

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -79,6 +79,85 @@ pub static GENESIS_KEYPAIR: Lazy<(Ed25519PrivateKey, Ed25519PublicKey)> = Lazy::
     (private_key, public_key)
 });
 
+pub fn encode_aptos_mainnet_genesis_transaction(
+    accounts: &[AccountMap],
+    employees: &[EmployeeAccountMap],
+    validators: &[ValidatorWithCommissionRate],
+    framework: &ReleaseBundle,
+    chain_id: ChainId,
+    genesis_config: &GenesisConfiguration,
+) -> Transaction {
+    assert!(!genesis_config.is_test, "This is mainnet!");
+    validate_genesis_config(genesis_config);
+
+    // Create a Move VM session so we can invoke on-chain genesis intializations.
+    let mut state_view = GenesisStateView::new();
+    for (module_bytes, module) in framework.code_and_compiled_modules() {
+        state_view.add_module(&module.self_id(), module_bytes);
+    }
+    let data_cache = StateViewCache::new(&state_view).into_move_resolver();
+    let move_vm = MoveVmExt::new(
+        NativeGasParameters::zeros(),
+        AbstractValueSizeGasParameters::zeros(),
+        Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+    )
+    .unwrap();
+    let id1 = HashValue::zero();
+    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1));
+
+    // On-chain genesis process.
+    let consensus_config = OnChainConsensusConfig::V1(ConsensusConfigV1::default());
+    initialize(
+        &mut session,
+        consensus_config,
+        chain_id,
+        genesis_config,
+        true,
+    );
+    initialize_aptos_coin(&mut session);
+    initialize_on_chain_governance(&mut session, genesis_config);
+    create_accounts(&mut session, accounts);
+    create_employee_validators(&mut session, employees);
+    create_and_initialize_validators_with_commission(&mut session, validators);
+    set_genesis_end(&mut session);
+
+    // Reconfiguration should happen after all on-chain invocations.
+    emit_new_block_and_epoch_event(&mut session);
+
+    let mut session1_out = session.finish().unwrap();
+
+    // Publish the framework, using a different session id, in case both scripts creates tables
+    let state_view = GenesisStateView::new();
+    let data_cache = StateViewCache::new(&state_view).into_move_resolver();
+
+    let mut id2_arr = [0u8; 32];
+    id2_arr[31] = 1;
+    let id2 = HashValue::new(id2_arr);
+    let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id2));
+    publish_framework(&mut session, framework);
+    let session2_out = session.finish().unwrap();
+
+    session1_out.squash(session2_out).unwrap();
+
+    let change_set_ext = session1_out.into_change_set(&mut ()).unwrap();
+    let (delta_change_set, change_set) = change_set_ext.into_inner();
+
+    // Publishing stdlib should not produce any deltas around aggregators and map to write ops and
+    // not deltas. The second session only publishes the framework module bundle, which should not
+    // produce deltas either.
+    assert!(
+        delta_change_set.is_empty(),
+        "non-empty delta change set in genesis"
+    );
+
+    assert!(!change_set
+        .write_set()
+        .iter()
+        .any(|(_, op)| op.is_deletion()));
+    verify_genesis_write_set(change_set.events());
+    Transaction::GenesisTransaction(WriteSetPayload::Direct(change_set))
+}
+
 pub fn encode_genesis_transaction(
     aptos_root_key: Ed25519PublicKey,
     validators: &[Validator],
@@ -166,15 +245,10 @@ pub fn encode_genesis_change_set(
     let change_set_ext = session1_out.into_change_set(&mut ()).unwrap();
     let (delta_change_set, change_set) = change_set_ext.into_inner();
 
-    // Publishing stdlib should not produce any deltas.
-    // Proof: First session output is obtained during genesis when we initialize
-    // the data. This implies that all values which are aggregators know their
-    // real values, and therefore map to write ops and not deltas. For example,
-    // `create_and_initialize_validators` mints aptos coins which has aggregatable
-    // supply, but since supply is initialized during the same session there will
-    // be no deltas. The second session pusblishes framework module bundle which
-    // does not produce deltas either.
-    debug_assert!(
+    // Publishing stdlib should not produce any deltas around aggregators and map to write ops and
+    // not deltas. The second session only publishes the framework module bundle, which should not
+    // produce deltas either.
+    assert!(
         delta_change_set.is_empty(),
         "non-empty delta change set in genesis"
     );
@@ -368,6 +442,35 @@ fn initialize_on_chain_governance(
     );
 }
 
+fn create_accounts(session: &mut SessionExt<impl MoveResolver>, accounts: &[AccountMap]) {
+    let accounts_bytes = bcs::to_bytes(accounts).expect("AccountMaps can be serialized");
+    let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
+    serialized_values.push(accounts_bytes);
+    exec_function(
+        session,
+        GENESIS_MODULE_NAME,
+        "create_accounts",
+        vec![],
+        serialized_values,
+    );
+}
+
+fn create_employee_validators(
+    session: &mut SessionExt<impl MoveResolver>,
+    employees: &[EmployeeAccountMap],
+) {
+    let employees_bytes = bcs::to_bytes(employees).expect("AccountMaps can be serialized");
+    let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
+    serialized_values.push(employees_bytes);
+    exec_function(
+        session,
+        GENESIS_MODULE_NAME,
+        "create_employee_validators",
+        vec![],
+        serialized_values,
+    );
+}
+
 /// Creates and initializes each validator owner and validator operator. This method creates all
 /// the required accounts, sets the validator operators for each validator owner, and sets the
 /// validator config on-chain.
@@ -382,6 +485,22 @@ fn create_and_initialize_validators(
         session,
         GENESIS_MODULE_NAME,
         "create_initialize_validators",
+        vec![],
+        serialized_values,
+    );
+}
+
+fn create_and_initialize_validators_with_commission(
+    session: &mut SessionExt<impl MoveResolver>,
+    validators: &[ValidatorWithCommissionRate],
+) {
+    let validators_bytes = bcs::to_bytes(validators).expect("Validators can be serialized");
+    let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
+    serialized_values.push(validators_bytes);
+    exec_function(
+        session,
+        GENESIS_MODULE_NAME,
+        "create_initialize_validators_with_commission",
         vec![],
         serialized_values,
     );
@@ -643,24 +762,49 @@ pub fn generate_mainnet_genesis(
         framework,
         OnChainConsensusConfig::default(),
         ChainId::test(),
-        // TODO: Update once mainnet numbers are decided. These numbers are just placeholders.
-        &GenesisConfiguration {
-            allow_new_validators: true,
-            epoch_duration_secs: 2 * 3600, // 2 hours
-            is_test: false,
-            min_stake: 1_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 1M APT
-            // 400M APT
-            min_voting_threshold: (400_000_000 * APTOS_COINS_BASE_WITH_DECIMALS as u128),
-            max_stake: 50_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 50M APT.
-            recurring_lockup_duration_secs: 30 * 24 * 3600,         // 1 month
-            required_proposer_stake: 1_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 1M APT
-            rewards_apy_percentage: 10,
-            voting_duration_secs: 7 * 24 * 3600, // 7 days
-            voting_power_increase_limit: 30,
-        },
+        &mainnet_genesis_config(),
         use_gas_schedule_v2,
     );
     (genesis, test_validators)
+}
+
+fn mainnet_genesis_config() -> GenesisConfiguration {
+    // TODO: Update once mainnet numbers are decided. These numbers are just placeholders.
+    GenesisConfiguration {
+        allow_new_validators: true,
+        epoch_duration_secs: 2 * 3600, // 2 hours
+        is_test: false,
+        min_stake: 1_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 1M APT
+        // 400M APT
+        min_voting_threshold: (400_000_000 * APTOS_COINS_BASE_WITH_DECIMALS as u128),
+        max_stake: 50_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 50M APT.
+        recurring_lockup_duration_secs: 30 * 24 * 3600,         // 1 month
+        required_proposer_stake: 1_000_000 * APTOS_COINS_BASE_WITH_DECIMALS, // 1M APT
+        rewards_apy_percentage: 10,
+        voting_duration_secs: 7 * 24 * 3600, // 7 days
+        voting_power_increase_limit: 30,
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountMap {
+    account_address: AccountAddress,
+    balance: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmployeeAccountMap {
+    accounts: Vec<AccountAddress>,
+    // Note: the owner account address is irrelevant, this will be derived from a resource account
+    validator: ValidatorWithCommissionRate,
+    vesting_schedule_numerators: Vec<u64>,
+    vesting_schedule_denominator: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValidatorWithCommissionRate {
+    validator: Validator,
+    validator_commission_percentage: u64,
 }
 
 #[test]
@@ -682,4 +826,69 @@ pub fn test_genesis_module_publishing() {
     let id1 = HashValue::zero();
     let mut session = move_vm.new_session(&data_cache, SessionId::genesis(id1));
     publish_framework(&mut session, cached_packages::head_release_bundle());
+}
+
+#[test]
+pub fn test_mainnet_end_to_end() {
+    let test_validators = TestValidator::new_test_set(Some(3), Some(0));
+    let employee_validator = test_validators[0].data.clone();
+    let mut direct_validator = test_validators[1].data.clone();
+    let commissioned_validator = test_validators[2].data.clone();
+
+    // currently just test that all functions have the right interface
+    let balance = 10_000_000 * APTOS_COINS_BASE_WITH_DECIMALS;
+    let account45 = AccountAddress::from_hex_literal("0x45").unwrap();
+    let account46 = AccountAddress::from_hex_literal("0x46").unwrap();
+    let account47 = AccountAddress::from_hex_literal("0x47").unwrap();
+    let account48 = AccountAddress::from_hex_literal("0x48").unwrap();
+
+    let accounts = vec![
+        AccountMap {
+            account_address: account45,
+            balance,
+        },
+        AccountMap {
+            account_address: account46,
+            balance,
+        },
+        AccountMap {
+            account_address: account47,
+            balance,
+        },
+        AccountMap {
+            account_address: account48,
+            balance,
+        },
+    ];
+
+    let employees = vec![EmployeeAccountMap {
+        accounts: vec![account46, account47],
+        validator: ValidatorWithCommissionRate {
+            validator: employee_validator,
+            validator_commission_percentage: 10,
+        },
+        vesting_schedule_numerators: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 1],
+        vesting_schedule_denominator: 48,
+    }];
+
+    direct_validator.owner_address = account45;
+    let validators = vec![
+        ValidatorWithCommissionRate {
+            validator: commissioned_validator,
+            validator_commission_percentage: 10,
+        },
+        ValidatorWithCommissionRate {
+            validator: direct_validator,
+            validator_commission_percentage: 0,
+        },
+    ];
+
+    encode_aptos_mainnet_genesis_transaction(
+        &accounts,
+        &employees,
+        &validators,
+        cached_packages::head_release_bundle(),
+        ChainId::mainnet(),
+        &mainnet_genesis_config(),
+    );
 }

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -166,6 +166,10 @@ impl ChainId {
     pub fn test() -> Self {
         ChainId::new(NamedChain::TESTING.id())
     }
+
+    pub fn mainnet() -> Self {
+        ChainId::new(NamedChain::MAINNET.id())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- [x] Add a new mainnet-only genesis function: create_accounts. This creates each account and funds it.
- [x] Add a new mainnet-only genesis native create_signer: takes an address and produces a signer
- [x] Modify create_initialize_validators : check if account exists, if it does, just use create_signer if it doesn't use the legacy behavior
- [x] Don't allow for creation of the same validator or account
- [ ]  Add a new function for creating commissioned validators, if commission is zero don't create the contracts and just call into the legacy behavior
- [ ]  create a framework for creating employee vesting contracts and validators
- [ ] build some sort of test that at least ensures that the output writeset is sensible -- MVP might be just that our move tests pass and that the transaction can be built...

This is still a bit early:
* I'll ask @movekevin  to kindly land at least his interfaces and data structures as soon as possible, so I can rebase on top of them...
* I'll ask @gregnazario to start looking at these interfaces and consider the right way to make the tooling work.... maybe we just have a dedicated main function / binary?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4182)
<!-- Reviewable:end -->
