### PR TITLE
markuze/haproxy v3

### DIFF
--- a/terraform/helm/aptos-node/files/haproxy.cfg
+++ b/terraform/helm/aptos-node/files/haproxy.cfg
@@ -1,51 +1,164 @@
 global
     log stdout len 10240 format raw local0
-    maxconn 500000
-    nbthread 16
+
+    # Config manual: https://cbonte.github.io/haproxy-dconv/2.5/configuration.html
+    # magic values : terraform/helm/aptos-node/values.yaml
+
+    # 256 connections/sec * upgrade_to(30 sec)
+    maxconn 8192
+    # This limits the whole HA Proxy impacting both validators and other frontends
+    # maxconnrate 128
+    nbthread 4
+
+    #4MB for client facing sndbuf/rcvbuf. -- 100Mb/s with 300 mili latency (e.g., us-asia)
+    tune.rcvbuf.client {{ $.Values.haproxy.limits.validator.tcpBufSize }}
+
     user nobody
 
+## TCP port defaults
 defaults
     log global
-    option tcplog
-    maxconn 500000
-    timeout queue 1s
-    timeout connect 10s
-    timeout server 60s
-    timeout client 60s
-    timeout client-fin 5s
+    mode tcp
+    #option tcplog
+    option dontlog-normal
+    log-format "%ci:%cp - %sp[%rt] [%t] %ft %Tw/%Tc/%Tt %B [%ts] %ac/%fc/%bc/%sc/%rc %sq/%bq"
+    maxconn 8192		#Validator network mesh + FN x2
+    retries 3
+    timeout queue 5s  #limits num of concurrent connections. Not clear if t/o connect is needed. #https://www.papertrail.com/solution/tips/haproxy-logging-how-to-tune-timeouts-for-performance/
+    timeout connect 5s
+    # enough for 1 successfull + 5 unsuccessfull HB(10 sec interval) + 20 sec timeout
+    timeout server 80s
+    timeout client 80s
 
-frontend validator
+    timeout client-fin 3s #How long to hold an interrupted client connection.
+    timeout server-fin 1s
+
+frontend fe-{{ include "aptos-validator.fullname" $ }}-validator
     bind :6180
-    default_backend validator
+    default_backend {{ include "aptos-validator.fullname" $ }}-validator
 
     # Deny requests from blocked IPs
-    tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+    tcp-request connection silent-drop if { src -n -f /usr/local/etc/haproxy/blocked.ips }
 
-    # Limit to N TCP connections per minute per source IP
-    stick-table type ip size 500k expire 1m store gpc0_rate(1m)
-    tcp-request connection track-sc0 src
-    # TODO: Reject at content phase for now so we get logs, but this should be
-    # done at connection phase for higher efficiency
-    tcp-request content reject if { sc_gpc0_rate(0) ge {{ $.Values.haproxy.limits.validator.connectionsPerIPPerMin }} }
-    tcp-request content sc-inc-gpc0(0) unless { nbsrv(validator) eq 0 }
+    acl ip_high_conn_rate sc0_conn_rate gt {{ $.Values.haproxy.limits.validator.connectionsPerIPPerMin }}
 
-backend validator
-    default-server maxconn 1024 {{ if $.Values.haproxy.config.send_proxy_protocol }}send-proxy-v2{{ end }}
+    stick-table type ip size 10m expire 30m store gpc0,gpc1,conn_rate(1m),bytes_out_rate(10s),bytes_out_cnt	##about 500MB of memory
+    tcp-request connection track-sc0 src 						   #update table with src ip as key, store in sc0
+
+    #We Count rate-limit manualy -- Will be more CPU intensieve but will allow whitelists to enter and up to rateLimitSession non blacklisted IPs.
+    tcp-request connection track-sc1 int(1) table CONN_RATE
+
+    #tcp-request connection sc-set-gpt0(0) int(...) if ip_high_conn_rate is better but dies with:
+    #parsing [/usr/local/etc/haproxy/haproxy.cfg:53] : internal error, unexpected rule->from=0, please report this bug!
+    #<1> Mark Blacklist
+    tcp-request connection sc-inc-gpc0(0) if ip_high_conn_rate
+
+    #This connection is silently dropped no reason to count it for rateLimitSession
+    tcp-request connection sc-inc-gpc1(1) unless { sc0_get_gpc0() ge 1 }
+
+    # an IP that was blacklisted due to to many unsucsessfull tcp attempts
+    #-1- Enforece Blacklist
+    tcp-request connection silent-drop if { sc0_get_gpc0() ge 1 }
+
+    #an IP that had a sucessfull connection.
+    #-2- Allow Whitelist
+    tcp-request connection accept if { sc0_get_gpc1() ge 1 }
+
+    #-3- Enforece RateLimit
+    tcp-request connection reject if { sc1_gpc1_rate(CONN_RATE) gt  {{ $.Values.haproxy.limits.validator.rateLimitSession }} }
+
+    # This is a successfull connection i.e., was sent more than 16K bytes in the last 30 min
+    #tcp-request session sc-set-gpt0(0) int(...)  if { sc0_kbytes_out gt 16 }
+    #<2> Mark Whitelist
+    tcp-request session sc-inc-gpc1(0) if { sc0_kbytes_out gt 4 }
+
+    # -4- Break a long high rate connection
+    tcp-request session reject if { sc0_bytes_out_rate gt  {{ $.Values.haproxy.limits.validator.maxBytesOutRate10sec }} }
+
+backend {{ include "aptos-validator.fullname" $ }}-validator
+    default-server maxconn 8192
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:6180
+
+frontend fe-{{ include "aptos-validator.fullname" $ }}-validator-fn
+    bind :6181
+    default_backend {{ include "aptos-validator.fullname" $ }}-validator-fn
+
+    # Deny requests from blocked IPs
+    tcp-request connection silent-drop if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+
+    acl ip_high_conn_rate sc0_conn_rate gt {{ $.Values.haproxy.limits.validator.connectionsPerIPPerMin }}
+
+    stick-table type ip size 10m expire 30m store gpc0,gpc1,conn_rate(1m),bytes_out_rate(10s),bytes_out_cnt	##about 500MB of memory
+    tcp-request connection track-sc0 src 						   #update table with src ip as key, store in sc0
+
+    #We Count rate-limit manualy -- Will be more CPU intensieve but will allow whitelists to enter and up to rateLimitSession non blacklisted IPs.
+    tcp-request connection track-sc1 int(1) table CONN_RATE
+
+    #tcp-request connection sc-set-gpt0(0) int(...) if ip_high_conn_rate is better but dies with:
+    #parsing [/usr/local/etc/haproxy/haproxy.cfg:53] : internal error, unexpected rule->from=0, please report this bug!
+    #<1> Mark Blacklist
+    tcp-request connection sc-inc-gpc0(0) if ip_high_conn_rate
+
+    #This connection is silently dropped no reason to count it for rateLimitSession
+    tcp-request connection sc-inc-gpc1(1) unless { sc0_get_gpc0() ge 1 }
+
+    # an IP that was blacklisted due to to many unsucsessfull tcp attempts
+    #-1- Enforece Blacklist
+    tcp-request connection silent-drop if { sc0_get_gpc0() ge 1 }
+
+    #an IP that had a sucessfull connection.
+    #-2- Allow Whitelist
+    tcp-request connection accept if { sc0_get_gpc1() ge 1 }
+
+    #-3- Enforece RateLimit
+    tcp-request connection reject if { sc1_gpc1_rate(CONN_RATE) gt  {{ $.Values.haproxy.limits.validator.rateLimitSession }} }
+
+    # This is a successfull connection i.e., was sent more than 16K bytes in the last 30 min
+    #tcp-request session sc-set-gpt0(0) int(...)  if { sc0_kbytes_out gt 16 }
+    #<2> Mark Whitelist
+    tcp-request session sc-inc-gpc1(0) if { sc0_kbytes_out gt 4 }
+
+    # -4- Break a long high rate connection
+    tcp-request session reject if { sc0_bytes_out_rate gt  {{ $.Values.haproxy.limits.validator.maxBytesOutRate10sec }} }
+
+backend {{ include "aptos-validator.fullname" $ }}-validator-fn
+    default-server maxconn 8192
+    server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:6181
+
+
+#CONNRATE holds only entry with key 1: used for determening global conn rate
+backend CONN_RATE
+    stick-table type integer size 1 expire 10m store gpc1,gpc1_rate(1s)
+
+##################  HTTP: metrics & API
+defaults
+	retries 3
+	timeout queue 5s  #limits num of concurrent connections. Not clear if t/o connect is needed. #https://www.papertrail.com/solution/tips/haproxy-logging-how-to-tune-timeouts-for-performance/
+	timeout connect 5s
+	timeout server 60s #what makes sense? for silence between nodes?
+	timeout client 60s
+
+	timeout client-fin 3s #How long to hold an interrupted client connection.
+	timeout server-fin 1s
+
+	timeout http-request 60 #len of http request
+	timeout http-keep-alive 2s
+
+	rate-limit sessions 128
 
 frontend validator-metrics
     mode http
     option httplog
     bind :9102
     default_backend validator-metrics
-    http-request add-header Forwarded "for=%ci"
 
     # Deny requests from blocked IPs
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+    http-request add-header Forwarded "for=%ci"
 
 backend validator-metrics
     mode http
-    default-server maxconn 1024
+    default-server maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:9101
 
 # Exposes the validator's own REST API
@@ -55,14 +168,14 @@ frontend validator-api
     option httplog
     bind :8180
     default_backend validator-api
-    http-request add-header Forwarded "for=%ci"
 
     # Deny requests from blocked IPs
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+    http-request add-header Forwarded "for=%ci"
 
 backend validator-api
     mode http
-    default-server maxconn 1024
+    default-server maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:8080
 {{- end }}
 
@@ -87,14 +200,14 @@ frontend {{ $config.name }}-api
     default_backend {{ $config.name }}-api
     # add Forwarded header, which behaves differently than X-Forwarded-For
     # see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
-    http-request add-header Forwarded "for=%ci"
 
     # Deny requests from blocked IPs
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+    http-request add-header Forwarded "for=%ci"
 
 backend {{ $config.name }}-api
     mode http
-    default-server maxconn 1024
+    default-server maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }} {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }}:8080
 
 frontend {{ $config.name }}-metrics
@@ -102,14 +215,14 @@ frontend {{ $config.name }}-metrics
     option httplog
     bind :{{ add 9103 $index }}
     default_backend {{ $config.name }}-metrics
-    http-request add-header Forwarded "for=%ci"
 
     # Deny requests from blocked IPs
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+    http-request add-header Forwarded "for=%ci"
 
 backend {{ $config.name }}-metrics
     mode http
-    default-server maxconn 1024
+    default-server maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }} {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }}:9101
 
 {{- end }}

--- a/terraform/helm/aptos-node/values.yaml
+++ b/terraform/helm/aptos-node/values.yaml
@@ -31,18 +31,23 @@ haproxy:
     pullPolicy: IfNotPresent
   resources:
     limits:
-      cpu: 1.5
-      memory: 2Gi
+      cpu: 4
+      memory: 8Gi
     requests:
-      cpu: 1.5
-      memory: 2Gi
+      cpu: 4
+      memory: 8Gi
   nodeSelector: {}
   tolerations: []
   affinity: {}
   limits:
     validator:
-      # -- Limit the number of connections per IP address per minute
+      # -- Limit the number of connections per IP address per sec
       connectionsPerIPPerMin: 2
+      # Sustained 100mb/s for 10 sec.
+      maxBytesOutRate10sec: 134217728
+      rateLimitSession: 256
+      tcpBufSize: 524288
+
   config:
     # -- Whether to send Proxy Protocol v2
     send_proxy_protocol: &send_proxy_protocol false


### PR DESCRIPTION
- [forge] fix grafana namespace (#4602)
- [HApropxy] new haproxy config and resources
- [Docker] Adding HAProxy to docker compose
- [tokio-console] Configuring tokio-console default port
- [aptos-cli] Bump to version 0.3.6
- [storage] larger default state prune window
- refactor: add "strict" to SDK tsconfig
- [helm][aptos-node] override NodeConfig with deep merge (#4546)
- add indexer to cli (#4586)
- Node docs (#4572)
- [SDK][API] Remove event key endpoint / client code (#4338)
- [backup] tf: add back backup intervals
- [consensus] support a recovery mode if consensusdb is gone
- [forge][telemetry] enable node telemetry in forge (#4490)
- [storage] rename target_snapshot_size (#4615)
- [txn-emitter] Fix computation for needed coin balance (#4614)
- [executor] fix integration test helper
- enable backup-cli unit tests in ci
- [gha] Make forge namespace optional
- [network] limit the max fragments in stream message
- [consensus] limit the payload size and remove unused quorum store variant
- [doc] update doc to remove test mode (#4626)
- [gha] Enable release on PR, enable HAProxy on release test
- [Aptos Stdlib] Make scaling factor actually useful in pool_u64
- [API Client] Fix wait_for_transaction to wait for expiry and return better messages (#4456)
- [Lint only] Fix docs lint
- [Vesting][Audit] Fix several minor issues in the vesting contract (#4560)
- [Audit][Aptos Framework][Staking contract] Zero out distribution pool when settling dust (#4585)
- [Token] Enfore no zero balance token
- [move] Do not include vector native implementations (#4621)
- [Stake] Validate lockup (#4632)
- [forge] fix max_block_txns rename (#4643)
- [move-examples] nft move example (#4512)
- [Staking] Move validator to pending_inactive instead of directly removing (#4633)
- [consensus] Remove skip_serializing_if from BlockRetreivalRequest (#4644)
- [telemetry] Send build info periodically
- [telemetry] Retry sending telemetry on transient errors
- [telemetry] Reset RUST_LOG_TELEMETRY to original value on unset
- [telemetry] send node config as event periodically
- Update connect-to-aptos-network.md
- [Config] Update disk size to 1000Gi. (#4622)
- Update API changelog
- [audit] timestamp.move (#4619)
- [cli] Increase REST endpoint timeout to 30s (#4628)
- [Token] reorgnize code
- [mempool] more/better metrics (#4616)
- [Prover spec only] Fix a typo in the bit_vector.move's prover specs (#4654)
- Fixed the spec in the stake module (#4656)
- [forge] Add tests for validation set changes (#4279)
- [Audit] Fix minor issues from audit
- Add complex token table indexing (#4324)
- added gas-estimation benchmarks for BLS12-381, Ed25519, secp256k1, Ristretto255 and cryptographic hash functions (#4630)
- [gas] initial gas parameters for table operations (#4659)
- [Token] Relax time constraint
- [Token] deprecate the token_coin_swap
- [Voting] Ensure proposal execution cannot happen in the same transaction as the last vote (#4612)
- [aggregator] Fix delta merging with history
- fixed a typo
- fixed ordering of delta merging
- fixed ordering of delta merging 2
- fixed a typo
- fixed naming
- changed names, used unwrap_or
- refactored code to remove duplication between match arms
- changed old names in macros
- [aptos-node] fixing the VM natives by excluding move-deps from the dependency tree (#4660)
- Revert "[HApropxy] new haproxy config and resources"
- [cli] Make faucet compatible with more faucet implementations
- [cached-packages] Update cached move packages
- [Execution][Fix] Do not panic when proof fetcher cannot send proof. (#4663)
- [rest-client] Change warn level message to debug for a transaction not being present
- [cli] Bump version to 0.3.7
- [genesis] Make is test optional as a layout field
- [cli] Fix genesis mainnet input to be a flag
- [genesis] Support mainnet genesis balance files
- [genesis] Fix employee map loading
- [genesis] Make a better message if a file isn't found
- [genesis] Check for accounts that aren't in the initial balances
- [genesis] Cleanup error messages to use enumerated for employee pools
- [genesis] Ensure vesting schedule adds up properly
- [genesis] Add more verification checks
- [genesis] Change genesis error output to be more helpful
- [genesis] Add more validations to validators
- [genesis] Check employee validators with other validators
- [genesis] Check total supply
- [genesis] Add total stake checks for employee accounts
- [genesis] Ensure full node host and validator host aren't the same
- [genesis] Fix tests for mainnet genesis
- [vm] Invalidate loader cache on any module bundle loading errors (#4668)
- [gas] storage_gas initial value fix (#4658)
- Validate string arguments to transaction
- Fix: typos
- [Trivial] Remove an used index variable
- [sdk-builder] Fix default sdk builder language
- change backup pod log level to info
- [aggregator] Fixed the description of sub()
- [Prover] fix the spec of `bit_vector::unset`
- [framework] eliminate front running of resource accounts
- [Docs] Adding sitemap option.
- [Docs] Consolidating all the troubleshooting sections into a new top-level doc.
- [Docs] Fixing index link.
- Make small direct edits
- Fix links to docs with .md extension and relative paths
- [test on forge] Add state sync catching up stress tests (#4036)
- [helm] redirect primary ingress (#4682)
- [helm][fullnode] option to load genesis from k8s secret (#4679)
- [api] Add git hash to index API
- [rosetta]  Split operator overriding function out
- [rosetta] Add error message for when max gas is too low
- [txn-emitter] fix mint and add transfer traffic (#4349)
- [audit] property_map.move (#4597)
- [haproxy] haproxy config and resources v3

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4691)
<!-- Reviewable:end -->
