### PR TITLE
[aptos-logger] Add key to error message telling that serialization failed

### DIFF
--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -112,7 +112,8 @@ impl LogEntry {
                     Value::Serde(s) => match serde_json::to_value(s) {
                         Ok(value) => value,
                         Err(e) => {
-                            eprintln!("error serializing structured log: {}", e);
+                            // Log and skip the value that can't be serialized
+                            eprintln!("error serializing structured log: {} for key {:?}", e, key);
                             return;
                         }
                     },


### PR DESCRIPTION
### Description
For better debugging

### Test Plan
Key is required to have debug, so we'd at least know which field name is failing.  That should be good enough to narrow down which one causes the issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4417)
<!-- Reviewable:end -->
