### PR TITLE
[Minor changes][Staking] Reorder checks in get_validator_state to optimize performance

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -289,11 +289,11 @@ module aptos_framework::stake {
         let validator_set = borrow_global<ValidatorSet>(@aptos_framework);
         if (option::is_some(&find_validator(&validator_set.pending_active, pool_address))) {
             VALIDATOR_STATUS_PENDING_ACTIVE
-        } else if (option::is_some(&find_validator(&validator_set.active_validators, pool_address))) {
-            VALIDATOR_STATUS_ACTIVE
         } else if (option::is_some(&find_validator(&validator_set.pending_inactive, pool_address))) {
             VALIDATOR_STATUS_PENDING_INACTIVE
-        } else {
+        } else if (option::is_some(&find_validator(&validator_set.active_validators, pool_address))) {
+            VALIDATOR_STATUS_ACTIVE
+        }  else {
             VALIDATOR_STATUS_INACTIVE
         }
     }


### PR DESCRIPTION
### Description
This assumes that the numbers of pending active and pending inactive validators are always much smaller than the total number of active validators. This PR moves the check for pending active and pending inactive to before active to hopefully return early if a validator is in either of those lists.

### Test Plan
No functional changes. Existing tests should keep passing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4539)
<!-- Reviewable:end -->
