### PR TITLE
[mempool] reduce default capacity per user

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -38,7 +38,7 @@ impl Default for MempoolConfig {
             mempool_snapshot_interval_secs: 180,
             capacity: 2_000_000,
             capacity_bytes: 2 * 1024 * 1024 * 1024,
-            capacity_per_user: 100,
+            capacity_per_user: 20,
             default_failovers: 3,
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -462,7 +462,7 @@ pub async fn execute_and_wait_transactions(
             (indices, txns)
         };
 
-        let results = client.submit_batch_bcs(&txns).await.unwrap().into_inner();
+        let results = client.submit_batch_bcs(&txns).await?.into_inner();
         let mut failures = results
             .transaction_failures
             .into_iter()

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -225,7 +225,7 @@ impl EmitJobRequest {
                     wait_millis: 0,
                     txn_expiration_time_secs: self.txn_expiration_time_secs,
                     transactions_per_account,
-                    max_submit_batch_size: 100,
+                    max_submit_batch_size: 20,
                     start_offset_multiplier_millis: 0.0,
                     start_jitter_millis: 5000,
                     accounts_per_worker: 1,
@@ -298,7 +298,7 @@ impl EmitJobRequest {
                     wait_millis: wait_seconds * 1000,
                     txn_expiration_time_secs: self.txn_expiration_time_secs,
                     transactions_per_account,
-                    max_submit_batch_size: 100,
+                    max_submit_batch_size: 20,
                     start_offset_multiplier_millis: (wait_seconds * 1000) as f64
                         / (num_workers_per_endpoint * clients_count) as f64,
                     // Using jitter here doesn't make TPS vary enough, as we have many workers.

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -254,7 +254,7 @@ impl EmitJobRequest {
                 // In case we set a very low TPS, we need to still be able to spread out
                 // transactions, at least to the seconds granularity, so we reduce transactions_per_account
                 // if needed.
-                let transactions_per_account = min(100, tps);
+                let transactions_per_account = min(20, tps);
                 assert!(
                     transactions_per_account > 0,
                     "TPS ({}) needs to be larger than 0",

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -594,7 +594,6 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                     None,
                     None,
                 ))
-                .with_
         }
         // maximizing number of rounds and epochs within a given time, to stress test consensus
         // so using small constant traffic, small blocks and fast rounds, and short epochs.

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -183,7 +183,7 @@ fn main() -> Result<()> {
     logger.build();
 
     let args = Args::from_args();
-    let duration = Duration::from_secs(args.duration_secs as u64);
+    let duration = Duration::from_secs(2 * 60 * 60 as u64);
     let suite_name: &str = args.suite.as_ref();
 
     let runtime = Runtime::new()?;
@@ -574,25 +574,28 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                 }),
             )),
         // not scheduled on continuous
-        "load_vs_perf_benchmark" => config
-            .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
-            .with_initial_fullnode_count(10)
-            .with_network_tests(vec![&LoadVsPerfBenchmark {
-                test: &PerformanceBenchmarkWithFN,
-                tps: &[7500, 8000, 9000, 10000, 12000, 15000],
-            }])
-            .with_genesis_helm_config_fn(Arc::new(|helm_values| {
-                // no epoch change.
-                helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
-            }))
-            .with_success_criteria(SuccessCriteria::new(
-                0,
-                10000,
-                true,
-                Some(Duration::from_secs(60)),
-                None,
-                None,
-            )),
+        "load_vs_perf_benchmark" => {
+            config
+                .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
+                .with_initial_fullnode_count(10)
+                .with_network_tests(vec![&LoadVsPerfBenchmark {
+                    test: &PerformanceBenchmarkWithFN,
+                    tps: &[7500, 8000, 9000, 10000, 12000, 15000],
+                }])
+                .with_genesis_helm_config_fn(Arc::new(|helm_values| {
+                    // no epoch change.
+                    helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
+                }))
+                .with_success_criteria(SuccessCriteria::new(
+                    0,
+                    10000,
+                    true,
+                    Some(Duration::from_secs(60)),
+                    None,
+                    None,
+                ))
+                .with_
+        }
         // maximizing number of rounds and epochs within a given time, to stress test consensus
         // so using small constant traffic, small blocks and fast rounds, and short epochs.
         // reusing changing_working_quorum_test just for invariants/asserts, but with max_down_nodes = 0.

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -183,7 +183,7 @@ fn main() -> Result<()> {
     logger.build();
 
     let args = Args::from_args();
-    let duration = Duration::from_secs(2 * 60 * 60 as u64);
+    let duration = Duration::from_secs(args.duration_secs as u64);
     let suite_name: &str = args.suite.as_ref();
 
     let runtime = Runtime::new()?;
@@ -381,7 +381,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => single_test_suite("load_vs_perf_benchmark"),
+        "land_blocking" => Ok(land_blocking_test_suite(duration)),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),
@@ -574,27 +574,27 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
                 }),
             )),
         // not scheduled on continuous
-        "load_vs_perf_benchmark" => {
-            config
-                .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
-                .with_initial_fullnode_count(10)
-                .with_network_tests(vec![&LoadVsPerfBenchmark {
-                    test: &PerformanceBenchmarkWithFN,
-                    tps: &[7500, 8000, 9000, 10000, 12000, 15000],
-                }])
-                .with_genesis_helm_config_fn(Arc::new(|helm_values| {
-                    // no epoch change.
-                    helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
-                }))
-                .with_success_criteria(SuccessCriteria::new(
-                    0,
-                    10000,
-                    true,
-                    Some(Duration::from_secs(60)),
-                    None,
-                    None,
-                ))
-        }
+        "load_vs_perf_benchmark" => config
+            .with_initial_validator_count(NonZeroUsize::new(20).unwrap())
+            .with_initial_fullnode_count(10)
+            .with_network_tests(vec![&LoadVsPerfBenchmark {
+                test: &PerformanceBenchmarkWithFN,
+                tps: &[
+                    200, 1000, 3000, 5000, 7000, 7500, 8000, 9000, 10000, 12000, 15000,
+                ],
+            }])
+            .with_genesis_helm_config_fn(Arc::new(|helm_values| {
+                // no epoch change.
+                helm_values["chain"]["epoch_duration_secs"] = (24 * 3600).into();
+            }))
+            .with_success_criteria(SuccessCriteria::new(
+                0,
+                10000,
+                true,
+                Some(Duration::from_secs(60)),
+                None,
+                None,
+            )),
         // maximizing number of rounds and epochs within a given time, to stress test consensus
         // so using small constant traffic, small blocks and fast rounds, and short epochs.
         // reusing changing_working_quorum_test just for invariants/asserts, but with max_down_nodes = 0.

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -579,9 +579,7 @@ fn single_test_suite(test_name: &str) -> Result<ForgeConfig<'static>> {
             .with_initial_fullnode_count(10)
             .with_network_tests(vec![&LoadVsPerfBenchmark {
                 test: &PerformanceBenchmarkWithFN,
-                tps: &[
-                    200, 1000, 3000, 5000, 7000, 7500, 8000, 9000, 10000, 12000, 15000,
-                ],
+                tps: &[7500, 8000, 9000, 10000, 12000, 15000],
             }])
             .with_genesis_helm_config_fn(Arc::new(|helm_values| {
                 // no epoch change.

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -381,7 +381,7 @@ fn get_changelog(prev_commit: Option<&String>, upstream_commit: &str) -> String 
 
 fn get_test_suite(suite_name: &str, duration: Duration) -> Result<ForgeConfig<'static>> {
     match suite_name {
-        "land_blocking" => Ok(land_blocking_test_suite(duration)),
+        "land_blocking" => single_test_suite("load_vs_perf_benchmark"),
         "local_test_suite" => Ok(local_test_suite()),
         "pre_release" => Ok(pre_release_suite()),
         "run_forever" => Ok(run_forever()),


### PR DESCRIPTION
### Description

Reduce the default capacity per user: 100 -> 20. This should make it less likely that some users take over mempool capacity.

### Test Plan

Ran land_blocking and load_vs_perf_benchmark with good results. Will let CICD run the continuous tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4588)
<!-- Reviewable:end -->
