### PR TITLE
Fix HAProxy config for 8080 API

### DIFF
--- a/terraform/helm/aptos-node/files/haproxy.cfg
+++ b/terraform/helm/aptos-node/files/haproxy.cfg
@@ -141,7 +141,7 @@ defaults
 	timeout client-fin 3s #How long to hold an interrupted client connection.
 	timeout server-fin 1s
 
-	timeout http-request 60 #len of http request
+	timeout http-request 60s #len of http request
 	timeout http-keep-alive 2s
 
 	rate-limit sessions 128


### PR DESCRIPTION
Timeout using 60 does not work in most cases and would return 408 for request that takes longer. 60s -> 60 seconds, makes more sense and won't cause error.

### Description

### Test Plan
Just use curl to reach port 8080 of HAProxy. If the client takes longer than 60ms to reach the server, haproxy will return http code 408. We should expect 200.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4763)
<!-- Reviewable:end -->
