### PR TITLE
[community] Redirect to new project after creation.

### DIFF
--- a/ecosystem/platform/server/.rubocop.yml
+++ b/ecosystem/platform/server/.rubocop.yml
@@ -19,6 +19,9 @@ Metrics/PerceivedComplexity:
 Style/Documentation:
   Enabled: false
 
+Style/GuardClause:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 100
 

--- a/ecosystem/platform/server/app/controllers/projects_controller.rb
+++ b/ecosystem/platform/server/app/controllers/projects_controller.rb
@@ -32,8 +32,11 @@ class ProjectsController < ApplicationController
   # GET /projects/1
   def show
     @project = Project.find(params[:id])
-    head :not_found unless @project.verified
-    head :forbidden if @project.user_id != current_user&.id && !@project.public
+
+    if @project.user_id != current_user&.id
+      return head :not_found unless @project.verified
+      return head :forbidden unless @project.public
+    end
   end
 
   # GET /projects/new
@@ -58,8 +61,9 @@ class ProjectsController < ApplicationController
     return unless check_recaptcha
 
     if @project.save
-      redirect_to projects_url,
-                  notice: 'Project was successfully created. It will not be visible until approved by a moderator.'
+      redirect_to project_url(@project),
+                  notice: 'Project was successfully created. ' \
+                          'It will not be publicly visible until approved by a moderator.'
     else
       render :new, status: :unprocessable_entity
     end

--- a/ecosystem/platform/server/app/controllers/projects_controller.rb
+++ b/ecosystem/platform/server/app/controllers/projects_controller.rb
@@ -33,7 +33,7 @@ class ProjectsController < ApplicationController
   def show
     @project = Project.find(params[:id])
 
-    if @project.user_id != current_user&.id
+    if @project.user_id != current_user&.id && !current_user&.is_root
       return head :not_found unless @project.verified
       return head :forbidden unless @project.public
     end

--- a/ecosystem/platform/server/app/views/projects/show.html.erb
+++ b/ecosystem/platform/server/app/views/projects/show.html.erb
@@ -3,6 +3,7 @@
 
 <div class="bg-neutral-900 text-neutral-50 h-full">
   <div class="max-w-screen-xl mx-auto px-4 sm:px-6 md:px-8 py-8 sm:py-24">
+    <%= render 'layouts/flash' %>
     <div class="flex flex-col md:flex-row gap-8 md:gap-16">
       <div class="order-2 md:order-1">
         <div class="md:sticky top-32">

--- a/ecosystem/platform/server/test/controllers/projects_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/projects_controller_test.rb
@@ -59,6 +59,14 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test 'view unverified project succeeds if it belongs to the current user' do
+    user = FactoryBot.create(:user)
+    sign_in user
+    project = FactoryBot.create(:project, user:, verified: false)
+    get project_path(project)
+    assert_response :success
+  end
+
   test 'new project page' do
     get new_project_path
     assert_response :success
@@ -103,7 +111,7 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     end
 
     project = Project.last
-    assert_redirected_to projects_path
+    assert_redirected_to project_path(project)
     assert_equal @user, project.user
   end
 

--- a/ecosystem/platform/server/test/controllers/projects_controller_test.rb
+++ b/ecosystem/platform/server/test/controllers/projects_controller_test.rb
@@ -67,6 +67,14 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'view private, unverified project succeeds if user is admin' do
+    user = FactoryBot.create(:user, is_root: true)
+    sign_in user
+    project = FactoryBot.create(:project, user:, public: false, verified: false)
+    get project_path(project)
+    assert_response :success
+  end
+
   test 'new project page' do
     get new_project_path
     assert_response :success


### PR DESCRIPTION
### Description
![image](https://user-images.githubusercontent.com/310773/190717357-b5530102-657e-4dd3-a822-e02f8acd1ff7.png)

Redirects to the newly-created project instead of the index page upon submission.

Also allows admins to view all projects.
### Test Plan
Manual + automated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4275)
<!-- Reviewable:end -->
