### PR TITLE
Tests in aptos-move/aptos-transactional-test-harness fail after addin…

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bulletproofs.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bulletproofs.move
@@ -1,0 +1,6 @@
+/// This module implements Bulletproof-based zero-knowledge range proof: i.e., a proof that a value `v` committed in a
+/// Pedersen commitment `com` satisfies $v \in [0, 2^{num_bits})$. Currently, this module only supports num_bits \in
+/// {8, 16, 32, 64}.
+module aptos_std::bulletproofs {
+    use aptos_std::table;
+}


### PR DESCRIPTION
### Description

Trying to investigate why tests in `aptos-move/aptos-transactional-test-harness` fail after adding one simple `bulletproofs.move` file which does a `use aptos_std::table`.

@wrwg and @vgao1996, no rush to look into this. Just wanted to point out the issue to you.

### Test failure

To reproduce just `cd aptos-move/aptos-transactional-test-harness` and run

```
RUST_BACKTRACE=1 cargo test
```

You'll get some error having to do with the `move-compiler` crate. The `Lazy` from [this line](https://github.com/aptos-labs/aptos-core/blob/b89925d899a81204c6264dfeea2a0c41258c9b4b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs#L284) seems to be involved in the error.

You can see the [error logs in CI](https://github.com/aptos-labs/aptos-core/actions/runs/3071229517/jobs/4961729685) or below:

```
alinush@Aptos-MacBook [~/repos/aptos-core/aptos-move/aptos-transactional-test-harness] (alin/potential-atth-bug) $ RUST_BACKTRACE=1 cargo test
   Compiling aptos-crypto v0.0.3 (/Users/alinush/repos/aptos-core/crates/aptos-crypto)
   Compiling aptos-types v0.0.3 (/Users/alinush/repos/aptos-core/types)
   Compiling aptos-vault-client v0.1.0 (/Users/alinush/repos/aptos-core/secure/storage/vault)
   Compiling aptos-secure-storage v0.1.0 (/Users/alinush/repos/aptos-core/secure/storage)
   Compiling aptos-state-view v0.1.0 (/Users/alinush/repos/aptos-core/storage/state-view)
   Compiling aptos-sdk-builder v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/aptos-sdk-builder)
   Compiling scratchpad v0.1.0 (/Users/alinush/repos/aptos-core/storage/scratchpad)
   Compiling aptos-keygen v0.1.0 (/Users/alinush/repos/aptos-core/crates/aptos-keygen)
   Compiling aptos-config v0.1.0 (/Users/alinush/repos/aptos-core/config)
   Compiling aptos-aggregator v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/aptos-aggregator)
   Compiling framework v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/framework)
   Compiling mvhashmap v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/mvhashmap)
   Compiling aptos-parallel-executor v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/parallel-executor)
   Compiling cached-packages v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/framework/cached-packages)
   Compiling aptos-gas v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/aptos-gas)
   Compiling aptos-vm v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/aptos-vm)
   Compiling storage-interface v0.1.0 (/Users/alinush/repos/aptos-core/storage/storage-interface)
   Compiling aptos-api-types v0.0.1 (/Users/alinush/repos/aptos-core/api/types)
   Compiling vm-genesis v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/vm-genesis)
   Compiling language-e2e-tests v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/e2e-tests)
   Compiling aptos-transactional-test-harness v0.1.0 (/Users/alinush/repos/aptos-core/aptos-move/aptos-transactional-test-harness)
    Finished test [unoptimized + debuginfo] target(s) in 41.62s
     Running unittests src/lib.rs (/Users/alinush/repos/aptos-core/target/debug/deps/aptos_transactional_test_harness-68a5637704a0b233)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/tests.rs (/Users/alinush/repos/aptos-core/target/debug/deps/tests-822cecd892fc96a6)

running 4 tests
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', /Users/alinush/.cargo/git/checkouts/move-0639dd674f581c30/5926566/language/move-compiler/src/command_line/compiler.rs:494:34
stack backtrace:
   0: rust_begin_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panicking.rs:48:5
   3: core::option::Option<T>::unwrap
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/option.rs:775:21
   4: move_compiler::command_line::compiler::construct_pre_compiled_lib
             at /Users/alinush/.cargo/git/checkouts/move-0639dd674f581c30/5926566/language/move-compiler/src/command_line/compiler.rs:494:24
   5: aptos_transactional_test_harness::aptos_test_harness::PRECOMPILED_APTOS_FRAMEWORK::{{closure}}
             at ./src/aptos_test_harness.rs:290:23
   6: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
   7: core::ops::function::FnOnce::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
   8: once_cell::sync::Lazy<T,F>::force::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1230:28
   9: once_cell::sync::OnceCell<T>::get_or_init::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:57
  10: once_cell::imp::OnceCell<T>::initialize::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:85:23
  11: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:290:13
  12: once_cell::imp::initialize_or_wait
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:216:20
  13: once_cell::imp::OnceCell<T>::initialize
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:81:9
  14: once_cell::sync::OnceCell<T>::get_or_try_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1081:13
  15: once_cell::sync::OnceCell<T>::get_or_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:19
  16: once_cell::sync::Lazy<T,F>::force
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1229:13
  17: <once_cell::sync::Lazy<T,F> as core::ops::deref::Deref>::deref
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1256:13
  18: aptos_transactional_test_harness::aptos_test_harness::run_aptos_test
             at ./src/aptos_test_harness.rs:952:51
  19: datatest_stable::runner::Requirements::expand::{{closure}}::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/datatest-stable-0.1.3/src/runner.rs:59:25
  20: libtest_mimic::Trial::test::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:110:54
  21: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
  22: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/boxed.rs:1951:9
  23: libtest_mimic::run_single::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:43
  24: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panic/unwind_safe.rs:271:9
  25: std::panicking::try::do_call
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:492:40
  26: ___rust_try
  27: std::panicking::try
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:456:19
  28: std::panic::catch_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panic.rs:137:14
  29: libtest_mimic::run_single
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:5
  30: libtest_mimic::run::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:471:35
  31: <F as threadpool::FnBox>::call_box
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:95:9
  32: threadpool::spawn_in_pool::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:769:17
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread '<unnamed>' panicked at 'Lazy instance has previously been poisoned', /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1231:25
test run_aptos_test::aptos_test_harness/table.move          ... FAILED
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:616:12
   1: once_cell::sync::Lazy<T,F>::force::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1231:25
   2: once_cell::sync::OnceCell<T>::get_or_init::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:57
   3: once_cell::imp::OnceCell<T>::initialize::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:85:23
   4: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:290:13
   5: once_cell::imp::initialize_or_wait
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:216:20
   6: once_cell::imp::OnceCell<T>::initialize
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:81:9
   7: once_cell::sync::OnceCell<T>::get_or_try_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1081:13
   8: once_cell::sync::OnceCell<T>::get_or_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:19
   9: once_cell::sync::Lazy<T,F>::force
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1229:13
  10: <once_cell::sync::Lazy<T,F> as core::ops::deref::Deref>::deref
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1256:13
  11: aptos_transactional_test_harness::aptos_test_harness::run_aptos_test
             at ./src/aptos_test_harness.rs:952:51
  12: datatest_stable::runner::Requirements::expand::{{closure}}::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/datatest-stable-0.1.3/src/runner.rs:59:25
  13: libtest_mimic::Trial::test::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:110:54
  14: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
  15: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/boxed.rs:1951:9
  16: libtest_mimic::run_single::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:43
  17: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panic/unwind_safe.rs:271:9
  18: std::panicking::try::do_call
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:492:40
  19: ___rust_try
  20: std::panicking::try
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:456:19
  21: std::panic::catch_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panic.rs:137:14
  22: libtest_mimic::run_single
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:5
  23: libtest_mimic::run::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:471:35
  24: <F as threadpool::FnBox>::call_box
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:95:9
  25: threadpool::spawn_in_pool::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:769:17
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread '<unnamed>' panicked at 'Lazy instance has previously been poisoned', /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1231:25
test run_aptos_test::aptos_test_harness/execute_script.move ... FAILED
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:616:12
   1: once_cell::sync::Lazy<T,F>::force::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1231:25
   2: once_cell::sync::OnceCell<T>::get_or_init::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:57
   3: once_cell::imp::OnceCell<T>::initialize::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:85:23
   4: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:290:13
   5: once_cell::imp::initialize_or_wait
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:216:20
   6: once_cell::imp::OnceCell<T>::initialize
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:81:9
   7: once_cell::sync::OnceCell<T>::get_or_try_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1081:13
   8: once_cell::sync::OnceCell<T>::get_or_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:19
   9: once_cell::sync::Lazy<T,F>::force
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1229:13
  10: <once_cell::sync::Lazy<T,F> as core::ops::deref::Deref>::deref
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1256:13
  11: aptos_transactional_test_harness::aptos_test_harness::run_aptos_test
             at ./src/aptos_test_harness.rs:952:51
  12: datatest_stable::runner::Requirements::expand::{{closure}}::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/datatest-stable-0.1.3/src/runner.rs:59:25
  13: libtest_mimic::Trial::test::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:110:54
  14: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
  15: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/boxed.rs:1951:9
  16: libtest_mimic::run_single::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:43
  17: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panic/unwind_safe.rs:271:9
  18: std::panicking::try::do_call
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:492:40
  19: ___rust_try
  20: std::panicking::try
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:456:19
  21: std::panic::catch_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panic.rs:137:14
  22: libtest_mimic::run_single
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:5
  23: libtest_mimic::run::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:471:35
  24: <F as threadpool::FnBox>::call_box
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:95:9
  25: threadpool::spawn_in_pool::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:769:17
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
thread '<unnamed>' panicked at 'Lazy instance has previously been poisoned', /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1231:25
test run_aptos_test::aptos_test_harness/call_function.move  ... FAILED
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:616:12
   1: once_cell::sync::Lazy<T,F>::force::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1231:25
   2: once_cell::sync::OnceCell<T>::get_or_init::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:57
   3: once_cell::imp::OnceCell<T>::initialize::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:85:23
   4: core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:290:13
   5: once_cell::imp::initialize_or_wait
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:216:20
   6: once_cell::imp::OnceCell<T>::initialize
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/imp_std.rs:81:9
   7: once_cell::sync::OnceCell<T>::get_or_try_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1081:13
   8: once_cell::sync::OnceCell<T>::get_or_init
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1041:19
   9: once_cell::sync::Lazy<T,F>::force
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1229:13
  10: <once_cell::sync::Lazy<T,F> as core::ops::deref::Deref>::deref
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/once_cell-1.13.1/src/lib.rs:1256:13
  11: aptos_transactional_test_harness::aptos_test_harness::run_aptos_test
             at ./src/aptos_test_harness.rs:952:51
  12: datatest_stable::runner::Requirements::expand::{{closure}}::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/datatest-stable-0.1.3/src/runner.rs:59:25
  13: libtest_mimic::Trial::test::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:110:54
  14: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/ops/function.rs:248:5
  15: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/alloc/src/boxed.rs:1951:9
  16: libtest_mimic::run_single::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:43
  17: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/panic/unwind_safe.rs:271:9
  18: std::panicking::try::do_call
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:492:40
  19: ___rust_try
  20: std::panicking::try
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panicking.rs:456:19
  21: std::panic::catch_unwind
             at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/std/src/panic.rs:137:14
  22: libtest_mimic::run_single
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:500:5
  23: libtest_mimic::run::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/libtest-mimic-0.5.2/src/lib.rs:471:35
  24: <F as threadpool::FnBox>::call_box
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:95:9
  25: threadpool::spawn_in_pool::{{closure}}
             at /Users/alinush/.cargo/registry/src/github.com-1ecc6299db9ec823/threadpool-1.8.1/src/lib.rs:769:17
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
test run_aptos_test::aptos_test_harness/publish_module.move ... FAILED

failures:

---- run_aptos_test::aptos_test_harness/table.move ----
test panicked: called `Option::unwrap()` on a `None` value

---- run_aptos_test::aptos_test_harness/execute_script.move ----
test panicked: Lazy instance has previously been poisoned

---- run_aptos_test::aptos_test_harness/call_function.move ----
test panicked: Lazy instance has previously been poisoned

---- run_aptos_test::aptos_test_harness/publish_module.move ----
test panicked: Lazy instance has previously been poisoned


failures:
    run_aptos_test::aptos_test_harness/table.move
    run_aptos_test::aptos_test_harness/execute_script.move
    run_aptos_test::aptos_test_harness/call_function.move
    run_aptos_test::aptos_test_harness/publish_module.move

test result: FAILED. 0 passed; 4 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.51s

error: test failed, to rerun pass '--test tests'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4293)
<!-- Reviewable:end -->
