### PR TITLE
[docs] Add links to Rust SDK to the system integration guide

### DIFF
--- a/developer-docs-site/docs/guides/system-integrators-guide.md
+++ b/developer-docs-site/docs/guides/system-integrators-guide.md
@@ -52,6 +52,7 @@ REST API service: https://fullnode.testnet.aptoslabs.com/v1
 Aptos currently has two SDKs:
 1. [Typescript](/sdks/typescript-sdk)
 2. [Python](/sdks/python-sdk)
+3. [Rust](/sdks/rust-sdk)
 
 
 ### Other Areas
@@ -59,6 +60,7 @@ Aptos currently has two SDKs:
 * [Using the CLI](../cli-tools/aptos-cli-tool/use-aptos-cli) which includes creating accounts, transferring coins, and publishing modules
 * [Typescript SDK](../sdks/typescript-sdk)
 * [Python SDK](../sdks/python-sdk)
+* [Rust SDK](../sdks/rust-sdk)
 * [REST API spec](https://fullnode.devnet.aptoslabs.com/v1/spec#/)
 * [Local testnet development flow](/guides/local-testnet-dev-flow)
 


### PR DESCRIPTION
While reading the docs found that the mention of Rust SDK is missing, so added the links to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4230)
<!-- Reviewable:end -->
