### PR TITLE
[Networking] Remove unicode support from dns names.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "aptos-crypto-derive",
  "bcs",
  "chrono",
+ "claims",
  "hex",
  "itertools",
  "move-deps",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -35,6 +35,7 @@ aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
 move-deps = { path = "../aptos-move/move-deps", features = ["address32"] }
 
 [dev-dependencies]
+claims = "0.7"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 regex = "1.5.5"


### PR DESCRIPTION
### Description
This PR updates the network parsing code to only support ASCII dns names and prevent unicode. The concern is that with unicode phishing attacks may be possible. I'm not sure how easy it is to exploit this given that we're also embedding public keys in network addresses, but let's play it safe 😄 .

For example, this is valid:
```
/dns6/example.com/tcp/123";
```

This is not:
```
/dns6/еxample.com/tcp/123";
```

Can you spot it? 😆 


### Test Plan
A new unit test has been added. I'm relying on existing test infrastructure to help verify that we aren't relying on unicode in production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4186)
<!-- Reviewable:end -->
