### PR TITLE
[framework] prepare for testnet upgrade

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/storage_gas.move
+++ b/aptos-move/framework/aptos-framework/sources/storage_gas.move
@@ -149,7 +149,7 @@ module aptos_framework::storage_gas {
         initialize(aptos_framework);
     }
 
-    public(friend) fun initialize(aptos_framework: &signer) {
+    public fun initialize(aptos_framework: &signer) {
         system_addresses::assert_aptos_framework(aptos_framework);
         assert!(
             !exists<StorageGasConfig>(@aptos_framework),


### PR DESCRIPTION
init_module isn't called on package upgrade even for new modules,  therefore we forever get to expose this initialize method  so that we  can call it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4368)
<!-- Reviewable:end -->
