### PR TITLE
[move] Enable runtime checks in MoveVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,8 +204,8 @@ dependencies = [
  "bcs",
  "better_any",
  "claims",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "move-table-extension",
  "once_cell",
  "smallvec",
@@ -237,8 +237,8 @@ dependencies = [
  "hex",
  "hyper",
  "mime",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-package 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
+ "move-package",
  "once_cell",
  "paste",
  "percent-encoding",
@@ -309,8 +309,8 @@ dependencies = [
  "bcs",
  "hex",
  "indoc",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "move-resource-viewer",
  "poem",
  "poem-openapi",
@@ -522,9 +522,9 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-package 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
+ "move-package",
  "once_cell",
  "prost 0.10.4",
  "serde 1.0.144",
@@ -608,9 +608,9 @@ dependencies = [
  "clap 3.2.17",
  "framework",
  "gas-algebra-ext",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
+ "move-model",
  "move-stdlib",
  "move-table-extension",
  "move-vm-types",
@@ -827,8 +827,8 @@ dependencies = [
 name = "aptos-module-verifier"
 version = "0.1.0"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
 ]
 
 [[package]]
@@ -1047,8 +1047,8 @@ dependencies = [
  "bytes 1.2.1",
  "futures",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "poem-openapi",
  "reqwest",
  "serde 1.0.144",
@@ -1152,7 +1152,7 @@ dependencies = [
  "cached-packages",
  "framework",
  "heck 0.3.3",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "once_cell",
  "regex",
  "serde-generate",
@@ -1367,7 +1367,7 @@ dependencies = [
  "claims",
  "hex",
  "itertools",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "move-table-extension",
  "num-derive",
  "num-traits 0.2.15",
@@ -1434,10 +1434,10 @@ dependencies = [
  "dashmap",
  "fail 0.5.0",
  "framework",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-bytecode-verifier",
+ "move-core-types",
  "move-stdlib",
  "move-table-extension",
  "move-unit-test",
@@ -1517,7 +1517,7 @@ dependencies = [
  "executor-types",
  "itertools",
  "lru",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "move-resource-viewer",
  "num-derive",
  "once_cell",
@@ -1550,7 +1550,7 @@ dependencies = [
  "aptos-vm",
  "bcs",
  "byteorder",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "move-resource-viewer",
  "num-derive",
  "proptest",
@@ -2203,7 +2203,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -2264,7 +2264,7 @@ dependencies = [
  "bcs",
  "framework",
  "include_dir 0.7.2",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -3597,7 +3597,7 @@ dependencies = [
  "executor-types",
  "fail 0.5.0",
  "itertools",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "once_cell",
  "proptest",
  "rand 0.7.3",
@@ -3912,13 +3912,13 @@ dependencies = [
  "itertools",
  "libsecp256k1",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
  "move-cli",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-package 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-model",
+ "move-package",
  "move-prover",
  "move-table-extension",
  "move-unit-test",
@@ -4065,7 +4065,7 @@ dependencies = [
 name = "gas-algebra-ext"
 version = "0.0.1"
 dependencies = [
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
 ]
 
 [[package]]
@@ -5510,57 +5510,27 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
  "heck 0.3.3",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-model 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "serde 1.0.144",
-]
-
-[[package]]
-name = "move-abigen"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "bcs",
- "heck 0.3.3",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-model",
  "serde 1.0.144",
 ]
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "once_cell",
- "ref-cast",
- "serde 1.0.144",
- "variant_count",
-]
-
-[[package]]
-name = "move-binary-format"
-version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "once_cell",
  "proptest",
  "proptest-derive",
@@ -5572,63 +5542,31 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
-
-[[package]]
-name = "move-borrow-graph"
-version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-types 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-symbol-pool 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "serde 1.0.144",
-]
-
-[[package]]
-name = "move-bytecode-source-map"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
  "serde 1.0.144",
 ]
 
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "petgraph 0.5.1",
- "serde-reflection",
-]
-
-[[package]]
-name = "move-bytecode-utils"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "petgraph 0.5.1",
  "serde-reflection",
 ]
@@ -5636,40 +5574,28 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-borrow-graph 0.0.1 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "petgraph 0.5.1",
-]
-
-[[package]]
-name = "move-bytecode-verifier"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-borrow-graph 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-core-types",
  "petgraph 0.5.1",
 ]
 
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
  "crossterm 0.21.0",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-disassembler 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-disassembler",
+ "move-ir-types",
  "regex",
  "tui",
 ]
@@ -5677,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5686,24 +5612,24 @@ dependencies = [
  "colored",
  "difference",
  "itertools",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-utils",
+ "move-bytecode-verifier",
  "move-bytecode-viewer",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-coverage 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-disassembler 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-docgen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-coverage",
+ "move-disassembler",
+ "move-docgen",
  "move-errmapgen",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-package 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-ir-types",
+ "move-package",
  "move-prover",
  "move-resource-viewer",
  "move-stdlib",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-symbol-pool",
  "move-unit-test",
  "move-vm-runtime",
  "move-vm-test-utils",
@@ -5723,30 +5649,13 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "difference",
  "dirs-next",
  "hex",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "num-bigint 0.4.3",
- "once_cell",
- "serde 1.0.144",
- "sha2 0.9.9",
- "walkdir",
-]
-
-[[package]]
-name = "move-command-line-common"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "difference",
- "dirs-next",
- "hex",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "num-bigint 0.4.3",
  "once_cell",
  "serde 1.0.144",
@@ -5757,7 +5666,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5765,44 +5674,15 @@ dependencies = [
  "codespan-reporting",
  "difference",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-borrow-graph 0.0.1 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-types 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-symbol-pool 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "num-bigint 0.4.3",
- "once_cell",
- "petgraph 0.5.1",
- "regex",
- "sha3",
- "tempfile",
- "walkdir",
-]
-
-[[package]]
-name = "move-compiler"
-version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "bcs",
- "clap 3.2.17",
- "codespan-reporting",
- "difference",
- "hex",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-borrow-graph 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode",
+ "move-ir-types",
+ "move-symbol-pool",
  "num-bigint 0.4.3",
  "once_cell",
  "petgraph 0.5.1",
@@ -5815,22 +5695,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
-dependencies = [
- "anyhow",
- "bcs",
- "hex",
- "once_cell",
- "rand 0.8.5",
- "ref-cast",
- "serde 1.0.144",
- "serde_bytes",
-]
-
-[[package]]
-name = "move-core-types"
-version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5847,38 +5712,18 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
  "clap 3.2.17",
  "codespan",
  "colored",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-types 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "once_cell",
- "petgraph 0.5.1",
- "serde 1.0.144",
-]
-
-[[package]]
-name = "move-coverage"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "bcs",
- "clap 3.2.17",
- "codespan",
- "colored",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
  "once_cell",
  "petgraph 0.5.1",
  "serde 1.0.144",
@@ -5888,26 +5733,26 @@ dependencies = [
 name = "move-deps"
 version = "0.0.1"
 dependencies = [
- "move-abigen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-abigen",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-bytecode-verifier",
  "move-cli",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-docgen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
  "move-errmapgen",
  "move-ir-compiler",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-package 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-model",
+ "move-package",
  "move-prover",
  "move-prover-boogie-backend",
  "move-prover-test-utils",
  "move-resource-viewer",
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-symbol-pool",
  "move-table-extension",
  "move-transactional-test-runner",
  "move-unit-test",
@@ -5921,69 +5766,33 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
  "colored",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-compiler 0.0.1 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-coverage 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-types 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
-]
-
-[[package]]
-name = "move-disassembler"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "clap 3.2.17",
- "colored",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-coverage 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-coverage",
+ "move-ir-types",
 ]
 
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "codespan",
  "codespan-reporting",
  "itertools",
  "log",
- "move-compiler 0.0.1 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-model 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "num",
- "once_cell",
- "regex",
- "serde 1.0.144",
-]
-
-[[package]]
-name = "move-docgen"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "codespan",
- "codespan-reporting",
- "itertools",
- "log",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-compiler",
+ "move-model",
  "num",
  "once_cell",
  "regex",
@@ -5993,14 +5802,14 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
  "log",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-model",
  "serde 1.0.144",
 ]
 
@@ -6019,56 +5828,37 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
  "clap 3.2.17",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode",
+ "move-ir-types",
+ "move-symbol-pool",
  "serde_json",
 ]
 
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-types 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-symbol-pool 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "ouroboros",
- "thiserror",
-]
-
-[[package]]
-name = "move-ir-to-bytecode"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "codespan-reporting",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-to-bytecode-syntax 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode-syntax",
+ "move-ir-types",
+ "move-symbol-pool",
  "ouroboros",
  "thiserror",
 ]
@@ -6076,53 +5866,26 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-types 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-symbol-pool 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
-]
-
-[[package]]
-name = "move-ir-to-bytecode-syntax"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-types",
+ "move-symbol-pool",
 ]
 
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-symbol-pool 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "once_cell",
- "serde 1.0.144",
-]
-
-[[package]]
-name = "move-ir-types"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "hex",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
+ "move-core-types",
+ "move-symbol-pool",
  "once_cell",
  "serde 1.0.144",
 ]
@@ -6130,7 +5893,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "codespan",
@@ -6138,41 +5901,15 @@ dependencies = [
  "internment",
  "itertools",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-compiler 0.0.1 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-disassembler 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-ir-types 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-symbol-pool 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "num",
- "once_cell",
- "regex",
- "serde 1.0.144",
-]
-
-[[package]]
-name = "move-model"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "codespan",
- "codespan-reporting",
- "internment",
- "itertools",
- "log",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-disassembler 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-disassembler",
+ "move-ir-types",
+ "move-symbol-pool",
  "num",
  "once_cell",
  "regex",
@@ -6182,7 +5919,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6190,52 +5927,16 @@ dependencies = [
  "colored",
  "dirs-next",
  "itertools",
- "move-abigen 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-binary-format 0.0.3 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-compiler 0.0.1 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-core-types 0.0.4 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-docgen 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-model 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-symbol-pool 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "named-lock",
- "once_cell",
- "petgraph 0.5.1",
- "ptree",
- "regex",
- "reqwest",
- "serde 1.0.144",
- "serde_yaml 0.8.26",
- "sha2 0.9.9",
- "tempfile",
- "toml",
- "walkdir",
- "whoami",
-]
-
-[[package]]
-name = "move-package"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
-dependencies = [
- "anyhow",
- "bcs",
- "clap 3.2.17",
- "colored",
- "dirs-next",
- "itertools",
- "move-abigen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-docgen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-abigen",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
+ "move-model",
+ "move-symbol-pool",
  "named-lock",
  "once_cell",
  "petgraph 0.5.1",
@@ -6254,7 +5955,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6266,15 +5967,15 @@ dependencies = [
  "hex",
  "itertools",
  "log",
- "move-abigen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-docgen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-abigen",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
  "move-errmapgen",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-ir-types",
+ "move-model",
  "move-prover-boogie-backend",
  "move-stackless-bytecode",
  "num",
@@ -6291,7 +5992,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6300,10 +6001,10 @@ dependencies = [
  "futures",
  "itertools",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
+ "move-model",
  "move-stackless-bytecode",
  "num",
  "once_cell",
@@ -6319,10 +6020,10 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
  "prettydiff",
  "regex",
 ]
@@ -6330,25 +6031,25 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "serde 1.0.144",
 ]
 
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "once_cell",
  "serde 1.0.144",
 ]
@@ -6356,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6364,14 +6065,14 @@ dependencies = [
  "im",
  "itertools",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-borrow-graph 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-to-bytecode 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-to-bytecode",
+ "move-model",
  "move-read-write-set-types",
  "num",
  "once_cell",
@@ -6383,16 +6084,16 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
  "clap 3.2.17",
  "codespan-reporting",
  "itertools",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
+ "move-model",
  "move-stackless-bytecode",
  "num",
  "serde 1.0.144",
@@ -6401,15 +6102,15 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-docgen 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-docgen",
  "move-errmapgen",
  "move-prover",
  "move-vm-runtime",
@@ -6423,16 +6124,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e#77750b37bb3663d00a7c4058937fed42ceb3089e"
-dependencies = [
- "once_cell",
- "serde 1.0.144",
-]
-
-[[package]]
-name = "move-symbol-pool"
-version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6441,13 +6133,13 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "bcs",
  "better_any",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-runtime",
  "move-vm-types",
  "once_cell",
@@ -6458,25 +6150,25 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
  "colored",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-source-map 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-source-map",
+ "move-bytecode-utils",
  "move-cli",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-disassembler 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-disassembler",
  "move-ir-compiler",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-ir-types",
  "move-resource-viewer",
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-symbol-pool",
  "move-vm-runtime",
  "move-vm-test-utils",
  "move-vm-types",
@@ -6489,7 +6181,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6497,17 +6189,17 @@ dependencies = [
  "codespan-reporting",
  "colored",
  "itertools",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-command-line-common 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-compiler 0.0.1 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-ir-types 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-command-line-common",
+ "move-compiler",
+ "move-core-types",
+ "move-ir-types",
+ "move-model",
  "move-resource-viewer",
  "move-stackless-bytecode-interpreter",
  "move-stdlib",
- "move-symbol-pool 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-symbol-pool",
  "move-table-extension",
  "move-vm-runtime",
  "move-vm-test-utils",
@@ -6520,13 +6212,13 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "better_any",
  "fail 0.4.0",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-verifier 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-verifier",
+ "move-core-types",
  "move-vm-types",
  "once_cell",
  "parking_lot 0.11.2",
@@ -6537,11 +6229,11 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "move-table-extension",
  "move-vm-types",
  "once_cell",
@@ -6551,11 +6243,11 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-core-types",
  "once_cell",
  "proptest",
  "serde 1.0.144",
@@ -7081,8 +6773,8 @@ dependencies = [
  "anyhow",
  "framework",
  "itertools",
- "move-command-line-common 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
- "move-package 0.1.0 (git+https://github.com/aptos-labs/move?rev=77750b37bb3663d00a7c4058937fed42ceb3089e)",
+ "move-command-line-common",
+ "move-package",
  "tempfile",
 ]
 
@@ -8095,13 +7787,13 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-model 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
+ "move-model",
  "move-read-write-set-types",
  "move-stackless-bytecode",
  "read-write-set-dynamic",
@@ -8110,12 +7802,12 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5#94552a7fd7381b84376f6d7008d1f3110b5eccc5"
+source = "git+https://github.com/move-language/move?rev=0155b47808de249f4030e84354fde154a1500a82#0155b47808de249f4030e84354fde154a1500a82"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-bytecode-utils 0.1.0 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-binary-format",
+ "move-bytecode-utils",
+ "move-core-types",
  "move-read-write-set-types",
 ]
 
@@ -9229,7 +8921,7 @@ dependencies = [
  "assert_unordered",
  "bcs",
  "crossbeam-channel",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "once_cell",
  "parking_lot 0.12.1",
  "rayon",
@@ -10472,7 +10164,7 @@ dependencies = [
  "bcs",
  "cached-packages",
  "framework",
- "move-core-types 0.0.4 (git+https://github.com/move-language/move?rev=94552a7fd7381b84376f6d7008d1f3110b5eccc5)",
+ "move-core-types",
  "move-vm-types",
  "once_cell",
  "proptest",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -41,7 +41,7 @@ aptos-vm = { path = "../aptos-move/aptos-vm" }
 
 storage-interface = { path = "../storage/storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
 
 [dev-dependencies]
 aptos-api-test-context = { path = "./test-context", package = "aptos-api-test-context" }
@@ -55,7 +55,7 @@ regex = "1.5.5"
 reqwest = { version = "0.11.10", features = ["blocking", "json"], default_features = false }
 warp = { version = "0.3.2", features = ["default"] }
 
-move-package = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-package = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [features]
 failpoints = ["fail/failpoints"]

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -28,6 +28,6 @@ aptos-vm = { path = "../../aptos-move/aptos-vm" }
 
 storage-interface = { path = "../../storage/storage-interface" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }

--- a/aptos-move/aptos-aggregator/Cargo.toml
+++ b/aptos-move/aptos-aggregator/Cargo.toml
@@ -19,10 +19,10 @@ smallvec = "1.8.0"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [dev-dependencies]
 claims = "0.7"

--- a/aptos-move/aptos-gas/Cargo.toml
+++ b/aptos-move/aptos-gas/Cargo.toml
@@ -14,12 +14,12 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 clap = { version = "3.1.17", features = ["derive"] }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-model = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-model = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 aptos-global-constants = { path = "../../config/global-constants" }
 aptos-types = { path = "../../types" }

--- a/aptos-move/aptos-module-verifier/Cargo.toml
+++ b/aptos-move/aptos-module-verifier/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 edition = "2021"
 
 [dependencies]
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }

--- a/aptos-move/aptos-sdk-builder/Cargo.toml
+++ b/aptos-move/aptos-sdk-builder/Cargo.toml
@@ -23,7 +23,7 @@ textwrap = "0.15.0"
 
 aptos-types = { path = "../../types" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
 
 [dev-dependencies]
 cached-packages = { path = "../../aptos-move/framework/cached-packages" }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -34,20 +34,20 @@ aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 
 framework =  { path = "../framework" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 mvhashmap = { path = "../mvhashmap" }
 
-move-table-extension = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
-move-unit-test = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["table-extension"], optional = true }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["table-extension"], optional = true }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/aptos-move/aptos-vm/src/counters.rs
+++ b/aptos-move/aptos-vm/src/counters.rs
@@ -7,6 +7,15 @@ use aptos_metrics_core::{
 };
 use once_cell::sync::Lazy;
 
+/// Count the number of transactions that brake invariants of VM.
+pub static TRANSACTIONS_INVARIANT_VIOLATION: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_vm_transactions_invariant_violation",
+        "Number of transactions that broke VM invariant",
+    )
+    .unwrap()
+});
+
 /// Count the number of transactions validated, with a "status" label to
 /// distinguish success or failure results.
 pub static TRANSACTIONS_VALIDATED: Lazy<IntCounterVec> = Lazy::new(|| {

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -28,12 +28,13 @@ impl MoveVmExt {
         treat_friend_as_private: bool,
     ) -> VMResult<Self> {
         Ok(Self {
-            inner: MoveVM::new_with_verifier_config(
+            inner: MoveVM::new_with_configs(
                 aptos_natives(native_gas_params, abs_val_size_gas_params),
                 VerifierConfig {
                     max_loop_depth: Some(5),
                     treat_friend_as_private,
                 },
+                crate::AptosVM::get_runtime_config(),
             )?,
         })
     }

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -42,26 +42,26 @@ aptos-sdk-builder = { path = "../aptos-sdk-builder" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 gas-algebra-ext =  { path = "../gas-algebra-ext" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-core-types ={ git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-model ={ git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-package ={ git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-table-extension ={ git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-runtime ={ git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-types ={ git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-core-types ={ git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-model ={ git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-package ={ git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-table-extension ={ git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-runtime ={ git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-types ={ git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [dev-dependencies]
 claims = "0.7"
 
 aptos-gas = { path = "../../aptos-move/aptos-gas" }
 aptos-vm = { path = "../../aptos-move/aptos-vm", features = ["testing"] }
-move-cli = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-prover = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-cli = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-prover = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
-move-unit-test = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [features]
 default = []

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -19,7 +19,7 @@ proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 tempfile = "3.3.0"
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
 
 [build-dependencies]
 framework = { path = ".." }

--- a/aptos-move/gas-algebra-ext/Cargo.toml
+++ b/aptos-move/gas-algebra-ext/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -21,34 +21,34 @@ edition = "2021"
 #   actively looking for solutions.
 #
 ##########################################################################################
-move-abigen = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-cli = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-model = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-package = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-prover = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-cli = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-model = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-package = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-prover = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [features]
 default = []

--- a/aptos-move/package-builder/Cargo.toml
+++ b/aptos-move/package-builder/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.57"
 itertools = "0.10.0"
 tempfile = "3.3.0"
 
-move-command-line-common = { git = "https://github.com/aptos-labs/move", rev = "77750b37bb3663d00a7c4058937fed42ceb3089e" }
-move-package = { git = "https://github.com/aptos-labs/move", rev = "77750b37bb3663d00a7c4058937fed42ceb3089e" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-package = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 framework = { path = "../framework" }

--- a/aptos-move/vm-genesis/Cargo.toml
+++ b/aptos-move/vm-genesis/Cargo.toml
@@ -24,8 +24,8 @@ aptos-vm = { path = "../aptos-vm" }
 cached-packages =  { path = "../framework/cached-packages" }
 framework =  { path = "../framework" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -33,7 +33,7 @@ proptest-derive = "0.3.0"
 
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32", "fuzzing"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32", "fuzzing"] }
 
 [features]
 default = []

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -608,6 +608,10 @@ pub fn setup_environment(
     } else {
         info!("Genesis txn not provided, it's fine if you don't expect to apply it otherwise please double check config");
     }
+    AptosVM::set_runtime_config(
+        node_config.execution.paranoid_type_verification,
+        node_config.execution.paranoid_hot_potato_verification,
+    );
     AptosVM::set_concurrency_level_once(node_config.execution.concurrency_level as usize);
     AptosVM::set_num_proof_reading_threads_once(
         node_config.execution.num_proof_reading_threads as usize,

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -20,6 +20,8 @@ pub struct ExecutionConfig {
     pub genesis_file_location: PathBuf,
     pub concurrency_level: u16,
     pub num_proof_reading_threads: u16,
+    pub paranoid_type_verification: bool,
+    pub paranoid_hot_potato_verification: bool,
 }
 
 impl std::fmt::Debug for ExecutionConfig {
@@ -46,6 +48,8 @@ impl Default for ExecutionConfig {
             // Parallel execution by default.
             concurrency_level: 8,
             num_proof_reading_threads: 32,
+            paranoid_type_verification: true,
+            paranoid_hot_potato_verification: true,
         }
     }
 }

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -33,5 +33,5 @@ aptos-infallible = { path = "../aptos-infallible" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-types = { path = "../../types" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }

--- a/ecosystem/sf-indexer/firehose-stream/Cargo.toml
+++ b/ecosystem/sf-indexer/firehose-stream/Cargo.toml
@@ -36,9 +36,9 @@ aptos-types = { path = "../../../types" }
 aptos-vm = { path = "../../../aptos-move/aptos-vm" }
 storage-interface = { path = "../../../storage/storage-interface" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-package = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-package = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [dev-dependencies]
 goldenfile = "1.1.0"

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -32,7 +32,7 @@ executor-types = { path = "../executor-types" }
 scratchpad = { path = "../../storage/scratchpad" }
 storage-interface = { path = "../../storage/storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -45,8 +45,8 @@ schemadb = { path = "../schemadb" }
 scratchpad = { path = "../scratchpad" }
 storage-interface = { path = "../storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/storage/indexer/Cargo.toml
+++ b/storage/indexer/Cargo.toml
@@ -33,8 +33,8 @@ schemadb = { path = "../schemadb" }
 scratchpad = { path = "../scratchpad" }
 storage-interface = { path = "../storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -29,7 +29,7 @@ aptos-vm = { path = "../../aptos-move/aptos-vm" }
 
 scratchpad = { path = "../scratchpad" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
 
 [dev-dependencies]
 assert_unordered = "0.1.1"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -31,9 +31,9 @@ tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"]
 aptos-bitvec = { path = "../crates/aptos-bitvec" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32"] }
 
-move-table-extension = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82" }
 
 [dev-dependencies]
 claims = "0.7"
@@ -44,7 +44,7 @@ serde_json = "1.0.81"
 
 aptos-crypto = { path = "../crates/aptos-crypto", features = ["fuzzing"] }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "94552a7fd7381b84376f6d7008d1f3110b5eccc5", features = ["address32", "fuzzing"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "0155b47808de249f4030e84354fde154a1500a82", features = ["address32", "fuzzing"] }
 
 [features]
 default = []


### PR DESCRIPTION
### Description

Update the Move commit hash to enable runtime type checks in MoveVM. This is another defense measure against possible type confusions in the move bytecode verifier.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4547)
<!-- Reviewable:end -->
