### PR TITLE
[Execution][Fix] Do not panic when proof fetcher cannot send proof.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9187,6 +9187,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-crypto",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-secure-net",
  "aptos-state-view",

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 
 aptos-crypto = { path = "../../crates/aptos-crypto" }
+aptos-logger = {path = "../../crates/aptos-logger" }
 aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-state-view = { path = "../state-view" }


### PR DESCRIPTION
### Description
This could happen when execution fails and proof fetch gets dropped.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4663)
<!-- Reviewable:end -->
