### PR TITLE
[mempool] further reduce gc logs

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -614,7 +614,11 @@ impl TransactionStore {
             }
         }
 
-        debug!(LogSchema::event_log(LogEntry::GCRemoveTxns, log_event).txns(gc_txns_log));
+        if !gc_txns_log.is_empty() {
+            debug!(LogSchema::event_log(LogEntry::GCRemoveTxns, log_event).txns(gc_txns_log));
+        } else {
+            trace!(LogSchema::event_log(LogEntry::GCRemoveTxns, log_event).txns(gc_txns_log));
+        }
         self.track_indices();
     }
 

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -65,6 +65,10 @@ impl TxnsLog {
         }
         self.len += 1;
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
 }
 
 impl fmt::Display for TxnsLog {

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -334,12 +334,12 @@ async fn handle_network_event<V>(
 
 /// Garbage collect all expired transactions by SystemTTL.
 pub(crate) async fn gc_coordinator(mempool: Arc<Mutex<CoreMempool>>, gc_interval_ms: u64) {
-    info!(LogSchema::event_log(LogEntry::GCRuntime, LogEvent::Start));
+    debug!(LogSchema::event_log(LogEntry::GCRuntime, LogEvent::Start));
     let mut interval = IntervalStream::new(interval(Duration::from_millis(gc_interval_ms)));
     while let Some(_interval) = interval.next().await {
         sample!(
             SampleRate::Duration(Duration::from_secs(60)),
-            info!(LogSchema::event_log(LogEntry::GCRuntime, LogEvent::Live))
+            debug!(LogSchema::event_log(LogEntry::GCRuntime, LogEvent::Live))
         );
         mempool.lock().gc();
     }


### PR DESCRIPTION
### Description

* Most GCRemoveTxns logs are when 0 txns are removed. These don't need to be logged (moving to trace).
* GC coordinator running (every 60 seconds) doesn't need to be info.

### Test Plan

Existing tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4278)
<!-- Reviewable:end -->
