### PR TITLE
[aptos-rosetta] Put decoded full transaction into parse transaction

### DIFF
--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -364,9 +364,13 @@ async fn construction_parse(
 ) -> ApiResult<ConstructionParseResponse> {
     debug!("/construction/parse {:?}", request);
     check_network(request.network_identifier, &server_context)?;
-
+    let metadata;
     let (account_identifier_signers, unsigned_txn) = if request.signed {
         let signed_txn: SignedTransaction = decode_bcs(&request.transaction, "SignedTransaction")?;
+        metadata = Some(ConstructionParseMetadata {
+            unsigned_transaction: None,
+            signed_transaction: Some(signed_txn.clone()),
+        });
         let mut account_identifier_signers: Vec<_> = vec![signed_txn.sender().into()];
 
         for account in signed_txn.authenticator().secondary_signer_addreses() {
@@ -379,6 +383,10 @@ async fn construction_parse(
         )
     } else {
         let unsigned_txn: RawTransaction = decode_bcs(&request.transaction, "UnsignedTransaction")?;
+        metadata = Some(ConstructionParseMetadata {
+            unsigned_transaction: Some(unsigned_txn.clone()),
+            signed_transaction: None,
+        });
         (None, unsigned_txn)
     };
     let sender = unsigned_txn.sender();
@@ -429,6 +437,7 @@ async fn construction_parse(
     Ok(ConstructionParseResponse {
         operations,
         account_identifier_signers,
+        metadata,
     })
 }
 

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -8,6 +8,7 @@ use crate::types::{
 };
 use aptos_rest_client::aptos_api_types::U64;
 use aptos_types::chain_id::ChainId;
+use aptos_types::transaction::{RawTransaction, SignedTransaction};
 use serde::{Deserialize, Serialize};
 
 /// Request for an account's currency balance either now, or historically
@@ -260,6 +261,16 @@ pub struct ConstructionParseResponse {
     /// The signers of the transaction, if it was a [`aptos_types::transaction::SignedTransaction`]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_identifier_signers: Option<Vec<AccountIdentifier>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<ConstructionParseMetadata>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct ConstructionParseMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unsigned_transaction: Option<RawTransaction>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signed_transaction: Option<SignedTransaction>,
 }
 
 /// Request to build payloads from the operations to sign


### PR DESCRIPTION
### Description
Adds debugging information to parse transaction in Rosetta.  Lets the viewer see all
the details for the transaction.

### Test Plan
E2E tests, but otherwise none

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4458)
<!-- Reviewable:end -->
