### PR TITLE
[aptos-cli] Pull latest packages by default for cached branch dependencies

### DIFF
--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -114,6 +114,7 @@ impl ReleaseTarget {
                     landing_page_template: Some("doc_template/overview.md".to_string()),
                     references_file: Some("doc_template/references.md".to_string()),
                 }),
+                skip_fetch_latest_git_deps: false,
             },
             packages: packages.iter().map(|(path, _)| path.to_owned()).collect(),
             rust_bindings: packages

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -26,6 +26,7 @@ use move_package::source_package::manifest_parser::{
 use move_package::{BuildConfig, ModelConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::stderr;
 use std::path::{Path, PathBuf};
 
 pub const METADATA_FILE_NAME: &str = "package-metadata.bcs";
@@ -123,8 +124,7 @@ impl BuiltPackage {
             skip_fetch_latest_git_deps: true,
         };
         eprintln!("Compiling, may take a little while to download git dependencies...");
-        let mut package =
-            build_config.compile_package_no_exit(&package_path, &mut std::io::stderr())?;
+        let mut package = build_config.compile_package_no_exit(&package_path, &mut stderr())?;
         for module in package.root_modules_map().iter_modules().iter() {
             verify_module_init_function(module)?;
         }

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -52,6 +52,8 @@ pub struct BuildOptions {
     pub named_addresses: BTreeMap<String, AccountAddress>,
     #[clap(skip)]
     pub docgen_options: Option<DocgenOptions>,
+    #[clap(long)]
+    pub skip_fetch_latest_git_deps: bool,
 }
 
 // Because named_addresses has no parser, we can't use clap's default impl. This must be aligned
@@ -67,6 +69,9 @@ impl Default for BuildOptions {
             install_dir: None,
             named_addresses: Default::default(),
             docgen_options: None,
+            // This is false by default, because it could accidentally pull new dependencies
+            // while in a test (and cause some havoc)
+            skip_fetch_latest_git_deps: false,
         }
     }
 }
@@ -121,7 +126,7 @@ impl BuiltPackage {
             test_mode: false,
             force_recompilation: false,
             fetch_deps_only: false,
-            skip_fetch_latest_git_deps: true,
+            skip_fetch_latest_git_deps: options.skip_fetch_latest_git_deps,
         };
         eprintln!("Compiling, may take a little while to download git dependencies...");
         let mut package = build_config.compile_package_no_exit(&package_path, &mut stderr())?;

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -912,6 +912,14 @@ pub struct MovePackageDir {
     /// Note: This will fail if there are duplicates in the Move.toml file remove those first.
     #[clap(long, parse(try_from_str = crate::common::utils::parse_map), default_value = "")]
     pub(crate) named_addresses: BTreeMap<String, AccountAddressWrapper>,
+
+    /// Skip pulling the latest git dependencies
+    ///
+    /// If you don't have a network connection, the compiler may fail due
+    /// to no ability to pull git dependencies.  This will allow overriding
+    /// this for local development.
+    #[clap(long)]
+    pub(crate) skip_fetch_latest_git_deps: bool,
 }
 
 impl MovePackageDir {
@@ -920,6 +928,7 @@ impl MovePackageDir {
             package_dir: Some(package_dir),
             output_dir: None,
             named_addresses: Default::default(),
+            skip_fetch_latest_git_deps: true,
         }
     }
 

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -587,15 +587,22 @@ fn compile_in_temp_dir(
     })?;
 
     // Compile the script
-    compile_script(package_dir)
+    compile_script(
+        framework_package_args.skip_fetch_latest_git_deps,
+        package_dir,
+    )
 }
 
-fn compile_script(package_dir: &Path) -> CliTypedResult<(Vec<u8>, HashValue)> {
+fn compile_script(
+    skip_fetch_latest_git_deps: bool,
+    package_dir: &Path,
+) -> CliTypedResult<(Vec<u8>, HashValue)> {
     let build_options = BuildOptions {
         with_srcs: false,
         with_abis: false,
         with_source_maps: false,
         with_error_map: false,
+        skip_fetch_latest_git_deps,
         ..BuildOptions::default()
     };
 
@@ -756,7 +763,10 @@ impl CliCommand<()> for GenerateUpgradeProposal {
             testnet,
         } = self;
         let package_path = move_options.get_package_path()?;
-        let options = included_artifacts.build_options(move_options.named_addresses());
+        let options = included_artifacts.build_options(
+            move_options.skip_fetch_latest_git_deps,
+            move_options.named_addresses(),
+        );
         let package = BuiltPackage::build(package_path, options)?;
         let release = ReleasePackage::new(package)?;
         if testnet {

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -793,6 +793,7 @@ impl CliTestFramework {
             framework_package_args: FrameworkPackageArgs {
                 framework_git_rev: None,
                 framework_local_dir: framework_dir,
+                skip_fetch_latest_git_deps: false,
             },
         }
         .execute()
@@ -925,6 +926,7 @@ impl CliTestFramework {
                 framework_package_args: FrameworkPackageArgs {
                     framework_git_rev: None,
                     framework_local_dir: Some(Self::aptos_framework_dir()),
+                    skip_fetch_latest_git_deps: false,
                 },
             },
             args: Vec::new(),
@@ -948,6 +950,7 @@ impl CliTestFramework {
             package_dir: Some(self.move_dir()),
             output_dir: None,
             named_addresses: Self::named_addresses(account_strs),
+            skip_fetch_latest_git_deps: true,
         }
     }
 


### PR DESCRIPTION
### Description
Now all the confusion is gone around why dependencies are out of date, it follows similar to cargo, where you want to use a git hash if you want frozen dependencies.  Otherwise, it will updated.  Additionally, there's a flag to turn it off if your network is disconnected, or something like that.


### Test Plan
TBD. need to test locally, but it did work fine in the move CLI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4595)
<!-- Reviewable:end -->
