### PR TITLE
markuze/experiment vanila 20 nodes

### DIFF
--- a/testsuite/forge.py
+++ b/testsuite/forge.py
@@ -1213,8 +1213,7 @@ def create_forge_command(
         forge_args.append("--reuse")
     if forge_namespace_keep == "true":
         forge_args.append("--keep")
-    if forge_enable_haproxy == "true":
-        forge_args.append("--enable-haproxy")
+    forge_args.append("--enable-haproxy")
 
     if test_args:
         forge_args.extend(test_args)
@@ -1535,7 +1534,7 @@ def test(
         forge_cli_args=forge_cli_args,
         test_args=test_args,
     )
-    
+
     print(f"Using cluster: {forge_cluster_name}")
     temp = context.filesystem.mkstemp()
     forge_cluster = ForgeCluster(forge_cluster_name, temp)


### PR DESCRIPTION
- [forge] fix grafana namespace (#4602)
- [HApropxy] new haproxy config and resources
- [Docker] Adding HAProxy to docker compose
- [tokio-console] Configuring tokio-console default port
- [aptos-cli] Bump to version 0.3.6
- [storage] larger default state prune window
- refactor: add "strict" to SDK tsconfig
- [helm][aptos-node] override NodeConfig with deep merge (#4546)
- add indexer to cli (#4586)
- Node docs (#4572)
- [SDK][API] Remove event key endpoint / client code (#4338)
- [backup] tf: add back backup intervals
- [consensus] support a recovery mode if consensusdb is gone
- [forge][telemetry] enable node telemetry in forge (#4490)
- [storage] rename target_snapshot_size (#4615)
- [txn-emitter] Fix computation for needed coin balance (#4614)
- [executor] fix integration test helper
- enable backup-cli unit tests in ci
- [gha] Make forge namespace optional
- [network] limit the max fragments in stream message
- [consensus] limit the payload size and remove unused quorum store variant
- [doc] update doc to remove test mode (#4626)
- [gha] Enable release on PR, enable HAProxy on release test
- [Aptos Stdlib] Make scaling factor actually useful in pool_u64
- [API Client] Fix wait_for_transaction to wait for expiry and return better messages (#4456)
- [Lint only] Fix docs lint
- [Vesting][Audit] Fix several minor issues in the vesting contract (#4560)
- [Audit][Aptos Framework][Staking contract] Zero out distribution pool when settling dust (#4585)
- [Token] Enfore no zero balance token
- [move] Do not include vector native implementations (#4621)
- [Stake] Validate lockup (#4632)
- [forge] fix max_block_txns rename (#4643)
- [move-examples] nft move example (#4512)
- [Staking] Move validator to pending_inactive instead of directly removing (#4633)
- [consensus] Remove skip_serializing_if from BlockRetreivalRequest (#4644)
- [telemetry] Send build info periodically
- [telemetry] Retry sending telemetry on transient errors
- [telemetry] Reset RUST_LOG_TELEMETRY to original value on unset
- [telemetry] send node config as event periodically
- Update connect-to-aptos-network.md
- [Config] Update disk size to 1000Gi. (#4622)
- Update API changelog
- [audit] timestamp.move (#4619)
- [cli] Increase REST endpoint timeout to 30s (#4628)
- [Token] reorgnize code
- [mempool] more/better metrics (#4616)
- [Prover spec only] Fix a typo in the bit_vector.move's prover specs (#4654)
- Fixed the spec in the stake module (#4656)
- [forge] Add tests for validation set changes (#4279)
- [Audit] Fix minor issues from audit
- Add complex token table indexing (#4324)
- added gas-estimation benchmarks for BLS12-381, Ed25519, secp256k1, Ristretto255 and cryptographic hash functions (#4630)
- [gas] initial gas parameters for table operations (#4659)
- [Token] Relax time constraint
- [Token] deprecate the token_coin_swap
- [Voting] Ensure proposal execution cannot happen in the same transaction as the last vote (#4612)
- [aggregator] Fix delta merging with history
- fixed a typo
- fixed ordering of delta merging
- fixed ordering of delta merging 2
- fixed a typo
- fixed naming
- changed names, used unwrap_or
- refactored code to remove duplication between match arms
- changed old names in macros
- [aptos-node] fixing the VM natives by excluding move-deps from the dependency tree (#4660)
- 2HR vanila haproxy run - 20 nodes

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4675)
<!-- Reviewable:end -->
