### PR TITLE
[Bug] [Rust SDK] Increase `gas_unit_price` and fund balance in `transfer-coin` example

### DIFF
--- a/sdk/examples/transfer-coin.rs
+++ b/sdk/examples/transfer-coin.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     // Create the accounts on chain, but only fund Alice.
     // :!:>section_3
     faucet_client
-        .fund(alice.address(), 20_000)
+        .fund(alice.address(), 600_000)
         .await
         .context("Failed to fund Alice's account")?;
     faucet_client

--- a/sdk/src/coin_client.rs
+++ b/sdk/src/coin_client.rs
@@ -110,7 +110,7 @@ impl<'a> Default for TransferOptions<'a> {
     fn default() -> Self {
         Self {
             max_gas_amount: 5_000,
-            gas_unit_price: 1,
+            gas_unit_price: 100,
             timeout_secs: 10,
             coin_type: "0x1::aptos_coin::AptosCoin",
         }


### PR DESCRIPTION
Close https://github.com/aptos-labs/aptos-core/issues/4470

### Description

Increase `gas_unit_price` to fix error `GAS_UNIT_PRICE_BELOW_MIN_BOUND` in issue https://github.com/aptos-labs/aptos-core/issues/4470.

### Test Plan

Test with command `cargo run --example transfer-coin` in `sdk` folder.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4485)
<!-- Reviewable:end -->
