### PR TITLE
Add auth token to TS tests / examples to bypass devnet tap ratelimits

### DIFF
--- a/.github/workflows/check-sdk-examples.yaml
+++ b/.github/workflows/check-sdk-examples.yaml
@@ -19,6 +19,7 @@ jobs:
     env:
       APTOS_NODE_URL: https://fullnode.devnet.aptoslabs.com
       APTOS_FAUCET_URL: https://faucet.devnet.aptoslabs.com
+      FAUCET_AUTH_TOKEN: ${{ secrets.DEVNET_TAP_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -37,6 +37,7 @@ jobs:
     env:
       APTOS_NODE_URL: http://127.0.0.1:8080/v1
       APTOS_FAUCET_URL: http://127.0.0.1:8081
+      FAUCET_AUTH_TOKEN: ${{ secrets.DEVNET_TAP_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -87,6 +88,7 @@ jobs:
       # Set up dotenv file for tests (jest doesn't read env vars properly).
       - run: echo 'APTOS_NODE_URL="http://127.0.0.1:8080/v1"' >> ./ecosystem/typescript/sdk/.env
       - run: echo 'APTOS_FAUCET_URL="http://127.0.0.1:8081"' >> ./ecosystem/typescript/sdk/.env
+      - run: echo "FAUCET_AUTH_TOKEN=$FAUCET_AUTH_TOKEN" >> ./ecosystem/typescript/sdk/.env
       - run: cp ./ecosystem/typescript/sdk/.env ./ecosystem/typescript/sdk/examples/typescript/.env
       - run: cp ./ecosystem/typescript/sdk/.env ./ecosystem/typescript/sdk/examples/javascript/.env
 


### PR DESCRIPTION
### Description
This PR makes it that our tests / examples won't get ratelimited, leveraging the new auth token based ratelimit / check bypassing added to the tap.

Note: This won't do anything yet for the examples, they'll need to be upgraded to use a newer, yet unreleased version of the aptos package.

### Test Plan
See that CI works, it should test this change following @perryjrandall's changes to use pull_request for changes to `.github`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4716)
<!-- Reviewable:end -->
