### PR TITLE
[block store] fix some race conditions

### DIFF
--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -319,11 +319,6 @@ impl BlockStore {
         )
         .await;
 
-        let to_remove = self.inner.read().get_all_block_id();
-        if let Err(e) = self.storage.prune_tree(to_remove) {
-            // it's fine to fail here, the next restart will try to clean up dangling blocks again.
-            error!(error = ?e, "Fail to delete block from consensus db");
-        }
         // Unwrap the new tree and replace the existing tree.
         *self.inner.write() = Arc::try_unwrap(inner)
             .unwrap_or_else(|_| panic!("New block tree is not shared"))

--- a/consensus/src/block_storage/block_tree.rs
+++ b/consensus/src/block_storage/block_tree.rs
@@ -412,10 +412,6 @@ impl BlockTree {
         self.max_pruned_blocks_in_mem
     }
 
-    pub(super) fn get_all_block_id(&self) -> Vec<HashValue> {
-        self.id_to_block.keys().cloned().collect()
-    }
-
     /// Update the counters for committed blocks and prune them from the in-memory and persisted store.
     pub fn commit_callback(
         &mut self,

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -1,9 +1,11 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block_storage::tracing::{observe_block, BlockStage};
 use crate::{
-    block_storage::BlockStore,
+    block_storage::{
+        tracing::{observe_block, BlockStage},
+        BlockStore,
+    },
     commit_notifier::CommitNotifier,
     counters,
     error::{error_kind, DbError},
@@ -679,7 +681,7 @@ impl EpochManager {
         let initial_data = self
             .storage
             .start()
-            .expect_recovery_data("Consensusdb is corrupted, need to do a backup and restore");
+            .expect_recovery_data("consensusdb is not consistent with aptosdb");
         self.start_round_manager(
             initial_data,
             epoch_state,


### PR DESCRIPTION
The prune already happened here before rebuild the block tree https://github.com/aptos-labs/aptos-core/blob/1398201b2a1e339624dd2798c048cbac057000cd/consensus/src/block_storage/sync_manager.rs#L322
This prune may also prune blocks that's in the new tree if the old tree has overlap with the new tree.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4232)
<!-- Reviewable:end -->
