### PR TITLE
[Indexer] Remove event key

### DIFF
--- a/crates/indexer/migrations/2022-08-08-043603_core_tables/up.sql
+++ b/crates/indexer/migrations/2022-08-08-043603_core_tables/up.sql
@@ -206,17 +206,20 @@ CREATE INDEX sig_insat_index ON signatures (inserted_at);
  }
  */
 CREATE TABLE events (
-  key VARCHAR(100) NOT NULL,
   sequence_number BIGINT NOT NULL,
   creation_number BIGINT NOT NULL,
-  account_address VARCHAR(64) NOT NULL,
+  account_address VARCHAR(66) NOT NULL,
   transaction_version BIGINT NOT NULL,
   transaction_block_height BIGINT NOT NULL,
   type TEXT NOT NULL,
   data jsonb NOT NULL,
   inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
   -- Constraints
-  PRIMARY KEY (key, sequence_number),
+  PRIMARY KEY (
+    account_address,
+    creation_number,
+    sequence_number
+  ),
   CONSTRAINT fk_transaction_versions FOREIGN KEY (transaction_version) REFERENCES transactions (version)
 );
 CREATE INDEX ev_addr_type_index ON events (account_address);

--- a/crates/indexer/src/models/events.rs
+++ b/crates/indexer/src/models/events.rs
@@ -11,9 +11,8 @@ use serde::{Deserialize, Serialize};
 )]
 #[diesel(table_name = "events")]
 #[belongs_to(Transaction, foreign_key = "transaction_version")]
-#[primary_key(key, sequence_number)]
+#[primary_key(account_address, creation_number, sequence_number)]
 pub struct Event {
-    pub key: String,
     pub sequence_number: i64,
     pub creation_number: i64,
     pub account_address: String,
@@ -33,12 +32,11 @@ impl Event {
         transaction_block_height: i64,
     ) -> Self {
         Event {
-            key: event.key.to_string(),
             account_address: event.key.0.get_creator_address().to_string(),
             creation_number: event.key.0.get_creation_number() as i64,
+            sequence_number: event.sequence_number.0 as i64,
             transaction_version,
             transaction_block_height,
-            sequence_number: event.sequence_number.0 as i64,
             type_: event.typ.to_string(),
             data: event.data.clone(),
             inserted_at: chrono::Utc::now().naive_utc(),

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -237,7 +237,7 @@ fn insert_events(conn: &PgPoolConnection, ev: &[EventModel]) -> Result<(), diese
             conn,
             diesel::insert_into(schema::events::table)
                 .values(&ev[start_ind..end_ind])
-                .on_conflict((key, sequence_number))
+                .on_conflict((account_address, creation_number, sequence_number))
                 .do_nothing(),
         ) {
             Ok(_) => {}

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -34,8 +34,7 @@ table! {
 }
 
 table! {
-    events (key, sequence_number) {
-        key -> Varchar,
+    events (account_address, creation_number, sequence_number) {
         sequence_number -> Int8,
         creation_number -> Int8,
         account_address -> Varchar,


### PR DESCRIPTION
### Description
In preparation for https://github.com/aptos-labs/aptos-core/pull/4338

### Test Plan
`cargo run -p aptos-node --features "indexer" --release -- -f ./fullnode.yaml | grep -E tps`
```
...
2022-09-19T21:42:10.177070Z [indexer] INFO crates/indexer/src/runtime.rs:240 Processed batch version {"batch_end_version":1499,"batch_start_version":1000,"processor_name":"default_processor","tps":66666,"versions_processed":1000}
2022-09-19T21:42:10.216325Z [indexer] INFO crates/indexer/src/runtime.rs:240 Processed batch version {"batch_end_version":4499,"batch_start_version":4000,"processor_name":"default_processor","tps":37037,"versions_processed":2000}
```
Checked that DB is correct