### PR TITLE
Fix generation and lint issues

### DIFF
--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -274,10 +274,118 @@ pub enum EntryFunctionCall {
         withdraw_amount: u64,
     },
 
+    /// Add more stake to an existing staking contract.
+    StakingContractAddStake {
+        operator: AccountAddress,
+        amount: u64,
+    },
+
+    /// Staker can call this function to create a simple staking contract with a specified operator.
+    StakingContractCreateStakingContract {
+        operator: AccountAddress,
+        voter: AccountAddress,
+        amount: u64,
+        commission_percentage: u64,
+        contract_creation_seed: Vec<u8>,
+    },
+
+    /// Allow anyone to distribute already unlocked funds. This does not affect reward compounding and therefore does
+    /// not need to be restricted to just the staker or operator.
+    StakingContractDistribute {
+        staker: AccountAddress,
+        operator: AccountAddress,
+    },
+
+    /// Unlock commission amount from the stake pool. Operator needs to wait for the amount to become withdrawable
+    /// at the end of the stake pool's lockup period before they can actually can withdraw_commission.
+    ///
+    /// Only staker or operator can call this.
+    StakingContractRequestCommission {
+        staker: AccountAddress,
+        operator: AccountAddress,
+    },
+
+    /// Convenient function to allow the staker to reset their stake pool's lockup period to start now.
+    StakingContractResetLockup {
+        operator: AccountAddress,
+    },
+
+    /// Allows staker to switch operator without going through the lenghthy process to unstake.
+    StakingContractSwitchOperator {
+        old_operator: AccountAddress,
+        new_operator: AccountAddress,
+        new_commission_percentage: u64,
+    },
+
+    /// Unlock all accumulated rewards since the last recorded principals.
+    StakingContractUnlockRewards {
+        operator: AccountAddress,
+    },
+
+    /// Staker can call this to request withdrawal of part or all of their staking_contract.
+    /// This also triggers paying commission to the operator for accounting simplicity.
+    StakingContractUnlockStake {
+        operator: AccountAddress,
+        amount: u64,
+    },
+
+    /// Convenient function to allow the staker to update the voter address in a staking contract they made.
+    StakingContractUpdateVoter {
+        operator: AccountAddress,
+        new_voter: AccountAddress,
+    },
+
     /// Updates the major version to a larger version.
     /// This can be called by on chain governance.
     VersionSetVersion {
         major: u64,
+    },
+
+    /// Withdraw all funds to the preset vesting contract's withdrawal address. This can only be called if the contract
+    /// has already been terminated.
+    VestingAdminWithdraw {
+        contract_address: AccountAddress,
+    },
+
+    /// Distribute any withdrawable stake from the stake pool.
+    VestingDistribute {
+        contract_address: AccountAddress,
+    },
+
+    VestingResetLockup {
+        contract_address: AccountAddress,
+    },
+
+    VestingSetBeneficiary {
+        contract_address: AccountAddress,
+        shareholder: AccountAddress,
+        new_beneficiary: AccountAddress,
+    },
+
+    /// Terminate the vesting contract and send all funds back to the withdrawal address.
+    VestingTerminateVestingContract {
+        contract_address: AccountAddress,
+    },
+
+    /// Unlock any accumulated rewards.
+    VestingUnlockRewards {
+        contract_address: AccountAddress,
+    },
+
+    VestingUpdateOperator {
+        contract_address: AccountAddress,
+        new_operator: AccountAddress,
+        commission_percentage: u64,
+    },
+
+    VestingUpdateVoter {
+        contract_address: AccountAddress,
+        new_voter: AccountAddress,
+    },
+
+    /// Unlock any vested portion of the grant.
+    VestingVest {
+        contract_address: AccountAddress,
     },
 }
 
@@ -426,7 +534,69 @@ impl EntryFunctionCall {
                 new_fullnode_addresses,
             ),
             StakeWithdraw { withdraw_amount } => stake_withdraw(withdraw_amount),
+            StakingContractAddStake { operator, amount } => {
+                staking_contract_add_stake(operator, amount)
+            }
+            StakingContractCreateStakingContract {
+                operator,
+                voter,
+                amount,
+                commission_percentage,
+                contract_creation_seed,
+            } => staking_contract_create_staking_contract(
+                operator,
+                voter,
+                amount,
+                commission_percentage,
+                contract_creation_seed,
+            ),
+            StakingContractDistribute { staker, operator } => {
+                staking_contract_distribute(staker, operator)
+            }
+            StakingContractRequestCommission { staker, operator } => {
+                staking_contract_request_commission(staker, operator)
+            }
+            StakingContractResetLockup { operator } => staking_contract_reset_lockup(operator),
+            StakingContractSwitchOperator {
+                old_operator,
+                new_operator,
+                new_commission_percentage,
+            } => staking_contract_switch_operator(
+                old_operator,
+                new_operator,
+                new_commission_percentage,
+            ),
+            StakingContractUnlockRewards { operator } => staking_contract_unlock_rewards(operator),
+            StakingContractUnlockStake { operator, amount } => {
+                staking_contract_unlock_stake(operator, amount)
+            }
+            StakingContractUpdateVoter {
+                operator,
+                new_voter,
+            } => staking_contract_update_voter(operator, new_voter),
             VersionSetVersion { major } => version_set_version(major),
+            VestingAdminWithdraw { contract_address } => vesting_admin_withdraw(contract_address),
+            VestingDistribute { contract_address } => vesting_distribute(contract_address),
+            VestingResetLockup { contract_address } => vesting_reset_lockup(contract_address),
+            VestingSetBeneficiary {
+                contract_address,
+                shareholder,
+                new_beneficiary,
+            } => vesting_set_beneficiary(contract_address, shareholder, new_beneficiary),
+            VestingTerminateVestingContract { contract_address } => {
+                vesting_terminate_vesting_contract(contract_address)
+            }
+            VestingUnlockRewards { contract_address } => vesting_unlock_rewards(contract_address),
+            VestingUpdateOperator {
+                contract_address,
+                new_operator,
+                commission_percentage,
+            } => vesting_update_operator(contract_address, new_operator, commission_percentage),
+            VestingUpdateVoter {
+                contract_address,
+                new_voter,
+            } => vesting_update_voter(contract_address, new_voter),
+            VestingVest { contract_address } => vesting_vest(contract_address),
         }
     }
 
@@ -1153,6 +1323,199 @@ pub fn stake_withdraw(withdraw_amount: u64) -> TransactionPayload {
     ))
 }
 
+/// Add more stake to an existing staking contract.
+pub fn staking_contract_add_stake(operator: AccountAddress, amount: u64) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("add_stake").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&operator).unwrap(),
+            bcs::to_bytes(&amount).unwrap(),
+        ],
+    ))
+}
+
+/// Staker can call this function to create a simple staking contract with a specified operator.
+pub fn staking_contract_create_staking_contract(
+    operator: AccountAddress,
+    voter: AccountAddress,
+    amount: u64,
+    commission_percentage: u64,
+    contract_creation_seed: Vec<u8>,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("create_staking_contract").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&operator).unwrap(),
+            bcs::to_bytes(&voter).unwrap(),
+            bcs::to_bytes(&amount).unwrap(),
+            bcs::to_bytes(&commission_percentage).unwrap(),
+            bcs::to_bytes(&contract_creation_seed).unwrap(),
+        ],
+    ))
+}
+
+/// Allow anyone to distribute already unlocked funds. This does not affect reward compounding and therefore does
+/// not need to be restricted to just the staker or operator.
+pub fn staking_contract_distribute(
+    staker: AccountAddress,
+    operator: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("distribute").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&staker).unwrap(),
+            bcs::to_bytes(&operator).unwrap(),
+        ],
+    ))
+}
+
+/// Unlock commission amount from the stake pool. Operator needs to wait for the amount to become withdrawable
+/// at the end of the stake pool's lockup period before they can actually can withdraw_commission.
+///
+/// Only staker or operator can call this.
+pub fn staking_contract_request_commission(
+    staker: AccountAddress,
+    operator: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("request_commission").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&staker).unwrap(),
+            bcs::to_bytes(&operator).unwrap(),
+        ],
+    ))
+}
+
+/// Convenient function to allow the staker to reset their stake pool's lockup period to start now.
+pub fn staking_contract_reset_lockup(operator: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("reset_lockup").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&operator).unwrap()],
+    ))
+}
+
+/// Allows staker to switch operator without going through the lenghthy process to unstake.
+pub fn staking_contract_switch_operator(
+    old_operator: AccountAddress,
+    new_operator: AccountAddress,
+    new_commission_percentage: u64,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("switch_operator").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&old_operator).unwrap(),
+            bcs::to_bytes(&new_operator).unwrap(),
+            bcs::to_bytes(&new_commission_percentage).unwrap(),
+        ],
+    ))
+}
+
+/// Unlock all accumulated rewards since the last recorded principals.
+pub fn staking_contract_unlock_rewards(operator: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("unlock_rewards").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&operator).unwrap()],
+    ))
+}
+
+/// Staker can call this to request withdrawal of part or all of their staking_contract.
+/// This also triggers paying commission to the operator for accounting simplicity.
+pub fn staking_contract_unlock_stake(operator: AccountAddress, amount: u64) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("unlock_stake").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&operator).unwrap(),
+            bcs::to_bytes(&amount).unwrap(),
+        ],
+    ))
+}
+
+/// Convenient function to allow the staker to update the voter address in a staking contract they made.
+pub fn staking_contract_update_voter(
+    operator: AccountAddress,
+    new_voter: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("staking_contract").to_owned(),
+        ),
+        ident_str!("update_voter").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&operator).unwrap(),
+            bcs::to_bytes(&new_voter).unwrap(),
+        ],
+    ))
+}
+
 /// Updates the major version to a larger version.
 /// This can be called by on chain governance.
 pub fn version_set_version(major: u64) -> TransactionPayload {
@@ -1167,6 +1530,169 @@ pub fn version_set_version(major: u64) -> TransactionPayload {
         ident_str!("set_version").to_owned(),
         vec![],
         vec![bcs::to_bytes(&major).unwrap()],
+    ))
+}
+
+/// Withdraw all funds to the preset vesting contract's withdrawal address. This can only be called if the contract
+/// has already been terminated.
+pub fn vesting_admin_withdraw(contract_address: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("admin_withdraw").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&contract_address).unwrap()],
+    ))
+}
+
+/// Distribute any withdrawable stake from the stake pool.
+pub fn vesting_distribute(contract_address: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("distribute").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&contract_address).unwrap()],
+    ))
+}
+
+pub fn vesting_reset_lockup(contract_address: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("reset_lockup").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&contract_address).unwrap()],
+    ))
+}
+
+pub fn vesting_set_beneficiary(
+    contract_address: AccountAddress,
+    shareholder: AccountAddress,
+    new_beneficiary: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("set_beneficiary").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&contract_address).unwrap(),
+            bcs::to_bytes(&shareholder).unwrap(),
+            bcs::to_bytes(&new_beneficiary).unwrap(),
+        ],
+    ))
+}
+
+/// Terminate the vesting contract and send all funds back to the withdrawal address.
+pub fn vesting_terminate_vesting_contract(contract_address: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("terminate_vesting_contract").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&contract_address).unwrap()],
+    ))
+}
+
+/// Unlock any accumulated rewards.
+pub fn vesting_unlock_rewards(contract_address: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("unlock_rewards").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&contract_address).unwrap()],
+    ))
+}
+
+pub fn vesting_update_operator(
+    contract_address: AccountAddress,
+    new_operator: AccountAddress,
+    commission_percentage: u64,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("update_operator").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&contract_address).unwrap(),
+            bcs::to_bytes(&new_operator).unwrap(),
+            bcs::to_bytes(&commission_percentage).unwrap(),
+        ],
+    ))
+}
+
+pub fn vesting_update_voter(
+    contract_address: AccountAddress,
+    new_voter: AccountAddress,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("update_voter").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&contract_address).unwrap(),
+            bcs::to_bytes(&new_voter).unwrap(),
+        ],
+    ))
+}
+
+/// Unlock any vested portion of the grant.
+pub fn vesting_vest(contract_address: AccountAddress) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("vesting").to_owned(),
+        ),
+        ident_str!("vest").to_owned(),
+        vec![],
+        vec![bcs::to_bytes(&contract_address).unwrap()],
     ))
 }
 mod decoder {
@@ -1574,10 +2100,222 @@ mod decoder {
         }
     }
 
+    pub fn staking_contract_add_stake(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractAddStake {
+                operator: bcs::from_bytes(script.args().get(0)?).ok()?,
+                amount: bcs::from_bytes(script.args().get(1)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_create_staking_contract(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractCreateStakingContract {
+                operator: bcs::from_bytes(script.args().get(0)?).ok()?,
+                voter: bcs::from_bytes(script.args().get(1)?).ok()?,
+                amount: bcs::from_bytes(script.args().get(2)?).ok()?,
+                commission_percentage: bcs::from_bytes(script.args().get(3)?).ok()?,
+                contract_creation_seed: bcs::from_bytes(script.args().get(4)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_distribute(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractDistribute {
+                staker: bcs::from_bytes(script.args().get(0)?).ok()?,
+                operator: bcs::from_bytes(script.args().get(1)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_request_commission(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractRequestCommission {
+                staker: bcs::from_bytes(script.args().get(0)?).ok()?,
+                operator: bcs::from_bytes(script.args().get(1)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_reset_lockup(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractResetLockup {
+                operator: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_switch_operator(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractSwitchOperator {
+                old_operator: bcs::from_bytes(script.args().get(0)?).ok()?,
+                new_operator: bcs::from_bytes(script.args().get(1)?).ok()?,
+                new_commission_percentage: bcs::from_bytes(script.args().get(2)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_unlock_rewards(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractUnlockRewards {
+                operator: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_unlock_stake(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractUnlockStake {
+                operator: bcs::from_bytes(script.args().get(0)?).ok()?,
+                amount: bcs::from_bytes(script.args().get(1)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn staking_contract_update_voter(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::StakingContractUpdateVoter {
+                operator: bcs::from_bytes(script.args().get(0)?).ok()?,
+                new_voter: bcs::from_bytes(script.args().get(1)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
     pub fn version_set_version(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::VersionSetVersion {
                 major: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_admin_withdraw(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingAdminWithdraw {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_distribute(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingDistribute {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_reset_lockup(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingResetLockup {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_set_beneficiary(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingSetBeneficiary {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+                shareholder: bcs::from_bytes(script.args().get(1)?).ok()?,
+                new_beneficiary: bcs::from_bytes(script.args().get(2)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_terminate_vesting_contract(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingTerminateVestingContract {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_unlock_rewards(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingUnlockRewards {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_update_operator(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingUpdateOperator {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+                new_operator: bcs::from_bytes(script.args().get(1)?).ok()?,
+                commission_percentage: bcs::from_bytes(script.args().get(2)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_update_voter(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingUpdateVoter {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+                new_voter: bcs::from_bytes(script.args().get(1)?).ok()?,
+            })
+        } else {
+            None
+        }
+    }
+
+    pub fn vesting_vest(payload: &TransactionPayload) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(EntryFunctionCall::VestingVest {
+                contract_address: bcs::from_bytes(script.args().get(0)?).ok()?,
             })
         } else {
             None
@@ -1731,8 +2469,77 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
             Box::new(decoder::stake_withdraw),
         );
         map.insert(
+            "staking_contract_add_stake".to_string(),
+            Box::new(decoder::staking_contract_add_stake),
+        );
+        map.insert(
+            "staking_contract_create_staking_contract".to_string(),
+            Box::new(decoder::staking_contract_create_staking_contract),
+        );
+        map.insert(
+            "staking_contract_distribute".to_string(),
+            Box::new(decoder::staking_contract_distribute),
+        );
+        map.insert(
+            "staking_contract_request_commission".to_string(),
+            Box::new(decoder::staking_contract_request_commission),
+        );
+        map.insert(
+            "staking_contract_reset_lockup".to_string(),
+            Box::new(decoder::staking_contract_reset_lockup),
+        );
+        map.insert(
+            "staking_contract_switch_operator".to_string(),
+            Box::new(decoder::staking_contract_switch_operator),
+        );
+        map.insert(
+            "staking_contract_unlock_rewards".to_string(),
+            Box::new(decoder::staking_contract_unlock_rewards),
+        );
+        map.insert(
+            "staking_contract_unlock_stake".to_string(),
+            Box::new(decoder::staking_contract_unlock_stake),
+        );
+        map.insert(
+            "staking_contract_update_voter".to_string(),
+            Box::new(decoder::staking_contract_update_voter),
+        );
+        map.insert(
             "version_set_version".to_string(),
             Box::new(decoder::version_set_version),
         );
+        map.insert(
+            "vesting_admin_withdraw".to_string(),
+            Box::new(decoder::vesting_admin_withdraw),
+        );
+        map.insert(
+            "vesting_distribute".to_string(),
+            Box::new(decoder::vesting_distribute),
+        );
+        map.insert(
+            "vesting_reset_lockup".to_string(),
+            Box::new(decoder::vesting_reset_lockup),
+        );
+        map.insert(
+            "vesting_set_beneficiary".to_string(),
+            Box::new(decoder::vesting_set_beneficiary),
+        );
+        map.insert(
+            "vesting_terminate_vesting_contract".to_string(),
+            Box::new(decoder::vesting_terminate_vesting_contract),
+        );
+        map.insert(
+            "vesting_unlock_rewards".to_string(),
+            Box::new(decoder::vesting_unlock_rewards),
+        );
+        map.insert(
+            "vesting_update_operator".to_string(),
+            Box::new(decoder::vesting_update_operator),
+        );
+        map.insert(
+            "vesting_update_voter".to_string(),
+            Box::new(decoder::vesting_update_voter),
+        );
+        map.insert("vesting_vest".to_string(), Box::new(decoder::vesting_vest));
         map
     });

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -631,7 +631,7 @@ impl TransactionStore {
                 } else {
                     "ready"
                 };
-                let timestamp = self.get_insertion_time(account, *seq_num).map(|v| *v);
+                let timestamp = self.get_insertion_time(account, *seq_num).copied();
                 txns_log.add_full_metadata(*account, *seq_num, status, timestamp);
             }
         }


### PR DESCRIPTION
### Description
Clippy was failing on an issue

```
 Checking peer-monitoring-service-types v0.1.0 (/opt/git/aptos-core/network/peer-monitoring-service/types)
error: you are using an explicit closure for copying elements
   --> mempool/src/core_mempool/transaction_store.rs:634:33
    |
634 |                 let timestamp = self.get_insertion_time(account, *seq_num).map(|v| *v);
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider calling the dedicated `copied` method: `self.get_insertion_time(account, *seq_num).copied()`
    |
    = note: `-D clippy::map-clone` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#map_clone
```

### Test Plan
CI, plus I ran clippy

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4281)
<!-- Reviewable:end -->
