### PR TITLE
[cli] Add ability to see current epoch and the next epoch time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ dependencies = [
  "base64 0.13.0",
  "bcs 0.1.3 (git+https://github.com/aptos-labs/bcs?rev=f94869cdfa1b5d2c9892016e8fb0c59fda1eea2d)",
  "cached-packages",
+ "chrono",
  "clap 3.2.17",
  "clap_complete",
  "dirs 4.0.0",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.57"
 async-trait = "0.1.53"
 base64 = "0.13.0"
 bcs = { git = "https://github.com/aptos-labs/bcs", rev = "f94869cdfa1b5d2c9892016e8fb0c59fda1eea2d" }
+chrono = "0.4.19"
 clap = "3.2.11"
 clap_complete = "3.2.3"
 dirs = "4.0.0"

--- a/types/src/account_config/events/new_block.rs
+++ b/types/src/account_config/events/new_block.rs
@@ -128,6 +128,10 @@ impl BlockResource {
     pub fn height(&self) -> u64 {
         self.height
     }
+
+    pub fn epoch_interval(&self) -> u64 {
+        self.epoch_interval
+    }
 }
 
 impl MoveStructType for BlockResource {


### PR DESCRIPTION
### Description
Everyone keeps asking, when is the next epoch?  Well now you know an estimated time for the next epoch based on the previous epoch.  Also, prints out in UTC to make the readability easier.

### Test Plan
Manual test
```
aptos node show-epoch-info --url https://fullnode.testnet.aptoslabs.com
{
  "Result": {
    "epoch": 550,
    "epoch_interval": 3600000000,
    "last_reconfiguration_time": {
      "unix_time": 1664928771964315,
      "utc_time": "2022-10-05T00:12:51.964315Z"
    },
    "estimated_next_reconfiguration_time": {
      "unix_time": 1664932371964315,
      "utc_time": "2022-10-05T01:12:51.964315Z"
    }
  }
}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4785)
<!-- Reviewable:end -->
