### PR TITLE
smoke-test: longer wait for local swarm to launch

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -249,7 +249,7 @@ impl LocalSwarm {
             validator.start()?;
         }
 
-        self.wait_all_alive(Duration::from_secs(60)).await?;
+        self.wait_all_alive(Duration::from_secs(90)).await?;
         info!("Swarm launched successfully.");
         Ok(())
     }
@@ -265,7 +265,7 @@ impl LocalSwarm {
     }
 
     async fn wait_for_startup(&mut self) -> Result<()> {
-        let num_attempts = 30;
+        let num_attempts = 60;
         let mut done = vec![false; self.validators.len()];
         for i in 0..num_attempts {
             info!("Wait for startup attempt: {} of {}", i, num_attempts);

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -36,6 +36,7 @@ async fn test_db_restore() {
     info!("---------- 1. pre-building finished.");
 
     let mut swarm = new_local_swarm_with_aptos(4).await;
+    info!("---------- 1.1 swarm built, sending some transactions.");
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let client_1 = swarm
         .validator(validator_peer_ids[1])
@@ -47,12 +48,14 @@ async fn test_db_restore() {
     let mut account_0 = create_and_fund_account(&mut swarm, 1000000).await;
     let account_1 = create_and_fund_account(&mut swarm, 1000000).await;
 
+    info!("---------- 1.2 wait for nodes to catch up.");
     // we need to wait for all nodes to see it, as client_1 is different node from the
     // one creating accounts above
     swarm
         .wait_for_all_nodes_to_catchup(Duration::from_secs(MAX_WAIT_SECS))
         .await
         .unwrap();
+    info!("---------- 1.3 caught up.");
 
     assert_balance(&client_1, &account_0, 1000000).await;
     assert_balance(&client_1, &account_1, 1000000).await;


### PR DESCRIPTION
### Description
I'm still seeing all failures in test_db_restore in waiting for the swarm to start.. wish to try to wait longer and see if it passes more

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4388)
<!-- Reviewable:end -->
