### PR TITLE
[api] Use gas schedule v2 for gas estimation

### DIFF
--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -7,7 +7,7 @@ use aptos_rest_client::aptos_api_types::{MoveModuleId, TransactionData};
 use aptos_sdk::move_types::language_storage::StructTag;
 use aptos_types::account_address::AccountAddress;
 use aptos_types::account_config::{AccountResource, CORE_CODE_ADDRESS};
-use aptos_types::on_chain_config::GasSchedule;
+use aptos_types::on_chain_config::GasScheduleV2;
 use aptos_types::transaction::authenticator::AuthenticationKey;
 use aptos_types::transaction::{SignedTransaction, Transaction};
 use cached_packages::aptos_stdlib;
@@ -67,9 +67,9 @@ async fn test_gas_estimation() {
     let mut swarm = new_local_swarm_with_aptos(1).await;
     let mut public_info = swarm.aptos_public_info();
 
-    let gas_schedule: GasSchedule = public_info
+    let gas_schedule: GasScheduleV2 = public_info
         .client()
-        .get_account_resource_bcs(CORE_CODE_ADDRESS, "0x1::gas_schedule::GasSchedule")
+        .get_account_resource_bcs(CORE_CODE_ADDRESS, "0x1::gas_schedule::GasScheduleV2")
         .await
         .unwrap()
         .into_inner();


### PR DESCRIPTION
### Description
There's now V2.  For compatibility, it will use V1 if V2 doesn't exist

### Test Plan
E2E test only tests V2

Tested locally against a testnet full node, and got http://localhost:8080/v1/estimate_gas_price -> `{"gas_estimate":1}`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4258)
<!-- Reviewable:end -->
