### PR TITLE
[mempool] fix GC'd txn metric

### DIFF
--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -598,14 +598,10 @@ impl TransactionStore {
                     let account = txn.get_sender();
                     let txn_sequence_number = txn.sequence_info.transaction_sequence_number;
                     gc_txns_log.add_with_status(account, txn_sequence_number, status);
-                    if let Some(&creation_time) =
-                        self.get_insertion_time(&account, txn_sequence_number)
-                    {
-                        if let Ok(time_delta) = SystemTime::now().duration_since(creation_time) {
-                            counters::CORE_MEMPOOL_GC_LATENCY
-                                .with_label_values(&[metric_label, status])
-                                .observe(time_delta.as_secs_f64());
-                        }
+                    if let Ok(time_delta) = SystemTime::now().duration_since(txn.insertion_time) {
+                        counters::CORE_MEMPOOL_GC_LATENCY
+                            .with_label_values(&[metric_label, status])
+                            .observe(time_delta.as_secs_f64());
                     }
 
                     // remove txn
@@ -629,14 +625,13 @@ impl TransactionStore {
     pub(crate) fn gen_snapshot(&self) -> TxnsLog {
         let mut txns_log = TxnsLog::new();
         for (account, txns) in self.transactions.iter() {
-            for (seq_num, _txn) in txns.iter() {
+            for (seq_num, txn) in txns.iter() {
                 let status = if self.parking_lot_index.contains(account, seq_num) {
                     "parked"
                 } else {
                     "ready"
                 };
-                let timestamp = self.get_insertion_time(account, *seq_num).copied();
-                txns_log.add_full_metadata(*account, *seq_num, status, timestamp);
+                txns_log.add_full_metadata(*account, *seq_num, status, txn.insertion_time);
             }
         }
         txns_log

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -57,11 +57,11 @@ impl TxnsLog {
         account: AccountAddress,
         seq_num: u64,
         status: &str,
-        timestamp: Option<SystemTime>,
+        timestamp: SystemTime,
     ) {
         if self.txns.len() < self.max_displayed {
             self.txns
-                .push((account, seq_num, Some(status.to_string()), timestamp));
+                .push((account, seq_num, Some(status.to_string()), Some(timestamp)));
         }
         self.len += 1;
     }

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -380,7 +380,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => Ok(single_test_suite("graceful_overload").unwrap()),
+        "land_blocking" => Ok(land_blocking_test_suite(duration)),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -380,7 +380,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => Ok(land_blocking_test_suite(duration)),
+        "land_blocking" => Ok(single_test_suite("graceful_overload").unwrap()),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),


### PR DESCRIPTION
### Description

There was a bug where GC'd txns were not showing up in metrics, because `get_insertion_time` did not return anything. Instead, directly use `txn.insertion_time`.

### Test Plan

Ran 15K TPS test. Where previously no GC's are shown, now client expired txns show up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4502)
<!-- Reviewable:end -->
