### PR TITLE
fix: longer default txn wait time

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
 ## Unreleased
+
+- Increase the default wait time for `waitForTransactionWithResult` to 20s.
 - A new function called `getEventsByCreationNumber` has been added, corresponding to the new endpoint on the API. For more information on this change, see the [API changelog](https://github.com/aptos-labs/aptos-core/blob/main/api/doc/CHANGELOG.md) for API version 1.1.0.
 - **[Deprecated]** The `getEventsByEventKey` function is now deprecated. In the next release it will be removed entirely. You must migrate to the new function, `getEventsByCreationNumber`, by then.
 - Included in the `Event` struct (which is what the events endpoints return) is a new field called `guid`. This is a more easily interpretable representation of an event identifier than the `key` field. See the [API changelog](https://github.com/aptos-labs/aptos-core/blob/main/api/doc/CHANGELOG.md) for an example of the new field.

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -464,7 +464,7 @@ export class AptosClient {
     txnHash: string,
     extraArgs?: { timeoutSecs?: number; checkSuccess?: boolean },
   ): Promise<Gen.Transaction> {
-    const timeoutSecs = extraArgs?.timeoutSecs ?? 10;
+    const timeoutSecs = extraArgs?.timeoutSecs ?? 20;
     const checkSuccess = extraArgs?.checkSuccess ?? false;
 
     let isPending = true;

--- a/ecosystem/typescript/sdk/src/faucet_client.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.ts
@@ -45,9 +45,10 @@ export class FaucetClient extends AptosClient {
    * coins into that account
    * @param address Hex-encoded 16 bytes Aptos account address wich mints tokens
    * @param amount Amount of tokens to mint
+   * @param timeoutSecs
    * @returns Hashes of submitted transactions
    */
-  async fundAccount(address: MaybeHexString, amount: number): Promise<string[]> {
+  async fundAccount(address: MaybeHexString, amount: number, timeoutSecs = 20): Promise<string[]> {
     const tnxHashes = await this.faucetRequester.request<Array<string>>({
       method: "POST",
       url: "/mint",
@@ -60,7 +61,7 @@ export class FaucetClient extends AptosClient {
     const promises: Promise<void>[] = [];
     for (let i = 0; i < tnxHashes.length; i += 1) {
       const tnxHash = tnxHashes[i];
-      promises.push(this.waitForTransaction(tnxHash));
+      promises.push(this.waitForTransaction(tnxHash, { timeoutSecs }));
     }
     await Promise.all(promises);
     return tnxHashes;


### PR DESCRIPTION
### Description
10s is the borderline timeout time. Recently, we received a couple of reports. Plus, we also observed the timeouts ourselves.  Change 10s to 20s, and this should reduce the timeouts.

### Test Plan
yarn test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4190)
<!-- Reviewable:end -->
