### PR TITLE
[prometheus] remove aptos-procs job for k8s pod discovery

### DIFF
--- a/dashboards/overview.json
+++ b/dashboards/overview.json
@@ -222,7 +222,7 @@
         {
           "refId": "A",
           "datasource": { "type": "prometheus", "uid": "${Datasource}" },
-          "expr": "up{job=\"federate\", chain_name=~\"$chain_name\", namespace=~\"$namespace\"} == 0 or up{job=\"aptos-procs\", role=\"validator\", chain_name=~\"$chain_name\", namespace=~\"$namespace\"} == 0",
+          "expr": "up{job=\"federate\", chain_name=~\"$chain_name\", namespace=~\"$namespace\"} == 0 or up{chain_name=~\"$chain_name\", namespace=~\"$namespace\"} == 0",
           "instant": true,
           "format": "table"
         }

--- a/dashboards/shared-monitoring.json
+++ b/dashboards/shared-monitoring.json
@@ -85,7 +85,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "up{job=\"federate\"} == 0 or up{job=\"aptos-procs\"} == 0 or up{job=\"kubernetes-cadvisor\"} == 0 or up{job=\"pushgateway\"} == 0",
+          "expr": "up{job=\"federate\"} == 0 or up{job=\"kubernetes-pods\"} == 0 or up{job=\"kubernetes-cadvisor\"} == 0 or up{job=\"pushgateway\"} == 0",
           "instant": true,
           "format": "table"
         }

--- a/dashboards/validator-connectivity.json
+++ b/dashboards/validator-connectivity.json
@@ -129,7 +129,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "up{chain_name=~\"$chain_name\", namespace=~\"$namespace\", job=\"federate\"} == 0 or up{chain_name=~\"$chain_name\", namespace=~\"$namespace\", job=\"aptos-procs\", role=\"validator\"} == 0",
+          "expr": "up{chain_name=~\"$chain_name\", namespace=~\"$namespace\", job=\"federate\"} == 0 or up{chain_name=~\"$chain_name\", namespace=~\"$namespace\", role=\"validator\"} == 0",
           "instant": true,
           "format": "table"
         }

--- a/terraform/helm/monitoring/files/prometheus.yml
+++ b/terraform/helm/monitoring/files/prometheus.yml
@@ -183,26 +183,6 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_namespace]
     action: replace
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
-    action: replace
-    target_label: kubernetes_pod_name
-  # Explicitly drop all vector metrics
-  - source_labels: [namespace]
-    regex: 'vector'
-    action: drop
-
-- job_name: "aptos-procs"
-
-  kubernetes_sd_configs:
-  - role: pod
-
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_pod_container_port_number]
-    action: keep
-    regex: "9101"
-  - source_labels: [__meta_kubernetes_namespace]
-    action: replace
-    target_label: namespace
   - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
     action: replace
     target_label: role
@@ -212,6 +192,10 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: kubernetes_pod_name
+  # Explicitly drop all vector metrics
+  - source_labels: [namespace]
+    regex: 'vector'
+    action: drop
 
 {{ if .Values.monitoring.prometheus.remote_write.enabled }}
 {{ with .Values.monitoring.prometheus.remote_write }}


### PR DESCRIPTION
### Description

these metrics are getting double scraped now that this has landed https://github.com/aptos-labs/aptos-core/commit/413dc2e3b09f2393b2966645d0f7c1c2f759cd21

* remove the `aptos-procs` job since it's now double scraping the same endpoints with the annotation
* also update some of the dashboards that use `aptos-procs` as the job name explicitly

TODO: vmagent scrape config needs to update as well


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4495)
<!-- Reviewable:end -->
