### PR TITLE
[TS][SDK] Replace CancelToken with AbortController to cancel requests in axios

### DIFF
--- a/ecosystem/node-checker/ts-client/src/core/request.ts
+++ b/ecosystem/node-checker/ts-client/src/core/request.ts
@@ -195,7 +195,7 @@ const sendRequest = async <T>(
     headers: Record<string, string>,
     onCancel: OnCancel
 ): Promise<AxiosResponse<T>> => {
-    const source = axios.CancelToken.source();
+    const controller = new AbortController();
 
     const requestConfig: AxiosRequestConfig = {
         url,
@@ -203,10 +203,10 @@ const sendRequest = async <T>(
         data: body ?? formData,
         method: options.method,
         withCredentials: config.WITH_CREDENTIALS,
-        cancelToken: source.token,
+        signal: controller.signal
     };
 
-    onCancel(() => source.cancel('The user aborted a request.'));
+    onCancel(() => controller.abort());
 
     try {
         return await axios.request(requestConfig);

--- a/ecosystem/typescript/sdk/src/generated/core/request.ts
+++ b/ecosystem/typescript/sdk/src/generated/core/request.ts
@@ -300,7 +300,7 @@ const sendRequest = async <T>(
     headers: Record<string, string>,
     onCancel: OnCancel
 ): Promise<AxiosResponse<T>> => {
-    const source = axios.CancelToken.source();
+    const controller = new AbortController();
 
     const requestConfig: AxiosRequestConfig = {
         url,
@@ -308,7 +308,7 @@ const sendRequest = async <T>(
         data: body ?? formData,
         method: options.method,
         withCredentials: config.WITH_CREDENTIALS,
-        cancelToken: source.token,
+        signal: controller.signal
     };
 
     const isBCS = Object.keys(config.HEADERS || {})
@@ -319,7 +319,7 @@ const sendRequest = async <T>(
     requestConfig.responseType = "arraybuffer";
   }
 
-    onCancel(() => source.cancel('The user aborted a request.'));
+    onCancel(() => controller.abort());
 
     try {
         return await axios.request(requestConfig);


### PR DESCRIPTION
https://axios-http.com/docs/cancellation

Starting from v0.22.0 Axios supports [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) to cancel requests in fetch API way.

CancelToken is deprecated since v0.22.0 and shouldn't be used in new projects

### Description
Close https://github.com/aptos-labs/aptos-core/issues/4604

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
In my local laptop environment, I use `yarn link "aptos"` and the bug in https://github.com/aptos-labs/aptos-core/issues/4604 is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4629)
<!-- Reviewable:end -->
