### PR TITLE
[gha] Make forge namespace optional

### DIFF
--- a/.github/workflows/forge-continuous.yaml
+++ b/.github/workflows/forge-continuous.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/forge-continuous.yaml'
+      - '.github/workflows/run-forge.yaml'
 
 # cancel redundant builds
 concurrency:

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -13,7 +13,7 @@ on:
         type: string
         description: The docker image tag to test. If not specified, falls back on GIT_SHA, and then to the latest commits on the current branch
       FORGE_NAMESPACE:
-        required: true
+        required: false
         type: string
         description: The Forge k8s namespace to be used for test. This value should manage Forge test concurrency. It may be truncated.
       FORGE_CLUSTER_NAME:

--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -362,6 +362,7 @@ class SystemContext:
     shell: Shell
     filesystem: Filesystem
     processes: Processes
+    time: Time
 
 
 @dataclass
@@ -1242,10 +1243,12 @@ async def run_multiple(
     pending_suites = []
     pending_comment = []
 
+    start_time = context.time.now()
+
     for suite in forge_test_suites:
         new_namespace = f"{forge_namespace}-{suite}"
         short_link = shorten_link(get_humio_forge_link(new_namespace, True))
-        pending_comment.append(f"Running {suite}: [Runner logs]{short_link}")
+        pending_comment.append(f"Running {suite}: [Runner logs]({short_link})")
         if forge_runner_mode != "pre-forge":
             pending_results.append(
                 context.shell.gen_run(
@@ -1270,10 +1273,12 @@ async def run_multiple(
     else:
         final_forge_comment = []
         results = await asyncio.gather(*pending_results)
+        stop_time = context.time.now()
         assert len(results) == len(pending_suites)
         failed = False
         for i, result in enumerate(results):
             suite, namespace = pending_suites[i]
+            short_link = shorten_link(get_humio_forge_link(namespace, (start_time, stop_time)))
             if result.succeeded():
                 final_forge_comment.append(f"{suite} succeeded")
             else:
@@ -1385,11 +1390,11 @@ def test(
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
     time = SystemTime()
-    context = SystemContext(shell, filesystem, processes)
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
     config.init()
 
-    if forge_namespace is None:
+    if not forge_namespace:
         forge_namespace = f"forge-{processes.user()}-{time.epoch()}"
 
     assert forge_namespace is not None, "Forge namespace is required"
@@ -1733,7 +1738,8 @@ def list_jobs(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
     config.init()
 
@@ -1767,7 +1773,8 @@ def tail(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
     config.init()
 
@@ -1957,7 +1964,8 @@ def create_config() -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
     config.create()
 
@@ -1967,7 +1975,8 @@ def get_config() -> None:
     shell = LocalShell(True)
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
     config.init()
     pprint(config.dump())
@@ -1996,7 +2005,8 @@ def set_config(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     if config_path:
@@ -2022,7 +2032,7 @@ def config_edit(ctx: click.Context) -> None:
     shell = LocalShell(True)
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
     config.init()
 
@@ -2049,7 +2059,7 @@ def cluster_config_delete(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2072,7 +2082,8 @@ def cluster_config_add(cluster: str) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2092,7 +2103,8 @@ def cluster_config_enable(cluster: str) -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2116,7 +2128,8 @@ def cluster_config_disable(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2133,7 +2146,8 @@ def cluster_config_list() -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2168,7 +2182,8 @@ def test_config_add(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2207,7 +2222,8 @@ def test_config_show(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2235,7 +2251,8 @@ def test_config_list() -> None:
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2256,7 +2273,8 @@ def test_config_delete(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2286,7 +2304,8 @@ def test_config_enable(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()
@@ -2318,7 +2337,8 @@ def test_config_disable(
     shell = LocalShell()
     filesystem = LocalFilesystem()
     processes = SystemProcesses()
-    context = SystemContext(shell, filesystem, processes)
+    time = SystemTime()
+    context = SystemContext(shell, filesystem, processes, time)
     config = ForgeConfig(S3ForgeConfigBackend(context, DEFAULT_CONFIG))
 
     config.init()

--- a/testsuite/forge_test.py
+++ b/testsuite/forge_test.py
@@ -552,24 +552,24 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
 
     def testGetHumioLogsLinkRelative(self) -> None:
         link = get_humio_logs_link("forge-pr-2983", True)
-        self.assertFixture(link, "testGetHumioLogsLinkRelative.fixture")
         self.assertIn("forge-pr-2983", link)
+        self.assertFixture(link, "testGetHumioLogsLinkRelative.fixture")
 
     def testGetHumioLogsLinkAbsolute(self) -> None:
         time = FakeTime()
         link = get_humio_logs_link("forge-pr-2984", (time.now(), time.now()))
-        self.assertFixture(link, "testGetHumioLogsLinkAbsolute.fixture")
         self.assertIn("forge-pr-2984", link)
+        self.assertFixture(link, "testGetHumioLogsLinkAbsolute.fixture")
 
     def testGetHumioForgeLinkRelative(self) -> None:
         link = get_humio_forge_link("forge-pr-2985", True)
-        self.assertFixture(link, "testGetHumioForgeLinkRelative.fixture")
         self.assertIn("forge-pr-2985", link)
+        self.assertFixture(link, "testGetHumioForgeLinkRelative.fixture")
 
     def testGetHumioForgeLinkAbsolute(self) -> None:
         link = get_humio_forge_link("forge-pr-2986", True)
-        self.assertFixture(link, "testGetHumioForgeLinkAbsolute.fixture")
         self.assertIn("forge-pr-2986", link)
+        self.assertFixture(link, "testGetHumioForgeLinkAbsolute.fixture")
 
     def testDashboardLinkAutoRefresh(self) -> None:
         self.assertFixture(
@@ -596,10 +596,14 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
 
     def testFormatPreComment(self) -> None:
         context = fake_context()
-        self.assertFixture(
-            format_pre_comment(context),
-            "testFormatPreComment.fixture",
+        pre_comment = format_pre_comment(context)
+        self.maxDiff = 10
+        self.assertIn(
+            "var-namespace=forge-potato",
+            pre_comment,
+            "Wrong forge namespace in pre comment"
         )
+        self.assertFixture(pre_comment, "testFormatPreComment.fixture")
 
     def testFormatComment(self) -> None:
         context = fake_context()
@@ -607,10 +611,13 @@ class ForgeFormattingTests(unittest.TestCase, AssertFixtureMixin):
         with ForgeResult.with_context(context) as forge_result:
             forge_result.set_state(ForgeState.PASS)
             forge_result.set_output(report_fixture.read_text())
-        self.assertFixture(
-            format_comment(context, forge_result),
-            "testFormatComment.fixture",
+        forge_comment = format_comment(context, forge_result)
+        self.assertIn(
+            "var-namespace=forge-potato",
+            forge_comment,
+            "Wrong forge namespace in comment"
         )
+        self.assertFixture(forge_comment, "testFormatComment.fixture")
 
     def testFormatReport(self) -> None:
         context = fake_context()
@@ -842,7 +849,7 @@ class GetForgeJobsTests(unittest.IsolatedAsyncioTestCase):
         )
         filesystem = SpyFilesystem({}, {}, ["temp1", "temp2"])
         processes = SpyProcesses()
-        context = SystemContext(shell, filesystem, processes)
+        context = SystemContext(shell, filesystem, processes, FakeTime())
         jobs = await get_all_forge_jobs(context, fake_clusters)
         expected_jobs = [
             ForgeJob(


### PR DESCRIPTION
Namespace should be optional, this allows for overlapping test runs which could
exhaust capacity, however that risk is already present and this shouldnt be our
defense against overscheduling.

Test Plan: this pr will run forge-continuous and run-forge as pull request which will actually test this! :D

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4603)
<!-- Reviewable:end -->
