### PR TITLE
[TS SDK] Add getBlock

### DIFF
--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -5,11 +5,8 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 **Note:** The Aptos TS SDK does not follow semantic version while we are in active development. Instead, breaking changes will be announced with each devnet cut. Once we launch our mainnet, the SDK will follow semantic versioning closely.
 
 ## Unreleased
-N/A
 
-## 1.3.14 (2022-09-16)
-
-- Added new functions `getBlockByHeight` and `getBlockByVersion`. 
+- Added new functions `getBlockByHeight` and `getBlockByVersion`.
 
 ## 1.3.13 (2022-09-15)
 

--- a/ecosystem/typescript/sdk/CHANGELOG.md
+++ b/ecosystem/typescript/sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to the Aptos Node SDK will be captured in this file. This ch
 ## Unreleased
 N/A
 
+## 1.3.14 (2022-09-16)
+
+- Added new functions `getBlockByHeight` and `getBlockByVersion`. 
+
 ## 1.3.13 (2022-09-15)
 
 - Increase the default wait time for `waitForTransactionWithResult` to 20s.

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -71,5 +71,5 @@
     "tsup": "6.2.3",
     "typescript": "4.8.2"
   },
-  "version": "1.3.13"
+  "version": "1.3.14"
 }

--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -71,5 +71,5 @@
     "tsup": "6.2.3",
     "typescript": "4.8.2"
   },
-  "version": "1.3.14"
+  "version": "1.3.13"
 }

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -479,7 +479,7 @@ test(
 );
 
 test(
-  "gets block by height", 
+  "gets block by height",
   async () => {
     const blockHeight = 100;
     const client = new AptosClient(NODE_URL);
@@ -490,7 +490,7 @@ test(
 );
 
 test(
-  "gets block by version", 
+  "gets block by version",
   async () => {
     const version = 100;
     const client = new AptosClient(NODE_URL);

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -478,17 +478,25 @@ test(
   30 * 1000,
 );
 
-test("gets block by height", async () => {
-  const blockHeight = 100;
-  const client = new AptosClient(NODE_URL);
-  const block = await client.getBlockByHeight(blockHeight);
-  expect(block.block_height).toBe(blockHeight.toString());
-});
+test(
+  "gets block by height", 
+  async () => {
+    const blockHeight = 100;
+    const client = new AptosClient(NODE_URL);
+    const block = await client.getBlockByHeight(blockHeight);
+    expect(block.block_height).toBe(blockHeight.toString());
+  },
+  30 * 1000,
+);
 
-test("gets block by version", async () => {
-  const version = 100;
-  const client = new AptosClient(NODE_URL);
-  const block = await client.getBlockByVersion(version);
-  expect(parseInt(block.first_version)).toBeLessThanOrEqual(version);
-  expect(parseInt(block.last_version)).toBeGreaterThanOrEqual(version);
-});
+test(
+  "gets block by version", 
+  async () => {
+    const version = 100;
+    const client = new AptosClient(NODE_URL);
+    const block = await client.getBlockByVersion(version);
+    expect(parseInt(block.first_version, 10)).toBeLessThanOrEqual(version);
+    expect(parseInt(block.last_version, 10)).toBeGreaterThanOrEqual(version);
+  },
+  30 * 1000,
+);

--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -477,3 +477,18 @@ test(
   },
   30 * 1000,
 );
+
+test("gets block by height", async () => {
+  const blockHeight = 100;
+  const client = new AptosClient(NODE_URL);
+  const block = await client.getBlockByHeight(blockHeight);
+  expect(block.block_height).toBe(blockHeight.toString());
+});
+
+test("gets block by version", async () => {
+  const version = 100;
+  const client = new AptosClient(NODE_URL);
+  const block = await client.getBlockByVersion(version);
+  expect(parseInt(block.first_version)).toBeLessThanOrEqual(version);
+  expect(parseInt(block.last_version)).toBeGreaterThanOrEqual(version);
+});

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -786,27 +786,27 @@ export class AptosClient {
 
   /**
    * Get block by height
-   * 
+   *
    * @param blockHeight Block height to lookup.  Starts at 0
    * @param withTransactions If set to true, include all transactions in the block
-   * 
+   *
    * @returns Block
    */
   @parseApiError
-  async getBlockByHeight(blockHeight: number, withTransactions?:boolean): Promise<Gen.Block> {
+  async getBlockByHeight(blockHeight: number, withTransactions?: boolean): Promise<Gen.Block> {
     return this.client.blocks.getBlockByHeight(blockHeight, withTransactions);
   }
 
   /**
    * Get block by block transaction version
-   * 
+   *
    * @param version Ledger version to lookup block information for
    * @param withTransactions If set to true, include all transactions in the block
-   * 
+   *
    * @returns Block
    */
   @parseApiError
-  async getBlockByVersion(version: number, withTransactions?:boolean): Promise<Gen.Block> {
+  async getBlockByVersion(version: number, withTransactions?: boolean): Promise<Gen.Block> {
     return this.client.blocks.getBlockByVersion(version, withTransactions);
   }
 

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -784,6 +784,26 @@ export class AptosClient {
     return new HexString(origAddress);
   }
 
+  /**
+   * Get block by height
+   * @param blockHeight
+   * @param withTransactions
+   * @returns
+   */
+  async getBlockByHeight(blockHeight: number, withTransactions?:boolean): Promise<Gen.Block> {
+    return this.client.blocks.getBlockByHeight(blockHeight, withTransactions);
+  }
+
+  /**
+   * Get block by block transaction version
+   * @param version
+   * @param withTransactions
+   * @returns
+   */
+  async getBlockByVersion(version: number, withTransactions?:boolean): Promise<Gen.Block> {
+    return this.client.blocks.getBlockByVersion(version, withTransactions);
+  }
+
   // eslint-disable-next-line class-methods-use-this
   clearCache(tags: string[]) {
     clear(tags);

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -786,20 +786,26 @@ export class AptosClient {
 
   /**
    * Get block by height
-   * @param blockHeight
-   * @param withTransactions
-   * @returns
+   * 
+   * @param blockHeight Block height to lookup.  Starts at 0
+   * @param withTransactions If set to true, include all transactions in the block
+   * 
+   * @returns Block
    */
+  @parseApiError
   async getBlockByHeight(blockHeight: number, withTransactions?:boolean): Promise<Gen.Block> {
     return this.client.blocks.getBlockByHeight(blockHeight, withTransactions);
   }
 
   /**
    * Get block by block transaction version
-   * @param version
-   * @param withTransactions
-   * @returns
+   * 
+   * @param version Ledger version to lookup block information for
+   * @param withTransactions If set to true, include all transactions in the block
+   * 
+   * @returns Block
    */
+  @parseApiError
   async getBlockByVersion(version: number, withTransactions?:boolean): Promise<Gen.Block> {
     return this.client.blocks.getBlockByVersion(version, withTransactions);
   }


### PR DESCRIPTION
### Description
Add two functions for AptosClient sdk:
* getBlockByHeight
* getBlockByVersion
### Test Plan
Run a local node (run from the root of the repo):

```
cargo run -p aptos -- node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
```

Run the SDK tests and make sure they pass. Go to the SDK directory, and setup an env to configure the URLs:

```
rm .env
echo 'APTOS_NODE_URL="http://127.0.0.1:8080/v1"' >> .env
echo 'APTOS_FAUCET_URL="http://127.0.01:8081"' >> .env
```

Run the tests:

```
yarn test
```

<img width="770" alt="Screen Shot 2022-09-19 at 1 07 52 PM" src="https://user-images.githubusercontent.com/109111707/191107350-4f141e1e-ff27-4516-82fb-8e360cc3f04f.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4287)
<!-- Reviewable:end -->
