### PR TITLE
[configs] Update block size (txns/bytes) and make configs consistent across deployments

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -35,8 +35,10 @@ pub struct ConsensusConfig {
 impl Default for ConsensusConfig {
     fn default() -> ConsensusConfig {
         ConsensusConfig {
-            max_block_txns: 3500,
-            max_block_bytes: 5 * 1024 * 1024, // 5MB
+            max_block_txns: 2500,
+            // defaulting to under 0.5s to broadcast the proposal to 100 validators
+            // over 1gbps link
+            max_block_bytes: 600 * 1024, // 600 KB
             max_pruned_blocks_in_mem: 100,
             mempool_executed_txn_timeout_ms: 1000,
             mempool_txn_pull_timeout_ms: 1000,
@@ -51,7 +53,7 @@ impl Default for ConsensusConfig {
             use_quorum_store: false,
 
             quorum_store_pull_timeout_ms: 1000,
-            quorum_store_poll_count: 5,
+            quorum_store_poll_count: 10,
             intra_consensus_channel_buffer_size: 10,
         }
     }

--- a/docker/compose/aptos-node/validator.yaml
+++ b/docker/compose/aptos-node/validator.yaml
@@ -17,11 +17,9 @@ consensus:
         waypoint:
           from_file: /opt/aptos/genesis/waypoint.txt
         identity_blob_path: /opt/aptos/genesis/validator-identity.yaml
-  quorum_store_poll_count: 1
 
 execution:
   genesis_file_location: "/opt/aptos/genesis/genesis.blob"
-  concurrency_level: 4
 
 validator_network:
   discovery_method: "onchain"

--- a/terraform/helm/aptos-node/files/configs/validator.yaml
+++ b/terraform/helm/aptos-node/files/configs/validator.yaml
@@ -19,21 +19,14 @@ consensus:
         identity_blob_path: /opt/aptos/genesis/validator-identity.yaml
 {{- if $.Values.validator.config.consensus -}}{{- toYaml $.Values.validator.config.consensus | nindent 4 -}}{{- end }}
 
-{{ if $.Values.validator.config.storage -}}
-storage:
-{{- toYaml $.Values.validator.config.storage | nindent 4 -}}
+{{ if $.Values.validator.config.mempool -}}
+mempool:
+{{- toYaml $.Values.validator.config.mempool | nindent 4 -}}
 {{- end }}
 
 execution:
   genesis_file_location: /opt/aptos/genesis/genesis.blob
 {{- if $.Values.validator.config.execution -}}{{- toYaml $.Values.validator.config.execution | nindent 4 -}}{{- end }}
-
-validator_network:
-  discovery_method: "onchain"
-  identity:
-    type: "from_file"
-    path: /opt/aptos/genesis/validator-identity.yaml
-{{- if $.Values.validator.config.validator_network -}}{{- toYaml $.Values.validator.config.validator_network | nindent 4 -}}{{- end }}
 
 full_node_networks:
 - network_id:
@@ -49,3 +42,15 @@ api:
   enabled: true
   address: "0.0.0.0:8080"
 {{- if $.Values.validator.config.api -}}{{- toYaml $.Values.validator.config.api | nindent 4 -}}{{- end }}
+
+{{ if $.Values.validator.config.storage -}}
+storage:
+{{- toYaml $.Values.validator.config.storage | nindent 4 -}}
+{{- end }}
+
+validator_network:
+  discovery_method: "onchain"
+  identity:
+    type: "from_file"
+    path: /opt/aptos/genesis/validator-identity.yaml
+{{- if $.Values.validator.config.validator_network -}}{{- toYaml $.Values.validator.config.validator_network | nindent 4 -}}{{- end }}

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -86,21 +86,11 @@ validator:
     consensus: {}
     execution: {}
     full_node_networks: []
-    inspection_service: {}
-    logger: {}
-    mempool:
-      shared_mempool_max_concurrent_inbound_syncs: 16 # default 4
-      max_broadcasts_per_peer: 2 # default 1
-      default_failovers: 0 # default 3
-    metrics: {}
-    peer_monitoring_service: {}
+    mempool: {}
     api: {}
-    state_sync: {}
-    firehose_stream: {}
     storage: {}
-    test: {}
     validator_network: {}
-    failpoints: {}
+
   # -- Lock down network ingress and egress with Kubernetes NetworkPolicy
   enableNetworkPolicy: true
 


### PR DESCRIPTION
- reduce block size to 2.5k (to reduce chance of stalls and lags, while potentially trading off some minimal TPS)
- corresponding max bytes should be 500-600k, to have the similar load
- I think we wanted to increase quorum poll count to be around 250ms, correct?
- made all three deployments have the same configs

### Description

### Test Plan
CI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4505)
<!-- Reviewable:end -->
