### PR TITLE
[Aptos Framework] Add a function to return all operators for a staker in stkaing_contract

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/simple_map.move
+++ b/aptos-move/framework/aptos-stdlib/sources/simple_map.move
@@ -28,6 +28,17 @@ module aptos_std::simple_map {
         vector::length(&map.data)
     }
 
+    public fun keys<Key: copy + store, Value: store>(map: &SimpleMap<Key, Value>): vector<Key> {
+        let keys = vector::empty<Key>();
+        let len = length(map);
+        let i = 0;
+        while (i < len) {
+            vector::push_back(&mut keys, vector::borrow(&map.data, i).key);
+            i = i + 1;
+        };
+        keys
+    }
+
     public fun create<Key: store, Value: store>(): SimpleMap<Key, Value> {
         SimpleMap {
             data: vector::empty(),
@@ -207,6 +218,14 @@ module aptos_std::simple_map {
 
         remove(&mut map, &3);
         destroy_empty(map);
+    }
+
+    #[test]
+    public fun test_keys() {
+        let map = create<u64, u64>();
+        add(&mut map, 1, 1);
+        add(&mut map, 2, 2);
+        assert!(keys(&map) == vector[1, 2], 0);
     }
 
     #[test]


### PR DESCRIPTION
### Description
This PR makes two changes:
1. Update simple_map to allow return the keys for a map if they're copyable
2. Add a new function to staking contract that returns all operator addresses a staker is in contracts with. These are just keys in the simple_map from address => StakingContract

### Test Plan
Unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4521)
<!-- Reviewable:end -->
