### PR TITLE
[aptos-cli] Allow compiling scripts and proposals with local framework

### DIFF
--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -18,8 +18,8 @@ use crate::common::types::{
 };
 use crate::common::utils::write_to_file;
 use crate::move_tool::{
-    ArgWithType, CompilePackage, DownloadPackage, IncludedArtifacts, InitPackage, MemberId,
-    PublishPackage, RunFunction, TestPackage,
+    ArgWithType, CompilePackage, DownloadPackage, FrameworkPackageArgs, IncludedArtifacts,
+    InitPackage, MemberId, PublishPackage, RunFunction, TestPackage,
 };
 use crate::node::{
     AnalyzeMode, AnalyzeValidatorPerformance, InitializeValidator, JoinValidatorSet,
@@ -706,7 +706,10 @@ impl CliTestFramework {
                 assume_yes: false,
                 assume_no: true,
             },
-            for_test_framework: framework_dir,
+            framework_package_args: FrameworkPackageArgs {
+                framework_git_rev: None,
+                framework_local_dir: framework_dir,
+            },
         }
         .execute()
         .await


### PR DESCRIPTION
### Description
The remote git framework can be cached funny, and for the need for speed it should not have users be pulling down a git repo that they may already have.

This is also needed to test creating proposals, and running scripts

### Test Plan
E2E tests, as well as some testing

```
aptos move run-script --script-path script.move --framework-local-dir /opt/git/aptos-core/aptos-move/framework/aptos-framework
Do you want to execute a transaction for a maximum of 10000000 coins at a gas unit price of 100? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0x875c36d8f6f68134365014df03e1ed200b6197f035ffd61df292981f87722554",
    "gas_used": 151,
    "gas_unit_price": 100,
    "sender": "b6dbf76636021a840c64da0ca6aa94297b4ead015f7398521f57347f68364898",
    "sequence_number": 0,
    "success": true,
    "timestamp_us": 1663787494093360,
    "version": 2063930,
    "vm_status": "Executed successfully"
  }
}

```

```
$ aptos move init --name test --assume-yes; cat Move.toml
{
  "Result": "Success"
}
[package]
name = 'test'
version = '1.0.0'
[dependencies.AptosFramework]
git = 'https://github.com/aptos-labs/aptos-core.git'
rev = 'main'
subdir = 'aptos-move/framework/aptos-framework'

$ aptos move init --name test --framework-git-rev main --assume-yes; cat Move.toml
{
  "Result": "Success"
}
[package]
name = 'test'
version = '1.0.0'
[dependencies.AptosFramework]
git = 'https://github.com/aptos-labs/aptos-core.git'
rev = 'main'
subdir = 'aptos-move/framework/aptos-framework'

$ aptos move init --name test --framework-local-dir aptos-move/framework/aptos-framework --assume-yes; cat Move.toml
{
  "Result": "Success"
}
[package]
name = 'test'
version = '1.0.0'
[dependencies.AptosFramework]
local = 'aptos-move/framework/aptos-framework'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4426)
<!-- Reviewable:end -->
