### PR TITLE
[types] fix feature flags for itertools

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.57"
 bcs = "0.1.3"
 chrono = { version = "0.4.19", default-features = false, features = ["clock"] }
 hex = "0.4.3"
-itertools = { version = "0.10.3", default-features = false }
+itertools = { version = "0.10.3" }
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 once_cell = "1.10.0"


### PR DESCRIPTION
`aptos-types` depends on `itertools` with all default features disabled. `itertools::IterTools::collect_vec` is only available with feature "use_alloc" so `aptos-types` is now failing to build in standalone mode. This is a preexisting issue but it wasn't exposed in the past due to feature unification. This PR fixes the broken build by enabling the default features

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4684)
<!-- Reviewable:end -->
