### PR TITLE
Limit the upper bound of `rewards_rate`

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/staking_config.spec.move
@@ -3,4 +3,12 @@ spec aptos_framework::staking_config {
         use aptos_framework::chain_status;
         invariant chain_status::is_operating() ==> exists<StakingConfig>(@aptos_framework);
     }
+    spec StakingConfig {
+        // `rewards_rate` which is the numerator is limited to be `<= MAX_REWARDS_RATE` in order to avoid the arithmetic
+        // overflow in the rewards calculation. `rewards_rate_denominator` can be adjusted to get the desired rewards
+        // rate (i.e., rewards_rate / rewards_rate_denominator).
+        invariant rewards_rate <= MAX_REWARDS_RATE;
+        invariant rewards_rate_denominator > 0;
+        invariant rewards_rate <= rewards_rate_denominator;
+    }
 }


### PR DESCRIPTION
### Description
This commit adds assertions and a spec to ensure `rewards_rate <= MAX_REWARDS_RATE` where `MAX_REWARDS_RATE = 1000000`, and `rewards_rate <= rewards_rate_denominator`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4185)
<!-- Reviewable:end -->
