### PR TITLE
feat: enable cookies for ts-sdk axios client

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
 ## Unreleased
-N/A
+
+- Enable SDK axios client to carry cookies for both the browser and node environments.
 
 ## 1.3.13 (2022-09-15)
 

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -63,7 +63,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "jest": "28.1.3",
-    "openapi-typescript-codegen": "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p2/openapi-typescript-codegen-v0.23.0-p2.tgz",
+    "openapi-typescript-codegen": "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p4/openapi-typescript-codegen-v0.23.0-p4.tgz",
     "prettier": "2.6.2",
     "ts-jest": "28.0.8",
     "ts-loader": "9.3.1",

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -40,6 +40,14 @@ export class AptosClient {
     } else {
       conf.BASE = fixNodeUrl(nodeUrl);
     }
+
+    // Do not carry cookies when `WITH_CREDENTIALS` is explicitly set to `false`. By default, cookies will be sent
+    if (config?.WITH_CREDENTIALS === false) {
+      conf.WITH_CREDENTIALS = false;
+    } else {
+      conf.WITH_CREDENTIALS = true;
+    }
+
     this.client = new Gen.AptosGeneratedClient(conf);
   }
 

--- a/ecosystem/typescript/sdk/src/generated/core/request.ts
+++ b/ecosystem/typescript/sdk/src/generated/core/request.ts
@@ -12,6 +12,111 @@ import { CancelablePromise } from './CancelablePromise';
 import type { OnCancel } from './CancelablePromise';
 import type { OpenAPIConfig } from './OpenAPI';
 
+interface Cookie {
+  name: string;
+  value: string;
+  expires?: Date;
+  path?: string;
+  sameSite?: "Lax" | "None" | "Strict";
+  secure?: boolean;
+}
+
+class CookieJar {
+  constructor(private jar = new Map<string, Cookie[]>()) {}
+
+  setCookie(url: URL, cookieStr: string) {
+    const key = url.origin.toLowerCase();
+    if (!this.jar.has(key)) {
+      this.jar.set(key, []);
+    }
+
+    const cookie = CookieJar.parse(cookieStr);
+    this.jar.set(key, [...(this.jar.get(key)?.filter((c) => c.name !== cookie.name) || []), cookie]);
+  }
+
+  getCookies(url: URL): Cookie[] {
+    const key = url.origin.toLowerCase();
+    if (!this.jar.get(key)) {
+      return [];
+    }
+
+    // Filter out expired cookies
+    return this.jar.get(key)?.filter((cookie) => !cookie.expires || cookie.expires > new Date()) || [];
+  }
+
+  static parse(str: string): Cookie {
+    if (typeof str !== "string") {
+      throw new Error("argument str must be a string");
+    }
+
+    const parts = str.split(";").map((part) => part.trim());
+
+    let cookie: Cookie;
+
+    if (parts.length > 0) {
+      const [name, value] = parts[0].split("=");
+      if (!name || !value) {
+        throw new Error("Invalid cookie");
+      }
+
+      cookie = {
+        name,
+        value,
+      };
+    } else {
+      throw new Error("Invalid cookie");
+    }
+
+    parts.slice(1).forEach((part) => {
+      const [name, value] = part.split("=");
+      if (!name.trim()) {
+        throw new Error("Invalid cookie");
+      }
+
+      const nameLow = name.toLowerCase();
+      // eslint-disable-next-line quotes
+      const val = value?.charAt(0) === "'" || value?.charAt(0) === '"' ? value?.slice(1, -1) : value;
+      if (nameLow === "expires") {
+        cookie.expires = new Date(val);
+      }
+      if (nameLow === "path") {
+        cookie.path = val;
+      }
+      if (nameLow === "samesite") {
+        if (val !== "Lax" && val !== "None" && val !== "Strict") {
+          throw new Error("Invalid cookie SameSite value");
+        }
+        cookie.sameSite = val;
+      }
+      if (nameLow === "secure") {
+        cookie.secure = true;
+      }
+    });
+
+    return cookie;
+  }
+}
+
+const jar = new CookieJar();
+
+axios.interceptors.response.use((response) => {
+  if (Array.isArray(response.headers["set-cookie"])) {
+    response.headers["set-cookie"].forEach((c) => {
+      jar.setCookie(new URL(response.config.url), c);
+    });
+  }
+  return response;
+});
+
+axios.interceptors.request.use(function (config) {
+  const cookies = jar.getCookies(new URL(config.url));
+
+  if (cookies?.length > 0) {
+    config.headers.cookie = cookies.map((cookie) => `${cookie.name}=${cookie.value}`).join("; ");
+  }
+  return config;
+});
+
 const isDefined = <T>(value: T | null | undefined): value is Exclude<T, null | undefined> => {
     return value !== undefined && value !== null;
 };
@@ -205,6 +310,14 @@ const sendRequest = async <T>(
         withCredentials: config.WITH_CREDENTIALS,
         cancelToken: source.token,
     };
+
+    const isBCS = Object.keys(config.HEADERS || {})
+    .filter((k) => k.toLowerCase() === "accept")
+    .map((k) => (config.HEADERS as Record<string, string>)[k])
+    .includes("application/x-bcs");
+  if (isBCS) {
+    requestConfig.responseType = "arraybuffer";
+  }
 
     onCancel(() => source.cancel('The user aborted a request.'));
 

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -31,7 +31,7 @@ import { argToTransactionArgument, TypeTagParser, serializeArg } from "./builder
 import * as Gen from "../generated/index";
 import { MemoizeExpiring } from "../utils";
 
-export { TypeTagParser } from "./builder_utils.js";
+export { TypeTagParser } from "./builder_utils";
 
 const { sha3_256: sha3Hash } = sha3;
 

--- a/ecosystem/typescript/sdk/yarn.lock
+++ b/ecosystem/typescript/sdk/yarn.lock
@@ -3041,9 +3041,9 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-"openapi-typescript-codegen@https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p2/openapi-typescript-codegen-v0.23.0-p2.tgz":
-  version "0.23.0-p2"
-  resolved "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p2/openapi-typescript-codegen-v0.23.0-p2.tgz#273123a28737f2e099fcddf2d76f1011374e6855"
+"openapi-typescript-codegen@https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p4/openapi-typescript-codegen-v0.23.0-p4.tgz":
+  version "0.23.0-p4"
+  resolved "https://github.com/aptos-labs/openapi-typescript-codegen/releases/download/v0.23.0-p4/openapi-typescript-codegen-v0.23.0-p4.tgz#8c463437cc4c8c933e6107899de64e7265f11487"
   dependencies:
     camelcase "^6.3.0"
     commander "^9.3.0"


### PR DESCRIPTION
### Description
For ts-sdk to support cookies in browser environment, we need to set `WITH_CREDENTIALS` to true. However, this doesn't work in nodejs environment. `axios` doesn't have a built-in cookie store. The best cookie store for nodejs is 'tough-cookie'. However, 'tough-cookie' doesn't bundle well in a browser environment. Since we don't need a full cookie store, it is best for us to write a simple cookie store manually.

### Test Plan
1. Made sure all tests pass 
2. Made sure cookie headers are set in both the browser and the nodejs environments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4285)
<!-- Reviewable:end -->
