### PR TITLE
[gas] initial gas parameters for table operations

### DIFF
--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -21,7 +21,14 @@ use move_vm_types::{
 };
 use std::collections::BTreeMap;
 
-pub const LATEST_GAS_FEATURE_VERSION: u64 = 1;
+// Change log:
+// - V2
+//   - Table
+//     - Fix the gas formula for loading resources so that they are consistent with other
+//       global operations.
+// - V1
+//   - TBA
+pub const LATEST_GAS_FEATURE_VERSION: u64 = 2;
 
 /// A trait for converting from a map representation of the on-chain gas schedule.
 pub trait FromOnChainGasSchedule: Sized {

--- a/aptos-move/aptos-gas/src/table.rs
+++ b/aptos-move/aptos-gas/src/table.rs
@@ -4,25 +4,25 @@
 use move_table_extension::GasParameters;
 
 crate::natives::define_gas_parameters_for_natives!(GasParameters, "table", [
-    [.common.load_base, "common.load.base", 1],
-    [.common.load_per_byte, "common.load.per_byte", 1],
-    [.common.load_failure, "common.load.failure", 1],
+    [.common.load_base, "common.load.base", 8000],
+    [.common.load_per_byte, "common.load.per_byte", 1000],
+    [.common.load_failure, "common.load.failure", 0],
 
-    [.new_table_handle.base, "new_table_handle.base", 1],
+    [.new_table_handle.base, "new_table_handle.base", 1000],
 
-    [.add_box.base, "add_box.base", 1],
-    [.add_box.per_byte_serialized, "add_box.per_byte_serialized", 1],
+    [.add_box.base, "add_box.base", 1200],
+    [.add_box.per_byte_serialized, "add_box.per_byte_serialized", 10],
 
-    [.borrow_box.base, "borrow_box.base", 1],
-    [.borrow_box.per_byte_serialized, "borrow_box.per_byte_serialized", 1],
+    [.borrow_box.base, "borrow_box.base", 1200],
+    [.borrow_box.per_byte_serialized, "borrow_box.per_byte_serialized", 10],
 
-    [.contains_box.base, "contains_box.base", 1],
-    [.contains_box.per_byte_serialized, "contains_box.per_byte_serialized", 1],
+    [.contains_box.base, "contains_box.base", 1200],
+    [.contains_box.per_byte_serialized, "contains_box.per_byte_serialized", 10],
 
-    [.remove_box.base, "remove_box.base", 1],
-    [.remove_box.per_byte_serialized, "remove_box.per_byte_serialized", 1],
+    [.remove_box.base, "remove_box.base", 1200],
+    [.remove_box.per_byte_serialized, "remove_box.per_byte_serialized", 10],
 
-    [.destroy_empty_box.base, "destroy_empty_box.base", 1],
+    [.destroy_empty_box.base, "destroy_empty_box.base", 1200],
 
-    [.drop_unchecked_box.base, "drop_unchecked_box.base", 1],
+    [.drop_unchecked_box.base, "drop_unchecked_box.base", 100],
 ]);

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -62,7 +62,7 @@ impl AptosVMImpl {
         let storage = StorageAdapter::new(state);
 
         // Get the gas parameters
-        let (gas_params, gas_feature_version): (Option<AptosGasParameters>, u64) =
+        let (mut gas_params, gas_feature_version): (Option<AptosGasParameters>, u64) =
             match GasScheduleV2::fetch_config(&storage) {
                 Some(gas_schedule) => {
                     let feature_version = gas_schedule.feature_version;
@@ -81,11 +81,23 @@ impl AptosVMImpl {
                 },
             };
 
-        let storage_gas_params = match gas_feature_version {
+        let storage_gas_params: Option<StorageGasParameters> = match gas_feature_version {
             0 => None,
             _ => StorageGasSchedule::fetch_config(&storage)
                 .map(|storage_gas_schedule| storage_gas_schedule.into()),
         };
+
+        if gas_feature_version >= 2 {
+            if let (Some(gas_params), Some(storage_gas_params)) =
+                (&mut gas_params, &storage_gas_params)
+            {
+                gas_params.natives.table.common.load_base =
+                    u64::from(storage_gas_params.per_item_read).into();
+                gas_params.natives.table.common.load_per_byte =
+                    u64::from(storage_gas_params.per_byte_read).into();
+                gas_params.natives.table.common.load_failure = 0.into();
+            }
+        }
 
         // TODO(Gas): Right now, we have to use some dummy values for gas parameters if they are not found on-chain.
         //            This only happens in a edge case that is probably related to write set transactions or genesis,

--- a/aptos-move/framework/cached-packages/src/aptos_token_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_token_sdk_builder.rs
@@ -87,7 +87,6 @@ pub enum EntryFunctionCall {
         amount: u64,
     },
 
-    /// Deprecated function call
     TokenInitializeTokenScript {},
 
     /// Mint more token from an existing token_data. Mint only adds more token to property_version 0
@@ -482,7 +481,6 @@ pub fn token_direct_transfer_script(
     ))
 }
 
-/// Deprecated function call
 pub fn token_initialize_token_script() -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(


### PR DESCRIPTION
Previously I forgot to set the initial gas parameters for table. This gets them added and also makes sure that when a table op loads data from storage, it is charged in the same way as other global operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4659)
<!-- Reviewable:end -->
