### PR TITLE
[consensus] fix edge case of block retrieval

### DIFF
--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -466,8 +466,8 @@ async fn test_need_sync_for_ledger_info() {
         .ledger_info()
         .clone()
     };
-    let ordered_round_too_far =
-        block_store.ordered_root().round() + block_store.back_pressure_limit + 1;
+    // it's larger and the block doesn't exist in the tree
+    let ordered_round_too_far = block_store.ordered_root().round() + 1;
     let ordered_too_far = create_ledger_info(ordered_round_too_far);
     assert!(block_store.need_sync_for_ledger_info(&ordered_too_far));
 

--- a/consensus/src/block_storage/sync_manager.rs
+++ b/consensus/src/block_storage/sync_manager.rs
@@ -43,7 +43,8 @@ impl BlockStore {
     /// Check if we're far away from this ledger info and need to sync.
     /// This ensures that the block referred by the ledger info is not in buffer manager.
     pub fn need_sync_for_ledger_info(&self, li: &LedgerInfoWithSignatures) -> bool {
-        self.ordered_root().round() + self.back_pressure_limit < li.commit_info().round()
+        (self.ordered_root().round() < li.commit_info().round()
+            && !self.block_exists(li.commit_info().id()))
             || self.commit_root().round() + 2 * self.back_pressure_limit < li.commit_info().round()
     }
 


### PR DESCRIPTION
There's no guarantee that nodes still have blocks beyond committed block, the current condition for sync allows a gap between local ordered round and remote committed round.

There's an edge case that remote peer may have already pruned those blocks in between and the node would never be able to sync the gap.

The fix guarantees the node always syncs if the remote committed block doesn't exist locally and only fetch blocks that are ancestors of committed block.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4445)
<!-- Reviewable:end -->
