### PR TITLE
observability: annotation based prometheus config and reduce logging volume slightly

### DIFF
--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -63,6 +63,8 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
         checksum/fullnode.yaml: {{ tpl ($.Files.Get "files/configs/fullnode.yaml") $ | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
     spec:
       terminationGracePeriodSeconds: 0
       containers:
@@ -100,7 +102,9 @@ spec:
         - containerPort: 6181
         - containerPort: 6182
         - containerPort: 8080
+          name: api
         - containerPort: 9101
+          name: metrics
         livenessProbe:
           tcpSocket:
             port: 9101

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -67,6 +67,8 @@ spec:
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
         checksum/validator.yaml: {{ tpl ($.Files.Get "files/configs/validator.yaml") $ | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
     spec:
       terminationGracePeriodSeconds: 0
       containers:
@@ -105,7 +107,9 @@ spec:
         - containerPort: 6181  # VFN
         - containerPort: 6182  # Public
         - containerPort: 8080
+          name: api
         - containerPort: 9101
+          name: metrics
         livenessProbe:
           tcpSocket:
             port: 9101

--- a/terraform/helm/fullnode/templates/fullnode.yaml
+++ b/terraform/helm/fullnode/templates/fullnode.yaml
@@ -20,6 +20,8 @@ spec:
         app.kubernetes.io/name: fullnode
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9101"
     spec:
       terminationGracePeriodSeconds: 0
       containers:
@@ -67,9 +69,11 @@ spec:
         ports:
         - containerPort: 6182
         - containerPort: 6186
-        - containerPort: 8080
         - containerPort: 8081
+        - containerPort: 8080
+          name: api
         - containerPort: 9101
+          name: metrics
         livenessProbe:
           tcpSocket:
             port: 9101

--- a/terraform/helm/vector-log-agent/files/vector-transforms.yaml
+++ b/terraform/helm/vector-log-agent/files/vector-transforms.yaml
@@ -25,7 +25,13 @@ transforms:
       del(.k8s.node_labels."kubernetes.io/os")
       del(.k8s.node_labels."kubernetes.io/hostname")
       del(.k8s.node_labels."topology.kubernetes.io/region")
-
+      del(.k8s.node_labels."topology.kubernetes.io/zone")
+      del(.k8s.node_labels."k8s.io/cloud-provider-aws")
+      del(.k8s.node_labels."eks.amazonaws.com/nodegroup")
+      del(.k8s.labels."statefulset.kubernetes.io/pod-name")
+      del(.k8s.pod_owner)
+      del(.k8s.labels."forge-image-tag")
+      del(.k8s.labels."controller-uid")
 
       del(.k8s.annotations."kubectl.kubernetes.io/last-applied-configuration")
       del(.k8s.annotations."seccomp.security.alpha.kubernetes.io/pod")


### PR DESCRIPTION
This PR does two things:
1. add explicit annotation-based prometheus scrape config. This is a step towards getting rid of aptos-specific configuration in prometheus/vmagent and make it easier to use other metric collectors.
2. Delete some redundant log attributes in vector config to reduce log ingest volume.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4327)
<!-- Reviewable:end -->
