### PR TITLE
[gha] pin compat at latest build on testnet

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -172,28 +172,28 @@ jobs:
       FORGE_NAMESPACE: forge-e2e-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   # Run e2e compat test against testnet branch
-  # forge-compat-test:
-  #   needs: [rust-images, rust-images-testing, rust-images-performance, determine-docker-build-metadata]
-  #   if: |
-  #     !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
-  #       (github.event_name == 'push' && github.ref_name != 'main') ||
-  #       github.event_name == 'workflow_dispatch' ||
-  #       contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
-  #       github.event.pull_request.auto_merge != null ||
-  #       contains(github.event.pull_request.body, '#e2e')
-  #     )
-  #   uses: ./.github/workflows/run-forge.yaml
-  #   secrets: inherit
-  #   with:
-  #     GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-  #     FORGE_TEST_SUITE: compat
-  #     IMAGE_TAG: testnet
-  #     FORGE_RUNNER_DURATION_SECS: 300
-  #     COMMENT_HEADER: forge-compat
-  #     # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
-  #     # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
-  #     # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
-  #     FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
+  forge-compat-test:
+    needs: [rust-images, rust-images-testing, rust-images-performance, determine-docker-build-metadata]
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'CICD:skip-forge-e2e-test') && (
+        (github.event_name == 'push' && github.ref_name != 'main') ||
+        github.event_name == 'workflow_dispatch' ||
+        contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
+        github.event.pull_request.auto_merge != null ||
+        contains(github.event.pull_request.body, '#e2e')
+      )
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: compat
+      IMAGE_TAG: 843b204dce971d98449b82624f4f684c7a18b991 # test against the latest build on testnet branch
+      FORGE_RUNNER_DURATION_SECS: 300
+      COMMENT_HEADER: forge-compat
+      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
+      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
+      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
+      FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
   community-platform:
     needs: [permission-check]


### PR DESCRIPTION
### Description

There's no current protections on the `testnet` branch. Pin the git rev we're testing compat against to be consistent

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4283)
<!-- Reviewable:end -->
