### PR TITLE
[telemetry-service] Metrics instrumentation and tracing bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,17 +1265,20 @@ dependencies = [
  "aptos-crypto-derive",
  "aptos-infallible",
  "aptos-logger",
+ "aptos-metrics-core",
  "aptos-rest-client",
  "aptos-types",
  "base64 0.13.0",
  "bcs 0.1.3 (git+https://github.com/aptos-labs/bcs?rev=f94869cdfa1b5d2c9892016e8fb0c59fda1eea2d)",
  "chrono",
  "clap 3.2.17",
+ "debug-ignore",
  "flate2",
  "gcp-bigquery-client",
  "hex",
  "httpmock",
  "jsonwebtoken",
+ "once_cell",
  "prometheus",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -3196,6 +3199,15 @@ dependencies = [
  "executor",
  "storage-interface",
  "structopt 0.3.26",
+]
+
+[[package]]
+name = "debug-ignore"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b48b0b49e2f473c499ddcd133e78f0f2629aaa997ee61adadb2d1753e6af4cf"
+dependencies = [
+ "serde 1.0.144",
 ]
 
 [[package]]

--- a/crates/aptos-telemetry-service/Cargo.toml
+++ b/crates/aptos-telemetry-service/Cargo.toml
@@ -16,6 +16,7 @@ aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../../crates/aptos-crypto-derive" }
 aptos-infallible = { path = "../../crates/aptos-infallible" }
 aptos-logger = { path = "../../crates/aptos-logger" }
+aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
 aptos-rest-client = { path = "../../crates/aptos-rest-client" }
 aptos-types = { path = "../../types" }
 
@@ -24,10 +25,12 @@ base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs", rev = "f94869cdfa1b5d2c9892016e8fb0c59fda1eea2d" }
 chrono = "0.4"
 clap = "3.1.8"
+debug-ignore = { version = "1.0.3", features = ["serde"] }
 flate2 = "1.0.24"
 gcp-bigquery-client = "0.13"
 hex = "0.4.3"
 jsonwebtoken = "8.1"
+once_cell = "1.10.0"
 prometheus = { version = "0.13.1", default-features = false }
 rand = "0.7.3"
 rand_core = { version = "0.5.1", default-features = false }

--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -2,20 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::context::Context;
-use crate::error::ServiceError;
+use crate::error::{AuthError, ServiceError, ServiceErrorCode};
 use crate::jwt_auth::{authorize_jwt, create_jwt_token, jwt_from_header};
 use crate::types::auth::{AuthRequest, AuthResponse, Claims};
 use crate::types::common::NodeType;
-use anyhow::{anyhow, Result};
-use aptos_config::config::{PeerRole, RoleType};
-use aptos_crypto::{noise, x25519};
-use aptos_types::chain_id::ChainId;
-use aptos_types::PeerId;
+
+use anyhow::Result;
 use reqwest::header::AUTHORIZATION;
 use tracing::{debug, error, warn};
 use warp::filters::BoxedFilter;
 use warp::{reject, Filter, Rejection};
 use warp::{reply, Reply};
+
+use aptos_config::config::{PeerRole, RoleType};
+use aptos_crypto::{noise, x25519};
+use aptos_types::chain_id::ChainId;
+use aptos_types::PeerId;
 
 pub fn auth(context: Context) -> BoxedFilter<(impl Reply,)> {
     warp::path!("auth")
@@ -37,7 +39,7 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
     // invalid server public key.
     if body.server_public_key != context.noise_config().public_key() {
         return Err(reject::custom(ServiceError::bad_request(
-            "invalid public key",
+            ServiceErrorCode::AuthError(AuthError::InvalidServerPublicKey, body.chain_id),
         )));
     }
 
@@ -55,9 +57,10 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
         .parse_client_init_message(&prologue, client_init_message)
         .map_err(|e| {
             debug!("error performing noise handshake: {}", e);
-            reject::custom(ServiceError::invalid_request_body(
-                "error performing handshake",
-            ))
+            reject::custom(ServiceError::bad_request(ServiceErrorCode::AuthError(
+                AuthError::NoiseHandshakeError(e),
+                body.chain_id,
+            )))
         })?;
 
     let cache = if body.role_type == RoleType::Validator {
@@ -74,7 +77,10 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
                     if !peer.keys.contains(remote_public_key) {
                         warn!("peer found in peer set but public_key is not found. request body: {}, role_type: {}, peer_id: {}, received public_key: {}", body.chain_id, body.role_type, body.peer_id, remote_public_key);
                         return Err(reject::custom(ServiceError::forbidden(
-                            "public key not found in peer keys",
+                            ServiceErrorCode::AuthError(
+                                AuthError::PeerPublicKeyNotFound,
+                                body.chain_id,
+                            ),
                         )));
                     }
                     Ok((*epoch, peer.role))
@@ -85,7 +91,10 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
                         aptos_types::account_address::from_identity_public_key(remote_public_key);
                     if derived_remote_peer_id != body.peer_id {
                         return Err(reject::custom(ServiceError::forbidden(
-                            "public key does not match identity",
+                            ServiceErrorCode::AuthError(
+                                AuthError::PublicKeyMismatch,
+                                body.chain_id,
+                            ),
                         )));
                     } else {
                         Ok((*epoch, PeerRole::Unknown))
@@ -98,10 +107,9 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
                 "Validator set unavailable for Chain ID {}. Rejecting request.",
                 body.chain_id
             );
-            Err(reject::custom(ServiceError::unauthorized(format!(
-                "unable to authenticate: validator set unavailable for supplied chain id {}",
-                body.chain_id
-            ))))
+            Err(reject::custom(ServiceError::unauthorized(
+                ServiceErrorCode::AuthError(AuthError::ValidatorSetUnavailable, body.chain_id),
+            )))
         }
     }?;
 
@@ -132,7 +140,10 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
     )
     .map_err(|e| {
         error!("unable to create jwt token: {}", e);
-        reject::custom(ServiceError::internal(anyhow!("unable to authenticate")))
+        reject::custom(ServiceError::internal(ServiceErrorCode::AuthError(
+            AuthError::from(e),
+            body.chain_id,
+        )))
     })?;
 
     let mut rng = rand::rngs::OsRng;
@@ -148,7 +159,10 @@ pub async fn handle_auth(context: Context, body: AuthRequest) -> Result<impl Rep
         )
         .map_err(|e| {
             error!("unable to complete handshake {}", e);
-            ServiceError::internal(anyhow!("error during authentication"))
+            ServiceError::internal(ServiceErrorCode::AuthError(
+                AuthError::NoiseHandshakeError(e),
+                body.chain_id,
+            ))
         })?;
 
     Ok(reply::json(&AuthResponse {

--- a/crates/aptos-telemetry-service/src/constants.rs
+++ b/crates/aptos-telemetry-service/src/constants.rs
@@ -1,7 +1,13 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-// The maximum content length to accept in the http body.
+/// The maximum content length to accept in the http body.
 pub const MAX_CONTENT_LENGTH: u64 = 1024 * 1024;
 
+/// GCP Header field for the current request's trace ID.
 pub const GCP_CLOUD_TRACE_CONTEXT_HEADER: &str = "X-Cloud-Trace-Context";
+
+/// GCP Cloud Run env variable for the current deployment revision
+pub const GCP_CLOUD_RUN_REVISION_ENV: &str = "K_REVISION";
+/// GCP Cloud Run env variable for service name
+pub const GCP_CLOUD_RUN_SERVICE_ENV: &str = "K_SERVICE";

--- a/crates/aptos-telemetry-service/src/constants.rs
+++ b/crates/aptos-telemetry-service/src/constants.rs
@@ -5,4 +5,3 @@
 pub const MAX_CONTENT_LENGTH: u64 = 1024 * 1024;
 
 pub const GCP_CLOUD_TRACE_CONTEXT_HEADER: &str = "X-Cloud-Trace-Context";
-pub const LOG_TRACE_FIELD: &str = "logging.googleapis.com/trace";

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -6,7 +6,8 @@ use std::time::Duration;
 use crate::{
     auth::with_auth,
     context::Context,
-    error::ServiceError,
+    error::{CustomEventIngestError, ServiceError},
+    metrics::BIG_QUERY_BACKEND_REQUEST_DURATION,
     types::{
         auth::Claims,
         common::{EventIdentity, NodeType},
@@ -16,8 +17,9 @@ use crate::{
 use anyhow::anyhow;
 use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
 use serde_json::json;
+use tokio::time::Instant;
 use tracing::{debug, error};
-use warp::{filters::BoxedFilter, reject, reply, Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, hyper::StatusCode, reject, reply, Filter, Rejection, Reply};
 
 /// TODO: Cleanup after v1 API is ramped up
 pub fn custom_event_legacy(context: Context) -> BoxedFilter<(impl Reply,)> {
@@ -65,15 +67,14 @@ pub(crate) async fn handle_custom_event(
         .user_id
         .eq_ignore_ascii_case(&claims.peer_id.to_string())
     {
-        return Err(reject::custom(ServiceError::bad_request(format!(
-            "user_id {} in event does not match peer_id {}",
-            body.user_id, claims.peer_id
-        ))));
+        return Err(reject::custom(ServiceError::bad_request(
+            CustomEventIngestError::InvalidEvent(body.user_id, claims.peer_id).into(),
+        )));
     }
 
     if body.events.is_empty() {
         return Err(reject::custom(ServiceError::bad_request(
-            "no events found in payload",
+            CustomEventIngestError::EmptyPayload.into(),
         )));
     }
 
@@ -91,12 +92,12 @@ pub(crate) async fn handle_custom_event(
         })
         .collect();
 
-    let duration = Duration::from_micros(
-        body.timestamp_micros
-            .as_str()
-            .parse::<u64>()
-            .map_err(|_| ServiceError::bad_request("unable to parse timestamp"))?,
-    );
+    let duration =
+        Duration::from_micros(body.timestamp_micros.as_str().parse::<u64>().map_err(|_| {
+            ServiceError::bad_request(
+                CustomEventIngestError::InvalidTimestamp(body.timestamp_micros).into(),
+            )
+        })?);
 
     let row = BigQueryRow {
         event_identity: EventIdentity::from(claims),
@@ -107,23 +108,45 @@ pub(crate) async fn handle_custom_event(
 
     insert_request.add_row(None, &row).map_err(|e| {
         error!("unable to create row: {}", e);
-        ServiceError::from(anyhow!("unable to insert row into bigquery"))
+        ServiceError::internal(CustomEventIngestError::from(e).into())
     })?;
+
+    let start_timer = Instant::now();
 
     context
         .bigquery_client()
         .ok_or_else(|| {
             error!("big query client is not configured");
-            ServiceError::from(anyhow!("unable to insert row into bigquery"))
+            ServiceError::internal(
+                CustomEventIngestError::from(anyhow!("BQ client is not configured")).into(),
+            )
         })?
         .insert_all(insert_request)
         .await
         .map_err(|e| {
+            BIG_QUERY_BACKEND_REQUEST_DURATION
+                .with_label_values(&["request_error"])
+                .observe(start_timer.elapsed().as_millis() as f64);
             error!("unable to insert row into bigquery: {}", e);
-            ServiceError::from(anyhow!("unable to insert row into bigquery"))
+            ServiceError::internal(CustomEventIngestError::from(e).into())
+        })
+        .and_then(|result| {
+            if let Some(err) = result.insert_errors {
+                BIG_QUERY_BACKEND_REQUEST_DURATION
+                    .with_label_values(&["insert_error"])
+                    .observe(start_timer.elapsed().as_millis() as f64);
+                Err(ServiceError::bad_request(
+                    CustomEventIngestError::from(err[0].clone()).into(),
+                ))
+            } else {
+                BIG_QUERY_BACKEND_REQUEST_DURATION
+                    .with_label_values(&["success"])
+                    .observe(start_timer.elapsed().as_millis() as f64);
+                Ok(result)
+            }
         })?;
 
     debug!("row inserted succeefully: {:?}", &row);
 
-    Ok(reply::reply())
+    Ok(reply::with_status(reply::reply(), StatusCode::CREATED))
 }

--- a/crates/aptos-telemetry-service/src/error.rs
+++ b/crates/aptos-telemetry-service/src/error.rs
@@ -1,70 +1,190 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
+use std::fmt::{self, Debug};
+
+use aptos_crypto::noise::NoiseError;
+use aptos_rest_client::error::RestError;
+use aptos_types::{chain_id::ChainId, PeerId};
+use debug_ignore::DebugIgnore;
+use gcp_bigquery_client::{
+    error::BQError,
+    model::table_data_insert_all_response_insert_errors::TableDataInsertAllResponseInsertErrors,
+};
+use thiserror::Error as ThisError;
 use warp::{http::StatusCode, reject::Reject};
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-pub struct ServiceError {
-    pub code: u16,
-    pub message: String,
+#[derive(Debug, ThisError)]
+pub(crate) enum AuthError {
+    #[error("invalid public key")]
+    InvalidServerPublicKey,
+    #[error("error performing noise handshake")]
+    NoiseHandshakeError(NoiseError),
+    #[error("public key not found in peer keys")]
+    PeerPublicKeyNotFound,
+    #[error("public key does not match identity")]
+    PublicKeyMismatch,
+    #[error("validator set unavailable for chain")]
+    ValidatorSetUnavailable,
+    #[error("unable to authenticate")]
+    CreateJwtError(DebugIgnore<jsonwebtoken::errors::Error>),
+}
+
+impl From<jsonwebtoken::errors::Error> for AuthError {
+    fn from(val: jsonwebtoken::errors::Error) -> Self {
+        Self::CreateJwtError(DebugIgnore(val))
+    }
+}
+
+#[derive(Debug, ThisError)]
+pub(crate) enum JwtAuthError {
+    #[error("invalid authorization token")]
+    InvalidAuthToken,
+    #[error("expired authorization token")]
+    ExpiredAuthToken,
+    #[error("access denied to this resource")]
+    AccessDenied,
+    #[error("invalid authorization header: {0}")]
+    InvalidAuthHeader(DebugIgnore<String>),
+}
+
+impl From<String> for JwtAuthError {
+    fn from(val: String) -> Self {
+        Self::InvalidAuthHeader(DebugIgnore(val))
+    }
+}
+
+#[derive(Debug, ThisError)]
+pub(crate) enum CustomEventIngestError {
+    #[error("user_id {0} in event does not match peer_id {1}")]
+    InvalidEvent(String, PeerId),
+    #[error("no events in payload")]
+    EmptyPayload,
+    #[error("invalid payload timestamp: {0}")]
+    InvalidTimestamp(String),
+    #[error("unable to insert row into big query")]
+    BigQueryClientError(DebugIgnore<BQError>),
+    #[error("invalid payload schema: {0}")]
+    BigQueryInsertError(DebugIgnore<TableDataInsertAllResponseInsertErrors>),
+    #[error("{0}")]
+    Other(DebugIgnore<anyhow::Error>),
+}
+
+impl From<BQError> for CustomEventIngestError {
+    fn from(err: BQError) -> Self {
+        Self::BigQueryClientError(DebugIgnore(err))
+    }
+}
+
+impl From<TableDataInsertAllResponseInsertErrors> for CustomEventIngestError {
+    fn from(err: TableDataInsertAllResponseInsertErrors) -> Self {
+        Self::BigQueryInsertError(DebugIgnore(err))
+    }
+}
+
+impl From<anyhow::Error> for CustomEventIngestError {
+    fn from(err: anyhow::Error) -> Self {
+        Self::Other(DebugIgnore(err))
+    }
+}
+
+#[derive(Debug, ThisError)]
+pub(crate) enum LogIngestError {
+    #[error(
+        "unexpected payload body. Payload should be an array of strings possibly in gzip format"
+    )]
+    UnexpectedPayloadBody,
+    #[error("unexpected content encoding. Supported encodings are: gzip")]
+    UnexpectedContentEncoding,
+    #[error("unable to ingest logs")]
+    IngestionError,
+}
+
+#[derive(Debug, ThisError)]
+pub(crate) enum MetricsIngestError {
+    #[error("unable to ingest metrics")]
+    IngestionError,
+}
+
+#[derive(Debug, ThisError)]
+pub(crate) enum ValidatorCacheUpdateError {
+    #[error("invalid url")]
+    InvalidUrl,
+    #[error("request error")]
+    RestError(#[source] RestError),
+    #[error("chain id mismatch")]
+    ChainIdMismatch,
+    #[error("both peer set empty")]
+    BothPeerSetEmpty,
+    #[error("validator set empty")]
+    ValidatorSetEmpty,
+    #[error("vfn set empty")]
+    VfnSetEmpty,
+}
+
+#[derive(Debug, ThisError)]
+pub(crate) enum ServiceErrorCode {
+    #[error("authentication error: {0}")]
+    AuthError(AuthError, ChainId),
+    #[error("custom event ingest error: {0}")]
+    CustomEventIngestError(#[from] CustomEventIngestError),
+    #[error("authorization error: {0}")]
+    JwtAuthError(#[from] JwtAuthError),
+    #[error("log ingest error: {0}")]
+    LogIngestError(#[from] LogIngestError),
+    #[error("metrics ingest error: {0}")]
+    MetricsIngestError(#[from] MetricsIngestError),
+}
+
+#[derive(Debug)]
+pub(crate) struct ServiceError {
+    http_code: StatusCode,
+    error_code: ServiceErrorCode,
 }
 
 impl ServiceError {
-    pub fn new(code: StatusCode, message: String) -> Self {
+    pub(crate) fn new(http_code: StatusCode, error_code: ServiceErrorCode) -> Self {
         Self {
-            code: code.as_u16(),
-            message,
+            http_code,
+            error_code,
         }
     }
 
-    pub fn from_anyhow_error(code: StatusCode, err: anyhow::Error) -> Self {
-        Self::new(code, err.to_string())
+    pub(crate) fn bad_request(error_code: ServiceErrorCode) -> Self {
+        Self::new(StatusCode::BAD_REQUEST, error_code)
     }
 
-    pub fn bad_request<S: Display>(msg: S) -> Self {
-        Self::new(StatusCode::BAD_REQUEST, msg.to_string())
+    pub(crate) fn unauthorized(error_code: ServiceErrorCode) -> Self {
+        Self::new(StatusCode::UNAUTHORIZED, error_code)
     }
 
-    pub fn invalid_request_body<S: Display>(msg: S) -> Self {
-        Self::bad_request(format!("invalid request body: {}", msg))
+    pub(crate) fn forbidden(error_code: ServiceErrorCode) -> Self {
+        Self::new(StatusCode::FORBIDDEN, error_code)
     }
 
-    pub fn unauthorized<S: Display>(msg: S) -> Self {
-        Self::new(StatusCode::UNAUTHORIZED, msg.to_string())
+    pub(crate) fn internal(error_code: ServiceErrorCode) -> Self {
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, error_code)
     }
 
-    pub fn forbidden<S: Display>(msg: S) -> Self {
-        Self::new(StatusCode::FORBIDDEN, msg.to_string())
+    pub(crate) fn http_status_code(&self) -> StatusCode {
+        self.http_code
     }
 
-    pub fn internal(err: anyhow::Error) -> Self {
-        Self::from_anyhow_error(StatusCode::INTERNAL_SERVER_ERROR, err)
+    #[cfg(test)]
+    pub(crate) fn error_as_string(&self) -> String {
+        self.error_code.to_string()
     }
 
-    pub fn status_code(&self) -> StatusCode {
-        StatusCode::from_u16(self.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
-    }
-}
-
-impl fmt::Display for ServiceError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}: {}", self.status_code(), &self.message)?;
-        Ok(())
+    pub(crate) fn error_code(&self) -> &ServiceErrorCode {
+        &self.error_code
     }
 }
 
 impl Reject for ServiceError {}
 
-impl From<anyhow::Error> for ServiceError {
-    fn from(e: anyhow::Error) -> Self {
-        Self::internal(e)
-    }
-}
-
-impl From<serde_json::error::Error> for ServiceError {
-    fn from(err: serde_json::error::Error) -> Self {
-        Self::internal(err.into())
+impl fmt::Display for ServiceError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}: {}", self.http_code, self.error_code)?;
+        Ok(())
     }
 }

--- a/crates/aptos-telemetry-service/src/jwt_auth.rs
+++ b/crates/aptos-telemetry-service/src/jwt_auth.rs
@@ -9,6 +9,7 @@ use tracing::error;
 use warp::{reject, Rejection};
 
 use crate::context::JsonWebTokenService;
+use crate::error::JwtAuthError;
 use crate::{context::Context, types::auth::Claims};
 use crate::{error::ServiceError, types::common::NodeType};
 
@@ -45,7 +46,9 @@ pub async fn authorize_jwt(
 ) -> anyhow::Result<Claims, Rejection> {
     let decoded: TokenData<Claims> = context.jwt_service().decode(&token).map_err(|e| {
         error!("unable to authorize jwt token: {}", e);
-        reject::custom(ServiceError::unauthorized("invalid authorization token"))
+        reject::custom(ServiceError::unauthorized(
+            JwtAuthError::InvalidAuthToken.into(),
+        ))
     })?;
     let claims = decoded.claims;
 
@@ -53,14 +56,14 @@ pub async fn authorize_jwt(
         Some(info) => info.0,
         None => {
             return Err(reject::custom(ServiceError::unauthorized(
-                "expired authorization token",
+                JwtAuthError::ExpiredAuthToken.into(),
             )));
         }
     };
 
     if !allow_roles.contains(&claims.node_type) {
         return Err(reject::custom(ServiceError::forbidden(
-            "the peer does not have access to this resource",
+            JwtAuthError::AccessDenied.into(),
         )));
     }
 
@@ -68,7 +71,7 @@ pub async fn authorize_jwt(
         Ok(claims)
     } else {
         Err(reject::custom(ServiceError::unauthorized(
-            "expired authorization token",
+            JwtAuthError::ExpiredAuthToken.into(),
         )))
     }
 }
@@ -78,7 +81,7 @@ pub async fn jwt_from_header(auth_header: Option<String>) -> anyhow::Result<Stri
         Some(v) => v,
         None => {
             return Err(reject::custom(ServiceError::unauthorized(
-                "no/invalid authorization header",
+                JwtAuthError::from("bearer token missing".to_owned()).into(),
             )))
         }
     };
@@ -89,7 +92,7 @@ pub async fn jwt_from_header(auth_header: Option<String>) -> anyhow::Result<Stri
         .eq_ignore_ascii_case(BEARER)
     {
         return Err(reject::custom(ServiceError::unauthorized(
-            "invalid authorization header",
+            JwtAuthError::from("malformed bearer token".to_owned()).into(),
         )));
     }
     Ok(auth_header
@@ -102,6 +105,8 @@ pub async fn jwt_from_header(auth_header: Option<String>) -> anyhow::Result<Stri
 mod tests {
 
     use std::collections::HashMap;
+
+    use warp::hyper::StatusCode;
 
     use super::super::tests::test_context;
     use super::*;
@@ -175,9 +180,13 @@ mod tests {
         .unwrap();
         let result = authorize_jwt(token, test_context.inner, vec![NodeType::Validator]).await;
         assert!(result.is_err());
+
+        let rejection = result.err().unwrap();
+        let service_error = rejection.find::<ServiceError>().unwrap();
+        assert_eq!(service_error.http_status_code(), StatusCode::FORBIDDEN);
         assert_eq!(
-            *result.err().unwrap().find::<ServiceError>().unwrap(),
-            ServiceError::forbidden("the peer does not have access to this resource",)
-        )
+            service_error.error_as_string(),
+            "authorization error: access denied to this resource"
+        );
     }
 }

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -6,12 +6,14 @@ use crate::{
     clients::humio::{CHAIN_ID_TAG_NAME, EPOCH_FIELD_NAME, PEER_ID_FIELD_NAME, PEER_ROLE_TAG_NAME},
     constants::MAX_CONTENT_LENGTH,
     context::Context,
-    error::ServiceError,
+    error::{LogIngestError, ServiceError},
+    metrics::LOG_INGEST_BACKEND_REQUEST_DURATION,
     types::{auth::Claims, common::NodeType, humio::UnstructuredLog},
 };
 use flate2::bufread::GzDecoder;
 use reqwest::{header::CONTENT_ENCODING, StatusCode};
 use std::collections::HashMap;
+use tokio::time::Instant;
 use tracing::{debug, error};
 use warp::{filters::BoxedFilter, reject, reply, Buf, Filter, Rejection, Reply};
 
@@ -67,17 +69,17 @@ pub async fn handle_log_ingest(
             let decoder = GzDecoder::new(body.reader());
             serde_json::from_reader(decoder).map_err(|e| {
                 debug!("unable to decode and deserialize body: {}", e);
-                ServiceError::bad_request("Unexpected payload body. Payload should be an array of strings possibly in gzip format.")
+                ServiceError::bad_request(LogIngestError::UnexpectedPayloadBody.into())
             })?
         } else {
             return Err(reject::custom(ServiceError::bad_request(
-                "Unexpected content encoding. Supported encodings are: gzip.",
+                LogIngestError::UnexpectedContentEncoding.into(),
             )));
         }
     } else {
         serde_json::from_reader(body.reader()).map_err(|e| {
             error!("unable to deserialize body: {}", e);
-            ServiceError::bad_request("Unexpected payload body. Payload should be an array of strings possibly in gzip format")
+            ServiceError::bad_request(LogIngestError::UnexpectedPayloadBody.into())
         })?
     };
 
@@ -97,6 +99,8 @@ pub async fn handle_log_ingest(
 
     debug!("ingesting to humio: {:?}", unstructured_log);
 
+    let start_timer = Instant::now();
+
     let res = context
         .humio_client()
         .ingest_unstructured_log(unstructured_log)
@@ -104,6 +108,9 @@ pub async fn handle_log_ingest(
 
     match res {
         Ok(res) => {
+            LOG_INGEST_BACKEND_REQUEST_DURATION
+                .with_label_values(&[res.status().as_str()])
+                .observe(start_timer.elapsed().as_millis() as f64);
             if res.status().is_success() {
                 debug!("log ingested into humio succeessfully");
             } else {
@@ -111,10 +118,19 @@ pub async fn handle_log_ingest(
                     "humio log ingestion failed: {}",
                     res.error_for_status().err().unwrap()
                 );
+                return Err(reject::custom(ServiceError::bad_request(
+                    LogIngestError::IngestionError.into(),
+                )));
             }
         }
         Err(err) => {
+            LOG_INGEST_BACKEND_REQUEST_DURATION
+                .with_label_values(&["Unknown"])
+                .observe(start_timer.elapsed().as_millis() as f64);
             error!("error sending log ingest request: {}", err);
+            return Err(reject::custom(ServiceError::bad_request(
+                LogIngestError::IngestionError.into(),
+            )));
         }
     }
 

--- a/crates/aptos-telemetry-service/src/metrics.rs
+++ b/crates/aptos-telemetry-service/src/metrics.rs
@@ -1,0 +1,163 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{env, io::Write, time::Duration};
+
+use anyhow::anyhow;
+use aptos_metrics_core::{
+    register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec,
+};
+use flate2::{write::GzEncoder, Compression};
+use once_cell::sync::Lazy;
+use tokio::time::{self, Instant};
+use tracing::{debug, error};
+use warp::hyper::body::Bytes;
+
+use crate::{
+    clients::victoria_metrics_api,
+    constants::{GCP_CLOUD_RUN_REVISION_ENV, GCP_CLOUD_RUN_SERVICE_ENV},
+};
+
+const METRICS_EXPORT_FREQUENCY: Duration = Duration::from_secs(15);
+
+pub(crate) static SERVICE_ERROR_COUNTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "telemetry_web_service_internal_error_counts",
+        "Service errors returned by the telemety web service by error_code",
+        &["error_code"]
+    )
+    .unwrap()
+});
+
+pub(crate) static LOG_INGEST_BACKEND_REQUEST_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "telemetry_web_service_log_ingest_backend_request_duration",
+        "Number of log ingest backend requests by response code",
+        &["response_code"]
+    )
+    .unwrap()
+});
+
+pub(crate) static METRICS_INGEST_BACKEND_REQUEST_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "telemetry_web_service_metrics_ingest_backend_request_duration",
+        "Number of metrics ingest backend requests by response code",
+        &["response_code"]
+    )
+    .unwrap()
+});
+
+pub(crate) static BIG_QUERY_BACKEND_REQUEST_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "telemetry_web_service_big_query_backend_request_duration",
+        "Number of big query backend requests by response kind",
+        &["kind"]
+    )
+    .unwrap()
+});
+
+pub(crate) static METRICS_EXPORT_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "telemetry_web_service_metrics_export_duration",
+        "Number of metrics export requests by response code",
+        &["response_code"]
+    )
+    .unwrap()
+});
+
+pub(crate) static VALIDATOR_SET_UPDATE_SUCCESS_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "telemetry_web_service_validator_set_update_success_count",
+        "Number of metrics validator set update successes",
+        &["chain_id"]
+    )
+    .unwrap()
+});
+
+pub(crate) static VALIDATOR_SET_UPDATE_FAILED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "telemetry_web_service_validator_set_update_failed_count",
+        "Number of metrics validator set update failures",
+        &["chain_id", "error_code"]
+    )
+    .unwrap()
+});
+
+pub struct PrometheusExporter {
+    revision: String,
+    service: String,
+    client: victoria_metrics_api::Client,
+}
+
+impl PrometheusExporter {
+    pub fn new(client: victoria_metrics_api::Client) -> Self {
+        let revision = env::var(GCP_CLOUD_RUN_REVISION_ENV).unwrap_or_else(|_| "Unknown".into());
+        let service = env::var(GCP_CLOUD_RUN_SERVICE_ENV).unwrap_or_else(|_| "Unknown".into());
+
+        Self {
+            revision,
+            service,
+            client,
+        }
+    }
+
+    pub fn run(self) {
+        tokio::spawn(async move {
+            let mut interval = time::interval(METRICS_EXPORT_FREQUENCY);
+            loop {
+                interval.tick().await;
+                match self.gather_and_send().await {
+                    Ok(()) => debug!("service metrics exported successfully"),
+                    Err(err) => error!("error exporting metrics {}", err),
+                }
+            }
+        });
+    }
+
+    async fn gather_and_send(&self) -> Result<(), anyhow::Error> {
+        let scraped_metrics = prometheus::TextEncoder::new()
+            .encode_to_string(&prometheus::default_registry().gather())
+            .map_err(|e| anyhow!("text encoding error {}", e))?;
+
+        let mut gzip_encoder = GzEncoder::new(Vec::new(), Compression::default());
+        gzip_encoder
+            .write_all(scraped_metrics.as_bytes())
+            .map_err(|e| anyhow!("gzip encoding error {}", e))?;
+        let metrics_body = gzip_encoder.finish()?;
+
+        let extra_labels = vec![
+            "namespace=telemetry-web-service".into(),
+            format!("cloud_run_revision={}", self.revision),
+            format!("cloud_run_service={}", self.service),
+        ];
+
+        let start_timer = Instant::now();
+
+        let res = self
+            .client
+            .post_prometheus_metrics(Bytes::from(metrics_body), extra_labels, "gzip".into())
+            .await;
+
+        match res {
+            Ok(res) => {
+                METRICS_EXPORT_DURATION
+                    .with_label_values(&[res.status().as_str()])
+                    .observe(start_timer.elapsed().as_millis() as f64);
+                if !res.status().is_success() {
+                    return Err(anyhow!(
+                        "remote write failed to victoria_metrics: {}",
+                        res.error_for_status().err().unwrap()
+                    ));
+                }
+            }
+            Err(err) => {
+                METRICS_EXPORT_DURATION
+                    .with_label_values(&["Unknown"])
+                    .observe(start_timer.elapsed().as_millis() as f64);
+                return Err(anyhow!("error sending remote write request: {}", err));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -5,11 +5,14 @@ use crate::{
     auth::with_auth,
     constants::MAX_CONTENT_LENGTH,
     context::Context,
+    error::{MetricsIngestError, ServiceError},
+    metrics::METRICS_INGEST_BACKEND_REQUEST_DURATION,
     types::{auth::Claims, common::NodeType},
 };
 use reqwest::{header::CONTENT_ENCODING, StatusCode};
+use tokio::time::Instant;
 use tracing::{debug, error};
-use warp::{filters::BoxedFilter, hyper::body::Bytes, reply, Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, hyper::body::Bytes, reject, reply, Filter, Rejection, Reply};
 
 /// TODO: Cleanup after v1 API is ramped up
 pub fn metrics_ingest_legacy(context: Context) -> BoxedFilter<(impl Reply,)> {
@@ -60,6 +63,8 @@ pub async fn handle_metrics_ingest(
 
     let extra_labels = claims_to_extra_labels(&claims);
 
+    let start_timer = Instant::now();
+
     let res = context
         .metrics_client()
         .post_prometheus_metrics(metrics_body, extra_labels, encoding.unwrap_or_default())
@@ -67,6 +72,9 @@ pub async fn handle_metrics_ingest(
 
     match res {
         Ok(res) => {
+            METRICS_INGEST_BACKEND_REQUEST_DURATION
+                .with_label_values(&[res.status().as_str()])
+                .observe(start_timer.elapsed().as_millis() as f64);
             if res.status().is_success() {
                 debug!("remote write to victoria metrics succeeded");
             } else {
@@ -74,10 +82,19 @@ pub async fn handle_metrics_ingest(
                     "remote write failed to victoria_metrics: {}",
                     res.error_for_status().err().unwrap()
                 );
+                return Err(reject::custom(ServiceError::internal(
+                    MetricsIngestError::IngestionError.into(),
+                )));
             }
         }
         Err(err) => {
+            METRICS_INGEST_BACKEND_REQUEST_DURATION
+                .with_label_values(&["Unknown"])
+                .observe(start_timer.elapsed().as_millis() as f64);
             error!("error sending remote write request: {}", err);
+            return Err(reject::custom(ServiceError::internal(
+                MetricsIngestError::IngestionError.into(),
+            )));
         }
     }
 

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -35,6 +35,7 @@ pub async fn new_test_context() -> TestContext {
         humio_url: "".into(),
         pfn_allowlist: HashMap::new(),
         log_env_map: HashMap::new(),
+        metrics_exporter_base_url: "".into(),
     };
 
     let peers = PeerStoreTuple::default();

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -69,13 +69,37 @@ pub mod common {
     }
 }
 
-pub mod index {
+pub mod response {
     use aptos_crypto::x25519;
+    use reqwest::StatusCode;
     use serde::{Deserialize, Serialize};
+
+    use crate::error::ServiceError;
 
     #[derive(Serialize, Deserialize)]
     pub struct IndexResponse {
         pub public_key: x25519::PublicKey,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    pub struct ErrorResponse {
+        code: u16,
+        message: String,
+    }
+
+    impl ErrorResponse {
+        pub fn new(code: StatusCode, message: String) -> Self {
+            Self {
+                code: code.as_u16(),
+                message,
+            }
+        }
+    }
+
+    impl From<&ServiceError> for ErrorResponse {
+        fn from(err: &ServiceError) -> Self {
+            Self::new(err.http_status_code(), err.to_string())
+        }
     }
 }
 

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -3,7 +3,7 @@
 
 use aptos_config::config::{Peer, PeerRole, PeerSet};
 use aptos_infallible::RwLock;
-use aptos_rest_client::{error::RestError, Response};
+use aptos_rest_client::Response;
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS, chain_id::ChainId, on_chain_config::ValidatorSet, PeerId,
 };
@@ -12,7 +12,11 @@ use tokio::time;
 use tracing::{debug, error};
 use url::Url;
 
-use crate::types::common::EpochedPeerStore;
+use crate::{
+    error::ValidatorCacheUpdateError,
+    metrics::{VALIDATOR_SET_UPDATE_FAILED_COUNT, VALIDATOR_SET_UPDATE_SUCCESS_COUNT},
+    types::common::EpochedPeerStore,
+};
 
 #[derive(Clone)]
 pub struct PeerSetCacheUpdater {
@@ -38,107 +42,140 @@ impl PeerSetCacheUpdater {
         }
     }
 
-    pub fn run(&self) {
+    pub fn run(self) {
         let mut interval = time::interval(self.update_interval);
-        let cloned_self = self.clone();
         tokio::spawn(async move {
             loop {
-                cloned_self.clone().update().await;
+                self.update().await;
                 interval.tick().await;
             }
         });
     }
 
-    pub async fn update(&self) {
+    async fn update(&self) {
         for (chain_id, url) in self.query_addresses.iter() {
-            let client = aptos_rest_client::Client::new(Url::parse(url).unwrap());
-            let result: Result<Response<ValidatorSet>, RestError> = client
-                .get_account_resource_bcs(CORE_CODE_ADDRESS, "0x1::stake::ValidatorSet")
-                .await;
-            match result {
-                Ok(response) => {
-                    let (peer_addrs, state) = response.into_parts();
-
-                    let received_chain_id = ChainId::new(state.chain_id);
-                    if received_chain_id != *chain_id {
-                        error!("Chain Id mismatch: Received in headers: {}. Provided in configuration: {} for {}", received_chain_id, chain_id, url);
-                        continue;
-                    }
-
-                    let mut validator_cache = self.validators.write();
-                    let mut vfn_cache = self.validator_fullnodes.write();
-
-                    let validator_peers: PeerSet = peer_addrs
-                        .clone()
-                        .into_iter()
-                        .filter_map(|validator_info| -> Option<(PeerId, Peer)> {
-                            validator_info
-                                .config()
-                                .validator_network_addresses()
-                                .map(|addresses| {
-                                    (
-                                        *validator_info.account_address(),
-                                        Peer::from_addrs(PeerRole::Validator, addresses),
-                                    )
-                                })
-                                .map_err(|err| {
-                                    error!(
-                                        "unable to parse validator network address for validator info {}: {}",
-                                        validator_info, err
-                                    )
-                                })
-                                .ok()
-                        })
-                        .collect();
-
-                    debug!(
-                        "Validator peers for chain id {} at epoch {}: {:?}",
-                        chain_id, state.epoch, validator_peers
-                    );
-
-                    if !validator_peers.is_empty() {
-                        validator_cache.insert(*chain_id, (state.epoch, validator_peers));
-                    }
-
-                    let vfn_peers: PeerSet = peer_addrs
-                        .into_iter()
-                        .filter_map(|validator_info| -> Option<(PeerId, Peer)> {
-                            validator_info
-                                .config()
-                                .fullnode_network_addresses()
-                                .map(|addresses| {
-                                    (
-                                        *validator_info.account_address(),
-                                        Peer::from_addrs(PeerRole::ValidatorFullNode, addresses),
-                                    )
-                                })
-                                .map_err(|err| {
-                                    error!(
-                                        "unable to parse fullnode network address for validator info {}: {}",
-                                        validator_info, err
-                                    )
-                                })
-                                .ok()
-                        })
-                        .collect();
-
-                    debug!(
-                        "Validator fullnode peers for chain id {} at epoch {}: {:?}",
-                        chain_id, state.epoch, vfn_peers
-                    );
-
-                    if !vfn_peers.is_empty() {
-                        vfn_cache.insert(*chain_id, (state.epoch, vfn_peers));
-                    }
+            match self.update_for_chain(chain_id, url).await {
+                Ok(_) => {
+                    VALIDATOR_SET_UPDATE_SUCCESS_COUNT
+                        .with_label_values(&[&chain_id.to_string()])
+                        .inc();
+                    debug!("validator set update successful for chain id {}", chain_id);
                 }
                 Err(err) => {
+                    VALIDATOR_SET_UPDATE_FAILED_COUNT
+                        .with_label_values(&[&chain_id.to_string(), &err.to_string()])
+                        .inc();
                     error!(
-                        "Fetching validator set failed for Chain Id {}. Err: {}",
+                        "validator set update error for chain id {}: {:?}",
                         chain_id, err
-                    )
+                    );
                 }
             }
         }
+    }
+
+    async fn update_for_chain(
+        &self,
+        chain_id: &ChainId,
+        url: &String,
+    ) -> Result<(), ValidatorCacheUpdateError> {
+        let client = aptos_rest_client::Client::new(Url::parse(url).map_err(|e| {
+            error!("invalid url for chain_id {}: {}", chain_id, e);
+            ValidatorCacheUpdateError::InvalidUrl
+        })?);
+        let response: Response<ValidatorSet> = client
+            .get_account_resource_bcs(CORE_CODE_ADDRESS, "0x1::stake::ValidatorSet")
+            .await
+            .map_err(ValidatorCacheUpdateError::RestError)?;
+
+        let (peer_addrs, state) = response.into_parts();
+
+        let received_chain_id = ChainId::new(state.chain_id);
+        if received_chain_id != *chain_id {
+            error!(
+                "Chain Id mismatch: Received in headers: {}. Provided in configuration: {} for {}",
+                received_chain_id, chain_id, url
+            );
+            return Err(ValidatorCacheUpdateError::ChainIdMismatch);
+        }
+
+        let mut validator_cache = self.validators.write();
+        let mut vfn_cache = self.validator_fullnodes.write();
+
+        let validator_peers: PeerSet = peer_addrs
+            .clone()
+            .into_iter()
+            .filter_map(|validator_info| -> Option<(PeerId, Peer)> {
+                validator_info
+                    .config()
+                    .validator_network_addresses()
+                    .map(|addresses| {
+                        (
+                            *validator_info.account_address(),
+                            Peer::from_addrs(PeerRole::Validator, addresses),
+                        )
+                    })
+                    .map_err(|err| {
+                        error!(
+                            "unable to parse validator network address for validator info {} for chain id {}: {}",
+                            validator_info, chain_id, err
+                        )
+                    })
+                    .ok()
+            })
+            .collect();
+
+        let vfn_peers: PeerSet = peer_addrs
+            .into_iter()
+            .filter_map(|validator_info| -> Option<(PeerId, Peer)> {
+                validator_info
+                    .config()
+                    .fullnode_network_addresses()
+                    .map(|addresses| {
+                        (
+                            *validator_info.account_address(),
+                            Peer::from_addrs(PeerRole::ValidatorFullNode, addresses),
+                        )
+                    })
+                    .map_err(|err| {
+                        error!(
+                            "unable to parse fullnode network address for validator info {} in chain id {}: {}",
+                            validator_info, chain_id, err
+                        );
+                    })
+                    .ok()
+            })
+            .collect();
+
+        debug!(
+            "Validator peers for chain id {} at epoch {}: {:?}",
+            chain_id, state.epoch, validator_peers
+        );
+
+        let result = if validator_peers.is_empty() && vfn_peers.is_empty() {
+            Err(ValidatorCacheUpdateError::BothPeerSetEmpty)
+        } else if validator_peers.is_empty() {
+            Err(ValidatorCacheUpdateError::ValidatorSetEmpty)
+        } else if vfn_peers.is_empty() {
+            Err(ValidatorCacheUpdateError::VfnSetEmpty)
+        } else {
+            Ok(())
+        };
+
+        if !validator_peers.is_empty() {
+            validator_cache.insert(*chain_id, (state.epoch, validator_peers));
+        }
+
+        debug!(
+            "Validator fullnode peers for chain id {} at epoch {}: {:?}",
+            chain_id, state.epoch, vfn_peers
+        );
+
+        if !vfn_peers.is_empty() {
+            vfn_cache.insert(*chain_id, (state.epoch, vfn_peers));
+        }
+
+        result
     }
 }
 

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -12,7 +12,7 @@ use aptos_infallible::{Mutex, RwLock};
 use aptos_logger::debug;
 use aptos_telemetry_service::types::{
     auth::{AuthRequest, AuthResponse},
-    index::IndexResponse,
+    response::IndexResponse,
     telemetry::TelemetryDump,
 };
 use aptos_types::{chain_id::ChainId, PeerId};


### PR DESCRIPTION
### Description

**NOTE: This PR only has telemetry service related changes and does not affect node behavior**

This PR instruments the telemetry service with prometheus metrics and exports them to Victoria metrics in the same way ingested metrics are exported. The metrics can be exported to a separate VM instance if necessary to isolate points of failure.

Also provides a workaround to an issue with GCP tracing support where the log fields have span names as prefix. The trace Id field also has a prefix which prevents GCP from picking this traceID and grouping logs accordingly.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

- Ensured that metrics are exported to Victoria Metrics by running locally.
- Deployed to cloudrun and has been serving traffic for few days now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4573)
<!-- Reviewable:end -->
