### PR TITLE
Add multi-signer wallet doc

### DIFF
--- a/developer-docs-site/docs/guides/building-your-own-wallet.md
+++ b/developer-docs-site/docs/guides/building-your-own-wallet.md
@@ -92,7 +92,7 @@ There will be some apis that certain wallets may add but there should be a few a
 // For multi-signer account, there are multiple publicKeys and minKeysRequired value.
 interface PublicAccount {
     address: string;
-    publicKeys: string[];
+    publicKey: string | string[];
     minKeysRequired?: number; // for multi-signer account
 }
 
@@ -149,7 +149,7 @@ export interface SignMessageResponse {
   message: string; // The message passed in by the user
   nonce: string,
   prefix: string, // Should always be APTOS
-  signatures: string[]; // The signed full message
+  signature: string | string[]; // The signed full message
   bitmap?: Uint8Array; // a 4-byte (32 bits) bit-vector of length N
 }
 ```
@@ -160,7 +160,7 @@ export interface SignMessageResponse {
 An example:
 `signMessage({nonce: 1234034, message: "Welcome to dapp!", address: true, application: true, chainId: true })`
 
-This would generate the `fullMessage` to be signed and returned as the `signatures`:
+This would generate the `fullMessage` to be signed and returned as the `signature`:
 ```yaml
 APTOS
 address: 0x000001
@@ -170,9 +170,9 @@ nonce: 1234034
 message: Welcome to dapp!
 ```
 
-If the wallet is single-signer account, there is one signature in `signatures` array and `bitmap` is null.
+If the wallet is single-signer account, there is one signature and `bitmap` is null.
 
-If the wallet is multi-signers account, there are multiple `signatures` and `bitmap` value. `bitmap` masks which public key has signed message.
+If the wallet is multi-signers account, there are multiple `signature` and `bitmap` value. `bitmap` masks which public key has signed message.
 
 ### Event listening (In progress)
 

--- a/developer-docs-site/docs/guides/building-your-own-wallet.md
+++ b/developer-docs-site/docs/guides/building-your-own-wallet.md
@@ -142,9 +142,9 @@ export interface SignMessagePayload {
 }
 
 export interface SignMessageResponse {
-  address: string;
-  application: string;
-  chainId: number;
+  address?: string;
+  application?: string;
+  chainId?: number;
   fullMessage: string; // The message that was generated to sign
   message: string; // The message passed in by the user
   nonce: string,

--- a/developer-docs-site/docs/guides/building-your-own-wallet.md
+++ b/developer-docs-site/docs/guides/building-your-own-wallet.md
@@ -88,9 +88,12 @@ There will be some apis that certain wallets may add but there should be a few a
 ```typescript
 // Common Args and Responses
 
+// For single-signer account, there is one publicKey and minKeysRequired is null.
+// For multi-signer account, there are multiple publicKeys and minKeysRequired value.
 interface PublicAccount {
-    string address;
-    string publicKey;
+    address: string;
+    publicKeys: string[];
+    minKeysRequired?: number; // for multi-signer account
 }
 
 // The important thing to return here is the transaction hash the dapp can wait for it
@@ -146,7 +149,8 @@ export interface SignMessageResponse {
   message: string; // The message passed in by the user
   nonce: string,
   prefix: string, // Should always be APTOS
-  signature: string; // The signed full message
+  signatures: string[]; // The signed full message
+  bitmap?: Uint8Array; // a 4-byte (32 bits) bit-vector of length N
 }
 ```
 
@@ -156,7 +160,7 @@ export interface SignMessageResponse {
 An example:
 `signMessage({nonce: 1234034, message: "Welcome to dapp!", address: true, application: true, chainId: true })`
 
-This would generate the `fullMessage` to be signed and returned as the `signature`:
+This would generate the `fullMessage` to be signed and returned as the `signatures`:
 ```yaml
 APTOS
 address: 0x000001
@@ -165,6 +169,10 @@ application: badsite.firebase.google.com
 nonce: 1234034
 message: Welcome to dapp!
 ```
+
+If the wallet is single-signer account, there is one signature in `signatures` array and `bitmap` is null.
+
+If the wallet is multi-signers account, there are multiple `signatures` and `bitmap` value. `bitmap` masks which public key has signed message.
 
 ### Event listening (In progress)
 


### PR DESCRIPTION
### Description
Add multi-signer account case to building-your-own-wallet and update some interfaces.

### Test Plan
Just update document. No test needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4416)
<!-- Reviewable:end -->
