### PR TITLE
[Docs] New file listing all the downloadable files during installation

### DIFF
--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -16,7 +16,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
     ```bash
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose.yaml
+    wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose.yaml
     ```
 
 ## validator.yaml
@@ -25,7 +25,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml
+  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml
   ```
 
 ## genesis.blob 
@@ -34,7 +34,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-genesis-waypoint
 - **Command to download:**
   ```bash
-  wget genesis.blob https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/premainnet/genesis.blob
+  wget -O genesis.blob https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/premainnet/genesis.blob
   ```
 
 ## waypoint.txt
@@ -43,7 +43,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-genesis-waypoint
 - **Command to download:**
   ```bash
-  wget waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/premainnet/waypoint.txt
+  wget -O waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/premainnet/waypoint.txt
   ```
 
 ## haproxy.cfg
@@ -52,7 +52,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/haproxy.cfg
+  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/haproxy.cfg
   ```
 
 ## blocked.ips 
@@ -61,7 +61,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/blocked.ips
+  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/blocked.ips
   ```
 
 ## docker-compose-fullnode.yaml (fullnode only)
@@ -74,7 +74,7 @@ Fullnode means either a validator fullnode or a public fullnode.
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
+  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
   ```
 
 ## fullnode.yaml (fullnode only)
@@ -87,5 +87,5 @@ Fullnode means either a validator fullnode or a public fullnode.
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/fullnode.yaml
+  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/fullnode.yaml
   ```

--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -1,0 +1,91 @@
+---
+title: "Node Files"
+slug: "node-files"
+---
+
+# Node Files
+
+When you are deploying an Aptos node, you will need the following files. These can be downloaded from separate `aptos-labs` repos on GitHub. The `wget` commands provided below for will work on macOS and Linux. Open a terminal and paste the `wget` command to download the file. 
+
+:::tip Unless specified, all these files are required for validator node.
+:::
+
+## docker-compose.yaml
+
+- **Git repo:** `aptos-core`
+- **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
+- **Command to download:**
+    ```bash
+    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose.yaml
+    ```
+
+## validator.yaml
+
+- **Git repo:** `aptos-core`
+- **Git branch:** `main` on https://github.com/aptos-labs/aptos-core
+- **Command to download:**
+  ```bash
+  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml
+  ```
+
+## genesis.blob 
+
+- **Git repo:** `aptos-genesis-waypoint`
+- **Git branch:** `main` on https://github.com/aptos-labs/aptos-genesis-waypoint
+- **Command to download:**
+  ```bash
+  wget genesis.blob https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/premainnet/genesis.blob
+  ```
+
+## waypoint.txt
+
+- **Git repo:** `aptos-genesis-waypoint`
+- **Git branch:** `main` on https://github.com/aptos-labs/aptos-genesis-waypoint
+- **Command to download:**
+  ```bash
+  wget waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/premainnet/waypoint.txt
+  ```
+
+## haproxy.cfg
+
+- **Git repo:** `aptos-core`
+- **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
+- **Command to download:**
+  ```bash
+  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/haproxy.cfg
+  ```
+
+## blocked.ips 
+
+- **Git repo:** `aptos-core`
+- **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
+- **Command to download:**
+  ```bash
+  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/blocked.ips
+  ```
+
+## docker-compose-fullnode.yaml (fullnode only)
+
+:::tip Fullnode 
+Fullnode means either a validator fullnode or a public fullnode.
+:::
+
+- **Git repo:** `aptos-core`
+- **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
+- **Command to download:**
+  ```bash
+  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
+  ```
+
+## fullnode.yaml (fullnode only)
+
+:::tip Fullnode 
+Fullnode means either a validator fullnode or a public fullnode.
+:::
+
+- **Git repo:** `aptos-core`
+- **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
+- **Command to download:**
+  ```bash
+  wget https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/fullnode.yaml
+  ```

--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -5,7 +5,7 @@ slug: "node-files"
 
 # Node Files
 
-When you are deploying an Aptos node, you will need the following files. These can be downloaded from separate `aptos-labs` repos on GitHub. The `wget` commands provided below for will work on macOS and Linux. Open a terminal and paste the `wget` command to download the file. 
+When you are deploying an Aptos node, you will need the following files. These can be downloaded from separate `aptos-labs` repos on GitHub. The `wget` commands provided below will work on macOS and Linux. Open a terminal and paste the `wget` command to download the file. 
 
 :::tip Unless specified, all these files are required for validator node.
 :::

--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -25,7 +25,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O validator.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml
+  wget -O validator.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/validator.yaml
   ```
 
 ## genesis.blob 

--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -74,7 +74,7 @@ Fullnode means either a validator fullnode or a public fullnode.
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O docker-compose-fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
+  wget -O docker-compose.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
   ```
 
 ## fullnode.yaml (fullnode only)

--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -46,15 +46,6 @@ When you are deploying an Aptos node, you will need the following files. These c
   wget -O waypoint.txt https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/premainnet/waypoint.txt
   ```
 
-## haproxy.cfg
-
-- **Git repo:** `aptos-core`
-- **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
-- **Command to download:**
-  ```bash
-  wget -O haproxy.cfg https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/haproxy.cfg
-  ```
-
 ## blocked.ips 
 
 - **Git repo:** `aptos-core`

--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -16,7 +16,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
     ```bash
-    wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose.yaml
+    wget -O docker-compose.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose.yaml
     ```
 
 ## validator.yaml
@@ -25,7 +25,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `main` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml
+  wget -O validator.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml
   ```
 
 ## genesis.blob 
@@ -52,7 +52,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/haproxy.cfg
+  wget -O haproxy.cfg https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/haproxy.cfg
   ```
 
 ## blocked.ips 
@@ -61,7 +61,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/blocked.ips
+  wget -O blocked.ips https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/blocked.ips
   ```
 
 ## docker-compose-fullnode.yaml (fullnode only)
@@ -74,7 +74,7 @@ Fullnode means either a validator fullnode or a public fullnode.
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
+  wget -O docker-compose-fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/docker-compose-fullnode.yaml
   ```
 
 ## fullnode.yaml (fullnode only)
@@ -87,5 +87,5 @@ Fullnode means either a validator fullnode or a public fullnode.
 - **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
-  wget -O https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/fullnode.yaml
+  wget -O fullnode.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/mainnet/docker/compose/aptos-node/fullnode.yaml
   ```

--- a/developer-docs-site/docs/nodes/node-files.md
+++ b/developer-docs-site/docs/nodes/node-files.md
@@ -22,7 +22,7 @@ When you are deploying an Aptos node, you will need the following files. These c
 ## validator.yaml
 
 - **Git repo:** `aptos-core`
-- **Git branch:** `main` on https://github.com/aptos-labs/aptos-core
+- **Git branch:** `mainnet` on https://github.com/aptos-labs/aptos-core
 - **Command to download:**
   ```bash
   wget -O validator.yaml https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml

--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -96,6 +96,7 @@ const sidebars = {
     },
     "nodes/aptos-deployments",
     "nodes/leaderboard-metrics",
+    "nodes/node-files",
     /** Delete during clean up
     {
       type: "category",


### PR DESCRIPTION
A new doc listing all the downloadable files, like yaml, genesis and waypoint. Needed for either a validator node or a validator/public fullnode, so keeping it at a higher level. **Merge only when we finalize the haproxy files.** as per this [Slack thread.](https://aptos-org.slack.com/archives/C042WTC9S3A/p1665013166144089)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4812)
<!-- Reviewable:end -->
