### PR TITLE
[API] Respond with Access-Control-Allow-Credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,7 +5209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
-name = "listner"
+name = "listener"
 version = "0.1.0"
 dependencies = [
  "bytes 1.2.1",

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -168,6 +168,10 @@ pub fn attach_poem_to_runtime(
         .context("Failed to get socket addr from local addr for Poem webserver")?;
     runtime_handle.spawn(async move {
         let cors = Cors::new()
+            // To allow browsers to use cookies (for cookie-based sticky
+            // routing in the LB) we must enable this:
+            // https://stackoverflow.com/a/24689738/3846032
+            .allow_credentials(true)
             .allow_methods(vec![Method::GET, Method::POST])
             .allow_headers(vec![header::CONTENT_TYPE, header::ACCEPT]);
 


### PR DESCRIPTION
## Description
Needed to allow browsers to use cookies, which we need for cookie-based session.

I can see in the Poem code that this does what we want:
```
        if self.allow_credentials {
            builder = builder.header(header::ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
        }
```

## Test Plan
CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4198)
<!-- Reviewable:end -->
