### PR TITLE
[txn-emitter] fix mint and add transfer traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10072,6 +10072,7 @@ dependencies = [
  "aptos-logger",
  "aptos-rest-client",
  "aptos-sdk",
+ "async-trait",
  "clap 3.2.17",
  "futures",
  "itertools",

--- a/crates/transaction-emitter-lib/Cargo.toml
+++ b/crates/transaction-emitter-lib/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 again = "0.1.2"
 anyhow = { version = "1.0.57", features = ["backtrace"] }
+async-trait = "0.1.53"
 clap = "3.1.17"
 futures = "0.3.21"
 itertools = "0.10.3"

--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -58,7 +58,7 @@ pub struct ClusterArgs {
 pub enum TransactionType {
     P2P,
     AccountGeneration,
-    NftMint,
+    NftMintAndTransfer,
 }
 
 impl Default for TransactionType {

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -40,7 +40,8 @@ use crate::{
         submission_worker::SubmissionWorker,
     },
     transaction_generator::{
-        account_generator::AccountGeneratorCreator, nft_mint::NFTMintGeneratorCreator,
+        account_generator::AccountGeneratorCreator,
+        nft_mint_and_transfer::NFTMintAndTransferGeneratorCreator,
         p2p_transaction_generator::P2PTransactionGeneratorCreator,
         transaction_mix_generator::TxnMixGeneratorCreator, TransactionGeneratorCreator,
     },
@@ -419,8 +420,8 @@ impl TxnEmitter {
                     req.max_account_working_set,
                     req.gas_price,
                 )),
-                TransactionType::NftMint => Box::new(
-                    NFTMintGeneratorCreator::new(
+                TransactionType::NftMintAndTransfer => Box::new(
+                    NFTMintAndTransferGeneratorCreator::new(
                         self.from_rng(),
                         txn_factory.clone(),
                         root_account,
@@ -460,9 +461,10 @@ impl TxnEmitter {
             for client in &req.rest_clients {
                 let accounts = (&mut all_accounts)
                     .take(mode_params.accounts_per_worker)
-                    .collect();
+                    .collect::<Vec<_>>();
                 let stop = stop.clone();
                 let stats = Arc::clone(&stats);
+                let txn_generator = txn_generator_creator.create_transaction_generator().await;
 
                 let worker = SubmissionWorker::new(
                     accounts,
@@ -470,7 +472,7 @@ impl TxnEmitter {
                     stop,
                     mode_params.clone(),
                     stats,
-                    txn_generator_creator.create_transaction_generator(),
+                    txn_generator,
                     workers.len(),
                     check_account_sequence_only_once_for.contains(&workers.len()),
                     self.from_rng(),

--- a/crates/transaction-emitter-lib/src/transaction_generator/account_generator.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/account_generator.rs
@@ -9,6 +9,7 @@ use aptos_sdk::{
     transaction_builder::{aptos_stdlib, TransactionFactory},
     types::{transaction::SignedTransaction, LocalAccount},
 };
+use async_trait::async_trait;
 use rand::prelude::StdRng;
 use rand::Rng;
 use rand_core::{OsRng, SeedableRng};
@@ -58,6 +59,7 @@ impl AccountGenerator {
     }
 }
 
+#[async_trait]
 impl TransactionGenerator for AccountGenerator {
     fn generate_transactions(
         &mut self,
@@ -128,8 +130,9 @@ impl AccountGeneratorCreator {
     }
 }
 
+#[async_trait]
 impl TransactionGeneratorCreator for AccountGeneratorCreator {
-    fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
         Box::new(AccountGenerator::new(
             StdRng::from_seed(OsRng.gen()),
             self.txn_factory.clone(),

--- a/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/mod.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};
+use async_trait::async_trait;
 
 pub mod account_generator;
-pub mod nft_mint;
+pub mod nft_mint_and_transfer;
 pub mod p2p_transaction_generator;
 pub mod transaction_mix_generator;
 
@@ -16,6 +17,7 @@ pub trait TransactionGenerator: Sync + Send {
     ) -> Vec<SignedTransaction>;
 }
 
+#[async_trait]
 pub trait TransactionGeneratorCreator: Sync + Send {
-    fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator>;
+    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator>;
 }

--- a/crates/transaction-emitter-lib/src/transaction_generator/nft_mint_and_transfer.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/nft_mint_and_transfer.rs
@@ -1,41 +1,67 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
+
 use crate::transaction_generator::{TransactionGenerator, TransactionGeneratorCreator};
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{
     transaction_builder::{aptos_stdlib::aptos_token_stdlib, TransactionFactory},
     types::{transaction::SignedTransaction, LocalAccount},
 };
+use std::collections::HashMap;
 
 use crate::emitter::{account_minter::create_and_fund_account_request, RETRY_POLICY};
+use aptos_infallible::Mutex;
 use aptos_logger::{info, warn};
+use aptos_sdk::types::account_address::AccountAddress;
+use async_trait::async_trait;
 use rand::rngs::StdRng;
+use rand::thread_rng;
 use std::{sync::Arc, time::Duration};
 
-pub struct NFTMint {
+const INITIAL_NFT_BALANCE: u64 = 50_000;
+
+pub struct NFTMintAndTransfer {
     txn_factory: TransactionFactory,
-    creator_account: Arc<LocalAccount>,
+    creator_address: AccountAddress,
+    faucet_account: LocalAccount,
     collection_name: Vec<u8>,
     token_name: Vec<u8>,
+    account_funded: HashMap<AccountAddress, bool>,
 }
 
-impl NFTMint {
-    pub fn new(
+impl NFTMintAndTransfer {
+    pub async fn new(
         txn_factory: TransactionFactory,
-        creator_account: Arc<LocalAccount>,
+        creator_account: Arc<Mutex<LocalAccount>>,
         collection_name: Vec<u8>,
         token_name: Vec<u8>,
+        rest_client: &RestClient,
     ) -> Self {
+        let creator_address = creator_account.lock().address();
+        let faucet_account = LocalAccount::generate(&mut thread_rng());
+        let fund_faucet_account_txn = create_nft_transfer_request(
+            &mut creator_account.lock(),
+            &faucet_account,
+            creator_address,
+            &collection_name,
+            &token_name,
+            &txn_factory,
+            1_000_000_000,
+        );
+        submit_retry_and_wait(rest_client, &fund_faucet_account_txn).await;
+
         Self {
             txn_factory,
-            creator_account,
+            faucet_account,
+            creator_address,
             collection_name,
             token_name,
+            account_funded: Default::default(),
         }
     }
 }
 
-impl TransactionGenerator for NFTMint {
+impl TransactionGenerator for NFTMintAndTransfer {
     fn generate_transactions(
         &mut self,
         accounts: Vec<&mut LocalAccount>,
@@ -43,15 +69,44 @@ impl TransactionGenerator for NFTMint {
     ) -> Vec<SignedTransaction> {
         let mut requests = Vec::with_capacity(accounts.len() * transactions_per_account);
         for account in accounts {
-            for _ in 0..transactions_per_account {
-                requests.push(create_nft_transfer_request(
-                    account,
-                    &self.creator_account,
-                    &self.collection_name,
-                    &self.token_name,
-                    &self.txn_factory,
-                ));
+            let account_funded = self
+                .account_funded
+                .get(&account.address())
+                .cloned()
+                .unwrap_or(false);
+            for i in 0..transactions_per_account {
+                requests.push(if account_funded {
+                    create_nft_transfer_request(
+                        account,
+                        &self.faucet_account,
+                        self.creator_address,
+                        &self.collection_name,
+                        &self.token_name,
+                        &self.txn_factory,
+                        if i != transactions_per_account - 1 {
+                            1
+                        } else {
+                            INITIAL_NFT_BALANCE + 1 - transactions_per_account as u64
+                        },
+                    )
+                } else {
+                    create_nft_transfer_request(
+                        &mut self.faucet_account,
+                        account,
+                        self.creator_address,
+                        &self.collection_name,
+                        &self.token_name,
+                        &self.txn_factory,
+                        if i != transactions_per_account - 1 {
+                            1
+                        } else {
+                            INITIAL_NFT_BALANCE + 1 - transactions_per_account as u64
+                        },
+                    )
+                });
             }
+            self.account_funded
+                .insert(account.address(), !account_funded);
         }
         requests
     }
@@ -79,7 +134,7 @@ async fn submit_retry_and_wait(rest_client: &RestClient, txn: &SignedTransaction
 }
 
 pub async fn initialize_nft_collection(
-    rest_client: RestClient,
+    rest_client: &RestClient,
     root_account: &mut LocalAccount,
     creator_account: &mut LocalAccount,
     txn_factory: &TransactionFactory,
@@ -114,21 +169,21 @@ pub async fn initialize_nft_collection(
         txn_factory,
     );
 
-    submit_retry_and_wait(&rest_client, &create_account_txn).await;
+    submit_retry_and_wait(rest_client, &create_account_txn).await;
 
     info!("create_account_txn complete");
 
     let collection_txn =
         create_nft_collection_request(creator_account, collection_name, txn_factory);
 
-    submit_retry_and_wait(&rest_client, &collection_txn).await;
+    submit_retry_and_wait(rest_client, &collection_txn).await;
 
     info!("collection_txn complete");
 
     let token_txn =
         create_nft_token_request(creator_account, collection_name, token_name, txn_factory);
 
-    submit_retry_and_wait(&rest_client, &token_txn).await;
+    submit_retry_and_wait(rest_client, &token_txn).await;
 
     info!("token_txn complete");
 }
@@ -160,7 +215,7 @@ pub fn create_nft_token_request(
             collection_name.to_vec(),
             token_name.to_vec(),
             "collection description".to_owned().into_bytes(),
-            1_000_000_000,
+            100_000_000_000,
             u64::MAX,
             "uri".to_owned().into_bytes(),
             creation_account.address(),
@@ -175,32 +230,35 @@ pub fn create_nft_token_request(
 }
 
 pub fn create_nft_transfer_request(
-    owner_account: &mut LocalAccount,
-    creation_account: &LocalAccount,
+    sender: &mut LocalAccount,
+    receiver: &LocalAccount,
+    creation_address: AccountAddress,
     collection_name: &[u8],
     token_name: &[u8],
     txn_factory: &TransactionFactory,
+    amount: u64,
 ) -> SignedTransaction {
-    owner_account.sign_multi_agent_with_transaction_builder(
-        vec![creation_account],
+    sender.sign_multi_agent_with_transaction_builder(
+        vec![receiver],
         txn_factory.payload(aptos_token_stdlib::token_direct_transfer_script(
-            creation_account.address(),
+            creation_address,
             collection_name.to_vec(),
             token_name.to_vec(),
             0,
-            1,
+            amount,
         )),
     )
 }
 
-pub struct NFTMintGeneratorCreator {
+pub struct NFTMintAndTransferGeneratorCreator {
     txn_factory: TransactionFactory,
-    creator_account: Arc<LocalAccount>,
+    creator_account: Arc<Mutex<LocalAccount>>,
     collection_name: Vec<u8>,
     token_name: Vec<u8>,
+    rest_client: RestClient,
 }
 
-impl NFTMintGeneratorCreator {
+impl NFTMintAndTransferGeneratorCreator {
     pub async fn new(
         mut rng: StdRng,
         txn_factory: TransactionFactory,
@@ -211,7 +269,7 @@ impl NFTMintGeneratorCreator {
         let collection_name = "collection name".to_owned().into_bytes();
         let token_name = "token name".to_owned().into_bytes();
         initialize_nft_collection(
-            rest_client,
+            &rest_client,
             root_account,
             &mut creator_account,
             &txn_factory,
@@ -221,20 +279,26 @@ impl NFTMintGeneratorCreator {
         .await;
         Self {
             txn_factory,
-            creator_account: Arc::new(creator_account),
+            creator_account: Arc::new(Mutex::new(creator_account)),
             collection_name,
             token_name,
+            rest_client,
         }
     }
 }
 
-impl TransactionGeneratorCreator for NFTMintGeneratorCreator {
-    fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
-        Box::new(NFTMint::new(
-            self.txn_factory.clone(),
-            self.creator_account.clone(),
-            self.collection_name.clone(),
-            self.token_name.clone(),
-        ))
+#[async_trait]
+impl TransactionGeneratorCreator for NFTMintAndTransferGeneratorCreator {
+    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+        Box::new(
+            NFTMintAndTransfer::new(
+                self.txn_factory.clone(),
+                self.creator_account.clone(),
+                self.collection_name.clone(),
+                self.token_name.clone(),
+                &self.rest_client,
+            )
+            .await,
+        )
     }
 }

--- a/crates/transaction-emitter-lib/src/transaction_generator/p2p_transaction_generator.rs
+++ b/crates/transaction-emitter-lib/src/transaction_generator/p2p_transaction_generator.rs
@@ -7,6 +7,7 @@ use aptos_sdk::{
     transaction_builder::{aptos_stdlib, TransactionFactory},
     types::{chain_id::ChainId, transaction::SignedTransaction, LocalAccount},
 };
+use async_trait::async_trait;
 use rand::{
     distributions::{Distribution, Standard},
     prelude::{SliceRandom, StdRng},
@@ -212,8 +213,9 @@ impl P2PTransactionGeneratorCreator {
     }
 }
 
+#[async_trait]
 impl TransactionGeneratorCreator for P2PTransactionGeneratorCreator {
-    fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
+    async fn create_transaction_generator(&self) -> Box<dyn TransactionGenerator> {
         Box::new(P2PTransactionGenerator::new(
             self.rng.clone(),
             self.amount,

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -533,7 +533,7 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                     .transaction_type(if test_name == "account_creation" {
                         TransactionType::AccountGeneration
                     } else {
-                        TransactionType::NftMint
+                        TransactionType::NftMintAndTransfer
                     }),
             )
             .with_success_criteria(SuccessCriteria::new(

--- a/testsuite/smoke-test/src/txn_emitter.rs
+++ b/testsuite/smoke-test/src/txn_emitter.rs
@@ -38,7 +38,7 @@ pub async fn generate_traffic(
         .transaction_mix(vec![
             (TransactionType::P2P, 70),
             (TransactionType::AccountGeneration, 20),
-            (TransactionType::NftMint, 10),
+            (TransactionType::NftMintAndTransfer, 10),
         ])
         .mode(EmitJobMode::ConstTps { tps: 20 });
     emitter


### PR DESCRIPTION
### Description

I believe there is some issue with the previous version of code. The nft is distributed from receiver side to the sender side. I don't know how this can be successful. Talk to Zekun, it seems currently all txns not aborted will be regarded as successful...

Fix the issue and add transfer logic to transfer all the NFTs to another account if the current account has NFTs, otherwise mint it from a faucet account(creator account)

### Test Plan
ut

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4349)
<!-- Reviewable:end -->
