### PR TITLE
[Stake] Fixed the spec in the stake module

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -389,16 +389,8 @@ module aptos_framework::stake {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
-        remove_validators_internal(validator_set, validators);
-    }
-
-    /// Helper function to remove the `validators` from the `active_validators`.
-    /// This function helps proving the global invariant.
-    fun remove_validators_internal(
-        validator_set: &mut ValidatorSet,
-        validators: &vector<address>,
-    ) {
         let active_validators = &mut validator_set.active_validators;
+        let pending_inactive = &mut validator_set.pending_inactive;
         let len = vector::length(validators);
         let i = 0;
         // Remove each validator from the validator set.
@@ -406,6 +398,8 @@ module aptos_framework::stake {
             spec {
                 invariant spec_validators_are_initialized(active_validators);
                 invariant spec_validator_indices_are_valid(active_validators);
+                invariant spec_validators_are_initialized(pending_inactive);
+                invariant spec_validator_indices_are_valid(pending_inactive);
             };
             i < len
         }) {
@@ -413,7 +407,7 @@ module aptos_framework::stake {
             let validator_index = find_validator(active_validators, validator);
             if (option::is_some(&validator_index)) {
                 let validator_info = vector::swap_remove(active_validators, *option::borrow(&validator_index));
-                vector::push_back(&mut validator_set.pending_inactive, validator_info);
+                vector::push_back(pending_inactive, validator_info);
             };
             i = i + 1;
         };

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -119,12 +119,7 @@ spec aptos_framework::stake {
     }
 
     spec remove_validators {
-        pragma disable_invariants_in_body;
-    }
-
-    spec remove_validators_internal {
-        requires spec_validators_are_initialized(active_validators);
-        requires spec_validator_indices_are_valid(active_validators);
+        requires chain_status::is_operating();
     }
 
     spec is_current_epoch_validator {


### PR DESCRIPTION
### Description

- Fixed the spec which was broken due to the recent change in the module
- `remove_validators_internal` is removed. It was needed for specification, but not anymore.

### Test Plan
aptos move prove
cargo test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4656)
<!-- Reviewable:end -->
