### PR TITLE
[executor] fix integration test helper

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -90,7 +90,7 @@ jobs:
       - uses: taiki-e/install-action@v1.5.6
         with:
           tool: nextest
-      - run: cargo nextest run --profile ci --workspace --exclude smoke-test --exclude backup-cli --exclude testcases --retries 3 --no-fail-fast
+      - run: cargo nextest run --profile ci --workspace --exclude smoke-test --exclude testcases --retries 3 --no-fail-fast
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 


### PR DESCRIPTION
when run via `cargo nextest -p executor`, GAS_UNIT_PRICE is 100 instead of 0 as in unit tests or when it's run via `cargo nextest --workspace`. Better to make it work with non-zero gas charge anyway.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4608)
<!-- Reviewable:end -->
