### PR TITLE
fix: fix typo coin_client.ts parameter description

### DIFF
--- a/ecosystem/typescript/sdk/src/coin_client.ts
+++ b/ecosystem/typescript/sdk/src/coin_client.ts
@@ -33,7 +33,7 @@ export class CoinClient {
    * transfer AptosCoin from one account to another.
    *
    * @param from Account sending the coins
-   * @param from Account to receive the coins
+   * @param to Account to receive the coins
    * @param amount Number of coins to transfer
    * @param extraArgs Extra args for building the transaction or configuring how
    * the client should submit and wait for the transaction


### PR DESCRIPTION
### Description
fixed typo CoinClient `transfer` method parameter description.
before `from` after `to`.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
