### PR TITLE
[aptos-cli] Move to using account transfer over coin transfer

### DIFF
--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -16,7 +16,7 @@ use std::str::FromStr;
 /// Command to create a resource account on-chain
 ///
 /// To create an account there are two options:
-/// 1. Submit a create account transaction with an account that has coins
+/// 1. Submit a create account transaction with an account that has APT coins
 /// 2. Use a faucet to create the account
 #[derive(Debug, Parser)]
 pub struct CreateResourceAccount {

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -59,7 +59,7 @@ impl CliCommand<String> for FundWithFaucet {
             client.wait_for_transaction_by_hash(hash, sys_time).await?;
         }
         return Ok(format!(
-            "Added {} coins to account {}",
+            "Added {} Octas to account {}",
             self.amount, self.account
         ));
     }

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -38,7 +38,10 @@ impl CliCommand<TransferSummary> for TransferCoins {
 
     async fn execute(self) -> CliTypedResult<TransferSummary> {
         self.txn_options
-            .submit_transaction(aptos_stdlib::aptos_coin_transfer(self.account, self.amount))
+            .submit_transaction(aptos_stdlib::aptos_account_transfer(
+                self.account,
+                self.amount,
+            ))
             .await
             .map(TransferSummary::from)
     }

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -14,15 +14,15 @@ use clap::Parser;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
-/// Command to transfer coins between accounts
+/// Command to transfer APT coins between accounts
 ///
 #[derive(Debug, Parser)]
 pub struct TransferCoins {
-    /// Address of account you want to send coins to
+    /// Address of account you want to send APT coins to
     #[clap(long, parse(try_from_str = crate::common::types::load_account_arg))]
     pub(crate) account: AccountAddress,
 
-    /// Amount of coins to transfer
+    /// Amount of Octas (10^-8 APT) to transfer
     #[clap(long)]
     pub(crate) amount: u64,
 

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -172,7 +172,7 @@ impl CliCommand<()> for InitTool {
         if let Some(faucet_url) = faucet_url {
             if client.get_account(address).await.is_err() {
                 eprintln!(
-                    "Account {} doesn't exist, creating it and funding it with {} coins",
+                    "Account {} doesn't exist, creating it and funding it with {} Octas",
                     address, NUM_DEFAULT_COINS
                 );
                 fund_account(faucet_url, NUM_DEFAULT_COINS, address).await?;

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1129,9 +1129,9 @@ impl FaucetOptions {
 pub struct GasOptions {
     /// Gas multiplier per unit of gas
     ///
-    /// The amount of coins used for a transaction is equal
+    /// The amount of Octas (10^-8 APT) used for a transaction is equal
     /// to (gas unit price * gas used).  The gas_unit_price can
-    /// be used as a multiplier for the amount of coins willing
+    /// be used as a multiplier for the amount of Octas willing
     /// to be paid for a transaction.  This will prioritize the
     /// transaction with a higher gas unit price.
     ///
@@ -1141,12 +1141,12 @@ pub struct GasOptions {
     /// Maximum amount of gas units to be used to send this transaction
     ///
     /// The maximum amount of gas units willing to pay for the transaction.
-    /// This is the (max gas in coins / gas unit price).
+    /// This is the (max gas in Octas / gas unit price).
     ///
-    /// For example if I wanted to pay a maximum of 100 coins, I may have the
+    /// For example if I wanted to pay a maximum of 100 Octas, I may have the
     /// max gas set to 100 if the gas unit price is 1.  If I want it to have a
     /// gas unit price of 2, the max gas would need to be 50 to still only have
-    /// a maximum price of 100 coins.
+    /// a maximum price of 100 Octas.
     ///
     /// Without a value, it will determine the price based on simulating the current transaction
     #[clap(long)]
@@ -1249,7 +1249,7 @@ impl TransactionOptions {
         let max_gas = if let Some(max_gas) = self.gas_options.max_gas {
             // If the gas unit price was estimated ask, but otherwise you've chosen hwo much you want to spend
             if ask_to_confirm_price {
-                let message = format!("Do you want to submit transaction for a maximum of {} coins at a gas unit price of {}?",  max_gas * gas_unit_price, gas_unit_price);
+                let message = format!("Do you want to submit transaction for a maximum of {} Octas at a gas unit price of {} Octas?",  max_gas * gas_unit_price, gas_unit_price);
                 prompt_yes_with_override(&message, self.prompt_options)?;
             }
             max_gas
@@ -1296,7 +1296,7 @@ impl TransactionOptions {
             let upper_cost_bound = adjusted_max_gas * gas_unit_price;
             let lower_cost_bound = simulated_txn.info.gas_used() * gas_unit_price;
             let message = format!(
-                    "Do you want to execute a transaction for a range of [{} - {}] coins at a gas unit price of {}?",
+                    "Do you want to submit a transaction for a range of [{} - {}] Octas at a gas unit price of {} Octas?",
                     lower_cost_bound,
                     upper_cost_bound,
                     gas_unit_price);

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -315,13 +315,13 @@ pub fn read_line(input_name: &'static str) -> CliTypedResult<String> {
 /// Fund account (and possibly create it) from a faucet
 pub async fn fund_account(
     faucet_url: Url,
-    num_coins: u64,
+    num_octas: u64,
     address: AccountAddress,
 ) -> CliTypedResult<Vec<HashValue>> {
     let response = reqwest::Client::new()
         .post(format!(
             "{}mint?amount={}&auth_key={}",
-            faucet_url, num_coins, address
+            faucet_url, num_octas, address
         ))
         .send()
         .await

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -608,7 +608,7 @@ const TESTNET_FOLDER: &str = "testnet";
 /// Run local testnet
 ///
 /// This local testnet will run it's own Genesis and run as a single node
-/// network locally.  Optionally, a faucet can be added for minting coins.
+/// network locally.  Optionally, a faucet can be added for minting APT coins.
 #[derive(Parser)]
 pub struct RunLocalTestnet {
     /// An overridable config template for the test node

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -37,12 +37,12 @@ impl StakeTool {
     }
 }
 
-/// Stake coins to the stake pool
+/// Stake APT coins to the stake pool
 ///
-/// This command allows stake pool owners to add coins to their stake.
+/// This command allows stake pool owners to add APT coins to their stake.
 #[derive(Parser)]
 pub struct AddStake {
-    /// Amount of coins to add to stake
+    /// Amount of Octas (10^-8 APT) to add to stake
     #[clap(long)]
     pub amount: u64,
 
@@ -64,12 +64,12 @@ impl CliCommand<TransactionSummary> for AddStake {
     }
 }
 
-/// Unlock staked coins
+/// Unlock staked APT coins
 ///
-/// Coins can only be unlocked if they no longer have an applied lockup period
+/// APT coins can only be unlocked if they no longer have an applied lockup period
 #[derive(Parser)]
 pub struct UnlockStake {
-    /// Amount of coins to unlock
+    /// Amount of Octas (10^-8 APT) to unlock
     #[clap(long)]
     pub amount: u64,
 
@@ -91,13 +91,13 @@ impl CliCommand<TransactionSummary> for UnlockStake {
     }
 }
 
-/// Withdraw unlocked staked coins
+/// Withdraw unlocked staked APT coins
 ///
 /// This allows users to withdraw stake back into their CoinStore.
 /// Before calling `WithdrawStake`, `UnlockStake` must be called first.
 #[derive(Parser)]
 pub struct WithdrawStake {
-    /// Amount of coins to withdraw
+    /// Amount of Octas (10^-8 APT) to withdraw
     #[clap(long)]
     pub amount: u64,
 
@@ -119,7 +119,7 @@ impl CliCommand<TransactionSummary> for WithdrawStake {
     }
 }
 
-/// Increase lockup of all staked coins in the stake pool
+/// Increase lockup of all staked APT coins in the stake pool
 ///
 /// Lockup may need to be increased in order to vote on a proposal.
 #[derive(Parser)]
@@ -148,7 +148,7 @@ impl CliCommand<TransactionSummary> for IncreaseLockup {
 /// stake pool to an operator, or delegate voting to a different account.
 #[derive(Parser)]
 pub struct InitializeStakeOwner {
-    /// Initial amount of coins to be staked
+    /// Initial amount of Octas (10^-8 APT) to be staked
     #[clap(long)]
     pub initial_stake_amount: u64,
 

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -39,8 +39,11 @@ use aptos_crypto::{bls12381, ed25519::Ed25519PrivateKey, x25519, PrivateKey};
 use aptos_genesis::config::HostAndPort;
 use aptos_keygen::KeyGen;
 use aptos_logger::warn;
+use aptos_rest_client::aptos_api_types::{IdentifierWrapper, MoveStructTag};
 use aptos_rest_client::{aptos_api_types::MoveType, Transaction};
 use aptos_sdk::move_types::account_address::AccountAddress;
+use aptos_sdk::move_types::identifier::Identifier;
+use aptos_sdk::move_types::language_storage::ModuleId;
 use aptos_temppath::TempPath;
 use aptos_types::on_chain_config::ValidatorSet;
 use aptos_types::validator_config::ValidatorConfig;
@@ -261,11 +264,23 @@ impl CliTestFramework {
         sender_index: usize,
         amount: u64,
         gas_options: Option<GasOptions>,
-    ) -> CliTypedResult<TransferSummary> {
-        TransferCoins {
+    ) -> CliTypedResult<TransactionSummary> {
+        RunFunction {
+            function_id: MemberId {
+                module_id: ModuleId::new(
+                    AccountAddress::ONE,
+                    Identifier::from_str("coin").unwrap(),
+                ),
+                member_id: Identifier::from_str("transfer").unwrap(),
+            },
+            args: vec![ArgWithType::from_str(&format!("u64:{}", amount)).unwrap()],
+            type_args: vec![MoveType::Struct(MoveStructTag::new(
+                AccountAddress::ONE.into(),
+                IdentifierWrapper::from_str("aptos_coin").unwrap(),
+                IdentifierWrapper::from_str("AptosCoin").unwrap(),
+                vec![],
+            ))],
             txn_options: self.transaction_options(sender_index, gas_options),
-            account: AccountAddress::from_hex_literal(INVALID_ACCOUNT).unwrap(),
-            amount,
         }
         .execute()
         .await

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -273,7 +273,10 @@ impl CliTestFramework {
                 ),
                 member_id: Identifier::from_str("transfer").unwrap(),
             },
-            args: vec![ArgWithType::from_str(&format!("u64:{}", amount)).unwrap()],
+            args: vec![
+                ArgWithType::from_str("address:0xdeadbeefcafebabe").unwrap(),
+                ArgWithType::from_str(&format!("u64:{}", amount)).unwrap(),
+            ],
             type_args: vec![MoveType::Struct(MoveStructTag::new(
                 AccountAddress::ONE.into(),
                 IdentifierWrapper::from_str("aptos_coin").unwrap(),

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -32,6 +32,7 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "genesis", "generate-layout-template", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "genesis", "set-validator-configuration", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "genesis", "setup-git", "--help"]).await;
+    assert_cmd_not_panic(&["aptos", "genesis", "generate-admin-write-set", "--help"]).await;
 
     assert_cmd_not_panic(&["aptos", "governance"]).await;
     assert_cmd_not_panic(&["aptos", "governance", "execute-proposal", "--help"]).await;

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -1393,6 +1393,7 @@ fn assert_failed_transfer_transaction(
     let rosetta_txn_metadata = &rosetta_txn.metadata;
     assert_eq!(TransactionType::User, rosetta_txn_metadata.transaction_type);
     assert_eq!(actual_txn.info.version.0, rosetta_txn_metadata.version.0);
+    // Failed transactions aren't cared about too much in Rosetta
     // This should have 3, the deposit, withdraw, and fee
     assert_eq!(rosetta_txn.operations.len(), 3);
 

--- a/testsuite/smoke-test/src/rosetta.rs
+++ b/testsuite/smoke-test/src/rosetta.rs
@@ -1393,7 +1393,6 @@ fn assert_failed_transfer_transaction(
     let rosetta_txn_metadata = &rosetta_txn.metadata;
     assert_eq!(TransactionType::User, rosetta_txn_metadata.transaction_type);
     assert_eq!(actual_txn.info.version.0, rosetta_txn_metadata.version.0);
-    // Failed transactions aren't cared about too much in Rosetta
     // This should have 3, the deposit, withdraw, and fee
     assert_eq!(rosetta_txn.operations.len(), 3);
 


### PR DESCRIPTION
### Description
We were using the non-create with transfer in the CLI.  We should fix this accordingly.

### Test Plan
Tested with manual testing
```
aptos account transfer --profile devnet --account 0x77 --amount 50
Do you want to submit a transaction for a range of [26200 - 39300] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "gas_unit_price": 100,
    "gas_used": 271,
    "balance_changes": {
      "0000000000000000000000000000000000000000000000000000000000000077": {
        "coin": {
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4473)
<!-- Reviewable:end -->
