### PR TITLE
[aptos-rosetta] Drop transactions that don't have associated operations

### DIFF
--- a/crates/aptos-rosetta-cli/src/block.rs
+++ b/crates/aptos-rosetta-cli/src/block.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::common::{format_output, BlockArgs, NetworkArgs, UrlArgs};
-use aptos_rosetta::types::{BlockRequest, BlockResponse};
+use aptos_rosetta::types::{BlockRequest, BlockRequestMetadata, BlockResponse};
 use clap::{Parser, Subcommand};
 
 /// Block APIs
@@ -38,9 +38,16 @@ pub struct GetBlockCommand {
 
 impl GetBlockCommand {
     pub async fn execute(self) -> anyhow::Result<BlockResponse> {
+        let metadata = self
+            .block_args
+            .keep_all_transactions
+            .map(|inner| BlockRequestMetadata {
+                keep_empty_transactions: Some(inner),
+            });
         let request = BlockRequest {
             network_identifier: self.network_args.network_identifier(),
             block_identifier: self.block_args.into(),
+            metadata,
         };
         self.url_args.client().block(&request).await
     }

--- a/crates/aptos-rosetta-cli/src/common.rs
+++ b/crates/aptos-rosetta-cli/src/common.rs
@@ -91,6 +91,9 @@ pub struct BlockArgs {
     /// The hash of the block to request
     #[clap(long)]
     block_hash: Option<String>,
+
+    #[clap(long)]
+    pub keep_all_transactions: Option<bool>,
 }
 
 impl From<BlockArgs> for Option<PartialBlockIdentifier> {

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -57,6 +57,14 @@ pub struct BlockRequest {
     /// A set of search parameters (latest, by hash, or by index)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_identifier: Option<PartialBlockIdentifier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<BlockRequestMetadata>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BlockRequestMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keep_empty_transactions: Option<bool>,
 }
 
 impl BlockRequest {
@@ -64,6 +72,7 @@ impl BlockRequest {
         Self {
             network_identifier: chain_id.into(),
             block_identifier,
+            metadata: None,
         }
     }
 
@@ -77,6 +86,13 @@ impl BlockRequest {
 
     pub fn by_index(chain_id: ChainId, index: u64) -> Self {
         Self::new(chain_id, Some(PartialBlockIdentifier::block_index(index)))
+    }
+
+    pub fn with_empty_transactions(mut self) -> Self {
+        self.metadata = Some(BlockRequestMetadata {
+            keep_empty_transactions: Some(true),
+        });
+        self
     }
 }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -734,20 +734,14 @@ async fn test_block() {
             "Block timestamp should match actual timestamp but in ms"
         );
 
-        // First transaction should be first in block
-        assert_eq!(
-            current_version, actual_block.first_version,
-            "First transaction in block should be the current version"
-        );
+        // TODO: double check that all transactions do show with the flag, and that all expected txns
+        // are shown without the flag
 
         let actual_txns = actual_block
             .transactions
             .as_ref()
             .expect("Every actual block should have transactions");
         parse_block_transactions(&block, &mut balances, actual_txns, &mut current_version).await;
-
-        // The full block must have been processed
-        assert_eq!(current_version - 1, actual_block.last_version);
 
         // Keep track of the previous
         previous_block_index = block_height;
@@ -764,18 +758,33 @@ async fn parse_block_transactions(
     actual_txns: &[TransactionOnChainData],
     current_version: &mut u64,
 ) {
-    for (txn_number, transaction) in block.transactions.iter().enumerate() {
-        let actual_txn = actual_txns
-            .get(txn_number)
-            .expect("There should be the same number of transactions in the actual block");
-        let actual_txn_info = &actual_txn.info;
+    let versions: Vec<_> = block
+        .transactions
+        .iter()
+        .map(|txn| txn.metadata.version.0)
+        .collect();
+    eprintln!(
+        "block: {} txns: {:?}",
+        block.block_identifier.index, versions
+    );
+    for transaction in block.transactions.iter() {
         let txn_metadata = &transaction.metadata;
+        let txn_version = txn_metadata.version.0;
+        let cur_version = *current_version;
+        assert!(
+            txn_version >= cur_version,
+            "Transaction version {} must be greater than previous {}",
+            txn_version,
+            cur_version
+        );
+
+        let actual_txn = actual_txns
+            .iter()
+            .find(|txn| txn.version == txn_version)
+            .expect("There should be the transaction in the actual block");
+        let actual_txn_info = &actual_txn.info;
 
         // Ensure transaction identifier is correct
-        assert_eq!(
-            *current_version, txn_metadata.version.0,
-            "There should be no gaps in transaction versions"
-        );
         assert_eq!(
             format!("{:x}", actual_txn_info.transaction_hash()),
             transaction.transaction_identifier.hash,
@@ -793,7 +802,7 @@ async fn parse_block_transactions(
         match txn_metadata.transaction_type {
             TransactionType::Genesis => {
                 // For this test, there should only be one genesis
-                assert_eq!(0, *current_version);
+                assert_eq!(0, cur_version);
                 assert!(matches!(
                     actual_txn.transaction,
                     aptos_types::transaction::Transaction::GenesisTransaction(_)
@@ -832,13 +841,13 @@ async fn parse_block_transactions(
         .await;
 
         for (_, account_balance) in balances.iter() {
-            if let Some(amount) = account_balance.get(current_version) {
+            if let Some(amount) = account_balance.get(&cur_version) {
                 assert!(*amount >= 0, "Amount shouldn't be negative!")
             }
         }
 
         // Increment to next version
-        *current_version += 1;
+        *current_version = txn_version + 1;
     }
 }
 
@@ -1184,7 +1193,8 @@ async fn test_invalid_transaction_gas_charged() {
     // Verify failed txn
     let rosetta_txn = block_with_transfer
         .transactions
-        .get(txn_version.saturating_sub(block_info.first_version.0) as usize)
+        .iter()
+        .find(|txn| txn.metadata.version.0 == txn_version)
         .unwrap();
 
     assert_failed_transfer_transaction(


### PR DESCRIPTION


### Description
This should save users who don't want to keep track of transactions without associated operations.  They can be re-enabled by a flag.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
