### PR TITLE
Update to `debian:bullseye-20220912` in our Rust images Dockerfile

### DIFF
--- a/docker/docker-bake-rust-all.sh
+++ b/docker/docker-bake-rust-all.sh
@@ -40,5 +40,5 @@ if [ "$CI" == "true" ]; then
   REGISTRY_BASE="$GCP_DOCKER_ARTIFACT_REPO" SOURCE_TAG="cache-${IMAGE_TAG_PREFIX}${NORMALIZED_GIT_BRANCH_OR_PR}" TARGET_TAG="cache-${IMAGE_TAG_PREFIX}${GIT_SHA}" ./docker/retag-rust-images.sh
 else
   BUILD_TARGET="${1:-all}"
-  TARGET_REGISTRY=local docker buildx bake --file docker/docker-bake-rust-all.hcl $BUILD_TARGET
+  TARGET_REGISTRY=local docker buildx bake --file docker/docker-bake-rust-all.hcl $BUILD_TARGET --load
 fi

--- a/docker/rust-all.Dockerfile
+++ b/docker/rust-all.Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.4
 
-FROM debian:buster-20220822@sha256:faa416b9eeda2cbdb796544422eedd698e716dbd99841138521a94db51bf6123 AS debian-base
+FROM debian:bullseye-20220912@sha256:3e82b1af33607aebaeb3641b75d6e80fd28d36e17993ef13708e9493e30e8ff9 AS debian-base
 
 # Add Tini to make sure the binaries receive proper SIGTERM signals when Docker is shut down
 ADD https://github.com/krallin/tini/releases/download/v0.19.0/tini /tini
@@ -37,7 +37,7 @@ ENV PROFILE ${PROFILE}
 ARG FEATURES
 ENV FEATURES ${FEATURES}
 
-RUN PROFILE=$PROFILE FEATURES=$FEATURES docker/build-rust-all.sh && rm -rf $CARGO_HOME && rm -rf target 
+RUN PROFILE=$PROFILE FEATURES=$FEATURES docker/build-rust-all.sh && rm -rf $CARGO_HOME && rm -rf target
 
 ### Validator Image ###
 FROM debian-base AS validator
@@ -133,7 +133,7 @@ RUN apt-get update && apt-get --no-install-recommends -y \
     ca-certificates \
     socat \
     python3-botocore/bullseye \
-    awscli/bullseye \ 
+    awscli/bullseye \
     && apt-get clean && rm -r /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/python3 /usr/local/bin/python
@@ -287,7 +287,7 @@ RUN apt-get update && apt-get install -y \
     htop \
     valgrind \
     bpfcc-tools \
-    python-bpfcc \
+    python3-bpfcc \
     libbpfcc \
     libbpfcc-dev \
     && apt-get clean && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
### Description
There were numerous problems found with the base image we were using. Upgrading changes the number of found issues from 127 to <TBA>. See here for the vulnerabilities: https://aptos-org.slack.com/archives/C03EP0XM99D/p1663630803709199.

We have yet to evaluate whether this is more beneficial than risky.

### Test Plan
Build images:
```
docker buildx create --use
docker/docker-bake-rust-all.sh
```

Scan validator image:
```
docker scan validator
```

Confirm the validator runs (from the tools image):
```
docker run tools aptos -- node run-local-testnet --with-faucet --faucet-port 8081 --force-restart --assume-yes
```

For now beyond that, I'll run the CI to build the images and run forge. **Update**: I haven't been able to actually do the above because the build just fails locally for one reason or another. So I'm just relying on CI.

There is much more testing to do here that isn't done via CI, e.g. with the tools image, perhaps indexer, etc. I'll test that further soon.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4344)
<!-- Reviewable:end -->
