### PR TITLE
[node-resource-metrics][bugfix] allow disk metrics for nvme disks

### DIFF
--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -107,6 +107,10 @@ pub fn start_telemetry_service(
     remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
     logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) -> Option<Runtime> {
+    if enable_prometheus_node_metrics() {
+        node_resource_metrics::register_node_metrics_collector();
+    }
+
     // Don't start the service if telemetry has been disabled
     if telemetry_is_disabled() {
         warn!("Aptos telemetry is disabled!");


### PR DESCRIPTION
### Description

- Stop filtering by `sd` prefix and filter out only loop devices. This was preventing metrics from nvme disks.
- Enable node metrics collection by default regardless of telemetry service is enabled.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Verified changes work properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4443)
<!-- Reviewable:end -->
