### PR TITLE
[Genesis] Update mainnet genesis flow

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -56,6 +56,7 @@ module aptos_framework::genesis {
     struct ValidatorConfigurationWithCommission has copy, drop {
         validator_config: ValidatorConfiguration,
         commission_percentage: u64,
+        join_during_genesis: bool,
     }
 
     /// Genesis step 1: Initialize aptos framework account and core modules on chain.
@@ -262,7 +263,9 @@ module aptos_framework::genesis {
                 account::exists_at(validator.voter_address),
                 error::not_found(EACCOUNT_DOES_NOT_EXIST),
             );
-            initialize_validator(pool_address, validator);
+            if (employee_group.validator.join_during_genesis) {
+                initialize_validator(pool_address, validator);
+            };
 
             i = i + 1;
         }
@@ -308,6 +311,7 @@ module aptos_framework::genesis {
             let validator_with_commission = ValidatorConfigurationWithCommission {
                 validator_config: vector::pop_back(&mut validators),
                 commission_percentage: 0,
+                join_during_genesis: true,
             };
             vector::push_back(&mut validators_with_commission, validator_with_commission);
 
@@ -348,7 +352,9 @@ module aptos_framework::genesis {
             staking_contract::stake_pool_address(validator.owner_address, validator.operator_address)
         };
 
-        initialize_validator(pool_address, validator);
+        if (commission_config.join_during_genesis) {
+            initialize_validator(pool_address, validator);
+        };
     }
 
     fun initialize_validator(pool_address: address, validator: &ValidatorConfiguration) {

--- a/aptos-move/framework/aptos-framework/sources/genesis.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.move
@@ -274,16 +274,8 @@ module aptos_framework::genesis {
     ) {
         let i = 0;
         let num_validators = vector::length(&validators);
-        let unique_accounts = vector::empty();
-
         while (i < num_validators) {
             let validator = vector::borrow(&validators, i);
-
-            assert!(
-                !vector::contains(&unique_accounts, &validator.validator_config.owner_address),
-                error::already_exists(EDUPLICATE_ACCOUNT),
-            );
-            vector::push_back(&mut unique_accounts, validator.validator_config.owner_address);
             create_initialize_validator(aptos_framework, validator);
 
             i = i + 1;
@@ -398,11 +390,8 @@ module aptos_framework::genesis {
         rewards_rate: u64,
         rewards_rate_denominator: u64,
         voting_power_increase_limit: u64,
-
         aptos_framework: &signer,
-
         validators: vector<ValidatorConfiguration>,
-
         min_voting_threshold: u128,
         required_proposer_stake: u64,
         voting_duration_secs: u64,

--- a/aptos-move/framework/aptos-framework/sources/genesis.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/genesis.spec.move
@@ -1,6 +1,6 @@
 spec aptos_framework::genesis {
     spec module {
-        // We are not proving each genesis step indivisually. Instead, we construct
+        // We are not proving each genesis step individually. Instead, we construct
         // and prove `initialize_for_verification` which is a "#[verify_only]" function that
         // simulates the genesis encoding process in `vm-genesis` (written in Rust).
         // So, we turn off the verification at the module level, but turn it on for

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -209,6 +209,8 @@ impl TryFrom<&ValidatorNodeConfig> for ValidatorConfiguration {
             full_node_host,
             stake_amount: config.genesis_stake_amount,
             commission_percentage: config.commission_percentage,
+            // Default to joining the genesis validator set.
+            join_during_genesis: true,
         })
     }
 }

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -121,6 +121,10 @@ pub struct ValidatorConfiguration {
     pub stake_amount: u64,
     /// Commission percentage for validator
     pub commission_percentage: u64,
+    /// Whether the validator should be joining the validator set during genesis.
+    /// If set to false, the validator will be fully initialized but won't be added to the
+    /// validator set.
+    pub join_during_genesis: bool,
 }
 
 impl TryFrom<ValidatorConfiguration> for ValidatorWithCommissionRate {
@@ -128,9 +132,11 @@ impl TryFrom<ValidatorConfiguration> for ValidatorWithCommissionRate {
 
     fn try_from(config: ValidatorConfiguration) -> Result<Self, Self::Error> {
         let validator_commission_percentage = config.commission_percentage;
+        let join_during_genesis = config.join_during_genesis;
         Ok(ValidatorWithCommissionRate {
             validator: config.try_into()?,
             validator_commission_percentage,
+            join_during_genesis,
         })
     }
 }
@@ -274,6 +280,7 @@ pub struct OwnerConfiguration {
     pub operator_account_public_key: Ed25519PublicKey,
     pub stake_amount: u64,
     pub commission_percentage: u64,
+    pub join_during_genesis: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -298,6 +305,7 @@ pub struct StringOwnerConfiguration {
     pub operator_account_public_key: Option<String>,
     pub stake_amount: Option<String>,
     pub commission_percentage: Option<String>,
+    pub join_during_genesis: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -118,6 +118,10 @@ pub struct SetValidatorConfiguration {
     #[clap(long, default_value_t = 0)]
     pub(crate) commission_percentage: u64,
 
+    /// Whether the validator will be joining the genesis validator set.
+    #[clap(long)]
+    pub(crate) join_during_genesis: bool,
+
     /// Path to private identity generated from GenerateKeys
     #[clap(long, parse(from_os_str))]
     pub(crate) owner_public_identity_file: Option<PathBuf>,
@@ -228,6 +232,7 @@ impl CliCommand<()> for SetValidatorConfiguration {
             operator_account_public_key: operator_identity.account_public_key,
             stake_amount: self.stake_amount,
             commission_percentage: self.commission_percentage,
+            join_during_genesis: self.join_during_genesis,
         };
 
         let directory = PathBuf::from(&self.username);

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -283,6 +283,15 @@ fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfigurat
     )?
     .unwrap_or_default();
 
+    // Default to true for whether the validator should be joining during genesis.
+    let join_during_genesis = parse_optional_option(
+        &owner_config.join_during_genesis,
+        owner_file,
+        "join_during_genesis",
+        bool::from_str,
+    )?
+    .unwrap_or(true);
+
     // Check and convert fields in operator file
     let operator_account_address_from_file = parse_required_option(
         &operator_config.operator_account_address,
@@ -359,6 +368,7 @@ fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfigurat
         full_node_host: operator_config.full_node_host,
         stake_amount,
         commission_percentage,
+        join_during_genesis,
     })
 }
 

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -83,6 +83,7 @@ async fn test_mainnet_genesis_e2e_flow() {
         PathBuf::from(git_dir),
         admin,
         &vec![vec![employee_1, employee_2], vec![employee_3, employee_4]],
+        &[true, false],
     )
     .await;
 
@@ -251,6 +252,7 @@ async fn set_validator_config(
         operator_public_identity_file: None,
         voter_public_identity_file: None,
         commission_percentage,
+        join_during_genesis: true,
     };
 
     command.execute().await.unwrap()
@@ -277,6 +279,7 @@ async fn create_employee_vesting_accounts_file(
     path: PathBuf,
     admin_address: AccountAddress,
     employee_groups: &Vec<Vec<AccountAddress>>,
+    join_during_genesis: &[bool],
 ) {
     let test_validators =
         TestValidator::new_test_set(Some(employee_groups.len()), Some(INITIAL_BALANCE));
@@ -293,6 +296,7 @@ async fn create_employee_vesting_accounts_file(
                 validator: ValidatorWithCommissionRate {
                     validator,
                     validator_commission_percentage: 10,
+                    join_during_genesis: join_during_genesis[index],
                 },
                 vesting_schedule_numerators: vec![
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 1,


### PR DESCRIPTION
### Description
1. Allow validators to have the same owner (but different operators) in genesis.
2. Allow validators to be set up but not yet join the validator set immediately during genesis.

### Test Plan
E2E tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4325)
<!-- Reviewable:end -->
