### PR TITLE
Revert "[CICD] Add an explicit step for running Move module tests"

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -154,12 +154,6 @@ jobs:
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 
-  rust-move-unit-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - run: cargo test -p framework
-
   rust-smoke-test:
     runs-on: high-perf-docker
     steps:


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#4260

turns out to be a false alarm

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4314)
<!-- Reviewable:end -->
