### PR TITLE
[framework] improve resource account with initial data

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.rs
@@ -288,38 +288,6 @@ fn code_publishing_arbitray_dep_different_address(#[case] features: Vec<FeatureF
 }
 
 #[rstest]
-#[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
-fn code_publishing_using_resource_account(#[case] features: Vec<FeatureFlag>) {
-    let mut h = MoveHarness::new_with_features(features);
-    let acc = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
-
-    let mut pack = PackageBuilder::new("Package1").with_policy(UpgradePolicy::compat());
-    pack.add_source("m", "module 0x0b6beee9bc1ad3177403a04efeefb1901c12b7b575ac5124c0205efc0dd2e32a::m { public fun f() {} }");
-    let pack_dir = pack.write_to_temp().unwrap();
-    let package = framework::BuiltPackage::build(
-        pack_dir.path().to_owned(),
-        framework::BuildOptions::default(),
-    )
-    .expect("building package must succeed");
-
-    let code = package.extract_code();
-    let metadata = package
-        .extract_metadata()
-        .expect("extracting package metadata must succeed");
-    let bcs_metadata = bcs::to_bytes(&metadata).expect("PackageMetadata has BCS");
-
-    let result = h.run_transaction_payload(
-        &acc,
-        cached_packages::aptos_stdlib::resource_account_create_resource_account_and_publish_package(
-            vec![],
-            bcs_metadata,
-            code,
-        ),
-    );
-    assert_success!(result);
-}
-
-#[rstest]
 #[case(vec![])]
 #[case(vec![FeatureFlag::CODE_DEPENDENCY_CHECK])]
 fn code_publishing_faked_dependency(#[case] features: Vec<FeatureFlag>) {

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -10,6 +10,7 @@ mod generate_upgrade_script;
 mod init_module;
 mod lazy_natives;
 mod max_loop_depth;
+mod resource_account;
 mod rotate_auth_key;
 mod stake;
 mod string_args;

--- a/aptos-move/e2e-move-tests/src/tests/resource_account.data/with_data/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/resource_account.data/with_data/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "resource_account"
+version = "0.0.0"
+
+[addresses]
+resource_account = "_"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/resource_account.data/with_data/sources/core.move
+++ b/aptos-move/e2e-move-tests/src/tests/resource_account.data/with_data/sources/core.move
@@ -1,0 +1,56 @@
+module resource_account::core {
+    use std::vector;
+    use aptos_framework::account::SignerCapability;
+    use aptos_framework::resource_account;
+    use aptos_std::from_bcs;
+
+    struct ModuleData has key {
+        u64_value: u64,
+        u8_value: u8,
+        address_value: address,
+        signer_cap: SignerCapability,
+    }
+
+    fun init_module(resource: &signer) {
+        let (signer_cap, blob) = resource_account::retrieve_resource_account_cap_and_data(resource, @0xCAFE);
+        let u64_blob = vector::empty();
+        let idx = 0;
+        let end = 8;
+
+        assert!(vector::length(&blob) == 41, vector::length(&blob));
+
+        loop {
+            vector::push_back(&mut u64_blob, *vector::borrow(&blob, idx));
+            idx = idx + 1;
+            if (idx == end) {
+                break
+            };
+        };
+        let u64_value = from_bcs::to_u64(u64_blob);
+
+        let u8_value = *vector::borrow(&blob, idx);
+        idx = idx + 1;
+
+        let address_blob = vector::empty();
+        end = idx + 32;
+
+        loop {
+            vector::push_back(&mut address_blob, *vector::borrow(&blob, idx));
+            idx = idx + 1;
+            if (end == idx) {
+                break
+            };
+        };
+        let address_value = from_bcs::to_address(address_blob);
+
+        move_to(
+            resource,
+            ModuleData {
+                u64_value,
+                u8_value,
+                address_value,
+                signer_cap,
+            }
+        );
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/resource_account.rs
+++ b/aptos-move/e2e-move-tests/src/tests/resource_account.rs
@@ -1,0 +1,68 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_types::account_address::AccountAddress;
+use cached_packages::aptos_stdlib;
+use framework::{BuildOptions, BuiltPackage};
+use move_deps::move_core_types::parser::parse_struct_tag;
+use serde::{Deserialize, Serialize};
+
+/// Mimics `0xcafe::test::ModuleData`
+#[derive(Serialize, Deserialize)]
+struct ModuleData {
+    u64_value: u64,
+    u8_value: u8,
+    address_value: AccountAddress,
+    signer_cap: AccountAddress,
+}
+
+#[test]
+fn resource_account_with_data() {
+    let mut h = MoveHarness::new();
+    let account = h.new_account_at(AccountAddress::from_hex_literal("0xcafe").unwrap());
+    let resource_address = aptos_types::account_address::create_resource_address(
+        *account.address(),
+        vec![].as_slice(),
+    );
+
+    let mut build_options = BuildOptions::default();
+    build_options
+        .named_addresses
+        .insert("resource_account".to_string(), resource_address);
+    let package = BuiltPackage::build(
+        common::test_dir_path("resource_account.data/with_data"),
+        build_options,
+    )
+    .expect("building package must succeed");
+    let code = package.extract_code();
+    let metadata = package
+        .extract_metadata()
+        .expect("extracting package metadata must succeed");
+
+    let u64_value = 12345u64;
+    let u8_value = 123u8;
+
+    let blob = bcs::to_bytes(&(u64_value, u8_value, account.address())).unwrap();
+    let txn = h.create_transaction_payload(
+        &account,
+        aptos_stdlib::resource_account_create_resource_account_and_publish_package_with_data(
+            vec![],
+            bcs::to_bytes(&metadata).expect("PackageMetadata has BCS"),
+            code,
+            blob,
+        ),
+    );
+    assert_success!(h.run(txn));
+
+    // Verify that init_module was called.
+    let module_data =
+        parse_struct_tag(&format!("0x{}::core::ModuleData", resource_address)).unwrap();
+    let resource = h
+        .read_resource::<ModuleData>(&resource_address, module_data.clone())
+        .unwrap();
+    assert_eq!(resource.u64_value, u64_value);
+    assert_eq!(resource.u8_value, u8_value);
+    assert_eq!(resource.address_value, *account.address());
+    assert_eq!(resource.signer_cap, resource_address);
+}


### PR DESCRIPTION
As we started deploying our own contracts, we realized that one would
need to pass in additional data out of band to make a really standalone
contract in some cases. This isn't ideal. This example isn't
particularly elegant but it is ... generalizable. we'll benefit from a
bcs parser (not deserializer) that can be told what to parse next.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4528)
<!-- Reviewable:end -->
