### PR TITLE
[aptos-vm] further restrictions on governance transaction sizes

### DIFF
--- a/aptos-move/aptos-vm/src/transaction_metadata.rs
+++ b/aptos-move/aptos-vm/src/transaction_metadata.rs
@@ -23,6 +23,7 @@ pub struct TransactionMetadata {
     pub expiration_timestamp_secs: u64,
     pub chain_id: ChainId,
     pub script_hash: Vec<u8>,
+    pub script_size: NumBytes,
 }
 
 impl TransactionMetadata {
@@ -48,6 +49,10 @@ impl TransactionMetadata {
                 TransactionPayload::EntryFunction(_) => vec![],
                 TransactionPayload::ModuleBundle(_) => vec![],
             },
+            script_size: match txn.payload() {
+                TransactionPayload::Script(s) => (s.code().len() as u64).into(),
+                _ => NumBytes::zero(),
+            },
         }
     }
 
@@ -57,6 +62,10 @@ impl TransactionMetadata {
 
     pub fn gas_unit_price(&self) -> FeePerGasUnit {
         self.gas_unit_price
+    }
+
+    pub fn script_size(&self) -> NumBytes {
+        self.script_size
     }
 
     pub fn sender(&self) -> AccountAddress {
@@ -109,6 +118,7 @@ impl Default for TransactionMetadata {
             expiration_timestamp_secs: 0,
             chain_id: ChainId::test(),
             script_hash: vec![],
+            script_size: NumBytes::zero(),
         }
     }
 }

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -30,7 +30,7 @@ use rand::{
     rngs::{OsRng, StdRng},
     Rng, SeedableRng,
 };
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 
@@ -319,6 +319,19 @@ impl MoveHarness {
     /// Checks whether resource exists.
     pub fn exists_resource(&self, addr: &AccountAddress, struct_tag: StructTag) -> bool {
         self.read_resource_raw(addr, struct_tag).is_some()
+    }
+
+    /// Write the resource data `T`.
+    pub fn set_resource<T: Serialize>(
+        &mut self,
+        addr: AccountAddress,
+        struct_tag: StructTag,
+        data: &T,
+    ) {
+        let path = AccessPath::resource_access_path(ResourceKey::new(addr, struct_tag));
+        let state_key = StateKey::AccessPath(path);
+        self.executor
+            .write_state_value(state_key, bcs::to_bytes(data).unwrap());
     }
 
     /// Enables features

--- a/aptos-move/e2e-move-tests/src/tests/governance_updates.rs
+++ b/aptos-move/e2e-move-tests/src/tests/governance_updates.rs
@@ -1,0 +1,88 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::MoveHarness;
+use aptos_crypto::HashValue;
+use aptos_types::{
+    account_address::AccountAddress,
+    on_chain_config::{ApprovedExecutionHashes, OnChainConfig},
+    transaction::{Script, TransactionArgument, TransactionStatus},
+};
+use language_e2e_tests::account::{Account, TransactionBuilder};
+
+#[test]
+fn large_transactions() {
+    // This test validates that only small txns (less than the maximum txn size) can be kept. It
+    // then evaluates the limits of the ApprovedExecutionHashes. Specifically, the hash is the code
+    // is the only portion that can exceed the size limits. There's a further restriction on the
+    // maximum transaction size of 1 MB even for governance, because the governance transaction can
+    // be submitted by any one and that can result in a large amount of large transactions making their
+    // way into consensus.
+    let mut h = MoveHarness::new();
+
+    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
+    let root = h.aptos_framework_account();
+    let entries = ApprovedExecutionHashes { entries: vec![] };
+    h.set_resource(
+        *root.address(),
+        ApprovedExecutionHashes::struct_tag(),
+        &entries,
+    );
+
+    let small = vec![0; 1024];
+    // Max size is 1024 * 1024
+    let large = vec![0; 1000 * 1024];
+    let very_large = vec![0; 1024 * 1024];
+
+    let status = run(&mut h, &alice, small.clone(), small.clone());
+    assert!(!status.is_discarded());
+    let status = run(&mut h, &alice, large.clone(), small.clone());
+    assert!(status.is_discarded());
+    let status = run(&mut h, &alice, small.clone(), large.clone());
+    assert!(status.is_discarded());
+    let status = run(&mut h, &alice, large.clone(), large.clone());
+    assert!(status.is_discarded());
+    let status = run(&mut h, &alice, very_large.clone(), small.clone());
+    assert!(status.is_discarded());
+
+    let entries = ApprovedExecutionHashes {
+        entries: vec![
+            (0, HashValue::sha3_256_of(&large).to_vec()),
+            (1, HashValue::sha3_256_of(&very_large).to_vec()),
+        ],
+    };
+    h.set_resource(
+        *root.address(),
+        ApprovedExecutionHashes::struct_tag(),
+        &entries,
+    );
+
+    let status = run(&mut h, &alice, small.clone(), small.clone());
+    assert!(!status.is_discarded());
+    let status = run(&mut h, &alice, large.clone(), small.clone());
+    assert!(!status.is_discarded());
+    let status = run(&mut h, &alice, small.clone(), large.clone());
+    assert!(status.is_discarded());
+    let status = run(&mut h, &alice, large.clone(), large);
+    assert!(status.is_discarded());
+    let status = run(&mut h, &alice, very_large, small);
+    assert!(status.is_discarded());
+}
+
+fn run(
+    h: &mut MoveHarness,
+    account: &Account,
+    code: Vec<u8>,
+    txn_arg: Vec<u8>,
+) -> TransactionStatus {
+    let script = Script::new(code, vec![], vec![TransactionArgument::U8Vector(txn_arg)]);
+
+    let txn = TransactionBuilder::new(account.clone())
+        .script(script)
+        .sequence_number(h.sequence_number(account.address()))
+        .max_gas_amount(1_000_000)
+        .gas_unit_price(1)
+        .sign();
+
+    h.run(txn)
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -7,6 +7,7 @@ mod common;
 mod error_map;
 mod framework_compatibility;
 mod generate_upgrade_script;
+mod governance_updates;
 mod init_module;
 mod lazy_natives;
 mod max_loop_depth;

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -465,6 +465,11 @@ impl FakeExecutor {
         StateView::get_state_value(&self.data_store, state_key).unwrap()
     }
 
+    /// Set the blob for the associated AccessPath
+    pub fn write_state_value(&mut self, state_key: StateKey, data_blob: Vec<u8>) {
+        self.data_store.set(state_key, data_blob);
+    }
+
     /// Verifies the given transaction by running it through the VM verifier.
     pub fn verify_transaction(&self, txn: SignedTransaction) -> VMValidatorResult {
         let vm = AptosVM::new(self.get_state_view());


### PR DESCRIPTION
* Limit the size of non-approved data to the maximum transaction size (64K)
* Limit the maximum governance transaction to 1MB
* Write a lot of tests to validate this

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4751)
<!-- Reviewable:end -->
