### PR TITLE
[forge][flaky] Create separate nft mint test, and remove nft minting from other tests

### DIFF
--- a/.github/workflows/continuous-e2e-account-creation-test.yaml
+++ b/.github/workflows/continuous-e2e-account-creation-test.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E Account Creation Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  ### Please remember to use different namespace for different tests
+  # Performance test in an optimal setting
+  run-forge-account-creation-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-account-creation-test
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: account_creation
+      POST_TO_SLACK: true

--- a/.github/workflows/continuous-e2e-nft-mint-test.yaml
+++ b/.github/workflows/continuous-e2e-nft-mint-test.yaml
@@ -1,4 +1,4 @@
-name: Continuous E2E Account Creation State Sync Test
+name: Continuous E2E Nft Mint Test
 
 permissions:
   issues: write
@@ -12,12 +12,12 @@ on:
 jobs:
   ### Please remember to use different namespace for different tests
   # Performance test in an optimal setting
-  run-forge-account-creation-ss:
+  run-forge-nft-mint-test:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-account-creation-ss
+      FORGE_NAMESPACE: forge-nft-mint-test
       FORGE_CLUSTER_NAME: aptos-forge-big-1
-      FORGE_RUNNER_DURATION_SECS: 1800
-      FORGE_TEST_SUITE: account_creation_state_sync
+      FORGE_RUNNER_DURATION_SECS: 900
+      FORGE_TEST_SUITE: nft_mint
       POST_TO_SLACK: true

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -517,19 +517,23 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                 None,
                 None,
             )),
-        "account_creation_state_sync" => config
+        "account_creation" | "nft_mint" => config
             .with_network_tests(vec![&PerformanceBenchmarkWithFN])
             .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
             .with_initial_fullnode_count(3)
             .with_genesis_helm_config_fn(Arc::new(|helm_values| {
-                helm_values["chain"]["epoch_duration_secs"] = 1200.into();
+                helm_values["chain"]["epoch_duration_secs"] = 600.into();
             }))
             .with_emit_job(
                 EmitJobRequest::default()
                     .mode(EmitJobMode::MaxLoad {
                         mempool_backlog: 30000,
                     })
-                    .transaction_type(TransactionType::AccountGeneration),
+                    .transaction_type(if test_name == "account_creation" {
+                        TransactionType::AccountGeneration
+                    } else {
+                        TransactionType::NftMint
+                    }),
             )
             .with_success_criteria(SuccessCriteria::new(
                 4000,
@@ -858,9 +862,8 @@ fn changing_working_quorum_test(
                     EmitJobMode::ConstTps { tps: target_tps }
                 })
                 .transaction_mix(vec![
-                    (TransactionType::P2P, 75),
+                    (TransactionType::P2P, 80),
                     (TransactionType::AccountGeneration, 20),
-                    (TransactionType::NftMint, 5),
                 ]),
         )
         .with_success_criteria(SuccessCriteria::new(


### PR DESCRIPTION
NFT mint is a bit flaky, so trying to improve it.
But also creating a separate test just for it, while having the other tests run without it, so they are not affected by it's flakiness (if it continues)

### Description

### Test Plan
e2e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4334)
<!-- Reviewable:end -->
