### PR TITLE
[gha] Enable release on PR, enable HAProxy on release test

### DIFF
--- a/.github/workflows/continuous-e2e-release-test.yaml
+++ b/.github/workflows/continuous-e2e-release-test.yaml
@@ -9,6 +9,10 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 */12 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/run-forge.yaml"
+      - ".github/workflows/continuous-e2e-release-test.yaml"
 
 jobs:
   # Run a faster chaos forge to quickly surface correctness failures
@@ -16,9 +20,9 @@ jobs:
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:
-      FORGE_NAMESPACE: forge-release-blocking
-      # Run for 5 hours
-      FORGE_RUNNER_DURATION_SECS: 18000
+      # Run for 5 hours unless its on a pr
+      FORGE_RUNNER_DURATION_SECS: ${{ github.event_name == 'pull_request' && 300 || 18000 }}
+      FORGE_ENABLE_HAPROXY: true
       FORGE_TEST_SUITE: land_blocking
       # Give us 12 hour timeout
       TIMEOUT_MINUTES: 720

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -44,6 +44,10 @@ on:
         required: false
         type: string
         description: Whether to use failpoints images. If this option is true, and you plan to manually pass in IMAGE_TAGs, note that the tagging schema is different
+      FORGE_ENABLE_HAPROXY:
+        required: false
+        type: string
+        description: Whether to use HAPRoxy
       FORGE_ENABLE_PERFORMANCE:
         required: false
         type: string
@@ -69,6 +73,7 @@ env:
   FORGE_RUNNER_MODE: k8s
   FORGE_RUNNER_DURATION_SECS: ${{ inputs.FORGE_RUNNER_DURATION_SECS }}
   FORGE_NAMESPACE: ${{ inputs.FORGE_NAMESPACE }}
+  FORGE_ENABLE_HAPROXY: ${{ inputs.FORGE_ENABLE_HAPROXY }}
   FORGE_TEST_SUITE: ${{ inputs.FORGE_TEST_SUITE }}
   POST_TO_SLACK: ${{ inputs.POST_TO_SLACK }}
   FORGE_ENABLE_FAILPOINTS: ${{ inputs.FORGE_ENABLE_FAILPOINTS }}


### PR DESCRIPTION
Change the release test to run (for only 5 mins) on PR and also to enable
haproxy on the release test for more confidence around haproxy change.

Test Plan: this workflow will run for a short time on the PR itself

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4609)
<!-- Reviewable:end -->
