### PR TITLE
[telemetry-service] security audit fixes and related refactorings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ dependencies = [
  "aptos-logger",
  "aptos-rest-client",
  "aptos-types",
+ "base64 0.13.0",
  "bcs",
  "chrono",
  "clap 3.2.17",

--- a/crates/aptos-telemetry-service/Cargo.toml
+++ b/crates/aptos-telemetry-service/Cargo.toml
@@ -20,6 +20,7 @@ aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-types = { path = "../../types" }
 
 anyhow = "1.0.57"
+base64 = "0.13.0"
 bcs = "0.1.3"
 chrono = "0.4"
 clap = "3.1.8"

--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -61,9 +61,9 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
         })?;
 
     let cache = if body.role_type == RoleType::Validator {
-        context.validator_cache()
+        context.peers().validators()
     } else {
-        context.vfn_cache()
+        context.peers().validator_fullnodes()
     };
 
     let (epoch, peer_role) = match cache.read().get(&body.chain_id) {
@@ -109,7 +109,8 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
         PeerRole::Validator => NodeType::Validator,
         PeerRole::ValidatorFullNode => NodeType::ValidatorFullNode,
         PeerRole::Unknown => context
-            .pfn_cache()
+            .peers()
+            .public_fullnodes()
             .get(&body.chain_id)
             .map(|peer_set| {
                 if peer_set.contains_key(&body.peer_id) {
@@ -123,7 +124,7 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
     };
 
     let token = create_jwt_token(
-        context.clone(),
+        context.jwt_service(),
         body.chain_id,
         body.peer_id,
         node_type,
@@ -161,7 +162,11 @@ pub fn with_auth(
 ) -> impl Filter<Extract = (Claims,), Error = Rejection> + Clone {
     warp::header::optional(AUTHORIZATION.as_str())
         .and_then(jwt_from_header)
-        .and(warp::any().map(move || (context.clone(), roles.clone())))
+        .and(
+            warp::any()
+                .map(move || (context.clone(), roles.clone()))
+                .untuple_one(),
+        )
         .and_then(authorize_jwt)
 }
 
@@ -177,6 +182,6 @@ async fn handle_check_chain_access(
     chain_id: ChainId,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
-    let present = context.configured_chains().contains(&chain_id);
+    let present = context.chain_set().contains(&chain_id);
     Ok(reply::json(&present))
 }

--- a/crates/aptos-telemetry-service/src/clients/humio.rs
+++ b/crates/aptos-telemetry-service/src/clients/humio.rs
@@ -38,7 +38,7 @@ impl IngestClient {
         let compressed_bytes = gzip_encoder.finish()?;
 
         self.inner
-            .post(format!("{}api/v1/ingest/humio-unstructured", self.base_url))
+            .post(self.base_url.join("api/v1/ingest/humio-unstructured")?)
             .bearer_auth(self.auth_token.clone())
             .header("Content-Encoding", "gzip")
             .body(compressed_bytes)

--- a/crates/aptos-telemetry-service/src/clients/mod.rs
+++ b/crates/aptos-telemetry-service/src/clients/mod.rs
@@ -50,3 +50,53 @@ pub mod victoria_metrics_api {
         }
     }
 }
+
+pub mod big_query {
+    use gcp_bigquery_client::{
+        error::BQError,
+        model::{
+            table_data_insert_all_request::TableDataInsertAllRequest,
+            table_data_insert_all_response::TableDataInsertAllResponse,
+        },
+        Client as BigQueryClient,
+    };
+
+    #[derive(Clone)]
+    pub struct TableWriteClient {
+        client: BigQueryClient,
+        project_id: String,
+        dataset_id: String,
+        table_id: String,
+    }
+
+    impl TableWriteClient {
+        pub fn new(
+            client: BigQueryClient,
+            project_id: String,
+            dataset_id: String,
+            table_id: String,
+        ) -> Self {
+            Self {
+                client,
+                project_id,
+                dataset_id,
+                table_id,
+            }
+        }
+
+        pub async fn insert_all(
+            &self,
+            insert_request: TableDataInsertAllRequest,
+        ) -> Result<TableDataInsertAllResponse, BQError> {
+            self.client
+                .tabledata()
+                .insert_all(
+                    &self.project_id,
+                    &self.dataset_id,
+                    &self.table_id,
+                    insert_request,
+                )
+                .await
+        }
+    }
+}

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -4,73 +4,137 @@
 use std::collections::{HashMap, HashSet};
 use std::{convert::Infallible, sync::Arc};
 
-use crate::validator_cache::PeerSetCache;
+use crate::clients::big_query::TableWriteClient;
+use crate::types::common::EpochedPeerStore;
 use crate::{
-    clients::humio, clients::victoria_metrics_api::Client as MetricsClient, GCPBigQueryConfig,
-    TelemetryServiceConfig,
+    clients::humio::IngestClient as HumioClient,
+    clients::victoria_metrics_api::Client as MetricsClient,
 };
 use aptos_crypto::{noise, x25519};
+use aptos_infallible::RwLock;
 use aptos_types::chain_id::ChainId;
 use aptos_types::PeerId;
-use gcp_bigquery_client::Client as BQClient;
-use jsonwebtoken::{DecodingKey, EncodingKey};
+
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, TokenData, Validation};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use warp::Filter;
+
+#[derive(Clone, Default)]
+pub struct PeerStoreTuple {
+    validators: Arc<RwLock<EpochedPeerStore>>,
+    validator_fullnodes: Arc<RwLock<EpochedPeerStore>>,
+    public_fullnodes: HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>>,
+}
+
+impl PeerStoreTuple {
+    pub fn new(
+        validators: Arc<RwLock<EpochedPeerStore>>,
+        validator_fullnodes: Arc<RwLock<EpochedPeerStore>>,
+        public_fullnodes: HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>>,
+    ) -> Self {
+        Self {
+            validators,
+            validator_fullnodes,
+            public_fullnodes,
+        }
+    }
+
+    pub fn validators(&self) -> &Arc<RwLock<EpochedPeerStore>> {
+        &self.validators
+    }
+
+    pub fn validator_fullnodes(&self) -> &Arc<RwLock<EpochedPeerStore>> {
+        &self.validator_fullnodes
+    }
+
+    pub fn public_fullnodes(&self) -> &HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>> {
+        &self.public_fullnodes
+    }
+}
+
+#[derive(Clone)]
+pub struct ClientTuple {
+    bigquery_client: TableWriteClient,
+    victoria_metrics_client: MetricsClient,
+    humio_client: HumioClient,
+}
+
+impl ClientTuple {
+    pub(crate) fn new(
+        bigquery_client: TableWriteClient,
+        victoria_metrics_client: MetricsClient,
+        humio_client: HumioClient,
+    ) -> ClientTuple {
+        Self {
+            bigquery_client,
+            victoria_metrics_client,
+            humio_client,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct JsonWebTokenService {
+    encoding_key: EncodingKey,
+    decoding_key: DecodingKey,
+}
+
+impl JsonWebTokenService {
+    pub fn from_base64_secret(secret: &str) -> Self {
+        let encoding_key = jsonwebtoken::EncodingKey::from_base64_secret(secret)
+            .expect("jsonwebtoken key should be in base64 format.");
+        let decoding_key = jsonwebtoken::DecodingKey::from_base64_secret(secret)
+            .expect("jsonwebtoken key should be in base64 format.");
+        Self {
+            encoding_key,
+            decoding_key,
+        }
+    }
+
+    pub fn encode<T: Serialize>(&self, claims: T) -> Result<String, jsonwebtoken::errors::Error> {
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS512);
+        jsonwebtoken::encode(&header, &claims, &self.encoding_key)
+    }
+
+    pub fn decode<T: DeserializeOwned>(
+        &self,
+        token: &str,
+    ) -> Result<TokenData<T>, jsonwebtoken::errors::Error> {
+        jsonwebtoken::decode::<T>(
+            token,
+            &self.decoding_key,
+            &Validation::new(Algorithm::HS512),
+        )
+    }
+}
 
 #[derive(Clone)]
 pub struct Context {
     noise_config: Arc<noise::NoiseConfig>,
-    validator_cache: PeerSetCache,
-    vfn_cache: PeerSetCache,
-    pfn_cache: HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>>,
-
-    configured_chains: HashSet<ChainId>,
+    peers: PeerStoreTuple,
+    clients: Option<ClientTuple>,
+    chain_set: HashSet<ChainId>,
+    jwt_service: JsonWebTokenService,
     log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
-
-    pub gcp_bq_client: Option<BQClient>,
-    pub gcp_bq_config: GCPBigQueryConfig,
-
-    pub victoria_metrics_client: Option<MetricsClient>,
-
-    pub jwt_encoding_key: EncodingKey,
-    pub jwt_decoding_key: DecodingKey,
-
-    pub humio_client: humio::IngestClient,
 }
 
 impl Context {
     pub fn new(
-        config: &TelemetryServiceConfig,
-        validator_cache: PeerSetCache,
-        vfn_cache: PeerSetCache,
-        pfn_cache: HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>>,
+        private_key: x25519::PrivateKey,
+        peers: PeerStoreTuple,
+        clients: Option<ClientTuple>,
+        chain_set: HashSet<ChainId>,
+        jwt_service: JsonWebTokenService,
         log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
-        gcp_bigquery_client: Option<BQClient>,
-        victoria_metrics_client: Option<MetricsClient>,
-        humio_client: humio::IngestClient,
     ) -> Self {
-        let private_key = config.server_private_key.private_key();
-        let configured_chains = config
-            .trusted_full_node_addresses
-            .iter()
-            .map(|(chain_id, _)| *chain_id)
-            .collect();
         Self {
             noise_config: Arc::new(noise::NoiseConfig::new(private_key)),
-            validator_cache,
-            vfn_cache,
-            pfn_cache,
-            configured_chains,
+            peers,
+            clients,
+            chain_set,
+            jwt_service,
             log_env_map,
-
-            gcp_bq_client: gcp_bigquery_client,
-            gcp_bq_config: config.gcp_bq_config.clone(),
-
-            victoria_metrics_client,
-
-            jwt_encoding_key: EncodingKey::from_secret(config.jwt_signing_key.as_bytes()),
-            jwt_decoding_key: DecodingKey::from_secret(config.jwt_signing_key.as_bytes()),
-
-            humio_client,
         }
     }
 
@@ -78,24 +142,37 @@ impl Context {
         warp::any().map(move || self.clone())
     }
 
-    pub fn validator_cache(&self) -> PeerSetCache {
-        self.validator_cache.clone()
-    }
-
-    pub fn vfn_cache(&self) -> PeerSetCache {
-        self.vfn_cache.clone()
-    }
-
-    pub fn pfn_cache(&self) -> &HashMap<ChainId, HashMap<PeerId, x25519::PublicKey>> {
-        &self.pfn_cache
-    }
-
     pub fn noise_config(&self) -> Arc<noise::NoiseConfig> {
         self.noise_config.clone()
     }
 
-    pub fn configured_chains(&self) -> &HashSet<ChainId> {
-        &self.configured_chains
+    pub fn peers(&self) -> &PeerStoreTuple {
+        &self.peers
+    }
+
+    pub fn jwt_service(&self) -> &JsonWebTokenService {
+        &self.jwt_service
+    }
+
+    pub fn metrics_client(&self) -> &MetricsClient {
+        &self.clients.as_ref().unwrap().victoria_metrics_client
+    }
+
+    pub fn humio_client(&self) -> &HumioClient {
+        &self.clients.as_ref().unwrap().humio_client
+    }
+
+    pub(crate) fn bigquery_client(&self) -> Option<&TableWriteClient> {
+        self.clients.as_ref().map(|c| &c.bigquery_client)
+    }
+
+    pub fn chain_set(&self) -> &HashSet<ChainId> {
+        &self.chain_set
+    }
+
+    #[cfg(test)]
+    pub fn chain_set_mut(&mut self) -> &mut HashSet<ChainId> {
+        &mut self.chain_set
     }
 
     pub fn log_env_map(&self) -> &HashMap<ChainId, HashMap<PeerId, String>> {
@@ -105,10 +182,5 @@ impl Context {
     #[cfg(test)]
     pub fn log_env_map_mut(&mut self) -> &mut HashMap<ChainId, HashMap<PeerId, String>> {
         &mut self.log_env_map
-    }
-
-    #[cfg(test)]
-    pub fn configured_chains_mut(&mut self) -> &mut HashSet<ChainId> {
-        &mut self.configured_chains
     }
 }

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -111,15 +111,12 @@ pub(crate) async fn handle_custom_event(
     })?;
 
     context
-        .gcp_bq_client
-        .unwrap()
-        .tabledata()
-        .insert_all(
-            context.gcp_bq_config.project_id.as_str(),
-            context.gcp_bq_config.dataset_id.as_str(),
-            context.gcp_bq_config.table_id.as_str(),
-            insert_request,
-        )
+        .bigquery_client()
+        .ok_or_else(|| {
+            error!("big query client is not configured");
+            ServiceError::from(anyhow!("unable to insert row into bigquery"))
+        })?
+        .insert_all(insert_request)
         .await
         .map_err(|e| {
             error!("unable to insert row into bigquery: {}", e);

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -98,7 +98,7 @@ pub async fn handle_log_ingest(
     debug!("ingesting to humio: {:?}", unstructured_log);
 
     let res = context
-        .humio_client
+        .humio_client()
         .ingest_unstructured_log(unstructured_log)
         .await;
 

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -61,8 +61,7 @@ pub async fn handle_metrics_ingest(
     let extra_labels = claims_to_extra_labels(&claims);
 
     let res = context
-        .victoria_metrics_client
-        .unwrap()
+        .metrics_client()
         .post_prometheus_metrics(metrics_body, extra_labels, encoding.unwrap_or_default())
         .await;
 

--- a/crates/aptos-telemetry-service/src/remote_config.rs
+++ b/crates/aptos-telemetry-service/src/remote_config.rs
@@ -62,12 +62,13 @@ mod tests {
 
         test_context
             .inner
-            .validator_cache()
+            .peers()
+            .validators()
             .write()
             .insert(chain_id, (epoch, PeerSet::default()));
 
         let jwt_token = create_jwt_token(
-            test_context.inner.clone(),
+            test_context.inner.jwt_service(),
             chain_id,
             peer_id,
             node_type,

--- a/crates/aptos-telemetry-service/src/tests/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/tests/custom_event.rs
@@ -28,12 +28,13 @@ async fn test_custom_event() {
 
     test_context
         .inner
-        .validator_cache()
+        .peers()
+        .validators()
         .write()
         .insert(chain_id, (epoch, PeerSet::default()));
 
     let jwt_token = create_jwt_token(
-        test_context.inner.clone(),
+        test_context.inner.jwt_service(),
         chain_id,
         peer_id,
         node_type,

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -1,21 +1,20 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-
-use crate::clients::humio;
-use crate::GCPBigQueryConfig;
-use crate::{context::Context, index, validator_cache::PeerSetCache, TelemetryServiceConfig};
-use aptos_config::keys::ConfigKey;
-use aptos_crypto::{x25519, Uniform};
-use aptos_rest_client::aptos_api_types::mime_types;
 use rand::SeedableRng;
 use reqwest::header::AUTHORIZATION;
-use reqwest::Url;
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 use warp::http::header::CONTENT_TYPE;
 use warp::http::Response;
 use warp::hyper::body::Bytes;
+
+use crate::context::{JsonWebTokenService, PeerStoreTuple};
+use crate::CustomEventConfig;
+use crate::{context::Context, index, TelemetryServiceConfig};
+
+use aptos_crypto::{x25519, Uniform};
+use aptos_rest_client::aptos_api_types::mime_types;
 
 pub async fn new_test_context() -> TestContext {
     let mut rng = ::rand::rngs::StdRng::from_seed([0u8; 32]);
@@ -26,42 +25,30 @@ pub async fn new_test_context() -> TestContext {
         tls_cert_path: None,
         tls_key_path: None,
         trusted_full_node_addresses: HashMap::new(),
-        server_private_key: ConfigKey::new(server_private_key),
-        jwt_signing_key: "jwt_signing_key".into(),
         update_interval: 60,
-        gcp_bq_config: GCPBigQueryConfig {
+        custom_event_config: CustomEventConfig {
             project_id: String::from("1"),
             dataset_id: String::from("2"),
             table_id: String::from("3"),
         },
         victoria_metrics_base_url: "".into(),
-        victoria_metrics_token: "".into(),
         humio_url: "".into(),
-        humio_auth_token: "".into(),
         pfn_allowlist: HashMap::new(),
         log_env_map: HashMap::new(),
     };
-    let humio_client = humio::IngestClient::new(
-        Url::parse("http://localhost/").unwrap(),
-        config.humio_auth_token.clone(),
-    );
-    let gcp_bigquery_client = gcp_bigquery_client::Client::with_workload_identity(false)
-        .await
-        .unwrap();
-    let validator_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
-    let vfn_cache = PeerSetCache::new(aptos_infallible::RwLock::new(HashMap::new()));
+
+    let peers = PeerStoreTuple::default();
+    let jwt_service = JsonWebTokenService::from_base64_secret(&base64::encode("jwt_secret_key"));
 
     TestContext::new(
-        config.clone(),
+        config,
         Context::new(
-            &config,
-            validator_cache,
-            vfn_cache,
-            HashMap::new(),
-            config.log_env_map.clone(),
-            Some(gcp_bigquery_client),
+            server_private_key,
+            peers,
             None,
-            humio_client,
+            HashSet::new(),
+            jwt_service,
+            HashMap::new(),
         ),
     )
 }

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -6,12 +6,17 @@ pub mod telemetry;
 
 pub mod common {
 
-    use std::fmt;
+    use std::{collections::HashMap, fmt};
 
     use crate::types::auth::Claims;
+    use aptos_config::config::PeerSet;
     use aptos_types::chain_id::ChainId;
     use aptos_types::PeerId;
     use serde::{Deserialize, Serialize};
+
+    pub type EpochNum = u64;
+    pub type EpochedPeerStore = HashMap<ChainId, (EpochNum, PeerSet)>;
+    pub type PeerStore = HashMap<ChainId, PeerSet>;
 
     #[derive(Debug, Serialize, Deserialize, Clone)]
     pub struct EventIdentity {

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -12,13 +12,12 @@ use tokio::time;
 use tracing::{debug, error};
 use url::Url;
 
-pub type EpochNum = u64;
-pub type PeerSetCache = Arc<RwLock<HashMap<ChainId, (EpochNum, PeerSet)>>>;
+use crate::types::common::EpochedPeerStore;
 
 #[derive(Clone)]
 pub struct PeerSetCacheUpdater {
-    validators: PeerSetCache,
-    validator_fullnodes: PeerSetCache,
+    validators: Arc<RwLock<EpochedPeerStore>>,
+    validator_fullnodes: Arc<RwLock<EpochedPeerStore>>,
 
     query_addresses: Arc<HashMap<ChainId, String>>,
     update_interval: time::Duration,
@@ -26,8 +25,8 @@ pub struct PeerSetCacheUpdater {
 
 impl PeerSetCacheUpdater {
     pub fn new(
-        validators: PeerSetCache,
-        validator_fullnodes: PeerSetCache,
+        validators: Arc<RwLock<EpochedPeerStore>>,
+        validator_fullnodes: Arc<RwLock<EpochedPeerStore>>,
         trusted_full_node_addresses: HashMap<ChainId, String>,
         update_interval: Duration,
     ) -> Self {

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -235,10 +235,6 @@ fn try_spawn_custom_event_sender(
 
 fn try_spawn_metrics_sender(telemetry_sender: TelemetrySender) {
     if enable_prometheus_push_metrics() {
-        if enable_prometheus_node_metrics() {
-            node_resource_metrics::register_node_metrics_collector();
-        }
-
         tokio::spawn(async move {
             // Periodically send ALL prometheus metrics (This replaces the previous core and network metrics implementation)
             let mut interval =


### PR DESCRIPTION
### Description

This PR introduces a set of security-audit related fixes to the Telemetry service.

- Removes fields that hold secrets from config. The config is logged at service startup and was logging the secrets.
- Secrets are read from the environment variables. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

- Unit tests pass
- Verified telemetry ingestion running a test node and the service locally

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4433)
<!-- Reviewable:end -->
