### PR TITLE
[cli] Add package source code verifier

### DIFF
--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -134,6 +134,62 @@ impl<'a> CachedPackageMetadata<'a> {
         }
         Ok(())
     }
+
+    pub fn verify(&self, package_metadata: &PackageMetadata) -> anyhow::Result<()> {
+        let self_metadata = self.metadata;
+
+        if self_metadata.name != package_metadata.name {
+            bail!(
+                "Package name doesn't match {} : {}",
+                package_metadata.name,
+                self_metadata.name
+            )
+        } else if self_metadata.deps != package_metadata.deps {
+            bail!(
+                "Dependencies don't match {:?} : {:?}",
+                package_metadata.deps,
+                self_metadata.deps
+            )
+        } else if self_metadata.modules != package_metadata.modules {
+            bail!(
+                "Modules don't match {:?} : {:?}",
+                package_metadata.modules,
+                self_metadata.modules
+            )
+        } else if self_metadata.manifest != package_metadata.manifest {
+            bail!(
+                "Manifest doesn't match {:?} : {:?}",
+                package_metadata.manifest,
+                self_metadata.manifest
+            )
+        } else if self_metadata.upgrade_policy != package_metadata.upgrade_policy {
+            bail!(
+                "Upgrade policy doesn't match {:?} : {:?}",
+                package_metadata.upgrade_policy,
+                self_metadata.upgrade_policy
+            )
+        } else if self_metadata.upgrade_number != package_metadata.upgrade_number {
+            bail!(
+                "Upgrade number doesn't match {:?} : {:?}",
+                package_metadata.upgrade_number,
+                self_metadata.upgrade_number
+            )
+        } else if self_metadata.extension != package_metadata.extension {
+            bail!(
+                "Extensions doesn't match {:?} : {:?}",
+                package_metadata.extension,
+                self_metadata.extension
+            )
+        } else if self_metadata.source_digest != package_metadata.source_digest {
+            bail!(
+                "Source digests doesn't match {:?} : {:?}",
+                package_metadata.source_digest,
+                self_metadata.source_digest
+            )
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> CachedModuleMetadata<'a> {


### PR DESCRIPTION
### Description
This was a requested feature by some users.

This does a byte code verification against local source.  The local source is packaged in the same way it was uploaded and verified that every piece is the same as is on-chain.  This ensures that you know that what is on chain is what you're using locally (if you have a local version or maybe a github repo).


### Test Plan
Manual testing, will need to add automated testing around this
```
aptos move verify-package --account 0x1 --package-dir aptos-move/framework/aptos-framework --profile local
{
  "Result": "Successfully verified source of package"
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4791)
<!-- Reviewable:end -->
