### PR TITLE
[indexer][ez] fix timestamp max

### DIFF
--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use aptos_api_types::Transaction;
 use async_trait::async_trait;
-use diesel::result::Error;
+use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods};
 use field_count::FieldCount;
 use std::fmt::Debug;
 
@@ -151,7 +151,20 @@ fn insert_user_transactions_w_sigs(
             diesel::insert_into(schema::user_transactions::table)
                 .values(&all_user_transactions[start_ind..end_ind])
                 .on_conflict(ut_schema::version)
-                .do_nothing(),
+                .do_update()
+                .set((
+                    ut_schema::block_height.eq(excluded(ut_schema::block_height)),
+                    ut_schema::parent_signature_type.eq(excluded(ut_schema::parent_signature_type)),
+                    ut_schema::sender.eq(excluded(ut_schema::sender)),
+                    ut_schema::sequence_number.eq(excluded(ut_schema::sequence_number)),
+                    ut_schema::max_gas_amount.eq(excluded(ut_schema::max_gas_amount)),
+                    ut_schema::expiration_timestamp_secs
+                        .eq(excluded(ut_schema::expiration_timestamp_secs)),
+                    ut_schema::gas_unit_price.eq(excluded(ut_schema::gas_unit_price)),
+                    ut_schema::timestamp.eq(excluded(ut_schema::timestamp)),
+                    ut_schema::entry_function_id_str.eq(excluded(ut_schema::entry_function_id_str)),
+                    ut_schema::inserted_at.eq(excluded(ut_schema::inserted_at)),
+                )),
         ) {
             Ok(_) => {}
             Err(e) => {

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -6,6 +6,9 @@ use bigdecimal::{FromPrimitive, Signed, ToPrimitive, Zero};
 use serde_json::Value;
 use sha2::Digest;
 
+// 9999-12-31 23:59:59, this is the max supported by Google BigQuery
+pub const MAX_TIMESTAMP_SECS: i64 = 253_402_300_799;
+
 pub fn hash_str(val: &str) -> String {
     hex::encode(sha2::Sha256::digest(val.as_bytes()))
 }
@@ -31,11 +34,8 @@ pub fn parse_timestamp(ts: U64, version: i64) -> chrono::NaiveDateTime {
 }
 
 pub fn parse_timestamp_secs(ts: U64, version: i64) -> chrono::NaiveDateTime {
-    chrono::NaiveDateTime::from_timestamp_opt(
-        std::cmp::min(ts.0 as i64, chrono::NaiveDateTime::MAX.timestamp()),
-        0,
-    )
-    .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
+    chrono::NaiveDateTime::from_timestamp_opt(std::cmp::min(ts.0 as i64, MAX_TIMESTAMP_SECS), 0)
+        .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
 }
 
 pub fn remove_null_bytes<T: serde::Serialize + for<'de> serde::Deserialize<'de>>(input: &T) -> T {
@@ -84,7 +84,7 @@ mod tests {
         assert_eq!(ts.year(), current_year);
 
         let ts2 = parse_timestamp_secs(U64::from(600000000000000), 2);
-        assert_eq!(ts2.year(), chrono::NaiveDateTime::MAX.date().year());
+        assert_eq!(ts2.year(), 9999);
 
         let ts3 = parse_timestamp_secs(U64::from(1659386386), 2);
         assert_eq!(ts3.timestamp(), 1659386386);


### PR DESCRIPTION
### Description
chrono::NaiveDateTime::MAX.timestamp() is for some reason year 54680

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4309)
<!-- Reviewable:end -->
