### PR TITLE
[backup] fix flaky test_save_list_metadata_files

### DIFF
--- a/storage/backup/backup-cli/src/storage/local_fs/mod.rs
+++ b/storage/backup/backup-cli/src/storage/local_fs/mod.rs
@@ -105,6 +105,7 @@ impl BackupStorage for LocalFs {
         file.write_all(content.as_ref().as_bytes())
             .await
             .err_notes(&path)?;
+        file.shutdown().await.err_notes(&path)?;
 
         Ok(())
     }


### PR DESCRIPTION
it's an overlook that LocalFs::save_metadata_line() didn't shutdown the file handle, resulting in chance that the written file not immediately visible on the FS.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4681)
<!-- Reviewable:end -->
