### PR TITLE
[Indexer] add coin indexing

### DIFF
--- a/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/down.sql
+++ b/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS coin_infos;
+DROP TABLE IF EXISTS coin_balances;
+DROP TABLE IF EXISTS current_coin_balances;
+DROP TABLE IF EXISTS coin_activities;

--- a/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/down.sql
+++ b/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/down.sql
@@ -1,5 +1,24 @@
 -- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS ps_name_succ_ver_index;
 DROP TABLE IF EXISTS coin_infos;
 DROP TABLE IF EXISTS coin_balances;
 DROP TABLE IF EXISTS current_coin_balances;
 DROP TABLE IF EXISTS coin_activities;
+ALTER TABLE token_activities
+DROP COLUMN IF EXISTS transaction_timestamp;
+ALTER TABLE current_token_pending_claims
+DROP COLUMN IF EXISTS last_transaction_timestamp;
+ALTER TABLE current_token_ownerships
+DROP COLUMN IF EXISTS last_transaction_timestamp;
+ALTER TABLE current_token_datas
+DROP COLUMN IF EXISTS last_transaction_timestamp;
+ALTER TABLE current_collection_datas
+DROP COLUMN IF EXISTS last_transaction_timestamp;
+ALTER TABLE tokens
+DROP COLUMN IF EXISTS transaction_timestamp;
+ALTER TABLE token_ownerships
+DROP COLUMN IF EXISTS transaction_timestamp;
+ALTER TABLE token_datas
+DROP COLUMN IF EXISTS transaction_timestamp;
+ALTER TABLE collection_datas
+DROP COLUMN IF EXISTS transaction_timestamp;

--- a/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/down.sql
+++ b/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/down.sql
@@ -22,3 +22,4 @@ ALTER TABLE token_datas
 DROP COLUMN IF EXISTS transaction_timestamp;
 ALTER TABLE collection_datas
 DROP COLUMN IF EXISTS transaction_timestamp;
+DROP VIEW IF EXISTS move_resources_view;

--- a/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/up.sql
+++ b/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/up.sql
@@ -1,4 +1,17 @@
 -- Your SQL goes here
+CREATE VIEW move_resources_view AS
+SELECT transaction_version,
+  write_set_change_index,
+  transaction_block_height,
+  name,
+  address,
+  "type",
+  "module",
+  generic_type_params,
+  data#>>'{}' as json_data,
+  is_deleted,
+  inserted_at
+FROM move_resources;
 CREATE INDEX ps_name_succ_ver_index ON processor_statuses (name, success, version ASC);
 -- adding timestamp to all token tables
 ALTER TABLE token_activities

--- a/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/up.sql
+++ b/crates/indexer/migrations/2022-10-04-073529_add_coin_tables/up.sql
@@ -1,0 +1,74 @@
+-- Your SQL goes here
+CREATE INDEX ps_name_succ_ver_index ON processor_statuses (name, success, version ASC);
+-- coin infos. Only first transaction matters
+CREATE TABLE coin_infos (
+  -- creator_address::name::symbol
+  -- Max length should actually only be 66 + 32 + 10 = 108 but we didn't enforce these in the beginning
+  coin_type VARCHAR(256) UNIQUE PRIMARY KEY NOT NULL,
+  -- transaction version where coin info was first defined
+  transaction_version_created BIGINT NOT NULL,
+  creator_address VARCHAR(66) NOT NULL,
+  name VARCHAR(32) NOT NULL,
+  symbol VARCHAR(10) NOT NULL,
+  decimals INT NOT NULL,
+  supply NUMERIC NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX ci_ca_name_symbol_index on coin_infos (creator_address, name, symbol);
+CREATE INDEX ci_insat_index ON coin_infos (inserted_at);
+-- current coin owned by user
+CREATE TABLE coin_balances (
+  transaction_version BIGINT NOT NULL,
+  owner_address VARCHAR(66) NOT NULL,
+  -- creator_address::name::symbol
+  coin_type VARCHAR(256) NOT NULL,
+  amount NUMERIC NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (transaction_version, owner_address, coin_type)
+);
+CREATE INDEX cb_oa_ct_index on coin_balances (owner_address, coin_type);
+CREATE INDEX cb_ct_a_index on coin_balances (coin_type, amount);
+CREATE INDEX cb_insat_index ON coin_balances (inserted_at);
+-- current coin owned by user
+CREATE TABLE current_coin_balances (
+  owner_address VARCHAR(66) NOT NULL,
+  -- creator_address::name::symbol
+  coin_type VARCHAR(256) NOT NULL,
+  amount NUMERIC NOT NULL,
+  last_transaction_version BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (owner_address, coin_type)
+);
+CREATE INDEX ccb_ct_a_index on current_coin_balances (coin_type, amount);
+CREATE INDEX ccb_insat_index on current_coin_balances (inserted_at);
+-- coinstore activities (send, receive, gas fees). Mint/burn not supported because event missing
+CREATE TABLE coin_activities (
+  transaction_version BIGINT NOT NULL,
+  event_account_address VARCHAR(66) NOT NULL,
+  event_creation_number BIGINT NOT NULL,
+  event_sequence_number BIGINT NOT NULL,
+  owner_address VARCHAR(66) NOT NULL,
+  -- creator_address::name::symbol
+  coin_type VARCHAR(256) NOT NULL,
+  amount NUMERIC NOT NULL,
+  activity_type VARCHAR(200) NOT NULL,
+  is_gas_fee BOOLEAN NOT NULL,
+  is_transaction_success BOOLEAN NOT NULL,
+  entry_function_id_str VARCHAR(100),
+  block_height BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (
+    transaction_version,
+    event_account_address,
+    event_creation_number,
+    event_sequence_number
+  )
+);
+CREATE INDEX ca_oa_ct_at_index on coin_activities (owner_address, coin_type, activity_type, amount);
+CREATE INDEX ca_oa_igf_index on coin_activities (owner_address, is_gas_fee);
+CREATE INDEX ca_ct_at_a_index on coin_activities (coin_type, activity_type, amount);
+CREATE INDEX ca_ct_a_index on coin_activities (coin_type, amount);
+CREATE INDEX ca_insat_index on coin_activities (inserted_at);

--- a/crates/indexer/src/indexer/tailer.rs
+++ b/crates/indexer/src/indexer/tailer.rs
@@ -270,7 +270,7 @@ mod test {
     use super::*;
     use crate::{
         database::{new_db_pool, PgPoolConnection},
-        models::transactions::TransactionModel,
+        models::transactions::TransactionQuery,
         processors::default_processor::DefaultTransactionProcessor,
     };
     use aptos_api_test_context::new_test_context;
@@ -652,7 +652,7 @@ mod test {
 
         // This is a block metadata transaction
         let (tx1, ut1, bmt1, events1, wsc1) =
-            TransactionModel::get_by_version(69158, &mut conn_pool.get().unwrap()).unwrap();
+            TransactionQuery::get_by_version(69158, &mut conn_pool.get().unwrap()).unwrap();
         assert_eq!(tx1.type_, "block_metadata_transaction");
         assert!(ut1.is_none());
         assert!(bmt1.is_some());
@@ -661,7 +661,7 @@ mod test {
 
         // This is the genesis transaction
         let (tx0, ut0, bmt0, events0, wsc0) =
-            TransactionModel::get_by_version(0, &mut conn_pool.get().unwrap()).unwrap();
+            TransactionQuery::get_by_version(0, &mut conn_pool.get().unwrap()).unwrap();
         assert_eq!(tx0.type_, "genesis_transaction");
         assert!(ut0.is_none());
         assert!(bmt0.is_none());
@@ -780,7 +780,7 @@ mod test {
 
         // This is a user transaction, so the bmt should be None
         let (tx2, ut2, bmt2, events2, wsc2) =
-            TransactionModel::get_by_version(691595, &mut conn_pool.get().unwrap()).unwrap();
+            TransactionQuery::get_by_version(691595, &mut conn_pool.get().unwrap()).unwrap();
         assert_eq!(
             tx2.hash,
             "0xefd4c865e00c240da0c426a37ceeda10d9b030d0e8a4fb4fb7ff452ad63401fb"

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -1,0 +1,250 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::{
+    coin_balances::{CoinBalance, CurrentCoinBalance},
+    coin_infos::{CoinInfo, CoinSupplyLookup},
+    coin_utils::{CoinEvent, EventGuidResource},
+};
+use crate::{schema::coin_activities, util::truncate_str};
+use aptos_api_types::{
+    Event as APIEvent, Transaction as APITransaction, TransactionInfo as APITransactionInfo,
+    TransactionPayload, UserTransactionRequest, WriteSetChange as APIWriteSetChange,
+};
+use aptos_types::APTOS_COIN_TYPE;
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+const GAS_FEE_EVENT: &str = "0x1::aptos_coin::GasFeeEvent";
+// We will never have a negative number on chain so this will avoid collision in postgres
+const BURN_GAS_EVENT_CREATION_NUM: i64 = -1;
+const MAX_ENTRY_FUNCTION_LENGTH: usize = 100;
+
+type OwnerAddress = String;
+type CoinType = String;
+// Primary key of the current_coin_balances table, i.e. (owner_address, coin_type)
+pub type CurrentCoinBalancePK = (OwnerAddress, CoinType);
+pub type EventToCoinType = HashMap<EventGuidResource, CoinType>;
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[diesel(primary_key(
+    transaction_version,
+    event_account_address,
+    event_creation_number,
+    event_sequence_number
+))]
+#[diesel(table_name = coin_activities)]
+pub struct CoinActivity {
+    pub transaction_version: i64,
+    pub event_account_address: String,
+    pub event_creation_number: i64,
+    pub event_sequence_number: i64,
+    pub owner_address: String,
+    pub coin_type: String,
+    pub amount: BigDecimal,
+    pub activity_type: String,
+    pub is_gas_fee: bool,
+    pub is_transaction_success: bool,
+    pub entry_function_id_str: Option<String>,
+    pub block_height: i64,
+    pub inserted_at: chrono::NaiveDateTime,
+}
+
+/// Coin information is mostly in Resources but some pieces are in table items (e.g. supply from aggregator table)
+pub struct CoinSupply {
+    pub coin_type: String,
+    pub transaction_version_created: i64,
+    pub creator_address: String,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: i32,
+    pub supply: BigDecimal,
+}
+
+impl CoinActivity {
+    /// There are different objects containing different information about balances and coins.
+    /// Events: Withdraw and Deposit event containing amounts. There is no coin type so we need to get that from Resources. (from event guid)
+    /// CoinInfo Resource: Contains name, symbol, decimals and supply. (if supply is aggregator, however, actual supply amount will live in a separate table)
+    /// CoinStore Resource: Contains owner address and coin type information used to complete events
+    /// Aggregator Table Item: Contains current supply of a coin
+    pub fn from_transaction(
+        transaction: &APITransaction,
+    ) -> (
+        Vec<Self>,
+        Vec<CoinBalance>,
+        HashMap<CoinType, CoinInfo>,
+        HashMap<CurrentCoinBalancePK, CurrentCoinBalance>,
+    ) {
+        let mut coin_activities = Vec::new();
+        let mut coin_balances = Vec::new();
+        let mut coin_infos: HashMap<CoinType, CoinInfo> = HashMap::new();
+        let mut current_coin_balances: HashMap<CurrentCoinBalancePK, CurrentCoinBalance> =
+            HashMap::new();
+        let mut all_event_to_coin_type: EventToCoinType = HashMap::new();
+
+        let (txn_info, writesets, events, maybe_user_request) = match &transaction {
+            APITransaction::GenesisTransaction(inner) => {
+                (&inner.info, &inner.info.changes, &inner.events, None)
+            }
+            APITransaction::UserTransaction(inner) => (
+                &inner.info,
+                &inner.info.changes,
+                &inner.events,
+                Some(&inner.request),
+            ),
+            _ => return Default::default(),
+        };
+
+        let mut entry_function_id_str = None;
+        if let Some(user_request) = maybe_user_request {
+            entry_function_id_str = match &user_request.payload {
+                TransactionPayload::EntryFunctionPayload(payload) => Some(truncate_str(
+                    &payload.function.to_string(),
+                    MAX_ENTRY_FUNCTION_LENGTH,
+                )),
+                _ => None,
+            };
+            coin_activities.push(Self::get_gas_event(
+                txn_info,
+                user_request,
+                &entry_function_id_str,
+            ));
+        }
+        // First we need to make a pass to get all tables that potentially contains coin supply information
+        let mut supply_lookup: CoinSupplyLookup = HashMap::new();
+        for wsc in writesets {
+            if let APIWriteSetChange::WriteTableItem(table_item) = &wsc {
+                let item = CoinInfo::get_aggregator_supply_lookup(table_item).unwrap();
+                supply_lookup.extend(item);
+            }
+        }
+
+        // Get coin info, then coin balances. We can leverage coin balances to get the metadata required for events
+        let txn_version = txn_info.version.0 as i64;
+        for wsc in writesets {
+            let (maybe_coin_info, maybe_coin_balance_data) =
+                if let APIWriteSetChange::WriteResource(write_resource) = wsc {
+                    (
+                        CoinInfo::from_write_resource(write_resource, txn_version, &supply_lookup)
+                            .unwrap(),
+                        CoinBalance::from_write_resource(write_resource, txn_version).unwrap(),
+                    )
+                } else {
+                    (None, None)
+                };
+            if let Some(coin_info) = maybe_coin_info {
+                coin_infos.insert(coin_info.coin_type.clone(), coin_info);
+            }
+            if let Some((coin_balance, current_coin_balance, event_to_coin_type)) =
+                maybe_coin_balance_data
+            {
+                current_coin_balances.insert(
+                    (
+                        coin_balance.owner_address.clone(),
+                        coin_balance.coin_type.clone(),
+                    ),
+                    current_coin_balance,
+                );
+                coin_balances.push(coin_balance);
+                all_event_to_coin_type.extend(event_to_coin_type);
+            }
+        }
+        for event in events {
+            let event_type = event.typ.to_string();
+            match CoinEvent::from_event(event_type.as_str(), &event.data, txn_version).unwrap() {
+                Some(parsed_event) => coin_activities.push(Self::from_parsed_event(
+                    &event_type,
+                    event,
+                    &parsed_event,
+                    txn_version,
+                    &all_event_to_coin_type,
+                    txn_info.block_height.unwrap().0 as i64,
+                    &entry_function_id_str,
+                )),
+                None => {}
+            };
+        }
+        (
+            coin_activities,
+            coin_balances,
+            coin_infos,
+            current_coin_balances,
+        )
+    }
+
+    fn from_parsed_event(
+        event_type: &str,
+        event: &APIEvent,
+        coin_event: &CoinEvent,
+        txn_version: i64,
+        event_to_coin_type: &EventToCoinType,
+        block_height: i64,
+        entry_function_id_str: &Option<String>,
+    ) -> Self {
+        let amount = match coin_event {
+            CoinEvent::WithdrawCoinEvent(inner) => inner.amount.clone(),
+            CoinEvent::DepositCoinEvent(inner) => inner.amount.clone(),
+        };
+        let event_move_guid = EventGuidResource {
+            addr: event.guid.account_address.to_string(),
+            creation_num: event.guid.creation_number.0 as i64,
+        };
+        let coin_type =
+            event_to_coin_type
+                .get(&event_move_guid)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "Could not find event in resources (CoinStore), version: {}, event guid: {:?}, mapping: {:?}",
+                        txn_version, event_move_guid, event_to_coin_type
+                    )
+                }).clone();
+
+        Self {
+            transaction_version: txn_version,
+            event_account_address: event.guid.account_address.to_string(),
+            event_creation_number: event.guid.creation_number.0 as i64,
+            event_sequence_number: event.sequence_number.0 as i64,
+            owner_address: event.guid.account_address.to_string(),
+            coin_type,
+            amount,
+            activity_type: event_type.to_string(),
+            is_gas_fee: false,
+            is_transaction_success: true,
+            entry_function_id_str: entry_function_id_str.clone(),
+            block_height,
+            inserted_at: chrono::Utc::now().naive_utc(),
+        }
+    }
+
+    fn get_gas_event(
+        txn_info: &APITransactionInfo,
+        user_transaction_request: &UserTransactionRequest,
+        entry_function_id_str: &Option<String>,
+    ) -> Self {
+        let aptos_coin_burned = BigDecimal::from(
+            txn_info.gas_used.0 * user_transaction_request.gas_unit_price.0 as u64,
+        );
+
+        Self {
+            transaction_version: txn_info.version.0 as i64,
+            event_account_address: user_transaction_request.sender.to_string(),
+            event_creation_number: BURN_GAS_EVENT_CREATION_NUM,
+            event_sequence_number: user_transaction_request.sequence_number.0 as i64,
+            owner_address: user_transaction_request.sender.to_string(),
+            coin_type: APTOS_COIN_TYPE.to_string(),
+            amount: aptos_coin_burned,
+            activity_type: GAS_FEE_EVENT.to_string(),
+            is_gas_fee: true,
+            is_transaction_success: txn_info.success,
+            entry_function_id_str: entry_function_id_str.clone(),
+            block_height: txn_info.block_height.unwrap().0 as i64,
+            inserted_at: chrono::Utc::now().naive_utc(),
+        }
+    }
+}

--- a/crates/indexer/src/models/coin_models/coin_balances.rs
+++ b/crates/indexer/src/models/coin_models/coin_balances.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::{
+    coin_activities::EventToCoinType,
+    coin_utils::{CoinInfoType, CoinResource},
+};
+use crate::{schema::coin_balances, schema::current_coin_balances};
+use aptos_api_types::WriteResource as APIWriteResource;
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[diesel(primary_key(transaction_version, owner_address, coin_type))]
+#[diesel(table_name = coin_balances)]
+pub struct CoinBalance {
+    pub transaction_version: i64,
+    pub owner_address: String,
+    pub coin_type: String,
+    pub amount: BigDecimal,
+    pub inserted_at: chrono::NaiveDateTime,
+}
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[diesel(primary_key(owner_address, coin_type))]
+#[diesel(table_name = current_coin_balances)]
+pub struct CurrentCoinBalance {
+    pub owner_address: String,
+    pub coin_type: String,
+    pub amount: BigDecimal,
+    pub last_transaction_version: i64,
+    pub inserted_at: chrono::NaiveDateTime,
+}
+
+impl CoinBalance {
+    /// We can find coin info from resources. If the coin info appears multiple times we will only keep the first transaction because it can't be modified.
+    pub fn from_write_resource(
+        write_resource: &APIWriteResource,
+        txn_version: i64,
+    ) -> anyhow::Result<Option<(Self, CurrentCoinBalance, EventToCoinType)>> {
+        match &CoinResource::from_write_resource(write_resource, txn_version)? {
+            Some(CoinResource::CoinStoreResource(inner)) => {
+                let coin_info_type = &CoinInfoType::from_move_type(
+                    &write_resource.data.typ.generic_type_params[0],
+                    txn_version,
+                )?;
+                let owner_address = write_resource.address.to_string();
+                let coin_balance = Self {
+                    transaction_version: txn_version,
+                    owner_address: owner_address.clone(),
+                    coin_type: coin_info_type.get_coin_type_trunc(),
+                    amount: inner.coin.value.clone(),
+                    inserted_at: chrono::Utc::now().naive_utc(),
+                };
+                let current_coin_balance = CurrentCoinBalance {
+                    owner_address,
+                    coin_type: coin_info_type.get_coin_type_trunc(),
+                    amount: inner.coin.value.clone(),
+                    last_transaction_version: txn_version,
+                    inserted_at: chrono::Utc::now().naive_utc(),
+                };
+                let event_to_coin_mapping: EventToCoinType = HashMap::from([
+                    (
+                        (inner.withdraw_events.guid.id.clone()),
+                        coin_balance.coin_type.clone(),
+                    ),
+                    (
+                        (inner.deposit_events.guid.id.clone()),
+                        coin_balance.coin_type.clone(),
+                    ),
+                ]);
+
+                Ok(Some((
+                    coin_balance,
+                    current_coin_balance,
+                    event_to_coin_mapping,
+                )))
+            }
+            _ => Ok(None),
+        }
+    }
+}

--- a/crates/indexer/src/models/coin_models/coin_infos.rs
+++ b/crates/indexer/src/models/coin_models/coin_infos.rs
@@ -1,0 +1,103 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use std::collections::HashMap;
+
+use super::coin_utils::{CoinInfoType, CoinResource};
+use crate::schema::coin_infos;
+use anyhow::Context;
+use aptos_api_types::{WriteResource as APIWriteResource, WriteTableItem as APIWriteTableItem};
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+pub type TableHandle = String;
+pub type TableKey = String;
+pub type Supply = BigDecimal;
+pub type CoinSupplyLookup = HashMap<(TableHandle, TableKey), Supply>;
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[diesel(primary_key(coin_type))]
+#[diesel(table_name = coin_infos)]
+pub struct CoinInfo {
+    pub coin_type: String,
+    pub transaction_version_created: i64,
+    pub creator_address: String,
+    pub name: String,
+    pub symbol: String,
+    pub decimals: i32,
+    pub supply: BigDecimal,
+    pub inserted_at: chrono::NaiveDateTime,
+}
+
+impl CoinInfo {
+    /// We can find coin info from resources. If the coin info appears multiple times we will only keep the first transaction because it can't be modified.
+    pub fn from_write_resource(
+        write_resource: &APIWriteResource,
+        txn_version: i64,
+        coin_supply_lookup: &CoinSupplyLookup,
+    ) -> anyhow::Result<Option<Self>> {
+        match &CoinResource::from_write_resource(write_resource, txn_version)? {
+            Some(CoinResource::CoinInfoResource(inner)) => {
+                let coin_info_type = &CoinInfoType::from_move_type(
+                    &write_resource.data.typ.generic_type_params[0],
+                    txn_version,
+                )?;
+                let supply = inner.get_supply(coin_supply_lookup).unwrap_or_else(|| {
+                    aptos_logger::warn!(
+                        "supply missing in coin info: {:?}, txn {}, coin_supply_lookup {:?}",
+                        inner,
+                        txn_version,
+                        coin_supply_lookup
+                    );
+                    BigDecimal::from(0)
+                });
+
+                Ok(Some(Self {
+                    coin_type: coin_info_type.get_coin_type_trunc(),
+                    transaction_version_created: txn_version,
+                    creator_address: coin_info_type.creator_address.clone(),
+                    name: inner.get_name_trunc(),
+                    symbol: inner.get_symbol_trunc(),
+                    decimals: inner.decimals,
+                    supply,
+                    inserted_at: chrono::Utc::now().naive_utc(),
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub fn get_aggregator_supply_lookup(
+        table_item: &APIWriteTableItem,
+    ) -> anyhow::Result<CoinSupplyLookup> {
+        if let Some(data) = &table_item.data {
+            if data.key_type == "address" && data.value_type == "u128" {
+                let value_str = data
+                    .value
+                    .as_str()
+                    .map(|s| s.parse::<BigDecimal>())
+                    .context(format!(
+                        "value is not a string: {:?}, table_item {:?}",
+                        data.value, table_item
+                    ))?
+                    .context(format!("cannot parse string as u128: {:?}", data.value))?;
+                return Ok(HashMap::from([(
+                    (
+                        table_item.handle.to_string(),
+                        data.key
+                            .as_str()
+                            .context(format!("key is not a string: {:?}", data.key))?
+                            .to_string(),
+                    ),
+                    value_str,
+                )]));
+            }
+        }
+        Ok(HashMap::new())
+    }
+}

--- a/crates/indexer/src/models/coin_models/coin_utils.rs
+++ b/crates/indexer/src/models/coin_models/coin_utils.rs
@@ -1,0 +1,262 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+
+use super::coin_infos::CoinSupplyLookup;
+use crate::{models::move_resources::MoveResource, util::truncate_str};
+use anyhow::{Context, Result};
+use aptos_api_types::{deserialize_from_string, MoveType, WriteResource};
+use bigdecimal::BigDecimal;
+use serde::{Deserialize, Serialize};
+
+/**
+ * This file defines deserialized coin types as defined in our 0x1 contracts.
+ */
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoinInfoResource {
+    name: String,
+    symbol: String,
+    pub decimals: i32,
+    pub supply: OptionalAggregatorWrapperResource,
+}
+
+impl CoinInfoResource {
+    pub fn get_name_trunc(&self) -> String {
+        truncate_str(&self.name, 32)
+    }
+
+    pub fn get_symbol_trunc(&self) -> String {
+        truncate_str(&self.symbol, 10)
+    }
+
+    pub fn get_supply(&self, supply_lookup: &CoinSupplyLookup) -> Option<BigDecimal> {
+        if let Some(inner) = self.supply.vec.get(0) {
+            let mut maybe_supply = inner.integer.get_supply();
+            if maybe_supply.is_none() {
+                maybe_supply = inner.aggregator.get_supply(supply_lookup);
+            }
+            maybe_supply
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OptionalAggregatorWrapperResource {
+    pub vec: Vec<OptionalAggregatorResource>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct OptionalAggregatorResource {
+    pub aggregator: AggregatorWrapperResource,
+    pub integer: IntegerWrapperResource,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AggregatorWrapperResource {
+    pub vec: Vec<AggregatorResource>,
+}
+
+impl AggregatorWrapperResource {
+    pub fn get_supply(&self, supply_lookup: &CoinSupplyLookup) -> Option<BigDecimal> {
+        if let Some(aggregator) = self.vec.get(0) {
+            let table_handle = aggregator.handle.clone();
+            let table_key = aggregator.key.clone();
+            supply_lookup.get(&(table_handle, table_key)).cloned()
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IntegerWrapperResource {
+    pub vec: Vec<IntegerResource>,
+}
+
+impl IntegerWrapperResource {
+    pub fn get_supply(&self) -> Option<BigDecimal> {
+        self.vec.get(0).map(|inner| inner.value.clone())
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AggregatorResource {
+    pub handle: String,
+    pub key: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct IntegerResource {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub value: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CoinStoreResource {
+    pub coin: Coin,
+    pub deposit_events: DepositEventResource,
+    pub withdraw_events: WithdrawEventResource,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Coin {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub value: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DepositEventResource {
+    pub guid: EventGuidResourceWrapper,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WithdrawEventResource {
+    pub guid: EventGuidResourceWrapper,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EventGuidResourceWrapper {
+    pub id: EventGuidResource,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, Eq, PartialEq)]
+pub struct EventGuidResource {
+    pub addr: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub creation_num: i64,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct WithdrawCoinEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct DepositCoinEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub amount: BigDecimal,
+}
+
+pub struct CoinInfoType {
+    coin_type: String,
+    pub creator_address: String,
+}
+
+impl CoinInfoType {
+    pub fn from_move_type(move_type: &MoveType, txn_version: i64) -> anyhow::Result<Self> {
+        let coin_type = move_type.to_string();
+        let (address, _, _) = if let MoveType::Struct(inner) = move_type {
+            (
+                inner.address.to_string(),
+                inner.module.to_string(),
+                inner.name.to_string(),
+            )
+        } else {
+            Err(anyhow::anyhow!(
+                "MoveType is not a struct: {:?}, version: {}",
+                move_type,
+                txn_version
+            ))?
+        };
+        Ok(Self {
+            coin_type,
+            creator_address: address,
+        })
+    }
+
+    pub fn get_coin_type_trunc(&self) -> String {
+        truncate_str(&self.coin_type, 256)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum CoinResource {
+    CoinInfoResource(CoinInfoResource),
+    CoinStoreResource(CoinStoreResource),
+}
+
+impl CoinResource {
+    pub fn is_resource_supported(data_type: &str) -> bool {
+        matches!(data_type, "0x1::coin::CoinInfo" | "0x1::coin::CoinStore")
+    }
+
+    pub fn from_resource(
+        data_type: &str,
+        data: &serde_json::Value,
+        txn_version: i64,
+    ) -> Result<CoinResource> {
+        match data_type {
+            "0x1::coin::CoinInfo" => serde_json::from_value(data.clone())
+                .map(|inner| Some(CoinResource::CoinInfoResource(inner))),
+            "0x1::coin::CoinStore" => serde_json::from_value(data.clone())
+                .map(|inner| Some(CoinResource::CoinStoreResource(inner))),
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {} failed! failed to parse type {}, data {:?}",
+            txn_version, data_type, data
+        ))?
+        .context(format!(
+            "Resource unsupported! Call is_resource_supported first. version {} type {}",
+            txn_version, data_type
+        ))
+    }
+
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> Result<Option<CoinResource>> {
+        let type_str = format!(
+            "{}::{}::{}",
+            write_resource.data.typ.address,
+            write_resource.data.typ.module,
+            write_resource.data.typ.name
+        );
+        if !CoinResource::is_resource_supported(type_str.as_str()) {
+            return Ok(None);
+        }
+        let resource = MoveResource::from_write_resource(
+            write_resource,
+            0, // Placeholder, this isn't used anyway
+            txn_version,
+            0, // Placeholder, this isn't used anyway
+        );
+        Ok(Some(Self::from_resource(
+            &type_str,
+            resource.data.as_ref().unwrap(),
+            txn_version,
+        )?))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum CoinEvent {
+    WithdrawCoinEvent(WithdrawCoinEvent),
+    DepositCoinEvent(DepositCoinEvent),
+}
+
+impl CoinEvent {
+    pub fn from_event(
+        data_type: &str,
+        data: &serde_json::Value,
+        txn_version: i64,
+    ) -> Result<Option<CoinEvent>> {
+        match data_type {
+            "0x1::coin::WithdrawEvent" => serde_json::from_value(data.clone())
+                .map(|inner| Some(CoinEvent::WithdrawCoinEvent(inner))),
+            "0x1::coin::DepositEvent" => serde_json::from_value(data.clone())
+                .map(|inner| Some(CoinEvent::DepositCoinEvent(inner))),
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {} failed! failed to parse type {}, data {:?}",
+            txn_version, data_type, data
+        ))
+    }
+}

--- a/crates/indexer/src/models/coin_models/mod.rs
+++ b/crates/indexer/src/models/coin_models/mod.rs
@@ -1,0 +1,7 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod coin_activities;
+pub mod coin_balances;
+pub mod coin_infos;
+mod coin_utils;

--- a/crates/indexer/src/models/events.rs
+++ b/crates/indexer/src/models/events.rs
@@ -6,9 +6,9 @@ use aptos_api_types::Event as APIEvent;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(
-    Associations, Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize,
-)]
+use super::transactions::TransactionQuery;
+
+#[derive(Associations, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(account_address, creation_number, sequence_number))]
 #[diesel(table_name = events)]
@@ -20,7 +20,21 @@ pub struct Event {
     pub transaction_block_height: i64,
     pub type_: String,
     pub data: serde_json::Value,
-    // Default time columns
+}
+
+/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
+#[derive(Associations, Debug, Deserialize, Identifiable, Queryable, Serialize)]
+#[diesel(belongs_to(TransactionQuery, foreign_key = transaction_version))]
+#[diesel(primary_key(account_address, creation_number, sequence_number))]
+#[diesel(table_name = events)]
+pub struct EventQuery {
+    pub sequence_number: i64,
+    pub creation_number: i64,
+    pub account_address: String,
+    pub transaction_version: i64,
+    pub transaction_block_height: i64,
+    pub type_: String,
+    pub data: serde_json::Value,
     pub inserted_at: chrono::NaiveDateTime,
 }
 
@@ -38,7 +52,6 @@ impl Event {
             transaction_block_height,
             type_: event.typ.to_string(),
             data: event.data.clone(),
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 

--- a/crates/indexer/src/models/mod.rs
+++ b/crates/indexer/src/models/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod block_metadata_transactions;
+pub mod coin_models;
 pub mod events;
 pub mod ledger_info;
 pub mod move_modules;

--- a/crates/indexer/src/models/move_modules.rs
+++ b/crates/indexer/src/models/move_modules.rs
@@ -7,15 +7,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Associations,
-    Clone,
-    Debug,
-    Deserialize,
-    FieldCount,
-    Identifiable,
-    Insertable,
-    Queryable,
-    Serialize,
+    Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
 )]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
@@ -31,8 +23,6 @@ pub struct MoveModule {
     pub friends: Option<serde_json::Value>,
     pub structs: Option<serde_json::Value>,
     pub is_deleted: bool,
-    // Default time columns
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
 pub struct MoveModuleByteCodeParsed {
@@ -66,7 +56,6 @@ impl MoveModule {
             friends: parsed_data.as_ref().map(|d| d.friends.clone()),
             structs: parsed_data.as_ref().map(|d| d.structs.clone()),
             is_deleted: false,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 
@@ -87,7 +76,6 @@ impl MoveModule {
             friends: None,
             structs: None,
             is_deleted: true,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 

--- a/crates/indexer/src/models/move_resources.rs
+++ b/crates/indexer/src/models/move_resources.rs
@@ -7,15 +7,7 @@ use aptos_api_types::{DeleteResource, MoveStructTag as APIMoveStructTag, WriteRe
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 #[derive(
-    Associations,
-    Clone,
-    Debug,
-    Deserialize,
-    FieldCount,
-    Identifiable,
-    Insertable,
-    Queryable,
-    Serialize,
+    Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
 )]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
@@ -31,8 +23,6 @@ pub struct MoveResource {
     pub generic_type_params: Option<serde_json::Value>,
     pub data: Option<serde_json::Value>,
     pub is_deleted: bool,
-    // Default time columns
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
 pub struct MoveStructTag {
@@ -60,7 +50,6 @@ impl MoveResource {
             generic_type_params: parsed_data.generic_type_params,
             data: Some(serde_json::to_value(&write_resource.data.data).unwrap()),
             is_deleted: false,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 
@@ -82,7 +71,6 @@ impl MoveResource {
             generic_type_params: parsed_data.generic_type_params,
             data: None,
             is_deleted: true,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 

--- a/crates/indexer/src/models/move_tables.rs
+++ b/crates/indexer/src/models/move_tables.rs
@@ -10,15 +10,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Associations,
-    Clone,
-    Debug,
-    Deserialize,
-    FieldCount,
-    Identifiable,
-    Insertable,
-    Queryable,
-    Serialize,
+    Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
 )]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(transaction_version, write_set_change_index))]
@@ -32,19 +24,15 @@ pub struct TableItem {
     pub decoded_key: serde_json::Value,
     pub decoded_value: Option<serde_json::Value>,
     pub is_deleted: bool,
-    // Default time columns
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
-#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(handle))]
 #[diesel(table_name = table_metadatas)]
 pub struct TableMetadata {
     pub handle: String,
     pub key_type: String,
     pub value_type: String,
-    // Default time columns
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
 impl TableItem {
@@ -63,7 +51,6 @@ impl TableItem {
             decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
             decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
             is_deleted: false,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 
@@ -92,7 +79,6 @@ impl TableItem {
                 .clone(),
             decoded_value: None,
             is_deleted: true,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 }
@@ -103,7 +89,6 @@ impl TableMetadata {
             handle: table_item.handle.to_string(),
             key_type: table_item.data.as_ref().unwrap().key_type.clone(),
             value_type: table_item.data.as_ref().unwrap().value_type.clone(),
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 }

--- a/crates/indexer/src/models/signatures.rs
+++ b/crates/indexer/src/models/signatures.rs
@@ -15,15 +15,7 @@ use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
 #[derive(
-    Associations,
-    Clone,
-    Debug,
-    Deserialize,
-    FieldCount,
-    Identifiable,
-    Insertable,
-    Queryable,
-    Serialize,
+    Associations, Clone, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize,
 )]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(
@@ -45,8 +37,6 @@ pub struct Signature {
     pub signature: String,
     pub threshold: i64,
     pub public_key_indices: serde_json::Value,
-    // Default time columns
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
 impl Signature {
@@ -121,7 +111,6 @@ impl Signature {
             signature: s.signature.to_string(),
             multi_agent_index,
             multi_sig_index: 0,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 
@@ -165,7 +154,6 @@ impl Signature {
                 ),
                 multi_agent_index,
                 multi_sig_index: index as i64,
-                inserted_at: chrono::Utc::now().naive_utc(),
             });
         }
         signatures

--- a/crates/indexer/src/models/token_models/ans_lookup.rs
+++ b/crates/indexer/src/models/token_models/ans_lookup.rs
@@ -21,7 +21,7 @@ type Subdomain = String;
 // PK of current_ans_lookup, i.e. domain and subdomain name
 pub type CurrentAnsLookupPK = (Domain, Subdomain);
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(domain, subdomain))]
 #[diesel(table_name = current_ans_lookup)]
 pub struct CurrentAnsLookup {
@@ -30,7 +30,6 @@ pub struct CurrentAnsLookup {
     pub registered_address: Option<String>,
     pub last_transaction_version: i64,
     pub expiration_timestamp: chrono::NaiveDateTime,
-    pub inserted_at: chrono::NaiveDateTime,
 }
 
 pub enum ANSEvent {
@@ -124,7 +123,6 @@ impl CurrentAnsLookup {
                                     registered_address: inner.new_address.get_string(),
                                     last_transaction_version: txn_version,
                                     expiration_timestamp,
-                                    inserted_at: chrono::Utc::now().naive_utc(),
                                 }
                             }
                             ANSEvent::RegisterNameEventV1(inner) => {
@@ -141,7 +139,6 @@ impl CurrentAnsLookup {
                                     registered_address: None,
                                     last_transaction_version: txn_version,
                                     expiration_timestamp,
-                                    inserted_at: chrono::Utc::now().naive_utc(),
                                 }
                             }
                         };

--- a/crates/indexer/src/models/token_models/token_claims.rs
+++ b/crates/indexer/src/models/token_models/token_claims.rs
@@ -15,7 +15,7 @@ use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(token_data_id_hash, property_version, from_address, to_address))]
 #[diesel(table_name = current_token_pending_claims)]
 pub struct CurrentTokenPendingClaim {
@@ -30,7 +30,7 @@ pub struct CurrentTokenPendingClaim {
     pub amount: BigDecimal,
     pub table_handle: String,
     pub last_transaction_version: i64,
-    pub inserted_at: chrono::NaiveDateTime,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
 }
 
 impl CurrentTokenPendingClaim {
@@ -39,6 +39,7 @@ impl CurrentTokenPendingClaim {
     pub fn from_write_table_item(
         table_item: &APIWriteTableItem,
         txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
         table_handle_to_owner: &TableHandleToOwner,
     ) -> anyhow::Result<Option<Self>> {
         let table_item_data = table_item.data.as_ref().unwrap();
@@ -86,7 +87,7 @@ impl CurrentTokenPendingClaim {
                         amount: token.amount,
                         table_handle,
                         last_transaction_version: txn_version,
-                        inserted_at: chrono::Utc::now().naive_utc(),
+                        last_transaction_timestamp: txn_timestamp,
                     }));
                 } else {
                     aptos_logger::warn!(
@@ -111,6 +112,7 @@ impl CurrentTokenPendingClaim {
     pub fn from_delete_table_item(
         table_item: &APIDeleteTableItem,
         txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
         table_handle_to_owner: &TableHandleToOwner,
     ) -> anyhow::Result<Option<Self>> {
         let table_item_data = table_item.data.as_ref().unwrap();
@@ -154,7 +156,7 @@ impl CurrentTokenPendingClaim {
                 amount: BigDecimal::zero(),
                 table_handle,
                 last_transaction_version: txn_version,
-                inserted_at: chrono::Utc::now().naive_utc(),
+                last_transaction_timestamp: txn_timestamp,
             }));
         }
         Ok(None)

--- a/crates/indexer/src/models/token_models/token_ownerships.rs
+++ b/crates/indexer/src/models/token_models/token_ownerships.rs
@@ -11,7 +11,7 @@ use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(
     token_data_id_hash,
     property_version,
@@ -30,11 +30,11 @@ pub struct TokenOwnership {
     pub owner_address: Option<String>,
     pub amount: BigDecimal,
     pub table_type: Option<String>,
-    pub inserted_at: chrono::NaiveDateTime,
     pub collection_data_id_hash: String,
+    pub transaction_timestamp: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(token_data_id_hash, property_version, owner_address))]
 #[diesel(table_name = current_token_ownerships)]
 pub struct CurrentTokenOwnership {
@@ -47,9 +47,9 @@ pub struct CurrentTokenOwnership {
     pub amount: BigDecimal,
     pub token_properties: serde_json::Value,
     pub last_transaction_version: i64,
-    pub inserted_at: chrono::NaiveDateTime,
     pub collection_data_id_hash: String,
     pub table_type: String,
+    pub last_transaction_timestamp: chrono::NaiveDateTime,
 }
 
 impl TokenOwnership {
@@ -77,8 +77,8 @@ impl TokenOwnership {
                     amount: amount.clone(),
                     token_properties: token.token_properties.clone(),
                     last_transaction_version: txn_version,
-                    inserted_at: chrono::Utc::now().naive_utc(),
                     table_type: tm.table_type.clone(),
+                    last_transaction_timestamp: token.transaction_timestamp,
                 }),
                 Some(tm.owner_address.clone()),
                 Some(tm.table_type.clone()),
@@ -117,7 +117,7 @@ impl TokenOwnership {
                 table_type,
                 transaction_version: token.transaction_version,
                 table_handle,
-                inserted_at: chrono::Utc::now().naive_utc(),
+                transaction_timestamp: token.transaction_timestamp,
             },
             curr_token_ownership,
         )

--- a/crates/indexer/src/models/token_models/token_utils.rs
+++ b/crates/indexer/src/models/token_models/token_utils.rs
@@ -11,6 +11,8 @@ use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 use std::fmt::{self, Formatter};
 
+const NAME_LENGTH: usize = 128;
+const URI_LENGTH: usize = 512;
 /**
  * This file defines deserialized move types as defined in our 0x3 contracts.
  */
@@ -33,11 +35,11 @@ impl TokenDataIdType {
     }
 
     pub fn get_collection_trunc(&self) -> String {
-        truncate_str(&self.collection, 128)
+        truncate_str(&self.collection, NAME_LENGTH)
     }
 
     pub fn get_name_trunc(&self) -> String {
-        truncate_str(&self.name, 128)
+        truncate_str(&self.name, NAME_LENGTH)
     }
 
     pub fn get_collection_data_id_hash(&self) -> String {
@@ -70,7 +72,7 @@ impl CollectionDataIdType {
     }
 
     pub fn get_name_trunc(&self) -> String {
-        truncate_str(&self.name, 128)
+        truncate_str(&self.name, NAME_LENGTH)
     }
 }
 
@@ -112,11 +114,11 @@ pub struct TokenDataType {
 
 impl TokenDataType {
     pub fn get_uri_trunc(&self) -> String {
-        truncate_str(&self.uri, 512)
+        truncate_str(&self.uri, URI_LENGTH)
     }
 
     pub fn get_name_trunc(&self) -> String {
-        truncate_str(&self.name, 128)
+        truncate_str(&self.name, NAME_LENGTH)
     }
 }
 
@@ -165,11 +167,11 @@ impl CollectionDataType {
     }
 
     pub fn get_uri_trunc(&self) -> String {
-        truncate_str(&self.uri, 512)
+        truncate_str(&self.uri, URI_LENGTH)
     }
 
     pub fn get_name_trunc(&self) -> String {
-        truncate_str(&self.name, 128)
+        truncate_str(&self.name, NAME_LENGTH)
     }
 }
 

--- a/crates/indexer/src/models/token_models/tokens.rs
+++ b/crates/indexer/src/models/token_models/tokens.rs
@@ -13,8 +13,10 @@ use super::{
     token_utils::{TokenResource, TokenWriteSet},
 };
 use crate::{
-    database::PgPoolConnection, models::move_resources::MoveResource, schema::tokens,
-    util::ensure_not_negative,
+    database::PgPoolConnection,
+    models::move_resources::MoveResource,
+    schema::tokens,
+    util::{ensure_not_negative, parse_timestamp},
 };
 use aptos_api_types::{
     DeleteTableItem as APIDeleteTableItem, Transaction as APITransaction,
@@ -38,7 +40,7 @@ pub type CurrentTokenPendingClaimPK = (TokenDataIdHash, BigDecimal, Address, Add
 // PK of tokens table, used to dedupe tokens
 pub type TokenPK = (TokenDataIdHash, BigDecimal);
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(token_data_id_hash, property_version, transaction_version))]
 #[diesel(table_name = tokens)]
 pub struct Token {
@@ -49,8 +51,8 @@ pub struct Token {
     pub collection_name: String,
     pub name: String,
     pub token_properties: serde_json::Value,
-    pub inserted_at: chrono::NaiveDateTime,
     pub collection_data_id_hash: String,
+    pub transaction_timestamp: chrono::NaiveDateTime,
 }
 
 #[derive(Debug)]
@@ -98,6 +100,7 @@ impl Token {
             > = HashMap::new();
 
             let txn_version = user_txn.info.version.0 as i64;
+            let txn_timestamp = parse_timestamp(user_txn.timestamp.0, txn_version);
             let mut table_handle_to_owner: TableHandleToOwner = HashMap::new();
             for wsc in &user_txn.info.changes {
                 if let APIWriteSetChange::WriteResource(write_resource) = wsc {
@@ -119,13 +122,20 @@ impl Token {
                         Self::from_write_table_item(
                             write_table_item,
                             txn_version,
+                            txn_timestamp,
                             &table_handle_to_owner,
                         )
                         .unwrap(),
-                        TokenData::from_write_table_item(write_table_item, txn_version).unwrap(),
+                        TokenData::from_write_table_item(
+                            write_table_item,
+                            txn_version,
+                            txn_timestamp,
+                        )
+                        .unwrap(),
                         CollectionData::from_write_table_item(
                             write_table_item,
                             txn_version,
+                            txn_timestamp,
                             &table_handle_to_owner,
                             conn,
                         )
@@ -135,6 +145,7 @@ impl Token {
                         Self::from_delete_table_item(
                             delete_table_item,
                             txn_version,
+                            txn_timestamp,
                             &table_handle_to_owner,
                         )
                         .unwrap(),
@@ -149,6 +160,7 @@ impl Token {
                         CurrentTokenPendingClaim::from_write_table_item(
                             write_table_item,
                             txn_version,
+                            txn_timestamp,
                             &table_handle_to_owner,
                         )
                         .unwrap()
@@ -157,6 +169,7 @@ impl Token {
                         CurrentTokenPendingClaim::from_delete_table_item(
                             delete_table_item,
                             txn_version,
+                            txn_timestamp,
                             &table_handle_to_owner,
                         )
                         .unwrap()
@@ -232,6 +245,7 @@ impl Token {
     pub fn from_write_table_item(
         table_item: &APIWriteTableItem,
         txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
         table_handle_to_owner: &TableHandleToOwner,
     ) -> anyhow::Result<Option<(Self, TokenOwnership, Option<CurrentTokenOwnership>)>> {
         let table_item_data = table_item.data.as_ref().unwrap();
@@ -262,7 +276,7 @@ impl Token {
                 property_version: token_id.property_version,
                 transaction_version: txn_version,
                 token_properties: token.token_properties,
-                inserted_at: chrono::Utc::now().naive_utc(),
+                transaction_timestamp: txn_timestamp,
             };
 
             let (token_ownership, current_token_ownership) = TokenOwnership::from_token(
@@ -284,6 +298,7 @@ impl Token {
     pub fn from_delete_table_item(
         table_item: &APIDeleteTableItem,
         txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
         table_handle_to_owner: &TableHandleToOwner,
     ) -> anyhow::Result<Option<(Self, TokenOwnership, Option<CurrentTokenOwnership>)>> {
         let table_item_data = table_item.data.as_ref().unwrap();
@@ -313,7 +328,7 @@ impl Token {
                 property_version: token_id.property_version,
                 transaction_version: txn_version,
                 token_properties: serde_json::Value::Null,
-                inserted_at: chrono::Utc::now().naive_utc(),
+                transaction_timestamp: txn_timestamp,
             };
             let (token_ownership, current_token_ownership) = TokenOwnership::from_token(
                 &token,

--- a/crates/indexer/src/models/token_models/tokens.rs
+++ b/crates/indexer/src/models/token_models/tokens.rs
@@ -346,7 +346,7 @@ impl TableMetadataForToken {
         }
         let resource = MoveResource::from_write_resource(
             write_resource,
-            0,
+            0, // Placeholder, this isn't used anyway
             txn_version,
             0, // Placeholder, this isn't used anyway
         );

--- a/crates/indexer/src/models/transactions.rs
+++ b/crates/indexer/src/models/transactions.rs
@@ -6,7 +6,6 @@
 #![allow(clippy::unused_unit)]
 
 use crate::{
-    models::{events::EventModel, write_set_changes::WriteSetChangeModel},
     schema::{block_metadata_transactions, transactions, user_transactions},
     util::u64_to_bigdecimal,
 };
@@ -21,11 +20,14 @@ use diesel::{
 };
 
 use super::{
-    block_metadata_transactions::BlockMetadataTransaction, signatures::Signature,
-    user_transactions::UserTransaction, write_set_changes::WriteSetChangeDetail,
+    block_metadata_transactions::{BlockMetadataTransaction, BlockMetadataTransactionQuery},
+    events::{EventModel, EventQuery},
+    signatures::Signature,
+    user_transactions::{UserTransaction, UserTransactionQuery},
+    write_set_changes::{WriteSetChangeDetail, WriteSetChangeModel, WriteSetChangeQuery},
 };
 
-#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize)]
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(version))]
 #[diesel(table_name = transactions)]
 pub struct Transaction {
@@ -43,7 +45,27 @@ pub struct Transaction {
     pub accumulator_root_hash: String,
     pub num_events: i64,
     pub num_write_set_changes: i64,
-    // Default time columns
+}
+
+/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
+#[derive(Debug, Deserialize, Identifiable, Queryable, Serialize)]
+#[diesel(primary_key(version))]
+#[diesel(table_name = transactions)]
+pub struct TransactionQuery {
+    pub version: i64,
+    pub block_height: i64,
+    pub hash: String,
+    pub type_: String,
+    pub payload: Option<serde_json::Value>,
+    pub state_change_hash: String,
+    pub event_root_hash: String,
+    pub state_checkpoint_hash: Option<String>,
+    pub gas_used: BigDecimal,
+    pub success: bool,
+    pub vm_status: String,
+    pub accumulator_root_hash: String,
+    pub num_events: i64,
+    pub num_write_set_changes: i64,
     pub inserted_at: chrono::NaiveDateTime,
 }
 
@@ -70,7 +92,6 @@ impl Transaction {
             accumulator_root_hash: info.accumulator_root_hash.to_string(),
             num_events,
             num_write_set_changes: info.changes.len() as i64,
-            inserted_at: chrono::Utc::now().naive_utc(),
         }
     }
 
@@ -222,42 +243,45 @@ impl Transaction {
         }
         (txns, txn_details, events, wscs, wsc_details)
     }
+}
 
+impl TransactionQuery {
     pub fn get_many_by_version(
         start_version: u64,
         number_to_get: i64,
         conn: &mut PgPoolConnection,
     ) -> diesel::QueryResult<
         Vec<(
-            Transaction,
-            Option<UserTransaction>,
-            Option<BlockMetadataTransaction>,
-            Vec<EventModel>,
-            Vec<WriteSetChangeModel>,
+            Self,
+            Option<UserTransactionQuery>,
+            Option<BlockMetadataTransactionQuery>,
+            Vec<EventQuery>,
+            Vec<WriteSetChangeQuery>,
         )>,
     > {
         let mut txs = transactions::table
             .filter(transactions::version.ge(start_version as i64))
             .order(transactions::version.asc())
             .limit(number_to_get as i64)
-            .load::<Transaction>(conn)?;
+            .load::<Self>(conn)?;
 
-        let mut user_transactions: Vec<Vec<UserTransaction>> = UserTransaction::belonging_to(&txs)
-            .load::<UserTransaction>(conn)?
-            .grouped_by(&txs);
-
-        let mut block_metadata_transactions: Vec<Vec<BlockMetadataTransaction>> =
-            BlockMetadataTransaction::belonging_to(&txs)
-                .load::<BlockMetadataTransaction>(conn)?
+        let mut user_transactions: Vec<Vec<UserTransactionQuery>> =
+            UserTransactionQuery::belonging_to(&txs)
+                .load::<UserTransactionQuery>(conn)?
                 .grouped_by(&txs);
 
-        let mut events: Vec<Vec<EventModel>> = EventModel::belonging_to(&txs)
-            .load::<EventModel>(conn)?
+        let mut block_metadata_transactions: Vec<Vec<BlockMetadataTransactionQuery>> =
+            BlockMetadataTransactionQuery::belonging_to(&txs)
+                .load::<BlockMetadataTransactionQuery>(conn)?
+                .grouped_by(&txs);
+
+        let mut events: Vec<Vec<EventQuery>> = EventQuery::belonging_to(&txs)
+            .load::<EventQuery>(conn)?
             .grouped_by(&txs);
 
-        let mut write_set_changes: Vec<Vec<WriteSetChangeModel>> =
-            WriteSetChangeModel::belonging_to(&txs)
-                .load::<WriteSetChangeModel>(conn)?
+        let mut write_set_changes: Vec<Vec<WriteSetChangeQuery>> =
+            WriteSetChangeQuery::belonging_to(&txs)
+                .load::<WriteSetChangeQuery>(conn)?
                 .grouped_by(&txs);
 
         // Convert to the nice result tuple
@@ -279,15 +303,15 @@ impl Transaction {
         version: u64,
         conn: &mut PgPoolConnection,
     ) -> diesel::QueryResult<(
-        Transaction,
-        Option<UserTransaction>,
-        Option<BlockMetadataTransaction>,
-        Vec<EventModel>,
-        Vec<WriteSetChangeModel>,
+        Self,
+        Option<UserTransactionQuery>,
+        Option<BlockMetadataTransactionQuery>,
+        Vec<EventQuery>,
+        Vec<WriteSetChangeQuery>,
     )> {
         let transaction = transactions::table
             .filter(transactions::version.eq(version as i64))
-            .first::<Transaction>(conn)?;
+            .first::<Self>(conn)?;
 
         let (user_transaction, block_metadata_transaction, events, write_set_changes) =
             transaction.get_details_for_transaction(conn)?;
@@ -305,15 +329,15 @@ impl Transaction {
         transaction_hash: &str,
         conn: &mut PgPoolConnection,
     ) -> diesel::QueryResult<(
-        Transaction,
-        Option<UserTransaction>,
-        Option<BlockMetadataTransaction>,
-        Vec<EventModel>,
-        Vec<WriteSetChangeModel>,
+        Self,
+        Option<UserTransactionQuery>,
+        Option<BlockMetadataTransactionQuery>,
+        Vec<EventQuery>,
+        Vec<WriteSetChangeQuery>,
     )> {
         let transaction = transactions::table
             .filter(transactions::hash.eq(&transaction_hash))
-            .first::<Transaction>(conn)?;
+            .first::<Self>(conn)?;
 
         let (user_transaction, block_metadata_transaction, events, write_set_changes) =
             transaction.get_details_for_transaction(conn)?;
@@ -331,33 +355,33 @@ impl Transaction {
         &self,
         conn: &mut PgPoolConnection,
     ) -> diesel::QueryResult<(
-        Option<UserTransaction>,
-        Option<BlockMetadataTransaction>,
-        Vec<EventModel>,
-        Vec<WriteSetChangeModel>,
+        Option<UserTransactionQuery>,
+        Option<BlockMetadataTransactionQuery>,
+        Vec<EventQuery>,
+        Vec<WriteSetChangeQuery>,
     )> {
-        let mut user_transaction: Option<UserTransaction> = None;
-        let mut block_metadata_transaction: Option<BlockMetadataTransaction> = None;
+        let mut user_transaction: Option<UserTransactionQuery> = None;
+        let mut block_metadata_transaction: Option<BlockMetadataTransactionQuery> = None;
 
         let events = crate::schema::events::table
             .filter(crate::schema::events::transaction_version.eq(&self.version))
-            .load::<EventModel>(conn)?;
+            .load::<EventQuery>(conn)?;
 
         let write_set_changes = crate::schema::write_set_changes::table
             .filter(crate::schema::write_set_changes::transaction_version.eq(&self.version))
-            .load::<WriteSetChangeModel>(conn)?;
+            .load::<WriteSetChangeQuery>(conn)?;
 
         match self.type_.as_str() {
             "user_transaction" => {
                 user_transaction = user_transactions::table
                     .filter(user_transactions::version.eq(&self.version))
-                    .first::<UserTransaction>(conn)
+                    .first::<UserTransactionQuery>(conn)
                     .optional()?;
             }
             "block_metadata_transaction" => {
                 block_metadata_transaction = block_metadata_transactions::table
                     .filter(block_metadata_transactions::version.eq(&self.version))
-                    .first::<BlockMetadataTransaction>(conn)
+                    .first::<BlockMetadataTransactionQuery>(conn)
                     .optional()?;
             }
             "genesis_transaction" => {}

--- a/crates/indexer/src/models/write_set_changes.rs
+++ b/crates/indexer/src/models/write_set_changes.rs
@@ -5,15 +5,14 @@ use super::{
     move_modules::MoveModule,
     move_resources::MoveResource,
     move_tables::{TableItem, TableMetadata},
+    transactions::TransactionQuery,
 };
 use crate::{models::transactions::Transaction, schema::write_set_changes};
 use aptos_api_types::WriteSetChange as APIWriteSetChange;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
 
-#[derive(
-    Associations, Debug, Deserialize, FieldCount, Identifiable, Insertable, Queryable, Serialize,
-)]
+#[derive(Associations, Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(belongs_to(Transaction, foreign_key = transaction_version))]
 #[diesel(primary_key(transaction_version, index))]
 #[diesel(table_name = write_set_changes)]
@@ -24,7 +23,20 @@ pub struct WriteSetChange {
     transaction_block_height: i64,
     pub type_: String,
     pub address: String,
-    // Default time columns
+}
+
+/// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
+#[derive(Associations, Debug, Deserialize, Identifiable, Queryable, Serialize)]
+#[diesel(belongs_to(TransactionQuery, foreign_key = transaction_version))]
+#[diesel(primary_key(transaction_version, index))]
+#[diesel(table_name = write_set_changes)]
+pub struct WriteSetChangeQuery {
+    pub transaction_version: i64,
+    pub index: i64,
+    pub hash: String,
+    transaction_block_height: i64,
+    pub type_: String,
+    pub address: String,
     pub inserted_at: chrono::NaiveDateTime,
 }
 
@@ -45,7 +57,6 @@ impl WriteSetChange {
                     type_,
                     address: module.address.to_string(),
                     index,
-                    inserted_at: chrono::Utc::now().naive_utc(),
                 },
                 WriteSetChangeDetail::Module(MoveModule::from_write_module(
                     module,
@@ -62,7 +73,6 @@ impl WriteSetChange {
                     type_,
                     address: module.address.to_string(),
                     index,
-                    inserted_at: chrono::Utc::now().naive_utc(),
                 },
                 WriteSetChangeDetail::Module(MoveModule::from_delete_module(
                     module,
@@ -79,7 +89,6 @@ impl WriteSetChange {
                     type_,
                     address: resource.address.to_string(),
                     index,
-                    inserted_at: chrono::Utc::now().naive_utc(),
                 },
                 WriteSetChangeDetail::Resource(MoveResource::from_write_resource(
                     resource,
@@ -96,7 +105,6 @@ impl WriteSetChange {
                     type_,
                     address: resource.address.to_string(),
                     index,
-                    inserted_at: chrono::Utc::now().naive_utc(),
                 },
                 WriteSetChangeDetail::Resource(MoveResource::from_delete_resource(
                     resource,
@@ -113,7 +121,6 @@ impl WriteSetChange {
                     type_,
                     address: String::default(),
                     index,
-                    inserted_at: chrono::Utc::now().naive_utc(),
                 },
                 WriteSetChangeDetail::Table(
                     TableItem::from_write_table_item(
@@ -133,7 +140,6 @@ impl WriteSetChange {
                     type_,
                     address: String::default(),
                     index,
-                    inserted_at: chrono::Utc::now().naive_utc(),
                 },
                 WriteSetChangeDetail::Table(
                     TableItem::from_delete_table_item(

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -134,7 +134,7 @@ fn insert_coin_activities(
                     is_gas_fee.eq(excluded(is_gas_fee)),
                     is_transaction_success.eq(excluded(is_transaction_success)),
                     entry_function_id_str.eq(excluded(entry_function_id_str)),
-                    inserted_at.eq(excluded(inserted_at)),
+                    transaction_timestamp.eq(excluded(transaction_timestamp)),
                 )),
             None,
         )?;
@@ -154,7 +154,7 @@ fn insert_coin_infos(
             conn,
             diesel::insert_into(schema::coin_infos::table)
                 .values(&item_to_insert[start_ind..end_ind])
-                .on_conflict(coin_type)
+                .on_conflict(coin_type_hash)
                 .do_update()
                 .set((
                     transaction_version_created.eq(excluded(transaction_version_created)),
@@ -162,8 +162,7 @@ fn insert_coin_infos(
                     name.eq(excluded(name)),
                     symbol.eq(excluded(symbol)),
                     decimals.eq(excluded(decimals)),
-                    supply.eq(excluded(supply)),
-                    inserted_at.eq(excluded(inserted_at)),
+                    transaction_created_timestamp.eq(excluded(transaction_created_timestamp)),
                 )),
             Some(" WHERE coin_infos.transaction_version_created >= EXCLUDED.transaction_version_created "),
         )?;
@@ -183,11 +182,11 @@ fn insert_coin_balances(
             conn,
             diesel::insert_into(schema::coin_balances::table)
                 .values(&item_to_insert[start_ind..end_ind])
-                .on_conflict((transaction_version, owner_address, coin_type))
+                .on_conflict((transaction_version, owner_address, coin_type_hash))
                 .do_update()
                 .set((
                     amount.eq(excluded(amount)),
-                    inserted_at.eq(excluded(inserted_at)),
+                    transaction_timestamp.eq(excluded(transaction_timestamp)),
                 )),
             None,
         )?;
@@ -207,12 +206,12 @@ fn insert_current_coin_balances(
             conn,
             diesel::insert_into(schema::current_coin_balances::table)
                 .values(&item_to_insert[start_ind..end_ind])
-                .on_conflict((owner_address, coin_type))
+                .on_conflict((owner_address, coin_type_hash))
                 .do_update()
                 .set((
                     amount.eq(excluded(amount)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    inserted_at.eq(excluded(inserted_at)),
+                    last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
                 )),
                 Some(" WHERE current_coin_balances.last_transaction_version <= excluded.last_transaction_version "),
             )?;

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -1,0 +1,292 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    database::{
+        clean_data_for_db, execute_with_better_error, get_chunks, PgDbPool, PgPoolConnection,
+    },
+    indexer::{
+        errors::TransactionProcessingError, processing_result::ProcessingResult,
+        transaction_processor::TransactionProcessor,
+    },
+    models::coin_models::{
+        coin_activities::{CoinActivity, CurrentCoinBalancePK},
+        coin_balances::{CoinBalance, CurrentCoinBalance},
+        coin_infos::CoinInfo,
+    },
+    schema,
+};
+use aptos_api_types::Transaction as APITransaction;
+use async_trait::async_trait;
+use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods, PgConnection};
+use field_count::FieldCount;
+use std::{collections::HashMap, fmt::Debug};
+
+pub const NAME: &str = "coin_processor";
+pub struct CoinTransactionProcessor {
+    connection_pool: PgDbPool,
+}
+
+impl CoinTransactionProcessor {
+    pub fn new(connection_pool: PgDbPool) -> Self {
+        Self { connection_pool }
+    }
+}
+
+impl Debug for CoinTransactionProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = &self.connection_pool.state();
+        write!(
+            f,
+            "CoinTransactionProcessor {{ connections: {:?}  idle_connections: {:?} }}",
+            state.connections, state.idle_connections
+        )
+    }
+}
+
+fn insert_to_db_impl(
+    conn: &mut PgConnection,
+    coin_activities: &[CoinActivity],
+    coin_infos: &[CoinInfo],
+    coin_balances: &[CoinBalance],
+    current_coin_balances: &[CurrentCoinBalance],
+) -> Result<(), diesel::result::Error> {
+    insert_coin_activities(conn, coin_activities)?;
+    insert_coin_infos(conn, coin_infos)?;
+    insert_coin_balances(conn, coin_balances)?;
+    insert_current_coin_balances(conn, current_coin_balances)?;
+    Ok(())
+}
+
+fn insert_to_db(
+    conn: &mut PgPoolConnection,
+    name: &'static str,
+    start_version: u64,
+    end_version: u64,
+    coin_activities: Vec<CoinActivity>,
+    coin_infos: Vec<CoinInfo>,
+    coin_balances: Vec<CoinBalance>,
+    current_coin_balances: Vec<CurrentCoinBalance>,
+) -> Result<(), diesel::result::Error> {
+    aptos_logger::trace!(
+        name = name,
+        start_version = start_version,
+        end_version = end_version,
+        "Inserting to db",
+    );
+    match conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|pg_conn| {
+            insert_to_db_impl(
+                pg_conn,
+                &coin_activities,
+                &coin_infos,
+                &coin_balances,
+                &current_coin_balances,
+            )
+        }) {
+        Ok(_) => Ok(()),
+        Err(_) => conn
+            .build_transaction()
+            .read_write()
+            .run::<_, Error, _>(|pg_conn| {
+                let coin_activities = clean_data_for_db(coin_activities, true);
+                let coin_infos = clean_data_for_db(coin_infos, true);
+                let coin_balances = clean_data_for_db(coin_balances, true);
+                let current_coin_balances = clean_data_for_db(current_coin_balances, true);
+
+                insert_to_db_impl(
+                    pg_conn,
+                    &coin_activities,
+                    &coin_infos,
+                    &coin_balances,
+                    &current_coin_balances,
+                )
+            }),
+    }
+}
+
+fn insert_coin_activities(
+    conn: &mut PgConnection,
+    item_to_insert: &[CoinActivity],
+) -> Result<(), diesel::result::Error> {
+    use schema::coin_activities::dsl::*;
+
+    let chunks = get_chunks(item_to_insert.len(), CoinActivity::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::coin_activities::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict((
+                    transaction_version,
+                    event_account_address,
+                    event_creation_number,
+                    event_sequence_number,
+                ))
+                .do_update()
+                .set((
+                    owner_address.eq(excluded(owner_address)),
+                    coin_type.eq(excluded(coin_type)),
+                    amount.eq(excluded(amount)),
+                    activity_type.eq(excluded(activity_type)),
+                    is_gas_fee.eq(excluded(is_gas_fee)),
+                    is_transaction_success.eq(excluded(is_transaction_success)),
+                    entry_function_id_str.eq(excluded(entry_function_id_str)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
+            None,
+        )?;
+    }
+    Ok(())
+}
+
+fn insert_coin_infos(
+    conn: &mut PgConnection,
+    item_to_insert: &[CoinInfo],
+) -> Result<(), diesel::result::Error> {
+    use schema::coin_infos::dsl::*;
+
+    let chunks = get_chunks(item_to_insert.len(), CoinInfo::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::coin_infos::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict(coin_type)
+                .do_update()
+                .set((
+                    transaction_version_created.eq(excluded(transaction_version_created)),
+                    creator_address.eq(excluded(creator_address)),
+                    name.eq(excluded(name)),
+                    symbol.eq(excluded(symbol)),
+                    decimals.eq(excluded(decimals)),
+                    supply.eq(excluded(supply)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
+            Some(" WHERE coin_infos.transaction_version_created >= EXCLUDED.transaction_version_created "),
+        )?;
+    }
+    Ok(())
+}
+
+fn insert_coin_balances(
+    conn: &mut PgConnection,
+    item_to_insert: &[CoinBalance],
+) -> Result<(), diesel::result::Error> {
+    use schema::coin_balances::dsl::*;
+
+    let chunks = get_chunks(item_to_insert.len(), CoinBalance::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::coin_balances::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict((transaction_version, owner_address, coin_type))
+                .do_update()
+                .set((
+                    amount.eq(excluded(amount)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
+            None,
+        )?;
+    }
+    Ok(())
+}
+
+fn insert_current_coin_balances(
+    conn: &mut PgConnection,
+    item_to_insert: &[CurrentCoinBalance],
+) -> Result<(), diesel::result::Error> {
+    use schema::current_coin_balances::dsl::*;
+
+    let chunks = get_chunks(item_to_insert.len(), CurrentCoinBalance::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::current_coin_balances::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict((owner_address, coin_type))
+                .do_update()
+                .set((
+                    amount.eq(excluded(amount)),
+                    last_transaction_version.eq(excluded(last_transaction_version)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
+                Some(" WHERE current_coin_balances.last_transaction_version <= excluded.last_transaction_version "),
+            )?;
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl TransactionProcessor for CoinTransactionProcessor {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    async fn process_transactions(
+        &self,
+        transactions: Vec<APITransaction>,
+        start_version: u64,
+        end_version: u64,
+    ) -> Result<ProcessingResult, TransactionProcessingError> {
+        let mut all_coin_activities = vec![];
+        let mut all_coin_balances = vec![];
+        let mut all_coin_infos: HashMap<String, CoinInfo> = HashMap::new();
+        let mut all_current_coin_balances: HashMap<CurrentCoinBalancePK, CurrentCoinBalance> =
+            HashMap::new();
+
+        for txn in &transactions {
+            let (mut coin_activities, mut coin_balances, coin_infos, current_coin_balances) =
+                CoinActivity::from_transaction(txn);
+            all_coin_activities.append(&mut coin_activities);
+            all_coin_balances.append(&mut coin_balances);
+            // For coin infos, we only want to keep the first version, so insert only if key is not present already
+            for (key, value) in coin_infos {
+                all_coin_infos.entry(key).or_insert(value);
+            }
+            all_current_coin_balances.extend(current_coin_balances);
+        }
+        let mut all_coin_infos = all_coin_infos.into_values().collect::<Vec<CoinInfo>>();
+        let mut all_current_coin_balances = all_current_coin_balances
+            .into_values()
+            .collect::<Vec<CurrentCoinBalance>>();
+
+        // Sort by PK
+        all_coin_infos.sort_by(|a, b| a.coin_type.cmp(&b.coin_type));
+        all_current_coin_balances.sort_by(|a, b| {
+            (&a.owner_address, &a.coin_type).cmp(&(&b.owner_address, &b.coin_type))
+        });
+
+        let mut conn = self.get_conn();
+        let tx_result = insert_to_db(
+            &mut conn,
+            self.name(),
+            start_version,
+            end_version,
+            all_coin_activities,
+            all_coin_infos,
+            all_coin_balances,
+            all_current_coin_balances,
+        );
+        match tx_result {
+            Ok(_) => Ok(ProcessingResult::new(
+                self.name(),
+                start_version,
+                end_version,
+            )),
+            Err(err) => Err(TransactionProcessingError::TransactionCommitError((
+                anyhow::Error::from(err),
+                start_version,
+                end_version,
+                self.name(),
+            ))),
+        }
+    }
+
+    fn connection_pool(&self) -> &PgDbPool {
+        &self.connection_pool
+    }
+}

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -159,7 +159,6 @@ fn insert_user_transactions_w_sigs(
                     ut_schema::gas_unit_price.eq(excluded(ut_schema::gas_unit_price)),
                     ut_schema::timestamp.eq(excluded(ut_schema::timestamp)),
                     ut_schema::entry_function_id_str.eq(excluded(ut_schema::entry_function_id_str)),
-                    ut_schema::inserted_at.eq(excluded(ut_schema::inserted_at)),
                 )),
             None,
         )?;

--- a/crates/indexer/src/processors/mod.rs
+++ b/crates/indexer/src/processors/mod.rs
@@ -1,13 +1,16 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod coin_processor;
 pub mod default_processor;
 pub mod token_processor;
 
+use self::coin_processor::NAME as COIN_PROCESSOR_NAME;
 use self::default_processor::NAME as DEFAULT_PROCESSOR_NAME;
 use self::token_processor::NAME as TOKEN_PROCESSOR_NAME;
 
 pub enum Processor {
+    CoinProcessor,
     DefaultProcessor,
     TokenProcessor,
 }
@@ -17,6 +20,7 @@ impl Processor {
         match input_str.as_str() {
             DEFAULT_PROCESSOR_NAME => Self::DefaultProcessor,
             TOKEN_PROCESSOR_NAME => Self::TokenProcessor,
+            COIN_PROCESSOR_NAME => Self::CoinProcessor,
             _ => panic!("Processor unsupported {}", input_str),
         }
     }

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -176,10 +176,7 @@ fn insert_tokens(
                 .values(&tokens_to_insert[start_ind..end_ind])
                 .on_conflict((token_data_id_hash, property_version, transaction_version))
                 .do_update()
-                .set((
-                    inserted_at.eq(excluded(inserted_at)),
-                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
-                )),
+                .set((collection_data_id_hash.eq(excluded(collection_data_id_hash)),)),
             None,
         )?;
     }
@@ -209,7 +206,6 @@ fn insert_token_ownerships(
                 ))
                 .do_update()
                 .set((
-                    inserted_at.eq(excluded(inserted_at)),
                     collection_data_id_hash.eq(excluded(collection_data_id_hash)),
                     table_type.eq(excluded(table_type)),
                 )),
@@ -233,10 +229,7 @@ fn insert_token_datas(
                 .values(&token_datas_to_insert[start_ind..end_ind])
                 .on_conflict((token_data_id_hash, transaction_version))
                 .do_update()
-                .set((
-                    inserted_at.eq(excluded(inserted_at)),
-                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
-                )),
+                .set((collection_data_id_hash.eq(excluded(collection_data_id_hash)),)),
             None,
         )?;
     }
@@ -260,10 +253,7 @@ fn insert_collection_datas(
                 .values(&collection_datas_to_insert[start_ind..end_ind])
                 .on_conflict((collection_data_id_hash, transaction_version))
                 .do_update()
-                .set((
-                    inserted_at.eq(excluded(inserted_at)),
-                    table_handle.eq(excluded(table_handle)),
-                )),
+                .set((table_handle.eq(excluded(table_handle)),)),
             None,
         )?;
     }
@@ -292,7 +282,6 @@ fn insert_current_token_ownerships(
                     amount.eq(excluded(amount)),
                     token_properties.eq(excluded(token_properties)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    inserted_at.eq(excluded(inserted_at)),
                     collection_data_id_hash.eq(excluded(collection_data_id_hash)),
                     table_type.eq(excluded(table_type)),
                 )),
@@ -335,7 +324,6 @@ fn insert_current_token_datas(
                     royalty_mutable.eq(excluded(royalty_mutable)),
                     default_properties.eq(excluded(default_properties)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    inserted_at.eq(excluded(inserted_at)),
                     collection_data_id_hash.eq(excluded(collection_data_id_hash)),
                 )),
             Some(" WHERE current_token_datas.last_transaction_version <= excluded.last_transaction_version "),
@@ -370,7 +358,6 @@ fn insert_current_collection_datas(
                     uri_mutable.eq(excluded(uri_mutable)),
                     description_mutable.eq(excluded(description_mutable)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    inserted_at.eq(excluded(inserted_at)),
                     table_handle.eq(excluded(table_handle)),
                 )),
             Some(" WHERE current_collection_datas.last_transaction_version <= excluded.last_transaction_version "),
@@ -432,7 +419,6 @@ fn insert_current_token_claims(
                     amount.eq(excluded(amount)),
                     table_handle.eq(excluded(table_handle)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    inserted_at.eq(excluded(inserted_at)),
                 )),
             Some(" WHERE current_token_pending_claims.last_transaction_version <= excluded.last_transaction_version "),
         )?;
@@ -459,7 +445,6 @@ fn insert_current_ans_lookups(
                     registered_address.eq(excluded(registered_address)),
                     expiration_timestamp.eq(excluded(expiration_timestamp)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
-                    inserted_at.eq(excluded(inserted_at)),
                 )),
                 Some(" WHERE current_ans_lookup.last_transaction_version <= excluded.last_transaction_version "),
             )?;

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -8,8 +8,8 @@ use crate::{
         transaction_processor::TransactionProcessor,
     },
     processors::{
-        default_processor::DefaultTransactionProcessor, token_processor::TokenTransactionProcessor,
-        Processor,
+        coin_processor::CoinTransactionProcessor, default_processor::DefaultTransactionProcessor,
+        token_processor::TokenTransactionProcessor, Processor,
     },
 };
 
@@ -138,6 +138,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
             conn_pool.clone(),
             config.ans_contract_address,
         )),
+        Processor::CoinProcessor => Arc::new(CoinTransactionProcessor::new(conn_pool.clone())),
     };
 
     let options =

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -19,6 +19,47 @@ diesel::table! {
 }
 
 diesel::table! {
+    coin_activities (transaction_version, event_account_address, event_creation_number, event_sequence_number) {
+        transaction_version -> Int8,
+        event_account_address -> Varchar,
+        event_creation_number -> Int8,
+        event_sequence_number -> Int8,
+        owner_address -> Varchar,
+        coin_type -> Varchar,
+        amount -> Numeric,
+        activity_type -> Varchar,
+        is_gas_fee -> Bool,
+        is_transaction_success -> Bool,
+        entry_function_id_str -> Nullable<Varchar>,
+        block_height -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    coin_balances (transaction_version, owner_address, coin_type) {
+        transaction_version -> Int8,
+        owner_address -> Varchar,
+        coin_type -> Varchar,
+        amount -> Numeric,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    coin_infos (coin_type) {
+        coin_type -> Varchar,
+        transaction_version_created -> Int8,
+        creator_address -> Varchar,
+        name -> Varchar,
+        symbol -> Varchar,
+        decimals -> Int4,
+        supply -> Numeric,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     collection_datas (collection_data_id_hash, transaction_version) {
         collection_data_id_hash -> Varchar,
         transaction_version -> Int8,
@@ -42,6 +83,16 @@ diesel::table! {
         subdomain -> Varchar,
         registered_address -> Nullable<Varchar>,
         expiration_timestamp -> Timestamp,
+        last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
+    current_coin_balances (owner_address, coin_type) {
+        owner_address -> Varchar,
+        coin_type -> Varchar,
+        amount -> Numeric,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
     }
@@ -358,8 +409,12 @@ diesel::table! {
 
 diesel::allow_tables_to_appear_in_same_query!(
     block_metadata_transactions,
+    coin_activities,
+    coin_balances,
+    coin_infos,
     collection_datas,
     current_ans_lookup,
+    current_coin_balances,
     current_collection_datas,
     current_token_datas,
     current_token_ownerships,

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -32,29 +32,33 @@ diesel::table! {
         is_transaction_success -> Bool,
         entry_function_id_str -> Nullable<Varchar>,
         block_height -> Int8,
+        transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
     }
 }
 
 diesel::table! {
-    coin_balances (transaction_version, owner_address, coin_type) {
+    coin_balances (transaction_version, owner_address, coin_type_hash) {
         transaction_version -> Int8,
         owner_address -> Varchar,
+        coin_type_hash -> Varchar,
         coin_type -> Varchar,
         amount -> Numeric,
+        transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
     }
 }
 
 diesel::table! {
-    coin_infos (coin_type) {
+    coin_infos (coin_type_hash) {
+        coin_type_hash -> Varchar,
         coin_type -> Varchar,
         transaction_version_created -> Int8,
         creator_address -> Varchar,
         name -> Varchar,
         symbol -> Varchar,
         decimals -> Int4,
-        supply -> Numeric,
+        transaction_created_timestamp -> Timestamp,
         inserted_at -> Timestamp,
     }
 }
@@ -74,6 +78,7 @@ diesel::table! {
         description_mutable -> Bool,
         inserted_at -> Timestamp,
         table_handle -> Varchar,
+        transaction_timestamp -> Timestamp,
     }
 }
 
@@ -89,11 +94,13 @@ diesel::table! {
 }
 
 diesel::table! {
-    current_coin_balances (owner_address, coin_type) {
+    current_coin_balances (owner_address, coin_type_hash) {
         owner_address -> Varchar,
+        coin_type_hash -> Varchar,
         coin_type -> Varchar,
         amount -> Numeric,
         last_transaction_version -> Int8,
+        last_transaction_timestamp -> Timestamp,
         inserted_at -> Timestamp,
     }
 }
@@ -113,6 +120,7 @@ diesel::table! {
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
         table_handle -> Varchar,
+        last_transaction_timestamp -> Timestamp,
     }
 }
 
@@ -138,6 +146,7 @@ diesel::table! {
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
         collection_data_id_hash -> Varchar,
+        last_transaction_timestamp -> Timestamp,
     }
 }
 
@@ -155,6 +164,7 @@ diesel::table! {
         inserted_at -> Timestamp,
         collection_data_id_hash -> Varchar,
         table_type -> Text,
+        last_transaction_timestamp -> Timestamp,
     }
 }
 
@@ -172,6 +182,7 @@ diesel::table! {
         table_handle -> Varchar,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        last_transaction_timestamp -> Timestamp,
     }
 }
 
@@ -298,6 +309,7 @@ diesel::table! {
         coin_type -> Nullable<Text>,
         coin_amount -> Nullable<Numeric>,
         inserted_at -> Timestamp,
+        transaction_timestamp -> Timestamp,
     }
 }
 
@@ -323,6 +335,7 @@ diesel::table! {
         default_properties -> Jsonb,
         inserted_at -> Timestamp,
         collection_data_id_hash -> Varchar,
+        transaction_timestamp -> Timestamp,
     }
 }
 
@@ -340,6 +353,7 @@ diesel::table! {
         table_type -> Nullable<Text>,
         inserted_at -> Timestamp,
         collection_data_id_hash -> Varchar,
+        transaction_timestamp -> Timestamp,
     }
 }
 
@@ -354,6 +368,7 @@ diesel::table! {
         token_properties -> Jsonb,
         inserted_at -> Timestamp,
         collection_data_id_hash -> Varchar,
+        transaction_timestamp -> Timestamp,
     }
 }
 

--- a/testsuite/smoke-test/src/indexer.rs
+++ b/testsuite/smoke-test/src/indexer.rs
@@ -3,7 +3,7 @@
 
 use aptos_indexer::{
     database::{new_db_pool, PgDbPool, PgPoolConnection},
-    models::transactions::TransactionModel,
+    models::transactions::TransactionQuery,
 };
 use aptos_sdk::types::LocalAccount;
 use cached_packages::aptos_stdlib::aptos_token_stdlib;
@@ -138,7 +138,7 @@ async fn test_old_indexer() {
     let mut transactions = vec![];
     for v in 0..2 {
         transactions
-            .push(TransactionModel::get_by_version(v, &mut conn_pool.get().unwrap()).unwrap());
+            .push(TransactionQuery::get_by_version(v, &mut conn_pool.get().unwrap()).unwrap());
     }
     transactions.sort_by(|a, b| a.0.type_.partial_cmp(&b.0.type_).unwrap());
 
@@ -159,7 +159,7 @@ async fn test_old_indexer() {
     assert!(wsc0.len() > 10);
 
     // This is the transfer
-    let (tx2, ut2, bmt2, events2, wsc2) = TransactionModel::get_by_hash(
+    let (tx2, ut2, bmt2, events2, wsc2) = TransactionQuery::get_by_hash(
         t_tx.hash.to_string().as_str(),
         &mut conn_pool.get().unwrap(),
     )


### PR DESCRIPTION
### Description
* current_coin_activities tracks gas burn, withdraw, and deposit events (we artificially create the event for gas burn since it's not a registered event)
* coin_balances and current_coin_balances tracks coins in user's 0x1::coin::CoinStore
* coin_infos tracks a coin's initial registration. Note that coin info cannot change (supply, decimals, type) once it's created. 

### Test Plan
Run locally against testnet
`cargo run -p aptos-node --features "indexer" --release -- -f ./fullnode.yaml`

additional config in fullnode.yaml
```
storage:
    enable_indexer: true

indexer:
    enabled: true
    check_chain_id: true
    emit_every: 1000
    postgres_uri: "postgres://postgres@localhost:5432/indexer_v2"
    processor: "coin_processor"
    fetch_tasks: 10
    processor_tasks: 10
```
<img width="958" alt="image" src="https://user-images.githubusercontent.com/11738325/193393696-bc2fe02c-6d55-4d44-899a-d3de07eb4044.png">


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4579)
<!-- Reviewable:end -->
