### PR TITLE
[TS][SDK] Add ability to build FaucetClient with auth token

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_client.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.test.ts
@@ -3,12 +3,11 @@
 
 import { AptosClient } from "./aptos_client";
 import * as Gen from "./generated/index";
-import { FaucetClient } from "./faucet_client";
 import { AptosAccount } from "./aptos_account";
 import { TxnBuilderTypes, TransactionBuilderMultiEd25519, TransactionBuilderRemoteABI } from "./transaction_builder";
 import { TokenClient } from "./token_client";
 import { HexString } from "./hex_string";
-import { FAUCET_URL, NODE_URL } from "./utils/test_helper.test";
+import { getFaucetClient, NODE_URL } from "./utils/test_helper.test";
 import { bcsSerializeUint64, bcsToBytes } from "./bcs";
 
 const account = "0x1::account::Account";
@@ -74,7 +73,7 @@ test(
   "submits bcs transaction",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const account1 = new AptosAccount();
     await faucetClient.fundAccount(account1.address(), 100_000_000);
@@ -117,7 +116,7 @@ test(
   "submits transaction with remote ABI",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const account1 = new AptosAccount();
     await faucetClient.fundAccount(account1.address(), 100_000_000);
@@ -154,7 +153,7 @@ test(
   "submits multisig transaction",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const account1 = new AptosAccount();
     const account2 = new AptosAccount();
@@ -228,7 +227,7 @@ test(
   "submits json transaction simulation",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const account1 = new AptosAccount();
     const account2 = new AptosAccount();
@@ -282,7 +281,7 @@ test(
   "submits bcs transaction simulation",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const account1 = new AptosAccount();
     const account2 = new AptosAccount();
@@ -340,7 +339,7 @@ test(
   "submits multiagent transaction",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
     const tokenClient = new TokenClient(client);
 
     const alice = new AptosAccount();
@@ -422,7 +421,7 @@ test(
   "publishes a package",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const account1 = new AptosAccount(
       new HexString("0x883fdd67576e5fdceb370ba665b8af8856d0cae63fd808b8d16077c6b008ea8c").toUint8Array(),
@@ -457,7 +456,7 @@ test(
   "rotates auth key ed25519",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const alice = new AptosAccount();
     await faucetClient.fundAccount(alice.address(), 100_000_000);
@@ -507,7 +506,7 @@ test(
   "estimates max gas amount",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const alice = new AptosAccount();
     await faucetClient.fundAccount(alice.address(), 10000000);

--- a/ecosystem/typescript/sdk/src/coin_client.test.ts
+++ b/ecosystem/typescript/sdk/src/coin_client.test.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosClient } from "./aptos_client";
-import { FAUCET_URL, NODE_URL } from "./utils/test_helper.test";
-import { FaucetClient } from "./faucet_client";
+import { getFaucetClient, NODE_URL } from "./utils/test_helper.test";
 import { AptosAccount } from "./aptos_account";
 import { CoinClient } from "./coin_client";
 
@@ -11,7 +10,7 @@ test(
   "transferCoins and checkBalance works",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
     const coinClient = new CoinClient(client);
 
     const alice = new AptosAccount();

--- a/ecosystem/typescript/sdk/src/faucet_client.test.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.test.ts
@@ -7,7 +7,7 @@ import { AptosAccount } from "./aptos_account";
 import { HexString } from "./hex_string";
 import * as Gen from "./generated/index";
 
-import { NODE_URL, FAUCET_URL } from "./utils/test_helper.test";
+import { NODE_URL, FAUCET_URL, getFaucetClient } from "./utils/test_helper.test";
 
 const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 
@@ -22,7 +22,7 @@ test(
   "full tutorial faucet flow",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
 
     const account1 = new AptosAccount();
     const txns = await faucetClient.fundAccount(account1.address(), 1000000);

--- a/ecosystem/typescript/sdk/src/faucet_client.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.ts
@@ -21,7 +21,7 @@ export class FaucetClient extends AptosClient {
    * @param config An optional config for inner axios instance
    * Detailed config description: {@link https://github.com/axios/axios#request-config}
    */
-  constructor(nodeUrl: string, faucetUrl: string, config?: OpenAPIConfig) {
+  constructor(nodeUrl: string, faucetUrl: string, config?: Partial<OpenAPIConfig>) {
     super(nodeUrl, config);
 
     if (!faucetUrl) {

--- a/ecosystem/typescript/sdk/src/token_client.test.ts
+++ b/ecosystem/typescript/sdk/src/token_client.test.ts
@@ -1,18 +1,17 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-import { FaucetClient } from "./faucet_client";
 import { AptosAccount } from "./aptos_account";
 import { AptosClient } from "./aptos_client";
 import { TokenClient } from "./token_client";
 
-import { FAUCET_URL, NODE_URL } from "./utils/test_helper.test";
+import { getFaucetClient, NODE_URL } from "./utils/test_helper.test";
 
 test(
   "full tutorial nft token flow",
   async () => {
     const client = new AptosClient(NODE_URL);
-    const faucetClient = new FaucetClient(NODE_URL, FAUCET_URL);
+    const faucetClient = getFaucetClient();
     const tokenClient = new TokenClient(client);
 
     const alice = new AptosAccount();

--- a/ecosystem/typescript/sdk/src/utils/test_helper.test.ts
+++ b/ecosystem/typescript/sdk/src/utils/test_helper.test.ts
@@ -1,5 +1,22 @@
+import { FaucetClient } from "../faucet_client";
+import { OpenAPIConfig } from "../generated";
+
 export const NODE_URL = process.env.APTOS_NODE_URL!;
 export const FAUCET_URL = process.env.APTOS_FAUCET_URL!;
+
+/**
+ * Returns an instance of a FaucetClient with NODE_URL and FAUCET_URL from the
+ * environment. If the FAUCET_AUTH_TOKEN environment variable is set, it will
+ * pass that along in the header in the format the faucet expects.
+ */
+export function getFaucetClient(): FaucetClient {
+  let config: Partial<OpenAPIConfig> = {};
+  if (process.env.FAUCET_AUTH_TOKEN) {
+    config.HEADERS = { Authorization: `Bearer ${process.env.FAUCET_AUTH_TOKEN}` };
+  }
+  return new FaucetClient(NODE_URL, FAUCET_URL, config);
+}
+
 test("noop", () => {
   // All TS files are compiled by default into the npm package
   // Adding this empty test allows us to:


### PR DESCRIPTION
### Description
The tap (new faucet) has the ability to let clients set an auth token which will let them bypass ratelimits. This PR adds support for enabling this via an env var in the SDK tests. This will be helpful for CI/CD.

I'll update `ecosystem/typescript/sdk/examples` to use this after we land a package with this in it.

### Test Plan
Run a local testnet like this:
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes --with-faucet
```

Run tap locally like this:
```
curl https://gist.github.com/banool/94ef72c03cf1ed79d06fa99799cd5e04 > /tmp/config.yaml
cargo run -- run -c /tmp/config.yaml
```

To switch between each faucet, change env:
```
APTOS_NODE_URL="http://127.0.0.1:8080/v1"
APTOS_FAUCET_URL="http://127.0.0.1:10212"
FAUCET_AUTH_TOKEN="abc123"
```

I ran `yarn test` for all of these situations:
- `.env` where FAUCET_AUTH_TOKEN is not set, against existing faucet.
    - Works as before.
- `.env` where FAUCET_AUTH_TOKEN is set, against existing faucet.
    - Works as before.
- `.env` where FAUCET_AUTH_TOKEN is not set, against tap
    - Gets ratelimited as expected.
- `.env` where FAUCET_AUTH_TOKEN is set, against tap
    - Tests pass.

I'll make the CI changes later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4692)
<!-- Reviewable:end -->
