### PR TITLE
[tf/helm] deployment fixes for mainnet

### DIFF
--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -86,7 +86,7 @@ resource "google_container_node_pool" "utilities" {
       for_each = var.utility_instance_enable_taint ? ["utilities"] : []
       content {
         key    = "aptos.org/nodepool"
-        value  = each.key
+        value  = taint.key
         effect = "NO_EXECUTE"
       }
     }
@@ -121,7 +121,7 @@ resource "google_container_node_pool" "validators" {
       for_each = var.validator_instance_enable_taint ? ["validators"] : []
       content {
         key    = "aptos.org/nodepool"
-        value  = each.key
+        value  = taint.key
         effect = "NO_EXECUTE"
       }
     }

--- a/terraform/fullnode/aws/kubernetes.tf
+++ b/terraform/fullnode/aws/kubernetes.tf
@@ -56,7 +56,8 @@ resource "helm_release" "fullnode" {
   values = [
     jsonencode({
       chain = {
-        era = var.era
+        era  = var.era
+        name = var.chain_name
       }
       image = {
         tag = local.image_tag

--- a/terraform/fullnode/aws/variables.tf
+++ b/terraform/fullnode/aws/variables.tf
@@ -63,6 +63,11 @@ variable "chain_id" {
   default     = "DEVNET"
 }
 
+variable "chain_name" {
+  description = "Aptos chain name"
+  default     = "devnet"
+}
+
 variable "pfn_helm_values" {
   description = "Map of values to pass to testnet Helm"
   type        = any

--- a/terraform/fullnode/digital_ocean/kubernetes.tf
+++ b/terraform/fullnode/digital_ocean/kubernetes.tf
@@ -34,7 +34,8 @@ resource "helm_release" "fullnode" {
   values = [
     jsonencode({
       chain = {
-        era = var.era
+        era  = var.era
+        name = var.chain_name
       }
       image = {
         tag = var.image_tag

--- a/terraform/fullnode/digital_ocean/variables.tf
+++ b/terraform/fullnode/digital_ocean/variables.tf
@@ -56,6 +56,11 @@ variable "chain_id" {
   default     = "DEVNET"
 }
 
+variable "chain_name" {
+  description = "Aptos chain name"
+  default     = "devnet"
+}
+
 variable "machine_type" {
   description = "Machine type for running fullnode"
   default     = "s-16vcpu-32gb"

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -45,7 +45,8 @@ resource "helm_release" "fullnode" {
   values = [
     jsonencode({
       chain = {
-        era = var.era
+        era  = var.era
+        name = var.chain_name
       }
       image = {
         tag = var.image_tag

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -66,6 +66,11 @@ variable "chain_id" {
   default     = "DEVNET"
 }
 
+variable "chain_name" {
+  description = "Aptos chain name"
+  default     = "devnet"
+}
+
 variable "machine_type" {
   description = "Machine type for running fullnode"
   default     = "c2-standard-16"

--- a/terraform/fullnode/vultr/kubernetes.tf
+++ b/terraform/fullnode/vultr/kubernetes.tf
@@ -36,7 +36,8 @@ resource "helm_release" "fullnode" {
   values = [
     jsonencode({
       chain = {
-        era = var.era
+        era  = var.era
+        name = var.chain_name
       }
       image = {
         tag = var.image_tag

--- a/terraform/fullnode/vultr/variables.tf
+++ b/terraform/fullnode/vultr/variables.tf
@@ -46,6 +46,11 @@ variable "chain_id" {
   default     = "DEVNET"
 }
 
+variable "chain_name" {
+  description = "Aptos chain name"
+  default     = "devnet"
+}
+
 variable "machine_type" {
   description = "Machine type for running fullnode. All configurations can be obtained at https://www.vultr.com/api/#tag/plans"
   default     = "vc2-16c-32gb"


### PR DESCRIPTION
### Description

* Fix the validator node tainting for GCP -- which fixes scheduling errors and guarantees that only validators and critical pods are scheduled on `validator` nodegroup. NOTE: this re-creates the entire nodegroup, so operators applying this change will see some downtime. It's possible that their nodes are not working without this change anyways, so it should be fine
* Make `chain_name` configurable at the TF level. This makes it easier for node oeprators to know which chain they're pointed to, and make one place to override the config. Instead of doing:

```
module "fullnode" {
...
  fullnode_helm_values = {
    chain = {
    name = "mainnet"              # replace with `ait3` or other values if connecting to different networks.
    }
  }
```

we can do now

```
module "fullnode" {
...
chain_name = "mainnet"
```

#### Deployment branches

After we pick the above into mainnet branch, we can then point folks to deploy like the below, for terraform:

```
module "fullnode" {
  # download Terraform module from aptos-labs/aptos-core repo
  source        = "github.com/aptos-labs/aptos-core.git//terraform/fullnode/gcp?ref=mainnet"

}
```

NOTE: this needs to be accompanied by a docs change, which points folks to which docker image tag + git branch to use for deployments. The idea is that we should move away from `main` branch deployments, since like in the above example, we can pin Terraform modules at a git ref.

### Test Plan

apply to validators/fullnodes and helm/tf lint

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4717)
<!-- Reviewable:end -->
