### PR TITLE
[community] Use 303 instead of 302 for unconfirmed email redirect.

### DIFF
--- a/ecosystem/platform/server/app/controllers/application_controller.rb
+++ b/ecosystem/platform/server/app/controllers/application_controller.rb
@@ -37,7 +37,7 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_confirmed!
-    redirect_to onboarding_email_path unless current_user&.registration_completed?
+    redirect_to onboarding_email_path, status: :see_other unless current_user&.registration_completed?
   end
 
   def append_info_to_payload(payload)

--- a/ecosystem/platform/server/app/javascript/controllers/claim_nft_controller.ts
+++ b/ecosystem/platform/server/app/javascript/controllers/claim_nft_controller.ts
@@ -92,6 +92,10 @@ export default class extends Controller<HTMLAnchorElement> {
     });
 
     if (!response.ok) {
+      if (response.redirected) {
+        location.href = response.url;
+        return;
+      }
       throw "Unable to retrieve claim details.";
     }
 

--- a/ecosystem/platform/server/test/controllers/nft_offers_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/nft_offers_controller_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Copyright (c) Aptos
+# SPDX-License-Identifier: Apache-2.0
+
+require 'test_helper'
+
+class NftOffersControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'claiming an nft with unconfirmed email' do
+    Flipper.enable(:require_email_verification_for_nft)
+    user = FactoryBot.create(:user, email: nil, unconfirmed_email: Faker::Internet.email)
+    wallet = FactoryBot.create(:wallet, user:)
+    sign_in user
+
+    put nft_offer_path(slug: 'aptos-zero'), params: {
+      wallet: wallet.public_key,
+      wallet_name: wallet.wallet_name
+    }
+
+    assert_response :see_other
+    assert_redirected_to onboarding_email_path
+  end
+end


### PR DESCRIPTION
### Description

Use HTTP 303 instead of 302 for the `ensure_confirmed!` redirect. This indicates that clients should issue a GET for the redirect URL (so it should work even if the initial method was POST/PUT/etc.).

### Test Plan
Manual + automated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4259)
<!-- Reviewable:end -->
