### PR TITLE
[Genesis][Tests only] Remove unnecessary zeros

### DIFF
--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -977,7 +977,7 @@ pub fn test_mainnet_end_to_end() {
                 validator_commission_percentage: 10,
                 join_during_genesis: true,
             },
-            vesting_schedule_numerators: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 1],
+            vesting_schedule_numerators: vec![3, 3, 3, 3, 1],
             vesting_schedule_denominator: 48,
         },
         EmployeeAccountMap {
@@ -987,7 +987,7 @@ pub fn test_mainnet_end_to_end() {
                 validator_commission_percentage: 10,
                 join_during_genesis: false,
             },
-            vesting_schedule_numerators: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 1],
+            vesting_schedule_numerators: vec![3, 3, 3, 3, 1],
             vesting_schedule_denominator: 48,
         },
     ];

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -298,9 +298,7 @@ async fn create_employee_vesting_accounts_file(
                     validator_commission_percentage: 10,
                     join_during_genesis: join_during_genesis[index],
                 },
-                vesting_schedule_numerators: vec![
-                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 1,
-                ],
+                vesting_schedule_numerators: vec![3, 3, 3, 3, 1],
                 vesting_schedule_denominator: 48,
             }
         })


### PR DESCRIPTION
### Description
Remove unnecessary zeroes in the vesting schedule. Vesting's cliff is protected with the vesting schedule's start time: https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/vesting.move#L442

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4377)
<!-- Reviewable:end -->
