### PR TITLE
[telemetry] configure mainnet telemetry service URL

### DIFF
--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -30,6 +30,7 @@ pub(crate) const APTOS_GA_API_SECRET: &str = "ArtslKPTTjeiMi1n-IR39g";
 pub(crate) const GA4_URL: &str = "https://www.google-analytics.com/mp/collect";
 pub(crate) const HTTPBIN_URL: &str = "https://httpbin.org/ip";
 pub(crate) const TELEMETRY_SERVICE_URL: &str = "https://telemetry.aptoslabs.com";
+pub(crate) const MAINNET_TELEMETRY_SERVICE_URL: &str = "https://telemetry.mainnet.aptoslabs.com";
 
 // Frequencies for the various metrics and pushes
 pub(crate) const NODE_BUILD_INFO_FREQ_SECS: u64 = 60 * 60; // 60 minutes

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -9,7 +9,7 @@ use aptos_logger::{
     LoggerFilterUpdater,
 };
 use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
-use aptos_types::chain_id::ChainId;
+use aptos_types::chain_id::{ChainId, NamedChain};
 use futures::channel::mpsc::{self, Receiver};
 use once_cell::sync::Lazy;
 use rand::Rng;
@@ -149,8 +149,13 @@ async fn spawn_telemetry_service(
     remote_log_rx: Option<mpsc::Receiver<TelemetryLog>>,
     logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) {
-    let telemetry_svc_url =
-        env::var(ENV_TELEMETRY_SERVICE_URL).unwrap_or_else(|_| TELEMETRY_SERVICE_URL.into());
+    let telemetry_svc_url = env::var(ENV_TELEMETRY_SERVICE_URL).unwrap_or_else(|_| {
+        if chain_id == ChainId::mainnet() || chain_id == ChainId::new(NamedChain::PREMAINNET.id()) {
+            MAINNET_TELEMETRY_SERVICE_URL.into()
+        } else {
+            TELEMETRY_SERVICE_URL.into()
+        }
+    });
 
     let telemetry_sender = TelemetrySender::new(telemetry_svc_url, chain_id, &node_config);
 


### PR DESCRIPTION
### Description

We will have a separate high availability instance of telemetry service and Victoria metrics backend for mainnet chain. This PR hardcodes the mainnet URL to telemetry crate and configures its use when node starts with mainnet chainID.

__Alternatives Considered:__

Alternatively, we could have a redirect from telemetry.aptoslabs.com to telemetry.mainnet.aptoslabs.com if chain ID is mainnet ID. This will not require any node code changes but only telemetry service changes. However, this would defeat the purpose of separating the telemetry service and make the mainnet dependent of telemetry.aptoslabs.com.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Ensured that requests hit mainnet URL if Chain ID is 1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4715)
<!-- Reviewable:end -->
