### PR TITLE
[aptos-cli] Use named networks

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::init::Network;
 use crate::common::utils::prompt_yes_with_override;
 use crate::{
     common::{
@@ -186,6 +187,8 @@ pub const CONFIG_FOLDER: &str = ".aptos";
 /// An individual profile
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ProfileConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<Network>,
     /// Private key for commands.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub private_key: Option<Ed25519PrivateKey>,

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -9,7 +9,7 @@ use crate::account::{
     list::{ListAccount, ListQuery},
     transfer::{TransferCoins, TransferSummary},
 };
-use crate::common::init::InitTool;
+use crate::common::init::{InitTool, Network};
 use crate::common::types::{
     account_address_from_public_key, AccountAddressWrapper, CliError, CliTypedResult,
     EncodingOptions, FaucetOptions, GasOptions, KeyType, MoveManifestAccountWrapper,
@@ -505,6 +505,7 @@ impl CliTestFramework {
 
     pub async fn init(&self, private_key: &Ed25519PrivateKey) -> CliTypedResult<()> {
         InitTool {
+            network: Some(Network::Custom),
             rest_url: Some(self.endpoint.clone()),
             faucet_url: Some(self.faucet_endpoint.clone()),
             rng_args: RngArgs::from_seed([0; 32]),


### PR DESCRIPTION
### Description
I finally got tired of typing in two URLs every time.  This gives pretyped CLI network names and associated URLs.  Defaults to custom so the current behavior sticks (other than an extra enter)

There's confusion between the faucet and network endpoints.  This just adds prenamed combinations that can be used, while leaving the ability for custom combinations.  Additionally, stops making the init fail if the faucet fails.

### Test Plan
```
$ aptos init --profile new
Aptos already initialized for profile new, do you want to overwrite the existing config? [yes/no] >
yes
Configuring for profile new
Choose network from [testnet, devnet, local, custom | defaults to custom]
testnet
Enter your private key as a hex literal (0x...) [Current: Redacted | No input: Generate new key (or keep one if present)]

No key given, keeping existing key...

---
Aptos is now set up for account ad683c3bd5812acc8a7f1c89b54724691cf8f8e6dceea48a4f9f6ba9775d8fad!  Run `aptos help` for more information about commands
{
  "Result": "Success"
}

$ apt config show-profiles        
{
  "Result": {
    "new": {
      "has_private_key": true,
      "public_key": "0xa76994d3c9fb97ca0311f45cbefdce163053ed570c60ce7cc29f9fb477fc6549",
      "account": "ad683c3bd5812acc8a7f1c89b54724691cf8f8e6dceea48a4f9f6ba9775d8fad",
      "rest_url": "https://fullnode.testnet.aptoslabs.com",
      "faucet_url": "https://faucet.testnet.aptoslabs.com"
    },
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4451)
<!-- Reviewable:end -->
