### PR TITLE
[node-resource-metrics] Fix double prometheus register

### DIFF
--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -1,16 +1,27 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_infallible::Mutex;
 use cfg_if::cfg_if;
 use collectors::{
     CollectorLatencyCollector, CpuMetricsCollector, DiskMetricsCollector, LoadAvgCollector,
     MemoryMetricsCollector, NetworkMetricsCollector, ProcessMetricsCollector,
 };
+use once_cell::sync::Lazy;
 
 mod collectors;
 
+static IS_REGISTERED: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
+
 /// Registers the node metrics collector with the default registry.
 pub fn register_node_metrics_collector() {
+    let mut registered = IS_REGISTERED.lock();
+    if *registered {
+        return;
+    } else {
+        *registered = true;
+    }
+
     prometheus::register(Box::new(CpuMetricsCollector::default())).unwrap();
     prometheus::register(Box::new(MemoryMetricsCollector::default())).unwrap();
     prometheus::register(Box::new(DiskMetricsCollector::default())).unwrap();


### PR DESCRIPTION
### Description
Double register caused node to crash.  Now there's a mutex so it doesn't double register

### Test Plan
Ran node locally, didn't crash immmediately

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4482)
<!-- Reviewable:end -->
