### PR TITLE
[forge] Support multi region

### DIFF
--- a/.github/workflows/forge-continuous.yaml
+++ b/.github/workflows/forge-continuous.yaml
@@ -7,6 +7,7 @@ on:
     paths:
       - '.github/workflows/forge-continuous.yaml'
       - '.github/workflows/run-forge.yaml'
+      - 'testsuite/**.py'
 
 # cancel redundant builds
 concurrency:


### PR DESCRIPTION
Right now region is global for a forge run which would
work fine for a single test in a single cluster 
but in
order to run multiple tests across multiple regions we
need to couple region to cluster.

In order to be able to store this in the config we also
have to restructure the config so that its not directly
accessing the enabled / all cluster fields so I can swap
them out safely.

Test Plan: unittests, PR

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4635)
<!-- Reviewable:end -->
