### PR TITLE
[api/storage] Allow for a configurable max page size up to 10000

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -65,6 +65,14 @@ impl Context {
         }
     }
 
+    pub fn max_transactions_page_size(&self) -> u16 {
+        self.node_config.api.max_transactions_page_size
+    }
+
+    pub fn max_events_page_size(&self) -> u16 {
+        self.node_config.api.max_events_page_size
+    }
+
     pub fn move_resolver(&self) -> Result<StorageAdapterOwned<DbStateView>> {
         self.db
             .latest_state_checkpoint_view()

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -54,7 +54,11 @@ impl EventsApi {
         fail_point_poem("endpoint_get_events_by_event_key")?;
         self.context
             .check_api_output_enabled("Get events by event key", &accept_type)?;
-        let page = Page::new(start.0.map(|v| v.0), limit.0);
+        let page = Page::new(
+            start.0.map(|v| v.0),
+            limit.0,
+            self.context.max_events_page_size(),
+        );
 
         // Ensure that account exists
         let account = Account::new(
@@ -99,7 +103,11 @@ impl EventsApi {
         fail_point_poem("endpoint_get_events_by_event_handle")?;
         self.context
             .check_api_output_enabled("Get events by event handle", &accept_type)?;
-        let page = Page::new(start.0.map(|v| v.0), limit.0);
+        let page = Page::new(
+            start.0.map(|v| v.0),
+            limit.0,
+            self.context.max_events_page_size(),
+        );
         let account = Account::new(self.context.clone(), address.0, None)?;
         let key = account
             .find_event_key(event_handle.0, field_name.0.into())?

--- a/api/src/page.rs
+++ b/api/src/page.rs
@@ -7,18 +7,20 @@ use serde::Deserialize;
 
 const DEFAULT_PAGE_SIZE: u16 = 25;
 
-/// This MAX_PAGE_SIZE must always be smaller than the `aptos_db::MAX_LIMIT` in the DB
-const MAX_PAGE_SIZE: u16 = 1000;
-
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct Page {
     start: Option<u64>,
     limit: Option<u16>,
+    max_page_size: u16,
 }
 
 impl Page {
-    pub fn new(start: Option<u64>, limit: Option<u16>) -> Self {
-        Self { start, limit }
+    pub fn new(start: Option<u64>, limit: Option<u16>, max_page_size: u16) -> Self {
+        Self {
+            start,
+            limit,
+            max_page_size,
+        }
     }
 
     /// Compute the start of the page for transactions
@@ -68,11 +70,11 @@ impl Page {
                 ledger_info,
             ));
         }
-        if limit > MAX_PAGE_SIZE {
+        if limit > self.max_page_size {
             return Err(E::bad_request_with_code(
                 &format!(
                     "Given limit value ({}) is too large, it must be < {}",
-                    limit, MAX_PAGE_SIZE
+                    limit, self.max_page_size
                 ),
                 AptosErrorCode::InvalidInput,
                 ledger_info,

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -129,7 +129,11 @@ impl TransactionsApi {
         fail_point_poem("endpoint_get_transactions")?;
         self.context
             .check_api_output_enabled("Get transactions", &accept_type)?;
-        let page = Page::new(start.0.map(|v| v.0), limit.0);
+        let page = Page::new(
+            start.0.map(|v| v.0),
+            limit.0,
+            self.context.max_transactions_page_size(),
+        );
         self.list(&accept_type, page)
     }
 
@@ -219,7 +223,11 @@ impl TransactionsApi {
         fail_point_poem("endpoint_get_accounts_transactions")?;
         self.context
             .check_api_output_enabled("Get account transactions", &accept_type)?;
-        let page = Page::new(start.0.map(|v| v.0), limit.0);
+        let page = Page::new(
+            start.0.map(|v| v.0),
+            limit.0,
+            self.context.max_transactions_page_size(),
+        );
         self.list_by_account(&accept_type, page, address.0)
     }
 

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -32,11 +32,17 @@ pub struct ApiConfig {
     pub transaction_simulation_enabled: bool,
 
     pub max_submit_transaction_batch_size: usize,
+
+    /// Maximum page size for paginated APIs
+    pub max_transactions_page_size: u16,
+    pub max_events_page_size: u16,
 }
 
 pub const DEFAULT_ADDRESS: &str = "127.0.0.1";
 pub const DEFAULT_PORT: u16 = 8080;
 pub const DEFAULT_REQUEST_CONTENT_LENGTH_LIMIT: u64 = 8 * 1024 * 1024; // 8 MB
+pub const DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE: usize = 100;
+pub const DEFAULT_MAX_PAGE_SIZE: u16 = 1000;
 
 fn default_enabled() -> bool {
     true
@@ -62,7 +68,9 @@ impl Default for ApiConfig {
             encode_submission_enabled: default_enabled(),
             transaction_submission_enabled: default_enabled(),
             transaction_simulation_enabled: default_enabled(),
-            max_submit_transaction_batch_size: 100,
+            max_submit_transaction_batch_size: DEFAULT_MAX_SUBMIT_TRANSACTION_BATCH_SIZE,
+            max_transactions_page_size: DEFAULT_MAX_PAGE_SIZE,
+            max_events_page_size: DEFAULT_MAX_PAGE_SIZE,
         }
     }
 }

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -121,7 +121,7 @@ use storage_interface::{
 pub const LEDGER_DB_NAME: &str = "ledger_db";
 pub const STATE_MERKLE_DB_NAME: &str = "state_merkle_db";
 
-const MAX_LIMIT: u64 = 5000;
+const MAX_LIMIT: u64 = 10000;
 
 // TODO: Either implement an iteration API to allow a very old client to loop through a long history
 // or guarantee that there is always a recent enough waypoint and client knows to boot from there.


### PR DESCRIPTION
### Description
This allows users to change their max page size to make their own choices.  Additionally, it's only 1000 by default.

This is a bugfix, if the transactions are greater than 5000 per block, the API will currently fail.

### Test Plan
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4371)
<!-- Reviewable:end -->
