### PR TITLE
[Aptos Stdlib][Audit] Make scaling factor actually useful in pool_u64

### DIFF
--- a/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.move
+++ b/aptos-move/framework/aptos-stdlib/sources/cryptography/bls12381.move
@@ -430,7 +430,6 @@ module aptos_std::bls12381 {
         while (i < std::vector::length(&sigs)) {
             std::vector::push_back(&mut accum_sigs, *std::vector::borrow(&sigs, i));
 
-            std::debug::print(&i);
             let multisig = option::extract(&mut aggregate_signatures(accum_sigs));
 
             // Make sure sigs were aggregated correctly


### PR DESCRIPTION
### Description
Currently scaling_factor is useless as the calculation multiplies by it and then immediately divides. This PR makes it useful in minimize rounding errors by multiplying shares by it.

### Test Plan
Unit tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4558)
<!-- Reviewable:end -->
