### PR TITLE
[forge][telemetry] Enable node telemetry service in forge

### DIFF
--- a/terraform/helm/aptos-node/templates/fullnode.yaml
+++ b/terraform/helm/aptos-node/templates/fullnode.yaml
@@ -81,10 +81,13 @@ spec:
           value: {{ .rust_log }}
         - name: RUST_LOG_REMOTE
           value: {{ .rust_log_remote }}
-      {{- end }}
         {{- if $.Values.validator.remoteLogAddress }}
         - name: STRUCT_LOG_TCP_ADDR
           value: {{ $.Values.validator.remoteLogAddress }}
+        {{- end }}
+        {{- if .force_enable_telemetry }}
+        - name: APTOS_FORCE_ENABLE_TELEMETRY
+          value: "true"
         {{- end }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
@@ -92,6 +95,7 @@ spec:
               fieldPath: metadata.namespace
         - name: RUST_BACKTRACE
           value: "0"
+      {{- end }}
         volumeMounts:
         - name: aptos-config
           mountPath: /opt/aptos/etc

--- a/terraform/helm/aptos-node/templates/validator.yaml
+++ b/terraform/helm/aptos-node/templates/validator.yaml
@@ -89,13 +89,17 @@ spec:
         - name: STRUCT_LOG_TCP_ADDR
           value: {{ .remoteLogAddress }}
         {{- end }}
-      {{- end }}
+        {{- if .force_enable_telemetry }}
+        - name: APTOS_FORCE_ENABLE_TELEMETRY
+          value: "true"
+        {{- end }}
         - name: KUBERNETES_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         - name: RUST_BACKTRACE
           value: "0"
+      {{- end }}
         volumeMounts:
         - name: aptos-config
           mountPath: /opt/aptos/etc

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -77,6 +77,8 @@ validator:
   rust_log_remote: debug,hyper=off
   # -- Address for remote logging. See `logger` helm chart
   remoteLogAddress:
+  # -- Flag to force enable telemetry service (useful for forge tests)
+  force_enable_telemetry: false
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -125,6 +127,8 @@ fullnode:
   rust_log: info
   # -- Remote log level for the fullnode
   rust_log_remote: debug,hyper=off
+  # -- Flag to force enable telemetry service (useful for forge tests)
+  force_enable_telemetry: false
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
+++ b/testsuite/forge/src/backend/k8s/helm-values/aptos-node-default-values.yaml
@@ -1,6 +1,8 @@
 validator:
   enableNetworkPolicy: false
   rust_log: debug,hyper=off
+  # force enable the telemetry service to try to send telemetry
+  force_enable_telemetry: true
 
 fullnode:
   # at most one VFN per validator, depending on numFullnodeGroups
@@ -8,6 +10,8 @@ fullnode:
   - name: fullnode
     replicas: 1
   rust_log: debug,hyper=off
+  # force enable the telemetry service to try to send telemetry
+  force_enable_telemetry: true
 
 # Make all services internal NodePort and open all ports
 # NodePort is required for ChaosMesh to function correctly: https://github.com/chaos-mesh/chaos-mesh/issues/3278#issuecomment-1134248492


### PR DESCRIPTION
### Description

This PR enables the node's telemetry in forge to assert the telemetry crate code paths during forge tests. A bug introduced in #4443 was uncaught in forge e2e test because the telemetry crate wasn't enabled. 

Enabling the `APTOS_FORCE_ENABLE_TELEMETRY` env variable does not still assert the telemetry web service code path in forge, but it's not in the critical path of the nodes' operation.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4490)
<!-- Reviewable:end -->
