### PR TITLE
[Node CLI] Add a command that returns the stake pool address

### DIFF
--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -24,9 +24,11 @@ use aptos_config::config::NodeConfig;
 use aptos_crypto::{bls12381, x25519, ValidCryptoMaterialStringExt};
 use aptos_faucet::FaucetArgs;
 use aptos_genesis::config::{HostAndPort, OperatorConfiguration};
+use aptos_types::account_address::{create_vesting_pool_address, default_stake_pool_address};
 use aptos_types::chain_id::ChainId;
 use aptos_types::network_address::NetworkAddress;
 use aptos_types::on_chain_config::{ConsensusScheme, ValidatorSet};
+use aptos_types::stake_pool::StakePool;
 use aptos_types::validator_config::ValidatorConfig;
 use aptos_types::validator_info::ValidatorInfo;
 use aptos_types::{account_address::AccountAddress, account_config::CORE_CODE_ADDRESS};
@@ -57,6 +59,7 @@ use tokio::time::Instant;
 /// identify issues with nodes, and show related information.
 #[derive(Parser)]
 pub enum NodeTool {
+    GetPoolAddress(GetPoolAddress),
     InitializeValidator(InitializeValidator),
     JoinValidatorSet(JoinValidatorSet),
     LeaveValidatorSet(LeaveValidatorSet),
@@ -74,6 +77,7 @@ impl NodeTool {
     pub async fn execute(self) -> CliResult {
         use NodeTool::*;
         match self {
+            GetPoolAddress(tool) => tool.execute_serialized().await,
             InitializeValidator(tool) => tool.execute_serialized().await,
             JoinValidatorSet(tool) => tool.execute_serialized().await,
             LeaveValidatorSet(tool) => tool.execute_serialized().await,
@@ -228,6 +232,66 @@ impl ValidatorNetworkAddressesArgs {
             validator_host,
             full_node_host,
         ))
+    }
+}
+
+#[derive(Parser)]
+pub struct GetPoolAddress {
+    // The owner address that directly or indirectly owns the stake pool.
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) owner_address: AccountAddress,
+    // Optional. The operator address. If not specified, the address from profile config will be
+    // used.
+    #[clap(long, parse(try_from_str=crate::common::types::load_account_arg))]
+    pub(crate) operator_address: Option<AccountAddress>,
+    // Optional. The employee account index if the owner is an admin of multiple employee vesting accounts.
+    // This would be required if the owner is an admin of employee vesting accounts.
+    #[clap(long)]
+    pub(crate) employee_account_index: Option<u64>,
+    // Configurations for where queries will be sent to.
+    #[clap(flatten)]
+    pub(crate) rest_options: RestOptions,
+    // Configurations for CLI profile to use.
+    #[clap(flatten)]
+    pub(crate) profile_options: ProfileOptions,
+}
+
+#[async_trait]
+impl CliCommand<AccountAddress> for GetPoolAddress {
+    fn command_name(&self) -> &'static str {
+        "GetPoolAddress"
+    }
+
+    async fn execute(mut self) -> CliTypedResult<AccountAddress> {
+        let owner_address = self.owner_address;
+
+        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let stake_pool_exists = client
+            .get_account_resource_bcs::<StakePool>(owner_address, "0x1::stake::StakePool")
+            .await
+            .is_ok();
+        let stake_pool_address = if stake_pool_exists {
+            owner_address
+        } else {
+            let staking_contract_store_exists = client
+                .get_resource::<Vec<u8>>(owner_address, "0x1::staking_contract::Store")
+                .await
+                .is_ok();
+            let operator_address = self
+                .operator_address
+                .unwrap_or(self.profile_options.account_address()?);
+            if staking_contract_store_exists {
+                default_stake_pool_address(owner_address, operator_address)
+            } else {
+                create_vesting_pool_address(
+                    owner_address,
+                    operator_address,
+                    self.employee_account_index.unwrap(),
+                    &[],
+                )
+            }
+        };
+        Ok(stake_pool_address)
     }
 }
 

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -22,9 +22,9 @@ use crate::move_tool::{
     InitPackage, MemberId, PublishPackage, RunFunction, TestPackage,
 };
 use crate::node::{
-    AnalyzeMode, AnalyzeValidatorPerformance, InitializeValidator, JoinValidatorSet,
-    LeaveValidatorSet, OperatorArgs, OperatorConfigFileArgs, ShowValidatorConfig, ShowValidatorSet,
-    ShowValidatorStake, UpdateConsensusKey, UpdateValidatorNetworkAddresses,
+    AnalyzeMode, AnalyzeValidatorPerformance, GetPoolAddress, InitializeValidator,
+    JoinValidatorSet, LeaveValidatorSet, OperatorArgs, OperatorConfigFileArgs, ShowValidatorConfig,
+    ShowValidatorSet, ShowValidatorStake, UpdateConsensusKey, UpdateValidatorNetworkAddresses,
     ValidatorConsensusKeyArgs, ValidatorNetworkAddressesArgs,
 };
 use crate::op::key::{ExtractPeer, GenerateKey, NetworkKeyInputOptions, SaveKey};
@@ -503,6 +503,18 @@ impl CliTestFramework {
             prompt_options: PromptOptions::yes(),
             encoding_options: EncodingOptions::default(),
             skip_faucet: false,
+        }
+        .execute()
+        .await
+    }
+
+    pub async fn get_pool_address(&self, owner_index: usize) -> CliTypedResult<AccountAddress> {
+        GetPoolAddress {
+            owner_address: self.account_id(owner_index),
+            operator_address: None,
+            employee_account_index: None,
+            rest_options: self.rest_options(),
+            profile_options: Default::default(),
         }
         .execute()
         .await

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -62,6 +62,7 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "move", "transactional-test", "--help"]).await;
 
     assert_cmd_not_panic(&["aptos", "node"]).await;
+    assert_cmd_not_panic(&["aptos", "node", "get-pool-address", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "analyze-validator-performance", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "bootstrap-db-from-backup", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "node", "initialize-validator", "--help"]).await;


### PR DESCRIPTION
### Description
We now have three type of stake pools an account can own:
1. Directly via the stake module
2. Via forming multiple staking contracts with different operators
3. Indirectly via vesting module

### Test Plan
Manual tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4503)
<!-- Reviewable:end -->
