### PR TITLE
[backup] restore coordinator: fix snapshot selection

### DIFF
--- a/storage/backup/backup-cli/src/coordinators/restore.rs
+++ b/storage/backup/backup-cli/src/coordinators/restore.rs
@@ -133,8 +133,11 @@ impl RestoreCoordinator {
                 );
                 metadata_view.expect_state_snapshot(version)?
             } else {
+                let max_txn_ver = metadata_view
+                    .max_transaction_version()?
+                    .ok_or_else(|| anyhow!("No transaction backup found."))?;
                 metadata_view
-                    .select_state_snapshot(self.target_version())?
+                    .select_state_snapshot(std::cmp::min(self.target_version(), max_txn_ver))?
                     .ok_or_else(|| anyhow!("No usable state snapshot."))?
             };
         let version = state_snapshot_backup.version;

--- a/storage/backup/backup-cli/src/metadata/view.rs
+++ b/storage/backup/backup-cli/src/metadata/view.rs
@@ -84,6 +84,15 @@ impl MetadataView {
         Ok(res)
     }
 
+    pub fn max_transaction_version(&self) -> Result<Option<Version>> {
+        Ok(self
+            .transaction_backups
+            .iter()
+            .sorted()
+            .last()
+            .map(|backup| backup.last_version))
+    }
+
     pub fn select_epoch_ending_backups(
         &self,
         target_version: Version,


### PR DESCRIPTION

### Description
There's an edge case where the latest state snapshot is at an newer version than the transaction backup.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

cargo test -p smoke-test -- test_db_restore