### PR TITLE
[Aptos Framework][Voting][Audit issue] Do not allow changing votes after voting is over

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -295,9 +295,6 @@ module aptos_framework::aptos_governance {
             error::invalid_argument(EALREADY_VOTED));
         table::add(&mut voting_records.votes, record_key, true);
 
-        // Voting power does not include pending_active or pending_inactive balances.
-        // In general, the stake pool should not have pending_inactive balance if it still has lockup (required to vote)
-        // And if pending_active will be added to active in the next epoch.
         let voting_power = get_voting_power(stake_pool);
         // Short-circuit if the voter has no voting power.
         assert!(voting_power > 0, error::invalid_argument(ENO_VOTING_POWER));


### PR DESCRIPTION
### Description

This is not a critical issue if proposal resolution always happens instantly but can be an issue otherwise as outcome can change with more votes coming in after the voting period is already over.

### Test Plan
New unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4518)
<!-- Reviewable:end -->
