### PR TITLE
[Token] create a general token event store for new token events 

### DIFF
--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -31,6 +31,7 @@ use rand::{
 use serde::de::DeserializeOwned;
 use std::collections::BTreeMap;
 use std::path::Path;
+use aptos_types::contract_event::ContractEvent;
 
 /// A simple test harness for defining Move e2e tests.
 ///
@@ -125,6 +126,15 @@ impl MoveHarness {
             self.executor.apply_write_set(output.write_set());
         }
         output.status().to_owned()
+    }
+
+    /// Runs a signed transaction. On success, applies the write set.
+    pub fn run_with_events(&mut self, txn: SignedTransaction) -> (TransactionStatus,  Vec<ContractEvent>) {
+        let output = self.executor.execute_transaction(txn);
+        if matches!(output.status(), TransactionStatus::Keep(_)) {
+            self.executor.apply_write_set(output.write_set());
+        }
+        (output.status().to_owned(), output.events().to_owned())
     }
 
     /// Runs a block of signed transactions. On success, applies the write set.

--- a/aptos-move/e2e-move-tests/src/tests/general_event.rs
+++ b/aptos-move/e2e-move-tests/src/tests/general_event.rs
@@ -1,0 +1,54 @@
+use crate::{assert_success, MoveHarness};
+use cached_packages::aptos_stdlib::aptos_token_stdlib;
+
+#[test]
+fn test_token_creation_with_general_events() {
+    let mut h = MoveHarness::new();
+
+    // Deploy a package that initially does not have the module that has the init_module function.
+    let acc = h.aptos_framework_account();
+    let token_owner = acc.address();
+    let collection_name = b"collection_name".to_vec();
+    let token_name = b"token_name".to_vec();
+    // create the collection and token
+
+    h.run_transaction_payload(
+        &acc,
+        aptos_token_stdlib::token_create_collection_script(
+            collection_name.clone(),
+            "collection description".to_owned().into_bytes(),
+            "uri".to_owned().into_bytes(),
+            100000,
+            vec![false, false, false],
+        )
+    );
+    h.run_transaction_payload(
+        &acc,
+        aptos_token_stdlib::token_create_token_script(
+            collection_name.clone(),
+            token_name.clone(),
+            "collection description".to_owned().into_bytes(),
+            10,
+            u64::MAX,
+            "uri".to_owned().into_bytes(),
+            *token_owner,
+            0,
+            0,
+            vec![false, false, false, false, true],
+            vec![Vec::new()],
+            vec![Vec::new()],
+            vec![Vec::new()],
+        )
+    );
+
+    // mutate the token properties
+    let signed_txn = h.create_transaction_payload(
+        &acc,
+        aptos_token_stdlib::token_opt_in_direct_transfer(
+            true
+        )
+    );
+    let ( _, mut events) = h.run_with_events(signed_txn);
+    let event = events.pop().unwrap();
+    assert_eq!("0x3::token_event_utils::GeneralTokenEvent".to_string(), event.type_tag().to_string());
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -13,3 +13,4 @@ mod max_loop_depth;
 mod rotate_auth_key;
 mod stake;
 mod string_args;
+mod general_event;

--- a/aptos-move/framework/aptos-token/sources/property_map.move
+++ b/aptos-move/framework/aptos-token/sources/property_map.move
@@ -106,7 +106,7 @@ module aptos_token::property_map {
 
     public fun borrow(map: &PropertyMap, key: &String): &PropertyValue {
         let found = contains_key(map, key);
-        assert!(found, EPROPERTY_NOT_EXIST);
+        assert!(found, error::not_found(EPROPERTY_NOT_EXIST));
         simple_map::borrow(&map.map, key)
     }
 
@@ -216,18 +216,7 @@ module aptos_token::property_map {
     /// create a property value from generic type data
     public fun create_property_value<T: copy>(data: &T): PropertyValue {
         let name = type_name<T>();
-        if (
-            name == string::utf8(b"bool") ||
-                name == string::utf8(b"u8") ||
-                name == string::utf8(b"u64") ||
-                name == string::utf8(b"u128") ||
-                name == string::utf8(b"address") ||
-                name == string::utf8(b"0x1::string::String")
-        ) {
-            create_property_value_raw(bcs::to_bytes<T>(data), name)
-        } else {
-            create_property_value_raw(bcs::to_bytes<T>(data), string::utf8(b"vector<u8>"))
-        }
+        create_property_value_raw(bcs::to_bytes<T>(data), name)
     }
 
     #[test_only]

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -12,6 +12,7 @@ module aptos_token::token {
     use aptos_framework::timestamp;
     use aptos_std::table::{Self, Table};
     use aptos_token::property_map::{Self, PropertyMap};
+    use aptos_token::token_event_utils as utils;
 
     //
     // Constants
@@ -255,7 +256,7 @@ module aptos_token::token {
         mutability_config: CollectionMutabilityConfig,
     }
 
-    /// capability to withdraw without signer, this struct should be non-copyable
+    /// Capability to withdraw without signer, this struct should be non-copyable
     struct WithdrawCapability has drop, store {
         token_owner: address,
         token_id: TokenId,
@@ -275,7 +276,7 @@ module aptos_token::token {
         amount: u64,
     }
 
-    /// token creation event id of token created
+    /// TokenData creation event
     struct CreateTokenDataEvent has drop, store {
         id: TokenDataId,
         description: String,
@@ -291,19 +292,19 @@ module aptos_token::token {
         property_types: vector<String>,
     }
 
-    /// mint token event. This event triggered when creator adds more supply to existing token
+    /// Mint token event. This event triggered when creator adds more supply to existing TokenData
     struct MintTokenEvent has drop, store {
         id: TokenDataId,
         amount: u64,
     }
 
-    ///
+    /// Burn token event
     struct BurnTokenEvent has drop, store {
         id: TokenId,
         amount: u64,
     }
 
-    ///
+    /// Mutate Token Property Event
     struct MutateTokenPropertyMapEvent has drop, store {
         old_id: TokenId,
         new_id: TokenId,
@@ -312,7 +313,7 @@ module aptos_token::token {
         types: vector<String>,
     }
 
-    /// create collection event with creator address and collection name
+    /// Create collection event
     struct CreateCollectionEvent has drop, store {
         creator: address,
         collection_name: String,
@@ -393,7 +394,85 @@ module aptos_token::token {
         initialize_token_store(account);
         let opt_in_flag = &mut borrow_global_mut<TokenStore>(addr).direct_transfer;
         *opt_in_flag = opt_in;
+
+        utils::emit_token_opt_in_event(account, opt_in);
     }
+
+    /// create token with raw inputs
+    public entry fun create_token_script(
+        account: &signer,
+        collection: String,
+        name: String,
+        description: String,
+        balance: u64,
+        maximum: u64,
+        uri: String,
+        royalty_payee_address: address,
+        royalty_points_denominator: u64,
+        royalty_points_numerator: u64,
+        mutate_setting: vector<bool>,
+        property_keys: vector<String>,
+        property_values: vector<vector<u8>>,
+        property_types: vector<String>
+    ) acquires Collections, TokenStore {
+        let token_mut_config = create_token_mutability_config(&mutate_setting);
+
+        let tokendata_id = create_tokendata(
+            account,
+            collection,
+            name,
+            description,
+            maximum,
+            uri,
+            royalty_payee_address,
+            royalty_points_denominator,
+            royalty_points_numerator,
+            token_mut_config,
+            property_keys,
+            property_values,
+            property_types
+        );
+
+        mint_token(
+            account,
+            tokendata_id,
+            balance,
+        );
+    }
+
+    /// mutate the token property and save the new property in TokenStore
+    /// if the token property_version is 0, we will create a new property_version per token to generate a new token_id per token
+    /// if the token property_version is not 0, we will just update the propertyMap and use the existing token_id (property_version)
+    public entry fun mutate_token_properties(
+        account: &signer,
+        token_owner: address,
+        creator: address,
+        collection_name: String,
+        token_name: String,
+        token_property_version: u64,
+        amount: u64,
+        keys: vector<String>,
+        values: vector<vector<u8>>,
+        types: vector<String>,
+    ) acquires Collections, TokenStore {
+        assert!(signer::address_of(account) == creator, error::not_found(ENO_MUTATE_CAPABILITY));
+        let i = 0;
+        let token_id = create_token_id_raw(
+            creator,
+            collection_name,
+            token_name,
+            token_property_version,
+        );
+        // give a new property_version for each token
+        while (i < amount) {
+            mutate_one_token(account, token_owner, token_id, keys, values, types);
+            i = i + 1;
+        };
+    }
+
+    //
+    // Public functions for creating and maintaining tokens
+    //
 
     /// Allow creator to mutate the default properties in TokenData
     public fun mutate_tokendata_property(
@@ -415,6 +494,13 @@ module aptos_token::token {
         let token_data = table::borrow_mut(all_token_data, token_data_id);
         assert!(token_data.mutability_config.properties, error::permission_denied(EFIELD_NOT_MUTABLE));
         property_map::update_property_map(&mut token_data.default_properties, keys, values, types);
+        utils::emit_tokendata_property_mutate_event(
+            creator,
+            token_data.default_properties,
+            token_data_id.creator,
+            token_data_id.collection,
+            token_data_id.name,
+        );
     }
 
     public fun mutate_one_token(
@@ -426,9 +512,9 @@ module aptos_token::token {
         types: vector<String>,
     ): TokenId acquires Collections, TokenStore {
         let creator = token_id.token_data_id.creator;
-        assert!(signer::address_of(account) == creator, ENO_MUTATE_CAPABILITY);
+        assert!(signer::address_of(account) == creator, error::permission_denied(ENO_MUTATE_CAPABILITY));
         // validate if the properties is mutable
-        assert!(exists<Collections>(creator), ECOLLECTIONS_NOT_PUBLISHED);
+        assert!(exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
         let all_token_data = &mut borrow_global_mut<Collections>(
             creator
         ).token_data;
@@ -447,7 +533,6 @@ module aptos_token::token {
             let token_prop_mutable = property_map::read_bool(&token_data.default_properties, &string::utf8(TOKEN_PROPERTY_MUTABLE));
             assert!(token_prop_mutable, error::permission_denied(EFIELD_NOT_MUTABLE));
         };
-
         // check if the property_version is 0 to determine if we need to update the property_version
         if (token_id.property_version == 0) {
             let token = withdraw_with_event_internal(token_owner, token_id, 1);
@@ -512,51 +597,7 @@ module aptos_token::token {
         let token_data = table::borrow_mut(all_token_data, token_data_id);
         assert!(token_data.mutability_config.uri, error::permission_denied(EFIELD_NOT_MUTABLE));
         token_data.uri = uri;
-    }
-
-    /// mutate the token property and save the new property in TokenStore
-    /// if the token property_version is 0, we will create a new property_version per token to generate a new token_id per token
-    /// if the token property_version is not 0, we will just update the propertyMap and use the existing token_id (property_version)
-    public entry fun mutate_token_properties(
-        account: &signer,
-        token_owner: address,
-        creator: address,
-        collection_name: String,
-        token_name: String,
-        token_property_version: u64,
-        amount: u64,
-        keys: vector<String>,
-        values: vector<vector<u8>>,
-        types: vector<String>,
-    ) acquires Collections, TokenStore {
-        assert!(signer::address_of(account) == creator, error::not_found(ENO_MUTATE_CAPABILITY));
-        let i = 0;
-        let token_id = create_token_id_raw(
-            creator,
-            collection_name,
-            token_name,
-            token_property_version,
-        );
-        // give a new property_version for each token
-        while (i < amount) {
-            mutate_one_token(account, token_owner, token_id, keys, values, types);
-            i = i + 1;
-        };
-    }
-
-    fun update_token_property_internal(
-        token_owner: address,
-        token_id: TokenId,
-        keys: vector<String>,
-        values: vector<vector<u8>>,
-        types: vector<String>,
-    ) acquires TokenStore {
-        let tokens = &mut borrow_global_mut<TokenStore>(token_owner).tokens;
-        assert!(table::contains(tokens, token_id), error::not_found(ENO_TOKEN_IN_TOKEN_STORE));
-
-        let value = &mut table::borrow_mut(tokens, token_id).token_properties;
-
-        property_map::update_property_map(value, keys, values, types);
+        utils::emit_token_uri_mutate_event(creator, uri, token_data_id.collection, token_data_id.name);
     }
 
     /// Deposit the token balance into the owner's account and emit an event.
@@ -572,28 +613,6 @@ module aptos_token::token {
         let opt_in_transfer = borrow_global<TokenStore>(account_addr).direct_transfer;
         assert!(opt_in_transfer, error::permission_denied(EUSER_NOT_OPT_IN_DIRECT_TRANSFER));
         direct_deposit(account_addr, token);
-    }
-
-    /// Deposit the token balance into the recipients account and emit an event.
-    fun direct_deposit(account_addr: address, token: Token) acquires TokenStore {
-        let token_store = borrow_global_mut<TokenStore>(account_addr);
-
-        event::emit_event<DepositEvent>(
-            &mut token_store.deposit_events,
-            DepositEvent { id: token.id, amount: token.amount },
-        );
-
-        assert!(
-            exists<TokenStore>(account_addr),
-            error::not_found(ETOKEN_STORE_NOT_PUBLISHED),
-        );
-
-        if (!table::contains(&token_store.tokens, token.id)) {
-            table::add(&mut token_store.tokens, token.id, token);
-        } else {
-            let recipient_token = table::borrow_mut(&mut token_store.tokens, token.id);
-            merge(recipient_token, token);
-        };
     }
 
     public fun direct_transfer(
@@ -661,7 +680,6 @@ module aptos_token::token {
         direct_deposit(to, token);
     }
 
-
     /// Token owner can create this one-time withdraw capability with an expiration time
     public fun create_withdraw_capability(
         owner: &signer,
@@ -698,41 +716,6 @@ module aptos_token::token {
     ): Token acquires TokenStore {
         let account_addr = signer::address_of(account);
         withdraw_with_event_internal(account_addr, id, amount)
-    }
-
-    fun withdraw_with_event_internal(
-        account_addr: address,
-        id: TokenId,
-        amount: u64,
-    ): Token acquires TokenStore {
-        // It does not make sense to withdraw 0 tokens.
-        assert!(amount > 0, error::invalid_argument(EWITHDRAW_ZERO));
-        // Make sure the account has sufficient tokens to withdraw.
-        assert!(balance_of(account_addr, id) >= amount, error::invalid_argument(EINSUFFICIENT_BALANCE));
-
-        assert!(
-            exists<TokenStore>(account_addr),
-            error::not_found(ETOKEN_STORE_NOT_PUBLISHED),
-        );
-
-        let token_store = borrow_global_mut<TokenStore>(account_addr);
-        event::emit_event<WithdrawEvent>(
-            &mut token_store.withdraw_events,
-            WithdrawEvent { id, amount },
-        );
-        let tokens = &mut borrow_global_mut<TokenStore>(account_addr).tokens;
-        assert!(
-            table::contains(tokens, id),
-            error::not_found(ENO_TOKEN_IN_TOKEN_STORE),
-        );
-        // balance > amount and amount > 0 indirectly asserted that balance > 0.
-        let balance = &mut table::borrow_mut(tokens, id).amount;
-        if (*balance > amount) {
-            *balance = *balance - amount;
-            Token { id, amount, token_properties: property_map::empty() }
-        } else {
-            table::remove(tokens, id)
-        }
     }
 
     //
@@ -902,6 +885,10 @@ module aptos_token::token {
         token_data_id
     }
 
+    //
+    // Public Getter Functions For Token Related Info
+    //
+
     /// return the number of distinct token_data_id created under this collection
     public fun get_collection_supply(creator_address: address, collection_name: String): Option<u64> acquires Collections {
         assert!(exists<Collections>(creator_address), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
@@ -959,48 +946,6 @@ module aptos_token::token {
             uri: *vector::borrow(mutate_setting, COLLECTION_URI_MUTABLE_IND),
             maximum: *vector::borrow(mutate_setting, COLLECTION_MAX_MUTABLE_IND),
         }
-    }
-
-    /// create token with raw inputs
-    public entry fun create_token_script(
-        account: &signer,
-        collection: String,
-        name: String,
-        description: String,
-        balance: u64,
-        maximum: u64,
-        uri: String,
-        royalty_payee_address: address,
-        royalty_points_denominator: u64,
-        royalty_points_numerator: u64,
-        mutate_setting: vector<bool>,
-        property_keys: vector<String>,
-        property_values: vector<vector<u8>>,
-        property_types: vector<String>
-    ) acquires Collections, TokenStore {
-        let token_mut_config = create_token_mutability_config(&mutate_setting);
-
-        let tokendata_id = create_tokendata(
-            account,
-            collection,
-            name,
-            description,
-            maximum,
-            uri,
-            royalty_payee_address,
-            royalty_points_denominator,
-            royalty_points_numerator,
-            token_mut_config,
-            property_keys,
-            property_values,
-            property_types
-        );
-
-        mint_token(
-            account,
-            tokendata_id,
-            balance,
-        );
     }
 
     public fun mint_token(
@@ -1080,7 +1025,6 @@ module aptos_token::token {
             }
         );
     }
-
 
     /// Burn a token by creator when the token's BURNABLE_BY_CREATOR is true
     /// The token is owned at address owner
@@ -1336,6 +1280,81 @@ module aptos_token::token {
 
         let token_data = table::borrow(all_token_data, token_data_id);
         token_data.uri
+    }
+
+    //
+    // Private or friend-only functions
+    //
+
+    fun update_token_property_internal(
+        token_owner: address,
+        token_id: TokenId,
+        keys: vector<String>,
+        values: vector<vector<u8>>,
+        types: vector<String>,
+    ) acquires TokenStore {
+        let tokens = &mut borrow_global_mut<TokenStore>(token_owner).tokens;
+        assert!(table::contains(tokens, token_id), error::not_found(ENO_TOKEN_IN_TOKEN_STORE));
+        let value = &mut table::borrow_mut(tokens, token_id).token_properties;
+
+        property_map::update_property_map(value, keys, values, types);
+    }
+
+    fun withdraw_with_event_internal(
+        account_addr: address,
+        id: TokenId,
+        amount: u64,
+    ): Token acquires TokenStore {
+        // It does not make sense to withdraw 0 tokens.
+        assert!(amount > 0, error::invalid_argument(EWITHDRAW_ZERO));
+        // Make sure the account has sufficient tokens to withdraw.
+        assert!(balance_of(account_addr, id) >= amount, error::invalid_argument(EINSUFFICIENT_BALANCE));
+
+        assert!(
+            exists<TokenStore>(account_addr),
+            error::not_found(ETOKEN_STORE_NOT_PUBLISHED),
+        );
+
+        let token_store = borrow_global_mut<TokenStore>(account_addr);
+        event::emit_event<WithdrawEvent>(
+            &mut token_store.withdraw_events,
+            WithdrawEvent{ id, amount },
+        );
+        let tokens = &mut borrow_global_mut<TokenStore>(account_addr).tokens;
+        assert!(
+            table::contains(tokens, id),
+            error::not_found(ENO_TOKEN_IN_TOKEN_STORE),
+        );
+        // balance > amount and amount > 0 indirectly asserted that balance > 0.
+        let balance = &mut table::borrow_mut(tokens, id).amount;
+        if (*balance > amount) {
+            *balance = *balance - amount;
+            Token{ id, amount, token_properties: property_map::empty() }
+        } else {
+            table::remove(tokens, id)
+        }
+    }
+
+    /// Deposit the token balance into the recipients account and emit an event.
+    fun direct_deposit(account_addr: address, token: Token) acquires TokenStore {
+        let token_store = borrow_global_mut<TokenStore>(account_addr);
+
+        event::emit_event<DepositEvent>(
+            &mut token_store.deposit_events,
+            DepositEvent { id: token.id, amount: token.amount },
+        );
+
+        assert!(
+            exists<TokenStore>(account_addr),
+            error::not_found(ETOKEN_STORE_NOT_PUBLISHED),
+        );
+
+        if (!table::contains(&token_store.tokens, token.id)) {
+            table::add(&mut token_store.tokens, token.id, token);
+        } else {
+            let recipient_token = table::borrow_mut(&mut token_store.tokens, token.id);
+            merge(recipient_token, token);
+        };
     }
 
     // ****************** TEST-ONLY FUNCTIONS **************
@@ -2023,5 +2042,31 @@ module aptos_token::token {
         );
         mutate_tokendata_uri(creator, token_id.token_data_id, string::utf8(b"new_url"));
         assert!(get_tokendata_uri(signer::address_of(creator), token_id.token_data_id) == string::utf8(b"new_url"), 1);
+    }
+
+    #[test(creator=@0xcafe, owner=@0xafe)]
+    fun test_general_token_event_generation(
+        creator: &signer,
+        owner: &signer,
+    )acquires Collections, TokenStore {
+        account::create_account_for_test(signer::address_of(creator));
+        account::create_account_for_test(signer::address_of(owner));
+
+        // token owner mutate the token property
+        let token_id = create_collection_and_token(
+            creator,
+            2,
+            4,
+            4,
+            vector<String>[],
+            vector<vector<u8>>[],
+            vector<String>[],
+            vector<bool>[false, false, false],
+            vector<bool>[false, true, false, false, false],
+        );
+        let owner_addr = signer::address_of(owner);
+        initialize_token_store(owner);
+        opt_in_direct_transfer(owner, true);
+        transfer(creator, token_id, owner_addr, 1);
     }
 }

--- a/aptos-move/framework/aptos-token/sources/token_event_utils.move
+++ b/aptos-move/framework/aptos-token/sources/token_event_utils.move
@@ -1,0 +1,146 @@
+module aptos_token::token_event_utils {
+    use std::string::{utf8, String};
+    use std::signer;
+    use aptos_token::property_map::{Self, PropertyMap};
+    use aptos_framework::event::{Self, EventHandle};
+    use aptos_framework::account;
+
+    friend aptos_token::token;
+
+    const TOKEN_CREATOR: vector<u8> = b"creator";
+    const TOKEN_COLLECTION: vector<u8> = b"collection";
+    const TOKEN_NAME: vector<u8> = b"token_name";
+
+    //
+    // Token opt_in direct transfer
+    //
+    const TOEKN_OPT_IN_EVENT_NAME: vector<u8> = b"token_transfer_opt_in";
+    const TOEKN_OPT_IN_EVENT_IN: vector<u8> = b"opt_in";
+
+    //
+    // Token URI mutation event
+    //
+    const TOKEN_URI_MUTATION_EVENT_NAME: vector<u8> = b"token_uri_mutation";
+    const TOKEN_URI_MUTATION_EVENT_NEW_URI: vector<u8> = b"new_uri";
+
+    //
+    // TokenData property mutation event
+    //
+    const TOKENDATA_PROPERTY_MUTATION_EVENT_NAME: vector<u8> = b"tokendata_propertymap_mutation";
+    const TOKENDATA_PROPERTY_MUTATION_EVENT_NEW_PROPERTYMAP: vector<u8> = b"new_property_map";
+
+
+    /// General token event used for representing all new token events
+   /// The event is identified using event_name. Attributes of the event are stored in a PropertyMap
+    struct GeneralTokenEvent has drop, store {
+        token_event_name: String,
+        event_attributes: PropertyMap,
+    }
+
+    struct TokenEventStore has key {
+        events: EventHandle<GeneralTokenEvent>,
+    }
+
+    fun initialize_token_event_store(acct: &signer){
+        if (!exists<TokenEventStore>(signer::address_of(acct))) {
+            move_to(acct, TokenEventStore {
+                events: account::new_event_handle<GeneralTokenEvent>(acct),
+            });
+        };
+    }
+
+    /// Emit the direct opt-in event
+    public(friend) fun emit_token_opt_in_event(account: &signer, opt_in: bool) acquires TokenEventStore {
+        let pm = property_map::empty();
+        property_map::add(
+            &mut pm,
+            utf8(TOEKN_OPT_IN_EVENT_IN), property_map::create_property_value<bool>(&opt_in)
+        );
+
+        let gte = GeneralTokenEvent {
+            token_event_name: utf8(TOEKN_OPT_IN_EVENT_NAME),
+            event_attributes: pm,
+        };
+
+        initialize_token_event_store(account);
+        let token_event_store = borrow_global_mut<TokenEventStore>(signer::address_of(account));
+        event::emit_event<GeneralTokenEvent>(
+            &mut token_event_store.events,
+            gte,
+        );
+    }
+
+    /// Emit URI mutation event
+    public(friend) fun emit_token_uri_mutate_event(
+        account: &signer,
+        new_uri: String,
+        collection: String,
+        token_name: String,
+    ) acquires TokenEventStore {
+        let pm = property_map::empty();
+        property_map::add(
+            &mut pm,
+            utf8(TOKEN_URI_MUTATION_EVENT_NEW_URI), property_map::create_property_value<String>(&new_uri)
+        );
+        property_map::add(
+            &mut pm,
+            utf8(TOKEN_COLLECTION), property_map::create_property_value<String>(&collection)
+        );
+        property_map::add(
+            &mut pm,
+            utf8(TOKEN_NAME), property_map::create_property_value<String>(&token_name)
+        );
+
+        let gte = GeneralTokenEvent {
+            token_event_name: utf8(TOKEN_URI_MUTATION_EVENT_NAME),
+            event_attributes: pm,
+        };
+
+        initialize_token_event_store(account);
+        let token_event_store = borrow_global_mut<TokenEventStore>(signer::address_of(account));
+        event::emit_event<GeneralTokenEvent>(
+            &mut token_event_store.events,
+            gte,
+        );
+    }
+
+    /// Emit tokendata property map mutation event
+    public(friend) fun emit_tokendata_property_mutate_event(
+        account: &signer,
+        new_propertymap: PropertyMap,
+        creator: address,
+        collection: String,
+        token_name: String,
+    ) acquires TokenEventStore {
+        let pm = property_map::empty();
+        property_map::add(
+            &mut pm,
+            utf8(TOKENDATA_PROPERTY_MUTATION_EVENT_NEW_PROPERTYMAP), property_map::create_property_value<PropertyMap>(&new_propertymap)
+        );
+        property_map::add(
+            &mut pm,
+            utf8(TOKEN_CREATOR), property_map::create_property_value<address>(&creator)
+        );
+        property_map::add(
+            &mut pm,
+            utf8(TOKEN_COLLECTION), property_map::create_property_value<String>(&collection)
+        );
+        property_map::add(
+            &mut pm,
+            utf8(TOKEN_NAME), property_map::create_property_value<String>(&token_name)
+        );
+
+
+        let gte = GeneralTokenEvent {
+            token_event_name: utf8(TOKENDATA_PROPERTY_MUTATION_EVENT_NAME),
+            event_attributes: pm,
+        };
+
+        initialize_token_event_store(account);
+        let token_event_store = borrow_global_mut<TokenEventStore>(signer::address_of(account));
+        event::emit_event<GeneralTokenEvent>(
+            &mut token_event_store.events,
+            gte,
+        );
+    }
+}


### PR DESCRIPTION
### Description
1. create a new token event store for all future new token events
2. reorganize the code based on entry, public and private/friend to different sections for easy navigating
3. use transfer event as an example for this general token store. 


### Test Plan
add unit test
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4401)
<!-- Reviewable:end -->
