### PR TITLE
[cicd] smoke tests: build with all features

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -165,7 +165,7 @@ jobs:
           tool: nextest
       # prebuild node binary, so that tests don't start before node is built.
       # --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
-      - run: cargo build --bin=aptos-node --features=failpoints --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile ci --package smoke-test --test-threads 6 --retries 3
+      - run: cargo build --bin=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile ci --package smoke-test --test-threads 6 --retries 3
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 


### PR DESCRIPTION
### Description

This command was not updated when the indexer feature was added to smoke tests in `cargo.rs`.

### Test Plan

`test_error_report` (and concurrent tests) always took > 2min, now in this check it took under 2 s. So this does seem to reduce the time spent in cargo within the smoke tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4441)
<!-- Reviewable:end -->
