### PR TITLE
chore: clean up nullish coalescing (??) operators

### DIFF
--- a/ecosystem/typescript/sdk/package.json
+++ b/ecosystem/typescript/sdk/package.json
@@ -49,8 +49,7 @@
     "axios": "0.27.2",
     "form-data": "4.0.0",
     "js-sha3": "0.8.0",
-    "tweetnacl": "1.0.3",
-    "yarn": "^1.22.19"
+    "tweetnacl": "1.0.3"
   },
   "devDependencies": {
     "@types/jest": "28.1.8",

--- a/ecosystem/typescript/sdk/tsup.config.js
+++ b/ecosystem/typescript/sdk/tsup.config.js
@@ -4,4 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts"],
   splitting: false,
   sourcemap: true,
+  target: "es2018",
 });

--- a/ecosystem/typescript/sdk/typedoc.json
+++ b/ecosystem/typescript/sdk/typedoc.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": ["src/index.ts"],
-  "out": "docs",
-  "cleanOutputDir": false,
-  "excludeInternal": true,
-  "excludePrivate": true
-}

--- a/ecosystem/typescript/sdk/yarn.lock
+++ b/ecosystem/typescript/sdk/yarn.lock
@@ -3832,11 +3832,6 @@ yargs@^17.3.1:
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
 
-yarn@^1.22.19:
-  version "1.22.19"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"
-  integrity sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"


### PR DESCRIPTION
### Description
?? is not widely supported by browsers and frameworks. e.g. CRA older than 3.3.0 doesn't support `??` transpiling. We would like to transpile all `??` to ternary operators in SDK.

### Test Plan
yarn build

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4332)
<!-- Reviewable:end -->
