### PR TITLE
[move] small aptos_framework fixes

### DIFF
--- a/aptos-move/framework/aptos-framework/Move.toml
+++ b/aptos-move/framework/aptos-framework/Move.toml
@@ -6,6 +6,7 @@ version = "1.0.0"
 std = "0x1"
 aptos_std = "0x1"
 aptos_framework = "0x1"
+aptos_token = "0x3"
 core_resources = "0xA550C18"
 vm_reserved = "0x0"
 

--- a/aptos-move/framework/aptos-framework/sources/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account.move
@@ -129,8 +129,10 @@ module aptos_framework::account {
     public(friend) fun create_account(new_address: address): signer {
         // there cannot be an Account resource under new_addr already.
         assert!(!exists<Account>(new_address), error::already_exists(EACCOUNT_ALREADY_EXISTS));
+
+        // NOTE: @core_resources gets created via a `create_account` call, so we do not include it below.
         assert!(
-            new_address != @vm_reserved && new_address != @aptos_framework,
+            new_address != @vm_reserved && new_address != @aptos_framework && new_address != @aptos_token,
             error::invalid_argument(ECANNOT_RESERVED_ADDRESS)
         );
 

--- a/aptos-move/framework/aptos-framework/sources/event.move
+++ b/aptos-move/framework/aptos-framework/sources/event.move
@@ -2,7 +2,7 @@
 /// `EventHandle`s with unique GUIDs. It contains a counter for the number
 /// of `EventHandle`s it generates. An `EventHandle` is used to count the number of
 /// events emitted to a handle and emit events to the event store.
-module aptos_std::event {
+module aptos_framework::event {
     use std::bcs;
 
     use aptos_framework::guid::GUID;

--- a/aptos-move/framework/aptos-framework/sources/event.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/event.spec.move
@@ -1,4 +1,4 @@
-spec aptos_std::event {
+spec aptos_framework::event {
     spec emit_event {
         pragma opaque;
         aborts_if [abstract] false;

--- a/aptos-move/framework/aptos-framework/sources/guid.move
+++ b/aptos-move/framework/aptos-framework/sources/guid.move
@@ -1,5 +1,5 @@
 /// A module for generating globally unique identifiers
-module aptos_std::guid {
+module aptos_framework::guid {
     friend aptos_framework::account;
 
     /// A globally unique identifier derived from the sender's address and a counter

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.137", default-features = false }
 thiserror = "1.0.31"
 
 aptos-crypto = { path = "../../crates/aptos-crypto" }
-aptos-logger = {path = "../../crates/aptos-logger" }
+aptos-logger = { path = "../../crates/aptos-logger" }
 aptos-metrics-core = { path = "../../crates/aptos-metrics-core" }
 aptos-secure-net = { path = "../../secure/net" }
 aptos-state-view = { path = "../state-view" }


### PR DESCRIPTION
### Description

1. `create_account` must check **none** of our reserved system addresses are being created, including `@aptos_token` (`@core_resources` is actually created via `create_account` so it is excluded.)
2. `aptos_std::guid` was previously moved into `aptos_framework/` but not renamed to `aptos_framework::guid`; things only worked because `aptos_framework` and `aptos_std` have the same address.
3. `aptos_std::event` suffered the same treatment

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4725)
<!-- Reviewable:end -->
