### PR TITLE
[consensus] support a recovery mode if consensusdb is gone

### DIFF
--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -34,6 +34,7 @@ use crate::{
     payload_manager::QuorumStoreClient,
     persistent_liveness_storage::{LedgerRecoveryData, PersistentLivenessStorage, RecoveryData},
     quorum_store::direct_mempool_quorum_store::DirectMempoolQuorumStore,
+    recovery_manager::RecoveryManager,
     round_manager::{RoundManager, UnverifiedEvent, VerifiedEvent},
     state_replication::StateComputer,
     util::time_service::TimeService,
@@ -89,17 +90,8 @@ const PROPSER_ROUND_BEHIND_STORAGE_BUFFER: usize = 10;
 
 #[allow(clippy::large_enum_variant)]
 pub enum LivenessStorageData {
-    RecoveryData(RecoveryData),
-    LedgerRecoveryData(LedgerRecoveryData),
-}
-
-impl LivenessStorageData {
-    pub fn expect_recovery_data(self, msg: &str) -> RecoveryData {
-        match self {
-            LivenessStorageData::RecoveryData(data) => data,
-            LivenessStorageData::LedgerRecoveryData(_) => panic!("{}", msg),
-        }
-    }
+    FullRecoveryData(RecoveryData),
+    PartialRecoveryData(LedgerRecoveryData),
 }
 
 // Manager the components that shared across epoch and spawn per-epoch RoundManager with
@@ -542,6 +534,35 @@ impl EpochManager {
         self.block_retrieval_tx = None;
     }
 
+    async fn start_recovery_manager(
+        &mut self,
+        ledger_data: LedgerRecoveryData,
+        epoch_state: EpochState,
+    ) {
+        let network_sender = NetworkSender::new(
+            self.author,
+            self.network_sender.clone(),
+            self.self_sender.clone(),
+            epoch_state.verifier.clone(),
+        );
+        let (recovery_manager_tx, recovery_manager_rx) = aptos_channel::new(
+            QueueStyle::LIFO,
+            1,
+            Some(&counters::ROUND_MANAGER_CHANNEL_MSGS),
+        );
+        self.round_manager_tx = Some(recovery_manager_tx);
+        let (close_tx, close_rx) = oneshot::channel();
+        self.round_manager_close_tx = Some(close_tx);
+        let recovery_manager = RecoveryManager::new(
+            epoch_state,
+            network_sender,
+            self.storage.clone(),
+            self.commit_state_computer.clone(),
+            ledger_data.committed_round(),
+        );
+        tokio::spawn(recovery_manager.start(recovery_manager_rx, close_rx));
+    }
+
     async fn start_round_manager(
         &mut self,
         recovery_data: RecoveryData,
@@ -680,16 +701,19 @@ impl EpochManager {
 
         self.epoch_state = Some(epoch_state.clone());
 
-        let initial_data = self
-            .storage
-            .start()
-            .expect_recovery_data("consensusdb is not consistent with aptosdb");
-        self.start_round_manager(
-            initial_data,
-            epoch_state,
-            onchain_config.unwrap_or_default(),
-        )
-        .await;
+        match self.storage.start() {
+            LivenessStorageData::FullRecoveryData(initial_data) => {
+                self.start_round_manager(
+                    initial_data,
+                    epoch_state,
+                    onchain_config.unwrap_or_default(),
+                )
+                .await
+            }
+            LivenessStorageData::PartialRecoveryData(ledger_data) => {
+                self.start_recovery_manager(ledger_data, epoch_state).await
+            }
+        }
     }
 
     async fn process_message(

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(feature = "fuzzing", allow(dead_code))]
 #![recursion_limit = "512"]
 
+extern crate core;
+
 mod block_storage;
 mod commit_notifier;
 mod consensusdb;
@@ -28,6 +30,7 @@ mod payload_manager;
 mod pending_votes;
 mod persistent_liveness_storage;
 mod quorum_store;
+mod recovery_manager;
 mod round_manager;
 mod state_computer;
 mod state_replication;

--- a/consensus/src/recovery_manager.rs
+++ b/consensus/src/recovery_manager.rs
@@ -1,0 +1,151 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    block_storage::{BlockRetriever, BlockStore},
+    counters,
+    error::error_kind,
+    monitor,
+    network::NetworkSender,
+    persistent_liveness_storage::{PersistentLivenessStorage, RecoveryData},
+    round_manager::VerifiedEvent,
+    state_replication::StateComputer,
+};
+use anyhow::{anyhow, ensure, Context, Result};
+use aptos_logger::prelude::*;
+use aptos_types::{block_info::Round, epoch_state::EpochState};
+use channel::aptos_channel;
+use consensus_types::{
+    common::Author, proposal_msg::ProposalMsg, sync_info::SyncInfo, vote_msg::VoteMsg,
+};
+use futures::{FutureExt, StreamExt};
+use futures_channel::oneshot;
+use std::{mem::Discriminant, process, sync::Arc};
+
+/// If the node can't recover corresponding blocks from local storage, RecoveryManager is responsible
+/// for processing the events carrying sync info and use the info to retrieve blocks from peers
+pub struct RecoveryManager {
+    epoch_state: EpochState,
+    network: NetworkSender,
+    storage: Arc<dyn PersistentLivenessStorage>,
+    state_computer: Arc<dyn StateComputer>,
+    last_committed_round: Round,
+}
+
+impl RecoveryManager {
+    pub fn new(
+        epoch_state: EpochState,
+        network: NetworkSender,
+        storage: Arc<dyn PersistentLivenessStorage>,
+        state_computer: Arc<dyn StateComputer>,
+        last_committed_round: Round,
+    ) -> Self {
+        RecoveryManager {
+            epoch_state,
+            network,
+            storage,
+            state_computer,
+            last_committed_round,
+        }
+    }
+
+    pub async fn process_proposal_msg(
+        &mut self,
+        proposal_msg: ProposalMsg,
+    ) -> Result<RecoveryData> {
+        let author = proposal_msg.proposer();
+        let sync_info = proposal_msg.sync_info();
+        self.sync_up(sync_info, author).await
+    }
+
+    pub async fn process_vote_msg(&mut self, vote_msg: VoteMsg) -> Result<RecoveryData> {
+        let author = vote_msg.vote().author();
+        let sync_info = vote_msg.sync_info();
+        self.sync_up(sync_info, author).await
+    }
+
+    pub async fn sync_up(&mut self, sync_info: &SyncInfo, peer: Author) -> Result<RecoveryData> {
+        sync_info.verify(&self.epoch_state.verifier)?;
+        ensure!(
+            sync_info.highest_round() > self.last_committed_round,
+            "[RecoveryManager] Received sync info has lower round number than committed block"
+        );
+        ensure!(
+            sync_info.epoch() == self.epoch_state.epoch,
+            "[RecoveryManager] Received sync info is in different epoch than committed block"
+        );
+        let mut retriever = BlockRetriever::new(
+            self.network.clone(),
+            peer,
+            self.epoch_state
+                .verifier
+                .get_ordered_account_addresses_iter()
+                .collect(),
+        );
+        let recovery_data = BlockStore::fast_forward_sync(
+            sync_info.highest_ordered_cert(),
+            sync_info.highest_commit_cert(),
+            &mut retriever,
+            self.storage.clone(),
+            self.state_computer.clone(),
+        )
+        .await?;
+
+        Ok(recovery_data)
+    }
+
+    pub async fn start(
+        mut self,
+        mut event_rx: aptos_channel::Receiver<
+            (Author, Discriminant<VerifiedEvent>),
+            (Author, VerifiedEvent),
+        >,
+        close_rx: oneshot::Receiver<oneshot::Sender<()>>,
+    ) {
+        info!(epoch = self.epoch_state.epoch, "RecoveryManager started");
+        let mut close_rx = close_rx.into_stream();
+        loop {
+            futures::select! {
+                (peer_id, event) = event_rx.select_next_some() => {
+                    let result = match event {
+                        VerifiedEvent::ProposalMsg(proposal_msg) => {
+                            monitor!(
+                                "process_recovery",
+                                self.process_proposal_msg(*proposal_msg).await
+                            )
+                        }
+                        VerifiedEvent::VoteMsg(vote_msg) => {
+                            monitor!("process_recovery", self.process_vote_msg(*vote_msg).await)
+                        }
+                        VerifiedEvent::UnverifiedSyncInfo(sync_info) => {
+                            monitor!(
+                                "process_recovery",
+                                self.sync_up(&sync_info, peer_id).await
+                            )
+                        }
+                        unexpected_event => Err(anyhow!("Unexpected event: {:?}", unexpected_event)),
+                    }
+                    .with_context(|| format!("from peer {}", peer_id));
+
+                    match result {
+                        Ok(_) => {
+                            info!("Recovery finishes for epoch {}, RecoveryManager stopped. Please restart the node", self.epoch_state.epoch);
+                            process::exit(0);
+                        },
+                        Err(e) => {
+                            counters::ERROR_COUNT.inc();
+                            error!(error = ?e, kind = error_kind(&e));
+                        }
+                    }
+                }
+                close_req = close_rx.select_next_some() => {
+                    if let Ok(ack_sender) = close_req {
+                        ack_sender.send(()).expect("[RecoveryManager] Fail to ack shutdown");
+                    }
+                    break;
+                }
+            }
+        }
+        info!(epoch = self.epoch_state.epoch, "RecoveryManager stopped");
+    }
+}

--- a/testsuite/smoke-test/src/consensus/consensusdb_recovery.rs
+++ b/testsuite/smoke-test/src/consensus/consensusdb_recovery.rs
@@ -1,0 +1,81 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    smoke_test_environment::new_local_swarm_with_aptos,
+    test_utils::{assert_balance, create_and_fund_account, transfer_coins},
+};
+use consensus::CONSENSUS_DB_NAME;
+use forge::{HealthCheckError, NodeExt, Swarm};
+use std::{
+    fs,
+    time::{Duration, Instant},
+};
+
+#[tokio::test]
+async fn test_consensusdb_recovery() {
+    let mut swarm = new_local_swarm_with_aptos(4).await;
+    let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+    let client_1 = swarm
+        .validator(validator_peer_ids[1])
+        .unwrap()
+        .rest_client();
+    let transaction_factory = swarm.chain_info().transaction_factory();
+
+    let mut account_0 = create_and_fund_account(&mut swarm, 100).await;
+    let account_1 = create_and_fund_account(&mut swarm, 10).await;
+    let txn = transfer_coins(
+        &client_1,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        10,
+    )
+    .await;
+    assert_balance(&client_1, &account_0, 90).await;
+    assert_balance(&client_1, &account_1, 20).await;
+
+    // Stop a node
+    let node_to_restart = validator_peer_ids[0];
+    let node_config = swarm.validator(node_to_restart).unwrap().config().clone();
+    let node = swarm.validator_mut(node_to_restart).unwrap();
+    node.stop();
+    let consensus_db_path = node_config.storage.dir().join(CONSENSUS_DB_NAME);
+    // Verify that consensus db exists and
+    // we are not deleting a non-existent directory
+    assert!(consensus_db_path.as_path().exists());
+    // Delete the consensus db to simulate consensus db is nuked
+    fs::remove_dir_all(consensus_db_path).unwrap();
+    node.start().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while Instant::now() < deadline {
+        // after the node recovers, it'll exit with 0
+        if let Err(HealthCheckError::NotRunning(_)) = node.health_check().await {
+            break;
+        }
+    }
+
+    node.restart().await.unwrap();
+    node.wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .await
+        .unwrap();
+
+    let client_0 = swarm.validator(node_to_restart).unwrap().rest_client();
+    // Wait for the txn to by synced to the restarted node
+    client_0.wait_for_signed_transaction(&txn).await.unwrap();
+    assert_balance(&client_0, &account_0, 90).await;
+    assert_balance(&client_0, &account_1, 20).await;
+
+    let txn = transfer_coins(
+        &client_1,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        10,
+    )
+    .await;
+    client_0.wait_for_signed_transaction(&txn).await.unwrap();
+
+    assert_balance(&client_0, &account_0, 80).await;
+    assert_balance(&client_0, &account_1, 30).await;
+}

--- a/testsuite/smoke-test/src/consensus/mod.rs
+++ b/testsuite/smoke-test/src/consensus/mod.rs
@@ -2,3 +2,4 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod consensus_fault_tolerance;
+mod consensusdb_recovery;


### PR DESCRIPTION
This commit allows node to sync without a consensus db and the process would exit after it finishes and the validator can operator normally after restart.

It's not ideal that it requires another restart but it's better than what we have today.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4475)
<!-- Reviewable:end -->
