### PR TITLE
[safety-rules] switch back to file based backend

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -1,21 +1,20 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::keys::PublicIdentity;
 use crate::{
     config::ValidatorConfiguration,
-    keys::{generate_key_objects, PrivateIdentity},
+    keys::{generate_key_objects, PrivateIdentity, PublicIdentity},
     GenesisInfo,
 };
 use anyhow::ensure;
-use aptos_config::config::RocksDbStorageConfig;
-use aptos_config::keys::ConfigKey;
 use aptos_config::{
     config::{
         DiscoveryMethod, Identity, IdentityBlob, InitialSafetyRulesConfig, NetworkConfig,
-        NodeConfig, PeerRole, RoleType, SafetyRulesService, SecureBackend, WaypointConfig,
+        NodeConfig, OnDiskStorageConfig, PeerRole, RoleType, SafetyRulesService, SecureBackend,
+        WaypointConfig,
     },
     generator::build_seed_for_network,
+    keys::ConfigKey,
     network_id::NetworkId,
 };
 use aptos_crypto::{
@@ -551,10 +550,10 @@ impl Builder {
         // Ensure safety rules runs in a thread
         config.consensus.safety_rules.service = SafetyRulesService::Thread;
 
-        // Use a rocksdb storage backend for safety rules
-        let mut storage = RocksDbStorageConfig::default();
+        // Use a file based storage backend for safety rules
+        let mut storage = OnDiskStorageConfig::default();
         storage.set_data_dir(validator.dir.clone());
-        config.consensus.safety_rules.backend = SecureBackend::RocksDbStorage(storage);
+        config.consensus.safety_rules.backend = SecureBackend::OnDiskStorage(storage);
 
         if index > 0 || self.randomize_first_validator_ports {
             config.randomize_ports();

--- a/docker/compose/aptos-node/validator.yaml
+++ b/docker/compose/aptos-node/validator.yaml
@@ -9,8 +9,8 @@ consensus:
     service:
       type: "local"
     backend:
-      type: "rocks_db_storage"
-      path: secure_storage_db
+      type: "on_disk_storage"
+      path: /opt/aptos/data/secure-data.json
       namespace: ~
     initial_safety_rules_config:
       from_file:

--- a/terraform/helm/aptos-node/files/configs/validator.yaml
+++ b/terraform/helm/aptos-node/files/configs/validator.yaml
@@ -9,8 +9,8 @@ consensus:
     service:
       type: "local"
     backend:
-      type: "rocks_db_storage"
-      path: secure_storage_db
+      type: "on_disk_storage"
+      path: /opt/aptos/data/secure-data.json
       namespace: ~
     initial_safety_rules_config:
       from_file:

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -9,7 +9,6 @@ use aptos_sdk::{
     crypto::ed25519::Ed25519PrivateKey,
     types::{account_address::AccountAddress, PeerId},
 };
-use aptos_secure_storage::SECURE_STORAGE_DB_NAME;
 use aptosdb::{LEDGER_DB_NAME, STATE_MERKLE_DB_NAME};
 use state_sync_driver::metadata_storage::STATE_SYNC_DB_NAME;
 use std::{
@@ -270,14 +269,14 @@ impl Node for LocalNode {
         let node_config = self.config();
         let ledger_db_path = node_config.storage.dir().join(LEDGER_DB_NAME);
         let state_db_path = node_config.storage.dir().join(STATE_MERKLE_DB_NAME);
-        let secure_storage_db_path = node_config.base.data_dir.join(SECURE_STORAGE_DB_NAME);
+        let secure_storage_path = node_config.base.data_dir.join("secure_storage.json");
         let state_sync_db_path = node_config.storage.dir().join(STATE_SYNC_DB_NAME);
 
         debug!(
             "Deleting ledger, state, secure and state sync db paths ({:?}, {:?}, {:?}, {:?}) for node {:?}",
             ledger_db_path.as_path(),
             state_db_path.as_path(),
-            secure_storage_db_path.as_path(),
+            secure_storage_path.as_path(),
             state_sync_db_path.as_path(),
             self.name
         );
@@ -286,7 +285,7 @@ impl Node for LocalNode {
         assert!(ledger_db_path.as_path().exists() && state_db_path.as_path().exists());
         assert!(state_sync_db_path.as_path().exists());
         if self.config.base.role.is_validator() {
-            assert!(secure_storage_db_path.as_path().exists());
+            assert!(secure_storage_path.as_path().exists(),);
         }
 
         // Remove the files
@@ -300,7 +299,7 @@ impl Node for LocalNode {
             .map_err(anyhow::Error::from)
             .context("Failed to delete state_sync_db_path")?;
         if self.config.base.role.is_validator() {
-            fs::remove_dir_all(secure_storage_db_path)
+            fs::remove_file(secure_storage_path)
                 .map_err(anyhow::Error::from)
                 .context("Failed to delete secure_storage_db_path")?;
         }


### PR DESCRIPTION
Rocksdb seems unnecessary for the simple use case and creates friction to operate on it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4196)
<!-- Reviewable:end -->
