### PR TITLE
[gha] forge sticky hide and report failure only

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -155,6 +155,7 @@ jobs:
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
@@ -178,6 +179,7 @@ jobs:
       FORGE_TEST_SUITE: compat
       IMAGE_TAG: testnet
       FORGE_RUNNER_DURATION_SECS: 300
+      COMMENT_HEADER: forge-compat
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
       # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         description: Whether to use performance images. If this option is true, and you plan to manually pass in IMAGE_TAGs, note that the tagging schema is different
+      COMMENT_HEADER:
+        required: false
+        type: string
+        default: forge
+        description: A unique ID for Forge sticky comment on your PR. See https://github.com/marocchino/sticky-pull-request-comment#keep-more-than-one-comment
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
@@ -69,6 +74,7 @@ env:
   FORGE_TEST_SUITE: ${{ inputs.FORGE_TEST_SUITE }}
   POST_TO_SLACK: ${{ inputs.POST_TO_SLACK }}
   FORGE_ENABLE_FAILPOINTS: ${{ inputs.FORGE_ENABLE_FAILPOINTS }}
+  COMMENT_HEADER: ${{ inputs.COMMENT_HEADER }}
   VERBOSE: true
 
 jobs:
@@ -96,7 +102,9 @@ jobs:
         if: github.event.number != null
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          append: true
+          header: ${{ env.COMMENT_HEADER }}
+          hide_and_recreate: true # Hide the previous comment and add a comment at the end
+          hide_classify: "OUTDATED"
           path: ${{ env.FORGE_PRE_COMMENT }}
 
       - name: Run Forge
@@ -111,12 +119,13 @@ jobs:
         if: github.event.number != null && !cancelled()
         uses: marocchino/sticky-pull-request-comment@v2
         with:
-          append: true
-          recreate: true
+          header: ${{ env.COMMENT_HEADER }}
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
           path: ${{ env.FORGE_COMMENT }}
-      - name: Post to a Slack channel
+      - name: Post to a Slack channel on failure
         # Post a Slack comment if the run has not been cancelled and the envs are set
-        if: env.POST_TO_SLACK == 'true' && !cancelled()
+        if: env.POST_TO_SLACK == 'true' && failure()
         id: slack
         uses: slackapi/slack-github-action@v1.21.0
         with:


### PR DESCRIPTION
### Description

Instead of appending to a single comment (which can get massive + there are no reliable timestamps e.g. this massive comment https://github.com/aptos-labs/aptos-core/pull/4119#issuecomment-1247424891), hide the previous one and recreate the comment at the bottom. The old test runs are still able to be referenced

Also only report to slack the failures

### Test Plan

Land it

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4217)
<!-- Reviewable:end -->
