### PR TITLE
[Consensus] Don't allow execution and vote in sync_only mode

### DIFF
--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -628,6 +628,11 @@ impl RoundManager {
             self.round_state.current_round()
         );
 
+        ensure!(
+            !self.sync_only(),
+            "[RoundManager] sync_only flag is set, stop voting"
+        );
+
         let vote_proposal = executed_block.vote_proposal(self.decoupled_execution());
         let vote_result = self.safety_rules.lock().construct_and_sign_vote_two_chain(
             &vote_proposal,


### PR DESCRIPTION
### Description

This bug was introduced in https://github.com/aptos-labs/aptos-core/pull/3580, which breaks the sync_only mode for write set txns. 

### Test Plan

Will add a UT as a follow up, landing this without test as this is critical to unbreak the write set tool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4266)
<!-- Reviewable:end -->
