### PR TITLE
[network] Add REST API discovery for Validator full nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,7 @@ dependencies = [
  "serde 1.0.149",
  "serde_yaml 0.8.26",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,6 +1680,7 @@ dependencies = [
  "aptos-metrics-core",
  "aptos-netcore",
  "aptos-network",
+ "aptos-rest-client",
  "aptos-secure-storage",
  "aptos-short-hex-str",
  "aptos-temppath",
@@ -1691,6 +1692,7 @@ dependencies = [
  "rand 0.7.3",
  "serde_yaml 0.8.26",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -31,6 +31,7 @@ rand = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
 thiserror = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 aptos-crypto = { workspace = true }

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -362,7 +362,7 @@ pub struct FileDiscovery {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct RestDiscovery {
-    pub url: String,
+    pub url: url::Url,
     pub interval_secs: u64,
 }
 

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -25,7 +25,6 @@ use std::{
     fmt,
     path::PathBuf,
     string::ToString,
-    time::Duration,
 };
 
 // TODO: We could possibly move these constants somewhere else, but since they are defaults for the
@@ -348,8 +347,23 @@ impl Default for PeerMonitoringServiceConfig {
 #[serde(rename_all = "snake_case")]
 pub enum DiscoveryMethod {
     Onchain,
-    File(PathBuf, Duration),
+    File(FileDiscovery),
+    Rest(RestDiscovery),
     None,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FileDiscovery {
+    pub path: PathBuf,
+    pub interval_secs: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RestDiscovery {
+    pub url: String,
+    pub interval_secs: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -41,6 +41,7 @@ use aptos_types::{chain_id::ChainId, network_address::NetworkAddress};
 
 use aptos_netcore::transport::tcp::TCPBufferCfg;
 use aptos_network_discovery::DiscoveryChangeListener;
+use std::time::Duration;
 use std::{
     clone::Clone,
     collections::{HashMap, HashSet},
@@ -403,11 +404,18 @@ impl NetworkBuilder {
                     reconfig_events,
                 )
             }
-            DiscoveryMethod::File(path, interval_duration) => DiscoveryChangeListener::file(
+            DiscoveryMethod::File(file_discovery) => DiscoveryChangeListener::file(
                 self.network_context,
                 conn_mgr_reqs_tx,
-                path,
-                *interval_duration,
+                file_discovery.path.as_path(),
+                Duration::from_secs(file_discovery.interval_secs),
+                self.time_service.clone(),
+            ),
+            DiscoveryMethod::Rest(rest_discovery) => DiscoveryChangeListener::rest(
+                self.network_context,
+                conn_mgr_reqs_tx,
+                &rest_discovery.url,
+                Duration::from_secs(rest_discovery.interval_secs),
                 self.time_service.clone(),
             ),
             DiscoveryMethod::None => return,

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -414,7 +414,7 @@ impl NetworkBuilder {
             DiscoveryMethod::Rest(rest_discovery) => DiscoveryChangeListener::rest(
                 self.network_context,
                 conn_mgr_reqs_tx,
-                &rest_discovery.url,
+                rest_discovery.url.clone(),
                 Duration::from_secs(rest_discovery.interval_secs),
                 self.time_service.clone(),
             ),

--- a/network/discovery/Cargo.toml
+++ b/network/discovery/Cargo.toml
@@ -21,6 +21,7 @@ aptos-event-notifications = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-network = { workspace = true }
+aptos-rest-client = { workspace = true }
 aptos-secure-storage = { workspace = true }
 aptos-short-hex-str = { workspace = true }
 aptos-time-service = { workspace = true }
@@ -30,6 +31,7 @@ futures = { workspace = true }
 once_cell = { workspace = true }
 serde_yaml = { workspace = true }
 tokio = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 aptos-config = { workspace = true, features = ["testing"] }

--- a/network/discovery/src/lib.rs
+++ b/network/discovery/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::rest::RestStream;
 use crate::{counters::DISCOVERY_COUNTS, file::FileStream, validator_set::ValidatorSetStream};
 use aptos_config::{config::PeerSet, network_id::NetworkContext};
 use aptos_crypto::x25519;
@@ -23,12 +24,14 @@ use tokio::runtime::Handle;
 
 mod counters;
 mod file;
+mod rest;
 mod validator_set;
 
 #[derive(Debug)]
 pub enum DiscoveryError {
     IO(std::io::Error),
     Parsing(String),
+    Rest(aptos_rest_client::error::RestError),
 }
 
 /// A union type for all implementations of `DiscoveryChangeListenerTrait`
@@ -42,6 +45,7 @@ pub struct DiscoveryChangeListener {
 enum DiscoveryChangeStream {
     ValidatorSet(ValidatorSetStream),
     File(FileStream),
+    Rest(RestStream),
 }
 
 impl Stream for DiscoveryChangeStream {
@@ -51,6 +55,7 @@ impl Stream for DiscoveryChangeStream {
         match self.get_mut() {
             Self::ValidatorSet(stream) => Pin::new(stream).poll_next(cx),
             Self::File(stream) => Pin::new(stream).poll_next(cx),
+            Self::Rest(stream) => Pin::new(stream).poll_next(cx),
         }
     }
 }
@@ -89,6 +94,27 @@ impl DiscoveryChangeListener {
         ));
         DiscoveryChangeListener {
             discovery_source: DiscoverySource::File,
+            network_context,
+            update_channel,
+            source_stream,
+        }
+    }
+
+    pub fn rest(
+        network_context: NetworkContext,
+        update_channel: aptos_channels::Sender<ConnectivityRequest>,
+        rest_url: &str,
+        interval_duration: Duration,
+        time_service: TimeService,
+    ) -> Self {
+        let source_stream = DiscoveryChangeStream::Rest(RestStream::new(
+            network_context,
+            url::Url::parse(rest_url).expect("REST discovery URL is invalid"),
+            interval_duration,
+            time_service,
+        ));
+        DiscoveryChangeListener {
+            discovery_source: DiscoverySource::Rest,
             network_context,
             update_channel,
             source_stream,

--- a/network/discovery/src/lib.rs
+++ b/network/discovery/src/lib.rs
@@ -103,13 +103,13 @@ impl DiscoveryChangeListener {
     pub fn rest(
         network_context: NetworkContext,
         update_channel: aptos_channels::Sender<ConnectivityRequest>,
-        rest_url: &str,
+        rest_url: url::Url,
         interval_duration: Duration,
         time_service: TimeService,
     ) -> Self {
         let source_stream = DiscoveryChangeStream::Rest(RestStream::new(
             network_context,
-            url::Url::parse(rest_url).expect("REST discovery URL is invalid"),
+            rest_url,
             interval_duration,
             time_service,
         ));

--- a/network/discovery/src/rest.rs
+++ b/network/discovery/src/rest.rs
@@ -1,0 +1,73 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::validator_set::extract_validator_set_updates;
+use crate::DiscoveryError;
+use aptos_config::config::PeerSet;
+use aptos_config::network_id::NetworkContext;
+use aptos_logger::info;
+use aptos_time_service::{Interval, TimeService, TimeServiceTrait};
+use aptos_types::account_address::AccountAddress;
+use aptos_types::on_chain_config::ValidatorSet;
+use futures::executor::block_on;
+use futures::Stream;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+/// A discovery stream that uses the REST client to determine the validator
+/// set nodes.  Useful for when genesis is significantly far behind in time
+pub struct RestStream {
+    network_context: NetworkContext,
+    rest_client: aptos_rest_client::Client,
+    interval: Pin<Box<Interval>>,
+}
+
+impl RestStream {
+    pub(crate) fn new(
+        network_context: NetworkContext,
+        rest_url: url::Url,
+        interval_duration: Duration,
+        time_service: TimeService,
+    ) -> Self {
+        RestStream {
+            network_context,
+            rest_client: aptos_rest_client::Client::new(rest_url),
+            interval: Box::pin(time_service.interval(interval_duration)),
+        }
+    }
+}
+
+impl Stream for RestStream {
+    type Item = Result<PeerSet, DiscoveryError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Wait for delay, or add the delay for next call
+        futures::ready!(self.interval.as_mut().poll_next(cx));
+
+        // Retrieve the onchain resource at the interval
+        // TODO there should be a better way than converting this to a blocking call
+        let response = block_on(self.rest_client.get_account_resource_bcs::<ValidatorSet>(
+            AccountAddress::ONE,
+            "0x1::stake::ValidatorSet",
+        ));
+        Poll::Ready(match response {
+            Ok(inner) => {
+                let validator_set = inner.into_inner();
+                Some(Ok(extract_validator_set_updates(
+                    self.network_context,
+                    validator_set,
+                )))
+            }
+            Err(err) => {
+                info!(
+                    "Failed to retrieve validator set by REST discovery {:?}",
+                    err
+                );
+                Some(Err(DiscoveryError::Rest(err)))
+            }
+        })
+    }
+}

--- a/network/discovery/src/validator_set.rs
+++ b/network/discovery/src/validator_set.rs
@@ -105,7 +105,7 @@ impl Stream for ValidatorSetStream {
 }
 
 /// Extracts a set of ConnectivityRequests from a ValidatorSet which are appropriate for a network with type role.
-fn extract_validator_set_updates(
+pub(crate) fn extract_validator_set_updates(
     network_context: NetworkContext,
     node_set: ValidatorSet,
 ) -> PeerSet {

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -127,6 +127,7 @@ pub struct ConnectivityManager<TBackoff> {
 pub enum DiscoverySource {
     OnChainValidatorSet,
     File,
+    Rest,
     Config,
 }
 
@@ -145,6 +146,7 @@ impl fmt::Display for DiscoverySource {
                 DiscoverySource::OnChainValidatorSet => "OnChainValidatorSet",
                 DiscoverySource::File => "File",
                 DiscoverySource::Config => "Config",
+                DiscoverySource::Rest => "Rest",
             }
         )
     }

--- a/testsuite/smoke-test/src/network.rs
+++ b/testsuite/smoke-test/src/network.rs
@@ -4,7 +4,7 @@
 use crate::smoke_test_environment::{new_local_swarm_with_aptos, SwarmBuilder};
 use aptos::common::types::EncodingType;
 use aptos::test::CliTestFramework;
-use aptos_config::config::Peer;
+use aptos_config::config::{FileDiscovery, Peer};
 use aptos_config::{
     config::{DiscoveryMethod, Identity, NetworkConfig, NodeConfig, PeerSet},
     network_id::NetworkId,
@@ -38,10 +38,10 @@ async fn test_connection_limiting() {
         network.discovery_method = DiscoveryMethod::None;
         network.discovery_methods = vec![
             DiscoveryMethod::Onchain,
-            DiscoveryMethod::File(
-                discovery_file.as_ref().to_path_buf(),
-                Duration::from_secs(1),
-            ),
+            DiscoveryMethod::File(FileDiscovery {
+                path: discovery_file.path().to_path_buf(),
+                interval_secs: 1,
+            }),
         ];
         network.max_inbound_connections = 0;
     });
@@ -149,10 +149,10 @@ async fn test_file_discovery() {
                 network.discovery_method = DiscoveryMethod::None;
                 network.discovery_methods = vec![
                     DiscoveryMethod::Onchain,
-                    DiscoveryMethod::File(
-                        (*discovery_file_for_closure2).as_ref().to_path_buf(),
-                        Duration::from_millis(100),
-                    ),
+                    DiscoveryMethod::File(FileDiscovery {
+                        path: discovery_file_for_closure2.path().to_path_buf(),
+                        interval_secs: 1,
+                    }),
                 ];
             });
         }))


### PR DESCRIPTION
### Description
Now, if the network has fallen too far behind, a user can use the REST API discovery to parse the Validator set directly to get a more up to date view of the validator set.

### Test Plan
Tested locally with onchain discovery off.  It does get the nodes, and syncs from onchain

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4412)
<!-- Reviewable:end -->
