### PR TITLE
Genesis support for commissioned validators and employee vesting

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -14,6 +14,7 @@ module aptos_framework::genesis {
     use aptos_framework::gas_schedule;
     use aptos_framework::reconfiguration;
     use aptos_framework::stake;
+    use aptos_framework::staking_contract;
     use aptos_framework::staking_config;
     use aptos_framework::state_storage;
     use aptos_framework::storage_gas;
@@ -94,7 +95,6 @@ module aptos_framework::genesis {
             aptos_governance::store_signer_cap(&aptos_account, address, framework_signer_cap);
             i = i + 1;
         };
-
 
         consensus_config::initialize(&aptos_framework_account, consensus_config);
         version::initialize(&aptos_framework_account, initial_version);
@@ -184,15 +184,35 @@ module aptos_framework::genesis {
         }
     }
 
-    fun create_employee_validators(
-        _aptos_framework: &signer,
-        _employees: vector<EmployeeAccountMap>,
-    ) {
+    fun create_employee_validators(_aptos_framework: &signer, _employees: vector<EmployeeAccountMap>) {
     }
 
     fun create_initialize_validators_with_commission(
-        _aptos_framework: &signer,
-        _validators: vector<ValidatorConfigurationWithCommission>) {
+        aptos_framework: &signer,
+        validators: vector<ValidatorConfigurationWithCommission>,
+    ) {
+        let i = 0;
+        let num_validators = vector::length(&validators);
+        let unique_accounts = vector::empty();
+
+        while (i < num_validators) {
+            let validator = vector::borrow(&validators, i);
+
+            assert!(
+                !vector::contains(&unique_accounts, &validator.validator_config.owner_address),
+                error::already_exists(EDUPLICATE_ACCOUNT),
+            );
+            vector::push_back(&mut unique_accounts, validator.validator_config.owner_address);
+            create_initialize_validator(aptos_framework, validator);
+
+            i = i + 1;
+        };
+
+        // Destroy the aptos framework account's ability to mint coins now that we're done with setting up the initial
+        // validators.
+        aptos_coin::destroy_mint_cap(aptos_framework);
+
+        stake::on_new_epoch();
     }
 
     /// Sets up the initial validator set for the network.
@@ -208,50 +228,63 @@ module aptos_framework::genesis {
     fun create_initialize_validators(aptos_framework: &signer, validators: vector<ValidatorConfiguration>) {
         let i = 0;
         let num_validators = vector::length(&validators);
-        let unique_accounts = vector::empty();
+
+        let validators_with_commission = vector::empty();
 
         while (i < num_validators) {
-            let validator = vector::borrow(&validators, i);
+            let validator_with_commission = ValidatorConfigurationWithCommission {
+                validator_config: vector::pop_back(&mut validators),
+                commission_percentage: 0,
+            };
+            vector::push_back(&mut validators_with_commission, validator_with_commission);
 
-            assert!(
-                !vector::contains(&unique_accounts, &validator.owner_address),
-                error::already_exists(EDUPLICATE_ACCOUNT),
-            );
-            vector::push_back(&mut unique_accounts, validator.owner_address);
+            i = i + 1;
+        };
 
-            let owner = &create_account(aptos_framework, validator.owner_address, validator.stake_amount);
-            let operator = &create_account(aptos_framework, validator.operator_address, 0);
-            create_account(aptos_framework, validator.voter_address, 0);
+        create_initialize_validators_with_commission(aptos_framework, validators_with_commission);
+    }
 
-            // Initialize the stake pool and join the validator set.
+    fun create_initialize_validator(aptos_framework: &signer, commission_config: &ValidatorConfigurationWithCommission) {
+        let validator = &commission_config.validator_config;
+
+        let owner = &create_account(aptos_framework, validator.owner_address, validator.stake_amount);
+        let operator = &create_account(aptos_framework, validator.operator_address, 0);
+        create_account(aptos_framework, validator.voter_address, 0);
+
+        // Initialize the stake pool and join the validator set.
+        let pool_address = if (commission_config.commission_percentage == 0) {
             stake::initialize_stake_owner(
                 owner,
                 validator.stake_amount,
                 validator.operator_address,
                 validator.voter_address,
             );
-            stake::rotate_consensus_key(
-                operator,
-                validator.owner_address,
-                validator.consensus_pubkey,
-                validator.proof_of_possession,
+            validator.owner_address
+        } else {
+            staking_contract::create_staking_contract(
+                owner,
+                validator.operator_address,
+                validator.voter_address,
+                validator.stake_amount,
+                commission_config.commission_percentage,
+                x"",
             );
-            stake::update_network_and_fullnode_addresses(
-                operator,
-                validator.owner_address,
-                validator.network_addresses,
-                validator.full_node_network_addresses,
-            );
-            stake::join_validator_set_internal(operator, validator.owner_address);
-
-            i = i + 1;
+            staking_contract::stake_pool_address(validator.owner_address, validator.operator_address)
         };
 
-        // Destroy the aptos framework account's ability to mint coins now that we're done with setting up the initial
-        // validators.
-        aptos_coin::destroy_mint_cap(aptos_framework);
-
-        stake::on_new_epoch();
+        stake::rotate_consensus_key(
+            operator,
+            pool_address,
+            validator.consensus_pubkey,
+            validator.proof_of_possession,
+        );
+        stake::update_network_and_fullnode_addresses(
+            operator,
+            pool_address,
+            validator.network_addresses,
+            validator.full_node_network_addresses,
+        );
+        stake::join_validator_set_internal(operator, pool_address);
     }
 
     /// The last step of genesis.

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -662,7 +662,7 @@ module aptos_framework::vesting {
         contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability) acquires AdminStore {
         let admin_store = borrow_global_mut<AdminStore>(signer::address_of(admin));
-        let seed = bcs::to_bytes(admin);
+        let seed = bcs::to_bytes(&signer::address_of(admin));
         vector::append(&mut seed, bcs::to_bytes(&admin_store.nonce));
         admin_store.nonce = admin_store.nonce + 1;
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -832,7 +832,7 @@ pub fn test_genesis_module_publishing() {
 pub fn test_mainnet_end_to_end() {
     let balance = 10_000_000 * APTOS_COINS_BASE_WITH_DECIMALS;
     let test_validators = TestValidator::new_test_set(Some(3), Some(balance * 9 / 10));
-    let employee_validator = test_validators[0].data.clone();
+    let mut employee_validator = test_validators[0].data.clone();
     let mut direct_validator = test_validators[1].data.clone();
     let commissioned_validator = test_validators[2].data.clone();
 
@@ -841,6 +841,7 @@ pub fn test_mainnet_end_to_end() {
     let account46 = AccountAddress::from_hex_literal("0x46").unwrap();
     let account47 = AccountAddress::from_hex_literal("0x47").unwrap();
     let account48 = AccountAddress::from_hex_literal("0x48").unwrap();
+    let account49 = AccountAddress::from_hex_literal("0x49").unwrap();
 
     let accounts = vec![
         AccountMap {
@@ -859,8 +860,13 @@ pub fn test_mainnet_end_to_end() {
             account_address: account48,
             balance,
         },
+        AccountMap {
+            account_address: account49,
+            balance,
+        },
     ];
 
+    employee_validator.owner_address = account49;
     let employees = vec![EmployeeAccountMap {
         accounts: vec![account46, account47],
         validator: ValidatorWithCommissionRate {

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -830,13 +830,13 @@ pub fn test_genesis_module_publishing() {
 
 #[test]
 pub fn test_mainnet_end_to_end() {
-    let test_validators = TestValidator::new_test_set(Some(3), Some(0));
+    let balance = 10_000_000 * APTOS_COINS_BASE_WITH_DECIMALS;
+    let test_validators = TestValidator::new_test_set(Some(3), Some(balance * 9 / 10));
     let employee_validator = test_validators[0].data.clone();
     let mut direct_validator = test_validators[1].data.clone();
     let commissioned_validator = test_validators[2].data.clone();
 
     // currently just test that all functions have the right interface
-    let balance = 10_000_000 * APTOS_COINS_BASE_WITH_DECIMALS;
     let account45 = AccountAddress::from_hex_literal("0x45").unwrap();
     let account46 = AccountAddress::from_hex_literal("0x46").unwrap();
     let account47 = AccountAddress::from_hex_literal("0x47").unwrap();

--- a/types/src/account_address.rs
+++ b/types/src/account_address.rs
@@ -10,6 +10,7 @@ use aptos_crypto::{
 pub use move_deps::move_core_types::account_address::AccountAddress;
 
 const SALT: &[u8] = b"aptos_framework::staking_contract";
+const VESTING_POOL_SALT: &[u8] = b"aptos_framework::vesting";
 
 pub fn from_public_key(public_key: &Ed25519PublicKey) -> AccountAddress {
     AuthenticationKey::ed25519(public_key).derived_address()
@@ -36,7 +37,7 @@ pub fn default_stake_pool_address(
     owner: AccountAddress,
     operator: AccountAddress,
 ) -> AccountAddress {
-    create_stake_pool_address(owner, operator, &vec![])
+    create_stake_pool_address(owner, operator, &[])
 }
 
 pub fn create_stake_pool_address(
@@ -47,9 +48,32 @@ pub fn create_stake_pool_address(
     let mut full_seed = vec![];
     full_seed.extend(bcs::to_bytes(&owner).unwrap());
     full_seed.extend(bcs::to_bytes(&operator).unwrap());
-    full_seed.extend(SALT.clone());
-    full_seed.extend(seed.clone());
+    full_seed.extend(SALT);
+    full_seed.extend(seed);
     create_resource_address(owner, &full_seed)
+}
+
+pub fn create_vesting_contract_address(
+    admin: AccountAddress,
+    nonce: u64,
+    seed: &[u8],
+) -> AccountAddress {
+    let mut full_seed = vec![];
+    full_seed.extend(bcs::to_bytes(&admin).unwrap());
+    full_seed.extend(bcs::to_bytes(&nonce).unwrap());
+    full_seed.extend(VESTING_POOL_SALT);
+    full_seed.extend(seed);
+    create_resource_address(admin, &full_seed)
+}
+
+pub fn create_vesting_pool_address(
+    admin: AccountAddress,
+    operator: AccountAddress,
+    nonce: u64,
+    seed: &[u8],
+) -> AccountAddress {
+    let contract = create_vesting_contract_address(admin, nonce, seed);
+    create_stake_pool_address(contract, operator, seed)
 }
 
 pub fn create_resource_address(address: AccountAddress, seed: &[u8]) -> AccountAddress {


### PR DESCRIPTION
I tested commissioned validators by forcing the codebase to use it by default..

The reality is we'll likely want to extend the testing to validate the data was written (just as a check) and then also review the output binary, but this should be reasonably acceptable to move forward and unblock collaboration ... I think.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4310)
<!-- Reviewable:end -->
