### PR TITLE
[api] Add git build hash as an extra optional field in the API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "anyhow",
  "aptos-api-test-context",
  "aptos-api-types",
+ "aptos-build-info",
  "aptos-config",
  "aptos-crypto",
  "aptos-gas",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1.21.0", features = ["full"] }
 url = "2.2.2"
 
 aptos-api-types = { path = "./types", package = "aptos-api-types" }
+aptos-build-info = { path = "../crates/aptos-build-info" }
 aptos-config = { path = "../config" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-gas = { path = "../aptos-move/aptos-gas" }

--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -11257,7 +11257,7 @@
       },
       "IndexResponse": {
         "type": "object",
-        "description": "The struct holding all data returned to the client by the\nindex endpoint (i.e., GET \"/\").",
+        "description": "The struct holding all data returned to the client by the\nindex endpoint (i.e., GET \"/\").  Only for responding in JSON",
         "required": [
           "chain_id",
           "epoch",
@@ -11294,6 +11294,9 @@
           },
           "block_height": {
             "$ref": "#/components/schemas/U64"
+          },
+          "git_hash": {
+            "type": "string"
           }
         }
       },

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -8369,7 +8369,7 @@ components:
       type: object
       description: |-
         The struct holding all data returned to the client by the
-        index endpoint (i.e., GET "/").
+        index endpoint (i.e., GET "/").  Only for responding in JSON
       required:
       - chain_id
       - epoch
@@ -8398,6 +8398,8 @@ components:
           $ref: '#/components/schemas/U64'
         block_height:
           $ref: '#/components/schemas/U64'
+        git_hash:
+          type: string
     ModuleBundlePayload:
       type: object
       required:
@@ -9358,4 +9360,3 @@ components:
           $ref: '#/components/schemas/DecodedTableData'
 externalDocs:
   url: https://github.com/aptos-labs/aptos-core
-

--- a/api/goldens/aptos_api__tests__index_test__test_get_index.json
+++ b/api/goldens/aptos_api__tests__index_test__test_get_index.json
@@ -6,5 +6,6 @@
   "ledger_timestamp": "0",
   "node_role": "validator",
   "oldest_block_height": "0",
-  "block_height": "0"
+  "block_height": "0",
+  "git_hash": ""
 }

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -7,7 +7,7 @@ use crate::accept_type::AcceptType;
 use crate::context::Context;
 use crate::response::{BasicResponse, BasicResponseStatus, BasicResult};
 use crate::ApiTags;
-use aptos_api_types::IndexResponse;
+use aptos_api_types::{IndexResponse, IndexResponseBcs};
 use poem_openapi::OpenApi;
 
 /// API for the index, to retrieve the ledger information
@@ -33,13 +33,24 @@ impl IndexApi {
         let ledger_info = self.context.get_latest_ledger_info()?;
 
         let node_role = self.context.node_role();
-        let index_response = IndexResponse::new(ledger_info.clone(), node_role);
 
-        BasicResponse::try_from_rust_value((
-            index_response,
-            &ledger_info,
-            BasicResponseStatus::Ok,
-            &accept_type,
-        ))
+        match accept_type {
+            AcceptType::Json => {
+                let index_response = IndexResponse::new(
+                    ledger_info.clone(),
+                    node_role,
+                    Some(aptos_build_info::get_git_hash()),
+                );
+                BasicResponse::try_from_json((
+                    index_response,
+                    &ledger_info,
+                    BasicResponseStatus::Ok,
+                ))
+            }
+            AcceptType::Bcs => {
+                let index_response = IndexResponseBcs::new(ledger_info.clone(), node_role);
+                BasicResponse::try_from_bcs((index_response, &ledger_info, BasicResponseStatus::Ok))
+            }
+        }
     }
 }

--- a/api/types/src/index.rs
+++ b/api/types/src/index.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 // easier parsing for clients.
 
 /// The struct holding all data returned to the client by the
-/// index endpoint (i.e., GET "/").
+/// index endpoint (i.e., GET "/").  Only for responding in JSON
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, PoemObject, Serialize)]
 pub struct IndexResponse {
     /// Chain ID of the current chain
@@ -22,10 +22,48 @@ pub struct IndexResponse {
     pub node_role: RoleType,
     pub oldest_block_height: U64,
     pub block_height: U64,
+    // This must be optional to be backwards compatible
+    pub git_hash: Option<String>,
 }
 
 impl IndexResponse {
-    pub fn new(ledger_info: LedgerInfo, node_role: RoleType) -> IndexResponse {
+    pub fn new(
+        ledger_info: LedgerInfo,
+        node_role: RoleType,
+        git_hash: Option<String>,
+    ) -> IndexResponse {
+        Self {
+            chain_id: ledger_info.chain_id,
+            epoch: ledger_info.epoch,
+            ledger_version: ledger_info.ledger_version,
+            oldest_ledger_version: ledger_info.oldest_ledger_version,
+            ledger_timestamp: ledger_info.ledger_timestamp,
+            oldest_block_height: ledger_info.oldest_block_height,
+            block_height: ledger_info.block_height,
+            node_role,
+            git_hash,
+        }
+    }
+}
+
+/// The struct holding all data returned to the client by the
+/// index endpoint (i.e., GET "/").  This is just for the BCS response and
+/// cannot change
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PoemObject, Serialize)]
+pub struct IndexResponseBcs {
+    /// Chain ID of the current chain
+    pub chain_id: u8,
+    pub epoch: U64,
+    pub ledger_version: U64,
+    pub oldest_ledger_version: U64,
+    pub ledger_timestamp: U64,
+    pub node_role: RoleType,
+    pub oldest_block_height: U64,
+    pub block_height: U64,
+}
+
+impl IndexResponseBcs {
+    pub fn new(ledger_info: LedgerInfo, node_role: RoleType) -> IndexResponseBcs {
         Self {
             chain_id: ledger_info.chain_id,
             epoch: ledger_info.epoch,

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -26,7 +26,7 @@ pub use convert::{new_vm_utf8_string, AsConverter, ExplainVMStatus, MoveConverte
 pub use error::{AptosError, AptosErrorCode};
 pub use hash::HashValue;
 pub use headers::*;
-pub use index::IndexResponse;
+pub use index::{IndexResponse, IndexResponseBcs};
 pub use ledger_info::LedgerInfo;
 pub use move_types::{
     verify_field_identifier, verify_function_identifier, verify_module_identifier, EntryFunctionId,

--- a/crates/aptos-build-info/src/lib.rs
+++ b/crates/aptos-build-info/src/lib.rs
@@ -103,6 +103,17 @@ pub fn get_build_information() -> BTreeMap<String, String> {
     build_information
 }
 
+pub fn get_git_hash() -> String {
+    // Docker builds don't have the git directory so it has to be provided by this variable
+    // Otherwise, shadow will have the right commit hash
+    if let Ok(git_sha) = std::env::var("GIT_SHA") {
+        git_sha
+    } else {
+        shadow!(build);
+        build::COMMIT_HASH.into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::*;

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -14,7 +14,7 @@ pub mod state;
 pub mod types;
 
 pub use aptos_api_types::{
-    self, IndexResponse, MoveModuleBytecode, PendingTransaction, Transaction,
+    self, IndexResponseBcs, MoveModuleBytecode, PendingTransaction, Transaction,
 };
 pub use state::State;
 pub use types::{deserialize_from_prefixed_hex_string, Account, Resource};
@@ -26,8 +26,8 @@ use aptos_api_types::{
     deserialize_from_string,
     mime_types::{BCS, BCS_SIGNED_TRANSACTION as BCS_CONTENT_TYPE},
     AptosError, BcsBlock, Block, Bytecode, ExplainVMStatus, GasEstimation, HexEncodedBytes,
-    MoveModuleId, TransactionData, TransactionOnChainData, TransactionsBatchSubmissionResult,
-    UserTransaction, VersionedEvent,
+    IndexResponse, MoveModuleId, TransactionData, TransactionOnChainData,
+    TransactionsBatchSubmissionResult, UserTransaction, VersionedEvent,
 };
 use aptos_crypto::HashValue;
 use aptos_logger::{debug, info, sample, sample::SampleRate, sample::Sampling};
@@ -281,7 +281,7 @@ impl Client {
         self.get(self.build_path("")?).await
     }
 
-    pub async fn get_index_bcs(&self) -> AptosResult<Response<IndexResponse>> {
+    pub async fn get_index_bcs(&self) -> AptosResult<Response<IndexResponseBcs>> {
         let url = self.build_path("")?;
         let response = self.get_bcs(url).await?;
         Ok(response.and_then(|inner| bcs::from_bytes(&inner))?)

--- a/ecosystem/node-checker/src/configuration/types.rs
+++ b/ecosystem/node-checker/src/configuration/types.rs
@@ -21,7 +21,7 @@ use crate::{
 use anyhow::{bail, format_err, Context, Result};
 use aptos_config::config::RoleType;
 use aptos_crypto::{x25519, ValidCryptoMaterialStringExt};
-use aptos_rest_client::{Client as AptosRestClient, IndexResponse};
+use aptos_rest_client::{aptos_api_types::IndexResponse, Client as AptosRestClient};
 use aptos_sdk::types::{chain_id::ChainId, network_address::NetworkAddress};
 use clap::Parser;
 use once_cell::sync::Lazy;

--- a/ecosystem/node-checker/src/evaluators/direct/types.rs
+++ b/ecosystem/node-checker/src/evaluators/direct/types.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{configuration::NodeAddress, server::NodeInformation};
-use aptos_rest_client::IndexResponse;
+use aptos_rest_client::aptos_api_types::IndexResponse;
 use aptos_sdk::types::chain_id::ChainId;
 
 /// This type of evaluator just takes in the target node address and then

--- a/ecosystem/typescript/sdk/src/generated/models/IndexResponse.ts
+++ b/ecosystem/typescript/sdk/src/generated/models/IndexResponse.ts
@@ -7,7 +7,7 @@ import type { U64 } from './U64';
 
 /**
  * The struct holding all data returned to the client by the
- * index endpoint (i.e., GET "/").
+ * index endpoint (i.e., GET "/").  Only for responding in JSON
  */
 export type IndexResponse = {
     /**
@@ -21,5 +21,6 @@ export type IndexResponse = {
     node_role: RoleType;
     oldest_block_height: U64;
     block_height: U64;
+    git_hash?: string;
 };
 

--- a/ecosystem/typescript/sdk/src/generated/schemas/$IndexResponse.ts
+++ b/ecosystem/typescript/sdk/src/generated/schemas/$IndexResponse.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 export const $IndexResponse = {
     description: `The struct holding all data returned to the client by the
-    index endpoint (i.e., GET "/").`,
+    index endpoint (i.e., GET "/").  Only for responding in JSON`,
     properties: {
         chain_id: {
             type: 'number',
@@ -38,6 +38,9 @@ export const $IndexResponse = {
         block_height: {
             type: 'U64',
             isRequired: true,
+        },
+        git_hash: {
+            type: 'string',
         },
     },
 } as const;


### PR DESCRIPTION
### Description
The BCS type for `IndexResponse` is now named `IndexResponseBcs`.  The JSON type includes a new field `git_hash` which is an optional parameter, so it should be backwards compatible with the old version unless strict JSON matching is used by a downstream reader.

### Test Plan
Tested manually.  It shows up on the JSON index

```
curl localhost:8080/v1
{"chain_id":4,"epoch":"3","ledger_version":"573","oldest_ledger_version":"0","ledger_timestamp":"1664557571835805","node_role":"validator","oldest_block_height":"0","block_height":"286","git_hash":"254d1af5f6d994d142a48c70528d861682c0908f"}%
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4662)
<!-- Reviewable:end -->
