### PR TITLE
[vm] Invalidate loader cache on module loading errors

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -535,11 +535,25 @@ impl AptosVM {
                 }
             }
 
-            // Publish the bundle
-            session.publish_module_bundle(bundle.into_inner(), destination, gas_meter)?;
-
-            // Execute initializers
-            self.execute_module_initialization(session, gas_meter, &modules, exists, &[destination])
+            // Publish the bundle and execute initializers
+            session
+                .publish_module_bundle(bundle.into_inner(), destination, gas_meter)
+                .and_then(|_| {
+                    self.execute_module_initialization(
+                        session,
+                        gas_meter,
+                        &modules,
+                        exists,
+                        &[destination],
+                    )
+                })
+                .map_err(|e| {
+                    // Be sure to flash the loader cache to align storage with the cache.
+                    // None of the modules in the bundle will be committed to storage,
+                    // but some of them may have ended up in the cache.
+                    self.0.mark_loader_cache_as_invalid();
+                    e
+                })
         } else {
             Ok(())
         }

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -131,6 +131,10 @@ impl AptosVMImpl {
         vm
     }
 
+    pub(crate) fn mark_loader_cache_as_invalid(&self) {
+        self.move_vm.mark_loader_cache_as_invalid();
+    }
+
     /// Provides access to some internal APIs of the VM.
     pub fn internals(&self) -> AptosVMInternals {
         AptosVMInternals(self)

--- a/aptos-move/e2e-move-tests/src/tests/init_module.rs
+++ b/aptos-move/e2e-move-tests/src/tests/init_module.rs
@@ -1,8 +1,10 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{assert_success, tests::common, MoveHarness};
+use crate::{assert_abort, assert_success, tests::common, MoveHarness};
+use aptos_types::account_address::AccountAddress;
 use move_deps::move_core_types::parser::parse_struct_tag;
+use package_builder::PackageBuilder;
 use serde::{Deserialize, Serialize};
 
 /// Mimics `0xcafe::test::ModuleData`
@@ -61,4 +63,34 @@ fn init_module_when_republishing_package() {
             .global_counter,
         42
     );
+}
+
+#[test]
+fn init_module_with_abort_and_republish() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x12").unwrap());
+
+    let mut p1 = PackageBuilder::new("Pack");
+    p1.add_source(
+        "m.move",
+        "module 0x12::M { fun init_module(_s: &signer) { abort 1 } }",
+    );
+    let path1 = p1.write_to_temp().unwrap();
+
+    let mut p2 = PackageBuilder::new("Pack");
+    p2.add_source(
+        "m.move",
+        "module 0x12::M { fun init_module(_s: &signer) {} }",
+    );
+    let path2 = p2.write_to_temp().unwrap();
+
+    let txn1 = h.create_publish_package(&acc, path1.path(), None, |_| {});
+    let txn2 = h.create_publish_package(&acc, path2.path(), None, |_| {});
+    let res = h.run_block(vec![txn1, txn2]);
+
+    // First publish aborts, package should not count as published.
+    assert_abort!(res[0], 1);
+
+    // 2nd publish succeeds, not the old but the new init_module is called.
+    assert_success!(res[1]);
 }


### PR DESCRIPTION
### Description

This invalidates the loader cache if an error happens either in module bundle loading or execution of `init_module`. In such case, none of the modules is committed to storage, but some may linger in the cache. This can lead to inconsistencies, like binding to `init_module` of an older (failed) version of a module.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

The added test fails with the code before this PR, and succeeds with this one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4668)
<!-- Reviewable:end -->
