### PR TITLE
refactor: replaces js-sha3 with @noble/hashes/sha3

### DIFF
--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -48,7 +48,6 @@
     "@scure/bip39": "1.1.0",
     "axios": "0.27.2",
     "form-data": "4.0.0",
-    "js-sha3": "0.8.0",
     "tweetnacl": "1.0.3"
   },
   "devDependencies": {

--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import nacl from "tweetnacl";
-import sha3 from "js-sha3";
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import * as bip39 from "@scure/bip39";
 import { bytesToHex } from "@noble/hashes/utils";
 import { derivePath } from "./utils/hd-key";
 import { HexString, MaybeHexString } from "./hex_string";
 import * as Gen from "./generated/index";
 import { Memoize } from "./utils";
-
-const { sha3_256: sha3Hash } = sha3;
 
 export interface AptosAccountObject {
   address?: Gen.HexEncodedBytes;
@@ -107,7 +105,7 @@ export class AptosAccount {
     const hash = sha3Hash.create();
     hash.update(this.signingKey.publicKey);
     hash.update("\x00");
-    return new HexString(hash.hex());
+    return HexString.fromUint8Array(hash.digest());
   }
 
   /**

--- a/ecosystem/typescript/sdk/src/aptos_types/authentication_key.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/authentication_key.ts
@@ -1,12 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-import sha3 from "js-sha3";
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { HexString } from "../hex_string";
 import { Bytes } from "../bcs";
 import { MultiEd25519PublicKey } from "./multi_ed25519";
-
-const { sha3_256: sha3Hash } = sha3;
 
 /**
  * Each account stores an authentication key. Authentication key enables account owners to rotate
@@ -44,7 +42,7 @@ export class AuthenticationKey {
     const hash = sha3Hash.create();
     hash.update(bytes);
 
-    return new AuthenticationKey(new Uint8Array(hash.arrayBuffer()));
+    return new AuthenticationKey(hash.digest());
   }
 
   /**

--- a/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/transaction.ts
@@ -5,7 +5,7 @@
 /* eslint-disable class-methods-use-this */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable max-classes-per-file */
-import sha3 from "js-sha3";
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { HexString } from "../hex_string";
 import {
   Deserializer,
@@ -23,8 +23,6 @@ import { AccountAddress } from "./account_address";
 import { TransactionAuthenticator } from "./authenticator";
 import { Identifier } from "./identifier";
 import { TypeTag } from "./type_tag";
-
-const { sha3_256: sha3Hash } = sha3;
 
 export class RawTransaction {
   /**
@@ -532,7 +530,7 @@ export abstract class Transaction {
   getHashSalt(): Bytes {
     const hash = sha3Hash.create();
     hash.update("APTOS::Transaction");
-    return new Uint8Array(hash.arrayBuffer());
+    return hash.digest();
   }
 
   static deserialize(deserializer: Deserializer): Transaction {
@@ -555,7 +553,7 @@ export class UserTransaction extends Transaction {
     const hash = sha3Hash.create();
     hash.update(this.getHashSalt());
     hash.update(bcsToBytes(this));
-    return new Uint8Array(hash.arrayBuffer());
+    return hash.digest();
   }
 
   serialize(serializer: Serializer): void {

--- a/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
+++ b/ecosystem/typescript/sdk/src/transaction_builder/builder.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-import sha3 from "js-sha3";
+import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import {
   Ed25519PublicKey,
   Ed25519Signature,
@@ -32,8 +32,6 @@ import * as Gen from "../generated/index";
 import { MemoizeExpiring } from "../utils";
 
 export { TypeTagParser } from "./builder_utils";
-
-const { sha3_256: sha3Hash } = sha3;
 
 const RAW_TRANSACTION_SALT = "APTOS::RawTransaction";
 const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";
@@ -78,7 +76,7 @@ export class TransactionBuilder<F extends SigningFn> {
       throw new Error("Unknown transaction type.");
     }
 
-    const prefix = new Uint8Array(hash.arrayBuffer());
+    const prefix = hash.digest();
 
     const body = bcsToBytes(rawTxn);
 

--- a/ecosystem/typescript/sdk/yarn.lock
+++ b/ecosystem/typescript/sdk/yarn.lock
@@ -2720,11 +2720,6 @@ joycon@^3.0.1:
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
-js-sha3@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
### Description
js-sha3 is not needed anymore. `@noble/hashes` is audited and easy to use. Since we have already used `@noble/hashes` in SDK, there is no need to keep js-sha3.

### Test Plan
All tests pass

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4300)
<!-- Reviewable:end -->
