### PR TITLE
Tutorial docs cleanup (three tutorials)

### DIFF
--- a/developer-docs-site/docs/concepts/coin-and-token/index.md
+++ b/developer-docs-site/docs/concepts/coin-and-token/index.md
@@ -17,7 +17,7 @@ See [Aptos Coin >](aptos-coin)
 
 ### [Aptos Token](aptos-token)
 
-The [`token.move`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move), Move module, on the other hand:
+The [`token.move`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) Move module, on the other hand:
 
 - Encapsulates rich, flexible assets, fungible and nonfungible, and collectibles. 
 - The token standard is deployed as a separate package at the Aptos blockchain address `0x3`. 

--- a/developer-docs-site/docs/tutorials/first-move-module.md
+++ b/developer-docs-site/docs/tutorials/first-move-module.md
@@ -208,7 +208,7 @@ where, after a call to set the message to `hello, blockchain, again`, the event 
 
 :::tip
 
-Other accounts can reuse the published module by calling the exact same function as in this example. It is left as an exercise to validate this.
+Other accounts can reuse the published module by calling the exact same function as in this example. It is left as an exercise to the reader.
 
 :::
 

--- a/developer-docs-site/docs/tutorials/first-move-module.md
+++ b/developer-docs-site/docs/tutorials/first-move-module.md
@@ -1,7 +1,6 @@
 ---
 title: "Your First Move Module"
 slug: "first-move-module"
-sidebar_position: 2
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,21 +8,32 @@ import TabItem from '@theme/TabItem';
 
 # Your First Move Module
 
-This tutorial details how to compile, test, publish and interact with Move Modules on the Aptos blockchain. The steps are:
+This tutorial details how to compile, test, publish and interact with Move modules on the Aptos blockchain. The steps in summary are:
 
-1. [Install the CLI from Git][install_cli]
-2. Compile and test a Move module
-3. Publish a Move module to the Aptos blockchain
-4. Interact with a Move module
-5. Understand the code
+1. Install the precombiled binary for the Aptos CLI.
+2. Create an account on the Aptos blockchain and fund it.
+3. Compile and test a Move module.
+4. Publish a Move module to the Aptos blockchain.
+5. Interact with a Move module.
 
+## Step 1: Install the CLI
 
-## Prepare the CLI environment
+[Install the precombiled binary for the Aptos CLI][install_cli].
 
-After installing the CLI from Git, prepare your environment for interacting with Aptos by creating and funding an account. Begin by starting a new terminal.
+---
 
-1. Initialize a new local account: `aptos init`. The output will be similar to below. The account mentioned here `a345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a` is your new account, and is aliased as the profile `default`.  This is generated randomly, and will differ for you  From now on, either `default` or `0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a` are interchangeable.
+## Step 2: Create an account and fund it 
+
+After installing the CLI binary, next step is to create and fund an account on the Aptos blockchain. 
+
+1. Begin by starting a new terminal and run the below command to initialize a new local account: 
+
+```bash
+aptos init
 ```
+
+The output will be similar to below. 
+```text
 Enter your rest endpoint [Current: None | No input: https://fullnode.devnet.aptoslabs.com/v1]
 
 No rest url given, using https://fullnode.devnet.aptoslabs.com/v1...
@@ -39,37 +49,63 @@ Aptos is now set up for account a345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c
   "Result": "Success"
 }
 ```
-2. Now fund this account: `aptos account fund-with-faucet --account default`
+
+The account address in the above output:  `a345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a` is your new account, and is aliased as the profile `default`. This account address will be different for you as it is generated randomly. From now on, either `default` or `0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a` are interchangeable.
+
+2. Now fund this account by running this command: 
+
+```bash
+aptos account fund-with-faucet --account default
+```
+You will see an output similar to the below:
 ```
 {
   "Result": "Added 10000 coins to account a345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a"
 }
 ```
 
-## Compile and test the module
+---
 
-There are many example Move modules in the [aptos-core/aptos-move/move-examples](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples) directory.
+## Step 3: Compile and test the module
 
-Load a terminal and change directories into the `hello_blockchain` directory: `cd aptos-core/aptos-move/move-examples/hello_blockchain`.
+Several example Move modules are available in the [aptos-core/aptos-move/move-examples](https://github.com/aptos-labs/aptos-core/tree/main/aptos-move/move-examples) directory. Open a terminal and change directories into the `hello_blockchain` directory: 
 
-To compile the module run: `aptos move compile --named-addresses hello_blockchain=default`.
-To test the module run: `aptos move test --named-addresses hello_blockchain=default`.
+```bash
+cd aptos-core/aptos-move/move-examples/hello_blockchain
+```
 
-The CLI entry must contain `--named-addresses` because the `Move.toml` file leaves this as undefined:
+Run the below command to compile the `hello_blockchain` module: 
+
+```bash
+aptos move compile --named-addresses hello_blockchain=default
+```
+
+To test the module run: 
+
+```bash
+aptos move test --named-addresses hello_blockchain=default
+```
+
+The CLI entry must contain `--named-addresses` because the [`Move.toml`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/move-examples/hello_blockchain/Move.toml) file leaves this as undefined (see below). To prepare the module for the account created in the previous step, we specify that the named address `hello_blockchain` is set to our account address, using the `default` profile alias.
 
 ```toml
 [addresses]
 hello_blockchain = "_"
 ```
 
-In order to prepare the module for the account created in the previous step, we specify that the named address `hello_blockchain` is set to our account address.
+---
 
-## Publish the Move module
+## Step 4: Publish the Move module
 
-Now that the code can be compiled and tests pass, let's publish the module to the account created for this tutorial:
-`aptos move publish --named-addresses hello_blockchain=default`
+After the code was compiled and tested, we can publish the module to the account created for this tutorial. Run this below command:
 
+```bash
+aptos move publish --named-addresses hello_blockchain=default
 ```
+
+You will see the output similar to the below:
+
+```json
 package size 1631 bytes
 {
   "Result": {
@@ -87,21 +123,23 @@ package size 1631 bytes
 }
 ```
 
-At this point, the module is now stored on the account.
+At this point, the module is now stored on the account in the Aptos blockchain.
 
-## Interact with the module
+---
 
-Move modules expose access points or `entry functions`. These can be called via transactions. The CLI allows for seamless access to these. `hello_blockchain` exposes a `set_message` entry function that takes in a `string`. This can be called via the CLI:
+## Step 5: Interact with the Move module
 
-```
+Move modules expose access points, also referred as `entry functions`. These access points can be called via transactions. The CLI allows for seamless access to these access points. The example Move module `hello_blockchain` exposes a `set_message` entry function that takes in a `string`. This can be called via the CLI:
+
+```bash
 aptos move run \
---function-id 'default::message::set_message' \
---args 'string:hello, blockchain'
+  --function-id 'default::message::set_message' \
+  --args 'string:hello, blockchain'
 ```
 
 Upon success, the CLI will print out the following:
 
-```
+```json
 {
   "Result": {
     "transaction_hash": "0x1fe06f61c49777086497b199f3d4acbee9ea58976d37fdc06d1ea48a511a9e82",
@@ -118,13 +156,16 @@ Upon success, the CLI will print out the following:
 }
 ```
 
-The `set_message` modifies the `hello_blockchain` `MessageHolder` resource. A resource is a data structure that is stored in [global storage](https://move-language.github.io/move/structs-and-resources.html#storing-resources-in-global-storage). The resource can be read by querying the following REST API:
+The `set_message` function modifies the `hello_blockchain` `MessageHolder` resource. A resource is a data structure that is stored in [global storage](https://move-language.github.io/move/structs-and-resources.html#storing-resources-in-global-storage). The resource can be read by querying the following REST API:
 
-`https://fullnode.devnet.aptoslabs.com/v1/accounts/a345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a/resource/0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a::message::MessageHolder`
+```bash
 
-Which after the first execution contains the following:
-
+https://fullnode.devnet.aptoslabs.com/v1/accounts/a345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a/resource/0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a::message::MessageHolder
 ```
+
+which, after the first execution contains the following:
+
+```json
 {
   "type":"0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a::message::MessageHolder",
   "data":{
@@ -142,14 +183,16 @@ Which after the first execution contains the following:
 }
 ```
 
-Notice the `message` field contains `hello, blockchain`.
+Notice that the `message` field contains `hello, blockchain`.
 
 Each successful call to `set_message` after the first call results in an update to `message_change_events`. The `message_change_events` for a given account can be accessed via the REST API: 
 
-`http://127.0.0.1:8080/v1/accounts/0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a/events/0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a::message::MessageHolder/message_change_events`
-
-Where after a call to set the message to `hello, blockchain, again`, the event stream would contain the following:
+```bash
+http://127.0.0.1:8080/v1/accounts/0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a/events/0xa345dbfb0c94416589721360f207dcc92ecfe4f06d8ddc1c286f569d59721e5a::message::MessageHolder/message_change_events
 ```
+
+where, after a call to set the message to `hello, blockchain, again`, the event stream would contain the following:
+```json
 [
   {
     "version":"8556",
@@ -172,5 +215,5 @@ Other accounts can reuse the published module by calling the exact same function
 [account_basics]: /concepts/basics-accounts
 [alice_account_rest]: https://fullnode.devnet.aptoslabs.com/v1/accounts/a52671f10dc3479b09d0a11ce47694c0/
 [bob_account_explorer]: https://explorer.devnet.aptos.dev/account/ec6ec14e4abe10aaa6ad53b0b63a1806
-[install_cli]: /cli-tools/aptos-cli-tool/install-aptos-cli
+[install_cli]: /cli-tools/aptos-cli-tool/install-aptos-cli#download-precompiled-binary
 [rest_spec]: https://fullnode.devnet.aptoslabs.com/v1/spec#/

--- a/developer-docs-site/docs/tutorials/first-move-module.md
+++ b/developer-docs-site/docs/tutorials/first-move-module.md
@@ -105,7 +105,7 @@ aptos move publish --named-addresses hello_blockchain=default
 
 You will see the output similar to the below:
 
-```json
+```bash
 package size 1631 bytes
 {
   "Result": {

--- a/developer-docs-site/docs/tutorials/first-transaction.md
+++ b/developer-docs-site/docs/tutorials/first-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: "Your First Transaction"
 slug: "your-first-transaction"
-sidebar_position: 0
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,21 +8,22 @@ import TabItem from '@theme/TabItem';
 
 # Your First Transaction
 
-This tutorial introduces the Aptos SDKs and how to generate, submit, and verify transactions submitted to the Aptos blockchain. We will be running the `transfer-coin` example.
+This tutorial describes how to generate and submit transactions to the Aptos blockchain, and verify these submitted transactions. The `transfer-coin` example used in this tutorial is built with the Aptos SDKs.
 
 ## Step 1: Pick an SDK
 
-* [Official Aptos Typescript SDK][typescript-sdk]
-* [Official Aptos Python SDK][python-sdk]
-* [Official Aptos Rust SDK][rust-sdk]
+Install your preferred SDK from the below list:
 
-## Step 2: Run the Example
+* [Typescript SDK][typescript-sdk]
+* [Python SDK][python-sdk]
+* [Rust SDK][rust-sdk]
 
-Clone `aptos-core`:
+## Step 2: Run the example
+
+Clone the `aptos-core` repo:
 ```sh
 git clone https://github.com/aptos-labs/aptos-core.git
 ```
-
 
 <Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
@@ -38,7 +38,8 @@ git clone https://github.com/aptos-labs/aptos-core.git
   yarn install
   ```
 
-  Run the `transfer_coin` example:
+  Run the [`transfer_coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/transfer_coin.ts) example:
+  
   ```sh
   yarn run transfer_coin
   ```

--- a/developer-docs-site/docs/tutorials/first-transaction.md
+++ b/developer-docs-site/docs/tutorials/first-transaction.md
@@ -18,6 +18,8 @@ Install your preferred SDK from the below list:
 * [Python SDK][python-sdk]
 * [Rust SDK][rust-sdk]
 
+---
+
 ## Step 2: Run the example
 
 Clone the `aptos-core` repo:
@@ -76,11 +78,13 @@ git clone https://github.com/aptos-labs/aptos-core.git
   </TabItem>
 </Tabs>
 
+---
+
 ## Step 3: Understand the output
 
 An output very similar to the following will appear after executing the above command:
 
-```
+```yaml
 === Addresses ===
 Alice: 0x0baec07bfc42f8018ea304ddc307a359c1c6ab20fbce598065b6cb19acff7043
 Bob: 0xc98ceafadaa32e50d06d181842406dbbf518b6586ab67cfa2b736aaddeb7c74f
@@ -111,6 +115,8 @@ The above output demonstrates that the `transfer-coin` example executes the foll
 
 Next, see below a walk-through of the SDK functions that are used to accomplish the above steps.
 
+---
+
 ## Step 4: The SDK in depth
 
 The `transfer-coin` example code uses helper functions to interact with the [REST API][rest_spec]. This section reviews each of the calls and gives insights into functionality.
@@ -118,23 +124,25 @@ The `transfer-coin` example code uses helper functions to interact with the [RES
 <Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
-:::tip See the full example
+:::tip See the full code
 See the Typescript [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/transfer_coin.ts) for the complete code as you follow the below steps.
 :::
   </TabItem>
   <TabItem value="python" label="Python">
 
-:::tip See the full example
+:::tip See the full code
 See the Python [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/transfer-coin.py) for the complete code as you follow the below steps.
 :::
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-:::tip See the full example
+:::tip See the full code
 See the Rust [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/sdk/examples/transfer-coin.rs) for the complete code as you follow the below steps.
 :::
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.1: Initializing the clients
 
@@ -197,6 +205,8 @@ By default the URLs for both the services point to Aptos devnet services. Howeve
   - `APTOS_FAUCET_URL`
 :::
 
+---
+
 ### Step 4.2: Creating local accounts
 
 The next step is to create two accounts locally. [Accounts][account_basics] represent both on and off-chain state. Off-chain state consists of an address and the public, private key pair used to authenticate ownership. This step demonstrates how to generate that off-chain state.
@@ -222,6 +232,8 @@ The next step is to create two accounts locally. [Accounts][account_basics] repr
   </TabItem>
 </Tabs>
 
+---
+
 ### Step 4.3: Creating blockchain accounts
 
 In Aptos, each account must have an on-chain representation in order to support receive tokens and coins as well as interacting in other dApps. An account represents a medium for storing assets, hence it must be explicitly created. This example leverages the Faucet to create and fund Alice's account and to only create Bob's account:
@@ -246,6 +258,8 @@ In Aptos, each account must have an on-chain representation in order to support 
 ```
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.4: Reading balances
 
@@ -293,6 +307,8 @@ let balance = self
 ```
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.5: Transferring
 
@@ -363,6 +379,8 @@ Breaking the above down into pieces:
   </TabItem>
 </Tabs>
 
+---
+
 ### Step 4.6: Waiting for transaction resolution
 
 <Tabs groupId="sdk-examples">
@@ -395,7 +413,7 @@ The transaction hash can be used to query the status of a transaction:
 </Tabs>
 
 [account_basics]: /concepts/basics-accounts
-[typescript-sdk]: /sdks/typescript-sdk
+[typescript-sdk]: /sdks/ts-sdk/index
 [python-sdk]: /sdks/python-sdk
 [rust-sdk]: /sdks/rust-sdk
 [rest_spec]: https://fullnode.devnet.aptoslabs.com/v1/spec#/

--- a/developer-docs-site/docs/tutorials/first-transaction.md
+++ b/developer-docs-site/docs/tutorials/first-transaction.md
@@ -21,7 +21,7 @@ Install your preferred SDK from the below list:
 ## Step 2: Run the example
 
 Clone the `aptos-core` repo:
-```sh
+```bash
 git clone https://github.com/aptos-labs/aptos-core.git
 ```
 
@@ -29,54 +29,54 @@ git clone https://github.com/aptos-labs/aptos-core.git
   <TabItem value="typescript" label="Typescript">
 
   Navigate to the Typescript SDK examples directory:
-  ```sh
+  ```bash
   cd ~/aptos-core/ecosystem/typescript/sdk/examples/typescript
   ```
 
   Install the necessary dependencies:
-  ```
+  ```bash
   yarn install
   ```
 
   Run the [`transfer_coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/transfer_coin.ts) example:
-  
-  ```sh
+
+  ```bash
   yarn run transfer_coin
   ```
   </TabItem>
   <TabItem value="python" label="Python">
 
   Navigate to the Python SDK directory:
-  ```sh
+  ```bash
   cd ~/aptos-core/ecosystem/python/sdk
   ```
 
   Install the necessary dependencies:
-  ```
+  ```bash
   curl -sSL https://install.python-poetry.org | python3
   poetry update
   ```
 
-  Run the `transfer-coin` example:
-  ```sh
+  Run the [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/transfer-coin.py) example:
+  ```bash
   poetry run python -m examples.transfer-coin
   ```
   </TabItem>
   <TabItem value="rust" label="Rust">
 
   Navigate to the Rust SDK directory:
-  ```sh
+  ```bash
   cd ~/aptos-core/sdk
   ```
 
-  Run the `transfer-coin` example:
-  ```sh
+  Run the [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/sdk/examples/transfer-coin.rs) example:
+  ```bash
   cargo run --example transfer-coin
   ```
   </TabItem>
 </Tabs>
 
-## Step 3: Understand the Output
+## Step 3: Understand the output
 
 An output very similar to the following will appear after executing the above command:
 
@@ -109,9 +109,9 @@ The above output demonstrates that the `transfer-coin` example executes the foll
 * Another transfer of 1000 coins from Alice to Bob.
 * The additional 4 coins of gas paid for by Alice to make that transfer.
 
-Next, see below a walk-through of the Python SDK functions that are used to accomplish the above steps.
+Next, see below a walk-through of the SDK functions that are used to accomplish the above steps.
 
-## Step 4: The SDK in Depth
+## Step 4: The SDK in depth
 
 The `transfer-coin` example code uses helper functions to interact with the [REST API][rest_spec]. This section reviews each of the calls and gives insights into functionality.
 
@@ -119,24 +119,24 @@ The `transfer-coin` example code uses helper functions to interact with the [RES
   <TabItem value="typescript" label="Typescript">
 
 :::tip See the full example
-See [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/transfer_coin.ts) for the complete code as you follow the below steps.
+See the Typescript [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/transfer_coin.ts) for the complete code as you follow the below steps.
 :::
   </TabItem>
   <TabItem value="python" label="Python">
 
 :::tip See the full example
-See [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/transfer-coin.py) for the complete code as you follow the below steps.
+See the Python [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/transfer-coin.py) for the complete code as you follow the below steps.
 :::
   </TabItem>
   <TabItem value="rust" label="Rust">
 
 :::tip See the full example
-See [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/sdk/examples/transfer-coin.rs) for the complete code as you follow the below steps.
+See the Rust [`transfer-coin`](https://github.com/aptos-labs/aptos-core/blob/main/sdk/examples/transfer-coin.rs) for the complete code as you follow the below steps.
 :::
   </TabItem>
 </Tabs>
 
-### Step 4.1: Initializing the Clients
+### Step 4.1: Initializing the clients
 
 In the first step, the `transfer-coin` example initializes both the REST and faucet clients.
 
@@ -249,7 +249,7 @@ In Aptos, each account must have an on-chain representation in order to support 
 
 ### Step 4.4: Reading balances
 
-In this step, the Python SDK translates a single call into the process of querying a resource and reading a field from that resource.
+In this step, the SDK translates a single call into the process of querying a resource and reading a field from that resource.
 
 <Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">

--- a/developer-docs-site/docs/tutorials/index.md
+++ b/developer-docs-site/docs/tutorials/index.md
@@ -1,37 +1,32 @@
 ---
 title: "Developer Tutorials"
 slug: "aptos-quickstarts"
-hidden: false
 ---
 
 # Developer Tutorials
 
-If you are new to the Aptos blockchain, begin with these quickstarts before you get into in-depth development. These tutorials will help you familiarize yourself with how to develop for the Aptos blockchain using the Aptos SDK.
+If you are new to the Aptos blockchain, begin with these quickstarts before you get into in-depth development. These tutorials will help you become familiar with how to develop for the Aptos blockchain using the Aptos SDK. 
 
-- ### [Your First Transaction](first-transaction.md)
+### [Your First Transaction](first-transaction.md)
 
-    How to generate, submit and verify a transaction to the Aptos blockchain. 
+How to generate, submit and verify a transaction to the Aptos blockchain. 
 
-- ### [Your First Move Module](first-move-module.md)
+### [Your First Move Module](first-move-module.md)
 
-    Write your first Move module for the Aptos blockchain. Make sure to run the above [Your First Transaction](first-transaction.md) tutorial before running this.
+Write your first Move module for the Aptos blockchain. 
 
-<!--
-This needs to be updated to use the CLI
+:::tip
+Make sure to run the above [Your First Transaction](first-transaction.md) tutorial before running this.
+:::
 
-- ### [Your First Coin](first-coin.md)
+### [Your First Dapp](first-dapp.md)
 
-    Deploy your first coin on the Aptos blockchain. Make sure to run the above [Your First Transaction](first-transaction.md) tutorial before running this.
--->
+Learn how to build your first dapp. Focuses on building the user interface for the dapp.
 
-- ### [Your First Dapp](first-dapp.md)
+### [Your First NFT](your-first-nft.md)
 
-    Learn how to build your first dapp. Focuses on building the user interface for the dapp.
+Learn the Aptos `token` interface and how to use it. This interface is defined in the [`token.move`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) Move module.
 
-- ### [Your First NFT](your-first-nft.md)
+### [Your First Coin](first-coin.md)
 
-    Learn the Aptos `Token` interface and how to use it.
-
-- ### [Your First Coin](first-coin.md)
-
-    Learn how to deploy and managed a coin.
+Learn how to deploy and managed a coin. The `coin` interface is defined in the [`coin.move`](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-framework/sources/coin.move) Move module.

--- a/developer-docs-site/docs/tutorials/your-first-nft.md
+++ b/developer-docs-site/docs/tutorials/your-first-nft.md
@@ -10,20 +10,24 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Your First NFT
 
-This tutorial describes, in the following step-by-step approach, how to create and transfer NFTs on the Aptos blockchain. The Aptos implementation for core NFTs or Tokens can be found in [token.move](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move).
+This tutorial describes how to create and transfer NFTs on the Aptos blockchain. The Aptos implementation for core NFTs can be found in the [token.move](https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-token/sources/token.move) Move module.
 
 ## Step 1: Pick an SDK
 
-* [Official Aptos Typescript SDK][typescript-sdk]
-* [Official Aptos Python SDK][python-sdk]
-* Official Aptos Rust SDK -- TBA
+Install your preferred SDK from the below list:
 
-## Step 2: Run the Example
+* [Typescript SDK][typescript-sdk]
+* [Python SDK][python-sdk]
+* [Rust SDK][rust-sdk]
 
-Each SDK provides an examples directory. This tutorial covers the `simple-nft` example.
+---
 
-Clone `aptos-core`:
-```sh
+## Step 2: Run the example
+
+Each SDK provides an `examples` directory. This tutorial covers the `simple-nft` example.
+
+Clone the `aptos-core` repo:
+```bash
 git clone git@github.com:aptos-labs/aptos-core.git ~/aptos-core
 ```
 
@@ -31,49 +35,51 @@ git clone git@github.com:aptos-labs/aptos-core.git ~/aptos-core
   <TabItem value="typescript" label="Typescript">
 
   Navigate to the Typescript SDK examples directory:
-  ```sh
+  ```bash
   cd ~/aptos-core/ecosystem/typescript/sdk/examples/typescript
   ```
 
   Install the necessary dependencies:
-  ```
+  ```bash
   yarn install
   ```
 
-  Run the `simple_nft` example:
-  ```sh
+  Run the Typescript [`simple_nft`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/simple_nft.ts) example:
+  ```bash
   yarn run simple_nft
   ```
   </TabItem>
   <TabItem value="python" label="Python">
 
   Navigate to the Python SDK directory:
-  ```sh
+  ```bash
   cd ~/aptos-core/ecosystem/python/sdk
   ```
 
   Install the necessary dependencies:
-  ```
+  ```bash
   curl -sSL https://install.python-poetry.org | python3
   poetry update
   ```
 
-  Run the `simple-nft` example:
-  ```sh
+  Run the Python [`simple-nft`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/simple-nft.py) example:
+  ```bash
   poetry run python -m examples.simple-nft
   ```
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
 
-## Step 3: Understand the Output
+---
+
+## Step 3: Understand the output
 
 The following output should appear after executing the `simple-nft` example, though some values will be different:
 
-```
+```yaml
 === Addresses ===
 Alice: 0x9df0f527f3a0b445e4d5c320cfa269cdefafc7cd1ed17ffce4b3fd485b17aafb
 Bob: 0xfcc74af84dde26b0050dce35d6b3d11c60f5c8c58728ca3a0b11035942a0b1de
@@ -133,35 +139,39 @@ Bob's token balance: 0
 
 This example demonstrates:
 
-* Initializing the REST and Faucet clients
-* The creation of two accounts: Alice and Bob
-* The funding and creation of Alice and Bob's accounts
-* The creation of a collection and a token using Alice's account
-* Alice offering a token and Bob claiming it
-* Bob unilaterally sending the token to Alice via a multiagent transaction
+* Initializing the REST and faucet clients.
+* The creation of two accounts: Alice and Bob.
+* The funding and creation of Alice and Bob's accounts.
+* The creation of a collection and a token using Alice's account.
+* Alice offering a token and Bob claiming it.
+* Bob unilaterally sending the token to Alice via a multiagent transaction.
 
-## Step 4: The SDK in Depth
+---
+
+## Step 4: The SDK in depth
 
 <Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
-:::tip See the full example
+:::tip See the full code
 See [`simple_nft`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/simple_nft.ts) for the complete code as you follow the below steps.
 :::
   </TabItem>
   <TabItem value="python" label="Python">
 
-:::tip See the full example
+:::tip See the full code
 See [`simple-nft`](https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/python/sdk/examples/simple-nft.py) for the complete code as you follow the below steps.
 :::
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
 
-### Step 4.1: Initializing the Clients
+---
+
+### Step 4.1: Initializing the clients
 
 In the first step the example initializes both the API and faucet clients.
 
@@ -199,9 +209,10 @@ Using the API client we can create a `TokenClient`, which we use for common toke
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
 
 :::tip
 
@@ -210,6 +221,7 @@ By default the URLs for both the services point to Aptos devnet services. Howeve
   - `APTOS_FAUCET_URL`
 :::
 
+---
 
 ### Step 4.2: Creating local accounts
 
@@ -230,9 +242,11 @@ The next step is to create two accounts locally. [Accounts][account_basics] repr
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.3: Creating blockchain accounts
 
@@ -253,9 +267,11 @@ In Aptos, each account must have an on-chain representation in order to support 
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.4: Creating a collection
 
@@ -288,9 +304,11 @@ The function signature of `create_collection`. It returns a transaction hash:
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.5: Creating a token
 
@@ -323,9 +341,11 @@ The function signature of `create_token`. It returns a transaction hash:
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.6: Reading token and collection metadata
 
@@ -370,9 +390,11 @@ Here's how `get_token_data` queries the token metadata:
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.7: Reading a token balance
 
@@ -393,9 +415,11 @@ Each token within Aptos is a distinct asset, the assets owned by the user are st
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.8: Offering and claiming a token
 
@@ -439,13 +463,16 @@ To claim a token:
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
+
+---
 
 ### Step 4.9: Safe unilateral transferring of a token
 
 To support safe unilateral transfers of a token, the sender may first ask the recipient to acknowledge off-chain about a pending transfer. This comes in the form of a multiagent transaction request. Multiagent transactions contain multiple signatures, one for each on-chain account. Move then can leverage this to give `signer` level permissions to all that signed. For token transfers, this ensures that the receiving party does indeed desire to receive this token without requiring the use of the token transfer framework described above.
+
 <Tabs groupId="sdk-examples">
   <TabItem value="typescript" label="Typescript">
 
@@ -461,30 +488,33 @@ To support safe unilateral transfers of a token, the sender may first ask the re
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
 
+---
+
 ### Step 4.10: Enabling unilateral token transfers
 
-Coming soon!
+Coming soon.
 
 <Tabs groupId="sdk-examples">
   <TabItem value="python" label="Python">
 
-Coming soon!
+Coming soon.
   </TabItem>
   <TabItem value="rust" label="Rust">
 
-Coming soon!
+Coming soon.
   </TabItem>
   <TabItem value="typescript" label="Typescript">
 
-Coming soon!
+Coming soon.
   </TabItem>
 </Tabs>
 
 [account_basics]: /concepts/basics-accounts
-[typescript-sdk]: /sdks/typescript-sdk
+[typescript-sdk]: /sdks/ts-sdk/index
 [python-sdk]: /sdks/python-sdk
+[rust-sdk]: /sdks/rust-sdk
 [rest_spec]: https://fullnode.devnet.aptoslabs.com/v1/spec#/


### PR DESCRIPTION
If we no more touch these tutorials, these are ready for the prime time, formatting and readability wise.
- Better code snippet highlighting 
- Editing to fix minor snafus
- Horizontal ruler between each step for tutorials. Enhances readability, especially with the tabs.
- Change CLI install pointer from git source to precompiled binary.
- Reflowed the Move module tutorial with a slight modification, adding step numbers. 
I will have a separate PR for the remaining tutorials.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4407)
<!-- Reviewable:end -->
