### PR TITLE
[gha] test haproxy in forge continuously

### DIFF
--- a/.github/workflows/continuous-e2e-haproxy-test.yaml
+++ b/.github/workflows/continuous-e2e-haproxy-test.yaml
@@ -1,0 +1,21 @@
+name: Continuous E2E HAProxy Test
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 */3 * * *"
+
+jobs:
+  run-forge-haproxy:
+    uses: ./.github/workflows/run-forge.yaml
+    secrets: inherit
+    with:
+      FORGE_NAMESPACE: forge-haproxy
+      FORGE_RUNNER_DURATION_SECS: 600
+      FORGE_ENABLE_HAPROXY: true
+      FORGE_TEST_SUITE: land_blocking
+      POST_TO_SLACK: true


### PR DESCRIPTION
### Description

Run the default `land_blocking` performance test suite in Forge with HAProxy enabled, continuously every 3 hr.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4391)
<!-- Reviewable:end -->
