### PR TITLE
[mempool] bucketed broadcast

### DIFF
--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -101,6 +101,7 @@ async fn test_get_transactions_with_zero_limit() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore]
 async fn test_get_transactions_param_limit_exceeds_limit() {
     let mut context = new_test_context(current_function_name!());
     let resp = context

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -23,6 +23,7 @@ pub struct MempoolConfig {
     pub system_transaction_timeout_secs: u64,
     pub system_transaction_gc_interval_ms: u64,
     pub shared_mempool_validator_broadcast: bool,
+    pub broadcast_buckets: Vec<u64>,
 }
 
 impl Default for MempoolConfig {
@@ -43,6 +44,7 @@ impl Default for MempoolConfig {
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
             shared_mempool_validator_broadcast: true,
+            broadcast_buckets: vec![0, 101, 201],
         }
     }
 }

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -44,7 +44,7 @@ impl Default for MempoolConfig {
             system_transaction_timeout_secs: 600,
             system_transaction_gc_interval_ms: 60_000,
             shared_mempool_validator_broadcast: true,
-            broadcast_buckets: vec![0, 101, 201],
+            broadcast_buckets: vec![0, 151, 301, 901, 2001, 10001], // (1, 1.5, 3, 9, 20, 100)
         }
     }
 }

--- a/mempool/src/core_mempool/index.rs
+++ b/mempool/src/core_mempool/index.rs
@@ -259,6 +259,7 @@ impl TimelineIndex {
 pub struct MultiBucketTimelineIndex {
     timelines: Vec<TimelineIndex>,
     bucket_mins: Vec<u64>,
+    bucket_mins_to_string: Vec<String>,
 }
 
 impl MultiBucketTimelineIndex {
@@ -276,9 +277,15 @@ impl MultiBucketTimelineIndex {
             timelines.push(TimelineIndex::new());
         }
 
+        let bucket_mins_to_string: Vec<_> = bucket_mins
+            .iter()
+            .map(|bucket_min| bucket_min.to_string())
+            .collect();
+
         Ok(Self {
             timelines,
             bucket_mins,
+            bucket_mins_to_string,
         })
     }
 
@@ -351,6 +358,14 @@ impl MultiBucketTimelineIndex {
             size += timeline.size()
         }
         size
+    }
+
+    pub(crate) fn get_sizes(&self) -> Vec<(&str, usize)> {
+        self.bucket_mins_to_string
+            .iter()
+            .zip(self.timelines.iter())
+            .map(|(bucket_min, timeline)| (bucket_min.as_str(), timeline.size()))
+            .collect()
     }
 }
 

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -4,7 +4,7 @@
 //! Mempool is used to track transactions which have been submitted but not yet
 //! agreed upon.
 use crate::counters::{CONSENSUS_PULLED_LABEL, E2E_LABEL, INSERT_LABEL, LOCAL_LABEL, REMOVE_LABEL};
-use crate::shared_mempool::types::TimelineId;
+use crate::shared_mempool::types::MultiBucketTimelineIndexIds;
 use crate::{
     core_mempool::{
         index::TxnPointer,
@@ -268,9 +268,9 @@ impl Mempool {
     /// Returns block of transactions and new last_timeline_id.
     pub(crate) fn read_timeline(
         &self,
-        timeline_id: &TimelineId,
+        timeline_id: &MultiBucketTimelineIndexIds,
         count: usize,
-    ) -> (Vec<SignedTransaction>, TimelineId) {
+    ) -> (Vec<SignedTransaction>, MultiBucketTimelineIndexIds) {
         self.transactions.read_timeline(timeline_id, count)
     }
 

--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -4,6 +4,7 @@
 //! Mempool is used to track transactions which have been submitted but not yet
 //! agreed upon.
 use crate::counters::{CONSENSUS_PULLED_LABEL, E2E_LABEL, INSERT_LABEL, LOCAL_LABEL, REMOVE_LABEL};
+use crate::shared_mempool::types::TimelineId;
 use crate::{
     core_mempool::{
         index::TxnPointer,
@@ -267,15 +268,18 @@ impl Mempool {
     /// Returns block of transactions and new last_timeline_id.
     pub(crate) fn read_timeline(
         &self,
-        timeline_id: u64,
+        timeline_id: &TimelineId,
         count: usize,
-    ) -> (Vec<SignedTransaction>, u64) {
+    ) -> (Vec<SignedTransaction>, TimelineId) {
         self.transactions.read_timeline(timeline_id, count)
     }
 
     /// Read transactions from timeline from `start_id` (exclusive) to `end_id` (inclusive).
-    pub(crate) fn timeline_range(&self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
-        self.transactions.timeline_range(start_id, end_id)
+    pub(crate) fn timeline_range(
+        &self,
+        start_end_pairs: &Vec<(u64, u64)>,
+    ) -> Vec<SignedTransaction> {
+        self.transactions.timeline_range(start_end_pairs)
     }
 
     pub fn gen_snapshot(&self) -> TxnsLog {

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -90,7 +90,7 @@ impl TransactionStore {
             })),
             priority_index: PriorityIndex::new(),
             timeline_index: MultiBucketTimelineIndex::new(config.broadcast_buckets.clone())
-                .expect("MultiBucketTimelineIndex must be initialized"),
+                .unwrap(),
             parking_lot_index: ParkingLotIndex::new(),
             hash_index: HashMap::new(),
 
@@ -299,6 +299,7 @@ impl TransactionStore {
             counters::TIMELINE_INDEX_LABEL,
             self.timeline_index.size(),
         );
+        counters::core_mempool_timeline_index_size(&self.timeline_index.get_sizes());
         counters::core_mempool_index_size(
             counters::TRANSACTION_HASH_INDEX_LABEL,
             self.hash_index.len(),

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -4,7 +4,7 @@
 use crate::counters::{
     BROADCAST_BATCHED_LABEL, BROADCAST_READY_LABEL, CONSENSUS_READY_LABEL, E2E_LABEL, LOCAL_LABEL,
 };
-use crate::shared_mempool::types::TimelineId;
+use crate::shared_mempool::types::MultiBucketTimelineIndexIds;
 use crate::{
     core_mempool::{
         index::{
@@ -540,12 +540,12 @@ impl TransactionStore {
     /// Returns block of transactions and new last_timeline_id.
     pub(crate) fn read_timeline(
         &self,
-        timeline_id: &TimelineId,
+        timeline_id: &MultiBucketTimelineIndexIds,
         count: usize,
-    ) -> (Vec<SignedTransaction>, TimelineId) {
+    ) -> (Vec<SignedTransaction>, MultiBucketTimelineIndexIds) {
         let mut batch = vec![];
         let mut batch_total_bytes: u64 = 0;
-        let mut last_timeline_id = timeline_id.0.clone();
+        let mut last_timeline_id = timeline_id.id_per_bucket.clone();
 
         // Add as many transactions to the batch as possible
         for (i, bucket) in self

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -4,11 +4,12 @@
 use crate::counters::{
     BROADCAST_BATCHED_LABEL, BROADCAST_READY_LABEL, CONSENSUS_READY_LABEL, E2E_LABEL, LOCAL_LABEL,
 };
+use crate::shared_mempool::types::TimelineId;
 use crate::{
     core_mempool::{
         index::{
-            AccountTransactions, ParkingLotIndex, PriorityIndex, PriorityQueueIter, TTLIndex,
-            TimelineIndex,
+            AccountTransactions, MultiBucketTimelineIndex, ParkingLotIndex, PriorityIndex,
+            PriorityQueueIter, TTLIndex,
         },
         transaction::{MempoolTransaction, TimelineState},
     },
@@ -54,7 +55,7 @@ pub struct TransactionStore {
     // we keep it separate from `expiration_time_index` so Mempool can't be clogged
     //  by old transactions even if it hasn't received commit callbacks for a while
     system_ttl_index: TTLIndex,
-    timeline_index: TimelineIndex,
+    timeline_index: MultiBucketTimelineIndex,
     // keeps track of "non-ready" txns (transactions that can't be included in next block)
     parking_lot_index: ParkingLotIndex,
 
@@ -88,7 +89,8 @@ impl TransactionStore {
                 Duration::from_secs(t.txn.expiration_timestamp_secs())
             })),
             priority_index: PriorityIndex::new(),
-            timeline_index: TimelineIndex::new(),
+            timeline_index: MultiBucketTimelineIndex::new(config.broadcast_buckets.clone())
+                .expect("MultiBucketTimelineIndex must be initialized"),
             parking_lot_index: ParkingLotIndex::new(),
             hash_index: HashMap::new(),
 
@@ -538,46 +540,54 @@ impl TransactionStore {
     /// Returns block of transactions and new last_timeline_id.
     pub(crate) fn read_timeline(
         &self,
-        timeline_id: u64,
+        timeline_id: &TimelineId,
         count: usize,
-    ) -> (Vec<SignedTransaction>, u64) {
+    ) -> (Vec<SignedTransaction>, TimelineId) {
         let mut batch = vec![];
         let mut batch_total_bytes: u64 = 0;
-        let mut last_timeline_id = timeline_id;
+        let mut last_timeline_id = timeline_id.0.clone();
 
         // Add as many transactions to the batch as possible
-        for (address, sequence_number) in self.timeline_index.read_timeline(timeline_id, count) {
-            if let Some(txn) = self
-                .transactions
-                .get(&address)
-                .and_then(|txns| txns.get(&sequence_number))
-            {
-                let transaction_bytes = txn.txn.raw_txn_bytes_len() as u64;
-                if batch_total_bytes.saturating_add(transaction_bytes) > self.max_batch_bytes {
-                    break; // The batch is full
-                } else {
-                    batch.push(txn.txn.clone());
-                    batch_total_bytes = batch_total_bytes.saturating_add(transaction_bytes);
-                    if let TimelineState::Ready(timeline_id) = txn.timeline_state {
-                        last_timeline_id = timeline_id;
-                    }
-                    if let Ok(time_delta) = SystemTime::now().duration_since(txn.insertion_time) {
-                        counters::core_mempool_txn_commit_latency(
-                            BROADCAST_BATCHED_LABEL,
-                            E2E_LABEL,
-                            time_delta,
-                        );
+        for (i, bucket) in self
+            .timeline_index
+            .read_timeline(timeline_id, count)
+            .iter()
+            .enumerate()
+            .rev()
+        {
+            for (address, sequence_number) in bucket {
+                if let Some(txn) = self.get_mempool_txn(address, *sequence_number) {
+                    let transaction_bytes = txn.txn.raw_txn_bytes_len() as u64;
+                    if batch_total_bytes.saturating_add(transaction_bytes) > self.max_batch_bytes {
+                        break; // The batch is full
+                    } else {
+                        batch.push(txn.txn.clone());
+                        batch_total_bytes = batch_total_bytes.saturating_add(transaction_bytes);
+                        if let TimelineState::Ready(timeline_id) = txn.timeline_state {
+                            last_timeline_id[i] = timeline_id;
+                        }
+                        if let Ok(time_delta) = SystemTime::now().duration_since(txn.insertion_time)
+                        {
+                            counters::core_mempool_txn_commit_latency(
+                                BROADCAST_BATCHED_LABEL,
+                                E2E_LABEL,
+                                time_delta,
+                            );
+                        }
                     }
                 }
             }
         }
 
-        (batch, last_timeline_id)
+        (batch, last_timeline_id.into())
     }
 
-    pub(crate) fn timeline_range(&self, start_id: u64, end_id: u64) -> Vec<SignedTransaction> {
+    pub(crate) fn timeline_range(
+        &self,
+        start_end_pairs: &Vec<(u64, u64)>,
+    ) -> Vec<SignedTransaction> {
         self.timeline_index
-            .timeline_range(start_id, end_id)
+            .timeline_range(start_end_pairs)
             .iter()
             .filter_map(|(account, sequence_number)| {
                 self.transactions

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -103,6 +103,24 @@ pub fn core_mempool_index_size(label: &'static str, size: usize) {
         .set(size as i64)
 }
 
+/// Counter tracking size of each bucket in timeline index
+static CORE_MEMPOOL_TIMELINE_INDEX_SIZE: Lazy<IntGaugeVec> = Lazy::new(|| {
+    register_int_gauge_vec!(
+        "aptos_core_mempool_timeline_index_size",
+        "Size of each bucket in core mempool timeline index",
+        &["bucket"]
+    )
+    .unwrap()
+});
+
+pub fn core_mempool_timeline_index_size(bucket_min_size_pairs: &Vec<(&str, usize)>) {
+    for &(bucket_min, size) in bucket_min_size_pairs {
+        CORE_MEMPOOL_TIMELINE_INDEX_SIZE
+            .with_label_values(&[bucket_min])
+            .set(size as i64)
+    }
+}
+
 /// Counter tracking number of txns removed from core mempool
 pub static CORE_MEMPOOL_REMOVED_TXNS: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared_mempool::types::{BatchId, QuorumStoreRequest};
+use crate::shared_mempool::types::{MultiBatchId, QuorumStoreRequest};
 use anyhow::Error;
 use aptos_config::network_id::{NetworkId, PeerNetworkId};
 use aptos_logger::Schema;
@@ -112,7 +112,7 @@ pub struct LogSchema<'a> {
     network_level: Option<usize>,
     upstream_network: Option<&'a NetworkId>,
     #[schema(debug)]
-    batch_id: Option<&'a BatchId>,
+    batch_id: Option<&'a MultiBatchId>,
     backpressure: Option<bool>,
 }
 

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -8,8 +8,8 @@ use crate::{
     logging::{LogEntry, LogEvent, LogSchema},
     network::{BroadcastError, MempoolSyncMsg},
     shared_mempool::types::{
-        notify_subscribers, BatchId, ScheduledBroadcast, SharedMempool, SharedMempoolNotification,
-        SubmissionStatusBundle,
+        notify_subscribers, MultiBatchId, ScheduledBroadcast, SharedMempool,
+        SharedMempoolNotification, SubmissionStatusBundle,
     },
     thread_pool::IO_POOL,
     QuorumStoreRequest, QuorumStoreResponse, SubmissionStatus,
@@ -155,7 +155,7 @@ pub(crate) async fn process_client_get_transaction<V>(
 pub(crate) async fn process_transaction_broadcast<V>(
     smp: SharedMempool<V>,
     transactions: Vec<SignedTransaction>,
-    request_id: BatchId,
+    request_id: MultiBatchId,
     timeline_state: TimelineState,
     peer: PeerNetworkId,
     timer: HistogramTimer,
@@ -187,7 +187,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
 
 /// If `MempoolIsFull` on any of the transactions, provide backpressure to the downstream peer.
 fn gen_ack_response(
-    request_id: BatchId,
+    request_id: MultiBatchId,
     results: Vec<SubmissionStatusBundle>,
     peer: &PeerNetworkId,
 ) -> MempoolSyncMsg {

--- a/mempool/src/tests/common.rs
+++ b/mempool/src/tests/common.rs
@@ -20,10 +20,17 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 pub(crate) fn setup_mempool() -> (CoreMempool, ConsensusMock) {
-    (
-        CoreMempool::new(&NodeConfig::random()),
-        ConsensusMock::new(),
-    )
+    let mut config = NodeConfig::random();
+    config.mempool.broadcast_buckets = vec![0];
+    (CoreMempool::new(&config), ConsensusMock::new())
+}
+
+pub(crate) fn setup_mempool_with_broadcast_buckets(
+    buckets: Vec<u64>,
+) -> (CoreMempool, ConsensusMock) {
+    let mut config = NodeConfig::random();
+    config.mempool.broadcast_buckets = buckets;
+    (CoreMempool::new(&config), ConsensusMock::new())
 }
 
 static ACCOUNTS: Lazy<Vec<AccountAddress>> = Lazy::new(|| {

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -172,13 +172,4 @@ impl MockSharedMempool {
         let mut pool = self.mempool.lock();
         pool.commit_transaction(&txn.sender(), txn.sequence_number())
     }
-
-    /// True if all the given txns are in mempool, else false.
-    pub fn read_timeline(&self, timeline_id: u64, count: usize) -> Vec<SignedTransaction> {
-        let pool = self.mempool.lock();
-        pool.read_timeline(timeline_id, count)
-            .0
-            .into_iter()
-            .collect()
-    }
 }

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -47,7 +47,7 @@ fn test_consensus_events_rejected_txns() {
     });
 
     let pool = smp.mempool.lock();
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0, 0, 0, 0].into(), 10);
     assert_eq!(timeline.len(), 2);
     assert_eq!(timeline.first().unwrap(), &kept_txn);
 }
@@ -93,7 +93,7 @@ fn test_mempool_notify_committed_txns() {
     });
 
     let pool = smp.mempool.lock();
-    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0, 0, 0, 0].into(), 10);
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline.first().unwrap(), &kept_txn);
 }

--- a/mempool/src/tests/shared_mempool_test.rs
+++ b/mempool/src/tests/shared_mempool_test.rs
@@ -47,7 +47,7 @@ fn test_consensus_events_rejected_txns() {
     });
 
     let pool = smp.mempool.lock();
-    let (timeline, _) = pool.read_timeline(0, 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
     assert_eq!(timeline.len(), 2);
     assert_eq!(timeline.first().unwrap(), &kept_txn);
 }
@@ -93,7 +93,7 @@ fn test_mempool_notify_committed_txns() {
     });
 
     let pool = smp.mempool.lock();
-    let (timeline, _) = pool.read_timeline(0, 10);
+    let (timeline, _) = pool.read_timeline(&vec![0, 0, 0].into(), 10);
     assert_eq!(timeline.len(), 1);
     assert_eq!(timeline.first().unwrap(), &kept_txn);
 }

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared_mempool::types::BatchId;
+use crate::shared_mempool::types::MultiBatchId;
 use crate::tests::common;
 use crate::{
     core_mempool::CoreMempool,
@@ -239,9 +239,9 @@ impl MempoolNode {
         let network_id = remote_peer_network_id.network_id();
         let remote_peer_id = remote_peer_network_id.peer_id();
         let inbound_handle = self.get_inbound_handle(network_id);
-        let batch_id = BatchId(1, 10);
+        let batch_id = MultiBatchId::from_timeline_ids(&vec![1].into(), &vec![10].into());
         let msg = MempoolSyncMsg::BroadcastTransactionsRequest {
-            request_id: batch_id,
+            request_id: batch_id.clone(),
             transactions: sign_transactions(txns),
         };
         let data = protocol_id.to_bytes(&msg).unwrap().into();


### PR DESCRIPTION
### Description

Instead of a single timeline for broadcast, divide the timeline into buckets of ranking_score (gas) ranges. This allows gas prioritization even when broadcast is saturated.

### Test Plan

Add unit tests. Confirm high pri transactions run well in "graceful overload" test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4728)
<!-- Reviewable:end -->
