### PR TITLE
[gas] do not release memory for table natives

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/memory_quota.data/table_and_vec/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/memory_quota.data/table_and_vec/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[dependencies]
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }
+MoveStdlib = { local = "../../../../../framework/move-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/memory_quota.data/table_and_vec/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/memory_quota.data/table_and_vec/sources/test.move
@@ -1,0 +1,42 @@
+module 0xbeef::test {
+    use std::vector;
+    use aptos_std::table_with_length as table;
+
+    public entry fun just_under_quota() {
+        let v = vector::empty();
+        let i = 0;
+        while (i < 1000) {
+            vector::push_back(&mut v, 0u128);
+            i = i + 1;
+        };
+
+        let t = table::new();
+
+        i = 0;
+        while (i < 622) {
+            table::add(&mut t, i, copy v);
+            i = i + 1;
+        };
+
+        table::destroy_empty(t);
+    }
+
+    public entry fun just_above_quota() {
+        let v = vector::empty();
+        let i = 0;
+        while (i < 1000) {
+            vector::push_back(&mut v, 0u128);
+            i = i + 1;
+        };
+
+        let t = table::new();
+
+        i = 0;
+        while (i < 623) {
+            table::add(&mut t, i, copy v);
+            i = i + 1;
+        };
+
+        table::destroy_empty(t);
+    }
+}


### PR DESCRIPTION
### Description
Right now we do not have a way to keep track of memory usage within the table extension. This adds a temporary workaround so that all values enter the table extension are considered "leaked" -- their heap memory will not be considered released. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4803)
<!-- Reviewable:end -->
