### PR TITLE
markuze/default console port

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,6 +20,9 @@
 /aptos-move/parallel-executor/ @gelash @zekun000
 /aptos-move/vm-genesis/ @davidiw @movekevin
 
+# Owner for logger config
+/config/src/config/logger_config.rs @markuze
+
 # Owners for the `/consensus` directory and all its subdirectories.
 /consensus/ @zekun000
 

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -30,7 +30,10 @@ impl Default for LoggerConfig {
             enable_backtrace: false,
             is_async: true,
             level: Level::Info,
-            console_port: None,
+            // This is the default port used by tokio-console
+            // setting console_port to None will disable tokio console even if aptos-console
+            // feature is enabled
+            console_port: Some(6669),
             enable_telemetry_remote_log: true,
             enable_telemetry_flush: true,
             telemetry_level: Level::Error,


### PR DESCRIPTION

- [tokio-console] Configuring tokio-console default port

### Description
 Configuring tokio-console default port

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4589)
<!-- Reviewable:end -->
