### PR TITLE
[Genesis][Tooling] Allow skipping operator config file if validator is not joining genesis validator set

### DIFF
--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -195,14 +195,14 @@ impl TryFrom<&ValidatorNodeConfig> for ValidatorConfiguration {
             operator_account_public_key: private_identity.account_private_key.public_key(),
             voter_account_address: private_identity.account_address,
             voter_account_public_key: private_identity.account_private_key.public_key(),
-            consensus_public_key: private_identity.consensus_private_key.public_key(),
-            proof_of_possession: bls12381::ProofOfPossession::create(
+            consensus_public_key: Some(private_identity.consensus_private_key.public_key()),
+            proof_of_possession: Some(bls12381::ProofOfPossession::create(
                 &private_identity.consensus_private_key,
+            )),
+            validator_network_public_key: Some(
+                private_identity.validator_network_private_key.public_key(),
             ),
-            validator_network_public_key: private_identity
-                .validator_network_private_key
-                .public_key(),
-            validator_host,
+            validator_host: Some(validator_host),
             full_node_network_public_key: Some(
                 private_identity.full_node_network_private_key.public_key(),
             ),

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -225,10 +225,6 @@ fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfigurat
     let owner_file = owner_file.as_path();
     let owner_config = client.get::<StringOwnerConfiguration>(owner_file)?;
 
-    let operator_file = dir.join(OPERATOR_FILE);
-    let operator_file = operator_file.as_path();
-    let operator_config = client.get::<StringOperatorConfiguration>(operator_file)?;
-
     // Check and convert fields in owner file
     let owner_account_address = parse_required_option(
         &owner_config.owner_account_address,
@@ -283,7 +279,7 @@ fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfigurat
         "commission_percentage",
         u64::from_str,
     )?
-    .unwrap_or_default();
+    .unwrap_or(0);
 
     // Default to true for whether the validator should be joining during genesis.
     let join_during_genesis = parse_optional_option(
@@ -293,6 +289,31 @@ fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfigurat
         bool::from_str,
     )?
     .unwrap_or(true);
+
+    // We don't require the operator file if the validator is not joining during genesis.
+    if !join_during_genesis {
+        return Ok(ValidatorConfiguration {
+            owner_account_address,
+            owner_account_public_key,
+            operator_account_address,
+            operator_account_public_key,
+            voter_account_address,
+            voter_account_public_key,
+            consensus_public_key: None,
+            proof_of_possession: None,
+            validator_network_public_key: None,
+            validator_host: None,
+            full_node_network_public_key: None,
+            full_node_host: None,
+            stake_amount,
+            commission_percentage,
+            join_during_genesis,
+        });
+    };
+
+    let operator_file = dir.join(OPERATOR_FILE);
+    let operator_file = operator_file.as_path();
+    let operator_config = client.get::<StringOperatorConfiguration>(operator_file)?;
 
     // Check and convert fields in operator file
     let operator_account_address_from_file = parse_required_option(
@@ -316,7 +337,7 @@ fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfigurat
     let consensus_proof_of_possession = parse_required_option(
         &operator_config.consensus_proof_of_possession,
         operator_file,
-        "consensus_proof_of_possesion",
+        "consensus_proof_of_possession",
         bls12381::ProofOfPossession::from_encoded_string,
     )?;
     let validator_network_public_key = parse_required_option(
@@ -362,10 +383,10 @@ fn get_config(client: &Client, user: &str) -> CliTypedResult<ValidatorConfigurat
         operator_account_public_key,
         voter_account_address,
         voter_account_public_key,
-        consensus_public_key,
-        proof_of_possession: consensus_proof_of_possession,
-        validator_network_public_key,
-        validator_host: operator_config.validator_host,
+        consensus_public_key: Some(consensus_public_key),
+        proof_of_possession: Some(consensus_proof_of_possession),
+        validator_network_public_key: Some(validator_network_public_key),
+        validator_host: Some(operator_config.validator_host),
         full_node_network_public_key,
         full_node_host: operator_config.full_node_host,
         stake_amount,

--- a/terraform/helm/genesis/files/genesis.sh
+++ b/terraform/helm/genesis/files/genesis.sh
@@ -86,7 +86,8 @@ for i in $(seq 0 $(($NUM_VALIDATORS-1))); do
         --username $username \
         --validator-host $validator_host \
         --full-node-host $fullnode_host \
-        --stake-amount $CUR_STAKE_AMOUNT
+        --stake-amount $CUR_STAKE_AMOUNT \
+        --join-during-genesis
 done
 
 # get the framework


### PR DESCRIPTION
### Description
This will save validators who are joining post genesis from having to generate and verify operator.yaml file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4569)
<!-- Reviewable:end -->
