### PR TITLE
[cli] Increase REST endpoint timeout to 30s

### DIFF
--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -909,7 +909,7 @@ impl CliTestFramework {
     }
 
     pub fn rest_options(&self) -> RestOptions {
-        RestOptions::new(Some(self.endpoint.clone()))
+        RestOptions::new(Some(self.endpoint.clone()), None)
     }
 
     pub fn faucet_options(&self) -> FaucetOptions {


### PR DESCRIPTION
We saw bunch of timeouts with 10s timeout during loadtests, and then the experience is confusing - transaction actually goes through, but that is not clear.

We used 30s timeout for txn emitter, and that worked well.

together with #4456, CLI experience should be better now

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4628)
<!-- Reviewable:end -->
