### PR TITLE
[gha] remove external pushgateway reference

### DIFF
--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -112,10 +112,6 @@ jobs:
 
       - name: Run Forge
         shell: bash
-        env:
-          PUSH_GATEWAY: ${{ secrets.PUSH_GATEWAY }}
-          PUSH_GATEWAY_USER: ${{ secrets.PUSH_GATEWAY_USER }}
-          PUSH_GATEWAY_PASSWORD: ${{ secrets.PUSH_GATEWAY_PASSWORD }}
         run: testsuite/run_forge.sh
       - name: Post forge result comment
         # Post a Github comment if the run has not been cancelled and if we're running on a PR

--- a/terraform/fullnode/aws/fullnode/values.yaml
+++ b/terraform/fullnode/aws/fullnode/values.yaml
@@ -74,7 +74,7 @@ monitoring:
   grafana:
     image:
       repo: grafana/grafana
-      tag: latest
+      tag: 9.0.9@sha256:4a6b9d8d88522d2851f947f8f84cca10b6a43ca26d5e93102daf3a87935f10a5
       pullPolicy: IfNotPresent
     resources:
       limits:

--- a/terraform/helm/monitoring/values.yaml
+++ b/terraform/helm/monitoring/values.yaml
@@ -66,7 +66,7 @@ monitoring:
   grafana:
     image:
       repo: grafana/grafana
-      tag: 8.4.4@sha256:b1a82a9f837ce269542cc023f0607753ca7f709195d2bdec93e2e703fd13f8c0
+      tag: 9.0.9@sha256:4a6b9d8d88522d2851f947f8f84cca10b6a43ca26d5e93102daf3a87935f10a5
       pullPolicy: IfNotPresent
     resources:
       limits:


### PR DESCRIPTION
### Description

we're not longer collecting metrics via pushgateway, but rather prefer to parse them out of humio log events. the new python wrapper does not even use these env vars, so clean them up

also upgrade grafana to 9.0.9

### Test Plan

upgrade grafana in my cluster

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4707)
<!-- Reviewable:end -->
