### PR TITLE
[compression] limit (de)compression, to network application limit size

### DIFF
--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -129,7 +129,8 @@ pub fn decompress(
     Ok(raw_data)
 }
 
-// Derived from lz4 library
+/// Derived from lz4-rs crate, which starts the compressed payload with the original data size as i32
+/// see: https://github.com/10XGenomics/lz4-rs/blob/0abc0a52af1f6010f9a57640b1dc8eb8d2d697aa/src/block/mod.rs#L162
 fn get_decompressed_size(src: &CompressedData, max_size: usize) -> std::io::Result<usize> {
     if src.len() < 4 {
         return Err(Error::new(

--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -53,7 +53,7 @@ pub fn compress(
             increment_compression_error(COMPRESS, client);
             return Err(CompressionError(format!(
                 "Failed to compress the data: {}",
-                error.to_string()
+                error
             )));
         }
     };
@@ -100,7 +100,7 @@ pub fn decompress(
             increment_compression_error(DECOMPRESS, client);
             return Err(CompressionError(format!(
                 "Failed to decompress the data: {}",
-                error.to_string()
+                error
             )));
         }
     };
@@ -111,7 +111,7 @@ pub fn decompress(
         increment_compression_error(DECOMPRESS, client);
         return Err(CompressionError(format!(
             "Failed to decompress the data: {}",
-            error.to_string()
+            error
         )));
     };
 

--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -60,7 +60,7 @@ pub fn compress(
 
     if compressed_data.len() > max_bytes {
         return Err(CompressionError(format!(
-            "Compressed size too big: {} > {}",
+            "Compressed size greater than max. size: {}, max: {}",
             compressed_data.len(),
             max_bytes
         )));
@@ -99,7 +99,7 @@ pub fn decompress(
         Err(error) => {
             increment_compression_error(DECOMPRESS, client);
             return Err(CompressionError(format!(
-                "Failed to decompress the data: {}",
+                "Failed to get decompressed size: {}",
                 error
             )));
         }
@@ -149,14 +149,16 @@ fn get_decompressed_size(src: &CompressedData, max_size: usize) -> std::io::Resu
         ));
     }
 
-    if size as usize > max_size {
+    let size = size as usize;
+
+    if size > max_size {
         return Err(Error::new(
             ErrorKind::InvalidInput,
             format!("Given size parameter is too big: {} > {}", size, max_size),
         ));
     }
 
-    Ok(size as usize)
+    Ok(size)
 }
 
 /// Calculates the relative size (%) between the input and output after a

--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -8,6 +8,7 @@ use crate::metrics::{
 };
 use aptos_logger::prelude::*;
 use lz4::block::CompressionMode;
+use std::io::{Error, ErrorKind};
 use thiserror::Error;
 
 /// This crate provides a simple library interface for data compression.
@@ -39,6 +40,7 @@ pub struct CompressionError(String);
 pub fn compress(
     raw_data: Vec<u8>,
     client: CompressionClient,
+    max_bytes: usize,
 ) -> Result<CompressedData, CompressionError> {
     // Start the compression timer
     let timer = start_compression_operation_timer(COMPRESS, client.clone());
@@ -50,11 +52,19 @@ pub fn compress(
         Err(error) => {
             increment_compression_error(COMPRESS, client);
             return Err(CompressionError(format!(
-                "Failed to compress the data: {:?}",
+                "Failed to compress the data: {}",
                 error.to_string()
             )));
         }
     };
+
+    if compressed_data.len() > max_bytes {
+        return Err(CompressionError(format!(
+            "Compressed size too big: {} > {}",
+            compressed_data.len(),
+            max_bytes
+        )));
+    }
 
     // Stop the timer and update the metrics
     let compression_duration = timer.stop_and_record();
@@ -64,7 +74,7 @@ pub fn compress(
     // Log the relative data compression statistics
     let relative_data_size = calculate_relative_size(&raw_data, &compressed_data);
     trace!(
-        "Compressed {:?} bytes to {:?} bytes ({:?} %) in {:?} seconds.",
+        "Compressed {} bytes to {} bytes ({} %) in {} seconds.",
         raw_data.len(),
         compressed_data.len(),
         relative_data_size,
@@ -78,27 +88,38 @@ pub fn compress(
 pub fn decompress(
     compressed_data: &CompressedData,
     client: CompressionClient,
+    max_size: usize,
 ) -> Result<Vec<u8>, CompressionError> {
     // Start the decompression timer
     let timer = start_compression_operation_timer(DECOMPRESS, client.clone());
 
-    // Decompress the data
-    let raw_data = match lz4::block::decompress(compressed_data, None) {
-        Ok(raw_data) => raw_data,
+    // Check size of the data and initialize raw_data
+    let size = match get_decompressed_size(compressed_data, max_size) {
+        Ok(size) => size,
         Err(error) => {
             increment_compression_error(DECOMPRESS, client);
             return Err(CompressionError(format!(
-                "Failed to decompress the data: {:?}",
+                "Failed to decompress the data: {}",
                 error.to_string()
             )));
         }
+    };
+    let mut raw_data = vec![0u8; size];
+
+    // Decompress the data
+    if let Err(error) = lz4::block::decompress_to_buffer(compressed_data, None, &mut raw_data) {
+        increment_compression_error(DECOMPRESS, client);
+        return Err(CompressionError(format!(
+            "Failed to decompress the data: {}",
+            error.to_string()
+        )));
     };
 
     // Stop the timer and log the relative data compression statistics
     let decompression_duration = timer.stop_and_record();
     let relative_data_size = calculate_relative_size(compressed_data, &raw_data);
     trace!(
-        "Decompressed {:?} bytes to {:?} bytes ({:?} %) in {:?} seconds.",
+        "Decompressed {} bytes to {} bytes ({} %) in {} seconds.",
         compressed_data.len(),
         raw_data.len(),
         relative_data_size,
@@ -106,6 +127,35 @@ pub fn decompress(
     );
 
     Ok(raw_data)
+}
+
+// Derived from lz4 library
+fn get_decompressed_size(src: &CompressedData, max_size: usize) -> std::io::Result<usize> {
+    if src.len() < 4 {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Source buffer must at least contain size prefix.",
+        ));
+    }
+
+    let size =
+        (src[0] as i32) | (src[1] as i32) << 8 | (src[2] as i32) << 16 | (src[3] as i32) << 24;
+
+    if size < 0 {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "Parsed size prefix in buffer must not be negative.",
+        ));
+    }
+
+    if size as usize > max_size {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("Given size parameter is too big: {} > {}", size, max_size),
+        ));
+    }
+
+    Ok(size as usize)
 }
 
 /// Calculates the relative size (%) between the input and output after a

--- a/crates/aptos-compression/src/tests.rs
+++ b/crates/aptos-compression/src/tests.rs
@@ -20,6 +20,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::fmt::Debug;
 
+const MAX_COMPRESSION_SIZE: usize = 64 * 1024 * 1024;
+
 #[test]
 fn test_basic_compression() {
     // Test epoch ending ledger infos
@@ -35,14 +37,25 @@ fn test_basic_compression() {
     test_compress_and_decompress(transactions_with_proof);
 }
 
+#[test]
+fn test_compression_limits() {}
+
 /// Ensures that the given object can be compressed and decompressed successfully
 /// when BCS encoded.
 fn test_compress_and_decompress<T: Debug + DeserializeOwned + PartialEq + Serialize>(object: T) {
     let bcs_encoded_bytes = bcs::to_bytes(&object).unwrap();
-    let compressed_bytes =
-        crate::compress(bcs_encoded_bytes, CompressionClient::StateSync).unwrap();
-    let decompressed_bytes =
-        crate::decompress(&compressed_bytes, CompressionClient::StateSync).unwrap();
+    let compressed_bytes = crate::compress(
+        bcs_encoded_bytes,
+        CompressionClient::StateSync,
+        MAX_COMPRESSION_SIZE,
+    )
+    .unwrap();
+    let decompressed_bytes = crate::decompress(
+        &compressed_bytes,
+        CompressionClient::StateSync,
+        MAX_COMPRESSION_SIZE,
+    )
+    .unwrap();
     let decoded_object = bcs::from_bytes::<T>(&decompressed_bytes).unwrap();
 
     assert_eq!(object, decoded_object);

--- a/crates/aptos-compression/src/tests.rs
+++ b/crates/aptos-compression/src/tests.rs
@@ -38,7 +38,34 @@ fn test_basic_compression() {
 }
 
 #[test]
-fn test_compression_limits() {}
+fn test_compression_limits() {
+    let too_small_bytes = 1;
+    let transactions_with_proof = create_transaction_list_with_proof(1000, 1999, 1999, true);
+
+    // Test compression limit
+    let bcs_encoded_bytes = bcs::to_bytes(&transactions_with_proof).unwrap();
+    let maybe_compressed_bytes = crate::compress(
+        bcs_encoded_bytes,
+        CompressionClient::StateSync,
+        too_small_bytes,
+    );
+    assert!(maybe_compressed_bytes.is_err());
+
+    // Test decompression limit
+    let bcs_encoded_bytes = bcs::to_bytes(&transactions_with_proof).unwrap();
+    let compressed_bytes = crate::compress(
+        bcs_encoded_bytes,
+        CompressionClient::StateSync,
+        MAX_COMPRESSION_SIZE,
+    )
+    .unwrap();
+    let maybe_decompressed_bytes = crate::decompress(
+        &compressed_bytes,
+        CompressionClient::StateSync,
+        too_small_bytes,
+    );
+    assert!(maybe_decompressed_bytes.is_err());
+}
 
 /// Ensures that the given object can be compressed and decompressed successfully
 /// when BCS encoded.

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -5,7 +5,7 @@ use crate::core_mempool::{CoreMempool, TimelineState, TxnPointer};
 use crate::network::MempoolSyncMsg;
 use anyhow::{format_err, Result};
 use aptos_compression::metrics::CompressionClient;
-use aptos_config::config::NodeConfig;
+use aptos_config::config::{NodeConfig, MAX_APPLICATION_MESSAGE_SIZE};
 use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
 use aptos_types::{
     account_address::AccountAddress,
@@ -181,7 +181,12 @@ impl ConsensusMock {
 /// Decompresses and deserializes the raw message bytes into a message struct
 pub fn decompress_and_deserialize(message_bytes: &Vec<u8>) -> MempoolSyncMsg {
     bcs::from_bytes(
-        &aptos_compression::decompress(message_bytes, CompressionClient::Mempool).unwrap(),
+        &aptos_compression::decompress(
+            message_bytes,
+            CompressionClient::Mempool,
+            MAX_APPLICATION_MESSAGE_SIZE,
+        )
+        .unwrap(),
     )
     .unwrap()
 }


### PR DESCRIPTION
### Description

Adding limits to compression:
* On the receiving end, a limit is needed to prevent malicious node from sending messages that decompress into a large size. Given lz4, decompression could have been as large as 2 GiB (i32::MAX).
* On the sending end, a limit is needed to ensure delivery of the compressed message to honest nodes.

Each call will have to set a limit; for network messages `MAX_APPLICATION_MESSAGE_SIZE` should be a good value as anyway the message needs to be sent over the network.

### Test Plan

Add unit test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4556)
<!-- Reviewable:end -->
