### PR TITLE
[dev setup] Ensure unzip installed before protoc

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -885,6 +885,7 @@ fi
 
 if [[ "$INSTALL_PROTOC" == "true" ]]; then
   if [[ "$INSTALL_BUILD_TOOLS" == "false" ]]; then
+    install_pkg unzip "$PACKAGE_MANAGER"
     install_protoc
   fi
 fi


### PR DESCRIPTION
### Description
This failed on a new machine because unzip didn't exist.  Now it's fixed.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4557)
<!-- Reviewable:end -->
