### PR TITLE
[aptos-rosetta] Add SetVoter support

### DIFF
--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -248,6 +248,38 @@ impl RosettaClient {
         .await
     }
 
+    pub async fn set_voter(
+        &self,
+        network_identifier: &NetworkIdentifier,
+        private_key: &Ed25519PrivateKey,
+        new_voter: AccountAddress,
+        expiry_time_secs: u64,
+        sequence_number: Option<u64>,
+        max_gas: Option<u64>,
+        gas_unit_price: Option<u64>,
+    ) -> anyhow::Result<TransactionIdentifier> {
+        let sender = self
+            .get_account_address(network_identifier.clone(), private_key)
+            .await?;
+        let mut keys = HashMap::new();
+        keys.insert(sender, private_key);
+
+        // A transfer operation is made up of a withdraw and a deposit
+        let operations = vec![Operation::set_voter(0, None, sender, new_voter)];
+
+        self.submit_operations(
+            sender,
+            network_identifier.clone(),
+            &keys,
+            operations,
+            expiry_time_secs,
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+        )
+        .await
+    }
+
     /// Retrieves the account address from the derivation path if there isn't an overriding account specified
     async fn get_account_address(
         &self,

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -405,6 +405,9 @@ async fn construction_parse(
                 (AccountAddress::ONE, STAKE_MODULE, SET_OPERATOR_FUNCTION) => {
                     parse_set_operator_operation(sender, &type_args, &args)?
                 }
+                (AccountAddress::ONE, STAKE_MODULE, SET_VOTER_FUNCTION) => {
+                    parse_set_voter_operation(sender, &type_args, &args)?
+                }
                 _ => {
                     return Err(ApiError::TransactionParseError(Some(format!(
                         "Unsupported entry function type {:x}::{}::{}",
@@ -550,7 +553,6 @@ fn parse_set_operator_operation(
     type_args: &[TypeTag],
     args: &[Vec<u8>],
 ) -> ApiResult<Vec<Operation>> {
-    // There are no typeargs for create account
     if !type_args.is_empty() {
         return Err(ApiError::TransactionParseError(Some(format!(
             "Set operator should not have type arguments: {:?}",
@@ -565,7 +567,30 @@ fn parse_set_operator_operation(
         Ok(vec![Operation::set_operator(0, None, sender, operator)])
     } else {
         Err(ApiError::InvalidOperations(Some(
-            "Set operator doesn't have an address argument".to_string(),
+            "Set operator doesn't have a operator argument".to_string(),
+        )))
+    }
+}
+
+fn parse_set_voter_operation(
+    sender: AccountAddress,
+    type_args: &[TypeTag],
+    args: &[Vec<u8>],
+) -> ApiResult<Vec<Operation>> {
+    if !type_args.is_empty() {
+        return Err(ApiError::TransactionParseError(Some(format!(
+            "Set voter should not have type arguments: {:?}",
+            type_args
+        ))));
+    }
+
+    if let Some(encoded_operator) = args.first() {
+        let operator: AccountAddress = bcs::from_bytes(encoded_operator)?;
+
+        Ok(vec![Operation::set_voter(0, None, sender, operator)])
+    } else {
+        Err(ApiError::InvalidOperations(Some(
+            "Set voter doesn't have a voter argument".to_string(),
         )))
     }
 }

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -83,6 +83,7 @@ pub enum OperationType {
     Withdraw,
     Deposit,
     SetOperator,
+    SetVoter,
     // Fee must always be last for ordering
     Fee,
 }
@@ -93,6 +94,7 @@ impl OperationType {
     const WITHDRAW: &'static str = "withdraw";
     const FEE: &'static str = "fee";
     const SET_OPERATOR: &'static str = "set_operator";
+    const SET_VOTER: &'static str = "set_voter";
 
     pub fn all() -> Vec<OperationType> {
         vec![
@@ -101,6 +103,7 @@ impl OperationType {
             OperationType::Deposit,
             OperationType::Fee,
             OperationType::SetOperator,
+            OperationType::SetVoter,
         ]
     }
 }
@@ -115,6 +118,7 @@ impl FromStr for OperationType {
             Self::WITHDRAW => Ok(OperationType::Withdraw),
             Self::FEE => Ok(OperationType::Fee),
             Self::SET_OPERATOR => Ok(OperationType::SetOperator),
+            Self::SET_VOTER => Ok(OperationType::SetVoter),
             _ => Err(ApiError::DeserializationFailed(Some(format!(
                 "Invalid OperationType: {}",
                 s
@@ -130,6 +134,7 @@ impl Display for OperationType {
             OperationType::Deposit => Self::DEPOSIT,
             OperationType::Withdraw => Self::WITHDRAW,
             OperationType::SetOperator => Self::SET_OPERATOR,
+            OperationType::SetVoter => Self::SET_VOTER,
             OperationType::Fee => Self::FEE,
         })
     }

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -18,6 +18,7 @@ pub const STAKE_POOL_RESOURCE: &str = "StakePool";
 pub const CREATE_ACCOUNT_FUNCTION: &str = "create_account";
 pub const TRANSFER_FUNCTION: &str = "transfer";
 pub const SET_OPERATOR_FUNCTION: &str = "set_operator";
+pub const SET_VOTER_FUNCTION: &str = "set_delegated_voter";
 
 pub const DECIMALS_FIELD: &str = "decimal";
 pub const DEPOSIT_EVENTS_FIELD: &str = "deposit_events";

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -627,8 +627,8 @@ fn parse_failed_operations_from_txn_payload(
                     operations.push(Operation::set_operator(
                         operation_index,
                         Some(OperationStatusType::Failure),
-                        operator,
                         sender,
+                        operator,
                     ));
                 } else {
                     warn!("Failed to parse set operator {:?}", inner);
@@ -643,8 +643,8 @@ fn parse_failed_operations_from_txn_payload(
                     operations.push(Operation::set_voter(
                         operation_index,
                         Some(OperationStatusType::Failure),
-                        voter,
                         sender,
+                        voter,
                     ));
                 } else {
                     warn!("Failed to parse set voter {:?}", inner);
@@ -732,8 +732,8 @@ async fn parse_operations_from_write_set(
                 Ok(vec![Operation::set_voter(
                     operation_index,
                     Some(OperationStatusType::Success),
-                    voter,
                     sender,
+                    voter,
                 )])
             } else {
                 warn!("Failed to parse set voter {:?}", inner);

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -1093,6 +1093,7 @@ async fn parse_operations(
                     }
                 };
             }
+            operation_type => panic!("Unhandled operation type {}", operation_type),
         }
     }
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -659,6 +659,22 @@ async fn test_block() {
     // Also fail to set an operator
     cli.set_operator(1, 3).await.unwrap_err();
 
+    // Successfully, and fail setting a voter
+    set_voter_and_wait(
+        &rosetta_client,
+        &rest_client,
+        &network_identifier,
+        private_key_3,
+        account_id_1,
+        Duration::from_secs(5),
+        None,
+        None,
+        None,
+    )
+    .await
+    .expect("Set operator should work!");
+    cli.set_delegated_voter(1, 3).await.unwrap_err();
+
     // This one will fail (and skip estimation of gas)
     let maybe_final_txn = transfer_and_wait(
         &rosetta_client,
@@ -1019,38 +1035,81 @@ async fn parse_operations(
                         status,
                         "Successful transaction should have successful set operator operation"
                     );
-                    // Check that operator was set the same
-                    if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
-                        actual_txn.transaction
-                    {
-                        if let aptos_types::transaction::TransactionPayload::EntryFunction(
-                            ref payload,
-                        ) = txn.payload()
-                        {
-                            let actual_operator_address: AccountAddress =
-                                bcs::from_bytes(payload.args().first().unwrap()).unwrap();
-                            let operator = operation
-                                .metadata
-                                .as_ref()
-                                .unwrap()
-                                .operator
-                                .as_ref()
-                                .unwrap()
-                                .account_address()
-                                .unwrap();
-                            assert_eq!(actual_operator_address, operator)
-                        } else {
-                            panic!("Not an entry function");
-                        }
-                    } else {
-                        panic!("Not a user transaction");
-                    }
                 } else {
                     assert_eq!(
                         OperationStatusType::Failure,
                         status,
                         "Failed transaction should have failed set operator operation"
                     );
+                }
+
+                // Check that operator was set the same
+                if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
+                    actual_txn.transaction
+                {
+                    if let aptos_types::transaction::TransactionPayload::EntryFunction(
+                        ref payload,
+                    ) = txn.payload()
+                    {
+                        let actual_operator_address: AccountAddress =
+                            bcs::from_bytes(payload.args().first().unwrap()).unwrap();
+                        let operator = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .operator
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+                        assert_eq!(actual_operator_address, operator)
+                    } else {
+                        panic!("Not an entry function");
+                    }
+                } else {
+                    panic!("Not a user transaction");
+                }
+            }
+            OperationType::SetVoter => {
+                if actual_successful {
+                    assert_eq!(
+                        OperationStatusType::Success,
+                        status,
+                        "Successful transaction should have successful set voter operation"
+                    );
+                } else {
+                    assert_eq!(
+                        OperationStatusType::Failure,
+                        status,
+                        "Failed transaction should have failed set voter operation"
+                    );
+                }
+
+                // Check that voter was set the same
+                if let aptos_types::transaction::Transaction::UserTransaction(ref txn) =
+                    actual_txn.transaction
+                {
+                    if let aptos_types::transaction::TransactionPayload::EntryFunction(
+                        ref payload,
+                    ) = txn.payload()
+                    {
+                        let actual_voter_address: AccountAddress =
+                            bcs::from_bytes(payload.args().first().unwrap()).unwrap();
+                        let voter = operation
+                            .metadata
+                            .as_ref()
+                            .unwrap()
+                            .voter
+                            .as_ref()
+                            .unwrap()
+                            .account_address()
+                            .unwrap();
+                        assert_eq!(actual_voter_address, voter)
+                    } else {
+                        panic!("Not an entry function");
+                    }
+                } else {
+                    panic!("Not a user transaction");
                 }
             }
             OperationType::Fee => {
@@ -1105,7 +1164,6 @@ async fn parse_operations(
                     }
                 };
             }
-            operation_type => panic!("Unhandled operation type {}", operation_type),
         }
     }
 
@@ -1473,6 +1531,36 @@ async fn set_operator_and_wait(
             network_identifier,
             sender_key,
             new_operator,
+            expiry_time.as_secs(),
+            sequence_number,
+            max_gas,
+            gas_unit_price,
+        )
+        .await
+        .map_err(ErrorWrapper::BeforeSubmission)?
+        .hash;
+    wait_for_transaction(rest_client, expiry_time, txn_hash)
+        .await
+        .map_err(ErrorWrapper::AfterSubmission)
+}
+
+async fn set_voter_and_wait(
+    rosetta_client: &RosettaClient,
+    rest_client: &aptos_rest_client::Client,
+    network_identifier: &NetworkIdentifier,
+    sender_key: &Ed25519PrivateKey,
+    new_voter: AccountAddress,
+    txn_expiry_duration: Duration,
+    sequence_number: Option<u64>,
+    max_gas: Option<u64>,
+    gas_unit_price: Option<u64>,
+) -> Result<Box<UserTransaction>, ErrorWrapper> {
+    let expiry_time = expiry_time(txn_expiry_duration);
+    let txn_hash = rosetta_client
+        .set_voter(
+            network_identifier,
+            sender_key,
+            new_voter,
             expiry_time.as_secs(),
             sequence_number,
             max_gas,


### PR DESCRIPTION
### Description
This adds set voter support, and fixes a bug in set operator on failed transactions.

Note this does not add support for the staking contracts built on top of stake.move.

### Test Plan
E2E tests, including a set voter check

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4422)
<!-- Reviewable:end -->
