### PR TITLE
[Indexer] Add indexer to aptos cli

### DIFF
--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -60,13 +60,18 @@ vm-genesis = { path = "../../aptos-move/vm-genesis" }
 backup-cli = { path = "../../storage/backup/backup-cli" }
 cached-packages = { path = '../../aptos-move/framework/cached-packages' }
 framework = { path = '../../aptos-move/framework' }
-move-deps = { path = "../../aptos-move/move-deps", features = ["address32", "testing", "table-extension"] }
+move-deps = { path = "../../aptos-move/move-deps", features = [
+  "address32",
+  "testing",
+  "table-extension",
+] }
 storage-interface = { path = "../../storage/storage-interface" }
 
 [features]
 default = []
 fuzzing = []
 no-upload-proposal = []
+indexer = ["aptos-node/indexer"]
 
 [build-dependencies]
 shadow-rs = "0.16.2"


### PR DESCRIPTION
### Description
Add indexer feature to aptos cli so that we can run localnet with indexer

### Test Plan
```
cargo run -p aptos --features indexer node run-local-testnet --with-faucet
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4586)
<!-- Reviewable:end -->
