### PR TITLE
expose cloneable private key

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -27,3 +27,6 @@ once_cell = "1.13.0"
 rand = "0.7.3"
 tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
 url = "2.2.2"
+
+[features]
+cloneable-private-keys = ["aptos-crypto/cloneable-private-keys"]


### PR DESCRIPTION
### Description
There is a cloneable private key feature in aptos-crypto which can be exposed through the aptos-sdk Cargo.toml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4525)
<!-- Reviewable:end -->
