### PR TITLE
[community] Redirect /discord to the Discord invite URL.

### DIFF
--- a/ecosystem/platform/server/config/routes.rb
+++ b/ecosystem/platform/server/config/routes.rb
@@ -100,6 +100,9 @@ Rails.application.routes.draw do
   # Wallets
   resources :wallets, only: %i[show create]
 
+  # Discord invite link
+  get 'discord', to: redirect('https://discord.com/invite/aptoslabs')
+
   # Static pages
   get 'community', to: 'static_page#community'
   get 'incentivized-testnet', to: 'static_page#incentivized_testnet'


### PR DESCRIPTION
### Description

aptoslabs.com/discord should redirect to the Discord invite.

### Test Plan
Tested manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4215)
<!-- Reviewable:end -->
