### PR TITLE
feat(ts-sdk): expose nodeUrl

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -50,6 +50,8 @@ interface PaginationArgs {
 export class AptosClient {
   client: Gen.AptosGeneratedClient;
 
+  readonly nodeUrl: string;
+
   /**
    * Build a client configured to connect to an Aptos node at the given URL.
    *
@@ -65,11 +67,13 @@ export class AptosClient {
       throw new Error("Node URL cannot be empty.");
     }
     const conf = config === undefined || config === null ? {} : { ...config };
+
     if (doNotFixNodeUrl) {
-      conf.BASE = nodeUrl;
+      this.nodeUrl = nodeUrl;
     } else {
-      conf.BASE = fixNodeUrl(nodeUrl);
+      this.nodeUrl = fixNodeUrl(nodeUrl);
     }
+    conf.BASE = this.nodeUrl;
 
     // Do not carry cookies when `WITH_CREDENTIALS` is explicitly set to `false`. By default, cookies will be sent
     if (config?.WITH_CREDENTIALS === false) {


### PR DESCRIPTION
### Description
nodeUrl could be useful information for many use cases. Per user request, re-expose nodeUrl.

### Test Plan
yarn test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4553)
<!-- Reviewable:end -->
