### PR TITLE
[Prover] fix the spec of `bit_vector::unset`

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/bit_vector.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/bit_vector.move
@@ -73,7 +73,7 @@ module std::bit_vector {
     }
     spec unset {
         include UnsetAbortsIf;
-        ensures bitvector.bit_field[bit_index];
+        ensures !bitvector.bit_field[bit_index];
     }
     spec schema UnsetAbortsIf {
         bitvector: BitVector;

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib_incompat/sources/bit_vector.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib_incompat/sources/bit_vector.move
@@ -71,9 +71,9 @@ module std::bit_vector {
         let x = vector::borrow_mut(&mut bitvector.bit_field, bit_index);
         *x = false;
     }
-    spec set {
+    spec unset {
         include UnsetAbortsIf;
-        ensures bitvector.bit_field[bit_index];
+        ensures !bitvector.bit_field[bit_index];
     }
     spec schema UnsetAbortsIf {
         bitvector: BitVector;

--- a/aptos-move/framework/move-stdlib/sources/bit_vector.move
+++ b/aptos-move/framework/move-stdlib/sources/bit_vector.move
@@ -73,7 +73,7 @@ module std::bit_vector {
     }
     spec unset {
         include UnsetAbortsIf;
-        ensures bitvector.bit_field[bit_index];
+        ensures !bitvector.bit_field[bit_index];
     }
     spec schema UnsetAbortsIf {
         bitvector: BitVector;


### PR DESCRIPTION
### Description
- Fix the spec mistake which has existed since the Move repo

### Test Plan
aptos move prove

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4674)
<!-- Reviewable:end -->
