### PR TITLE
[smoke tests] add a retry for initializing swarm, apply to 2 tests

### DIFF
--- a/testsuite/forge/src/backend/local/swarm.rs
+++ b/testsuite/forge/src/backend/local/swarm.rs
@@ -249,7 +249,7 @@ impl LocalSwarm {
             validator.start()?;
         }
 
-        self.wait_all_alive(Duration::from_secs(90)).await?;
+        self.wait_all_alive(Duration::from_secs(60)).await?;
         info!("Swarm launched successfully.");
         Ok(())
     }
@@ -265,7 +265,7 @@ impl LocalSwarm {
     }
 
     async fn wait_for_startup(&mut self) -> Result<()> {
-        let num_attempts = 60;
+        let num_attempts = 30;
         let mut done = vec![false; self.validators.len()];
         for i in 0..num_attempts {
             info!("Wait for startup attempt: {} of {}", i, num_attempts);

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -1,8 +1,8 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::smoke_test_environment::{with_retry, SwarmBuilder};
 use crate::{
-    smoke_test_environment::new_local_swarm_with_aptos,
     test_utils::{
         assert_balance, create_and_fund_account, swarm_utils::insert_waypoint,
         transfer_and_reconfig, transfer_coins,
@@ -35,7 +35,11 @@ async fn test_db_restore() {
     workspace_builder::get_bin("db-backup-verify");
     info!("---------- 1. pre-building finished.");
 
-    let mut swarm = new_local_swarm_with_aptos(4).await;
+    let mut swarm = with_retry(
+        || Box::pin(SwarmBuilder::new_local(4).with_aptos().build_wrapped()),
+        3,
+    )
+    .await;
     info!("---------- 1.1 swarm built, sending some transactions.");
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let client_1 = swarm

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::smoke_test_environment::SwarmBuilder;
+use crate::smoke_test_environment::{with_retry, SwarmBuilder};
 use crate::test_utils::{assert_balance, create_and_fund_account, transfer_coins};
 use aptos_config::config::NodeConfig;
 use forge::{NodeExt, Swarm, SwarmExt};
@@ -10,19 +10,24 @@ use std::time::{Duration, Instant};
 
 const MAX_WAIT_SECS: u64 = 60;
 
-//TODO: debug me and re-enable the test!
 /// Checks txn goes through consensus even if the local validator is not creating proposals.
 /// This behavior should be true with both mempool and quorum store.
-#[ignore]
 #[tokio::test]
 async fn test_txn_broadcast() {
-    let mut swarm = SwarmBuilder::new_local(4)
-        .with_aptos()
-        .with_init_config(Arc::new(|_, conf, _| {
-            conf.api.failpoints_enabled = true;
-        }))
-        .build()
-        .await;
+    let mut swarm = with_retry(
+        || {
+            Box::pin(
+                SwarmBuilder::new_local(4)
+                    .with_aptos()
+                    .with_init_config(Arc::new(|_, conf, _| {
+                        conf.api.failpoints_enabled = true;
+                    }))
+                    .build_wrapped(),
+            )
+        },
+        3,
+    )
+    .await;
     let transaction_factory = swarm.chain_info().transaction_factory();
     let version = swarm.versions().max().unwrap();
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();


### PR DESCRIPTION
### Description

Applied to `test_db_restore` and `test_txn_broadcast`.
Includes re-enabling `test_txn_broadcast` which was previously disabled due to flakiness.

If this helps, can follow-up to apply the retry globally.

### Test Plan

Injected a retry and at least confirmed that we can successfully create a new swarm after having created a swarm (that was itself successful).

Will have to continue bake in CICD and observe the flakiness trend.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4437)
<!-- Reviewable:end -->
