### PR TITLE
Avoid using tasksfile in ts-tasks

### DIFF
--- a/.github/ts-tasks/package.json
+++ b/.github/ts-tasks/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@aptos/ts-tasks",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "scripts": {
-    "task": "yarn install --frozen-lockfile --silent && ts-node ./tasksfile.ts"
+    "pruneGithubWorkflowRuns": "yarn install --frozen-lockfile --silent && ts-node ./prune-github-workflow-runs.ts"
   },
   "license": "Apache-2.0",
   "dependencies": {
@@ -11,8 +11,7 @@
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.3",
     "@actions/glob": "^0.3.0",
-    "find-git-root": "^1.0.4",
-    "tasksfile": "^5.1.1"
+    "find-git-root": "^1.0.4"
   },
   "devDependencies": {
     "@types/node": "^16.10.5",

--- a/.github/ts-tasks/prune-github-workflow-runs.ts
+++ b/.github/ts-tasks/prune-github-workflow-runs.ts
@@ -75,3 +75,6 @@ Deleting their workflow runs now...`,
 
   core.info(`Deleted ${totalDeleted} workflow runs`);
 }
+
+// Run the function above.
+pruneGithubWorkflowRuns()

--- a/.github/ts-tasks/tasksfile.ts
+++ b/.github/ts-tasks/tasksfile.ts
@@ -1,6 +1,0 @@
-import { cli } from "tasksfile";
-import { pruneGithubWorkflowRuns } from "./prune-github-workflow-runs";
-
-cli({
-  pruneGithubWorkflowRuns,
-});

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: .node-version
-      - run: yarn task pruneGithubWorkflowRuns
+      - run: yarn pruneGithubWorkflowRuns
         env:
           GITHUB_TOKEN: ${{ github.token }}
         working-directory: .github/ts-tasks


### PR DESCRIPTION
## Description
Addressing https://github.com/aptos-labs/aptos-core/security/dependabot/64.

## Test Plan
```
cd .github/ts-tasks
yarn pruneGithubWorkflowRuns
```

I haven't tested that the CI itself works, but I can if yall want. It's just painful bc it's a cron / manual workflow, so I'll have to fork and experiment there. The above does work though (up to the point where the token isn't there).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4213)
<!-- Reviewable:end -->
