### PR TITLE
[faucet] track the ordering of transactions more effectively

### DIFF
--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -149,6 +149,7 @@ impl FaucetArgs {
 pub struct Service {
     pub faucet_account: Mutex<LocalAccount>,
     pub transaction_factory: TransactionFactory,
+    pub outstanding_requests: std::sync::RwLock<Vec<crate::mint::MintParams>>,
     client: Client,
     endpoint: Url,
     maximum_amount: Option<u64>,
@@ -167,6 +168,7 @@ impl Service {
             transaction_factory: TransactionFactory::new(chain_id)
                 .with_gas_unit_price(std::cmp::max(1, aptos_global_constants::GAS_UNIT_PRICE))
                 .with_transaction_expiration_time(30),
+            outstanding_requests: std::sync::RwLock::new(vec![]),
             client,
             endpoint,
             maximum_amount,

--- a/crates/aptos-faucet/src/mint.rs
+++ b/crates/aptos-faucet/src/mint.rs
@@ -63,7 +63,7 @@ impl std::fmt::Display for Response {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
 pub struct MintParams {
     pub amount: u64,
     pub auth_key: Option<String>,
@@ -129,10 +129,30 @@ pub async fn process(service: &Service, params: MintParams) -> Result<Response> 
         faucet_account.sequence_number()
     };
 
+    let mut set_outstanding = false;
     // We shouldn't have too many outstanding txns
     for _ in 0..60 {
         if our_faucet_seq < faucet_seq + 50 {
-            break;
+            // Enforce a stronger ordering of priorities based upon the MintParams that arrived
+            // first. Then put the other folks to sleep to try again until the queue fills up.
+            if !set_outstanding {
+                let mut requests = service.outstanding_requests.write().unwrap();
+                requests.push(params.clone());
+                set_outstanding = true;
+            }
+
+            if service.outstanding_requests.read().unwrap().first() == Some(&params) {
+                // There might have been two requests with the same parameters, so we ensure that
+                // we only pop off one of them. We do a read lock first since that is cheap,
+                // followed by a write lock.
+                let mut requests = service.outstanding_requests.write().unwrap();
+                if requests.first() == Some(&params) {
+                    requests.remove(0);
+                    break;
+                }
+            }
+            tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+            continue;
         }
         warn!(
             "We have too many outstanding transactions: {}. Sleeping to let the system catchup.",


### PR DESCRIPTION
we could get hammered rather hard. the queue isn't kept in order, it is arbitrary based upon how tokio schedules the works after a sleep. this may result in slightly less throughput fro instanteous tests, but it should result in a better experience.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4756)
<!-- Reviewable:end -->
