### PR TITLE
[forge] Adding latency check for high-gas fee transactions to graceful_overload test

### DIFF
--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -54,16 +54,19 @@ pub struct ClusterArgs {
     pub mint_args: MintArgs,
 }
 
-#[derive(Debug, Clone, Copy, ArgEnum, Deserialize, Parser, Serialize)]
+#[derive(Debug, Clone, Copy, ArgEnum, Deserialize, Parser, Serialize, PartialEq, Eq, Hash)]
 pub enum TransactionType {
+    // Deprecate P2P name
     P2P,
+    Transfer,
+    TransferHighPri,
     AccountGeneration,
     NftMint,
 }
 
 impl Default for TransactionType {
     fn default() -> Self {
-        TransactionType::P2P
+        TransactionType::Transfer
     }
 }
 

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -5,7 +5,7 @@ use anyhow::{format_err, Context, Result};
 use aptos_logger::Level;
 use aptos_rest_client::Client as RestClient;
 use aptos_sdk::{move_types::account_address::AccountAddress, transaction_builder::aptos_stdlib};
-use forge::success_criteria::{StateProgressThreshold, SuccessCriteria};
+use forge::success_criteria::{LatencyType, StateProgressThreshold, SuccessCriteria};
 use forge::system_metrics::{MetricsThreshold, SystemMetricsThreshold};
 use forge::{ForgeConfig, Options, *};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -185,6 +185,13 @@ fn main() -> Result<()> {
     let duration = Duration::from_secs(args.duration_secs as u64);
     let suite_name: &str = args.suite.as_ref();
 
+    if suite_name == "compat" {
+        panic!("{}", suite_name);
+    }
+
+    let duration = Duration::from_secs(20 * 60);
+    let suite_name = "graceful_overload";
+
     let runtime = Runtime::new()?;
     match args.cli_cmd {
         // cmd input for test
@@ -218,7 +225,6 @@ fn main() -> Result<()> {
                 TestCommand::LocalSwarm(..) => {
                     // Loosen all criteria for local runs
                     test_suite.get_success_criteria_mut().avg_tps = 400;
-                    test_suite.get_success_criteria_mut().max_latency_ms = 60000;
                     let previous_emit_job = test_suite.get_emit_job().clone();
                     let test_suite =
                         test_suite.with_emit_job(previous_emit_job.mode(EmitJobMode::MaxLoad {
@@ -440,14 +446,7 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
         "compat" => config
             .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
             .with_network_tests(vec![&SimpleValidatorUpgrade])
-            .with_success_criteria(SuccessCriteria::new(
-                5000,
-                10000,
-                false,
-                Some(Duration::from_secs(240)),
-                None,
-                None,
-            ))
+            .with_success_criteria(SuccessCriteria::new(5000).add_wait_for_catchup_s(240))
             .with_genesis_helm_config_fn(Arc::new(|helm_values| {
                 helm_values["chain"]["epoch_duration_secs"] = 30.into();
             })),
@@ -455,21 +454,26 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
         "network_partition" => config
             .with_initial_validator_count(NonZeroUsize::new(10).unwrap())
             .with_network_tests(vec![&NetworkPartitionTest])
-            .with_success_criteria(SuccessCriteria::new(
-                3000,
-                10000,
-                true,
-                Some(Duration::from_secs(240)),
-                None,
-                None,
-            )),
+            .with_success_criteria(
+                SuccessCriteria::new(3000)
+                    .add_no_restarts()
+                    .add_wait_for_catchup_s(240),
+            ),
         "three_region_simulation" => config
             .with_initial_validator_count(NonZeroUsize::new(12).unwrap())
             .with_initial_fullnode_count(12)
             .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 5000 }))
             .with_network_tests(vec![&ThreeRegionSimulationTest])
             // TODO(rustielin): tune these success critiera after we have a better idea of the test behavior
-            .with_success_criteria(SuccessCriteria::new(3000, 100000, true, None, None, None)),
+            .with_success_criteria(
+                SuccessCriteria::new(3000)
+                    .add_no_restarts()
+                    .add_wait_for_catchup_s(240)
+                    .add_chain_progress(StateProgressThreshold {
+                        max_no_progress_secs: 20.0,
+                        max_round_gap: 6,
+                    }),
+            ),
         "network_bandwidth" => config
             .with_initial_validator_count(NonZeroUsize::new(8).unwrap())
             .with_network_tests(vec![&NetworkBandwidthTest]),
@@ -480,26 +484,16 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_initial_validator_count(NonZeroUsize::new(1).unwrap())
             .with_initial_fullnode_count(1)
             .with_network_tests(vec![&PerformanceBenchmarkWithFN])
-            .with_success_criteria(SuccessCriteria::new(
-                5000,
-                10000,
-                true,
-                Some(Duration::from_secs(240)),
-                None,
-                None,
-            )),
+            .with_success_criteria(
+                SuccessCriteria::new(5000)
+                    .add_no_restarts()
+                    .add_wait_for_catchup_s(240),
+            ),
         "validator_reboot_stress_test" => config
             .with_initial_validator_count(NonZeroUsize::new(15).unwrap())
             .with_initial_fullnode_count(1)
             .with_network_tests(vec![&ValidatorRebootStressTest])
-            .with_success_criteria(SuccessCriteria::new(
-                2000,
-                50000,
-                false,
-                Some(Duration::from_secs(600)),
-                None,
-                None,
-            ))
+            .with_success_criteria(SuccessCriteria::new(2000).add_wait_for_catchup_s(600))
             .with_genesis_helm_config_fn(Arc::new(|helm_values| {
                 helm_values["chain"]["epoch_duration_secs"] = 120.into();
             })),
@@ -508,14 +502,7 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_initial_fullnode_count(10)
             .with_network_tests(vec![&FullNodeRebootStressTest])
             .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 5000 }))
-            .with_success_criteria(SuccessCriteria::new(
-                2000,
-                50000,
-                false,
-                Some(Duration::from_secs(600)),
-                None,
-                None,
-            )),
+            .with_success_criteria(SuccessCriteria::new(2000).add_wait_for_catchup_s(600)),
         "account_creation" | "nft_mint" => config
             .with_network_tests(vec![&PerformanceBenchmarkWithFN])
             .with_initial_validator_count(NonZeroUsize::new(5).unwrap())
@@ -534,43 +521,59 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                         TransactionType::NftMint
                     }),
             )
-            .with_success_criteria(SuccessCriteria::new(
-                4000,
-                10000,
-                true,
-                Some(Duration::from_secs(240)),
-                None,
-                None,
-            )),
+            .with_success_criteria(
+                SuccessCriteria::new(4000)
+                    .add_no_restarts()
+                    .add_wait_for_catchup_s(240)
+                    .add_chain_progress(StateProgressThreshold {
+                        max_no_progress_secs: 20.0,
+                        max_round_gap: 6,
+                    }),
+            ),
         // TODO: Add tracing latency of high-gas-fee transactions
         "graceful_overload" => config
             .with_initial_validator_count(NonZeroUsize::new(10).unwrap())
-            // if we have smaller number of full nodes, TPS drops.
+            // if we have full nodes for subset of validators, TPS drops.
             // Validators without VFN are proposing almost empty blocks,
             // as no useful transaction reach their mempool.
             // something to potentially improve upon.
-            .with_initial_fullnode_count(8)
+            // So having VFNs for all validators
+            .with_initial_fullnode_count(10)
             .with_network_tests(vec![&PerformanceBenchmarkWithFN])
-            .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 15000 }))
+            .with_emit_job(
+                EmitJobRequest::default()
+                    .mode(EmitJobMode::ConstTps { tps: 15000 })
+                    .transaction_mix(vec![
+                        (TransactionType::Transfer, 98),
+                        (TransactionType::TransferHighPri, 2),
+                    ]),
+            )
             .with_genesis_helm_config_fn(Arc::new(|helm_values| {
                 helm_values["chain"]["epoch_duration_secs"] = 300.into();
             }))
-            .with_success_criteria(SuccessCriteria::new(
-                6500,
-                50000,
-                true,
-                Some(Duration::from_secs(120)),
-                Some(SystemMetricsThreshold::new(
-                    // Check that we don't use more than 12 CPU cores for 30% of the time.
-                    MetricsThreshold::new(12, 30),
-                    // Check that we don't use more than 5 GB of memory for 30% of the time.
-                    MetricsThreshold::new(5 * 1024 * 1024 * 1024, 30),
-                )),
-                Some(StateProgressThreshold {
-                    max_no_progress_secs: 30.0,
-                    max_round_gap: 10,
-                }),
-            )),
+            .with_success_criteria(
+                // Additionally - we are not really gracefully handling overlaods,
+                // setting limits based on current reality, to make sure they
+                // don't regress, but something to investigate
+                SuccessCriteria::new(4000)
+                    .add_latency_threshold_for_type(
+                        25.0,
+                        TransactionType::TransferHighPri,
+                        LatencyType::P90,
+                    )
+                    .add_no_restarts()
+                    .add_wait_for_catchup_s(120)
+                    .add_system_metrics_threshold(SystemMetricsThreshold::new(
+                        // Check that we don't use more than 12 CPU cores for 30% of the time.
+                        MetricsThreshold::new(12, 30),
+                        // Check that we don't use more than 5 GB of memory for 30% of the time.
+                        MetricsThreshold::new(5 * 1024 * 1024 * 1024, 30),
+                    ))
+                    .add_chain_progress(StateProgressThreshold {
+                        max_no_progress_secs: 30.0,
+                        max_round_gap: 10,
+                    }),
+            ),
         // not scheduled on continuous
         "load_vs_perf_benchmark" => config
             .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
@@ -585,14 +588,15 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                 // no epoch change.
                 helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
             }))
-            .with_success_criteria(SuccessCriteria::new(
-                0,
-                10000,
-                true,
-                Some(Duration::from_secs(60)),
-                None,
-                None,
-            )),
+            .with_success_criteria(
+                SuccessCriteria::new(0)
+                    .add_no_restarts()
+                    .add_wait_for_catchup_s(60)
+                    .add_chain_progress(StateProgressThreshold {
+                        max_no_progress_secs: 30.0,
+                        max_round_gap: 10,
+                    }),
+            ),
         // maximizing number of rounds and epochs within a given time, to stress test consensus
         // so using small constant traffic, small blocks and fast rounds, and short epochs.
         // reusing changing_working_quorum_test just for invariants/asserts, but with max_down_nodes = 0.
@@ -693,22 +697,21 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_genesis_helm_config_fn(Arc::new(|helm_values| {
                 helm_values["chain"]["epoch_duration_secs"] = 300.into();
             }))
-            .with_success_criteria(SuccessCriteria::new(
-                6000,
-                10000,
-                true,
-                Some(Duration::from_secs(60)),
-                Some(SystemMetricsThreshold::new(
-                    // Check that we don't use more than 12 CPU cores for 30% of the time.
-                    MetricsThreshold::new(12, 30),
-                    // Check that we don't use more than 5 GB of memory for 30% of the time.
-                    MetricsThreshold::new(5 * 1024 * 1024 * 1024, 30),
-                )),
-                Some(StateProgressThreshold {
-                    max_no_progress_secs: 10.0,
-                    max_round_gap: 4,
-                }),
-            )),
+            .with_success_criteria(
+                SuccessCriteria::new(6000)
+                    .add_no_restarts()
+                    .add_wait_for_catchup_s(60)
+                    .add_system_metrics_threshold(SystemMetricsThreshold::new(
+                        // Check that we don't use more than 12 CPU cores for 30% of the time.
+                        MetricsThreshold::new(12, 30),
+                        // Check that we don't use more than 5 GB of memory for 30% of the time.
+                        MetricsThreshold::new(5 * 1024 * 1024 * 1024, 30),
+                    ))
+                    .add_chain_progress(StateProgressThreshold {
+                        max_no_progress_secs: 10.0,
+                        max_round_gap: 4,
+                    }),
+            ),
         _ => return Err(format_err!("Invalid --suite given: {:?}", test_name)),
     };
     Ok(single_test_suite)
@@ -737,7 +740,7 @@ fn state_sync_perf_fullnodes_apply_outputs(
             helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
                 ["continuous_syncing_mode"] = "ApplyTransactionOutputs".into();
         }))
-        .with_success_criteria(SuccessCriteria::new(10000, 10000, false, None, None, None))
+        .with_success_criteria(SuccessCriteria::new(10000))
 }
 
 /// The config for running a state sync performance test when executing
@@ -755,7 +758,7 @@ fn state_sync_perf_fullnodes_execute_transactions(
             helm_values["fullnode"]["config"]["state_sync"]["state_sync_driver"]
                 ["continuous_syncing_mode"] = "ExecuteTransactions".into();
         }))
-        .with_success_criteria(SuccessCriteria::new(5000, 10000, false, None, None, None))
+        .with_success_criteria(SuccessCriteria::new(5000))
 }
 
 /// The config for running a state sync performance test when applying
@@ -773,7 +776,7 @@ fn state_sync_perf_validators(forge_config: ForgeConfig<'static>) -> ForgeConfig
                 ["continuous_syncing_mode"] = "ApplyTransactionOutputs".into();
         }))
         .with_network_tests(vec![&StateSyncValidatorPerformance])
-        .with_success_criteria(SuccessCriteria::new(5000, 10000, false, None, None, None))
+        .with_success_criteria(SuccessCriteria::new(5000))
 }
 
 fn land_blocking_test_suite(duration: Duration) -> ForgeConfig<'static> {
@@ -785,30 +788,25 @@ fn land_blocking_test_suite(duration: Duration) -> ForgeConfig<'static> {
             // Have single epoch change in land blocking
             helm_values["chain"]["epoch_duration_secs"] = 300.into();
         }))
-        .with_success_criteria(SuccessCriteria::new(
-            if duration.as_secs() > 1200 {
+        .with_success_criteria(
+            SuccessCriteria::new(if duration.as_secs() > 1200 {
                 5000
             } else {
                 6000
-            },
-            10000,
-            true,
-            Some(Duration::from_secs(if duration.as_secs() > 1200 {
-                240
-            } else {
-                60
-            })),
-            Some(SystemMetricsThreshold::new(
+            })
+            .add_no_restarts()
+            .add_wait_for_catchup_s(if duration.as_secs() > 1200 { 240 } else { 60 })
+            .add_system_metrics_threshold(SystemMetricsThreshold::new(
                 // Check that we don't use more than 12 CPU cores for 30% of the time.
                 MetricsThreshold::new(12, 30),
                 // Check that we don't use more than 10 GB of memory for 30% of the time.
                 MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
-            )),
-            Some(StateProgressThreshold {
+            ))
+            .add_chain_progress(StateProgressThreshold {
                 max_no_progress_secs: 10.0,
                 max_round_gap: 4,
             }),
-        ))
+        )
 }
 
 fn pre_release_suite() -> ForgeConfig<'static> {
@@ -825,23 +823,20 @@ fn chaos_test_suite(duration: Duration) -> ForgeConfig<'static> {
             &ThreeRegionSimulationTest,
             &NetworkLossTest,
         ])
-        .with_success_criteria(SuccessCriteria::new(
-            if duration > Duration::from_secs(1200) {
+        .with_success_criteria(
+            SuccessCriteria::new(if duration > Duration::from_secs(1200) {
                 100
             } else {
                 1000
-            },
-            10000,
-            true,
-            None,
-            Some(SystemMetricsThreshold::new(
+            })
+            .add_no_restarts()
+            .add_system_metrics_threshold(SystemMetricsThreshold::new(
                 // Check that we don't use more than 12 CPU cores for 30% of the time.
                 MetricsThreshold::new(12, 30),
                 // Check that we don't use more than 5 GB of memory for 30% of the time.
                 MetricsThreshold::new(5 * 1024 * 1024 * 1024, 30),
             )),
-            None,
-        ))
+        )
 }
 
 fn changing_working_quorum_test(
@@ -891,29 +886,27 @@ fn changing_working_quorum_test(
                     (TransactionType::AccountGeneration, 20),
                 ]),
         )
-        .with_success_criteria(SuccessCriteria::new(
-            min_avg_tps,
-            10000,
-            true,
-            Some(Duration::from_secs(30)),
-            None,
-            Some(StateProgressThreshold {
-                max_no_progress_secs: if test.max_down_nodes == 0 {
-                    // very aggressive if no nodes are expected to be down
-                    3.0
-                } else if test.max_down_nodes * 3 + 1 + 2 < num_validators {
-                    // number of down nodes is at least 2 below the quorum limit, so
-                    // we can still be reasonably aggressive
-                    15.0
-                } else {
-                    // number of down nodes is close to the quorum limit, so
-                    // make a check a bit looser, as state sync might be required
-                    // to get the quorum back.
-                    30.0
-                },
-                max_round_gap: 6,
-            }),
-        ))
+        .with_success_criteria(
+            SuccessCriteria::new(min_avg_tps)
+                .add_no_restarts()
+                .add_wait_for_catchup_s(30)
+                .add_chain_progress(StateProgressThreshold {
+                    max_no_progress_secs: if test.max_down_nodes == 0 {
+                        // very aggressive if no nodes are expected to be down
+                        3.0
+                    } else if test.max_down_nodes * 3 + 1 + 2 < num_validators {
+                        // number of down nodes is at least 2 below the quorum limit, so
+                        // we can still be reasonably aggressive
+                        15.0
+                    } else {
+                        // number of down nodes is close to the quorum limit, so
+                        // make a check a bit looser, as state sync might be required
+                        // to get the quorum back.
+                        30.0
+                    },
+                    max_round_gap: 6,
+                }),
+        )
 }
 
 /// A simple test that runs the swarm forever. This is useful for

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -4,10 +4,11 @@
 use std::time::Duration;
 
 use super::Test;
-use crate::success_criteria::SuccessCriteria;
+use crate::success_criteria::{SuccessCriteria, SuccessCriteriaChecker};
 use crate::{CoreContext, Result, Swarm, TestReport};
 use tokio::runtime::Runtime;
-use transaction_emitter_lib::{EmitJobRequest, TxnStats};
+use transaction_emitter_lib::emitter::stats::DetailedTxnStats;
+use transaction_emitter_lib::EmitJobRequest;
 
 /// The testing interface which defines a test written with full control over an existing network.
 /// Tests written against this interface will have access to both the Root account as well as the
@@ -57,18 +58,19 @@ impl<'t> NetworkContext<'t> {
 
     pub fn check_for_success(
         &mut self,
-        stats: &TxnStats,
-        window: &Duration,
+        stats: &DetailedTxnStats,
+        window: Duration,
         start_time: i64,
         end_time: i64,
         start_version: u64,
         end_version: u64,
     ) -> Result<()> {
         self.runtime
-            .block_on(self.success_criteria.check_for_success(
+            .block_on(SuccessCriteriaChecker::check_for_success(
+                &self.success_criteria,
+                self.swarm,
                 stats,
                 window,
-                self.swarm,
                 start_time,
                 end_time,
                 start_version,

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -239,21 +239,16 @@ impl<'cfg> Default for ForgeConfig<'cfg> {
         let forge_run_mode =
             std::env::var("FORGE_RUNNER_MODE").unwrap_or_else(|_| "k8s".to_string());
         let success_criteria = if forge_run_mode.eq("local") {
-            SuccessCriteria::new(600, 60000, true, None, None, None)
+            SuccessCriteria::new(600).add_no_restarts()
         } else {
-            SuccessCriteria::new(
-                3500,
-                10000,
-                true,
-                None,
-                Some(SystemMetricsThreshold::new(
+            SuccessCriteria::new(3500)
+                .add_no_restarts()
+                .add_system_metrics_threshold(SystemMetricsThreshold::new(
                     // Check that we don't use more than 12 CPU cores for 30% of the time.
                     MetricsThreshold::new(12, 30),
                     // Check that we don't use more than 10 GB of memory for 30% of the time.
                     MetricsThreshold::new(10 * 1024 * 1024 * 1024, 30),
-                )),
-                None,
-            )
+                ))
         };
         Self {
             aptos_tests: vec![],

--- a/testsuite/forge/src/success_criteria.rs
+++ b/testsuite/forge/src/success_criteria.rs
@@ -5,23 +5,35 @@ use anyhow::bail;
 use aptos::node::analyze::fetch_metadata::FetchMetadata;
 use aptos_sdk::types::PeerId;
 use futures::future::join_all;
-use serde::Serialize;
 use std::time::Duration;
-use transaction_emitter_lib::emitter::stats::TxnStats;
+use transaction_emitter_lib::emitter::stats::DetailedTxnStats;
+use transaction_emitter_lib::TransactionType;
 
 use crate::system_metrics::SystemMetricsThreshold;
 use crate::{Swarm, SwarmExt};
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub struct StateProgressThreshold {
     pub max_no_progress_secs: f32,
     pub max_round_gap: u64,
 }
 
-#[derive(Default, Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
+pub enum LatencyType {
+    Average,
+    P50,
+    P90,
+    P99,
+}
+
+pub struct LatencyThreshold {
+    pub latency_thresholds: Vec<(Duration, Option<TransactionType>, LatencyType)>,
+}
+
+#[derive(Default, Clone, Debug)]
 pub struct SuccessCriteria {
     pub avg_tps: usize,
-    pub max_latency_ms: usize,
+    latency_thresholds: Vec<(Duration, Option<TransactionType>, LatencyType)>,
     check_no_restarts: bool,
     wait_for_all_nodes_to_catchup: Option<Duration>,
     // Maximum amount of CPU cores and memory bytes used by the nodes.
@@ -30,57 +42,96 @@ pub struct SuccessCriteria {
 }
 
 impl SuccessCriteria {
-    pub fn new(
-        tps: usize,
-        max_latency_ms: usize,
-        check_no_restarts: bool,
-        wait_for_all_nodes_to_catchup: Option<Duration>,
-        system_metrics_threshold: Option<SystemMetricsThreshold>,
-        chain_progress_check: Option<StateProgressThreshold>,
-    ) -> Self {
+    pub fn new(tps: usize) -> Self {
         Self {
             avg_tps: tps,
-            max_latency_ms,
-            check_no_restarts,
-            wait_for_all_nodes_to_catchup,
-            system_metrics_threshold,
-            chain_progress_check,
+            latency_thresholds: Vec::new(),
+            check_no_restarts: false,
+            wait_for_all_nodes_to_catchup: None,
+            system_metrics_threshold: None,
+            chain_progress_check: None,
         }
     }
 
+    pub fn add_no_restarts(mut self) -> Self {
+        self.check_no_restarts = true;
+        self
+    }
+
+    pub fn add_wait_for_catchup_s(mut self, duration_secs: u64) -> Self {
+        self.wait_for_all_nodes_to_catchup = Some(Duration::from_secs(duration_secs));
+        self
+    }
+
+    pub fn add_system_metrics_threshold(mut self, threshold: SystemMetricsThreshold) -> Self {
+        self.system_metrics_threshold = Some(threshold);
+        self
+    }
+
+    pub fn add_chain_progress(mut self, threshold: StateProgressThreshold) -> Self {
+        self.chain_progress_check = Some(threshold);
+        self
+    }
+
+    pub fn add_latency_threshold(mut self, threshold_s: f32, latency_type: LatencyType) -> Self {
+        self.latency_thresholds
+            .push((Duration::from_secs_f32(threshold_s), None, latency_type));
+        self
+    }
+
+    pub fn add_latency_threshold_for_type(
+        mut self,
+        threshold_s: f32,
+        transaction_type: TransactionType,
+        latency_type: LatencyType,
+    ) -> Self {
+        self.latency_thresholds.push((
+            Duration::from_secs_f32(threshold_s),
+            Some(transaction_type),
+            latency_type,
+        ));
+        self
+    }
+}
+
+pub struct SuccessCriteriaChecker {}
+
+impl SuccessCriteriaChecker {
     pub async fn check_for_success(
-        &self,
-        stats: &TxnStats,
-        window: &Duration,
+        success_criteria: &SuccessCriteria,
         swarm: &mut dyn Swarm,
+        stats: &DetailedTxnStats,
+        window: Duration,
         start_time: i64,
         end_time: i64,
         start_version: u64,
         end_version: u64,
     ) -> anyhow::Result<()> {
         // TODO: Add more success criteria like expired transactions, CPU, memory usage etc
-        let avg_tps = stats.committed / window.as_secs();
-        if avg_tps < self.avg_tps as u64 {
+        let avg_tps = stats.total.committed / window.as_secs();
+        if avg_tps < success_criteria.avg_tps as u64 {
             bail!(
                 "TPS requirement failed. Average TPS {}, minimum TPS requirement {}",
                 avg_tps,
-                self.avg_tps,
+                success_criteria.avg_tps,
             )
         }
 
-        if let Some(timeout) = self.wait_for_all_nodes_to_catchup {
+        Self::check_latency(&success_criteria.latency_thresholds, stats, window)?;
+
+        if let Some(timeout) = success_criteria.wait_for_all_nodes_to_catchup {
             swarm.wait_for_all_nodes_to_catchup_to_next(timeout).await?;
         }
 
-        if self.check_no_restarts {
+        if success_criteria.check_no_restarts {
             swarm.ensure_no_validator_restart().await?;
             swarm.ensure_no_fullnode_restart().await?;
         }
 
-        // TODO(skedia) Add latency success criteria after we have support for querying prometheus
-        // latency
+        // TODO(skedia) Add end-to-end latency from counters after we have support for querying prometheus
+        // latency (in addition to checking latency from txn-emitter)
 
-        if let Some(system_metrics_threshold) = self.system_metrics_threshold.clone() {
+        if let Some(system_metrics_threshold) = success_criteria.system_metrics_threshold.clone() {
             swarm
                 .ensure_healthy_system_metrics(
                     start_time as i64,
@@ -90,8 +141,8 @@ impl SuccessCriteria {
                 .await?;
         }
 
-        if let Some(chain_progress_threshold) = &self.chain_progress_check {
-            self.check_chain_progress(swarm, chain_progress_threshold, start_version, end_version)
+        if let Some(chain_progress_threshold) = &success_criteria.chain_progress_check {
+            Self::check_chain_progress(swarm, chain_progress_threshold, start_version, end_version)
                 .await?;
         }
 
@@ -99,7 +150,6 @@ impl SuccessCriteria {
     }
 
     async fn check_chain_progress(
-        &self,
         swarm: &mut dyn Swarm,
         chain_progress_threshold: &StateProgressThreshold,
         start_version: u64,
@@ -206,5 +256,46 @@ impl SuccessCriteria {
         }
 
         Ok(())
+    }
+
+    fn check_latency(
+        latency_thresholds: &Vec<(Duration, Option<TransactionType>, LatencyType)>,
+        stats: &DetailedTxnStats,
+        window: Duration,
+    ) -> anyhow::Result<()> {
+        let mut failures = Vec::new();
+        for (latency_threshold, transaction_type, latency_type) in latency_thresholds {
+            let type_stats = if let Some(ttype) = transaction_type {
+                stats.per_type.get(ttype).unwrap()
+            } else {
+                &stats.total
+            };
+
+            let rate = type_stats.rate(window);
+            let latency = Duration::from_millis(match latency_type {
+                LatencyType::Average => rate.latency,
+                LatencyType::P50 => rate.p50_latency,
+                LatencyType::P90 => rate.p90_latency,
+                LatencyType::P99 => rate.p99_latency,
+            });
+
+            if latency > *latency_threshold {
+                failures.push(
+                    format!(
+                        "{:?} latency for {} txns is {}s and exceeds limit of {}s",
+                        latency_type,
+                        transaction_type.map_or("all".to_string(), |t| format!("{:?}", t)),
+                        latency.as_secs_f32(),
+                        latency_threshold.as_secs_f32()
+                    )
+                    .to_string(),
+                );
+            }
+        }
+        if !failures.is_empty() {
+            bail!("Failed latency check, for {:?}", failures);
+        } else {
+            Ok(())
+        }
     }
 }

--- a/testsuite/testcases/src/load_vs_perf_benchmark.rs
+++ b/testsuite/testcases/src/load_vs_perf_benchmark.rs
@@ -48,7 +48,7 @@ impl LoadVsPerfBenchmark {
 
         Ok(SingleRunStats {
             tps,
-            stats,
+            stats: stats.total,
             ledger_transactions,
             actual_duration,
         })

--- a/testsuite/testcases/tests/forge-local-performance.rs
+++ b/testsuite/testcases/tests/forge-local-performance.rs
@@ -17,16 +17,11 @@ fn main() -> Result<()> {
         .with_initial_version(InitialVersion::Newest)
         .with_network_tests(vec![&PerformanceBenchmark, &NonZeroGasPrice])
         .with_emit_job(EmitJobRequest::default().mode(EmitJobMode::ConstTps { tps: 30 }))
-        .with_success_criteria(SuccessCriteria::new(
-            20,
-            60000,
-            false,
-            None,
-            None,
-            Some(StateProgressThreshold {
+        .with_success_criteria(SuccessCriteria::new(20).add_chain_progress(
+            StateProgressThreshold {
                 max_no_progress_secs: 0.0,
                 max_round_gap: 0,
-            }),
+            },
         ));
 
     let options = Options::from_args();


### PR DESCRIPTION
### Description

- added support for latency check in SuccessCriteria
- added tracking of stats per each transaction generator type, allowing us to have TransferHighPri vs Transfer breakdown.

### Test Plan

added checks to graceful test:

```
Transfer: 
submitted: 14698 txn/s, committed: 4964 txn/s, expired: 9733 txn/s, failed submission: 0 tnx/s, 
latency: 62637 ms, (p50: 62500 ms, p90: 64000 ms, p99: 65100 ms), latency samples: 106195"}
TransferHighPri: 
submitted: 294 txn/s, committed: 294 txn/s, expired: 0 txn/s, failed submission: 0 tnx/s, 
latency: 6429 ms, (p50: 5800 ms, p90: 9700 ms, p99: 16000 ms), latency samples: 315000"}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4480)
<!-- Reviewable:end -->
