### PR TITLE
[sdk-builder] Ensure string encoding is named a separate function

### DIFF
--- a/aptos-move/aptos-sdk-builder/src/common.rs
+++ b/aptos-move/aptos-sdk-builder/src/common.rs
@@ -113,7 +113,7 @@ pub(crate) fn mangle_type(type_tag: &TypeTag) -> String {
             _ => format!("vec{}", mangle_type(type_tag)),
         },
         Struct(tag) => match tag {
-            tag if tag == Lazy::force(&str_tag) => "u8vector".into(),
+            tag if tag == Lazy::force(&str_tag) => "string".into(),
             _ => type_not_allowed(type_tag),
         },
         Signer => type_not_allowed(type_tag),

--- a/aptos-move/aptos-sdk-builder/src/golang.rs
+++ b/aptos-move/aptos-sdk-builder/src/golang.rs
@@ -724,7 +724,7 @@ func decode_{0}_argument(arg aptostypes.TransactionArgument) (value {1}, err err
                 format!("[]{}", Self::quote_type(type_tag))
             }
             Struct(struct_tag) => match struct_tag {
-                tag if tag == Lazy::force(&str_tag) => "Bytes".into(),
+                tag if tag == Lazy::force(&str_tag) => "[]uint8".into(),
                 _ => common::type_not_allowed(type_tag),
             },
             Signer => common::type_not_allowed(type_tag),


### PR DESCRIPTION
### Description
Go SDK generation was conflicting on string and vec<u8> and we'll assume this will be an issue in other languages as well, so we rename the base type.

Additionally, fix the type for Go.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4563)
<!-- Reviewable:end -->
