### PR TITLE
[Prover spec only] Fix a typo in the bit_vector.move's prover specs

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/bit_vector.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/bit_vector.move
@@ -71,7 +71,7 @@ module std::bit_vector {
         let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
         *x = false;
     }
-    spec set {
+    spec unset {
         include UnsetAbortsIf;
         ensures bitvector.bit_field[bit_index];
     }

--- a/aptos-move/framework/move-stdlib/sources/bit_vector.move
+++ b/aptos-move/framework/move-stdlib/sources/bit_vector.move
@@ -71,7 +71,7 @@ module std::bit_vector {
         let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
         *x = false;
     }
-    spec set {
+    spec unset {
         include UnsetAbortsIf;
         ensures bitvector.bit_field[bit_index];
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4654)
<!-- Reviewable:end -->
