### PR TITLE
Make `rust_lint --check` exit with failure if it fails

### DIFF
--- a/scripts/rust_lint.sh
+++ b/scripts/rust_lint.sh
@@ -22,6 +22,7 @@ if [ "$1" = "--check" ]; then
     CHECK_ARG="--check"
 fi
 
+set -e
 set -x
 
 cargo xclippy


### PR DESCRIPTION
### Description
Making this exit with non zero if there is a problem with any commands, instead of just the last one.

### Test Plan
I introduced a formatting error (not the last command) and ran it with `--check` and it returned with 1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4286)
<!-- Reviewable:end -->
