### PR TITLE
Get TokenData's mutability config

### DIFF
--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -1254,6 +1254,18 @@ module aptos_token::token {
         token_data.uri
     }
 
+    public fun get_tokendata_mutability_config(
+        creator: address,
+        token_data_id: TokenDataId
+    ): TokenMutabilityConfig acquires Collections {
+        assert!(exists<Collections>(creator), error::not_found(ECOLLECTIONS_NOT_PUBLISHED));
+        let all_token_data = &borrow_global<Collections>(creator).token_data;
+        assert!(table::contains(all_token_data, token_data_id), error::not_found(ETOKEN_DATA_NOT_PUBLISHED));
+
+        let token_data = table::borrow(all_token_data, token_data_id);
+        token_data.mutability_config
+    }
+
     //
     // Private functions
     //


### PR DESCRIPTION
### Description

The function takes a creator's address and a `TokenDataId` instance, verifies if such `TokenData` exists in creator's `Collections` resource and return a copy of its mutability_config field.

I would like to check if all of the mutability_config's fields are set to false in my smart contract. Due to a token being destroyed and a new one issued when mutating a token for a first time, it invalidates a state of any smart contract storing `TokenId`s and manipulating tokens.

Using such function one will be able to check if a token is not mutable at all, hence their smart contract will be able to handle tokens with property_version of 0. 

### Test Plan

No tests are necessary as it is a simple accessor function.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4793)
<!-- Reviewable:end -->
