### PR TITLE
[txn-emitter] Fix underflow when first request fails

### DIFF
--- a/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
+++ b/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
@@ -332,7 +332,7 @@ pub async fn submit_transactions(
                             client
                                 .get_account_transactions_bcs(
                                     sender,
-                                    Some(account.into_inner().sequence_number() - 1),
+                                    Some(account.into_inner().sequence_number().saturating_sub(1)),
                                     Some(5),
                                 )
                                 .await


### PR DESCRIPTION
This debugging log was added to show txns around the failure, but when it is the first request, there is no previous transaction.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4567)
<!-- Reviewable:end -->
