### PR TITLE
[rest-client] Change warn level message to debug for a transaction not being present

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "aptos-bitvec",

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -30,7 +30,7 @@ use aptos_api_types::{
     UserTransaction, VersionedEvent,
 };
 use aptos_crypto::HashValue;
-use aptos_logger::{info, sample, sample::SampleRate, sample::Sampling, warn};
+use aptos_logger::{debug, info, sample, sample::SampleRate, sample::Sampling};
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{AccountResource, CoinStoreResource, NewBlockEvent, CORE_CODE_ADDRESS},
@@ -573,7 +573,7 @@ impl Client {
                     }
                     sample!(
                         SampleRate::Duration(Duration::from_secs(30)),
-                        warn!(
+                        debug!(
                             "Cannot yet find transaction in mempool on {:?}, continuing to wait.",
                             self.path_prefix_string(),
                         )
@@ -608,7 +608,7 @@ impl Client {
             if elapsed.as_secs() > 30 {
                 sample!(
                     SampleRate::Duration(Duration::from_secs(30)),
-                    warn!(
+                    debug!(
                         "Continuing to wait for transaction {}, ledger on endpoint ({}) is {}",
                         hash,
                         self.path_prefix_string(),

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"


### PR DESCRIPTION
### Description
Right now it's spitting out warnings in the CLI, and it should be info or lower.  I've changed these to DEBUG, as there's no reason to make people panic over a transaction not being present.

### Test Plan
CICD

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4667)
<!-- Reviewable:end -->
