### PR TITLE
[gha] Conditionally run pull request and pull request target based on files changed

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -25,6 +25,16 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
   workflow_dispatch:
   pull_request_target:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+    # For most PRs run workflows from main, not the PR commit for security
+    paths-ignore:
+      - 'documentation/**'
+      - '.github/**'
+  # For PR that modify .github, run from that PR
+  # This will fail to get secrets if you are not from aptos
+  pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+    paths:
+      - '.github/**'
   push:
     branches:
       - main
@@ -39,7 +49,7 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
 concurrency:
   # for push and workflow_dispatch events we use `github.sha` in the concurrency group and don't really cancel each other out/limit concurrency
   # for pull_request events newer jobs cancel earlier jobs to save on CI etc.
-  group: ${{ github.workflow }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.sha || github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
As a follow up to last week breakage, this attempts to run pull request and
pull request target to make sure that changes to a workflow using pull request
target are both forwards and backwards compatible.

For context, right now if you modify a workflow with pull reqeust target it
will not actually test the workflow on PR so you can break it completely and
the PR would just happily land immediately breaking all workflows!!!!

The longer term that would be ideal is getting rid of pull reqeust target
because currently its impossible to version.

Test Plan: ensure pull request running and passes on PR #e2e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4551)
<!-- Reviewable:end -->
