### PR TITLE
[mempool] Add counter for created block size in txn count and byte size

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -9,7 +9,7 @@ use crate::{
         transaction::{MempoolTransaction, TimelineState},
         transaction_store::TransactionStore,
     },
-    counters,
+    counters::{self, MEMPOOL_RETURNED_NUM_BYTES_PER_BLOCK, MEMPOOL_RETURNED_NUM_TXNS_PER_BLOCK},
     logging::{LogEntry, LogSchema, TxnsLog},
 };
 use aptos_config::config::NodeConfig;
@@ -201,6 +201,9 @@ impl Mempool {
             block_size = block.len(),
             byte_size = total_bytes,
         );
+
+        MEMPOOL_RETURNED_NUM_TXNS_PER_BLOCK.observe(block.len() as f64);
+        MEMPOOL_RETURNED_NUM_BYTES_PER_BLOCK.observe(total_bytes as f64);
         for transaction in &block {
             self.log_latency(
                 transaction.sender(),

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -9,7 +9,7 @@ use crate::{
         transaction::{MempoolTransaction, TimelineState},
         transaction_store::TransactionStore,
     },
-    counters::{self, MEMPOOL_RETURNED_NUM_BYTES_PER_BLOCK, MEMPOOL_RETURNED_NUM_TXNS_PER_BLOCK},
+    counters,
     logging::{LogEntry, LogSchema, TxnsLog},
 };
 use aptos_config::config::NodeConfig;
@@ -202,8 +202,8 @@ impl Mempool {
             byte_size = total_bytes,
         );
 
-        MEMPOOL_RETURNED_NUM_TXNS_PER_BLOCK.observe(block.len() as f64);
-        MEMPOOL_RETURNED_NUM_BYTES_PER_BLOCK.observe(total_bytes as f64);
+        counters::mempool_service_transactions(counters::GET_BLOCK_LABEL, block.len());
+        counters::MEMPOOL_SERVICE_BYTES_GET_BLOCK.observe(total_bytes as f64);
         for transaction in &block {
             self.log_latency(
                 transaction.sender(),

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -4,8 +4,8 @@
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_metrics_core::{
     op_counters::DurationHistogram, register_histogram, register_histogram_vec,
-    register_int_counter, register_int_counter_vec, register_int_gauge_vec, HistogramTimer,
-    HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    register_int_counter, register_int_counter_vec, register_int_gauge_vec, Histogram,
+    HistogramTimer, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 use short_hex_str::AsShortHexStr;
@@ -473,4 +473,22 @@ pub static MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {
         )
         .unwrap(),
     )
+});
+
+/// Histogram for the number of txns per (committed) blocks.
+pub static MEMPOOL_RETURNED_NUM_TXNS_PER_BLOCK: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_mempool_returned_num_txns_per_block",
+        "Histogram for the number of txns per (mempool returned for proposal) blocks."
+    )
+    .unwrap()
+});
+
+/// Histogram for the number of txns per (committed) blocks.
+pub static MEMPOOL_RETURNED_NUM_BYTES_PER_BLOCK: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_mempool_returned_num_bytes_per_block",
+        "Histogram for the number of txns per (mempool returned for proposal) blocks."
+    )
+    .unwrap()
 });

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -168,6 +168,15 @@ pub fn mempool_service_transactions(label: &'static str, num: usize) {
         .observe(num as f64)
 }
 
+/// Histogram for the byte size of transactions processed in get_block
+pub static MEMPOOL_SERVICE_BYTES_GET_BLOCK: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_mempool_service_bytes_get_block",
+        "Histogram for the number of txns per (mempool returned for proposal) blocks."
+    )
+    .unwrap()
+});
+
 /// Counter for tracking latency of mempool processing requests from consensus/state sync
 /// A 'fail' result means the mempool's callback response to consensus/state sync failed.
 static MEMPOOL_SERVICE_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
@@ -473,22 +482,4 @@ pub static MAIN_LOOP: Lazy<DurationHistogram> = Lazy::new(|| {
         )
         .unwrap(),
     )
-});
-
-/// Histogram for the number of txns per (committed) blocks.
-pub static MEMPOOL_RETURNED_NUM_TXNS_PER_BLOCK: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        "aptos_mempool_returned_num_txns_per_block",
-        "Histogram for the number of txns per (mempool returned for proposal) blocks."
-    )
-    .unwrap()
-});
-
-/// Histogram for the number of txns per (committed) blocks.
-pub static MEMPOOL_RETURNED_NUM_BYTES_PER_BLOCK: Lazy<Histogram> = Lazy::new(|| {
-    register_histogram!(
-        "aptos_mempool_returned_num_bytes_per_block",
-        "Histogram for the number of txns per (mempool returned for proposal) blocks."
-    )
-    .unwrap()
 });

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -412,7 +412,8 @@ pub(crate) fn process_quorum_store_request<V: TransactionValidation>(
                 let max_txns = cmp::max(max_txns, 1);
                 txns = mempool.get_batch(max_txns, max_bytes, exclude_transactions);
             }
-            counters::mempool_service_transactions(counters::GET_BLOCK_LABEL, txns.len());
+
+            // mempool_service_transactions is logged inside get_batch
 
             (
                 QuorumStoreResponse::GetBatchResponse(txns),


### PR DESCRIPTION
We have txn/committed block counter, but without re-serializing things there, I cannot easily get the size. This seems an easy place to measure it, and it also enables us to easily see if different nodes are trying to propose different sizes as well (irrespective of whether those land on the blockchain)

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4460)
<!-- Reviewable:end -->
