### PR TITLE
[mempool] possibly fix flaky fn_to_val_test

### DIFF
--- a/mempool/src/tests/integration_tests.rs
+++ b/mempool/src/tests/integration_tests.rs
@@ -342,8 +342,8 @@ async fn fn_to_val_test() {
 
         // NOTE: Always return node at end, or it will be dropped and channels closed
         let pfn_future = async move {
-            pfn.connect(pfn_vfn_network, vfn_metadata);
             pfn.add_txns_via_client(ALL_TXNS).await;
+            pfn.connect(pfn_vfn_network, vfn_metadata);
 
             // Forward to VFN
             pfn.send_next_network_msg(pfn_vfn_network).await;


### PR DESCRIPTION
### Description

The test fails and succeeds on retry in CICD sometimes: only the first transaction is propagated. There is a race condition where the broadcast from the pfn happens after txn0 is added but before txn1 is added. In that case, only txn0 is broadcasted (because the test is instrumented to only send a single message). By adding the txns first, we can avoid this.

### Test Plan

Will have to observe if flakiness goes down after land.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4468)
<!-- Reviewable:end -->
