### PR TITLE
[cli] Error out if a profile is not found

### DIFF
--- a/crates/aptos-rosetta-cli/src/construction.rs
+++ b/crates/aptos-rosetta-cli/src/construction.rs
@@ -95,10 +95,9 @@ impl CreateAccountCommand {
         info!("Create account: {:?}", self);
         let client = self.url_args.client();
         let network_identifier = self.network_args.network_identifier();
-        let private_key = self.private_key_options.extract_private_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )?;
+        let private_key = self
+            .private_key_options
+            .extract_private_key(self.encoding_options.encoding, &self.profile_options)?;
 
         client
             .create_account(
@@ -148,10 +147,9 @@ impl TransferCommand {
         info!("Transfer {:?}", self);
         let client = self.url_args.client();
         let network_identifier = self.network_args.network_identifier();
-        let private_key = self.private_key_options.extract_private_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )?;
+        let private_key = self
+            .private_key_options
+            .extract_private_key(self.encoding_options.encoding, &self.profile_options)?;
 
         client
             .transfer(
@@ -202,10 +200,9 @@ impl SetOperatorCommand {
         info!("Set operator {:?}", self);
         let client = self.url_args.client();
         let network_identifier = self.network_args.network_identifier();
-        let private_key = self.private_key_options.extract_private_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )?;
+        let private_key = self
+            .private_key_options
+            .extract_private_key(self.encoding_options.encoding, &self.profile_options)?;
 
         client
             .set_operator(
@@ -256,10 +253,9 @@ impl SetVoterCommand {
         info!("Set voter {:?}", self);
         let client = self.url_args.client();
         let network_identifier = self.network_args.network_identifier();
-        let private_key = self.private_key_options.extract_private_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )?;
+        let private_key = self
+            .private_key_options
+            .extract_private_key(self.encoding_options.encoding, &self.profile_options)?;
 
         client
             .set_voter(
@@ -313,10 +309,9 @@ impl CreateStakePoolCommand {
         info!("CreateStakePool {:?}", self);
         let client = self.url_args.client();
         let network_identifier = self.network_args.network_identifier();
-        let private_key = self.private_key_options.extract_private_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )?;
+        let private_key = self
+            .private_key_options
+            .extract_private_key(self.encoding_options.encoding, &self.profile_options)?;
 
         client
             .create_stake_pool(

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -43,8 +43,7 @@ impl CliCommand<String> for FundWithFaucet {
 
     async fn execute(self) -> CliTypedResult<String> {
         let hashes = fund_account(
-            self.faucet_options
-                .faucet_url(&self.profile_options.profile)?,
+            self.faucet_options.faucet_url(&self.profile_options)?,
             self.amount,
             self.account,
         )
@@ -54,7 +53,7 @@ impl CliCommand<String> for FundWithFaucet {
             .map_err(|e| CliError::UnexpectedError(e.to_string()))?
             .as_secs()
             + 30;
-        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let client = self.rest_options.client(&self.profile_options)?;
         for hash in hashes {
             client
                 .wait_for_transaction_by_hash(

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -253,15 +253,13 @@ pub struct LookupAddress {
 
 impl LookupAddress {
     pub(crate) fn public_key(&self) -> CliTypedResult<Ed25519PublicKey> {
-        self.public_key_options.extract_public_key(
-            self.encoding_options.encoding,
-            &self.profile_options.profile,
-        )
+        self.public_key_options
+            .extract_public_key(self.encoding_options.encoding, &self.profile_options)
     }
 
     /// Builds a rest client
     fn rest_client(&self) -> CliTypedResult<Client> {
-        self.rest_options.client(&self.profile_options.profile)
+        self.rest_options.client(&self.profile_options)
     }
 }
 

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -73,7 +73,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
         let account = if let Some(account) = self.account {
             account
         } else if let Some(Some(account)) = CliConfig::load_profile(
-            &self.profile_options.profile,
+            self.profile_options.profile_name(),
             ConfigSearchMode::CurrentDirAndParents,
         )?
         .map(|p| p.account)
@@ -85,7 +85,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
             ));
         };
 
-        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let client = self.rest_options.client(&self.profile_options)?;
         let response = match self.query {
             ListQuery::Balance => vec![
                 client

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::types::ConfigSearchMode;
+use crate::common::types::{ConfigSearchMode, DEFAULT_PROFILE};
 use crate::common::{
     types::{
         account_address_from_public_key, CliCommand, CliConfig, CliError, CliTypedResult,
@@ -62,17 +62,20 @@ impl CliCommand<()> for InitTool {
             CliConfig::default()
         };
 
+        let profile_name = self
+            .profile_options
+            .profile_name()
+            .unwrap_or(DEFAULT_PROFILE);
+
         // Select profile we're using
-        let mut profile_config = if let Some(profile_config) =
-            config.remove_profile(&self.profile_options.profile)
-        {
-            prompt_yes_with_override(&format!("Aptos already initialized for profile {}, do you want to overwrite the existing config?", self.profile_options.profile), self.prompt_options)?;
+        let mut profile_config = if let Some(profile_config) = config.remove_profile(profile_name) {
+            prompt_yes_with_override(&format!("Aptos already initialized for profile {}, do you want to overwrite the existing config?", profile_name), self.prompt_options)?;
             profile_config
         } else {
             ProfileConfig::default()
         };
 
-        eprintln!("Configuring for profile {}", self.profile_options.profile);
+        eprintln!("Configuring for profile {}", profile_name);
 
         // Rest Endpoint
         let rest_url = if let Some(rest_url) = self.rest_url {
@@ -187,7 +190,7 @@ impl CliCommand<()> for InitTool {
             .profiles
             .as_mut()
             .unwrap()
-            .insert(self.profile_options.profile, profile_config);
+            .insert(profile_name.to_string(), profile_config);
         config.save()?;
         eprintln!("Aptos is now set up for account {}!  Run `aptos help` for more information about commands", address);
         Ok(())

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -49,6 +49,7 @@ use std::{
 use thiserror::Error;
 
 const MAX_POSSIBLE_GAS_UNITS: u64 = 1_000_000;
+pub const DEFAULT_PROFILE: &str = "default";
 
 /// A common result to be returned to users
 pub type CliResult = Result<String, String>;
@@ -279,11 +280,24 @@ impl CliConfig {
     }
 
     pub fn load_profile(
-        profile: &str,
+        profile: Option<&str>,
         mode: ConfigSearchMode,
     ) -> CliTypedResult<Option<ProfileConfig>> {
         let mut config = Self::load(mode)?;
-        Ok(config.remove_profile(profile))
+
+        // If no profile was given, use `default`
+        if let Some(profile) = profile {
+            if let Some(account_profile) = config.remove_profile(profile) {
+                Ok(Some(account_profile))
+            } else {
+                Err(CliError::CommandArgumentError(format!(
+                    "Profile {} not found",
+                    profile
+                )))
+            }
+        } else {
+            Ok(config.remove_profile(DEFAULT_PROFILE))
+        }
     }
 
     pub fn remove_profile(&mut self, profile: &str) -> Option<ProfileConfig> {
@@ -355,14 +369,16 @@ impl FromStr for KeyType {
     }
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, Default, Parser)]
 pub struct ProfileOptions {
     /// Profile to use from the CLI config
     ///
     /// This will be used to override associated settings such as
-    /// the REST URL, the Faucet URL, and the private key arguments
-    #[clap(long, default_value = "default")]
-    pub profile: String,
+    /// the REST URL, the Faucet URL, and the private key arguments.
+    ///
+    /// Defaults to "default"
+    #[clap(long)]
+    pub profile: Option<String>,
 }
 
 impl ProfileOptions {
@@ -372,7 +388,11 @@ impl ProfileOptions {
             return Ok(account);
         }
 
-        Err(CliError::ConfigNotFoundError(self.profile.clone()))
+        Err(CliError::ConfigNotFoundError(
+            self.profile
+                .clone()
+                .unwrap_or_else(|| DEFAULT_PROFILE.to_string()),
+        ))
     }
 
     pub fn public_key(&self) -> CliTypedResult<Ed25519PublicKey> {
@@ -381,25 +401,29 @@ impl ProfileOptions {
             return Ok(public_key);
         }
 
-        Err(CliError::ConfigNotFoundError(self.profile.clone()))
+        Err(CliError::ConfigNotFoundError(
+            self.profile
+                .clone()
+                .unwrap_or_else(|| DEFAULT_PROFILE.to_string()),
+        ))
+    }
+
+    pub fn profile_name(&self) -> Option<&str> {
+        self.profile.as_ref().map(|inner| inner.trim())
     }
 
     pub fn profile(&self) -> CliTypedResult<ProfileConfig> {
         if let Some(profile) =
-            CliConfig::load_profile(&self.profile, ConfigSearchMode::CurrentDirAndParents)?
+            CliConfig::load_profile(self.profile_name(), ConfigSearchMode::CurrentDirAndParents)?
         {
             return Ok(profile);
         }
 
-        Err(CliError::ConfigNotFoundError(self.profile.clone()))
-    }
-}
-
-impl Default for ProfileOptions {
-    fn default() -> Self {
-        Self {
-            profile: "default".to_string(),
-        }
+        Err(CliError::ConfigNotFoundError(
+            self.profile
+                .clone()
+                .unwrap_or_else(|| DEFAULT_PROFILE.to_string()),
+        ))
     }
 }
 
@@ -596,16 +620,18 @@ impl ExtractPublicKey for PublicKeyInputOptions {
     fn extract_public_key(
         &self,
         encoding: EncodingType,
-        profile: &str,
+        profile: &ProfileOptions,
     ) -> CliTypedResult<Ed25519PublicKey> {
         if let Some(ref file) = self.public_key_file {
             encoding.load_key("--public-key-file", file.as_path())
         } else if let Some(ref key) = self.public_key {
             let key = key.as_bytes().to_vec();
             encoding.decode_key("--public-key", key)
-        } else if let Some(Some(public_key)) =
-            CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)?
-                .map(|p| p.public_key)
+        } else if let Some(Some(public_key)) = CliConfig::load_profile(
+            profile.profile_name(),
+            ConfigSearchMode::CurrentDirAndParents,
+        )?
+        .map(|p| p.public_key)
         {
             Ok(public_key)
         } else {
@@ -683,7 +709,7 @@ impl PrivateKeyInputOptions {
     pub fn extract_private_key_and_address(
         &self,
         encoding: EncodingType,
-        profile: &str,
+        profile: &ProfileOptions,
         maybe_address: Option<AccountAddress>,
     ) -> CliTypedResult<(Ed25519PrivateKey, AccountAddress)> {
         // Order of operations
@@ -698,9 +724,11 @@ impl PrivateKeyInputOptions {
                 let address = account_address_from_public_key(&key.public_key());
                 Ok((key, address))
             }
-        } else if let Some((Some(key), maybe_config_address)) =
-            CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)?
-                .map(|p| (p.private_key, p.account))
+        } else if let Some((Some(key), maybe_config_address)) = CliConfig::load_profile(
+            profile.profile_name(),
+            ConfigSearchMode::CurrentDirAndParents,
+        )?
+        .map(|p| (p.private_key, p.account))
         {
             match (maybe_address, maybe_config_address) {
                 (Some(address), _) => Ok((key, address)),
@@ -721,13 +749,15 @@ impl PrivateKeyInputOptions {
     pub fn extract_private_key(
         &self,
         encoding: EncodingType,
-        profile: &str,
+        profile: &ProfileOptions,
     ) -> CliTypedResult<Ed25519PrivateKey> {
         if let Some(key) = self.extract_private_key_cli(encoding)? {
             Ok(key)
-        } else if let Some(Some(private_key)) =
-            CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)?
-                .map(|p| p.private_key)
+        } else if let Some(Some(private_key)) = CliConfig::load_profile(
+            profile.profile_name(),
+            ConfigSearchMode::CurrentDirAndParents,
+        )?
+        .map(|p| p.private_key)
         {
             Ok(private_key)
         } else {
@@ -754,7 +784,7 @@ impl ExtractPublicKey for PrivateKeyInputOptions {
     fn extract_public_key(
         &self,
         encoding: EncodingType,
-        profile: &str,
+        profile: &ProfileOptions,
     ) -> CliTypedResult<Ed25519PublicKey> {
         self.extract_private_key(encoding, profile)
             .map(|private_key| private_key.public_key())
@@ -765,7 +795,7 @@ pub trait ExtractPublicKey {
     fn extract_public_key(
         &self,
         encoding: EncodingType,
-        profile: &str,
+        profile: &ProfileOptions,
     ) -> CliTypedResult<Ed25519PublicKey>;
 }
 
@@ -827,12 +857,14 @@ impl RestOptions {
     }
 
     /// Retrieve the URL from the profile or the command line
-    pub fn url(&self, profile: &str) -> CliTypedResult<reqwest::Url> {
+    pub fn url(&self, profile: &ProfileOptions) -> CliTypedResult<reqwest::Url> {
         if let Some(ref url) = self.url {
             Ok(url.clone())
-        } else if let Some(Some(url)) =
-            CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)?
-                .map(|p| p.rest_url)
+        } else if let Some(Some(url)) = CliConfig::load_profile(
+            profile.profile_name(),
+            ConfigSearchMode::CurrentDirAndParents,
+        )?
+        .map(|p| p.rest_url)
         {
             reqwest::Url::parse(&url)
                 .map_err(|err| CliError::UnableToParse("Rest URL", err.to_string()))
@@ -843,7 +875,7 @@ impl RestOptions {
         }
     }
 
-    pub fn client(&self, profile: &str) -> CliTypedResult<Client> {
+    pub fn client(&self, profile: &ProfileOptions) -> CliTypedResult<Client> {
         Ok(Client::new_with_timeout(
             self.url(profile)?,
             Duration::from_secs(self.connection_timeout_s),
@@ -919,7 +951,8 @@ pub fn load_account_arg(str: &str) -> Result<AccountAddress, CliError> {
     } else if let Ok(account_address) = AccountAddress::from_str(str) {
         Ok(account_address)
     } else if let Some(Some(private_key)) =
-        CliConfig::load_profile(str, ConfigSearchMode::CurrentDirAndParents)?.map(|p| p.private_key)
+        CliConfig::load_profile(Some(str), ConfigSearchMode::CurrentDirAndParents)?
+            .map(|p| p.private_key)
     {
         let public_key = private_key.public_key();
         Ok(account_address_from_public_key(&public_key))
@@ -959,7 +992,8 @@ pub fn load_manifest_account_arg(str: &str) -> Result<Option<AccountAddress>, Cl
     } else if let Ok(account_address) = AccountAddress::from_str(str) {
         Ok(Some(account_address))
     } else if let Some(Some(private_key)) =
-        CliConfig::load_profile(str, ConfigSearchMode::CurrentDirAndParents)?.map(|p| p.private_key)
+        CliConfig::load_profile(Some(str), ConfigSearchMode::CurrentDirAndParents)?
+            .map(|p| p.private_key)
     {
         let public_key = private_key.public_key();
         Ok(Some(account_address_from_public_key(&public_key)))
@@ -1131,12 +1165,14 @@ impl FaucetOptions {
         FaucetOptions { faucet_url }
     }
 
-    pub fn faucet_url(&self, profile: &str) -> CliTypedResult<reqwest::Url> {
+    pub fn faucet_url(&self, profile: &ProfileOptions) -> CliTypedResult<reqwest::Url> {
         if let Some(ref faucet_url) = self.faucet_url {
             Ok(faucet_url.clone())
-        } else if let Some(Some(url)) =
-            CliConfig::load_profile(profile, ConfigSearchMode::CurrentDirAndParents)?
-                .map(|profile| profile.faucet_url)
+        } else if let Some(Some(url)) = CliConfig::load_profile(
+            profile.profile_name(),
+            ConfigSearchMode::CurrentDirAndParents,
+        )?
+        .map(|profile| profile.faucet_url)
         {
             reqwest::Url::parse(&url)
                 .map_err(|err| CliError::UnableToParse("config faucet_url", err.to_string()))
@@ -1214,7 +1250,7 @@ pub struct TransactionOptions {
 impl TransactionOptions {
     /// Builds a rest client
     fn rest_client(&self) -> CliTypedResult<Client> {
-        self.rest_options.client(&self.profile_options.profile)
+        self.rest_options.client(&self.profile_options)
     }
 
     /// Retrieves the public key and the associated address
@@ -1222,7 +1258,7 @@ impl TransactionOptions {
     pub fn get_key_and_address(&self) -> CliTypedResult<(Ed25519PrivateKey, AccountAddress)> {
         self.private_key_options.extract_private_key_and_address(
             self.encoding_options.encoding,
-            &self.profile_options.profile,
+            &self.profile_options,
             self.sender_account,
         )
     }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -590,7 +590,7 @@ impl CliCommand<&'static str> for DownloadPackage {
     }
 
     async fn execute(self) -> CliTypedResult<&'static str> {
-        let url = self.rest_options.url(&self.profile_options.profile)?;
+        let url = self.rest_options.url(&self.profile_options)?;
         let registry = CachedPackageRegistry::create(url, self.account).await?;
         let output_dir = dir_default_to_current(self.output_dir)?;
 
@@ -666,7 +666,7 @@ impl CliCommand<&'static str> for ListPackage {
     }
 
     async fn execute(self) -> CliTypedResult<&'static str> {
-        let url = self.rest_options.url(&self.profile_options.profile)?;
+        let url = self.rest_options.url(&self.profile_options)?;
         let registry = CachedPackageRegistry::create(url, self.account).await?;
         match self.query {
             ListQuery::Packages => {

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -273,7 +273,7 @@ impl CliCommand<Vec<StakePoolResult>> for GetStakePool {
 
     async fn execute(mut self) -> CliTypedResult<Vec<StakePoolResult>> {
         let owner_address = self.owner_address;
-        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let client = self.rest_options.client(&self.profile_options)?;
 
         let mut stake_pool_results: Vec<StakePoolResult> = vec![];
         // Add direct stake pool if any.
@@ -521,7 +521,7 @@ impl CliCommand<serde_json::Value> for ShowValidatorStake {
     }
 
     async fn execute(mut self) -> CliTypedResult<serde_json::Value> {
-        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let client = self.rest_options.client(&self.profile_options)?;
         let address = self
             .operator_args
             .address_fallback_to_profile(&self.profile_options)?;
@@ -550,7 +550,7 @@ impl CliCommand<ValidatorConfigSummary> for ShowValidatorConfig {
     }
 
     async fn execute(mut self) -> CliTypedResult<ValidatorConfigSummary> {
-        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let client = self.rest_options.client(&self.profile_options)?;
         let address = self
             .operator_args
             .address_fallback_to_profile(&self.profile_options)?;
@@ -580,7 +580,7 @@ impl CliCommand<ValidatorSetSummary> for ShowValidatorSet {
     }
 
     async fn execute(mut self) -> CliTypedResult<ValidatorSetSummary> {
-        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let client = self.rest_options.client(&self.profile_options)?;
         let validator_set: ValidatorSet = client
             .get_account_resource_bcs(CORE_CODE_ADDRESS, "0x1::stake::ValidatorSet")
             .await?
@@ -1031,7 +1031,7 @@ impl CliCommand<()> for AnalyzeValidatorPerformance {
     }
 
     async fn execute(mut self) -> CliTypedResult<()> {
-        let client = self.rest_options.client(&self.profile_options.profile)?;
+        let client = self.rest_options.client(&self.profile_options)?;
 
         let epochs =
             FetchMetadata::fetch_new_block_events(&client, Some(self.start_epoch), self.end_epoch)


### PR DESCRIPTION
### Description
As brought up by @sirouk, profiles don't error out when they don't exist.  Well now they do!

### Test Plan
```
$ aptos account list --profile b
{
  "Error": "Invalid arguments: Profile b not found"
}
$ aptos account list --profile default
{
  "Error": "API error: API error Error(AccountNotFound): Account not found by Address(0xfdf0c99777dd2821101c0b1c26a140c8fcfd63f99a371c4103397ed27791e65d) and Ledger version(4341899)"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4750)
<!-- Reviewable:end -->
