### PR TITLE
[aptos-rest-client] Fix Error descriptions for simulated transactions / Remove default max gas for CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "aptos-types",
  "bcs",
  "bytes 1.2.1",
+ "futures",
  "hex",
  "move-deps",
  "poem-openapi",

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -679,70 +679,18 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
         ))
     }
 
-    fn explain_vm_status(&self, status: &ExecutionStatus) -> String {
-        match status {
-            ExecutionStatus::MoveAbort { location, code, info } => match &location {
-                AbortLocation::Module(_) => {
-
-                    info.as_ref().map(|i| {
-                        format!("Move abort in {}: {}({:#x}): {}", Self::abort_location_to_str(location), i.reason_name, code, i.description)
-                    }).unwrap_or_else(|| {
-                        format!("Move abort in {}: {:#x}", Self::abort_location_to_str(location), code)
-                    })
-                }
-                AbortLocation::Script => format!("Move abort: code {:#x}", code),
-            },
-            ExecutionStatus::Success => "Executed successfully".to_owned(),
-            ExecutionStatus::OutOfGas => "Out of gas".to_owned(),
-            ExecutionStatus::ExecutionFailure {
-                location,
-                function,
-                code_offset,
-            } => {
-                let func_name = match location {
-                    AbortLocation::Module(module_id) => self
-                        .explain_function_index(module_id, function)
-                        .map(|name| format!("{}::{}", Self::abort_location_to_str(location), name))
-                        .unwrap_or_else(|_| format!("{}::<#{} function>", Self::abort_location_to_str(location), function)),
-                    AbortLocation::Script => "script".to_owned(),
-                };
-                format!(
-                    "Execution failed in {} at code offset {}",
-                    func_name, code_offset
-                )
-            }
-            ExecutionStatus::MiscellaneousError(code) => {
-                code.map_or(
-                    "Move bytecode deserialization / verification failed, including entry function not found or invalid arguments".to_owned(),
-                    |e| format!(
-                        "Transaction Executed and Committed with Error {:#?}", e
-                    ),
-                )
-            }
-        }
-    }
-
-    fn abort_location_to_str(loc: &AbortLocation) -> String {
-        match loc {
-            AbortLocation::Module(mid) => {
-                format!("{}::{}", mid.address().to_hex_literal(), mid.name())
-            }
-            _ => loc.to_string(),
-        }
-    }
-
     pub fn try_into_move_value(&self, typ: &TypeTag, bytes: &[u8]) -> Result<MoveValue> {
         self.inner.view_value(typ, bytes)?.try_into()
     }
-
-    fn explain_function_index(&self, module_id: &ModuleId, function: &u16) -> Result<String> {
-        let code = self.inner.get_module(&module_id.clone())? as Rc<dyn Bytecode>;
-        let func = code.function_handle_at(FunctionHandleIndex::new(*function));
-        let id = code.identifier_at(func.name);
-        Ok(format!("{}", id))
-    }
 }
 
+impl<'a, R: MoveResolverExt + ?Sized> ExplainVMStatus for MoveConverter<'a, R> {
+    fn get_module_bytecode(&self, module_id: &ModuleId) -> Result<Rc<dyn Bytecode>> {
+        self.inner
+            .get_module(module_id)
+            .map(|inner| inner as Rc<dyn Bytecode>)
+    }
+}
 pub trait AsConverter<R> {
     fn as_converter(&self, db: Arc<dyn DbReader>) -> MoveConverter<R>;
 }
@@ -766,3 +714,66 @@ pub fn new_vm_utf8_string(string: &str) -> move_core_types::value::MoveValue {
     let move_string = MoveStruct::Runtime(vec![byte_vector]);
     MoveValue::Struct(move_string)
 }
+
+fn abort_location_to_str(loc: &AbortLocation) -> String {
+    match loc {
+        AbortLocation::Module(mid) => {
+            format!("{}::{}", mid.address().to_hex_literal(), mid.name())
+        }
+        _ => loc.to_string(),
+    }
+}
+
+pub trait ExplainVMStatus {
+    fn get_module_bytecode(&self, module_id: &ModuleId) -> Result<Rc<dyn Bytecode>>;
+
+    fn explain_vm_status(&self, status: &ExecutionStatus) -> String {
+        match status {
+            ExecutionStatus::MoveAbort { location, code, info } => match &location {
+                AbortLocation::Module(_) => {
+                    info.as_ref().map(|i| {
+                        format!("Move abort in {}: {}({:#x}): {}", abort_location_to_str(location), i.reason_name, code, i.description)
+                    }).unwrap_or_else(|| {
+                        format!("Move abort in {}: {:#x}", abort_location_to_str(location), code)
+                    })
+                }
+                AbortLocation::Script => format!("Move abort: code {:#x}", code),
+            },
+            ExecutionStatus::Success => "Executed successfully".to_owned(),
+            ExecutionStatus::OutOfGas => "Out of gas".to_owned(),
+            ExecutionStatus::ExecutionFailure {
+                location,
+                function,
+                code_offset,
+            } => {
+                let func_name = match location {
+                    AbortLocation::Module(module_id) => self.explain_function_index(module_id, function)
+                        .map(|name| format!("{}::{}", abort_location_to_str(location), name))
+                        .unwrap_or_else(|_| format!("{}::<#{} function>", abort_location_to_str(location), function)),
+                    AbortLocation::Script => "script".to_owned(),
+                };
+                format!(
+                    "Execution failed in {} at code offset {}",
+                    func_name, code_offset
+                )
+            }
+            ExecutionStatus::MiscellaneousError(code) => {
+                code.map_or(
+                    "Move bytecode deserialization / verification failed, including entry function not found or invalid arguments".to_owned(),
+                    |e| format!(
+                        "Transaction Executed and Committed with Error {:#?}", e
+                    ),
+                )
+            }
+        }
+    }
+
+    fn explain_function_index(&self, module_id: &ModuleId, function: &u16) -> Result<String> {
+        let code = self.get_module_bytecode(module_id)?;
+        let func = code.function_handle_at(FunctionHandleIndex::new(*function));
+        let id = code.identifier_at(func.name);
+        Ok(id.to_string())
+    }
+}
+
+// TODO: add caching?

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -23,7 +23,7 @@ pub use account::AccountData;
 pub use address::Address;
 pub use block::{BcsBlock, Block};
 pub use bytecode::Bytecode;
-pub use convert::{new_vm_utf8_string, AsConverter, MoveConverter};
+pub use convert::{new_vm_utf8_string, AsConverter, ExplainVMStatus, MoveConverter};
 pub use error::{AptosError, AptosErrorCode};
 pub use event_key::EventKey;
 pub use hash::HashValue;

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -17,6 +17,7 @@ dpn = []
 anyhow = "1.0.57"
 bcs = "0.1.3"
 bytes = "1.2.1"
+futures = "0.3.17"
 hex = "0.4.3"
 poem-openapi = { version = "2.0.10", features = ["url"] }
 reqwest = { version = "0.11.10", features = ["json", "cookies", "blocking"] }


### PR DESCRIPTION
### Description
This is the last CLI change that's needed to cleanup the default max gas in the CLI.

This fixes Error descriptions, by pulling from the onchain bytecode.  This allows people to actually see why they failed.

Additionally, makes the CLI by default no longer have a fixed max gas amount.  It will now always use estimation.  This also gives the basis for providing proper error messages in Rosetta as well via the Rest client.

### Test Plan
CLI now stops beforehand rather than still sending failed transactions with an explained error:
```
$ aptos account transfer --profile testnet --account testnet-operator --amount 10
{
  "Error": "Simulation failed with status: Move abort in 0x1::coin: 0x60005"
}
```

Successful actions will tell you the range (from the amount simulated, to what the max gas is being set to 1.5x) and prompt appropriately.
```
$ aptos account transfer --profile testnet --account other --amount 10
Do you want to execute a transaction for a range of [51 - 76] coins at a gas unit price of 1? [yes/no] >
yes 
{
  "Result": {
    "gas_unit_price": 1,
    "gas_used": 51,
    "balance_changes": {
      "bae0c087437aa14ecf78214e87627be0d0cad8fb477a1fb24cd772f236d91d83": {
        "coin": {
          "value": "999762"
        },
        "deposit_events": {
          "counter": "1",
          "guid": {
            "id": {
              "addr": "0xbae0c087437aa14ecf78214e87627be0d0cad8fb477a1fb24cd772f236d91d83",
              "creation_num": "2"
            }
          }

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4447)
<!-- Reviewable:end -->
