### PR TITLE
[cli] Add typeargs for script support and move example

### DIFF
--- a/aptos-move/move-examples/split_transfer/Move.toml
+++ b/aptos-move/move-examples/split_transfer/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "SplitTransfer"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../framework/aptos-framework" }

--- a/aptos-move/move-examples/split_transfer/sources/split_transfer.move
+++ b/aptos-move/move-examples/split_transfer/sources/split_transfer.move
@@ -1,0 +1,14 @@
+script {
+    use aptos_framework::coin;
+
+    // There are two ways to approach this problem
+    // 1. Withdraw the total then distribute the pieces by breaking it up or
+    // 2. Transfer for each amount individually
+    fun main<CoinType>(sender: &signer, reciever_a: address, receiver_b: address, amount: u64) {
+        let coins = coin::withdraw<CoinType>(sender, amount);
+
+        let coins_a = coin::extract(&mut coins, amount / 2);
+        coin::deposit(reciever_a, coins_a);
+        coin::deposit(receiver_b, coins);
+    }
+}


### PR DESCRIPTION
### Description
An example for splitting and using type args

### Test Plan
https://explorer.aptoslabs.com/txn/0x70a3380369c1c7e341faef036bb6f969b4bf4392fc5b16db62cbd24364e08da8
```
aptos move run-script --script-path aptos-move/move-examples/split_transfer/sources/split_transfer.move --type-args 0x1::aptos_coin::AptosCoin --args address:677c3d5724fdf179c86ae705614a404df978c9c6a8ca7735a995da4f2c83c73d address:3bec5a529b023449dfc86e9a6b5b51bf75cec4a62bf21c15bbbef08a75f7038f u64:10  --profile greg
Do you want to submit a transaction for a range of [30900 - 46300] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0x70a3380369c1c7e341faef036bb6f969b4bf4392fc5b16db62cbd24364e08da8",
    "gas_used": 317,
    "gas_unit_price": 100,
    "sender": "e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb",
    "sequence_number": 19,
    "success": true,
    "timestamp_us": 1664517741368009,
    "version": 138819789,
    "vm_status": "Executed successfully"
  }
}

```
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4669)
<!-- Reviewable:end -->
