### PR TITLE
[Indexer] Fix token indexing failure when collection table handle is missing

### DIFF
--- a/config/src/config/indexer_config.rs
+++ b/config/src/config/indexer_config.rs
@@ -60,6 +60,11 @@ pub struct IndexerConfig {
     /// Set to 0 to disable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub emit_every: Option<u64>,
+
+    /// Indicates how many versions we should look back for gaps (default 1.5M versions, meaning
+    /// we will only find gaps within MAX - 1.5M versions)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gap_lookback_versions: Option<u64>,
 }
 
 pub fn env_or_default<T: std::str::FromStr>(

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -358,6 +358,11 @@ impl NodeConfig {
         self.indexer.processor_tasks =
             default_if_zero_u8(self.indexer.processor_tasks, DEFAULT_PROCESSOR_TASKS);
         self.indexer.emit_every = self.indexer.emit_every.or(Some(0));
+        self.indexer.gap_lookback_versions = env_or_default(
+            "GAP_LOOKBACK_VERSIONS",
+            self.indexer.gap_lookback_versions.or(Some(1_500_000)),
+            None,
+        );
 
         Ok(self)
     }

--- a/crates/indexer/migrations/2022-10-02-011015_add_table_handle_to_collection/down.sql
+++ b/crates/indexer/migrations/2022-10-02-011015_add_table_handle_to_collection/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE collection_datas
+DROP COLUMN table_handle;
+ALTER TABLE current_collection_datas
+DROP COLUMN table_handle;

--- a/crates/indexer/migrations/2022-10-02-011015_add_table_handle_to_collection/up.sql
+++ b/crates/indexer/migrations/2022-10-02-011015_add_table_handle_to_collection/up.sql
@@ -1,0 +1,6 @@
+-- Your SQL goes here
+ALTER TABLE collection_datas
+ADD COLUMN table_handle VARCHAR(66) NOT NULL;
+ALTER TABLE current_collection_datas
+ADD COLUMN table_handle VARCHAR(66) NOT NULL;
+CREATE INDEX curr_cd_th_index ON current_collection_datas (table_handle);

--- a/crates/indexer/src/indexer/tailer.rs
+++ b/crates/indexer/src/indexer/tailer.rs
@@ -165,7 +165,11 @@ impl Tailer {
 
     /// Get starting version from database. Starting version is defined as the first version that's either
     /// not successful or missing from the DB.
-    pub fn get_start_version(&self, processor_name: &String) -> Option<i64> {
+    pub fn get_start_version(
+        &self,
+        processor_name: &String,
+        lookback_versions: i64,
+    ) -> Option<i64> {
         let mut conn = self
             .connection_pool
             .get()
@@ -240,7 +244,7 @@ impl Tailer {
         let mut res: Vec<Option<Gap>> = sql_query(sql)
             .bind::<Text, _>(processor_name)
             // This is the number used to determine how far we look back for gaps. Increasing it may result in slower startup
-            .bind::<BigInt, _>(1500000)
+            .bind::<BigInt, _>(lookback_versions)
             .get_results(&mut conn)
             .unwrap();
         res.pop().unwrap().map(|g| g.version)

--- a/crates/indexer/src/models/token_models/tokens.rs
+++ b/crates/indexer/src/models/token_models/tokens.rs
@@ -12,7 +12,10 @@ use super::{
     token_ownerships::{CurrentTokenOwnership, TokenOwnership},
     token_utils::{TokenResource, TokenWriteSet},
 };
-use crate::{models::move_resources::MoveResource, schema::tokens, util::ensure_not_negative};
+use crate::{
+    database::PgPoolConnection, models::move_resources::MoveResource, schema::tokens,
+    util::ensure_not_negative,
+};
 use aptos_api_types::{
     DeleteTableItem as APIDeleteTableItem, Transaction as APITransaction,
     WriteResource as APIWriteResource, WriteSetChange as APIWriteSetChange,
@@ -64,6 +67,7 @@ impl Token {
     /// state at the last transaction will be tracked, hence using hashmap to dedupe)
     pub fn from_transaction(
         transaction: &APITransaction,
+        conn: &mut PgPoolConnection,
     ) -> (
         Vec<Self>,
         Vec<TokenOwnership>,
@@ -123,6 +127,7 @@ impl Token {
                             write_table_item,
                             txn_version,
                             &table_handle_to_owner,
+                            conn,
                         )
                         .unwrap(),
                     ),

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -112,6 +112,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
     let processor_tasks = config.processor_tasks.unwrap();
     let emit_every = config.emit_every.unwrap();
     let batch_size = config.batch_size.unwrap();
+    let lookback_versions = config.gap_lookback_versions.unwrap() as i64;
 
     info!(processor_name = processor_name, "Starting indexer...");
 
@@ -148,7 +149,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
     }
 
     let starting_version_from_db = tailer
-        .get_start_version(&processor_name)
+        .get_start_version(&processor_name, lookback_versions)
         .unwrap_or_else(|| {
             info!(
                 processor_name = processor_name,

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -32,6 +32,7 @@ diesel::table! {
         uri_mutable -> Bool,
         description_mutable -> Bool,
         inserted_at -> Timestamp,
+        table_handle -> Varchar,
     }
 }
 
@@ -49,6 +50,7 @@ diesel::table! {
         description_mutable -> Bool,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        table_handle -> Varchar,
     }
 }
 


### PR DESCRIPTION
### Description
**Problem**
We currently panic when the collection resource is not present in the transaction but collection data is modified. 

https://fullnode.testnet.aptoslabs.com/v1/transactions/by_version/142269725 is an example of a transaction where this can happen. Basically a token is burned, the token data is also burned which reduces collection supply by 1, but the collection resource isn't there. 

**What this PR does**
In such an event we need to get the owner of the collection somehow. The quickest way (not necessarily the most scalable or efficient way though) to do this is via querying the db. This PR adds table handle as an indexed column in current_collection_datas table which keeps track of the latest collection state. 

### Test Plan
Backfilling error. Fix works. 
![image](https://user-images.githubusercontent.com/11738325/193437527-87545c86-b475-492d-8928-06554c00f14a.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4702)
<!-- Reviewable:end -->
