### PR TITLE
[move] Do not include vector native implementations

### DIFF
--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -25,6 +25,7 @@ pub fn aptos_natives(
 ) -> NativeFunctionTable {
     move_stdlib::natives::all_natives(CORE_CODE_ADDRESS, gas_params.move_stdlib)
         .into_iter()
+        .filter(|(_, name, _, _)| name.as_str() != "vector")
         .chain(framework::natives::all_natives(
             CORE_CODE_ADDRESS,
             gas_params.aptos_framework,


### PR DESCRIPTION
### Description

The native vector implementations in the Move stdlib are not longer needed as vectors are since a while implemented via new opcodes. Still someone could call them by manipulating bytecode. This PR just filters those natives from the list of Aptos natives. If in the future someone calls into them, this will generate a VM error.


### Test Plan

Existing tests pass without those natives

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4621)
<!-- Reviewable:end -->
