### PR TITLE
[cli] Fix cli faucet

### DIFF
--- a/aptos-move/framework/cached-packages/src/aptos_token_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_token_sdk_builder.rs
@@ -119,13 +119,13 @@ pub enum EntryFunctionCall {
     /// Token owner lists their token for swapping
     TokenCoinSwapListTokenForSwap {
         coin_type: TypeTag,
-        creators_address: AccountAddress,
-        collection: Vec<u8>,
-        name: Vec<u8>,
-        property_version: u64,
-        token_amount: u64,
-        min_coin_per_token: u64,
-        locked_until_secs: u64,
+        _creators_address: AccountAddress,
+        _collection: Vec<u8>,
+        _name: Vec<u8>,
+        _property_version: u64,
+        _token_amount: u64,
+        _min_coin_per_token: u64,
+        _locked_until_secs: u64,
     },
 
     TokenTransfersCancelOfferScript {
@@ -253,22 +253,22 @@ impl EntryFunctionCall {
             TokenOptInDirectTransfer { opt_in } => token_opt_in_direct_transfer(opt_in),
             TokenCoinSwapListTokenForSwap {
                 coin_type,
-                creators_address,
-                collection,
-                name,
-                property_version,
-                token_amount,
-                min_coin_per_token,
-                locked_until_secs,
+                _creators_address,
+                _collection,
+                _name,
+                _property_version,
+                _token_amount,
+                _min_coin_per_token,
+                _locked_until_secs,
             } => token_coin_swap_list_token_for_swap(
                 coin_type,
-                creators_address,
-                collection,
-                name,
-                property_version,
-                token_amount,
-                min_coin_per_token,
-                locked_until_secs,
+                _creators_address,
+                _collection,
+                _name,
+                _property_version,
+                _token_amount,
+                _min_coin_per_token,
+                _locked_until_secs,
             ),
             TokenTransfersCancelOfferScript {
                 receiver,
@@ -578,13 +578,13 @@ pub fn token_opt_in_direct_transfer(opt_in: bool) -> TransactionPayload {
 /// Token owner lists their token for swapping
 pub fn token_coin_swap_list_token_for_swap(
     coin_type: TypeTag,
-    creators_address: AccountAddress,
-    collection: Vec<u8>,
-    name: Vec<u8>,
-    property_version: u64,
-    token_amount: u64,
-    min_coin_per_token: u64,
-    locked_until_secs: u64,
+    _creators_address: AccountAddress,
+    _collection: Vec<u8>,
+    _name: Vec<u8>,
+    _property_version: u64,
+    _token_amount: u64,
+    _min_coin_per_token: u64,
+    _locked_until_secs: u64,
 ) -> TransactionPayload {
     TransactionPayload::EntryFunction(EntryFunction::new(
         ModuleId::new(
@@ -597,13 +597,13 @@ pub fn token_coin_swap_list_token_for_swap(
         ident_str!("list_token_for_swap").to_owned(),
         vec![coin_type],
         vec![
-            bcs::to_bytes(&creators_address).unwrap(),
-            bcs::to_bytes(&collection).unwrap(),
-            bcs::to_bytes(&name).unwrap(),
-            bcs::to_bytes(&property_version).unwrap(),
-            bcs::to_bytes(&token_amount).unwrap(),
-            bcs::to_bytes(&min_coin_per_token).unwrap(),
-            bcs::to_bytes(&locked_until_secs).unwrap(),
+            bcs::to_bytes(&_creators_address).unwrap(),
+            bcs::to_bytes(&_collection).unwrap(),
+            bcs::to_bytes(&_name).unwrap(),
+            bcs::to_bytes(&_property_version).unwrap(),
+            bcs::to_bytes(&_token_amount).unwrap(),
+            bcs::to_bytes(&_min_coin_per_token).unwrap(),
+            bcs::to_bytes(&_locked_until_secs).unwrap(),
         ],
     ))
 }
@@ -831,13 +831,13 @@ mod decoder {
         if let TransactionPayload::EntryFunction(script) = payload {
             Some(EntryFunctionCall::TokenCoinSwapListTokenForSwap {
                 coin_type: script.ty_args().get(0)?.clone(),
-                creators_address: bcs::from_bytes(script.args().get(0)?).ok()?,
-                collection: bcs::from_bytes(script.args().get(1)?).ok()?,
-                name: bcs::from_bytes(script.args().get(2)?).ok()?,
-                property_version: bcs::from_bytes(script.args().get(3)?).ok()?,
-                token_amount: bcs::from_bytes(script.args().get(4)?).ok()?,
-                min_coin_per_token: bcs::from_bytes(script.args().get(5)?).ok()?,
-                locked_until_secs: bcs::from_bytes(script.args().get(6)?).ok()?,
+                _creators_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+                _collection: bcs::from_bytes(script.args().get(1)?).ok()?,
+                _name: bcs::from_bytes(script.args().get(2)?).ok()?,
+                _property_version: bcs::from_bytes(script.args().get(3)?).ok()?,
+                _token_amount: bcs::from_bytes(script.args().get(4)?).ok()?,
+                _min_coin_per_token: bcs::from_bytes(script.args().get(5)?).ok()?,
+                _locked_until_secs: bcs::from_bytes(script.args().get(6)?).ok()?,
             })
         } else {
             None

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -57,7 +57,12 @@ impl CliCommand<String> for FundWithFaucet {
         let client = self.rest_options.client(&self.profile_options.profile)?;
         for hash in hashes {
             client
-                .wait_for_transaction_by_hash(hash, sys_time, Some(Duration::from_secs(60)), None)
+                .wait_for_transaction_by_hash(
+                    hash.into(),
+                    sys_time,
+                    Some(Duration::from_secs(60)),
+                    None,
+                )
                 .await?;
         }
         return Ok(format!(

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -6,8 +6,8 @@ use crate::{
     CliResult,
 };
 use aptos_build_info::build_information;
-use aptos_crypto::HashValue;
 use aptos_logger::{debug, Level};
+use aptos_rest_client::aptos_api_types::HashValue;
 use aptos_rest_client::{Account, Client};
 use aptos_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
 use itertools::Itertools;
@@ -323,6 +323,7 @@ pub async fn fund_account(
             "{}mint?amount={}&auth_key={}",
             faucet_url, num_octas, address
         ))
+        .body("{}")
         .send()
         .await
         .map_err(|err| CliError::ApiError(err.to_string()))?;


### PR DESCRIPTION
### Description
The underlying load balancer in front of the faucet doesn't allow for empty body.  This now supports that properly.

Additionally, this also supports `0x` in front of hashes, as well as updated the SDK changes.

### Test Plan
```
 apt account fund-with-faucet --profile local --account local
{
  "Result": "Added 500000 Octas to account 5ddf80d85bcd7bd8b833a2589def64ca0cf7df18b8b5ed0d7bdd067658fc49e3"
}

apt account fund-with-faucet --profile testnet --account testnet
{
  "Result": "Added 500000 Octas to account 5ddf80d85bcd7bd8b833a2589def64ca0cf7df18b8b5ed0d7bdd067658fc49e3"
}

apt account fund-with-faucet --profile testnet --account testnet
{
  "Error": "API error: Faucet issue: 429 Too Many Requests"
}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4666)
<!-- Reviewable:end -->
