### PR TITLE
[mempool] check hash for rejected transactions

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use aptos_crypto::HashValue;
 use aptos_types::{account_address::AccountAddress, transaction::SignedTransaction};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -23,6 +24,13 @@ impl fmt::Display for TransactionSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.sender, self.sequence_number,)
     }
+}
+
+#[derive(Clone)]
+pub struct RejectedTransactionSummary {
+    pub sender: AccountAddress,
+    pub sequence_number: u64,
+    pub hash: HashValue,
 }
 
 /// The payload in block.

--- a/consensus/src/txn_notifier.rs
+++ b/consensus/src/txn_notifier.rs
@@ -5,7 +5,7 @@ use crate::{error::MempoolError, monitor};
 use anyhow::{format_err, Result};
 use aptos_mempool::QuorumStoreRequest;
 use aptos_types::transaction::TransactionStatus;
-use consensus_types::{block::Block, common::TransactionSummary};
+use consensus_types::{block::Block, common::RejectedTransactionSummary};
 use executor_types::StateComputeResult;
 use futures::channel::{mpsc, oneshot};
 use itertools::Itertools;
@@ -78,9 +78,10 @@ impl TxnNotifier for MempoolNotifier {
         let user_txn_status = &compute_status[1..txns.len() + 1];
         for (txn, status) in txns.iter().zip_eq(user_txn_status) {
             if let TransactionStatus::Discard(_) = status {
-                rejected_txns.push(TransactionSummary {
+                rejected_txns.push(RejectedTransactionSummary {
                     sender: txn.sender(),
                     sequence_number: txn.sequence_number(),
+                    hash: txn.clone().committed_hash(),
                 });
             }
         }

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -71,7 +71,7 @@ impl Mempool {
     ) {
         trace!(
             LogSchema::new(LogEntry::RemoveTxn).txns(TxnsLog::new_txn(*sender, sequence_number)),
-            is_rejected = false
+            is_rejected = true
         );
         self.log_latency(*sender, sequence_number, counters::COMMIT_REJECTED_LABEL);
         if let Some(ranking_score) = self.transactions.get_ranking_score(sender, sequence_number) {

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -45,28 +45,45 @@ impl Mempool {
     }
 
     /// This function will be called once the transaction has been stored.
-    pub(crate) fn remove_transaction(
-        &mut self,
-        sender: &AccountAddress,
-        sequence_number: u64,
-        is_rejected: bool,
-    ) {
+    pub(crate) fn commit_transaction(&mut self, sender: &AccountAddress, sequence_number: u64) {
         trace!(
             LogSchema::new(LogEntry::RemoveTxn).txns(TxnsLog::new_txn(*sender, sequence_number)),
-            is_rejected = is_rejected
+            is_rejected = false
         );
-        let metric_label = if is_rejected {
-            counters::COMMIT_REJECTED_LABEL
-        } else {
-            counters::COMMIT_ACCEPTED_LABEL
-        };
-        self.log_latency(*sender, sequence_number, metric_label);
+        self.log_latency(*sender, sequence_number, counters::COMMIT_ACCEPTED_LABEL);
         if let Some(ranking_score) = self.transactions.get_ranking_score(sender, sequence_number) {
-            counters::core_mempool_txn_ranking_score(REMOVE_LABEL, metric_label, ranking_score);
+            counters::core_mempool_txn_ranking_score(
+                REMOVE_LABEL,
+                counters::COMMIT_ACCEPTED_LABEL,
+                ranking_score,
+            );
         }
 
         self.transactions
-            .remove(sender, sequence_number, is_rejected);
+            .commit_transaction(sender, sequence_number);
+    }
+
+    pub(crate) fn reject_transaction(
+        &mut self,
+        sender: &AccountAddress,
+        sequence_number: u64,
+        hash: &HashValue,
+    ) {
+        trace!(
+            LogSchema::new(LogEntry::RemoveTxn).txns(TxnsLog::new_txn(*sender, sequence_number)),
+            is_rejected = false
+        );
+        self.log_latency(*sender, sequence_number, counters::COMMIT_REJECTED_LABEL);
+        if let Some(ranking_score) = self.transactions.get_ranking_score(sender, sequence_number) {
+            counters::core_mempool_txn_ranking_score(
+                REMOVE_LABEL,
+                counters::COMMIT_REJECTED_LABEL,
+                ranking_score,
+            );
+        }
+
+        self.transactions
+            .reject_transaction(sender, sequence_number, hash);
     }
 
     fn log_latency(&self, account: AccountAddress, sequence_number: u64, stage: &'static str) {

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -182,7 +182,6 @@ fn handle_commit_notification<V>(
             })
             .collect(),
         msg.block_timestamp_usecs,
-        false,
     );
     smp.validator.write().notify_commit();
     let counter_result = if mempool_listener.ack_commit_notification(msg).is_err() {

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -16,7 +16,7 @@ use aptos_infallible::{Mutex, RwLock};
 use aptos_types::{
     mempool_status::MempoolStatus, transaction::SignedTransaction, vm_status::DiscardedVMStatus,
 };
-use consensus_types::common::TransactionSummary;
+use consensus_types::common::{RejectedTransactionSummary, TransactionSummary};
 use futures::{
     channel::{mpsc, mpsc::UnboundedSender, oneshot},
     future::Future,
@@ -164,7 +164,7 @@ pub enum QuorumStoreRequest {
     /// Notifications about *rejected* committed txns.
     RejectNotification(
         // rejected transactions from consensus
-        Vec<TransactionSummary>,
+        Vec<RejectedTransactionSummary>,
         // callback to respond to
         oneshot::Sender<Result<QuorumStoreResponse>>,
     ),

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -170,7 +170,7 @@ impl MockSharedMempool {
 
     pub fn remove_txn(&self, txn: &SignedTransaction) {
         let mut pool = self.mempool.lock();
-        pool.remove_transaction(&txn.sender(), txn.sequence_number(), false)
+        pool.commit_transaction(&txn.sender(), txn.sequence_number())
     }
 
     /// True if all the given txns are in mempool, else false.

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -7,7 +7,7 @@ use crate::{
     QuorumStoreRequest,
 };
 use aptos_types::transaction::Transaction;
-use consensus_types::common::TransactionSummary;
+use consensus_types::common::RejectedTransactionSummary;
 use futures::{channel::oneshot, executor::block_on, sink::SinkExt};
 use mempool_notifications::MempoolNotificationSender;
 use tokio::runtime::Builder;
@@ -16,17 +16,16 @@ use tokio::runtime::Builder;
 fn test_consensus_events_rejected_txns() {
     let smp = MockSharedMempool::new();
 
-    // Add txns 1, 2, 3, 4
-    // Txn 1: committed successfully
-    // Txn 2: not committed but older than gc block timestamp
-    // Txn 3: not committed and newer than block timestamp
-    let committed_txn =
-        TestTransaction::new(0, 0, 1).make_signed_transaction_with_expiration_time(0);
-    let kept_txn = TestTransaction::new(1, 0, 1).make_signed_transaction(); // not committed or cleaned out by block timestamp gc
+    // Add txns 1, 2, 3
+    // Txn 1: rejected during execution
+    // Txn 2: not committed with different address
+    // Txn 3: not committed with same address
+    let rejected_txn = TestTransaction::new(0, 0, 1).make_signed_transaction();
+    let kept_txn = TestTransaction::new(1, 0, 1).make_signed_transaction();
     let txns = vec![
-        committed_txn.clone(),
-        TestTransaction::new(0, 1, 1).make_signed_transaction_with_expiration_time(0),
+        rejected_txn.clone(),
         kept_txn.clone(),
+        TestTransaction::new(0, 1, 1).make_signed_transaction(),
     ];
     // Add txns to mempool
     {
@@ -34,9 +33,10 @@ fn test_consensus_events_rejected_txns() {
         assert!(batch_add_signed_txn(&mut pool, txns).is_ok());
     }
 
-    let transactions = vec![TransactionSummary {
-        sender: committed_txn.sender(),
-        sequence_number: committed_txn.sequence_number(),
+    let transactions = vec![RejectedTransactionSummary {
+        sender: rejected_txn.sender(),
+        sequence_number: rejected_txn.sequence_number(),
+        hash: rejected_txn.committed_hash(),
     }];
     let (callback, callback_rcv) = oneshot::channel();
     let req = QuorumStoreRequest::RejectNotification(transactions, callback);
@@ -48,7 +48,7 @@ fn test_consensus_events_rejected_txns() {
 
     let pool = smp.mempool.lock();
     let (timeline, _) = pool.read_timeline(0, 10);
-    assert_eq!(timeline.len(), 1);
+    assert_eq!(timeline.len(), 2);
     assert_eq!(timeline.first().unwrap(), &kept_txn);
 }
 
@@ -65,7 +65,7 @@ fn test_mempool_notify_committed_txns() {
     // Create a new mempool notifier, listener and shared mempool
     let smp = MockSharedMempool::new();
 
-    // Add txns 1, 2, 3, 4
+    // Add txns 1, 2, 3
     // Txn 1: committed successfully
     // Txn 2: not committed but older than gc block timestamp
     // Txn 3: not committed and newer than block timestamp

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -152,7 +152,7 @@ impl MempoolNode {
         for txn in sign_transactions(txns) {
             self.mempool
                 .lock()
-                .remove_transaction(&txn.sender(), txn.sequence_number(), false);
+                .commit_transaction(&txn.sender(), txn.sequence_number());
         }
     }
 


### PR DESCRIPTION
### Description

Avoid errantly removing transactions by checking hash when processing rejected transactions.

### Test Plan

Add unit tests for the new behavior. In particular `test_reject_transaction` checks bad rejected transactions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4694)
<!-- Reviewable:end -->
