### PR TITLE
[gas] fix pre-condition for AptosGasMeter::new

### DIFF
--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -162,7 +162,7 @@ impl AptosGasMeter {
     ) -> Self {
         assert!(
             (gas_feature_version == 0 && storage_gas_params.is_none())
-                || storage_gas_params.is_some(),
+                || (gas_feature_version > 0 && storage_gas_params.is_some()),
             "Invalid gas meter configuration"
         );
 


### PR DESCRIPTION
This fixes a pre-condition for `AptosGasMeter::new`. I made a mistake when simplifying the boolean expression. This is a fully compatible change since the only client already enforces the right condition.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4356)
<!-- Reviewable:end -->
