### PR TITLE
[Network] Fix comment and handle proxy else branch.

### DIFF
--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -202,15 +202,26 @@ async fn connect_via_proxy(proxy_addr: String, addr: NetworkAddress) -> io::Resu
                 return Err(io::Error::new(
                     io::ErrorKind::Other,
                     format!(
-                        "HTTP proxy CONNECT failed: {}",
+                        "HTTP proxy CONNECT failed. Len == 0. Message: {}",
                         String::from_utf8_lossy(msg)
                     ),
                 ));
-            } else if msg.len() >= 16
-                && (msg.starts_with(b"HTTP/1.1 200") || msg.starts_with(b"HTTP/1.0 200"))
-                && msg.ends_with(b"\r\n\r\n")
-            {
-                return Ok(stream);
+            } else if msg.len() >= 16 {
+                if (msg.starts_with(b"HTTP/1.1 200") || msg.starts_with(b"HTTP/1.0 200"))
+                    && msg.ends_with(b"\r\n\r\n")
+                {
+                    return Ok(stream);
+                } else {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!(
+                            "HTTP proxy CONNECT failed! Unexpected message: {}",
+                            String::from_utf8_lossy(msg)
+                        ),
+                    ));
+                }
+            } else {
+                // Keep reading until we get at least 16 bytes
             }
         }
     } else {

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -230,9 +230,9 @@ fn add_pp_addr(proxy_protocol_enabled: bool, error: io::Error, addr: &NetworkAdd
 
 /// Upgrade an inbound connection. This means we run a Noise IK handshake for
 /// authentication and then negotiate common supported protocols. If
-/// `ctxt.trusted_peers` is `Some(_)`, then we will only allow connections from
-/// peers with a pubkey in this set. Otherwise, we will allow inbound connections
-/// from any pubkey.
+/// `ctxt.noise.auth_mode` is `HandshakeAuthMode::Mutual( anti_replay_timestamps , trusted_peers )`,
+/// then we will only allow connections from peers with a pubkey in the `trusted_peers`
+/// set. Otherwise, we will allow inbound connections from any pubkey.
 async fn upgrade_inbound<T: TSocket>(
     ctxt: Arc<UpgradeContext>,
     fut_socket: impl Future<Output = io::Result<T>>,
@@ -322,7 +322,7 @@ async fn upgrade_inbound<T: TSocket>(
     })
 }
 
-/// Upgrade an inbound connection. This means we run a Noise IK handshake for
+/// Upgrade an outbound connection. This means we run a Noise IK handshake for
 /// authentication and then negotiate common supported protocols.
 pub async fn upgrade_outbound<T: TSocket>(
     ctxt: Arc<UpgradeContext>,


### PR DESCRIPTION
### Description
This PR offers two tiny fixes to the network code:
1. It fixes some comments for `upgrade_inbound` and `upgrade_outbound`.
2. It handles the else branch to `connect_via_proxy` to prevent us from ignoring an unexpected response and continuing to read until the buffer is full.

### Test Plan
Existing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4192)
<!-- Reviewable:end -->
