### PR TITLE
Replace escaped vertical line with Unicode

### DIFF
--- a/developer-docs-site/docs/concepts/base-gas.md
+++ b/developer-docs-site/docs/concepts/base-gas.md
@@ -121,7 +121,7 @@ Instruction gas parameters are defined at [`instr.rs`] and include the following
 
 | Parameter | Meaning           |
 |-----------|-------------------|
-| `bit_or`  | `OR`: `\|`        |
+| `bit_or`  | `OR`: <code>&#124;</code>         |
 | `bit_and` | `AND`: `&`        |
 | `xor`     | `XOR`: `^`        |
 | `shl`     | Shift left: `<<`  |
@@ -131,7 +131,7 @@ Instruction gas parameters are defined at [`instr.rs`] and include the following
 
 | Parameter | Meaning      |
 |-----------|--------------|
-| `or`      | `OR`: `\|\|` |
+| `or`      | `OR`: <code>&#124;&#124;</code> |
 | `and`     | `AND`: `&&`  |
 | `not`     | `NOT`: `!`   |
 


### PR DESCRIPTION
### Description

Addressing formatting issue reported in:
https://github.com/aptos-labs/aptos-core/pull/4720#issuecomment-1266109214

### Test Plan

Manual viewing in GitHub markdown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4736)
<!-- Reviewable:end -->
