### PR TITLE
[Token] add burn control flag

### DIFF
--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -163,7 +163,8 @@ module aptos_token::property_map {
         simple_map::remove(&mut map.map, key)
     }
 
-    /// update the property in the existing property map
+    /// Update the property in the existing property map
+    /// Allow updating existing Key's value and add new keys
     public fun update_property_map(
         map: &mut PropertyMap,
         keys: vector<String>,
@@ -182,7 +183,11 @@ module aptos_token::property_map {
                 value: *vector::borrow( &values, i),
                 type: *vector::borrow(&types, i),
             };
-            update_property_value(map, vector::borrow(&keys, i), prop_val);
+            if (contains_key(map, vector::borrow(&keys, i))){
+                update_property_value(map, vector::borrow(&keys, i), prop_val);
+            } else {
+                add(map, *vector::borrow(&keys, i), prop_val);
+            };
             i = i + 1;
         }
     }

--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -164,7 +164,7 @@ module aptos_token::property_map {
     }
 
     /// Update the property in the existing property map
-    /// Allow updating existing Key's value and add new keys
+    /// Allow updating existing keys' value and add new key-value pairs
     public fun update_property_map(
         map: &mut PropertyMap,
         keys: vector<String>,

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -30,8 +30,13 @@ module aptos_token::token {
 
     const MAX_COLLECTION_NAME_LENGTH: u64 = 128;
     const MAX_NFT_NAME_LENGTH: u64 = 128;
-    // URI lengths: Mean: 76.97, StdDev: 37.41, 95th%: 157, 99th%: 199 (http://www.supermind.org/blog/740/average-length-of-a-url-part-2)
     const MAX_URI_LENGTH: u64 = 512;
+
+    // Property key stored in default_properties controlling who can burn the token.
+    // the corresponding property value is BCS serialized bool.
+    const BURNABLE_BY_CREATOR: vector<u8> = b"TOKEN_BURNABLE_BY_CREATOR";
+    const BURNABLE_BY_OWNER: vector<u8> = b"TOKEN_BURNABLE_BY_OWNER";
+    const TOKEN_PROPERTY_MUTABLE: vector<u8> = b"TOKEN_PROPERTY_MUTATBLE";
 
     //
     // Errors
@@ -113,6 +118,16 @@ module aptos_token::token {
 
     /// Withdraw proof expires
     const EWITHDRAW_PROOF_EXPIRES: u64 = 29;
+
+    /// Token is not burnable by owner
+    const EOWNER_CANNOT_BURN_TOKEN: u64 = 30;
+
+    /// Token is not burnable by creator
+    const ECREATOR_CANNOT_BURN_TOKEN: u64 = 31;
+
+    /// Reserved fields for token contract
+    /// Cannot be updated by user
+    const ECANNOT_UPDATE_RESERVED_PROPERTY: u64 = 32;
 
     //
     // Core data structures for holding tokens
@@ -377,6 +392,28 @@ module aptos_token::token {
         *opt_in_flag = opt_in;
     }
 
+    /// Allow creator to mutate the default properties in TokenData
+    public fun mutate_tokendata_property(
+        creator: &signer,
+        token_data_id: TokenDataId,
+        keys: vector<String>,
+        values: vector<vector<u8>>,
+        types: vector<String>,
+    ) acquires Collections {
+        let creator_addr = token_data_id.creator;
+        assert!(signer::address_of(creator) == creator_addr, ENO_MUTATE_CAPABILITY);
+        // validate if the properties is mutable
+        assert!(exists<Collections>(creator_addr), ECOLLECTIONS_NOT_PUBLISHED);
+        let all_token_data = &mut borrow_global_mut<Collections>(
+            creator_addr
+        ).token_data;
+
+        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+        let token_data = table::borrow_mut(all_token_data, token_data_id);
+        assert!(token_data.mutability_config.properties, error::permission_denied(EFIELD_NOT_MUTABLE));
+        property_map::update_property_map(&mut token_data.default_properties, keys, values, types);
+    }
+
     public fun  mutate_one_token(
         account: &signer,
         token_owner: address,
@@ -396,7 +433,18 @@ module aptos_token::token {
         assert!(table::contains(all_token_data, token_id.token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
         let token_data = table::borrow_mut(all_token_data, token_id.token_data_id);
 
-        assert!(token_data.mutability_config.properties, EFIELD_NOT_MUTABLE);
+        // if default property is mutatable, token property is alwasy mutable
+        // we only need to check TOKEN_PROPERTY_MUTABLE when default property is immutable
+        if (!token_data.mutability_config.properties) {
+            assert!(
+                property_map::contains_key(&token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE)),
+                error::permission_denied(EFIELD_NOT_MUTABLE)
+            );
+
+            let token_prop_mutable = property_map::read_bool(&token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE));
+            assert!(token_prop_mutable, error::permission_denied(EFIELD_NOT_MUTABLE));
+        };
+
         // check if the property_version is 0 to determine if we need to update the property_version
         if (token_id.property_version == 0) {
             let token = withdraw_with_event_internal(token_owner, token_id, 1);
@@ -477,6 +525,8 @@ module aptos_token::token {
         };
     }
 
+
+
     fun update_token_property_internal(
         token_owner: address,
         token_id: TokenId,
@@ -486,6 +536,7 @@ module aptos_token::token {
     ) acquires TokenStore {
         let tokens = &mut borrow_global_mut<TokenStore>(token_owner).tokens;
         assert!(table::contains(tokens, token_id), error::not_found(ENO_TOKEN_IN_TOKEN_STORE));
+
         let value = &mut table::borrow_mut(tokens, token_id).token_properties;
 
         property_map::update_property_map(value, keys, values, types);
@@ -1013,6 +1064,76 @@ module aptos_token::token {
         );
     }
 
+
+    /// Burn a token by creator when the token's BURNABLE_BY_CREATOR is true
+    /// The token is owned at address owner
+    public entry fun burn_by_creator(
+        creator: &signer,
+        owner: address,
+        collection: String,
+        name: String,
+        property_version: u64,
+        amount: u64,
+    ) acquires Collections, TokenStore {
+        let creator_address = signer::address_of(creator);
+        assert!(amount > 0, error::invalid_argument(ENO_BURN_TOKEN_WITH_ZERO_AMOUNT));
+        let token_id = create_token_id_raw(creator_address, collection, name, property_version);
+        let creator_addr = token_id.token_data_id.creator;
+        assert!(
+            exists<Collections>(creator_addr),
+            error::not_found(ECOLLECTIONS_NOT_PUBLISHED),
+        );
+
+        let collections = borrow_global_mut<Collections>(creator_address);
+        assert!(
+            table::contains(&collections.token_data, token_id.token_data_id),
+            error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
+        );
+
+        let token_data = table::borrow_mut(
+            &mut collections.token_data,
+            token_id.token_data_id,
+        );
+
+        // The property should be explicitly set in the property_map for creator to burn the token
+        assert!(
+            property_map::contains_key(&token_data.default_properties, &string::utf8(BURNABLE_BY_CREATOR)),
+            error::permission_denied(ECREATOR_CANNOT_BURN_TOKEN)
+        );
+
+        let burn_by_creator_flag = property_map::read_bool(&token_data.default_properties, &string::utf8(BURNABLE_BY_CREATOR));
+        assert!(burn_by_creator_flag, error::permission_denied(ECREATOR_CANNOT_BURN_TOKEN));
+
+        // Burn the tokens.
+        let Token { id: _, amount: burned_amount, token_properties: _ } = withdraw_with_event_internal(owner, token_id, amount);
+        let token_store = borrow_global_mut<TokenStore>(owner);
+        event::emit_event<BurnTokenEvent>(
+            &mut token_store.burn_events,
+            BurnTokenEvent { id: token_id, amount: burned_amount},
+        );
+
+        if (token_data.maximum > 0) {
+            token_data.supply = token_data.supply - burned_amount;
+
+            // Delete the token_data if supply drops to 0.
+            if (token_data.supply == 0) {
+                let TokenData{
+                    maximum: _,
+                    largest_property_version: _,
+                    supply: _,
+                    uri: _,
+                    royalty: _,
+                    name: _,
+                    description: _,
+                    default_properties: _,
+                    mutability_config: _,
+                } = table::remove(&mut collections.token_data, token_id.token_data_id);
+            };
+        };
+    }
+
+
+    /// Burn a token by the token owner
     public entry fun burn(
         owner: &signer,
         creators_address: address,
@@ -1034,6 +1155,18 @@ module aptos_token::token {
             table::contains(&collections.token_data, token_id.token_data_id),
             error::not_found(ETOKEN_DATA_NOT_PUBLISHED),
         );
+
+        let token_data = table::borrow_mut(
+            &mut collections.token_data,
+            token_id.token_data_id,
+        );
+
+        assert!(
+            property_map::contains_key(&token_data.default_properties,  &string::utf8(BURNABLE_BY_OWNER)),
+            error::permission_denied(EOWNER_CANNOT_BURN_TOKEN)
+        );
+        let burn_by_owner_flag = property_map::read_bool(&token_data.default_properties, &string::utf8(BURNABLE_BY_OWNER));
+        assert!(burn_by_owner_flag, error::permission_denied(EOWNER_CANNOT_BURN_TOKEN));
 
         // Burn the tokens.
         let Token { id: _, amount: burned_amount, token_properties: _ } = withdraw_token(owner, token_id, amount);
@@ -1181,7 +1314,7 @@ module aptos_token::token {
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
-        let token_id = create_collection_and_token(&creator, 1, 1, 1);
+        let token_id = create_collection_and_token(&creator, 1, 1, 1, vector<String>[], vector<vector<u8>>[], vector<String>[]);
 
         let token = withdraw_token(&creator, token_id, 1);
         deposit_token(&owner, token);
@@ -1194,7 +1327,7 @@ module aptos_token::token {
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
-        let token_id = create_collection_and_token(&creator, 2, 5, 5);
+        let token_id = create_collection_and_token(&creator, 2, 5, 5, vector<String>[], vector<vector<u8>>[], vector<String>[]);
 
         let token_0 = withdraw_token(&creator, token_id, 1);
         let token_1 = withdraw_token(&creator, token_id, 1);
@@ -1209,7 +1342,7 @@ module aptos_token::token {
     public entry fun test_collection_maximum(creator: signer) acquires Collections, TokenStore {
         use std::bcs;
         account::create_account_for_test(signer::address_of(&creator));
-        let token_id = create_collection_and_token(&creator, 2, 2, 1);
+        let token_id = create_collection_and_token(&creator, 2, 2, 1, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         let default_keys = vector<String>[ string::utf8(b"attack"), string::utf8(b"num_of_use") ];
         let default_vals = vector<vector<u8>>[ bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5) ];
         let default_types = vector<String>[ string::utf8(b"u64"), string::utf8(b"u64") ];
@@ -1240,7 +1373,7 @@ module aptos_token::token {
     ) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
         account::create_account_for_test(signer::address_of(&owner));
-        let token_id = create_collection_and_token(&creator, 2, 2, 2);
+        let token_id = create_collection_and_token(&creator, 2, 2, 2, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         direct_transfer(&creator, &owner, token_id, 1);
         let token = withdraw_token(&owner, token_id, 1);
         deposit_token(&creator, token);
@@ -1263,7 +1396,10 @@ module aptos_token::token {
         creator: &signer,
         amount: u64,
         collection_max: u64,
-        token_max: u64
+        token_max: u64,
+        property_keys: vector<String>,
+        property_values: vector<vector<u8>>,
+        property_types: vector<String>,
     ): TokenId acquires Collections, TokenStore {
         use std::string;
         use std::bcs;
@@ -1278,9 +1414,9 @@ module aptos_token::token {
             mutate_setting
         );
 
-        let default_keys = vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")];
-        let default_vals = vector<vector<u8>>[bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5)];
-        let default_types = vector<String>[string::utf8(b"u64"), string::utf8(b"u64")];
+        let default_keys = if(vector::length<String>(&property_keys) == 0) {vector<String>[string::utf8(b"attack"), string::utf8(b"num_of_use")]} else {property_keys};
+        let default_vals = if (vector::length<vector<u8>>(&property_values) == 0) {vector<vector<u8>>[bcs::to_bytes<u64>(&10), bcs::to_bytes<u64>(&5)] } else {property_values};
+        let default_types = if (vector::length<String>(&property_types) == 0) {vector<String>[string::utf8(b"u64"), string::utf8(b"u64")] } else {property_types};
         let mutate_setting = vector<bool>[false, false, false, false, true];
         create_token_script(
             creator,
@@ -1304,7 +1440,7 @@ module aptos_token::token {
     #[test(creator = @0xFF)]
     fun test_create_events_generation(creator: signer) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(&creator));
-        create_collection_and_token(&creator, 1, 2, 1);
+        create_collection_and_token(&creator, 1, 2, 1, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         let collections = borrow_global<Collections>(signer::address_of(&creator));
         assert!(event::counter(&collections.create_collection_events) == 1, 1);
     }
@@ -1313,7 +1449,7 @@ module aptos_token::token {
     fun test_mint_token_from_tokendata(creator: &signer) acquires Collections, TokenStore {
         account::create_account_for_test(signer::address_of(creator));
 
-        create_collection_and_token(creator, 2, 4, 4);
+        create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         let token_data_id = create_token_data_id(
             signer::address_of(creator),
             get_collection_name(),
@@ -1335,7 +1471,7 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(owner));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         assert!(token_id.property_version == 0, 1);
         let new_keys = vector<String>[
             string::utf8(b"attack"), string::utf8(b"num_of_use")
@@ -1400,17 +1536,16 @@ module aptos_token::token {
     }
 
     #[test(creator = @0xAF, owner = @0xBB)]
-    #[expected_failure(abort_code = 393219)]
-    fun test_mutate_token_property_fail(creator: &signer) acquires Collections, TokenStore {
+    fun test_mutate_token_property_upsert(creator: &signer) acquires Collections, TokenStore {
         use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         assert!(token_id.property_version == 0, 1);
         // only be able to mutate the attributed defined when creating the token
         let new_keys = vector<String>[
-            string::utf8(b"attack"), string::utf8(b"num_of_use"), string::utf8(b"wrong_attribute")
+            string::utf8(b"attack"), string::utf8(b"num_of_use"), string::utf8(b"new_attribute")
         ];
         let new_vals = vector<vector<u8>>[
             bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
@@ -1439,7 +1574,7 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         assert!(token_id.property_version == 0, 1);
         // only be able to mutate the attributed defined when creating the token
         let new_keys = vector<String>[
@@ -1478,7 +1613,7 @@ module aptos_token::token {
     fun test_withdraw_with_proof(creator: &signer, framework: &signer): Token acquires TokenStore, Collections {
         timestamp::set_time_has_started_for_testing(framework);
         account::create_account_for_test(signer::address_of(creator));
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
 
         timestamp::update_global_time_for_test(1000000);
 
@@ -1499,21 +1634,38 @@ module aptos_token::token {
         another_creator: &signer,
     )acquires Collections, TokenStore {
         // create limited token and collection
+        use std::bcs;
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(another_creator));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(
+            creator,
+            2,
+            4,
+            4,
+            vector<String>[string::utf8(BURNABLE_BY_CREATOR)],
+            vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
+            vector<String>[string::utf8(b"bool")],
+        );
         // burn token from limited token
         let creator_addr = signer::address_of(creator);
         let pre_amount = &mut get_token_supply(creator_addr, token_id.token_data_id);
-        burn(creator, creator_addr, get_collection_name(), get_token_name(), 0, 1);
+        burn_by_creator(creator, creator_addr, get_collection_name(), get_token_name(), 0, 1);
         let aft_amount = &mut get_token_supply(creator_addr, token_id.token_data_id);
         assert!((option::extract<u64>(pre_amount) - option::extract<u64>(aft_amount)) == 1, 1);
 
         // create unlimited token and collection
         let new_addr = signer::address_of(another_creator);
-        let new_token_id = create_collection_and_token(another_creator, 2, 0, 0);
+        let new_token_id = create_collection_and_token(
+            another_creator,
+            2,
+            0,
+            0,
+            vector<String>[string::utf8(BURNABLE_BY_OWNER)],
+            vector<vector<u8>>[bcs::to_bytes<bool>(&true)],
+            vector<String>[string::utf8(b"bool")],
+        );
         let pre = balance_of(new_addr, new_token_id);
         // burn token from unlimited token and collection
         burn(another_creator, new_addr, get_collection_name(), get_token_name(), 0, 1);
@@ -1529,7 +1681,7 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
         // token owner mutate the token property
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         let owner_addr = signer::address_of(owner);
         opt_in_direct_transfer(owner, true);
         mint_token_to(creator, owner_addr, token_id.token_data_id, 1);
@@ -1545,7 +1697,7 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(creator));
         account::create_account_for_test(signer::address_of(owner));
         // token owner mutate the token property
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         let owner_addr = signer::address_of(owner);
         initialize_token_store(owner);
         transfer(creator, token_id, owner_addr, 1);
@@ -1561,10 +1713,93 @@ module aptos_token::token {
         account::create_account_for_test(signer::address_of(owner));
 
         // token owner mutate the token property
-        let token_id = create_collection_and_token(creator, 2, 4, 4);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         let owner_addr = signer::address_of(owner);
         let token = withdraw_token(creator, token_id, 2);
         initialize_token_store(owner);
         direct_deposit_with_opt_in(owner_addr, token);
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
+        opt_in_direct_transfer(owner, true);
+        initialize_token_store(owner);
+        transfer(creator, token_id, signer::address_of(owner), 2);
+        burn_by_creator(creator, signer::address_of(owner), get_collection_name(), get_token_name(), 0,1);
+
+    }
+
+    #[test(creator=@0xcafe, owner=@0x456)]
+    #[expected_failure(abort_code = 327710)]
+    fun test_burn_token_by_owner_without_burnable_config(
+        creator: &signer,
+        owner: &signer,
+    )acquires Collections, TokenStore {
+        account::create_account_for_test(signer::address_of(creator));
+        account::create_account_for_test(signer::address_of(owner));
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
+
+        opt_in_direct_transfer(owner, true);
+        initialize_token_store(owner);
+        transfer(creator, token_id, signer::address_of(owner), 2);
+
+        burn(owner, signer::address_of(creator), get_collection_name(), get_token_name(), 0,1);
+    }
+
+    #[test(creator=@0xcafe, owner=@0x456)]
+    fun test_burn_token_by_owner_and_creator(
+        creator: &signer,
+        owner: &signer,
+    ) acquires TokenStore, Collections {
+        use std::bcs;
+        account::create_account_for_test(signer::address_of(creator));
+        account::create_account_for_test(signer::address_of(owner));
+        let token_id = create_collection_and_token(
+            creator,
+            2,
+            4,
+            4,
+            vector<String>[string::utf8(BURNABLE_BY_CREATOR), string::utf8(BURNABLE_BY_OWNER)],
+            vector<vector<u8>>[bcs::to_bytes<bool>(&true),  bcs::to_bytes<bool>(&true)],
+            vector<String>[string::utf8(b"bool"), string::utf8(b"bool")],
+        );
+        opt_in_direct_transfer(owner, true);
+        initialize_token_store(owner);
+        transfer(creator, token_id, signer::address_of(owner), 2);
+        burn_by_creator(creator, signer::address_of(owner), get_collection_name(), get_token_name(), 0, 1);
+        burn(owner, signer::address_of(creator), get_collection_name(), get_token_name(), 0,1);
+        assert!(balance_of(signer::address_of(owner), token_id) == 0, 1);
+    }
+
+    #[test(creator=@0xcafe, owner=@0x456)]
+    fun test_mutate_default_token_properties(
+        creator: &signer,
+    ) acquires Collections, TokenStore {
+        use std::bcs;
+        account::create_account_for_test(signer::address_of(creator));
+
+        // token owner mutate the token property
+        let token_id = create_collection_and_token(creator, 2, 4, 4, vector<String>[], vector<vector<u8>>[], vector<String>[]);
+        assert!(token_id.property_version == 0, 1);
+        let new_keys = vector<String>[
+            string::utf8(b"attack"), string::utf8(b"num_of_use")
+        ];
+        let new_vals = vector<vector<u8>>[
+            bcs::to_bytes<u64>(&1), bcs::to_bytes<u64>(&1)
+        ];
+        let new_types = vector<String>[
+            string::utf8(b"u64"), string::utf8(b"u64")
+        ];
+
+        mutate_tokendata_property(
+            creator,
+            token_id.token_data_id,
+            new_keys,
+            new_vals,
+            new_types,
+        );
+
+
+        let all_token_data = &borrow_global<Collections>(signer::address_of(creator)).token_data;
+        assert!(table::contains(all_token_data,  token_id.token_data_id), 1);
+        let props = &table::borrow(all_token_data, token_id.token_data_id).default_properties;
+        assert!(property_map::read_u64(props, &string::utf8(b"attack")) == 1, 1);
     }
 }

--- a/aptos-move/framework/aptos-token/sources/token_coin_swap.move
+++ b/aptos-move/framework/aptos-token/sources/token_coin_swap.move
@@ -295,7 +295,7 @@ module aptos_token::token_coin_swap {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         timestamp::update_global_time_for_test(10000000);
         aptos_framework::account::create_account_for_test(signer::address_of(&token_owner));
-        let token_id = token::create_collection_and_token(&token_owner, 100, 100, 100);
+        let token_id = token::create_collection_and_token(&token_owner, 100, 100, 100, vector<String>[], vector<vector<u8>>[], vector<String>[]);
         aptos_framework::account::create_account_for_test(signer::address_of(&coin_owner));
         token::initialize_token_store(&coin_owner);
         coin::create_fake_money(&coin_owner, &token_owner, 100);

--- a/aptos-move/framework/aptos-token/sources/token_coin_swap.move
+++ b/aptos-move/framework/aptos-token/sources/token_coin_swap.move
@@ -295,7 +295,17 @@ module aptos_token::token_coin_swap {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
         timestamp::update_global_time_for_test(10000000);
         aptos_framework::account::create_account_for_test(signer::address_of(&token_owner));
-        let token_id = token::create_collection_and_token(&token_owner, 100, 100, 100, vector<String>[], vector<vector<u8>>[], vector<String>[]);
+        let token_id = token::create_collection_and_token(
+            &token_owner,
+            100,
+            100,
+            100,
+            vector<String>[],
+            vector<vector<u8>>[],
+            vector<String>[],
+            vector<bool>[false, false, false],
+            vector<bool>[false, false, false, false, false],
+        );
         aptos_framework::account::create_account_for_test(signer::address_of(&coin_owner));
         token::initialize_token_store(&coin_owner);
         coin::create_fake_money(&coin_owner, &token_owner, 100);


### PR DESCRIPTION
### Description

When creator creates NFTs, they can add a control flag in the default properties to indicate if the token is burnable by owner or creator.

These control flags are stored in default property map, which is immutable after token creation. 

The default behavior is the token cannot be burned by either owner or creator unless there is a config.



### Test Plan
added unit test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4358)
<!-- Reviewable:end -->
