### PR TITLE
[telemetry-service] remote log level configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,9 +1223,11 @@ dependencies = [
  "serde_json",
  "state-sync-driver",
  "sysinfo",
+ "thiserror",
  "tokio",
  "tokio-retry",
  "tokio-stream",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -190,7 +190,7 @@ pub fn start(
             .expect("Failed to build rayon global thread _pool.");
     }
 
-    let mut logger_builder = aptos_logger::Logger::new();
+    let mut logger_builder = aptos_logger::Logger::builder();
     logger_builder
         .channel_size(config.logger.chan_size)
         .is_async(config.logger.is_async)

--- a/crates/aptos-logger/Cargo.toml
+++ b/crates/aptos-logger/Cargo.toml
@@ -24,6 +24,7 @@ serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 strum = "0.24.1"
 strum_macros = "0.24.2"
+tokio = { version = "1.21.0", features = ["time"] }
 tracing = "0.1.34"
 tracing-subscriber = "0.3.11"
 

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -4,6 +4,7 @@
 //! Implementation of writing logs to both local printers (e.g. stdout) and remote loggers
 //! (e.g. Logstash)
 
+use crate::info;
 use crate::telemetry_log_writer::{TelemetryLog, TelemetryLogWriter};
 use crate::{
     counters::{
@@ -36,12 +37,14 @@ use strum_macros::EnumString;
 
 const RUST_LOG: &str = "RUST_LOG";
 const RUST_LOG_REMOTE: &str = "RUST_LOG_REMOTE";
-const RUST_LOG_TELEMETRY: &str = "RUST_LOG_TELEMETRY";
+pub const RUST_LOG_TELEMETRY: &str = "RUST_LOG_TELEMETRY";
 const RUST_LOG_FORMAT: &str = "RUST_LOG_FORMAT";
 /// Default size of log write channel, if the channel is full, logs will be dropped
 pub const CHANNEL_SIZE: usize = 10000;
 const NUM_SEND_RETRIES: u8 = 1;
 const FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
+const FILTER_REFRESH_INTERVAL: Duration =
+    Duration::from_secs(15 /* minutes */ * 60 /* seconds */);
 
 #[derive(EnumString)]
 #[strum(serialize_all = "lowercase")]
@@ -313,58 +316,60 @@ impl AptosDataBuilder {
         self.build();
     }
 
-    pub fn build(&mut self) -> Arc<AptosData> {
-        let filter = {
-            let local_filter = {
-                let mut filter_builder = Filter::builder();
+    fn build_filter(&self) -> FilterTuple {
+        let local_filter = {
+            let mut filter_builder = Filter::builder();
 
-                if env::var(RUST_LOG).is_ok() {
+            if env::var(RUST_LOG).is_ok() {
+                filter_builder.with_env(RUST_LOG);
+            } else {
+                filter_builder.filter_level(self.level.into());
+            }
+
+            filter_builder.build()
+        };
+        let remote_filter = {
+            let mut filter_builder = Filter::builder();
+
+            if self.is_async && self.address.is_some() {
+                if env::var(RUST_LOG_REMOTE).is_ok() {
+                    filter_builder.with_env(RUST_LOG_REMOTE);
+                } else if env::var(RUST_LOG).is_ok() {
                     filter_builder.with_env(RUST_LOG);
                 } else {
-                    filter_builder.filter_level(self.level.into());
+                    filter_builder.filter_level(self.remote_level.into());
                 }
-
-                filter_builder.build()
-            };
-            let remote_filter = {
-                let mut filter_builder = Filter::builder();
-
-                if self.is_async && self.address.is_some() {
-                    if env::var(RUST_LOG_REMOTE).is_ok() {
-                        filter_builder.with_env(RUST_LOG_REMOTE);
-                    } else if env::var(RUST_LOG).is_ok() {
-                        filter_builder.with_env(RUST_LOG);
-                    } else {
-                        filter_builder.filter_level(self.remote_level.into());
-                    }
-                } else {
-                    filter_builder.filter_level(LevelFilter::Off);
-                }
-
-                filter_builder.build()
-            };
-            let telemetry_filter = {
-                let mut filter_builder = Filter::builder();
-
-                if self.is_async && self.remote_log_tx.is_some() {
-                    if env::var(RUST_LOG_TELEMETRY).is_ok() {
-                        filter_builder.with_env(RUST_LOG_TELEMETRY);
-                    } else {
-                        filter_builder.filter_level(self.telemetry_level.into());
-                    }
-                } else {
-                    filter_builder.filter_level(LevelFilter::Off);
-                }
-
-                filter_builder.build()
-            };
-
-            FilterTuple {
-                local_filter,
-                remote_filter,
-                telemetry_filter,
+            } else {
+                filter_builder.filter_level(LevelFilter::Off);
             }
+
+            filter_builder.build()
         };
+        let telemetry_filter = {
+            let mut filter_builder = Filter::builder();
+
+            if self.is_async && self.remote_log_tx.is_some() {
+                if env::var(RUST_LOG_TELEMETRY).is_ok() {
+                    filter_builder.with_env(RUST_LOG_TELEMETRY);
+                } else {
+                    filter_builder.filter_level(self.telemetry_level.into());
+                }
+            } else {
+                filter_builder.filter_level(LevelFilter::Off);
+            }
+
+            filter_builder.build()
+        };
+
+        FilterTuple {
+            local_filter,
+            remote_filter,
+            telemetry_filter,
+        }
+    }
+
+    pub fn build(&mut self) -> Arc<AptosData> {
+        let filter = self.build_filter();
 
         if let Ok(log_format) = env::var(RUST_LOG_FORMAT) {
             let log_format = LogFormat::from_str(&log_format).unwrap();
@@ -377,8 +382,8 @@ impl AptosDataBuilder {
         let logger = if self.is_async {
             let (sender, receiver) = sync::mpsc::sync_channel(self.channel_size);
             let mut remote_tx = None;
-            if let Some(tx) = self.remote_log_tx.take() {
-                remote_tx = Some(tx);
+            if let Some(tx) = &self.remote_log_tx {
+                remote_tx = Some(tx.clone());
             }
 
             let logger = Arc::new(AptosData {
@@ -422,7 +427,7 @@ impl AptosDataBuilder {
 }
 
 /// A combination of `Filter`s to control where logs are written
-struct FilterTuple {
+pub struct FilterTuple {
     /// The local printer `Filter` to control what is logged in text output
     local_filter: Filter,
     /// The remote logging `Filter` to control what is sent to external logging
@@ -470,7 +475,11 @@ impl AptosData {
             .build();
     }
 
-    pub fn set_filter(&self, filter: Filter) {
+    pub fn set_filter(&self, filter_tuple: FilterTuple) {
+        *self.filter.write() = filter_tuple;
+    }
+
+    pub fn set_local_filter(&self, filter: Filter) {
         self.filter.write().local_filter = filter;
     }
 
@@ -749,6 +758,37 @@ fn json_format(entry: &LogEntry) -> Result<String, fmt::Error> {
             STRUCT_LOG_PARSE_ERROR_COUNT.inc();
             Err(fmt::Error)
         }
+    }
+}
+
+/// Periodically rebuilds the filter and replaces the current logger filter.
+/// This is useful for dynamically changing log levels at runtime via existing
+/// environment variables such as `RUST_LOG_TELEMETRY`.
+pub struct LoggerFilterUpdater {
+    logger: Arc<AptosData>,
+    logger_builder: AptosDataBuilder,
+}
+
+impl LoggerFilterUpdater {
+    pub fn new(logger: Arc<AptosData>, logger_builder: AptosDataBuilder) -> Self {
+        Self {
+            logger,
+            logger_builder,
+        }
+    }
+
+    pub fn run(self) {
+        thread::spawn(move || {
+            loop {
+                thread::sleep(FILTER_REFRESH_INTERVAL);
+
+                // TODO: check for change to env var before rebuilding filter.
+                let filter = self.logger_builder.build_filter();
+                self.logger.set_filter(filter);
+
+                info!("Logger filters rebuilt and reset.");
+            }
+        });
     }
 }
 

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -368,7 +368,7 @@ impl AptosDataBuilder {
         }
     }
 
-    pub fn build(&mut self) -> Arc<AptosData> {
+    fn build_logger(&mut self) -> Arc<AptosData> {
         let filter = self.build_filter();
 
         if let Ok(log_format) = env::var(RUST_LOG_FORMAT) {
@@ -379,7 +379,7 @@ impl AptosDataBuilder {
             }
         }
 
-        let logger = if self.is_async {
+        if self.is_async {
             let (sender, receiver) = sync::mpsc::sync_channel(self.channel_size);
             let mut remote_tx = None;
             if let Some(tx) = &self.remote_log_tx {
@@ -413,7 +413,11 @@ impl AptosDataBuilder {
                 enable_telemetry_flush: self.enable_telemetry_flush,
                 formatter: self.custom_format.take().unwrap_or(text_format),
             })
-        };
+        }
+    }
+
+    pub fn build(&mut self) -> Arc<AptosData> {
+        let logger = self.build_logger();
 
         let console_port = if cfg!(feature = "aptos-console") {
             self.console_port
@@ -778,17 +782,19 @@ impl LoggerFilterUpdater {
     }
 
     pub fn run(self) {
-        thread::spawn(move || {
-            loop {
-                thread::sleep(FILTER_REFRESH_INTERVAL);
+        thread::spawn(move || loop {
+            thread::sleep(FILTER_REFRESH_INTERVAL);
 
-                // TODO: check for change to env var before rebuilding filter.
-                let filter = self.logger_builder.build_filter();
-                self.logger.set_filter(filter);
+            self.update_filter();
 
-                info!("Logger filters rebuilt and reset.");
-            }
+            info!("Logger filters rebuilt and reset.");
         });
+    }
+
+    fn update_filter(&self) {
+        // TODO: check for change to env var before rebuilding filter.
+        let filter = self.logger_builder.build_filter();
+        self.logger.set_filter(filter);
     }
 }
 
@@ -796,8 +802,11 @@ impl LoggerFilterUpdater {
 mod tests {
     use super::LogEntry;
     use crate::{
-        aptos_logger::json_format, debug, error, info, logger::Logger, trace, warn, Event, Key,
-        KeyValue, Level, Metadata, Schema, Value, Visitor,
+        aptos_logger::{json_format, RUST_LOG_TELEMETRY},
+        debug, error, info,
+        logger::Logger,
+        trace, warn, AptosDataBuilder, Event, Key, KeyValue, Level, LoggerFilterUpdater, Metadata,
+        Schema, Value, Visitor,
     };
     use chrono::{DateTime, Utc};
     #[cfg(test)]
@@ -1011,5 +1020,30 @@ mod tests {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "DisplayStruct!")
         }
+    }
+
+    #[test]
+    fn test_logger_filter_updater() {
+        let mut logger_builder = AptosDataBuilder::new();
+        let logger = logger_builder.build_logger();
+
+        let debug_metadata = &Metadata::new(Level::Debug, "target", "module_path", "source_path");
+
+        assert!(!logger
+            .filter
+            .read()
+            .telemetry_filter
+            .enabled(debug_metadata));
+
+        std::env::set_var(RUST_LOG_TELEMETRY, "debug");
+
+        let updater = LoggerFilterUpdater::new(logger.clone(), logger_builder);
+        updater.update_filter();
+
+        assert!(!logger
+            .filter
+            .read()
+            .telemetry_filter
+            .enabled(debug_metadata));
     }
 }

--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -34,6 +34,7 @@ use std::{
     thread,
 };
 use strum_macros::EnumString;
+use tokio::time;
 
 const RUST_LOG: &str = "RUST_LOG";
 const RUST_LOG_REMOTE: &str = "RUST_LOG_REMOTE";
@@ -44,7 +45,7 @@ pub const CHANNEL_SIZE: usize = 10000;
 const NUM_SEND_RETRIES: u8 = 1;
 const FLUSH_TIMEOUT: Duration = Duration::from_secs(5);
 const FILTER_REFRESH_INTERVAL: Duration =
-    Duration::from_secs(15 /* minutes */ * 60 /* seconds */);
+    Duration::from_secs(5 /* minutes */ * 60 /* seconds */);
 
 #[derive(EnumString)]
 #[strum(serialize_all = "lowercase")]
@@ -781,14 +782,15 @@ impl LoggerFilterUpdater {
         }
     }
 
-    pub fn run(self) {
-        thread::spawn(move || loop {
-            thread::sleep(FILTER_REFRESH_INTERVAL);
+    pub async fn run(self) {
+        let mut interval = time::interval(FILTER_REFRESH_INTERVAL);
+        loop {
+            interval.tick().await;
 
             self.update_filter();
 
             info!("Logger filters rebuilt and reset.");
-        });
+        }
     }
 
     fn update_filter(&self) {

--- a/crates/aptos-logger/src/lib.rs
+++ b/crates/aptos-logger/src/lib.rs
@@ -157,7 +157,9 @@ pub mod tracing_adapter;
 mod security;
 mod struct_log;
 
-pub use crate::aptos_logger::{AptosData as Logger, AptosDataBuilder, Writer, CHANNEL_SIZE};
+pub use crate::aptos_logger::{
+    AptosData as Logger, AptosDataBuilder, LoggerFilterUpdater, Writer, CHANNEL_SIZE,
+};
 pub use event::Event;
 pub use filter::{Filter, LevelFilter};
 pub use logger::flush;

--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -110,7 +110,6 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
         PeerRole::ValidatorFullNode => NodeType::ValidatorFullNode,
         PeerRole::Unknown => context
             .pfn_cache()
-            .read()
             .get(&body.chain_id)
             .map(|peer_set| {
                 if peer_set.contains_key(&body.peer_id) {

--- a/crates/aptos-telemetry-service/src/index.rs
+++ b/crates/aptos-telemetry-service/src/index.rs
@@ -7,7 +7,7 @@ use crate::{
     context::Context,
     custom_event,
     error::ServiceError,
-    log_ingest, prometheus_push_metrics,
+    log_ingest, prometheus_push_metrics, remote_config,
     types::index::IndexResponse,
 };
 use std::convert::Infallible;
@@ -31,7 +31,8 @@ pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Inf
             .or(auth::auth(context.clone()))
             .or(custom_event::custom_event_ingest(context.clone()))
             .or(prometheus_push_metrics::metrics_ingest(context.clone()))
-            .or(log_ingest::log_ingest(context.clone())),
+            .or(log_ingest::log_ingest(context.clone()))
+            .or(remote_config::telemetry_log_env(context.clone())),
     );
 
     let legacy_api = index_legacy(context.clone())

--- a/crates/aptos-telemetry-service/src/remote_config.rs
+++ b/crates/aptos-telemetry-service/src/remote_config.rs
@@ -1,0 +1,85 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::common::NodeType;
+use crate::{auth::with_auth, context::Context, types::auth::Claims};
+use warp::filters::BoxedFilter;
+use warp::{reply, Filter, Rejection, Reply};
+
+pub fn telemetry_log_env(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("config" / "env" / "telemetry-log")
+        .and(warp::get())
+        .and(with_auth(
+            context.clone(),
+            vec![
+                NodeType::Validator,
+                NodeType::ValidatorFullNode,
+                NodeType::PublicFullNode,
+            ],
+        ))
+        .and(context.filter())
+        .and_then(handle_telemetry_log_env)
+        .boxed()
+}
+
+async fn handle_telemetry_log_env(
+    claims: Claims,
+    context: Context,
+) -> Result<impl Reply, Rejection> {
+    let env: Option<String> = context
+        .log_env_map()
+        .get(&claims.chain_id)
+        .and_then(|inner| inner.get(&claims.peer_id))
+        .cloned();
+    Ok(reply::json(&env))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use aptos_config::config::PeerSet;
+    use aptos_types::chain_id::ChainId;
+    use aptos_types::PeerId;
+
+    use crate::jwt_auth::create_jwt_token;
+    use crate::tests::test_context;
+    use crate::types::common::NodeType;
+
+    #[tokio::test]
+    async fn test_handle_telemetry_log_env() {
+        let log_level: String = String::from("debug,hyper=off");
+        let peer_id = PeerId::random();
+        let chain_id = ChainId::default();
+        let epoch = 10;
+        let node_type = NodeType::Validator;
+
+        let mut test_context = test_context::new_test_context().await;
+        test_context
+            .inner
+            .log_env_map_mut()
+            .insert(chain_id, HashMap::from([(peer_id, log_level.clone())]));
+
+        test_context
+            .inner
+            .validator_cache()
+            .write()
+            .insert(chain_id, (epoch, PeerSet::default()));
+
+        let jwt_token = create_jwt_token(
+            test_context.inner.clone(),
+            chain_id,
+            peer_id,
+            node_type,
+            epoch,
+        )
+        .unwrap();
+
+        let value = test_context
+            .with_bearer_auth(jwt_token)
+            .get("/api/v1/config/env/telemetry-log")
+            .await;
+
+        assert_eq!(value, log_level)
+    }
+}

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::clients::humio;
 use crate::GCPBigQueryConfig;
@@ -40,6 +39,7 @@ pub async fn new_test_context() -> TestContext {
         humio_url: "".into(),
         humio_auth_token: "".into(),
         pfn_allowlist: HashMap::new(),
+        log_env_map: HashMap::new(),
     };
     let humio_client = humio::IngestClient::new(
         Url::parse("http://localhost/").unwrap(),
@@ -50,7 +50,6 @@ pub async fn new_test_context() -> TestContext {
         .unwrap();
     let validator_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
     let vfn_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
-    let pfn_cache = Arc::new(aptos_infallible::RwLock::new(HashMap::new()));
 
     TestContext::new(
         config.clone(),
@@ -58,7 +57,8 @@ pub async fn new_test_context() -> TestContext {
             &config,
             validator_cache,
             vfn_cache,
-            pfn_cache,
+            HashMap::new(),
+            config.log_env_map.clone(),
             Some(gcp_bigquery_client),
             None,
             humio_client,

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -60,8 +60,6 @@ impl PeerSetCacheUpdater {
                 Ok(response) => {
                     let (peer_addrs, state) = response.into_parts();
 
-                    println!("peers: {}", peer_addrs);
-
                     let received_chain_id = ChainId::new(state.chain_id);
                     if received_chain_id != *chain_id {
                         error!("Chain Id mismatch: Received in headers: {}. Provided in configuration: {} for {}", received_chain_id, chain_id, url);

--- a/crates/aptos-telemetry/Cargo.toml
+++ b/crates/aptos-telemetry/Cargo.toml
@@ -24,9 +24,11 @@ reqwest = { version = "0.11.10", features = ["json"] }
 serde = { version = "1.0.137", features = ["derive"], default-features = false }
 serde_json = "1.0.81"
 sysinfo = "0.24.2"
+thiserror = "1.0.32"
 tokio = { version = "1.21.0" }
 tokio-retry = "0.3"
 tokio-stream = "0.1.8"
+url = "2.2.2"
 uuid = { version = "1.0.0", features = ["v4", "serde"] }
 
 aptos-api = { path = "../../api" }
@@ -35,7 +37,6 @@ aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-mempool = { path = "../../mempool" }
 aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
-
 aptosdb = { path = "../../storage/aptosdb" }
 consensus = { path = "../../consensus" }
 network = { path = "../../network" }

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -39,4 +39,4 @@ pub(crate) const NODE_SYS_INFO_FREQ_SECS: u64 = 5 * 60; // 5 minutes
 // TODO: consider making this interval configurable
 pub(crate) const PROMETHEUS_PUSH_METRICS_FREQ_SECS: u64 = 15; // 15 seconds
 pub(crate) const CHAIN_ACCESS_CHECK_FREQ_SECS: u64 = 30 * 60; // 30 minutes
-pub(crate) const LOG_ENV_POLL_FREQ_SECS: u64 = 30; // 5 minutes
+pub(crate) const LOG_ENV_POLL_FREQ_SECS: u64 = 5 * 60; // 5 minutes

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -13,6 +13,7 @@ pub(crate) const ENV_APTOS_DISABLE_TELEMETRY_PUSH_EVENTS: &str =
     "APTOS_DISABLE_TELEMETRY_PUSH_EVENTS";
 pub(crate) const ENV_APTOS_DISABLE_PROMETHEUS_NODE_METRICS: &str =
     "APTOS_DISABLE_PROMETHEUS_NODE_METRICS";
+pub(crate) const ENV_APTOS_DISABLE_LOG_ENV_POLLING: &str = "APTOS_DISABLE_LOG_ENV_POLLING";
 
 pub(crate) const ENV_GA_MEASUREMENT_ID: &str = "GA_MEASUREMENT_ID";
 pub(crate) const ENV_GA_API_SECRET: &str = "GA_API_SECRET";
@@ -37,3 +38,5 @@ pub(crate) const NODE_SYS_INFO_FREQ_SECS: u64 = 5 * 60; // 5 minutes
 
 // TODO: consider making this interval configurable
 pub(crate) const PROMETHEUS_PUSH_METRICS_FREQ_SECS: u64 = 15; // 15 seconds
+pub(crate) const CHAIN_ACCESS_CHECK_FREQ_SECS: u64 = 30 * 60; // 30 minutes
+pub(crate) const LOG_ENV_POLL_FREQ_SECS: u64 = 30; // 5 minutes

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -3,13 +3,14 @@
 
 #![forbid(unsafe_code)]
 
-pub mod cli_metrics;
 mod constants;
 mod core_metrics;
 mod metrics;
 mod network_metrics;
 mod sender;
+mod telemetry_log_sender;
+
+pub mod cli_metrics;
 pub mod service;
 pub mod system_information;
-mod telemetry_log_sender;
 pub mod utils;

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -342,6 +342,29 @@ impl TelemetrySender {
             }
         }
     }
+
+    pub(crate) async fn get_telemetry_log_env(&self) -> Option<String> {
+        let response = self
+            .send_authenticated_request(
+                self.client
+                    .get(format!("{}/api/v1/config/env/telemetry-log", self.base_url)),
+            )
+            .await;
+
+        match response {
+            Ok(response) => match error_for_status_with_body(response).await {
+                Ok(response) => response.json::<Option<String>>().await.unwrap_or_default(),
+                Err(e) => {
+                    debug!("Unable to get telemetry log env: {}", e);
+                    None
+                }
+            },
+            Err(e) => {
+                debug!("Unable to check chain access {}", e);
+                None
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -6,6 +6,7 @@
 use aptos_config::config::NodeConfig;
 use aptos_logger::{
     aptos_logger::RUST_LOG_TELEMETRY, prelude::*, telemetry_log_writer::TelemetryLog,
+    LoggerFilterUpdater,
 };
 use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
 use aptos_types::chain_id::ChainId;
@@ -104,6 +105,7 @@ pub fn start_telemetry_service(
     chain_id: ChainId,
     build_info: BTreeMap<String, String>,
     remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
+    logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) -> Option<Runtime> {
     // Don't start the service if telemetry has been disabled
     if telemetry_is_disabled() {
@@ -128,6 +130,7 @@ pub fn start_telemetry_service(
         chain_id,
         build_info,
         remote_log_rx,
+        logger_filter_update_job,
     ));
 
     Some(telemetry_runtime)
@@ -138,6 +141,7 @@ async fn spawn_telemetry_service(
     chain_id: ChainId,
     build_info: BTreeMap<String, String>,
     remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
+    logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) {
     let telemetry_svc_url =
         env::var(ENV_TELEMETRY_SERVICE_URL).unwrap_or_else(|_| TELEMETRY_SERVICE_URL.into());
@@ -176,6 +180,11 @@ async fn spawn_telemetry_service(
     try_spawn_metrics_sender(telemetry_sender.clone());
     try_spawn_custom_event_sender(node_config, telemetry_sender.clone(), chain_id, build_info);
     try_spawn_log_env_poll_task(telemetry_sender);
+
+    // Run the logger filter update job within the telemetry runtime.
+    if let Some(job) = logger_filter_update_job {
+        tokio::spawn(job.run());
+    }
 
     info!("Telemetry service started!");
 }

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -4,10 +4,12 @@
 #![forbid(unsafe_code)]
 
 use aptos_config::config::NodeConfig;
-use aptos_logger::{prelude::*, telemetry_log_writer::TelemetryLog};
+use aptos_logger::{
+    aptos_logger::RUST_LOG_TELEMETRY, prelude::*, telemetry_log_writer::TelemetryLog,
+};
 use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
 use aptos_types::chain_id::ChainId;
-use futures::channel::mpsc;
+use futures::channel::mpsc::{self, Receiver};
 use once_cell::sync::Lazy;
 use rand::Rng;
 use rand_core::OsRng;
@@ -52,35 +54,47 @@ static TELEMETRY_TOKEN: Lazy<String> = Lazy::new(|| {
 });
 
 /// Returns true iff telemetry is disabled
+#[inline]
 fn telemetry_is_disabled() -> bool {
     env::var(ENV_APTOS_DISABLE_TELEMETRY).is_ok()
 }
 
 /// Flag to force enabling/disabling of telemetry
+#[inline]
 fn force_enable_telemetry() -> bool {
     env::var(ENV_APTOS_FORCE_ENABLE_TELEMETRY).is_ok()
 }
 
 /// Flag to control enabling/disabling prometheus push metrics
+#[inline]
 fn enable_prometheus_push_metrics() -> bool {
     force_enable_telemetry()
         || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_TELEMETRY_PUSH_METRICS).is_ok())
 }
 
+#[inline]
 fn enable_prometheus_node_metrics() -> bool {
     env::var(ENV_APTOS_DISABLE_PROMETHEUS_NODE_METRICS).is_err()
 }
 
 /// Flag to control enabling/disabling push logs
+#[inline]
 fn enable_push_logs() -> bool {
     force_enable_telemetry()
         || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_TELEMETRY_PUSH_LOGS).is_ok())
 }
 
 /// Flag to control enabling/disabling telemetry push events
+#[inline]
 fn enable_push_custom_events() -> bool {
     force_enable_telemetry()
         || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_TELEMETRY_PUSH_EVENTS).is_ok())
+}
+
+#[inline]
+fn enable_log_env_polling() -> bool {
+    force_enable_telemetry()
+        || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_LOG_ENV_POLLING).is_ok())
 }
 
 /// Starts the telemetry service and returns the execution runtime.
@@ -132,46 +146,66 @@ async fn spawn_telemetry_service(
 
     if !force_enable_telemetry() && !telemetry_sender.check_chain_access(chain_id).await {
         warn!(
-            "Aptos telemetry is not sent to the telemetry service because the service is not configured for chain ID {}",
-            chain_id
-        );
+                "Aptos telemetry is not sent to the telemetry service because the service is not configured for chain ID {}",
+                chain_id
+            );
         // Spawn the custom event sender to send to GA4 only.
         // This is a temporary workaround while we deprecate and remove GA4 completely.
         let peer_id = fetch_peer_id(&node_config);
-        tokio::spawn(custom_event_sender(
+        let handle = tokio::spawn(custom_event_sender(
             None,
             peer_id,
             chain_id,
-            node_config,
-            build_info,
+            node_config.clone(),
+            build_info.clone(),
         ));
-        return;
-    }
+        info!("Telemetry service for GA4 started!");
 
-    if enable_push_logs() {
-        if let Some(rx) = remote_log_rx {
-            let telemetry_log_sender = TelemetryLogSender::new(telemetry_sender.clone());
-            tokio::spawn(telemetry_log_sender.start(rx));
+        // Check for chain access periodically in case the service is configured later
+        let mut interval = time::interval(Duration::from_secs(CHAIN_ACCESS_CHECK_FREQ_SECS));
+        loop {
+            interval.tick().await;
+            if telemetry_sender.check_chain_access(chain_id).await {
+                handle.abort();
+                break;
+            }
         }
     }
 
-    if enable_prometheus_push_metrics() {
-        if enable_prometheus_node_metrics() {
-            node_resource_metrics::register_node_metrics_collector();
-        }
+    try_spawn_log_sender(telemetry_sender.clone(), remote_log_rx);
+    try_spawn_metrics_sender(telemetry_sender.clone());
+    try_spawn_custom_event_sender(node_config, telemetry_sender.clone(), chain_id, build_info);
+    try_spawn_log_env_poll_task(telemetry_sender);
 
-        let telemetry_sender = telemetry_sender.clone();
+    info!("Telemetry service started!");
+}
+
+fn try_spawn_log_env_poll_task(sender: TelemetrySender) {
+    if enable_log_env_polling() {
         tokio::spawn(async move {
-            // Periodically send ALL prometheus metrics (This replaces the previous core and network metrics implementation)
-            let mut interval =
-                time::interval(Duration::from_secs(PROMETHEUS_PUSH_METRICS_FREQ_SECS));
+            let mut interval = time::interval(Duration::from_secs(LOG_ENV_POLL_FREQ_SECS));
             loop {
                 interval.tick().await;
-                telemetry_sender.try_push_prometheus_metrics().await;
+                if let Some(env) = sender.get_telemetry_log_env().await {
+                    info!(
+                        "Updating {} env variable: previous value: {:?}, new value: {}",
+                        RUST_LOG_TELEMETRY,
+                        env::var(RUST_LOG_TELEMETRY).ok(),
+                        env
+                    );
+                    env::set_var(RUST_LOG_TELEMETRY, env)
+                }
             }
         });
     }
+}
 
+fn try_spawn_custom_event_sender(
+    node_config: NodeConfig,
+    telemetry_sender: TelemetrySender,
+    chain_id: ChainId,
+    build_info: BTreeMap<String, String>,
+) {
     if enable_push_custom_events() {
         // Spawn the custom event sender
         let peer_id = fetch_peer_id(&node_config);
@@ -183,8 +217,36 @@ async fn spawn_telemetry_service(
             build_info,
         ));
     }
+}
 
-    info!("Telemetry service started!");
+fn try_spawn_metrics_sender(telemetry_sender: TelemetrySender) {
+    if enable_prometheus_push_metrics() {
+        if enable_prometheus_node_metrics() {
+            node_resource_metrics::register_node_metrics_collector();
+        }
+
+        tokio::spawn(async move {
+            // Periodically send ALL prometheus metrics (This replaces the previous core and network metrics implementation)
+            let mut interval =
+                time::interval(Duration::from_secs(PROMETHEUS_PUSH_METRICS_FREQ_SECS));
+            loop {
+                interval.tick().await;
+                telemetry_sender.try_push_prometheus_metrics().await;
+            }
+        });
+    }
+}
+
+fn try_spawn_log_sender(
+    telemetry_sender: TelemetrySender,
+    remote_log_rx: Option<Receiver<TelemetryLog>>,
+) {
+    if enable_push_logs() {
+        if let Some(rx) = remote_log_rx {
+            let telemetry_log_sender = TelemetryLogSender::new(telemetry_sender);
+            tokio::spawn(telemetry_log_sender.start(rx));
+        }
+    }
 }
 
 /// Returns the peer id given the node config.

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -171,6 +171,7 @@ async fn spawn_telemetry_service(
             interval.tick().await;
             if telemetry_sender.check_chain_access(chain_id).await {
                 handle.abort();
+                info!("Aptos telemetry service is now configured for Chain ID {}. Starting telemetry service...", chain_id);
                 break;
             }
         }


### PR DESCRIPTION
### Description

This changes introduces the ability to configure `RUST_TELEMETRY_LOG` remotely via the telemetry service. The telemetry crate polls the service periodically and updates the `RUST_TELEMETRY_LOG` to the value sent by the service, if any. A new periodic thread within `aptos_logger` rebuilds log filters, which already uses the aforementioned env variable. The periodicity is set to 5 minutes.

The telemetry service uses a static config mapping chain ID, peer ID to a log level. This will be replaced with a database in the future.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Validated locally, by changing log level in the service.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4367)
<!-- Reviewable:end -->
