### PR TITLE
[txn-emitter] Add Graceful Forge test, and Fix ConstTps txn-emitter

### DIFF
--- a/.github/workflows/continuous-e2e-graceful-overload-test.yaml
+++ b/.github/workflows/continuous-e2e-graceful-overload-test.yaml
@@ -1,0 +1,23 @@
+name: Continuous E2E Graceful Overload
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  ### Please remember to use different namespace for different tests
+  # Performance test in an optimal setting
+  run-forge-graceful-overload-test:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-graceful-overload-test
+      FORGE_CLUSTER_NAME: aptos-forge-big-1
+      FORGE_RUNNER_DURATION_SECS: 1800
+      FORGE_TEST_SUITE: graceful_overload
+      POST_TO_SLACK: true

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -152,7 +152,7 @@ impl Cluster {
     ) -> Result<LocalAccount> {
         let sequence_number = query_sequence_number(client, address).await.map_err(|e| {
             format_err!(
-                "query_sequence_numbers on {:?} for account {} failed: {:?}",
+                "query_sequence_number on {:?} for account {} failed: {:?}",
                 client,
                 address,
                 e

--- a/crates/transaction-emitter/src/diag.rs
+++ b/crates/transaction-emitter/src/diag.rs
@@ -11,7 +11,7 @@ use std::{
     cmp::min,
     time::{Duration, Instant},
 };
-use transaction_emitter_lib::{query_sequence_numbers, Cluster, TxnEmitter};
+use transaction_emitter_lib::{query_sequence_number, Cluster, TxnEmitter};
 
 pub async fn diag(cluster: &Cluster) -> Result<()> {
     let client = cluster.random_instance().rest_client();
@@ -40,20 +40,19 @@ pub async fn diag(cluster: &Cluster) -> Result<()> {
             faucet_account.sequence_number()
         );
         loop {
-            let addresses = &[faucet_account_address];
             let clients = instances
                 .iter()
                 .map(|instance| instance.rest_client())
                 .collect::<Vec<_>>();
             let futures = clients
                 .iter()
-                .map(|client| query_sequence_numbers(client, addresses.iter()));
+                .map(|client| query_sequence_number(client, faucet_account_address));
             let results = join_all(futures).await;
             let mut all_good = true;
             for (instance, result) in zip(instances.iter(), results) {
                 let seq = result.map_err(|e| {
                     format_err!("Failed to query sequence number from {}: {:?}", instance, e)
-                })?[0];
+                })?;
                 let host = instance.api_url().host().unwrap().to_string();
                 let status = if seq != faucet_account.sequence_number() {
                     all_good = false;

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -542,6 +542,31 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                 None,
                 None,
             )),
+        // TODO: Add tracing latency of high-gas-fee transactions
+        "graceful_overload" => config
+            .with_initial_validator_count(NonZeroUsize::new(10).unwrap())
+            .with_initial_fullnode_count(4)
+            .with_network_tests(vec![&PerformanceBenchmarkWithFN])
+            .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 15000 }))
+            .with_genesis_helm_config_fn(Arc::new(|helm_values| {
+                helm_values["chain"]["epoch_duration_secs"] = 300.into();
+            }))
+            .with_success_criteria(SuccessCriteria::new(
+                5500,
+                50000,
+                true,
+                Some(Duration::from_secs(120)),
+                Some(SystemMetricsThreshold::new(
+                    // Check that we don't use more than 12 CPU cores for 30% of the time.
+                    MetricsThreshold::new(12, 30),
+                    // Check that we don't use more than 5 GB of memory for 30% of the time.
+                    MetricsThreshold::new(5 * 1024 * 1024 * 1024, 30),
+                )),
+                Some(StateProgressThreshold {
+                    max_no_progress_secs: 30.0,
+                    max_round_gap: 10,
+                }),
+            )),
         // not scheduled on continuous
         "load_vs_perf_benchmark" => config
             .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
@@ -549,7 +574,7 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_network_tests(vec![&LoadVsPerfBenchmark {
                 test: &PerformanceBenchmarkWithFN,
                 tps: &[
-                    200, 1000, 3000, 5000, 6000, 6300, 6600, 7000, 7500, 8000, 10000, 12000,
+                    200, 1000, 3000, 5000, 7000, 7500, 8000, 9000, 10000, 12000, 15000,
                 ],
             }])
             .with_genesis_helm_config_fn(Arc::new(|helm_values| {

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -7,7 +7,7 @@ use crate::{
     interface::system_metrics::{query_prometheus_system_metrics, SystemMetricsThreshold},
     node::K8sNode,
     prometheus::{self, query_with_metadata},
-    query_sequence_numbers, set_stateful_set_image_tag, uninstall_testnet_resources, ChainInfo,
+    query_sequence_number, set_stateful_set_image_tag, uninstall_testnet_resources, ChainInfo,
     FullNode, Node, Result, Swarm, SwarmChaos, Validator, Version, HAPROXY_SERVICE_SUFFIX,
     REST_API_HAPROXY_SERVICE_PORT, REST_API_SERVICE_PORT,
 };
@@ -64,15 +64,13 @@ impl K8sSwarm {
         let key = load_root_key(root_key);
         let account_key = AccountKey::from_private_key(key);
         let address = aptos_sdk::types::account_config::aptos_test_root_address();
-        let sequence_number = query_sequence_numbers(&client, [address].iter())
-            .await
-            .map_err(|e| {
-                format_err!(
-                    "query_sequence_numbers on {:?} for dd account failed: {}",
-                    client,
-                    e
-                )
-            })?[0];
+        let sequence_number = query_sequence_number(&client, address).await.map_err(|e| {
+            format_err!(
+                "query_sequence_number on {:?} for dd account failed: {}",
+                client,
+                e
+            )
+        })?;
         let root_account = LocalAccount::new(address, account_key, sequence_number);
 
         let mut versions = HashMap::new();

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -31,8 +31,8 @@ use rand::{rngs::StdRng, SeedableRng};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::runtime::Builder;
 
-const WARMUP_DURATION_FRACTION: f32 = 0.05;
-const COOLDOWN_DURATION_FRACTION: f32 = 0.05;
+const WARMUP_DURATION_FRACTION: f32 = 0.07;
+const COOLDOWN_DURATION_FRACTION: f32 = 0.04;
 
 async fn batch_update(
     ctx: &mut NetworkContext<'_>,


### PR DESCRIPTION
Add graceful_overload test to confirm we see high TPS even when we send more txn than the system can handle.
(separate PR for high gas-fee txns going through)

Fix ConstTps txn-emitter to wait enough for transactions to be committed

When we overload the system, individual nodes can start being stale, so in order to check that transaction was definitelly not committed, we need to wait for ledger timestamp to be passed.

So change time waits to be based on ledger timestamp / txn expiration time, instead of relative.

Add some more (sampled) logs to help with future debugging



### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4354)
<!-- Reviewable:end -->
