### PR TITLE
[Compression] Enforce size limit before compression

### DIFF
--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -42,6 +42,13 @@ pub fn compress(
     client: CompressionClient,
     max_bytes: usize,
 ) -> Result<CompressedData, CompressionError> {
+    if raw_data.len() > max_bytes {
+        return Err(CompressionError(format!(
+            "Uncompressed size greater than max. size: {}, max: {}",
+            raw_data.len(),
+            max_bytes
+        )));
+    }
     // Start the compression timer
     let timer = start_compression_operation_timer(COMPRESS, client.clone());
 
@@ -57,14 +64,6 @@ pub fn compress(
             )));
         }
     };
-
-    if compressed_data.len() > max_bytes {
-        return Err(CompressionError(format!(
-            "Compressed size greater than max. size: {}, max: {}",
-            compressed_data.len(),
-            max_bytes
-        )));
-    }
 
     // Stop the timer and update the metrics
     let compression_duration = timer.stop_and_record();

--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -65,6 +65,17 @@ pub fn compress(
         }
     };
 
+    // Ensure that the compressed data size is not greater than the max bytes limit. This can
+    // happen in case of uncompressible data, where the compression size will be more than the
+    // uncompressed size.
+    if compressed_data.len() > max_bytes {
+        return Err(CompressionError(format!(
+            "Compressed size greater than max. size: {}, max: {}",
+            compressed_data.len(),
+            max_bytes
+        )));
+    }
+
     // Stop the timer and update the metrics
     let compression_duration = timer.stop_and_record();
     increment_compression_byte_count(RAW_BYTES, client.clone(), raw_data.len() as u64);


### PR DESCRIPTION
### Description

The compression limit needs to be checked before compression, not after - this is to ensure that on the receiver side, the receiver can successfully decompress a valid compressed message from the sender. 

### Test Plan
Existing UTs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4708)
<!-- Reviewable:end -->
