### PR TITLE
[docs] Make more explicit documentation per platform

### DIFF
--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
@@ -68,6 +68,11 @@ These instructions have been tested on Ubuntu 20.04
 These instructions have been tested on Windows 11 and Windows Server 2022
 :::
 
+:::info
+Windows support is fairly new, and some features may be not complete.  Please let us know your feedback and open
+Github issues for bugs.
+:::
+
 1. Go to the [Aptos CLI release page](https://github.com/aptos-labs/aptos-core/releases?q=cli&expanded=true).
 2. In the latest release section, you will see the zip files with the filename of the format: `aptos-cli-<version>-<platform>`. These are the platform-specific pre-compiled binaries of the CLI. Download the zip file for your platform.
 3. Unzip the downloaded file. This will extract the `aptos` CLI binary file into your default downloads folder. For example, on Windows it is the `\Users\user\Downloads` folder.

--- a/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
+++ b/developer-docs-site/docs/cli-tools/aptos-cli-tool/install-aptos-cli.md
@@ -14,6 +14,14 @@ If you want to use the Move Prover, then, [install the Move Prover dependencies]
 :::
 
 ## Download precompiled binary
+<details>
+<summary>MacOS installation instructions</summary>
+
+### Installing on MacOS
+:::tip
+These instructions have been tested on MacOS Monterey (12.6)
+:::
+
 
 1. Go to the [Aptos CLI release page](https://github.com/aptos-labs/aptos-core/releases?q=cli&expanded=true).
 2. In the latest release section, you will see the zip files with the filename of the format: `aptos-cli-<version>-<platform>`. These are the platform-specific pre-compiled binaries of the CLI. Download the zip file for your platform.
@@ -22,18 +30,97 @@ If you want to use the Move Prover, then, [install the Move Prover dependencies]
 :::tip Upgrading? Remember to look in the default download folder
 When you update the CLI binary with the latest version, note that the newer version binary will be downloaded to your default Downloads folder. Remember to move this newer version binary from the Downloads folder to `~/bin/aptos` folder (overwriting the older version).
 :::
-1. Make this `~/bin/aptos` as an executable by running this command: 
-   - On Linux and MacOS: `chmod +x ~/bin/aptos`.
-   - On MacOS when you attempt to run the `aptos` tool for the first time, you will be blocked by the MacOS that this app is from an "unknown developer". This is normal. Follow the simple steps recommended by the Apple support in [Open a Mac app from an unidentified developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) to remove this blocker. 
-2. Type `~/bin/aptos help` to read help instructions.
-3. Add `~/bin` to your path in your `.bashrc` or `.zshrc` file for future use.
+5. Make this `~/bin/aptos` as an executable by running this command: 
+   - `chmod +x ~/bin/aptos`.
+6. Type `~/bin/aptos help` to read help instructions.
+7. Add `~/bin` to your path in your `.bashrc` or `.zshrc` file for future use.
+</details>
+
+<details>
+<summary>Linux installation instructions</summary>
+
+### Installing on Linux
+:::tip
+These instructions have been tested on Ubuntu 20.04
+:::
+
+1. Go to the [Aptos CLI release page](https://github.com/aptos-labs/aptos-core/releases?q=cli&expanded=true).
+2. In the latest release section, you will see the zip files with the filename of the format: `aptos-cli-<version>-<platform>`. These are the platform-specific pre-compiled binaries of the CLI. Download the zip file for your platform.
+3. Unzip the downloaded file. This will extract the `aptos` CLI binary file into your default downloads folder. For example, on MacOS it is the `~/Downloads` folder.
+4. Move this extracted `aptos` binary file into your preferred local folder. For example, place it in `~/bin/aptos` folder on Linux or MacOS.
+   :::tip Upgrading? Remember to look in the default download folder
+   When you update the CLI binary with the latest version, note that the newer version binary will be downloaded to your default Downloads folder. Remember to move this newer version binary from the Downloads folder to `~/bin/aptos` folder (overwriting the older version).
+   :::
+5. Make this `~/bin/aptos` as an executable by running this command:
+    - `chmod +x ~/bin/aptos`.
+    - On MacOS when you attempt to run the `aptos` tool for the first time, you will be blocked by the MacOS that this app is from an "unknown developer". This is normal. Follow the simple steps recommended by the Apple support in [Open a Mac app from an unidentified developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac) to remove this blocker.
+6. Type `~/bin/aptos help` to read help instructions.
+7. Add `~/bin` to your path in your `.bashrc` or `.zshrc` file for future use.
+
+</details>
+
+<details>
+<summary>Windows installation instructions</summary>
+
+### Installing on Windows 10 / 11 and Windows Server 2022+
+
+:::tip
+These instructions have been tested on Windows 11 and Windows Server 2022
+:::
+
+1. Go to the [Aptos CLI release page](https://github.com/aptos-labs/aptos-core/releases?q=cli&expanded=true).
+2. In the latest release section, you will see the zip files with the filename of the format: `aptos-cli-<version>-<platform>`. These are the platform-specific pre-compiled binaries of the CLI. Download the zip file for your platform.
+3. Unzip the downloaded file. This will extract the `aptos` CLI binary file into your default downloads folder. For example, on Windows it is the `\Users\user\Downloads` folder.
+4. Move this extracted `aptos` binary file into your preferred local folder.
+   :::tip Upgrading? Remember to look in the default download folder
+   When you update the CLI binary with the latest version, note that the newer version binary will be downloaded to your default Downloads folder. Remember to move this newer version binary from the Downloads folder to your preferred location.
+   :::
+5. Open a powershell terminal via the windows start menu
+6. In the powershell terminal, you can get help instructions by running the command with help.  For example ` .\Downloads\aptos-cli-0.3.5-Windows-x86_64\aptos.exe help` to read help instructions.
+
+</details>
 
 ## (Optional) Install the dependencies of Move Prover
 
 If you want to use the Move Prover, install the dependencies by following the below steps:
 
-:::tip Windows is not supported
-The Move Prover is not supported on Windows.
+:::info
+Currently Windows is not supported for the prover
+:::
+
+<details>
+<summary>Prover MacOS installation instructions</summary>
+
+### Mac instructions
+:::tip
+These instructions have been tested on MacOS Monterey (12.6)
+:::
+
+
+1. Ensure you have `brew` installed https://brew.sh/
+2. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
+3. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`.
+4. Change directory into the `aptos-core` directory: `cd aptos-core`.
+5. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh -yp`.
+6. Source the profile file: `source ~/.profile`.
+   :::info
+   Note that you have to include environment variable definitions in `~/.profile` into your shell. Depending on your setup, the  `~/.profile` may be already automatically loaded for each login shell, or it may not. If not, you may
+   need to add `. ~/.profile` to your `~/.bash_profile` or other shell configuration manually.
+   :::
+7. You can now run the Move Prover to prove an example:
+    ```bash
+    aptos move prove --package-dir aptos-move/move-examples/hello_prover/
+    ```
+   
+</details>
+
+<details>
+<summary>Prover Linux installation instructions</summary>
+
+### Linux instructions
+:::tip 
+Some Linux distros not supported
+Currently, OpenSUSE and Amazon Linux do not support the automatic installation via the `dev_setup.sh` script
 :::
 
 1. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
@@ -41,31 +128,118 @@ The Move Prover is not supported on Windows.
 3. Change directory into the `aptos-core` directory: `cd aptos-core`.
 4. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh -yp`.
 5. Source the profile file: `source ~/.profile`.
-    :::info
-    Note that you have to include environment variable definitions in `~/.profile` into your shell. Depending on your setup, the  `~/.profile` may be already automatically loaded for each login shell, or it may not. If not, you may 
-    need to add `. ~/.profile` to your `~/.bash_profile` or other shell configuration manually.
-    :::
+   :::info
+   Note that you have to include environment variable definitions in `~/.profile` into your shell. Depending on your setup, the  `~/.profile` may be already automatically loaded for each login shell, or it may not. If not, you may
+   need to add `. ~/.profile` to your `~/.bash_profile` or other shell configuration manually.
+   :::
 6. You can now run the Move Prover to prove an example:
     ```bash
     aptos move prove --package-dir aptos-move/move-examples/hello_prover/
     ```
 
+</details>
+
+## (Advanced users only) Build the CLI binary from the source code
+
+If you are an advanced user and would like to build the CLI binary by downloading the source code, follow the below steps. **This is not recommended** unless you are on a platform unsupported by the prebuilt binaries.
+
 <details>
-<summary>(Advanced users only) Build the CLI binary from the source</summary>
+<summary>MacOS building instructions</summary>
 
-If you are an advanced user and would like to build the CLI binary by downloading the source code, follow the below steps. **This is not recommended.**
+### Setup dependencies
+#### Using the automated script
+1. If on Mac, ensure you have `brew` installed https://brew.sh/
+2. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
+3. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`.
+4. Change directory into the `aptos-core` directory: `cd aptos-core`.
+5. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh`.
+6. Update your current shell environment: `source ~/.cargo/env`.
 
-1. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
-2. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`.
-3. Change directory into the `aptos-core` directory: `cd aptos-core`.
-4. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh`.
-5. Update your current shell environment: `source ~/.cargo/env`.
-6. Checkout the correct branch `git checkout --track origin/<branch>`, where `<branch>` is:
+#### Manual installation of dependencies
+
+If the script above doesn't work for you, you can install these manually, but it's **not recommended**.
+
+1. Install [Rust](https://www.rust-lang.org/tools/install)
+2. Install [Git](https://git-scm.com/download)
+3. Install [CMake](https://cmake.org/download/)
+4. Install [LLVM](https://releases.llvm.org/)
+
+### Building the Aptos CLI
+
+1. Checkout the correct branch `git checkout --track origin/<branch>`, where `<branch>` is:
     - `devnet` for building on the Aptos devnet.
     - `testnet` for building on the Aptos testnet.
     - `main` for the current development branch.
-7. Build the CLI tool: `cargo build --package aptos --release`.
-8. The binary will be available in `target/release/aptos` folder.
-9. (Optional) Move this executable to a place on your path e.g. `~/bin/aptos`.
+2. Build the CLI tool: `cargo build --package aptos --release`.
+3. The binary will be available in at
+    - `target/release/aptos`
+4. (Optional) Move this executable to a place on your path e.g. `~/bin/aptos`.
+5. You can now get help instructions by running `~/bin/aptos help`
+
+</details>
+
+<details>
+<summary>Linux building instructions</summary>
+
+### Setup dependencies
+#### Using the automated script
+1. If on Mac, ensure you have `brew` installed https://brew.sh/
+2. Ensure you have `git` installed https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.
+3. Clone the Aptos core repo:  `git clone https://github.com/aptos-labs/aptos-core.git`.
+4. Change directory into the `aptos-core` directory: `cd aptos-core`.
+5. Run the dev setup script to prepare your environment: `./scripts/dev_setup.sh`.
+6. Update your current shell environment: `source ~/.cargo/env`.
+
+#### Manual installation of dependencies
+
+If the script above doesn't work for you, you can install these manually, but it's **not recommended**.
+
+1. Install [Rust](https://www.rust-lang.org/tools/install)
+2. Install [Git](https://git-scm.com/download)
+3. Install [CMake](https://cmake.org/download/)
+4. Install [LLVM](https://releases.llvm.org/)
+
+### Building the Aptos CLI
+
+1. Checkout the correct branch `git checkout --track origin/<branch>`, where `<branch>` is:
+    - `devnet` for building on the Aptos devnet.
+    - `testnet` for building on the Aptos testnet.
+    - `main` for the current development branch.
+2. Build the CLI tool: `cargo build --package aptos --release`.
+3. The binary will be available in at
+   - `target/release/aptos`
+4. (Optional) Move this executable to a place on your path e.g. `~/bin/aptos`.
+5. You can now get help instructions by running `~/bin/aptos help`
+
+</details>
+
+<details>
+<summary>Windows installation instructions</summary>
+
+## Setup dependencies
+
+:::tip
+The aptos-core codebase currently has no script similar to the `dev_setup.sh` script for
+Windows.  All dependencies must be manually installed.
+:::
+
+#### Manual installation of dependencies
+1. Install [Rust](https://www.rust-lang.org/tools/install)
+2. Install [Git](https://git-scm.com/download)
+3. Install [CMake](https://cmake.org/download/)
+4. If on Windows ARM, install [Visual Studio Preview](https://visualstudio.microsoft.com/vs/preview/)
+5. Install [C++ build tools for Windows](https://visualstudio.microsoft.com/downloads/#microsoft-visual-c-redistributable-for-visual-studio-2022)
+6. Install [LLVM](https://releases.llvm.org/)
+
+#### Building aptos-core
+
+1. Checkout the correct branch `git checkout --track origin/<branch>`, where `<branch>` is:
+    - `devnet` for building on the Aptos devnet.
+    - `testnet` for building on the Aptos testnet.
+    - `main` for the current development branch.
+2. Build the CLI tool: `cargo build --package aptos --release`.
+3. The binary will be available in at
+   - `target\release\aptos.exe`
+4. You can now get help instructions by running `target\release\aptos.exe` in a Powershell window.
 
 </details>


### PR DESCRIPTION
### Description
Now, the documentation is broken down by drop downs per platform, with platform specific instructions, and tips.  This allows users to be streamlined and easier for people who don't have English as a first language.

Resolves: https://github.com/aptos-labs/aptos-core/issues/4335

### Test Plan
I've been testing these out on multiple platforms to ensure that they're correct.  Windows Server 2022 plus looking around the internet got a lot of those instructions.

I'm sure that it will need more work in the future, but now it's split out by platform!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4538)
<!-- Reviewable:end -->
