### PR TITLE
[community] Add flag for nft captcha.

### DIFF
--- a/ecosystem/platform/server/app/controllers/nft_offers_controller.rb
+++ b/ecosystem/platform/server/app/controllers/nft_offers_controller.rb
@@ -105,6 +105,8 @@ class NftOffersController < ApplicationController
   end
 
   def check_recaptcha
+    return true unless Flipper.enabled?(:require_captcha_for_nft)
+
     recaptcha_v3_success = verify_recaptcha(action: 'claim_nft', minimum_score: 0.5,
                                             secret_key: ENV.fetch('RECAPTCHA_V3_SECRET_KEY', nil), model: @nft_offer)
     recaptcha_v2_success = verify_recaptcha(model: @nft_offer) unless recaptcha_v3_success


### PR DESCRIPTION
### Description

Only requires captcha for NFT minting if `:require_captcha_for_nft` is enabled.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4274)
<!-- Reviewable:end -->
