### PR TITLE
[Api] Expose Move error details for simulation endpoints

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -1117,7 +1117,7 @@ impl TransactionsApi {
 
         // Simulate transaction
         let move_resolver = self.context.move_resolver_poem(&ledger_info)?;
-        let (status, output_ext) = AptosVM::simulate_signed_transaction(&txn, &move_resolver);
+        let (_, output_ext) = AptosVM::simulate_signed_transaction(&txn, &move_resolver);
         let version = ledger_info.version();
 
         // Apply transaction outputs to build up a transaction
@@ -1127,7 +1127,7 @@ impl TransactionsApi {
         let output = output_ext.into_transaction_output(&move_resolver);
 
         // Ensure that all known statuses return their values in the output (even if they aren't supposed to)
-        let exe_status = match status.into() {
+        let exe_status = match output.status().clone() {
             TransactionStatus::Keep(exec_status) => exec_status,
             TransactionStatus::Discard(status) => ExecutionStatus::MiscellaneousError(Some(status)),
             _ => ExecutionStatus::MiscellaneousError(None),


### PR DESCRIPTION
### Description
Simulation endpoints did not expose Move error details. Aptos wrapped Move execution error details in execution output not the vanilla Move execution status. This PR allows clients to see the Move error details when running the simulations.

### Test Plan
Manually tested.
Before, printing exec_status:
MoveAbort { location: 0000000000000000000000000000000000000000000000000000000000000003::token, code: 65543, info: None }
After, printing exec_status:
MoveAbort { location: 0000000000000000000000000000000000000000000000000000000000000003::token, code: 65543, info: Some(AbortInfo { reason_name: "EMINT_WOULD_EXCEED_TOKEN_MAXIMUM", description: "Exceed the token data maximal allowed" }) }

End to end:
![Screen Shot 2022-09-26 at 4 57 05 PM](https://user-images.githubusercontent.com/962285/192400984-2054c355-58f5-44c2-a028-c702280618a7.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4562)
<!-- Reviewable:end -->
