### PR TITLE
[API Client] Fix wait_for_transaction to wait for expiry and return better messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,6 +1030,7 @@ dependencies = [
  "anyhow",
  "aptos-api-types",
  "aptos-crypto",
+ "aptos-infallible",
  "aptos-logger",
  "aptos-types",
  "bcs",

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -29,6 +29,7 @@ url = "2.2.2"
 
 aptos-api-types = { path = "../../api/types" }
 aptos-crypto = { path = "../aptos-crypto" }
+aptos-infallible = { path = "../aptos-infallible" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-types = { path = "../../types" }
 

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -30,11 +30,12 @@ use aptos_api_types::{
     UserTransaction, VersionedEvent,
 };
 use aptos_crypto::HashValue;
+use aptos_logger::{info, sample, sample::SampleRate, sample::Sampling, warn};
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{AccountResource, CoinStoreResource, NewBlockEvent, CORE_CODE_ADDRESS},
     contract_event::EventWithVersion,
-    transaction::{ExecutionStatus, SignedTransaction},
+    transaction::SignedTransaction,
 };
 use futures::executor::block_on;
 use move_deps::move_binary_format::CompiledModule;
@@ -56,6 +57,7 @@ const DEFAULT_MAX_WAIT_MS: u64 = 60000;
 const DEFAULT_INTERVAL_MS: u64 = 1000;
 static DEFAULT_MAX_WAIT_DURATION: Duration = Duration::from_millis(DEFAULT_MAX_WAIT_MS);
 static DEFAULT_INTERVAL_DURATION: Duration = Duration::from_millis(DEFAULT_INTERVAL_MS);
+const DEFAULT_MAX_SERVER_LAG_WAIT_DURATION: Duration = Duration::from_secs(60);
 
 type AptosResult<T> = Result<T, RestError>;
 
@@ -463,6 +465,8 @@ impl Client {
                 .request
                 .expiration_timestamp_secs
                 .inner(),
+            Some(DEFAULT_MAX_SERVER_LAG_WAIT_DURATION),
+            None,
         )
         .await
     }
@@ -477,6 +481,8 @@ impl Client {
                 .request
                 .expiration_timestamp_secs
                 .inner(),
+            Some(DEFAULT_MAX_SERVER_LAG_WAIT_DURATION),
+            None,
         )
         .await
     }
@@ -489,6 +495,8 @@ impl Client {
         self.wait_for_transaction_by_hash(
             transaction.clone().committed_hash(),
             expiration_timestamp,
+            Some(DEFAULT_MAX_SERVER_LAG_WAIT_DURATION),
+            None,
         )
         .await
     }
@@ -501,86 +509,209 @@ impl Client {
         self.wait_for_transaction_by_hash_bcs(
             transaction.clone().committed_hash(),
             expiration_timestamp,
+            Some(DEFAULT_MAX_SERVER_LAG_WAIT_DURATION),
+            None,
         )
         .await
+    }
+
+    /// Implementation of waiting for a transaction
+    /// * `hash`: hash of the submitted transaction
+    /// * `expiration_timestamp_secs`: expiration time of the submitted transaction
+    /// * `max_server_lag_wait`:
+    ///     Fullnodes generally lag some amount behind the authoritative blockchain ledger state.
+    ///     This field gives the node some time to update its ledger state to the point
+    ///     where your transaction might have expired.
+    ///     We recommend setting this value to at least 60 seconds.
+    /// * `timeout_from_call`:
+    ///     When an absolute timeout for this function is needed,
+    ///     irrespective of whether expiry time is reached.
+    async fn wait_for_transaction_by_hash_inner<F, Fut, T>(
+        &self,
+        hash: HashValue,
+        expiration_timestamp_secs: u64,
+        max_server_lag_wait: Option<Duration>,
+
+        timeout_from_call: Option<Duration>,
+        fetch: F,
+    ) -> AptosResult<Response<T>>
+    where
+        F: Fn(HashValue) -> Fut,
+        Fut: Future<Output = AptosResult<WaitForTransactionResult<T>>>,
+    {
+        const DEFAULT_DELAY: Duration = Duration::from_millis(500);
+
+        let start = std::time::Instant::now();
+        loop {
+            let mut chain_timestamp_usecs = None;
+            match fetch(hash).await? {
+                WaitForTransactionResult::Success(result) => {
+                    return Ok(result);
+                }
+                WaitForTransactionResult::FailedExecution(vm_status) => {
+                    return Err(anyhow!(
+                        "Transaction committed on chain, but failed execution: {}",
+                        vm_status
+                    ))?;
+                }
+                WaitForTransactionResult::Pending(state) => {
+                    if expiration_timestamp_secs <= state.timestamp_usecs / 1_000_000 {
+                        return Err(anyhow!("Transaction expired, it is guaranteed it will not be committed on chain.").into());
+                    }
+                    chain_timestamp_usecs = Some(state.timestamp_usecs);
+                }
+                WaitForTransactionResult::NotFound(error) => {
+                    if let RestError::Api(aptos_error_response) = error {
+                        if let Some(state) = aptos_error_response.state {
+                            if expiration_timestamp_secs <= state.timestamp_usecs / 1_000_000 {
+                                return Err(anyhow!("Transaction expired, it is guaranteed it will not be committed on chain.").into());
+                            }
+                            chain_timestamp_usecs = Some(state.timestamp_usecs);
+                        }
+                    } else {
+                        return Err(error);
+                    }
+                    sample!(
+                        SampleRate::Duration(Duration::from_secs(30)),
+                        warn!(
+                            "Cannot yet find transaction in mempool on {:?}, continuing to wait.",
+                            self.path_prefix_string(),
+                        )
+                    );
+                }
+            }
+
+            if let Some(max_server_lag_wait_duration) = max_server_lag_wait {
+                if aptos_infallible::duration_since_epoch().as_secs()
+                    > expiration_timestamp_secs + max_server_lag_wait_duration.as_secs()
+                {
+                    return Err(anyhow!(
+                        "Ledger on endpoint ({}) is more than {}s behind current time, timing out waiting for the transaction. Warning, transaction ({}) might still succeed.",
+                        self.path_prefix_string(),
+                        max_server_lag_wait_duration.as_secs(),
+                        hash,
+                    ).into());
+                }
+            }
+
+            let elapsed = start.elapsed();
+            if let Some(timeout_duration) = timeout_from_call {
+                if elapsed > timeout_duration {
+                    return Err(anyhow!(
+                        "Timeout of {}s after calling wait_for_transaction reached. Warning, transaction ({}) might still succeed.",
+                        timeout_duration.as_secs(),
+                        hash,
+                    ).into());
+                }
+            }
+
+            if elapsed.as_secs() > 30 {
+                sample!(
+                    SampleRate::Duration(Duration::from_secs(30)),
+                    warn!(
+                        "Continuing to wait for transaction {}, ledger on endpoint ({}) is {}",
+                        hash,
+                        self.path_prefix_string(),
+                        if let Some(timestamp_usecs) = chain_timestamp_usecs {
+                            format!(
+                                "{}s behind current time",
+                                aptos_infallible::duration_since_epoch()
+                                    .saturating_sub(Duration::from_micros(timestamp_usecs))
+                                    .as_secs()
+                            )
+                        } else {
+                            "unreachable".to_string()
+                        },
+                    )
+                );
+            }
+
+            tokio::time::sleep(DEFAULT_DELAY).await;
+        }
     }
 
     pub async fn wait_for_transaction_by_hash(
         &self,
         hash: HashValue,
         expiration_timestamp_secs: u64,
+        max_server_lag_wait: Option<Duration>,
+        timeout_from_call: Option<Duration>,
     ) -> AptosResult<Response<Transaction>> {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
-        const DEFAULT_DELAY: Duration = Duration::from_millis(500);
+        self.wait_for_transaction_by_hash_inner(
+            hash,
+            expiration_timestamp_secs,
+            max_server_lag_wait,
+            timeout_from_call,
+            |hash| async move {
+                let resp = self.get_transaction_by_hash_inner(hash).await?;
+                if resp.status() != StatusCode::NOT_FOUND {
+                    let txn_resp: Response<Transaction> = self.json(resp).await?;
+                    let (transaction, state) = txn_resp.into_parts();
 
-        let start = std::time::Instant::now();
-        while start.elapsed() < DEFAULT_TIMEOUT {
-            let resp = self.get_transaction_by_hash_inner(hash).await?;
-            if resp.status() != StatusCode::NOT_FOUND {
-                let txn_resp: Response<Transaction> = self.json(resp).await?;
-                let (transaction, state) = txn_resp.into_parts();
-
-                if !transaction.is_pending() {
-                    if !transaction.success() {
-                        return Err(anyhow!(
-                            "transaction execution failed: {}",
-                            transaction.vm_status()
-                        ))?;
+                    if !transaction.is_pending() {
+                        if !transaction.success() {
+                            Ok(WaitForTransactionResult::FailedExecution(
+                                transaction.vm_status(),
+                            ))
+                        } else {
+                            Ok(WaitForTransactionResult::Success(Response::new(
+                                transaction,
+                                state,
+                            )))
+                        }
+                    } else {
+                        Ok(WaitForTransactionResult::Pending(state))
                     }
-                    return Ok(Response::new(transaction, state));
+                } else {
+                    let error_response = parse_error(resp).await;
+                    Ok(WaitForTransactionResult::NotFound(error_response))
                 }
-                if expiration_timestamp_secs <= state.timestamp_usecs / 1_000_000 {
-                    return Err(anyhow!("transaction expired").into());
-                }
-            }
-
-            tokio::time::sleep(DEFAULT_DELAY).await;
-        }
-
-        Err(anyhow!("timeout").into())
+            },
+        )
+        .await
     }
 
     pub async fn wait_for_transaction_by_hash_bcs(
         &self,
         hash: HashValue,
         expiration_timestamp_secs: u64,
+        max_server_lag_wait: Option<Duration>,
+        timeout_from_call: Option<Duration>,
     ) -> AptosResult<Response<TransactionOnChainData>> {
-        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
-        const DEFAULT_DELAY: Duration = Duration::from_millis(500);
+        self.wait_for_transaction_by_hash_inner(
+            hash,
+            expiration_timestamp_secs,
+            max_server_lag_wait,
+            timeout_from_call,
+            |hash| async move {
+                let resp = self.get_transaction_by_hash_bcs_inner(hash).await?;
+                if resp.status() != StatusCode::NOT_FOUND {
+                    let resp = self.check_and_parse_bcs_response(resp).await?;
+                    let resp = resp.and_then(|bytes| bcs::from_bytes(&bytes))?;
+                    let (maybe_pending_txn, state) = resp.into_parts();
 
-        let start = std::time::Instant::now();
-        while start.elapsed() < DEFAULT_TIMEOUT {
-            let resp = self.get_transaction_by_hash_bcs_inner(hash).await?;
+                    // If we have a committed transaction, determine if it failed or not
+                    if let TransactionData::OnChain(txn) = maybe_pending_txn {
+                        let status = txn.info.status();
 
-            // If it's not found, keep waiting for it
-            if resp.status() != StatusCode::NOT_FOUND {
-                let resp = self.check_and_parse_bcs_response(resp).await?;
-                let resp = resp.and_then(|bytes| bcs::from_bytes(&bytes))?;
-                let (maybe_pending_txn, state) = resp.into_parts();
-
-                // If we have a committed transaction, determine if it failed or not
-                if let TransactionData::OnChain(txn) = maybe_pending_txn {
-                    let status = txn.info.status();
-
-                    // The user can handle the error
-                    return match status {
-                        ExecutionStatus::Success => Ok(Response::new(txn, state)),
-                        _ => Err(anyhow!("Transaction failed").into()),
-                    };
+                        if status.is_success() {
+                            Ok(WaitForTransactionResult::Success(Response::new(txn, state)))
+                        } else {
+                            Ok(WaitForTransactionResult::FailedExecution(format!(
+                                "{:?}",
+                                status
+                            )))
+                        }
+                    } else {
+                        Ok(WaitForTransactionResult::Pending(state))
+                    }
+                } else {
+                    let error_response = parse_error(resp).await;
+                    Ok(WaitForTransactionResult::NotFound(error_response))
                 }
-
-                // If it's expired lets give up
-                if Duration::from_secs(expiration_timestamp_secs)
-                    <= Duration::from_micros(state.timestamp_usecs)
-                {
-                    return Err(anyhow!("Transaction expired").into());
-                }
-            }
-
-            tokio::time::sleep(DEFAULT_DELAY).await;
-        }
-
-        Err(anyhow!("Timed out waiting for transaction").into())
+            },
+        )
+        .await
     }
 
     pub async fn wait_for_version(&self, version: u64) -> Result<State> {
@@ -1191,7 +1322,7 @@ impl Client {
                 break;
             }
 
-            aptos_logger::info!(
+            info!(
                 "Failed to call API, retrying in {}ms: {:?}",
                 backoff.as_millis(),
                 result.as_ref().err().unwrap()
@@ -1263,6 +1394,13 @@ async fn parse_error(response: reqwest::Response) -> RestError {
 pub struct GasEstimationParams {
     pub estimated_gas_used: u64,
     pub estimated_gas_price: u64,
+}
+
+enum WaitForTransactionResult<T> {
+    NotFound(RestError),
+    FailedExecution(String),
+    Pending(State),
+    Success(Response<T>),
 }
 
 impl ExplainVMStatus for Client {

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use crate::{
     account::create::DEFAULT_FUNDED_COINS,
@@ -53,10 +53,12 @@ impl CliCommand<String> for FundWithFaucet {
             .duration_since(SystemTime::UNIX_EPOCH)
             .map_err(|e| CliError::UnexpectedError(e.to_string()))?
             .as_secs()
-            + 10;
+            + 30;
         let client = self.rest_options.client(&self.profile_options.profile)?;
         for hash in hashes {
-            client.wait_for_transaction_by_hash(hash, sys_time).await?;
+            client
+                .wait_for_transaction_by_hash(hash, sys_time, Some(Duration::from_secs(60)), None)
+                .await?;
         }
         return Ok(format!(
             "Added {} Octas to account {}",

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -549,7 +549,14 @@ pub async fn execute_and_wait_transactions(
 
     for txn in state.txns.iter() {
         RETRY_POLICY
-            .retry(move || client.wait_for_signed_transaction_bcs(txn))
+            .retry(move || {
+                client.wait_for_transaction_by_hash_bcs(
+                    txn.clone().committed_hash(),
+                    txn.expiration_timestamp_secs(),
+                    Some(Duration::from_secs(120)),
+                    None,
+                )
+            })
             .await
             .map_err(|e| format_err!("Failed to wait for transactions: {:?}", e))?;
     }

--- a/ecosystem/python/sdk/aptos_sdk/client.py
+++ b/ecosystem/python/sdk/aptos_sdk/client.py
@@ -160,7 +160,7 @@ class RestClient:
         return response.json()["type"] == "pending_transaction"
 
     def wait_for_transaction(self, txn_hash: str) -> None:
-        """Waits up to 10 seconds for a transaction to move past pending state."""
+        """Waits up to 20 seconds for a transaction to move past pending state."""
 
         count = 0
         while self.transaction_pending(txn_hash):

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -266,10 +266,7 @@ async fn test_bcs() {
         .unwrap();
     let expected_txn_hash = pending_transaction.hash.into();
     let expected_txn = client
-        .wait_for_transaction_by_hash_bcs(
-            expected_txn_hash,
-            pending_transaction.request.expiration_timestamp_secs.0,
-        )
+        .wait_for_transaction_bcs(&pending_transaction)
         .await
         .unwrap()
         .into_inner();

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -1872,7 +1872,12 @@ async fn wait_for_transaction(
 ) -> Result<Box<UserTransaction>, Box<UserTransaction>> {
     let hash_value = HashValue::from_str(&txn_hash).unwrap();
     let response = rest_client
-        .wait_for_transaction_by_hash(hash_value, expiry_time.as_secs())
+        .wait_for_transaction_by_hash(
+            hash_value,
+            expiry_time.as_secs(),
+            Some(Duration::from_secs(60)),
+            None,
+        )
         .await;
     match response {
         Ok(response) => {


### PR DESCRIPTION
Previously wait_for_transaction waited only for 60 seconds, and then failed, even if expiry didn't finish. 

Error message was confusing (timeout vs expired), so clarifying all messages better (so user knows if transaction can still succeed or not)

But it seems very odd to not wait to the expiry time passed in, so fixing that. 

 wait_for_transaction_by_hash(_bcs) are now configurable with:

       server_lag_timeout_after_expiry: Option<Duration>,
       timeout_from_call: Option<Duration>,

First one is to finish at some point if rest endpoint is too stale. second one is if a caller wants absolute timeout (even before expiry)

Previously default would be server_lag_timeout_after_expiry=None and timeout_from_call=60s, and I am putting that for now in all other methods (wait_for_transaction/submit_and_wait/etc), so that their logic is unchanged for now.

I changed in fund cli to wait to completion, and in forge tests which had issues with above.(which is server_lag_timeout_after_expiry=60 or 120s, and timeout_from_call=None).
 we can see later if we want to change that to be default, but not changing any logic before the cut.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4456)
<!-- Reviewable:end -->
