### PR TITLE
[forge] Fix genesis.sh script when RANDOM_SEED is empty

### DIFF
--- a/terraform/helm/genesis/files/genesis.sh
+++ b/terraform/helm/genesis/files/genesis.sh
@@ -43,8 +43,6 @@ echo "NUM_VALIDATORS_WITH_LARGER_STAKE=${NUM_VALIDATORS_WITH_LARGER_STAKE}"
 echo "LARGER_STAKE_AMOUNT=${LARGER_STAKE_AMOUNT}"
 echo "RANDOM_SEED=${RANDOM_SEED}"
 
-RANDOM_SEED_IN_DECIMAL=$(printf "%d" 0x${RANDOM_SEED})
-
 # generate all validator configurations
 for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
     username="${USERNAME_PREFIX}-${i}"
@@ -75,6 +73,7 @@ for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
     if [[ -z "${RANDOM_SEED}" ]]; then
       aptos genesis generate-keys --output-dir $user_dir
     else
+      RANDOM_SEED_IN_DECIMAL=$(printf "%d" 0x${RANDOM_SEED})
       seed=$(printf "%064x" "$((${RANDOM_SEED_IN_DECIMAL}+i))")
       echo "seed=$seed for ${i}th validator"
       aptos genesis generate-keys --random-seed $seed --output-dir $user_dir


### PR DESCRIPTION
### Description
Define RANDOM_SEED_IN_DECIMAL only when RANDOM_SEED is set

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4245)
<!-- Reviewable:end -->
