### PR TITLE
[tf/gcp][aptos-node] fix taint

### DIFF
--- a/terraform/aptos-node/gcp/cluster.tf
+++ b/terraform/aptos-node/gcp/cluster.tf
@@ -86,7 +86,7 @@ resource "google_container_node_pool" "utilities" {
       for_each = var.utility_instance_enable_taint ? ["utilities"] : []
       content {
         key    = "aptos.org/nodepool"
-        value  = each.key
+        value  = taint.key
         effect = "NO_EXECUTE"
       }
     }
@@ -121,7 +121,7 @@ resource "google_container_node_pool" "validators" {
       for_each = var.validator_instance_enable_taint ? ["validators"] : []
       content {
         key    = "aptos.org/nodepool"
-        value  = each.key
+        value  = taint.key
         effect = "NO_EXECUTE"
       }
     }


### PR DESCRIPTION
### Description

Fix the terraform dynamic block which enables nodepool taints in GKE

### Test Plan

Terraform plan passes with `validator_instance_enable_taint = true`

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4733)
<!-- Reviewable:end -->
