### PR TITLE
[gha] only copy release images to dockerhub

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.0.0
         with:
           ref: ${{ github.ref }}
-          check-regexp: "rust-images.*"
+          check-name: "rust-images / rust-all" # only copy the release images to dockerhub
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 30 # wait 30 seconds between making polling API calls, default is 10 but we ran in the past into rate-limiting issues with too frequent polling
 


### PR DESCRIPTION
### Description

We wait in a separate GHA workflow for all docker builds to succeed, before copying them into Doeckerhub. This is done with a 3rd party github action, which waits on regexp of github job name

regexp sometimes doesn't work well with retries. This PR makes it such that we only wait on the release image builds `rust-images / rust-all`, rather than everything named `rust-images.*` (includes performance and testing builds, etc)

https://github.com/aptos-labs/aptos-core/actions/runs/3115987663/jobs/5053810467

```
Checks completed:
rust-images-performance / rust-all: completed (success)
rust-images / rust-all: completed (success)
rust-images-indexer / rust-all: completed (success)
rust-images-testing / rust-all: completed (success)
rust-images-testing / rust-all: completed (cancelled)
rust-images / rust-all: completed (success)
The conclusion of one or more checks were not allowed. Allowed conclusions are: success, skipped. This can be configured with the 'allowed-conclusions' param.
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4509)
<!-- Reviewable:end -->
