### PR TITLE
[move-deps & friend compat] Updates move-deps & relaxes friend compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,7 +2187,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -5209,7 +5209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
-name = "listner"
+name = "listener"
 version = "0.1.0"
 dependencies = [
  "bytes 1.2.1",
@@ -5484,7 +5484,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5501,7 +5501,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -5516,12 +5516,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5536,7 +5536,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5548,7 +5548,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5560,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "difference",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5669,7 +5669,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5686,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5740,7 +5740,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5758,7 +5758,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5776,7 +5776,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5821,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5840,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "hex",
@@ -5853,7 +5853,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "hex",
@@ -5867,7 +5867,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5893,7 +5893,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5929,7 +5929,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5966,7 +5966,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5994,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -6005,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6016,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6076,7 +6076,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "log",
@@ -6098,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6107,7 +6107,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6124,7 +6124,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6155,7 +6155,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6186,7 +6186,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -7755,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7770,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=51d4aa15e082efafb99e5158ed2bbc8b6daecac6#51d4aa15e082efafb99e5158ed2bbc8b6daecac6"
+source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/aptos-move/aptos-gas/Cargo.toml
+++ b/aptos-move/aptos-gas/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2021"
 
 [dependencies]
-move-binary-format = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
 
 aptos-types = { path = "../../types" }
 framework = { path = "../framework" }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -30,6 +30,7 @@ use aptos_logger::prelude::*;
 use aptos_module_verifier::module_init::verify_module_init_function;
 use aptos_state_view::StateView;
 use aptos_types::account_config::new_block_event_key;
+use aptos_types::on_chain_config::Features;
 use aptos_types::vm_status::AbortLocation;
 use aptos_types::{
     account_config,
@@ -98,9 +99,17 @@ impl AptosVM {
         Self::new(state)
     }
 
-    pub fn init_with_config(version: Version, gas_schedule: GasSchedule) -> Self {
+    pub fn init_with_config(
+        version: Version,
+        gas_schedule: GasSchedule,
+        features: Features,
+    ) -> Self {
         info!("Adapter restarted for Validation");
-        AptosVM(AptosVMImpl::init_with_config(version, gas_schedule))
+        AptosVM(AptosVMImpl::init_with_config(
+            version,
+            gas_schedule,
+            features,
+        ))
     }
 
     /// Sets execution concurrency level when invoked the first time.

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -27,12 +27,14 @@ impl MoveVmExt {
     pub fn new(
         native_gas_params: NativeGasParameters,
         abs_val_size_gas_params: AbstractValueSizeGasParameters,
+        treat_friend_as_private: bool,
     ) -> VMResult<Self> {
         Ok(Self {
             inner: MoveVM::new_with_verifier_config(
                 aptos_natives(native_gas_params, abs_val_size_gas_params),
                 VerifierConfig {
                     max_loop_depth: Some(5),
+                    treat_friend_as_private,
                 },
             )?,
         })

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -6,7 +6,7 @@ use aptos::move_tool::MemberId;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_crypto::{PrivateKey, Uniform};
 use aptos_gas::{AptosGasParameters, InitialGasSchedule, ToOnChainGasSchedule};
-use aptos_types::on_chain_config::GasSchedule;
+use aptos_types::on_chain_config::{FeatureFlag, GasSchedule};
 use aptos_types::{
     access_path::AccessPath,
     account_address::AccountAddress,
@@ -72,7 +72,7 @@ impl MoveHarness {
         }
     }
 
-    pub fn new_with_features(features: Vec<u64>) -> Self {
+    pub fn new_with_features(features: Vec<FeatureFlag>) -> Self {
         let mut h = Self::new();
         if !features.is_empty() {
             h.enable_features(features);
@@ -319,8 +319,9 @@ impl MoveHarness {
     }
 
     /// Enables features
-    pub fn enable_features(&mut self, features: Vec<u64>) {
+    pub fn enable_features(&mut self, features: Vec<FeatureFlag>) {
         let acc = self.aptos_framework_account();
+        let enable = features.into_iter().map(|f| f as u64).collect::<Vec<_>>();
         self.executor.exec(
             "features",
             "change_feature_flags",
@@ -329,7 +330,7 @@ impl MoveHarness {
                 MoveValue::Signer(*acc.address())
                     .simple_serialize()
                     .unwrap(),
-                bcs::to_bytes(&features).unwrap(),
+                bcs::to_bytes(&enable).unwrap(),
                 bcs::to_bytes(&Vec::<u64>::new()).unwrap(),
             ],
         );

--- a/aptos-move/e2e-move-tests/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/tests/code_publishing.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::account_address::AccountAddress;
-use aptos_types::on_chain_config::CODE_DEPENDENCY_CHECK;
+use aptos_types::on_chain_config::FeatureFlag;
 use e2e_move_tests::package_builder::PackageBuilder;
 use e2e_move_tests::{assert_abort, assert_success, assert_vm_status, MoveHarness};
 use framework::natives::code::{PackageRegistry, UpgradePolicy};
@@ -27,8 +27,8 @@ struct State {
 /// run tests which are expected to make a difference for legacy flag combinations.
 #[rstest]
 #[case(vec![])]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_basic(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_basic(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     assert_success!(h.publish_package(
@@ -65,8 +65,8 @@ fn code_publishing_basic(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_upgrade_success_no_compat(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_upgrade_success_no_compat(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
@@ -84,8 +84,8 @@ fn code_publishing_upgrade_success_no_compat(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_upgrade_success_compat(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_upgrade_success_compat(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
@@ -103,8 +103,8 @@ fn code_publishing_upgrade_success_compat(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_upgrade_fail_compat(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_upgrade_fail_compat(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
@@ -123,8 +123,8 @@ fn code_publishing_upgrade_fail_compat(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_upgrade_fail_immutable(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_upgrade_fail_immutable(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
@@ -143,8 +143,8 @@ fn code_publishing_upgrade_fail_immutable(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_upgrade_fail_overlapping_module(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_upgrade_fail_overlapping_module(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
@@ -206,8 +206,8 @@ fn code_publishing_upgrade_loader_cache_consistency() {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_framework_upgrade(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_framework_upgrade(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.aptos_framework_account();
 
@@ -220,8 +220,8 @@ fn code_publishing_framework_upgrade(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_framework_upgrade_fail(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_framework_upgrade_fail(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.aptos_framework_account();
 
@@ -235,8 +235,8 @@ fn code_publishing_framework_upgrade_fail(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_weak_dep_fail(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_weak_dep_fail(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
@@ -261,8 +261,8 @@ fn code_publishing_weak_dep_fail(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_arbitray_dep_different_address(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_arbitray_dep_different_address(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc1 = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     let acc2 = h.new_account_at(AccountAddress::from_hex_literal("0xdeaf").unwrap());
@@ -290,8 +290,8 @@ fn code_publishing_arbitray_dep_different_address(#[case] features: Vec<u64>) {
 }
 
 #[rstest]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_using_resource_account(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_using_resource_account(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features);
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
 
@@ -323,8 +323,8 @@ fn code_publishing_using_resource_account(#[case] features: Vec<u64>) {
 
 #[rstest]
 #[case(vec![])]
-#[case(vec![CODE_DEPENDENCY_CHECK])]
-fn code_publishing_faked_dependency(#[case] features: Vec<u64>) {
+#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
+fn code_publishing_faked_dependency(#[case] features: Vec<FeatureFlag>) {
     let mut h = MoveHarness::new_with_features(features.clone());
     let acc1 = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
     let acc2 = h.new_account_at(AccountAddress::from_hex_literal("0xdeaf").unwrap());
@@ -332,7 +332,7 @@ fn code_publishing_faked_dependency(#[case] features: Vec<u64>) {
     let mut pack1 = PackageBuilder::new("Package1").with_policy(UpgradePolicy::compat());
     pack1.add_source("m", "module 0xcafe::m { public fun f() {} }");
     let pack1_dir = pack1.write_to_temp().unwrap();
-    h.publish_package(&acc1, pack1_dir.path());
+    assert_success!(h.publish_package(&acc1, pack1_dir.path()));
 
     // pack2 has a higher policy and should not be able to depend on pack1
     let mut pack2 = PackageBuilder::new("Package2").with_policy(UpgradePolicy::immutable());
@@ -350,10 +350,39 @@ fn code_publishing_faked_dependency(#[case] features: Vec<u64>) {
         // this via checking the actual bytecode module dependencies.
         metadata.deps.clear()
     });
-    if !features.contains(&CODE_DEPENDENCY_CHECK) {
+    if !features.contains(&FeatureFlag::CODE_DEPENDENCY_CHECK) {
         // In the previous version we were not able to detect this problem
         assert_success!(result)
     } else {
         assert_vm_status!(result, StatusCode::CONSTRAINT_NOT_SATISFIED)
+    }
+}
+
+#[rstest]
+#[case(vec![])]
+#[case(vec![FeatureFlag::TREAT_FRIEND_AS_PRIVATE])]
+fn code_publishing_friend_as_private(#[case] features: Vec<FeatureFlag>) {
+    let mut h = MoveHarness::new_with_features(features.clone());
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+
+    let mut pack1 = PackageBuilder::new("Package").with_policy(UpgradePolicy::compat());
+    pack1.add_source(
+        "m",
+        "module 0xcafe::m { public fun f() {}  public(friend) fun g() {} }",
+    );
+    let pack1_dir = pack1.write_to_temp().unwrap();
+    assert_success!(h.publish_package(&acc, pack1_dir.path()));
+
+    let mut pack2 = PackageBuilder::new("Package").with_policy(UpgradePolicy::compat());
+    // Removes friend
+    pack2.add_source("m", "module 0xcafe::m { public fun f() {} }");
+    let pack2_dir = pack2.write_to_temp().unwrap();
+
+    let result = h.publish_package(&acc, pack2_dir.path());
+    if features.contains(&FeatureFlag::TREAT_FRIEND_AS_PRIVATE) {
+        // With this feature we can remove friends
+        assert_success!(result)
+    } else {
+        assert_vm_status!(result, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE)
     }
 }

--- a/aptos-move/e2e-move-tests/tests/framework_compatibility.rs
+++ b/aptos-move/e2e-move-tests/tests/framework_compatibility.rs
@@ -9,7 +9,7 @@ use move_deps::move_core_types::account_address::AccountAddress;
 mod common;
 
 #[test]
-fn can_upgrade_framework() {
+fn can_upgrade_framework_on_testnet() {
     let mut h = MoveHarness::new_testnet();
     h.increase_transaction_size();
 

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -22,6 +22,7 @@ use aptos_crypto::HashValue;
 use aptos_gas::{AbstractValueSizeGasParameters, NativeGasParameters};
 use aptos_keygen::KeyGen;
 use aptos_state_view::StateView;
+use aptos_types::on_chain_config::{FeatureFlag, Features};
 use aptos_types::{
     access_path::AccessPath,
     account_config::{
@@ -82,6 +83,7 @@ pub struct FakeExecutor {
     trace_dir: Option<PathBuf>,
     rng: KeyGen,
     no_parallel_exec: bool,
+    features: Features,
 }
 
 impl FakeExecutor {
@@ -94,6 +96,7 @@ impl FakeExecutor {
             trace_dir: None,
             rng: KeyGen::from_seed(RNG_SEED),
             no_parallel_exec: false,
+            features: Features::default(),
         };
         executor.apply_write_set(write_set);
         // As a set effect, also allow module bundle txns. TODO: Remove
@@ -131,6 +134,7 @@ impl FakeExecutor {
             trace_dir: None,
             rng: KeyGen::from_seed(RNG_SEED),
             no_parallel_exec: false,
+            features: Features::default(),
         }
     }
 
@@ -543,6 +547,8 @@ impl FakeExecutor {
             let vm = MoveVmExt::new(
                 NativeGasParameters::zeros(),
                 AbstractValueSizeGasParameters::zeros(),
+                self.features
+                    .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
             )
             .unwrap();
             let remote_view = StorageAdapter::new(&self.data_store);
@@ -586,6 +592,8 @@ impl FakeExecutor {
         let vm = MoveVmExt::new(
             NativeGasParameters::zeros(),
             AbstractValueSizeGasParameters::zeros(),
+            self.features
+                .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
         )
         .unwrap();
         let remote_view = StorageAdapter::new(&self.data_store);

--- a/aptos-move/framework/aptos-framework/sources/configs/features.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/features.move
@@ -31,8 +31,17 @@ module aptos_framework::features {
     /// available. This is needed because of introduction of a new native function.
     /// Lifetime: transient
     const CODE_DEPENDENCY_CHECK: u64 = 1;
-    public fun code_dependency_check_enabled(): bool acquires Features {
+    public(friend) fun code_dependency_check_enabled(): bool acquires Features {
         is_enabled(CODE_DEPENDENCY_CHECK)
+    }
+    friend aptos_framework::code;
+
+    /// Whether during upgrade compatibility checking, friend functions should be treated similar like
+    /// private functions.
+    /// Lifetime: ephemeral
+    const TREAT_FRIEND_AS_PRIVATE: u64 = 2;
+    public(friend) fun treat_friend_as_private(): bool acquires Features {
+        is_enabled(TREAT_FRIEND_AS_PRIVATE)
     }
 
     // ============================================================================================

--- a/aptos-move/gas-algebra-ext/Cargo.toml
+++ b/aptos-move/gas-algebra-ext/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-move-core-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -21,34 +21,34 @@ edition = "2021"
 #   actively looking for solutions.
 #
 ##########################################################################################
-move-abigen = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-cli = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-model = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-package = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-prover = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "51d4aa15e082efafb99e5158ed2bbc8b6daecac6" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-cli = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-model = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-package = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-prover = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "59265662d0a44ba53b09ba3c4b2248efdf08c622" }
 
 [features]
 default = []

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -16,6 +16,7 @@ use aptos_gas::{
     ToOnChainGasSchedule,
 };
 use aptos_types::account_config::aptos_test_root_address;
+use aptos_types::on_chain_config::{FeatureFlag, Features};
 use aptos_types::{
     account_config::{self, events::NewEpochEvent, CORE_CODE_ADDRESS},
     chain_id::ChainId,
@@ -114,6 +115,7 @@ pub fn encode_genesis_change_set(
     let move_vm = MoveVmExt::new(
         NativeGasParameters::zeros(),
         AbstractValueSizeGasParameters::zeros(),
+        Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
     )
     .unwrap();
     let id1 = HashValue::zero();
@@ -646,6 +648,7 @@ pub fn test_genesis_module_publishing() {
     let move_vm = MoveVmExt::new(
         NativeGasParameters::zeros(),
         AbstractValueSizeGasParameters::zeros(),
+        false,
     )
     .unwrap();
     let id1 = HashValue::zero();

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -5,6 +5,7 @@ use anyhow::format_err;
 use aptos_crypto::HashValue;
 use aptos_gas::{AbstractValueSizeGasParameters, NativeGasParameters};
 use aptos_state_view::StateView;
+use aptos_types::on_chain_config::{FeatureFlag, Features};
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{self, aptos_test_root_address},
@@ -110,6 +111,7 @@ where
     let move_vm = MoveVmExt::new(
         NativeGasParameters::zeros(),
         AbstractValueSizeGasParameters::zeros(),
+        Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
     )
     .unwrap();
     let state_view_storage = StorageAdapter::new(state_view);

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -4,8 +4,16 @@
 use crate::on_chain_config::OnChainConfig;
 use serde::{Deserialize, Serialize};
 
-/// Defines the features enabled on-chain.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+/// The feature flags define in the Move source. This must stay aligned with the constants there.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub enum FeatureFlag {
+    CODE_DEPENDENCY_CHECK = 1,
+    TREAT_FRIEND_AS_PRIVATE = 2,
+}
+
+/// Representation of features on chain as a bitset.
+#[derive(Default, Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Features {
     #[serde(with = "serde_bytes")]
     pub features: Vec<u8>,
@@ -17,14 +25,13 @@ impl OnChainConfig for Features {
 }
 
 impl Features {
-    pub fn is_enabled(&self, flag: u64) -> bool {
-        let byte_index = (flag / 8) as usize;
-        let bit_mask = 1 << (flag % 8);
+    pub fn is_enabled(&self, flag: FeatureFlag) -> bool {
+        let val = flag as u64;
+        let byte_index = (val / 8) as usize;
+        let bit_mask = 1 << (val % 8);
         byte_index < self.features.len() && (self.features[byte_index] & bit_mask != 0)
     }
 }
 
 // --------------------------------------------------------------------------------------------
 // Code Publishing
-
-pub const CODE_DEPENDENCY_CHECK: u64 = 1;


### PR DESCRIPTION
### Description

This PR does two things:

- Updates the move-deps to link to the commit of the new [aptos release branch on move-language](https://github.com/move-language/move/tree/aptos). 
- Based on the new feature in the Move repo/branch, adds the feature `TREAT_FRIEND_AS_PRIVATE` to Move and Rust code, inclusive a test.



### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

New test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4199)
<!-- Reviewable:end -->
