### PR TITLE
[CLI] Allow args to contain colons

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -943,7 +943,9 @@ impl FromStr for ArgWithType {
     type Err = CliError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<_> = s.split(':').collect();
+        // Splits on the first colon, returning at most `2` elements
+        // This is required to support args that contain a colon
+        let parts: Vec<_> = s.splitn(2, ':').collect();
         if parts.len() != 2 {
             return Err(CliError::CommandArgumentError(
                 "Arguments must be pairs of <type>:<arg> e.g. bool:true".to_string(),

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -1,8 +1,12 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{CliResult, Tool};
+use crate::{
+    move_tool::{ArgWithType, FunctionArgType},
+    CliResult, Tool,
+};
 use clap::Parser;
+use std::str::FromStr;
 
 /// In order to ensure that there aren't duplicate input arguments for untested CLI commands,
 /// we call help on every command to ensure it at least runs
@@ -89,6 +93,17 @@ async fn ensure_every_command_args_work() {
     assert_cmd_not_panic(&["aptos", "stake", "set-operator", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "stake", "unlock-stake", "--help"]).await;
     assert_cmd_not_panic(&["aptos", "stake", "withdraw-stake", "--help"]).await;
+}
+
+/// Ensure we can parse URLs for args
+#[tokio::test]
+async fn ensure_can_parse_args_with_urls() {
+    let result = ArgWithType::from_str("string:https://aptoslabs.com").unwrap();
+    matches!(result._ty, FunctionArgType::String);
+    assert_eq!(
+        result.arg,
+        bcs::to_bytes(&"https://aptoslabs.com".to_string()).unwrap()
+    );
 }
 
 async fn assert_cmd_not_panic(args: &[&str]) {


### PR DESCRIPTION
### Description
Support passing `"string:https://aptoslabs.com"` as args

### Test Plan
Added test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4706)
<!-- Reviewable:end -->
