### PR TITLE
[consensus] Add collected voting power counters

### DIFF
--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -81,6 +81,44 @@ pub static VOTE_NIL_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Total voting power of all votes collected for the last round this node was proposer
+pub static COLLECTED_VOTING_POWER_FOR_LAST_PROPOSAL: Lazy<Gauge> = Lazy::new(|| {
+    register_gauge!(
+        "aptos_collected_voting_power_for_last_proposal",
+        "Total voting power of all votes collected for the last round this node was proposer",
+    )
+    .unwrap()
+});
+
+/// Total number of votes collected for the last round this node was proposer
+pub static COLLECTED_VOTES_FOR_LAST_PROPOSAL: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_collected_votes_for_last_proposal",
+        "Total number of votes collected for the last round this node was proposer",
+    )
+    .unwrap()
+});
+
+/// Total voting power of all votes collected for the last round this node was proposer
+pub static COLLECTED_VOTING_POWER_FOR_LAST_PROPOSAL_INCLUDING_CONFLICTS: Lazy<Gauge> =
+    Lazy::new(|| {
+        register_gauge!(
+            "aptos_collected_voting_power_for_last_proposal_including_conflicts",
+            "Total voting power of all votes collected for the last round this node was proposer",
+        )
+        .unwrap()
+    });
+
+/// Total number of votes collected for the last round this node was proposer
+pub static COLLECTED_VOTES_FOR_LAST_PROPOSAL_INCLUDING_CONFLICTS: Lazy<IntGauge> =
+    Lazy::new(|| {
+        register_int_gauge!(
+            "aptos_collected_votes_for_last_proposal_including_conflicts",
+            "Total number of votes collected for the last round this node was proposer",
+        )
+        .unwrap()
+    });
+
 /// Committed proposals map when using LeaderReputation as the ProposerElection
 pub static COMMITTED_PROPOSALS_IN_WINDOW: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -638,6 +638,8 @@ impl EpochManager {
 
         self.round_manager_tx = Some(round_manager_tx.clone());
 
+        counters::TOTAL_VOTING_POWER.set(epoch_state.verifier.total_voting_power() as f64);
+
         let mut round_manager = RoundManager::new(
             epoch_state,
             block_store.clone(),

--- a/consensus/src/liveness/round_state.rs
+++ b/consensus/src/liveness/round_state.rs
@@ -235,6 +235,8 @@ impl RoundState {
         }
         let new_round = sync_info.highest_round() + 1;
         if new_round > self.current_round {
+            self.pending_votes.log_voting_power_if_proposer();
+
             // Start a new round.
             self.current_round = new_round;
             self.pending_votes = PendingVotes::new();

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -215,8 +215,16 @@ impl PendingVotes {
         VoteReceptionResult::VoteAdded(voting_power)
     }
 
-    pub fn drain_votes(&mut self) -> Vec<(HashValue, LedgerInfoWithPartialSignatures)> {
-        self.li_digest_to_votes.drain().collect()
+    pub fn drain_votes(
+        &mut self,
+    ) -> (
+        Vec<(HashValue, LedgerInfoWithPartialSignatures)>,
+        Option<TwoChainTimeoutWithPartialSignatures>,
+    ) {
+        (
+            self.li_digest_to_votes.drain().collect(),
+            self.maybe_partial_2chain_tc.take(),
+        )
     }
 }
 

--- a/consensus/src/pending_votes.rs
+++ b/consensus/src/pending_votes.rs
@@ -24,6 +24,12 @@ use std::{
     sync::Arc,
 };
 
+use crate::counters::{
+    COLLECTED_VOTES_FOR_LAST_PROPOSAL, COLLECTED_VOTES_FOR_LAST_PROPOSAL_INCLUDING_CONFLICTS,
+    COLLECTED_VOTING_POWER_FOR_LAST_PROPOSAL,
+    COLLECTED_VOTING_POWER_FOR_LAST_PROPOSAL_INCLUDING_CONFLICTS,
+};
+
 /// Result of the vote processing. The failure case (Verification error) is returned
 /// as the Error part of the result.
 #[derive(Debug, PartialEq, Eq)]
@@ -60,8 +66,8 @@ pub struct PendingVotes {
         HashMap<HashValue /* LedgerInfo digest */, LedgerInfoWithPartialSignatures>,
     /// Tracks all the signatures of the 2-chain timeout for the given round.
     maybe_partial_2chain_tc: Option<TwoChainTimeoutWithPartialSignatures>,
-    /// Map of Author to vote. This is useful to discard multiple votes.
-    author_to_vote: HashMap<Author, Vote>,
+    /// Map of Author to (vote, li_digest, voting_power). This is useful to discard multiple votes.
+    author_to_vote: HashMap<Author, (Vote, HashValue, u64)>,
     /// Whether we have echoed timeout for this round.
     echo_timeout: bool,
 }
@@ -91,9 +97,11 @@ impl PendingVotes {
         // 1. Has the author already voted for this round?
         //
 
-        if let Some(previously_seen_vote) = self.author_to_vote.get(&vote.author()) {
+        if let Some((previously_seen_vote, previous_li_digest, _)) =
+            self.author_to_vote.get(&vote.author())
+        {
             // is it the same vote?
-            if li_digest == previously_seen_vote.ledger_info().hash() {
+            if &li_digest == previous_li_digest {
                 // we've already seen an equivalent vote before
                 let new_timeout_vote = vote.is_timeout() && !previously_seen_vote.is_timeout();
                 if !new_timeout_vote {
@@ -117,7 +125,16 @@ impl PendingVotes {
         // 2. Store new vote (or update, in case it's a new timeout vote)
         //
 
-        self.author_to_vote.insert(vote.author(), vote.clone());
+        self.author_to_vote.insert(
+            vote.author(),
+            (
+                vote.clone(),
+                li_digest,
+                validator_verifier
+                    .get_voting_power(&vote.author())
+                    .unwrap_or(0),
+            ),
+        );
 
         //
         // 3. Let's check if we can create a QC
@@ -210,6 +227,42 @@ impl PendingVotes {
         //
 
         VoteReceptionResult::VoteAdded(voting_power)
+    }
+
+    pub fn log_voting_power_if_proposer(&self) {
+        // If we don't have any votes, we are not the proposer
+        if self.li_digest_to_votes.is_empty() {
+            return;
+        }
+
+        let votes_for_li = self
+            .li_digest_to_votes
+            .values()
+            .map(|li_with_sig| {
+                let (voting_power, votes): (Vec<_>, Vec<_>) = li_with_sig
+                    .signatures()
+                    .keys()
+                    .map(|author| {
+                        self.author_to_vote
+                            .get(author)
+                            .map(|(_, _, voting_power)| (*voting_power as u128, 1))
+                            .unwrap_or((0u128, 0))
+                    })
+                    .unzip();
+                (voting_power.iter().sum(), votes.iter().sum())
+            })
+            .collect::<Vec<(u128, usize)>>();
+
+        if let Some((max_voting_power, max_num_votes)) = votes_for_li.iter().max() {
+            COLLECTED_VOTES_FOR_LAST_PROPOSAL.set(*max_num_votes as i64);
+            COLLECTED_VOTING_POWER_FOR_LAST_PROPOSAL.set(*max_voting_power as f64);
+        }
+
+        let (voting_powers, votes_counts): (Vec<_>, Vec<_>) = votes_for_li.into_iter().unzip();
+        COLLECTED_VOTES_FOR_LAST_PROPOSAL_INCLUDING_CONFLICTS
+            .set(votes_counts.into_iter().sum::<usize>() as i64);
+        COLLECTED_VOTING_POWER_FOR_LAST_PROPOSAL_INCLUDING_CONFLICTS
+            .set(voting_powers.into_iter().sum::<u128>() as f64);
     }
 }
 

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -240,6 +240,44 @@ impl RoundManager {
             self.new_log(LogEvent::NewRound),
             reason = new_round_event.reason
         );
+
+        if self
+            .proposer_election
+            .is_valid_proposer(self.proposal_generator.author(), new_round_event.prev_round)
+        {
+            let prev_round_votes_for_li = new_round_event
+                .prev_round_votes
+                .iter()
+                .map(|(_, li_with_sig)| {
+                    let (voting_power, votes): (Vec<_>, Vec<_>) = li_with_sig
+                        .signatures()
+                        .keys()
+                        .map(|author| {
+                            self.epoch_state
+                                .verifier
+                                .get_voting_power(author)
+                                .map(|voting_power| (voting_power as u128, 1))
+                                .unwrap_or((0u128, 0))
+                        })
+                        .unzip();
+                    (voting_power.iter().sum(), votes.iter().sum())
+                })
+                .collect::<Vec<(u128, usize)>>();
+
+            let (max_voting_power, max_num_votes) =
+                prev_round_votes_for_li.iter().max().unwrap_or(&(0, 0));
+
+            counters::COLLECTED_VOTES_FOR_PROPOSAL.record(*max_num_votes as u64);
+            counters::COLLECTED_VOTING_POWER_FOR_PROPOSAL.record(*max_voting_power as f64);
+
+            let (voting_powers, votes_counts): (Vec<_>, Vec<_>) =
+                prev_round_votes_for_li.iter().cloned().unzip();
+            counters::COLLECTED_VOTES_FOR_PROPOSAL_INCLUDING_CONFLICTS
+                .record(votes_counts.into_iter().sum::<usize>() as u64);
+            counters::COLLECTED_VOTING_POWER_FOR_PROPOSAL_INCLUDING_CONFLICTS
+                .record(voting_powers.into_iter().sum::<u128>() as f64);
+        }
+
         if self
             .proposer_election
             .is_valid_proposer(self.proposal_generator.author(), new_round_event.round)

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -48,6 +48,8 @@ pub fn generate_corpus_proposal() -> Vec<u8> {
                 round: 1,
                 reason: NewRoundReason::QCReady,
                 timeout: std::time::Duration::new(5, 0),
+                prev_round: 0,
+                prev_round_votes_for_li: Vec::new(),
             })
             .await;
         // serialize and return proposal

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -48,8 +48,8 @@ pub fn generate_corpus_proposal() -> Vec<u8> {
                 round: 1,
                 reason: NewRoundReason::QCReady,
                 timeout: std::time::Duration::new(5, 0),
-                prev_round: 0,
-                prev_round_votes_for_li: Vec::new(),
+                prev_round_votes: Vec::new(),
+                prev_round_timeout_votes: None,
             })
             .await;
         // serialize and return proposal

--- a/crates/aptos-metrics-core/src/lib.rs
+++ b/crates/aptos-metrics-core/src/lib.rs
@@ -3,10 +3,10 @@
 
 // Re-export counter types from prometheus crate
 pub use prometheus::{
-    exponential_buckets, gather, register_gauge, register_histogram, register_histogram_vec,
-    register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
-    Encoder, Gauge, Histogram, HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-    IntGaugeVec, TextEncoder,
+    exponential_buckets, gather, register_counter, register_gauge, register_histogram,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, Counter, Encoder, Gauge, Histogram, HistogramTimer, HistogramVec,
+    IntCounter, IntCounterVec, IntGauge, IntGaugeVec, TextEncoder,
 };
 
 pub mod const_metric;


### PR DESCRIPTION
### Description
chain health metrics can see participation from successful rounds, and so is limited by >66%.

If network is in a really bad state, we want to see how many votes we can actually collect, which is what these counters do.

We can also see potentially for some failure rounds, how far were they able to collect votes.

### Test Plan
Looking at charts on CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4276)
<!-- Reviewable:end -->
