### PR TITLE
[node-resource-metrics] linux-specific stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6452,7 +6452,9 @@ dependencies = [
  "aptos-infallible",
  "aptos-logger",
  "aptos-metrics-core",
+ "cfg-if 1.0.0",
  "once_cell",
+ "procfs",
  "prometheus",
  "sysinfo",
 ]
@@ -7391,6 +7393,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static 1.4.0",
+ "rustix",
 ]
 
 [[package]]

--- a/crates/node-resource-metrics/Cargo.toml
+++ b/crates/node-resource-metrics/Cargo.toml
@@ -17,3 +17,7 @@ aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
 once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }
 sysinfo = "0.24.2"
+cfg-if = "1.0.0"
+
+[target.'cfg(target_os="linux")'.dependencies]
+procfs = "0.14.1"

--- a/crates/node-resource-metrics/Cargo.toml
+++ b/crates/node-resource-metrics/Cargo.toml
@@ -14,10 +14,11 @@ publish = false
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
+
+cfg-if = "1.0.0"
 once_cell = "1.10.0"
 prometheus = { version = "0.13.0", default-features = false }
 sysinfo = "0.24.2"
-cfg-if = "1.0.0"
 
 [target.'cfg(target_os="linux")'.dependencies]
 procfs = "0.14.1"

--- a/crates/node-resource-metrics/src/collectors/common.rs
+++ b/crates/node-resource-metrics/src/collectors/common.rs
@@ -1,4 +1,64 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Instant;
+
+use aptos_metrics_core::{exponential_buckets, HistogramVec};
+use once_cell::sync::Lazy;
+use prometheus::{
+    core::{self, Collector},
+    histogram_opts,
+    proto::MetricFamily,
+};
+
 pub const NAMESPACE: &str = "node";
+
+pub static LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
+        histogram_opts!(
+            "node_resource_metrics_collect_latency_micros",
+            "Latency to collect each node resource metric category.",
+            exponential_buckets(/*start=*/ 10.0, /*factor=*/ 2.0, /*count=*/ 12,).unwrap(),
+        ),
+        &["collector"],
+    )
+    .unwrap()
+});
+
+/// Collector for collector latency stats
+#[derive(Default)]
+pub(crate) struct CollectorLatencyCollector;
+
+impl Collector for CollectorLatencyCollector {
+    fn desc(&self) -> Vec<&core::Desc> {
+        LATENCY.desc()
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        LATENCY.collect()
+    }
+}
+
+/// Provides ability to measure latency and observe it in an histogram
+pub(crate) struct MeasureLatency {
+    start: Instant,
+    name: String,
+}
+
+impl MeasureLatency {
+    pub fn new(name: String) -> Self {
+        Self {
+            start: Instant::now(),
+            name,
+        }
+    }
+}
+
+impl Drop for MeasureLatency {
+    fn drop(&mut self) {
+        let elapsed = self.start.elapsed().as_micros();
+        LATENCY
+            .with_label_values(&[&self.name])
+            .observe(elapsed as f64);
+    }
+}

--- a/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
@@ -3,7 +3,9 @@
 
 use super::common::NAMESPACE;
 use aptos_infallible::Mutex;
+use aptos_logger::warn;
 use aptos_metrics_core::const_metric::ConstMetric;
+use procfs::KernelStats;
 use prometheus::{
     core::{Collector, Desc, Describer},
     proto::MetricFamily,
@@ -18,6 +20,11 @@ const SYSTEM_CPU_INFO: &str = "system_cpu_info";
 const CPU_ID_LABEL: &str = "cpu_id";
 const CPU_BRAND_LABEL: &str = "brand";
 const CPU_VENDOR_LABEL: &str = "vendor";
+
+const LINUX_SYSTEM_CPU_USAGE: &str = "linux_system_cpu_usage";
+
+const LINUX_CPU_METRICS_COUNT: usize = 10;
+const LINUX_CPU_STATE_LABEL: &str = "state";
 
 /// A Collector for exposing CPU metrics
 pub(crate) struct CpuMetricsCollector {
@@ -111,14 +118,101 @@ impl Collector for CpuMetricsCollector {
     }
 }
 
+pub(crate) struct LinuxCpuMetricsCollector {
+    cpu: Desc,
+}
+
+impl LinuxCpuMetricsCollector {
+    fn new() -> Self {
+        let cpu = Opts::new(LINUX_SYSTEM_CPU_USAGE, "Linux CPU usage.")
+            .namespace(NAMESPACE)
+            .variable_label(LINUX_CPU_STATE_LABEL)
+            .describe()
+            .unwrap();
+
+        Self { cpu }
+    }
+}
+
+impl Default for LinuxCpuMetricsCollector {
+    fn default() -> Self {
+        LinuxCpuMetricsCollector::new()
+    }
+}
+
+impl Collector for LinuxCpuMetricsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.cpu]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        macro_rules! cpu_time_counter {
+            ($METRICS:ident, $FIELD:expr, $LABEL:expr) => {
+                $METRICS.extend(
+                    ConstMetric::new_counter(
+                        self.cpu.clone(),
+                        $FIELD as f64,
+                        Some(&[$LABEL.into()]),
+                    )
+                    .unwrap()
+                    .collect(),
+                );
+            };
+        }
+        macro_rules! cpu_time_counter_opt {
+            ($METRICS:ident, $OPT_FIELD:expr, $LABEL:expr) => {
+                if let Some(field) = $OPT_FIELD {
+                    cpu_time_counter!($METRICS, field, $LABEL);
+                }
+            };
+        }
+
+        let mut mfs = Vec::with_capacity(LINUX_CPU_METRICS_COUNT);
+
+        let kernel_stats = KernelStats::new();
+        if kernel_stats.is_err() {
+            warn!(
+                "unable to collect cpu metrics for linux: {}",
+                kernel_stats.unwrap_err()
+            );
+            return mfs;
+        }
+
+        let kernal_stats = kernel_stats.unwrap();
+        let cpu_time = kernal_stats.total;
+
+        cpu_time_counter!(mfs, cpu_time.user_ms(), "user_ms");
+        cpu_time_counter!(mfs, cpu_time.nice_ms(), "nice_ms");
+        cpu_time_counter!(mfs, cpu_time.system_ms(), "system_ms");
+        cpu_time_counter!(mfs, cpu_time.idle_ms(), "idle_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.iowait_ms(), "iowait_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.irq_ms(), "irq_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.softirq_ms(), "softirq_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.steal_ms(), "steal_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.guest_ms(), "guest_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.guest_nice_ms(), "guest_nice_ms");
+
+        mfs
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::CpuMetricsCollector;
+    use super::{CpuMetricsCollector, LinuxCpuMetricsCollector};
     use prometheus::Registry;
 
     #[test]
     fn test_cpu_collector_register() {
         let collector = CpuMetricsCollector::default();
+
+        let r = Registry::new();
+        let res = r.register(Box::new(collector));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_linux_cpu_collector_register() {
+        let collector = LinuxCpuMetricsCollector::default();
 
         let r = Registry::new();
         let res = r.register(Box::new(collector));

--- a/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
@@ -4,9 +4,7 @@
 use super::common::NAMESPACE;
 use crate::collectors::common::MeasureLatency;
 use aptos_infallible::Mutex;
-use aptos_logger::warn;
 use aptos_metrics_core::const_metric::ConstMetric;
-use procfs::KernelStats;
 use prometheus::{
     core::{Collector, Desc, Describer},
     proto::MetricFamily,
@@ -21,11 +19,6 @@ const SYSTEM_CPU_INFO: &str = "system_cpu_info";
 const CPU_ID_LABEL: &str = "cpu_id";
 const CPU_BRAND_LABEL: &str = "brand";
 const CPU_VENDOR_LABEL: &str = "vendor";
-
-const LINUX_SYSTEM_CPU_USAGE: &str = "linux_system_cpu_usage";
-
-const LINUX_CPU_METRICS_COUNT: usize = 10;
-const LINUX_CPU_STATE_LABEL: &str = "state";
 
 /// A Collector for exposing CPU metrics
 pub(crate) struct CpuMetricsCollector {
@@ -121,104 +114,14 @@ impl Collector for CpuMetricsCollector {
     }
 }
 
-/// A Collector for exposing Linux CPU metrics
-pub(crate) struct LinuxCpuMetricsCollector {
-    cpu: Desc,
-}
-
-impl LinuxCpuMetricsCollector {
-    fn new() -> Self {
-        let cpu = Opts::new(LINUX_SYSTEM_CPU_USAGE, "Linux CPU usage.")
-            .namespace(NAMESPACE)
-            .variable_label(LINUX_CPU_STATE_LABEL)
-            .describe()
-            .unwrap();
-
-        Self { cpu }
-    }
-}
-
-impl Default for LinuxCpuMetricsCollector {
-    fn default() -> Self {
-        LinuxCpuMetricsCollector::new()
-    }
-}
-
-impl Collector for LinuxCpuMetricsCollector {
-    fn desc(&self) -> Vec<&Desc> {
-        vec![&self.cpu]
-    }
-
-    fn collect(&self) -> Vec<MetricFamily> {
-        let _measure = MeasureLatency::new("linux_cpu".into());
-
-        macro_rules! cpu_time_counter {
-            ($METRICS:ident, $FIELD:expr, $LABEL:expr) => {
-                $METRICS.extend(
-                    ConstMetric::new_counter(
-                        self.cpu.clone(),
-                        $FIELD as f64,
-                        Some(&[$LABEL.into()]),
-                    )
-                    .unwrap()
-                    .collect(),
-                );
-            };
-        }
-        macro_rules! cpu_time_counter_opt {
-            ($METRICS:ident, $OPT_FIELD:expr, $LABEL:expr) => {
-                if let Some(field) = $OPT_FIELD {
-                    cpu_time_counter!($METRICS, field, $LABEL);
-                }
-            };
-        }
-
-        let mut mfs = Vec::with_capacity(LINUX_CPU_METRICS_COUNT);
-
-        let kernel_stats = KernelStats::new();
-        if kernel_stats.is_err() {
-            warn!(
-                "unable to collect cpu metrics for linux: {}",
-                kernel_stats.unwrap_err()
-            );
-            return mfs;
-        }
-
-        let kernal_stats = kernel_stats.unwrap();
-        let cpu_time = kernal_stats.total;
-
-        cpu_time_counter!(mfs, cpu_time.user_ms(), "user_ms");
-        cpu_time_counter!(mfs, cpu_time.nice_ms(), "nice_ms");
-        cpu_time_counter!(mfs, cpu_time.system_ms(), "system_ms");
-        cpu_time_counter!(mfs, cpu_time.idle_ms(), "idle_ms");
-        cpu_time_counter_opt!(mfs, cpu_time.iowait_ms(), "iowait_ms");
-        cpu_time_counter_opt!(mfs, cpu_time.irq_ms(), "irq_ms");
-        cpu_time_counter_opt!(mfs, cpu_time.softirq_ms(), "softirq_ms");
-        cpu_time_counter_opt!(mfs, cpu_time.steal_ms(), "steal_ms");
-        cpu_time_counter_opt!(mfs, cpu_time.guest_ms(), "guest_ms");
-        cpu_time_counter_opt!(mfs, cpu_time.guest_nice_ms(), "guest_nice_ms");
-
-        mfs
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{CpuMetricsCollector, LinuxCpuMetricsCollector};
+    use super::CpuMetricsCollector;
     use prometheus::Registry;
 
     #[test]
     fn test_cpu_collector_register() {
         let collector = CpuMetricsCollector::default();
-
-        let r = Registry::new();
-        let res = r.register(Box::new(collector));
-        assert!(res.is_ok());
-    }
-
-    #[test]
-    fn test_linux_cpu_collector_register() {
-        let collector = LinuxCpuMetricsCollector::default();
 
         let r = Registry::new();
         let res = r.register(Box::new(collector));

--- a/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::common::NAMESPACE;
+use crate::collectors::common::MeasureLatency;
 use aptos_infallible::Mutex;
 use aptos_logger::warn;
 use aptos_metrics_core::const_metric::ConstMetric;
@@ -72,6 +73,8 @@ impl Collector for CpuMetricsCollector {
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("cpu".into());
+
         let mut system = self.system.lock();
 
         system.refresh_cpu();
@@ -118,6 +121,7 @@ impl Collector for CpuMetricsCollector {
     }
 }
 
+/// A Collector for exposing Linux CPU metrics
 pub(crate) struct LinuxCpuMetricsCollector {
     cpu: Desc,
 }
@@ -146,6 +150,8 @@ impl Collector for LinuxCpuMetricsCollector {
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("linux_cpu".into());
+
         macro_rules! cpu_time_counter {
             ($METRICS:ident, $FIELD:expr, $LABEL:expr) => {
                 $METRICS.extend(

--- a/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
@@ -25,6 +25,8 @@ const FILE_SYSTEM_LABEL: &str = "file_system";
 
 const LINUX_DISK_SUBSYSTEM: &str = "linux_disk";
 
+/// The following are the fields as reported by `/proc/diskstats` in Linux.
+/// More details on each of these fields are here: https://www.kernel.org/doc/Documentation/iostats.txt
 const LINUX_NUM_READS: &str = "num_reads";
 const LINUX_NUM_MERGED_READS: &str = "num_merged_reads";
 const LINUX_NUM_SECTORS_READ: &str = "num_sectors_read";
@@ -158,16 +160,43 @@ impl LinuxDiskMetricsCollector {
         }
 
         Self {
-            num_reads: disk_desc!(LINUX_NUM_READS, "Number of reads"),
-            num_merged_reads: disk_desc!(LINUX_NUM_MERGED_READS, "Number of merged reads"),
-            num_sectors_read: disk_desc!(LINUX_NUM_SECTORS_READ, "Number of sectors read"),
-            time_reading_ms: disk_desc!(LINUX_TIME_READING_MS, "Time spent reading in ms"),
-            num_writes: disk_desc!(LINUX_NUM_WRITES, "Number of writes"),
-            num_merged_writes: disk_desc!(LINUX_NUM_MERGED_WRITES, "Number of merged writes"),
-            num_sectors_written: disk_desc!(LINUX_NUM_SECTORS_WRITTEN, "Number of sectors written"),
-            time_writing_ms: disk_desc!(LINUX_TIME_WRITING_MS, "Time spent writing in ms"),
-            io_in_progress: disk_desc!(LINUX_PROGRESS_IO, "Number of IO in progress"),
-            total_io_time_ms: disk_desc!(LINUX_TOTAL_IO_TIME_MS, "Total IO time in ms"),
+            num_reads: disk_desc!(
+                LINUX_NUM_READS,
+                "Total number of reads completed successfully"
+            ),
+            num_merged_reads: disk_desc!(
+                LINUX_NUM_MERGED_READS,
+                "Total number of adjacent merged reads"
+            ),
+            num_sectors_read: disk_desc!(
+                LINUX_NUM_SECTORS_READ,
+                "Total number of sectors read successfully"
+            ),
+            time_reading_ms: disk_desc!(
+                LINUX_TIME_READING_MS,
+                "Total number of milliseconds spent by all reads "
+            ),
+            num_writes: disk_desc!(
+                LINUX_NUM_WRITES,
+                "Total number of writes completed successfully"
+            ),
+            num_merged_writes: disk_desc!(
+                LINUX_NUM_MERGED_WRITES,
+                "Total number of adjacent merged writes"
+            ),
+            num_sectors_written: disk_desc!(
+                LINUX_NUM_SECTORS_WRITTEN,
+                "Total number of sectors written successfully"
+            ),
+            time_writing_ms: disk_desc!(
+                LINUX_TIME_WRITING_MS,
+                "Total number of milliseconds spend by all writes"
+            ),
+            io_in_progress: disk_desc!(LINUX_PROGRESS_IO, "Number of IOs in progress"),
+            total_io_time_ms: disk_desc!(
+                LINUX_TOTAL_IO_TIME_MS,
+                "Total number of milliseconds spent in IO"
+            ),
         }
     }
 }

--- a/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
@@ -4,7 +4,6 @@
 use super::common::NAMESPACE;
 use crate::collectors::common::MeasureLatency;
 use aptos_infallible::Mutex;
-use aptos_logger::warn;
 use aptos_metrics_core::const_metric::ConstMetric;
 use prometheus::{
     core::{Collector, Desc, Describer},
@@ -22,21 +21,6 @@ const AVAILABLE_SPACE: &str = "available_space";
 const NAME_LABEL: &str = "name";
 const TYPE_LABEL: &str = "type";
 const FILE_SYSTEM_LABEL: &str = "file_system";
-
-const LINUX_DISK_SUBSYSTEM: &str = "linux_disk";
-
-/// The following are the fields as reported by `/proc/diskstats` in Linux.
-/// More details on each of these fields are here: https://www.kernel.org/doc/Documentation/iostats.txt
-const LINUX_NUM_READS: &str = "num_reads";
-const LINUX_NUM_MERGED_READS: &str = "num_merged_reads";
-const LINUX_NUM_SECTORS_READ: &str = "num_sectors_read";
-const LINUX_TIME_READING_MS: &str = "time_reading_ms";
-const LINUX_NUM_WRITES: &str = "num_writes";
-const LINUX_NUM_MERGED_WRITES: &str = "num_merged_writes";
-const LINUX_NUM_SECTORS_WRITTEN: &str = "num_sectors_written";
-const LINUX_TIME_WRITING_MS: &str = "time_writing_ms";
-const LINUX_PROGRESS_IO: &str = "io_in_progress";
-const LINUX_TOTAL_IO_TIME_MS: &str = "total_io_time_ms";
 
 /// A Collector for exposing Disk metrics
 pub(crate) struct DiskMetricsCollector {
@@ -132,167 +116,14 @@ impl Collector for DiskMetricsCollector {
     }
 }
 
-/// A Collector for exposing Linux Disk stats as metrics
-pub(crate) struct LinuxDiskMetricsCollector {
-    num_reads: Desc,
-    num_merged_reads: Desc,
-    num_sectors_read: Desc,
-    time_reading_ms: Desc,
-    num_writes: Desc,
-    num_merged_writes: Desc,
-    num_sectors_written: Desc,
-    time_writing_ms: Desc,
-    io_in_progress: Desc,
-    total_io_time_ms: Desc,
-}
-
-impl LinuxDiskMetricsCollector {
-    fn new() -> Self {
-        macro_rules! disk_desc {
-            ($NAME:ident, $HELP:expr) => {
-                Opts::new($NAME, $HELP)
-                    .namespace(NAMESPACE)
-                    .subsystem(LINUX_DISK_SUBSYSTEM)
-                    .variable_labels(vec![NAME_LABEL.into()])
-                    .describe()
-                    .unwrap()
-            };
-        }
-
-        Self {
-            num_reads: disk_desc!(
-                LINUX_NUM_READS,
-                "Total number of reads completed successfully"
-            ),
-            num_merged_reads: disk_desc!(
-                LINUX_NUM_MERGED_READS,
-                "Total number of adjacent merged reads"
-            ),
-            num_sectors_read: disk_desc!(
-                LINUX_NUM_SECTORS_READ,
-                "Total number of sectors read successfully"
-            ),
-            time_reading_ms: disk_desc!(
-                LINUX_TIME_READING_MS,
-                "Total number of milliseconds spent by all reads "
-            ),
-            num_writes: disk_desc!(
-                LINUX_NUM_WRITES,
-                "Total number of writes completed successfully"
-            ),
-            num_merged_writes: disk_desc!(
-                LINUX_NUM_MERGED_WRITES,
-                "Total number of adjacent merged writes"
-            ),
-            num_sectors_written: disk_desc!(
-                LINUX_NUM_SECTORS_WRITTEN,
-                "Total number of sectors written successfully"
-            ),
-            time_writing_ms: disk_desc!(
-                LINUX_TIME_WRITING_MS,
-                "Total number of milliseconds spend by all writes"
-            ),
-            io_in_progress: disk_desc!(LINUX_PROGRESS_IO, "Number of IOs in progress"),
-            total_io_time_ms: disk_desc!(
-                LINUX_TOTAL_IO_TIME_MS,
-                "Total number of milliseconds spent in IO"
-            ),
-        }
-    }
-}
-
-impl Default for LinuxDiskMetricsCollector {
-    fn default() -> Self {
-        LinuxDiskMetricsCollector::new()
-    }
-}
-
-impl Collector for LinuxDiskMetricsCollector {
-    fn desc(&self) -> Vec<&Desc> {
-        vec![
-            &self.num_reads,
-            &self.num_merged_reads,
-            &self.num_sectors_read,
-            &self.time_reading_ms,
-            &self.num_writes,
-            &self.num_merged_writes,
-            &self.num_sectors_written,
-            &self.time_writing_ms,
-            &self.io_in_progress,
-            &self.total_io_time_ms,
-        ]
-    }
-
-    fn collect(&self) -> Vec<MetricFamily> {
-        let _measure = MeasureLatency::new("linux_disk".into());
-
-        macro_rules! disk_stats_counter {
-            ($METRICS:ident, $DESC:ident, $FIELD:expr, $LABELS:expr) => {
-                $METRICS.extend(
-                    ConstMetric::new_counter(self.$DESC.clone(), $FIELD as f64, Some($LABELS))
-                        .unwrap()
-                        .collect(),
-                );
-            };
-        }
-        macro_rules! disk_stats_guage {
-            ($METRICS:ident, $DESC:ident, $FIELD:expr, $LABELS:expr) => {
-                $METRICS.extend(
-                    ConstMetric::new_gauge(self.$DESC.clone(), $FIELD as f64, Some($LABELS))
-                        .unwrap()
-                        .collect(),
-                );
-            };
-        }
-
-        let mut mfs = Vec::new();
-
-        let disk_stats = match procfs::diskstats() {
-            Ok(disk_stats) => disk_stats,
-            Err(err) => {
-                warn!("unable to collect disk metrics for linux: {}", err);
-                return mfs;
-            }
-        };
-
-        disk_stats
-            .into_iter()
-            .filter(|disk_stat| disk_stat.name.starts_with("sd"))
-            .for_each(|disk_stat| {
-                let labels = &[disk_stat.name.clone()];
-                disk_stats_counter!(mfs, num_reads, disk_stat.reads, labels);
-                disk_stats_counter!(mfs, num_merged_reads, disk_stat.merged, labels);
-                disk_stats_counter!(mfs, num_sectors_read, disk_stat.sectors_read, labels);
-                disk_stats_counter!(mfs, time_reading_ms, disk_stat.time_reading, labels);
-                disk_stats_counter!(mfs, num_writes, disk_stat.writes, labels);
-                disk_stats_counter!(mfs, num_merged_writes, disk_stat.writes_merged, labels);
-                disk_stats_counter!(mfs, num_sectors_written, disk_stat.sectors_written, labels);
-                disk_stats_counter!(mfs, time_writing_ms, disk_stat.time_writing, labels);
-                disk_stats_guage!(mfs, io_in_progress, disk_stat.in_progress, labels);
-                disk_stats_counter!(mfs, total_io_time_ms, disk_stat.time_in_progress, labels);
-            });
-
-        mfs
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{DiskMetricsCollector, LinuxDiskMetricsCollector};
+    use super::DiskMetricsCollector;
     use prometheus::Registry;
 
     #[test]
     fn test_disk_collector_register() {
         let collector = DiskMetricsCollector::default();
-
-        let r = Registry::new();
-        let res = r.register(Box::new(collector));
-        assert!(res.is_ok());
-    }
-
-    #[test]
-    fn test_linux_disk_collector_register() {
-        let collector = LinuxDiskMetricsCollector::default();
 
         let r = Registry::new();
         let res = r.register(Box::new(collector));

--- a/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
@@ -3,13 +3,15 @@
 
 use super::common::NAMESPACE;
 use aptos_infallible::Mutex;
+use aptos_logger::warn;
 use aptos_metrics_core::const_metric::ConstMetric;
+use procfs::DiskStat;
 use prometheus::{
     core::{Collector, Desc, Describer},
     proto::MetricFamily,
     Opts,
 };
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 use sysinfo::{DiskExt, RefreshKind, System, SystemExt};
 
 const DISK_SUBSYSTEM: &str = "disk";
@@ -20,6 +22,19 @@ const AVAILABLE_SPACE: &str = "available_space";
 const NAME_LABEL: &str = "name";
 const TYPE_LABEL: &str = "type";
 const FILE_SYSTEM_LABEL: &str = "file_system";
+
+const LINUX_DISK_SUBSYSTEM: &str = "linux_disk";
+
+const LINUX_NUM_READS: &str = "num_reads";
+const LINUX_NUM_MERGED_READS: &str = "num_merged_reads";
+const LINUX_NUM_SECTORS_READ: &str = "num_sectors_read";
+const LINUX_TIME_READING_MS: &str = "time_reading_ms";
+const LINUX_NUM_WRITES: &str = "num_writes";
+const LINUX_NUM_MERGED_WRITES: &str = "num_merged_writes";
+const LINUX_NUM_SECTORS_WRITTEN: &str = "num_sectors_written";
+const LINUX_TIME_WRITING_MS: &str = "time_writing_ms";
+const LINUX_PROGRESS_IO: &str = "io_in_progress";
+const LINUX_TOTAL_IO_TIME_MS: &str = "total_io_time_ms";
 
 /// A Collector for exposing Disk metrics
 pub(crate) struct DiskMetricsCollector {
@@ -113,14 +128,137 @@ impl Collector for DiskMetricsCollector {
     }
 }
 
+pub(crate) struct LinuxDiskMetricsCollector {
+    num_reads: Desc,
+    num_merged_reads: Desc,
+    num_sectors_read: Desc,
+    time_reading_ms: Desc,
+    num_writes: Desc,
+    num_merged_writes: Desc,
+    num_sectors_written: Desc,
+    time_writing_ms: Desc,
+    io_in_progress: Desc,
+    total_io_time_ms: Desc,
+}
+
+impl LinuxDiskMetricsCollector {
+    fn new() -> Self {
+        macro_rules! disk_desc {
+            ($NAME:ident, $HELP:expr) => {
+                Opts::new($NAME, $HELP)
+                    .namespace(NAMESPACE)
+                    .subsystem(LINUX_DISK_SUBSYSTEM)
+                    .variable_labels(vec![NAME_LABEL.into()])
+                    .describe()
+                    .unwrap()
+            };
+        }
+
+        Self {
+            num_reads: disk_desc!(LINUX_NUM_READS, "Number of reads"),
+            num_merged_reads: disk_desc!(LINUX_NUM_MERGED_READS, "Number of merged reads"),
+            num_sectors_read: disk_desc!(LINUX_NUM_SECTORS_READ, "Number of sectors read"),
+            time_reading_ms: disk_desc!(LINUX_TIME_READING_MS, "Time spent reading in ms"),
+            num_writes: disk_desc!(LINUX_NUM_WRITES, "Number of writes"),
+            num_merged_writes: disk_desc!(LINUX_NUM_MERGED_WRITES, "Number of merged writes"),
+            num_sectors_written: disk_desc!(LINUX_NUM_SECTORS_WRITTEN, "Number of sectors written"),
+            time_writing_ms: disk_desc!(LINUX_TIME_WRITING_MS, "Time spent writing in ms"),
+            io_in_progress: disk_desc!(LINUX_PROGRESS_IO, "Number of IO in progress"),
+            total_io_time_ms: disk_desc!(LINUX_TOTAL_IO_TIME_MS, "Total IO time in ms"),
+        }
+    }
+}
+
+impl Default for LinuxDiskMetricsCollector {
+    fn default() -> Self {
+        LinuxDiskMetricsCollector::new()
+    }
+}
+
+impl Collector for LinuxDiskMetricsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![
+            &self.num_reads,
+            &self.num_merged_reads,
+            &self.num_sectors_read,
+            &self.time_reading_ms,
+            &self.num_writes,
+            &self.num_merged_writes,
+            &self.num_sectors_written,
+            &self.time_writing_ms,
+            &self.io_in_progress,
+            &self.total_io_time_ms,
+        ]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        macro_rules! disk_stats_counter {
+            ($METRICS:ident, $DESC:ident, $FIELD:expr, $LABELS:expr) => {
+                $METRICS.extend(
+                    ConstMetric::new_counter(self.$DESC.clone(), $FIELD as f64, Some($LABELS))
+                        .unwrap()
+                        .collect(),
+                );
+            };
+        }
+        macro_rules! disk_stats_guage {
+            ($METRICS:ident, $DESC:ident, $FIELD:expr, $LABELS:expr) => {
+                $METRICS.extend(
+                    ConstMetric::new_gauge(self.$DESC.clone(), $FIELD as f64, Some($LABELS))
+                        .unwrap()
+                        .collect(),
+                );
+            };
+        }
+
+        let mut mfs = Vec::new();
+
+        let disk_stats = match procfs::diskstats() {
+            Ok(disk_stats) => disk_stats,
+            Err(err) => {
+                warn!("unable to collect disk metrics for linux: {}", err);
+                return mfs;
+            }
+        };
+
+        disk_stats
+            .into_iter()
+            .filter(|disk_stat| disk_stat.name.starts_with("sd"))
+            .for_each(|disk_stat| {
+                let labels = &[disk_stat.name.clone()];
+                disk_stats_counter!(mfs, num_reads, disk_stat.reads, labels);
+                disk_stats_counter!(mfs, num_merged_reads, disk_stat.merged, labels);
+                disk_stats_counter!(mfs, num_sectors_read, disk_stat.sectors_read, labels);
+                disk_stats_counter!(mfs, time_reading_ms, disk_stat.time_reading, labels);
+                disk_stats_counter!(mfs, num_writes, disk_stat.writes, labels);
+                disk_stats_counter!(mfs, num_merged_writes, disk_stat.writes_merged, labels);
+                disk_stats_counter!(mfs, num_sectors_written, disk_stat.sectors_written, labels);
+                disk_stats_counter!(mfs, time_writing_ms, disk_stat.time_writing, labels);
+                disk_stats_guage!(mfs, io_in_progress, disk_stat.in_progress, labels);
+                disk_stats_counter!(mfs, total_io_time_ms, disk_stat.time_in_progress, labels);
+            });
+
+        mfs
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::DiskMetricsCollector;
+    use super::{DiskMetricsCollector, LinuxDiskMetricsCollector};
     use prometheus::Registry;
 
     #[test]
     fn test_disk_collector_register() {
         let collector = DiskMetricsCollector::default();
+
+        let r = Registry::new();
+        let res = r.register(Box::new(collector));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_linux_disk_collector_register() {
+        let collector = LinuxDiskMetricsCollector::default();
 
         let r = Registry::new();
         let res = r.register(Box::new(collector));

--- a/crates/node-resource-metrics/src/collectors/linux_collectors.rs
+++ b/crates/node-resource-metrics/src/collectors/linux_collectors.rs
@@ -1,0 +1,283 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_logger::warn;
+use aptos_metrics_core::const_metric::ConstMetric;
+use procfs::KernelStats;
+use prometheus::{
+    core::{Collector, Desc, Describer},
+    proto::MetricFamily,
+    Opts,
+};
+
+use crate::collectors::common::MeasureLatency;
+
+use super::common::NAMESPACE;
+
+const LINUX_SYSTEM_CPU_USAGE: &str = "linux_system_cpu_usage";
+const LINUX_CPU_METRICS_COUNT: usize = 10;
+const LINUX_CPU_STATE_LABEL: &str = "state";
+
+const LINUX_DISK_SUBSYSTEM: &str = "linux_disk";
+const NAME_LABEL: &str = "name";
+/// The following are the fields as reported by `/proc/diskstats` in Linux.
+/// More details on each of these fields are here: https://www.kernel.org/doc/Documentation/iostats.txt
+const LINUX_NUM_READS: &str = "num_reads";
+const LINUX_NUM_MERGED_READS: &str = "num_merged_reads";
+const LINUX_NUM_SECTORS_READ: &str = "num_sectors_read";
+const LINUX_TIME_READING_MS: &str = "time_reading_ms";
+const LINUX_NUM_WRITES: &str = "num_writes";
+const LINUX_NUM_MERGED_WRITES: &str = "num_merged_writes";
+const LINUX_NUM_SECTORS_WRITTEN: &str = "num_sectors_written";
+const LINUX_TIME_WRITING_MS: &str = "time_writing_ms";
+const LINUX_PROGRESS_IO: &str = "io_in_progress";
+const LINUX_TOTAL_IO_TIME_MS: &str = "total_io_time_ms";
+
+/// A Collector for exposing Linux CPU metrics
+pub(crate) struct LinuxCpuMetricsCollector {
+    cpu: Desc,
+}
+
+impl LinuxCpuMetricsCollector {
+    fn new() -> Self {
+        let cpu = Opts::new(LINUX_SYSTEM_CPU_USAGE, "Linux CPU usage.")
+            .namespace(NAMESPACE)
+            .variable_label(LINUX_CPU_STATE_LABEL)
+            .describe()
+            .unwrap();
+
+        Self { cpu }
+    }
+}
+
+impl Default for LinuxCpuMetricsCollector {
+    fn default() -> Self {
+        LinuxCpuMetricsCollector::new()
+    }
+}
+
+impl Collector for LinuxCpuMetricsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.cpu]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("linux_cpu".into());
+
+        macro_rules! cpu_time_counter {
+            ($METRICS:ident, $FIELD:expr, $LABEL:expr) => {
+                $METRICS.extend(
+                    ConstMetric::new_counter(
+                        self.cpu.clone(),
+                        $FIELD as f64,
+                        Some(&[$LABEL.into()]),
+                    )
+                    .unwrap()
+                    .collect(),
+                );
+            };
+        }
+        macro_rules! cpu_time_counter_opt {
+            ($METRICS:ident, $OPT_FIELD:expr, $LABEL:expr) => {
+                if let Some(field) = $OPT_FIELD {
+                    cpu_time_counter!($METRICS, field, $LABEL);
+                }
+            };
+        }
+
+        let mut mfs = Vec::with_capacity(LINUX_CPU_METRICS_COUNT);
+
+        let kernel_stats = KernelStats::new();
+        if kernel_stats.is_err() {
+            warn!(
+                "unable to collect cpu metrics for linux: {}",
+                kernel_stats.unwrap_err()
+            );
+            return mfs;
+        }
+
+        let kernal_stats = kernel_stats.unwrap();
+        let cpu_time = kernal_stats.total;
+
+        cpu_time_counter!(mfs, cpu_time.user_ms(), "user_ms");
+        cpu_time_counter!(mfs, cpu_time.nice_ms(), "nice_ms");
+        cpu_time_counter!(mfs, cpu_time.system_ms(), "system_ms");
+        cpu_time_counter!(mfs, cpu_time.idle_ms(), "idle_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.iowait_ms(), "iowait_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.irq_ms(), "irq_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.softirq_ms(), "softirq_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.steal_ms(), "steal_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.guest_ms(), "guest_ms");
+        cpu_time_counter_opt!(mfs, cpu_time.guest_nice_ms(), "guest_nice_ms");
+
+        mfs
+    }
+}
+
+/// A Collector for exposing Linux Disk stats as metrics
+pub(crate) struct LinuxDiskMetricsCollector {
+    num_reads: Desc,
+    num_merged_reads: Desc,
+    num_sectors_read: Desc,
+    time_reading_ms: Desc,
+    num_writes: Desc,
+    num_merged_writes: Desc,
+    num_sectors_written: Desc,
+    time_writing_ms: Desc,
+    io_in_progress: Desc,
+    total_io_time_ms: Desc,
+}
+
+impl LinuxDiskMetricsCollector {
+    fn new() -> Self {
+        macro_rules! disk_desc {
+            ($NAME:ident, $HELP:expr) => {
+                Opts::new($NAME, $HELP)
+                    .namespace(NAMESPACE)
+                    .subsystem(LINUX_DISK_SUBSYSTEM)
+                    .variable_labels(vec![NAME_LABEL.into()])
+                    .describe()
+                    .unwrap()
+            };
+        }
+
+        Self {
+            num_reads: disk_desc!(
+                LINUX_NUM_READS,
+                "Total number of reads completed successfully"
+            ),
+            num_merged_reads: disk_desc!(
+                LINUX_NUM_MERGED_READS,
+                "Total number of adjacent merged reads"
+            ),
+            num_sectors_read: disk_desc!(
+                LINUX_NUM_SECTORS_READ,
+                "Total number of sectors read successfully"
+            ),
+            time_reading_ms: disk_desc!(
+                LINUX_TIME_READING_MS,
+                "Total number of milliseconds spent by all reads "
+            ),
+            num_writes: disk_desc!(
+                LINUX_NUM_WRITES,
+                "Total number of writes completed successfully"
+            ),
+            num_merged_writes: disk_desc!(
+                LINUX_NUM_MERGED_WRITES,
+                "Total number of adjacent merged writes"
+            ),
+            num_sectors_written: disk_desc!(
+                LINUX_NUM_SECTORS_WRITTEN,
+                "Total number of sectors written successfully"
+            ),
+            time_writing_ms: disk_desc!(
+                LINUX_TIME_WRITING_MS,
+                "Total number of milliseconds spend by all writes"
+            ),
+            io_in_progress: disk_desc!(LINUX_PROGRESS_IO, "Number of IOs in progress"),
+            total_io_time_ms: disk_desc!(
+                LINUX_TOTAL_IO_TIME_MS,
+                "Total number of milliseconds spent in IO"
+            ),
+        }
+    }
+}
+
+impl Default for LinuxDiskMetricsCollector {
+    fn default() -> Self {
+        LinuxDiskMetricsCollector::new()
+    }
+}
+
+impl Collector for LinuxDiskMetricsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![
+            &self.num_reads,
+            &self.num_merged_reads,
+            &self.num_sectors_read,
+            &self.time_reading_ms,
+            &self.num_writes,
+            &self.num_merged_writes,
+            &self.num_sectors_written,
+            &self.time_writing_ms,
+            &self.io_in_progress,
+            &self.total_io_time_ms,
+        ]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("linux_disk".into());
+
+        macro_rules! disk_stats_counter {
+            ($METRICS:ident, $DESC:ident, $FIELD:expr, $LABELS:expr) => {
+                $METRICS.extend(
+                    ConstMetric::new_counter(self.$DESC.clone(), $FIELD as f64, Some($LABELS))
+                        .unwrap()
+                        .collect(),
+                );
+            };
+        }
+        macro_rules! disk_stats_guage {
+            ($METRICS:ident, $DESC:ident, $FIELD:expr, $LABELS:expr) => {
+                $METRICS.extend(
+                    ConstMetric::new_gauge(self.$DESC.clone(), $FIELD as f64, Some($LABELS))
+                        .unwrap()
+                        .collect(),
+                );
+            };
+        }
+
+        let mut mfs = Vec::new();
+
+        let disk_stats = match procfs::diskstats() {
+            Ok(disk_stats) => disk_stats,
+            Err(err) => {
+                warn!("unable to collect disk metrics for linux: {}", err);
+                return mfs;
+            }
+        };
+
+        disk_stats
+            .into_iter()
+            .filter(|disk_stat| disk_stat.name.starts_with("sd"))
+            .for_each(|disk_stat| {
+                let labels = &[disk_stat.name.clone()];
+                disk_stats_counter!(mfs, num_reads, disk_stat.reads, labels);
+                disk_stats_counter!(mfs, num_merged_reads, disk_stat.merged, labels);
+                disk_stats_counter!(mfs, num_sectors_read, disk_stat.sectors_read, labels);
+                disk_stats_counter!(mfs, time_reading_ms, disk_stat.time_reading, labels);
+                disk_stats_counter!(mfs, num_writes, disk_stat.writes, labels);
+                disk_stats_counter!(mfs, num_merged_writes, disk_stat.writes_merged, labels);
+                disk_stats_counter!(mfs, num_sectors_written, disk_stat.sectors_written, labels);
+                disk_stats_counter!(mfs, time_writing_ms, disk_stat.time_writing, labels);
+                disk_stats_guage!(mfs, io_in_progress, disk_stat.in_progress, labels);
+                disk_stats_counter!(mfs, total_io_time_ms, disk_stat.time_in_progress, labels);
+            });
+
+        mfs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LinuxCpuMetricsCollector, LinuxDiskMetricsCollector};
+    use prometheus::Registry;
+
+    #[test]
+    fn test_linux_cpu_collector_register() {
+        let collector = LinuxCpuMetricsCollector::default();
+
+        let r = Registry::new();
+        let res = r.register(Box::new(collector));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_linux_disk_collector_register() {
+        let collector = LinuxDiskMetricsCollector::default();
+
+        let r = Registry::new();
+        let res = r.register(Box::new(collector));
+        assert!(res.is_ok());
+    }
+}

--- a/crates/node-resource-metrics/src/collectors/loadavg_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/loadavg_collector.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::collectors::common::{MeasureLatency, NAMESPACE};
 use aptos_metrics_core::const_metric::ConstMetric;
 use prometheus::{
     core::{Collector, Desc, Describer},
@@ -9,8 +10,6 @@ use prometheus::{
 };
 use std::vec;
 use sysinfo::{RefreshKind, System, SystemExt};
-
-use super::common::NAMESPACE;
 
 const LOAD_AVG_METRICS_COUNT: usize = 3;
 const LOAD_AVG_SUBSYSTEM: &str = "loadavg";
@@ -69,6 +68,8 @@ impl Collector for LoadAvgCollector {
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("load_avg".into());
+
         let load_avg = self.system.load_average();
 
         let load_one = ConstMetric::new_gauge(self.load_one.clone(), load_avg.one, None).unwrap();

--- a/crates/node-resource-metrics/src/collectors/memory_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/memory_metrics_collector.rs
@@ -7,11 +7,12 @@ use aptos_infallible::Mutex;
 use aptos_metrics_core::const_metric::ConstMetric;
 use prometheus::{
     core::{Collector, Desc, Describer},
+    proto::MetricFamily,
     Opts,
 };
 use sysinfo::{RefreshKind, System, SystemExt};
 
-use super::common::NAMESPACE;
+use crate::collectors::common::{MeasureLatency, NAMESPACE};
 
 const MEM_METRICS_COUNT: usize = 6;
 
@@ -99,7 +100,9 @@ impl Collector for MemoryMetricsCollector {
         ]
     }
 
-    fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+    fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("memory".into());
+
         let mut system = self.system.lock();
         system.refresh_memory();
 

--- a/crates/node-resource-metrics/src/collectors/mod.rs
+++ b/crates/node-resource-metrics/src/collectors/mod.rs
@@ -9,6 +9,7 @@ mod memory_metrics_collector;
 mod network_metrics_collector;
 mod process_metrics_collector;
 
+pub(crate) use common::CollectorLatencyCollector;
 pub(crate) use cpu_metrics_collector::CpuMetricsCollector;
 pub(crate) use cpu_metrics_collector::LinuxCpuMetricsCollector;
 pub(crate) use disk_metrics_collector::DiskMetricsCollector;

--- a/crates/node-resource-metrics/src/collectors/mod.rs
+++ b/crates/node-resource-metrics/src/collectors/mod.rs
@@ -11,10 +11,15 @@ mod process_metrics_collector;
 
 pub(crate) use common::CollectorLatencyCollector;
 pub(crate) use cpu_metrics_collector::CpuMetricsCollector;
-pub(crate) use cpu_metrics_collector::LinuxCpuMetricsCollector;
 pub(crate) use disk_metrics_collector::DiskMetricsCollector;
-pub(crate) use disk_metrics_collector::LinuxDiskMetricsCollector;
 pub(crate) use loadavg_collector::LoadAvgCollector;
 pub(crate) use memory_metrics_collector::MemoryMetricsCollector;
 pub(crate) use network_metrics_collector::NetworkMetricsCollector;
 pub(crate) use process_metrics_collector::ProcessMetricsCollector;
+
+#[cfg(all(target_os = "linux"))]
+mod linux_collectors;
+#[cfg(all(target_os = "linux"))]
+pub(crate) use linux_collectors::LinuxCpuMetricsCollector;
+#[cfg(all(target_os = "linux"))]
+pub(crate) use linux_collectors::LinuxDiskMetricsCollector;

--- a/crates/node-resource-metrics/src/collectors/mod.rs
+++ b/crates/node-resource-metrics/src/collectors/mod.rs
@@ -17,5 +17,4 @@ pub(crate) use disk_metrics_collector::LinuxDiskMetricsCollector;
 pub(crate) use loadavg_collector::LoadAvgCollector;
 pub(crate) use memory_metrics_collector::MemoryMetricsCollector;
 pub(crate) use network_metrics_collector::NetworkMetricsCollector;
-pub(crate) use process_metrics_collector::LinuxProcessMetricsCollector;
 pub(crate) use process_metrics_collector::ProcessMetricsCollector;

--- a/crates/node-resource-metrics/src/collectors/mod.rs
+++ b/crates/node-resource-metrics/src/collectors/mod.rs
@@ -10,8 +10,11 @@ mod network_metrics_collector;
 mod process_metrics_collector;
 
 pub(crate) use cpu_metrics_collector::CpuMetricsCollector;
+pub(crate) use cpu_metrics_collector::LinuxCpuMetricsCollector;
 pub(crate) use disk_metrics_collector::DiskMetricsCollector;
+pub(crate) use disk_metrics_collector::LinuxDiskMetricsCollector;
 pub(crate) use loadavg_collector::LoadAvgCollector;
 pub(crate) use memory_metrics_collector::MemoryMetricsCollector;
 pub(crate) use network_metrics_collector::NetworkMetricsCollector;
+pub(crate) use process_metrics_collector::LinuxProcessMetricsCollector;
 pub(crate) use process_metrics_collector::ProcessMetricsCollector;

--- a/crates/node-resource-metrics/src/collectors/network_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/network_metrics_collector.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::common::NAMESPACE;
+use crate::collectors::common::MeasureLatency;
 use aptos_infallible::Mutex;
 use aptos_metrics_core::const_metric::ConstMetric;
 use prometheus::{
@@ -117,6 +118,8 @@ impl Collector for NetworkMetricsCollector {
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("network".into());
+
         let mut system = self.system.lock();
         system.refresh_networks_list();
         system.refresh_networks();

--- a/crates/node-resource-metrics/src/collectors/process_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/process_metrics_collector.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_infallible::Mutex;
+use aptos_logger::warn;
 use aptos_metrics_core::const_metric::ConstMetric;
 use prometheus::{
     core::{Collector, Desc, Describer},
@@ -23,6 +24,12 @@ const RUN_TIME: &str = "run_time";
 const CPU_USAGE: &str = "cpu_usage";
 const TOTAL_READ_BYTES: &str = "disk_total_read_bytes";
 const TOTAL_WRITTEN_BYTES: &str = "disk_total_written_bytes";
+
+const LINUX_PROCESS_SUBSYSTEM: &str = "linux_process";
+const LINUX_PROCESS_METRICS_COUNT: usize = 2;
+
+const LINUX_VMEM_SIZE: &str = "vm_size_bytes";
+const LINUX_VMEM_RSS: &str = "vm_rss_bytes";
 
 /// A Collector for exposing process metrics
 pub(crate) struct ProcessMetricsCollector {
@@ -177,14 +184,102 @@ impl Collector for ProcessMetricsCollector {
     }
 }
 
+pub(crate) struct LinuxProcessMetricsCollector {
+    vm_size_bytes: Desc,
+    vm_rss_bytes: Desc,
+}
+
+impl LinuxProcessMetricsCollector {
+    fn new() -> Self {
+        let vm_size_bytes = Opts::new(LINUX_VMEM_SIZE, "Memory usage in bytes.")
+            .namespace(NAMESPACE)
+            .subsystem(LINUX_PROCESS_SUBSYSTEM)
+            .describe()
+            .unwrap();
+        let vm_rss_bytes = Opts::new(LINUX_VMEM_RSS, "Memory usage in bytes.")
+            .namespace(NAMESPACE)
+            .subsystem(LINUX_PROCESS_SUBSYSTEM)
+            .describe()
+            .unwrap();
+        Self {
+            vm_size_bytes,
+            vm_rss_bytes,
+        }
+    }
+}
+
+impl Default for LinuxProcessMetricsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Collector for LinuxProcessMetricsCollector {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.vm_size_bytes, &self.vm_rss_bytes]
+    }
+
+    fn collect(&self) -> Vec<MetricFamily> {
+        let mut mfs = Vec::with_capacity(LINUX_PROCESS_METRICS_COUNT);
+
+        let page_size = match procfs::page_size() {
+            Ok(page_size) => page_size,
+            Err(err) => {
+                warn!(
+                    "unable to get page_size in linux, not collecting process memory metrics: {}",
+                    err
+                );
+                return mfs;
+            }
+        };
+
+        let proc_statm = procfs::process::Process::myself().and_then(|p| p.statm());
+        if proc_statm.is_err() {
+            warn!(
+                "unable to collect process memory metrics for linux: {}",
+                proc_statm.unwrap_err()
+            );
+            return mfs;
+        }
+
+        let proc_statm = proc_statm.unwrap();
+        let vm_size_bytes = ConstMetric::new_gauge(
+            self.vm_size_bytes.clone(),
+            (proc_statm.size * page_size) as f64,
+            None,
+        )
+        .unwrap();
+        let vm_rss_bytes = ConstMetric::new_gauge(
+            self.vm_rss_bytes.clone(),
+            (proc_statm.resident * page_size) as f64,
+            None,
+        )
+        .unwrap();
+
+        mfs.extend(vm_size_bytes.collect());
+        mfs.extend(vm_rss_bytes.collect());
+
+        mfs
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ProcessMetricsCollector;
+    use super::{LinuxProcessMetricsCollector, ProcessMetricsCollector};
     use prometheus::Registry;
 
     #[test]
-    fn test_cpu_collector_register() {
+    fn test_process_collector_register() {
         let collector = ProcessMetricsCollector::default();
+
+        let r = Registry::new();
+        let res = r.register(Box::new(collector));
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_linux_process_collector_register() {
+        let collector = LinuxProcessMetricsCollector::default();
 
         let r = Registry::new();
         let res = r.register(Box::new(collector));

--- a/crates/node-resource-metrics/src/collectors/process_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/process_metrics_collector.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::collectors::common::{MeasureLatency, NAMESPACE};
 use aptos_infallible::Mutex;
 use aptos_logger::warn;
 use aptos_metrics_core::const_metric::ConstMetric;
@@ -11,8 +12,6 @@ use prometheus::{
 };
 use std::sync::Arc;
 use sysinfo::{ProcessExt, System, SystemExt};
-
-use super::common::NAMESPACE;
 
 const PROCESS_METRICS_COUNT: usize = 3;
 const PROCESS_SUBSYSTEM: &str = "process";
@@ -120,6 +119,8 @@ impl Collector for ProcessMetricsCollector {
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("process".into());
+
         let mut system = self.system.lock();
 
         let pid = if let Ok(pid) = sysinfo::get_current_pid() {
@@ -184,6 +185,7 @@ impl Collector for ProcessMetricsCollector {
     }
 }
 
+/// A Collector for exposing Linux process metrics
 pub(crate) struct LinuxProcessMetricsCollector {
     vm_size_bytes: Desc,
     vm_rss_bytes: Desc,
@@ -220,6 +222,8 @@ impl Collector for LinuxProcessMetricsCollector {
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
+        let _measure = MeasureLatency::new("linux_process".into());
+
         let mut mfs = Vec::with_capacity(LINUX_PROCESS_METRICS_COUNT);
 
         let page_size = match procfs::page_size() {

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -3,11 +3,9 @@
 
 use cfg_if::cfg_if;
 use collectors::{
-    CpuMetricsCollector, DiskMetricsCollector, LinuxCpuMetricsCollector, LinuxDiskMetricsCollector,
-    LoadAvgCollector, MemoryMetricsCollector, NetworkMetricsCollector, ProcessMetricsCollector,
+    CollectorLatencyCollector, CpuMetricsCollector, DiskMetricsCollector, LoadAvgCollector,
+    MemoryMetricsCollector, NetworkMetricsCollector, ProcessMetricsCollector,
 };
-
-use crate::collectors::CollectorLatencyCollector;
 
 mod collectors;
 
@@ -21,8 +19,8 @@ pub fn register_node_metrics_collector() {
     prometheus::register(Box::new(ProcessMetricsCollector::default())).unwrap();
     cfg_if! {
         if #[cfg(all(target_os="linux"))] {
-            prometheus::register(Box::new(LinuxCpuMetricsCollector::default())).unwrap();
-            prometheus::register(Box::new(LinuxDiskMetricsCollector::default())).unwrap();
+            prometheus::register(Box::new(collectors::LinuxCpuMetricsCollector::default())).unwrap();
+            prometheus::register(Box::new(collectors::LinuxDiskMetricsCollector::default())).unwrap();
         }
     }
     prometheus::register(Box::new(CollectorLatencyCollector::default())).unwrap();

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -4,8 +4,7 @@
 use cfg_if::cfg_if;
 use collectors::{
     CpuMetricsCollector, DiskMetricsCollector, LinuxCpuMetricsCollector, LinuxDiskMetricsCollector,
-    LinuxProcessMetricsCollector, LoadAvgCollector, MemoryMetricsCollector,
-    NetworkMetricsCollector, ProcessMetricsCollector,
+    LoadAvgCollector, MemoryMetricsCollector, NetworkMetricsCollector, ProcessMetricsCollector,
 };
 
 use crate::collectors::CollectorLatencyCollector;
@@ -24,7 +23,6 @@ pub fn register_node_metrics_collector() {
         if #[cfg(all(target_os="linux"))] {
             prometheus::register(Box::new(LinuxCpuMetricsCollector::default())).unwrap();
             prometheus::register(Box::new(LinuxDiskMetricsCollector::default())).unwrap();
-            prometheus::register(Box::new(LinuxProcessMetricsCollector::default())).unwrap();
         }
     }
     prometheus::register(Box::new(CollectorLatencyCollector::default())).unwrap();

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use cfg_if::cfg_if;
 use collectors::{
-    CpuMetricsCollector, DiskMetricsCollector, LoadAvgCollector, MemoryMetricsCollector,
+    CpuMetricsCollector, DiskMetricsCollector, LinuxCpuMetricsCollector, LinuxDiskMetricsCollector,
+    LinuxProcessMetricsCollector, LoadAvgCollector, MemoryMetricsCollector,
     NetworkMetricsCollector, ProcessMetricsCollector,
 };
 
@@ -16,4 +18,11 @@ pub fn register_node_metrics_collector() {
     prometheus::register(Box::new(NetworkMetricsCollector::default())).unwrap();
     prometheus::register(Box::new(LoadAvgCollector::default())).unwrap();
     prometheus::register(Box::new(ProcessMetricsCollector::default())).unwrap();
+    cfg_if! {
+        if #[cfg(all(target_os="linux"))] {
+            prometheus::register(Box::new(LinuxCpuMetricsCollector::default())).unwrap();
+            prometheus::register(Box::new(LinuxDiskMetricsCollector::default())).unwrap();
+            prometheus::register(Box::new(LinuxProcessMetricsCollector::default())).unwrap();
+        }
+    }
 }

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -8,6 +8,8 @@ use collectors::{
     NetworkMetricsCollector, ProcessMetricsCollector,
 };
 
+use crate::collectors::CollectorLatencyCollector;
+
 mod collectors;
 
 /// Registers the node metrics collector with the default registry.
@@ -25,4 +27,5 @@ pub fn register_node_metrics_collector() {
             prometheus::register(Box::new(LinuxProcessMetricsCollector::default())).unwrap();
         }
     }
+    prometheus::register(Box::new(CollectorLatencyCollector::default())).unwrap();
 }


### PR DESCRIPTION
### Description

This PR re-introduces #4301, ability to export linux-specific stats as prometheus metrics. The included ones are CPU time per state, disk IOPS stats, and memory (rss/ vm) stats.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Ensured that it builds on a Mac.

```
cargo build -p node-resource-metrics
   Compiling node-resource-metrics v0.1.0 (/Users/balaji/work/aptos-core/crates/node-resource-metrics)
    Finished dev [unoptimized + debuginfo] target(s) in 0.48s
```

Relevant metrics from `/metrics` endpoint
```
# HELP node_linux_disk_io_in_progress Number of IO in progress
# TYPE node_linux_disk_io_in_progress gauge
node_linux_disk_io_in_progress{name="sda"} 0
node_linux_disk_io_in_progress{name="sda1"} 0
node_linux_disk_io_in_progress{name="sdb"} 0
node_linux_disk_io_in_progress{name="sdb1"} 0
node_linux_disk_io_in_progress{name="sdb14"} 0
node_linux_disk_io_in_progress{name="sdb15"} 0
# HELP node_linux_disk_num_merged_reads Number of merged reads
# TYPE node_linux_disk_num_merged_reads counter
node_linux_disk_num_merged_reads{name="sda"} 0
node_linux_disk_num_merged_reads{name="sda1"} 0
node_linux_disk_num_merged_reads{name="sdb"} 6297
node_linux_disk_num_merged_reads{name="sdb1"} 6177
node_linux_disk_num_merged_reads{name="sdb14"} 0
node_linux_disk_num_merged_reads{name="sdb15"} 120
# HELP node_linux_disk_num_merged_writes Number of merged writes
# TYPE node_linux_disk_num_merged_writes counter
node_linux_disk_num_merged_writes{name="sda"} 75513
node_linux_disk_num_merged_writes{name="sda1"} 75513
node_linux_disk_num_merged_writes{name="sdb"} 147081
node_linux_disk_num_merged_writes{name="sdb1"} 147081
node_linux_disk_num_merged_writes{name="sdb14"} 0
node_linux_disk_num_merged_writes{name="sdb15"} 0
# HELP node_linux_disk_num_reads Number of reads
# TYPE node_linux_disk_num_reads counter
node_linux_disk_num_reads{name="sda"} 406
node_linux_disk_num_reads{name="sda1"} 128
node_linux_disk_num_reads{name="sdb"} 97809
node_linux_disk_num_reads{name="sdb1"} 95877
node_linux_disk_num_reads{name="sdb14"} 127
node_linux_disk_num_reads{name="sdb15"} 1754
# HELP node_linux_disk_num_sectors_read Number of sectors read
# TYPE node_linux_disk_num_sectors_read counter
node_linux_disk_num_sectors_read{name="sda"} 30498
node_linux_disk_num_sectors_read{name="sda1"} 8668
node_linux_disk_num_sectors_read{name="sdb"} 5422232
node_linux_disk_num_sectors_read{name="sdb1"} 5390328
node_linux_disk_num_sectors_read{name="sdb14"} 1002
node_linux_disk_num_sectors_read{name="sdb15"} 28583
# HELP node_linux_disk_num_sectors_written Number of sectors written
# TYPE node_linux_disk_num_sectors_written counter
node_linux_disk_num_sectors_written{name="sda"} 2794816
node_linux_disk_num_sectors_written{name="sda1"} 2794816
node_linux_disk_num_sectors_written{name="sdb"} 17202823
node_linux_disk_num_sectors_written{name="sdb1"} 17202818
node_linux_disk_num_sectors_written{name="sdb14"} 0
node_linux_disk_num_sectors_written{name="sdb15"} 5
# HELP node_linux_disk_num_writes Number of writes
# TYPE node_linux_disk_num_writes counter
node_linux_disk_num_writes{name="sda"} 10822
node_linux_disk_num_writes{name="sda1"} 10822
node_linux_disk_num_writes{name="sdb"} 99568
node_linux_disk_num_writes{name="sdb1"} 99563
node_linux_disk_num_writes{name="sdb14"} 0
node_linux_disk_num_writes{name="sdb15"} 5
# HELP node_linux_disk_time_reading_ms Time spent reading in ms
# TYPE node_linux_disk_time_reading_ms counter
node_linux_disk_time_reading_ms{name="sda"} 132
node_linux_disk_time_reading_ms{name="sda1"} 21
node_linux_disk_time_reading_ms{name="sdb"} 560485
node_linux_disk_time_reading_ms{name="sdb1"} 555090
node_linux_disk_time_reading_ms{name="sdb14"} 5
node_linux_disk_time_reading_ms{name="sdb15"} 5386
# HELP node_linux_disk_time_writing_ms Time spent writing in ms
# TYPE node_linux_disk_time_writing_ms counter
node_linux_disk_time_writing_ms{name="sda"} 23883
node_linux_disk_time_writing_ms{name="sda1"} 23883
node_linux_disk_time_writing_ms{name="sdb"} 569953
node_linux_disk_time_writing_ms{name="sdb1"} 569950
node_linux_disk_time_writing_ms{name="sdb14"} 0
node_linux_disk_time_writing_ms{name="sdb15"} 3
# HELP node_linux_disk_total_io_time_ms Total IO time in ms
# TYPE node_linux_disk_total_io_time_ms counter
node_linux_disk_total_io_time_ms{name="sda"} 13772
node_linux_disk_total_io_time_ms{name="sda1"} 13644
node_linux_disk_total_io_time_ms{name="sdb"} 525252
node_linux_disk_total_io_time_ms{name="sdb1"} 524724
node_linux_disk_total_io_time_ms{name="sdb14"} 60
node_linux_disk_total_io_time_ms{name="sdb15"} 572
# HELP node_linux_process_vm_rss_bytes Memory usage in bytes.
# TYPE node_linux_process_vm_rss_bytes gauge
node_linux_process_vm_rss_bytes 346501120
# HELP node_linux_process_vm_size_bytes Memory usage in bytes.
# TYPE node_linux_process_vm_size_bytes gauge
node_linux_process_vm_size_bytes 1174724608
# HELP node_linux_system_cpu_usage Linux CPU usage.
# TYPE node_linux_system_cpu_usage counter
node_linux_system_cpu_usage{state="guest_ms"} 0
node_linux_system_cpu_usage{state="guest_nice_ms"} 0
node_linux_system_cpu_usage{state="idle_ms"} 119592940
node_linux_system_cpu_usage{state="iowait_ms"} 452600
node_linux_system_cpu_usage{state="irq_ms"} 0
node_linux_system_cpu_usage{state="nice_ms"} 326910
node_linux_system_cpu_usage{state="softirq_ms"} 26410
node_linux_system_cpu_usage{state="steal_ms"} 0
node_linux_system_cpu_usage{state="system_ms"} 431960
node_linux_system_cpu_usage{state="user_ms"} 3341160
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4301)
<!-- Reviewable:end -->
