### PR TITLE
Turned the recursive `pow` functions into iterative ones

### DIFF
--- a/.github/workflows/prover-test.yaml
+++ b/.github/workflows/prover-test.yaml
@@ -1,15 +1,13 @@
 name: "Prover Test"
 on:
-  # Stop running on PR / main until this is fixed
-  # pull_request:
-  # push:
-  #   branches:
-  #     - main
-  #     - devnet
-  #     - testnet
-  #     - auto
-  #     - canary
-  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+      - devnet
+      - testnet
+      - auto
+      - canary
 
 env:
   HAS_BUILDPULSE_SECRETS: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID != '' && secrets.BUILDPULSE_SECRET_ACCESS_KEY != '' }}

--- a/aptos-move/framework/aptos-stdlib/sources/math128.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.move
@@ -20,17 +20,16 @@ module aptos_std::math128 {
     public fun pow(n: u128, e: u128): u128 {
         if (e == 0) {
             1
-        } else if (e == 1) {
-            n
         } else {
-            let p = pow(n, e / 2);
-            p = p * p;
-            if (e % 2 == 1) {
-                p = p * n;
-                p
-            } else {
-                p
-            }
+            let p = 1;
+            while(e > 1) {
+                if (e % 2 == 1) {
+                    p = p * n;
+                };
+                e = e / 2;
+                n = n * n;
+            };
+            p * n
         }
     }
 

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -20,17 +20,16 @@ module aptos_std::math64 {
     public fun pow(n: u64, e: u64): u64 {
         if (e == 0) {
             1
-        } else if (e == 1) {
-            n
         } else {
-            let p = pow(n, e / 2);
-            p = p * p;
-            if (e % 2 == 1) {
-                p = p * n;
-                p
-            } else {
-                p
-            }
+            let p = 1;
+            while(e > 1) {
+                if (e % 2 == 1) {
+                    p = p * n;
+                };
+                e = e / 2;
+                n = n * n;
+            };
+            p * n
         }
     }
 


### PR DESCRIPTION
### Description

- replaced the recursive `pow` functions with iterative ones
- the new implementation also has the logarithmic time complexity (log e).
- this bypasses the Prover's issue with recursive Move functions.
- turned on the CI test for prover because Prover is now back to working


### Test Plan
cargo test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4229)
<!-- Reviewable:end -->
