### PR TITLE
[Docs] Demoting the CLI install by source in the docs.

### DIFF
--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
@@ -7,16 +7,11 @@ id: "install-aptos-cli"
 
 The `aptos` tool is a command line interface (CLI) for developing on the Aptos blockchain, for debugging Move contracts, and for node operations. This document describes how to install the `aptos` CLI tool. See [Use Aptos CLI](use-aptos-cli) for how to use the CLI.
 
-You can install the CLI in one of the two ways: 
-
-1. Download the precompiled binary for your platform, or
-2. Build the binary locally from the source code.
+Install the CLI by downloading the precompiled binary for your platform, as described below. 
 
 :::tip Move Prover Dependencies
-If you want to use the Move Prover, then, [install the Move Prover dependencies](#optional-install-the-dependencies-of-move-prover) after installing the CLI. 
+If you want to use the Move Prover, then, [install the Move Prover dependencies](#optional-install-the-dependencies-of-move-prover) after installing the CLI binary. 
 :::
-
-Choose an option below and follow the step-by-step instructions to either install or upgrade the Aptos CLI tool.
 
 ## Download precompiled binary
 
@@ -32,25 +27,6 @@ When you update the CLI binary with the latest version, note that the newer vers
    - On MacOS when you attempt to run the `aptos` tool for the first time, you will be blocked by the MacOS that this app is from an "unknown developer". This is normal. Follow the simple steps recommended by the Apple support in [Open a Mac app from an unidentified developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) to remove this blocker. 
 2. Type `~/bin/aptos help` to read help instructions.
 3. Add `~/bin` to your path in your `.bashrc` or `.zshrc` file for future use.
-
-
-## Build the binary from the source
-
-Follow these steps to build the CLI binary locally by downloading the source code.
-
-1. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
-2. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`.
-3. Change directory into the `aptos-core` directory: `cd aptos-core`.
-4. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh`.
-5. Update your current shell environment: `source ~/.cargo/env`.
-6. Checkout the correct branch `git checkout --track origin/<branch>`, where `<branch>` is:
-    - `devnet` for building on the Aptos devnet.
-    - `testnet` for building on the Aptos testnet.
-    - `main` for the current development branch.
-7. Build the CLI tool: `cargo build --package aptos --release`.
-8. The binary will be available in `target/release/aptos` folder.
-9. (Optional) Move this executable to a place on your path e.g. `~/bin/aptos`.
-
 
 ## (Optional) Install the dependencies of Move Prover
 
@@ -73,3 +49,23 @@ The Move Prover is not supported on Windows.
     ```bash
     aptos move prove --package-dir aptos-move/move-examples/hello_prover/
     ```
+
+<details>
+<summary>(Advanced users only) Build the CLI binary from the source</summary>
+
+If you are an advanced user and would like to build the CLI binary by downloading the source code, follow the below steps. **This is not recommended.**
+
+1. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
+2. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`.
+3. Change directory into the `aptos-core` directory: `cd aptos-core`.
+4. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh`.
+5. Update your current shell environment: `source ~/.cargo/env`.
+6. Checkout the correct branch `git checkout --track origin/<branch>`, where `<branch>` is:
+    - `devnet` for building on the Aptos devnet.
+    - `testnet` for building on the Aptos testnet.
+    - `main` for the current development branch.
+7. Build the CLI tool: `cargo build --package aptos --release`.
+8. The binary will be available in `target/release/aptos` folder.
+9. (Optional) Move this executable to a place on your path e.g. `~/bin/aptos`.
+
+</details>


### PR DESCRIPTION
Demoted the CLI install by source method. Kept it in a collapsed section at the bottom of the page with sufficient warnings that it is for advanced users only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4421)
<!-- Reviewable:end -->
