### PR TITLE
[backup] fix that get_transaction_iter() on non-existent version can …

### DIFF
--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -143,6 +143,10 @@ impl ApplyChunkOutput {
         state_updates_vec: Vec<HashMap<StateKey, Option<StateValue>>>,
         state_checkpoint_hashes: Vec<Option<HashValue>>,
     ) -> (Vec<(Transaction, TransactionData)>, Vec<HashValue>) {
+        // these are guaranteed by caller side logic
+        assert_eq!(to_keep.len(), state_updates_vec.len());
+        assert_eq!(to_keep.len(), state_checkpoint_hashes.len());
+
         let mut to_commit = vec![];
         let mut txn_info_hashes = vec![];
         for (((txn, txn_output), state_checkpoint_hash), state_updates) in itertools::zip_eq(

--- a/storage/aptosdb/src/backup/test.rs
+++ b/storage/aptosdb/src/backup/test.rs
@@ -38,13 +38,31 @@ proptest! {
             .collect();
         prop_assert_eq!(expected.len() as u64, cur_ver);
 
-        let actual = db
-            .get_backup_handler()
+        let bh = db.get_backup_handler();
+
+        let actual = bh
             .get_transaction_iter(0, cur_ver as usize)
             .unwrap()
             .map(|res| Ok(res?.0))
             .collect::<Result<Vec<_>>>()
             .unwrap();
-        prop_assert_eq!(actual, expected);
+        prop_assert_eq!(&actual, &expected);
+
+        // try to overfetch, still expect the same result.
+        let overfetched = bh
+            .get_transaction_iter(0, cur_ver as usize + 10)
+            .unwrap()
+            .map(|res| Ok(res?.0))
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        prop_assert_eq!(&overfetched, &expected);
+
+        let non_existent = bh
+            .get_transaction_iter(100000, 100)
+            .unwrap()
+            .map(|res| Ok(res?.0))
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        prop_assert_eq!(&non_existent, &[]);
     }
 }

--- a/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/backup.rs
@@ -10,7 +10,7 @@ use crate::{
         should_cut_chunk, storage_ext::BackupStorageExt, GlobalBackupOpt,
     },
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, ensure, Result};
 use aptos_logger::prelude::*;
 use aptos_types::transaction::Version;
 use clap::Parser;
@@ -103,9 +103,12 @@ impl TransactionBackupController {
         }
 
         assert!(!chunk_bytes.is_empty());
-        assert_eq!(
+        let expected_next_version = self.start_version + self.num_transactions as u64;
+        ensure!(
+            current_ver == expected_next_version,
+            "Server did not return all transactions requested. Expecting last version {}, got {}",
+            expected_next_version,
             current_ver,
-            self.start_version + self.num_transactions as u64
         );
         let chunk = self
             .write_chunk(


### PR DESCRIPTION
…crash node

also audited all zip_eq usages under storage

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4523)
<!-- Reviewable:end -->
