### PR TITLE
fix([sdk][typescript]): isValidPath is not conform to BIP44

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -38,7 +38,7 @@ export class AptosAccount {
    * Test derive path
    */
   static isValidPath = (path: string): boolean => {
-    if (!/^m\/44'\/637'\/[0-9]+'\/[0-9]+'\/[0-9]+'+$/.test(path)) {
+    if (!/^m\/44'\/637'\/[0-9]+'\/[0-9]+\/[0-9]+$/.test(path)) {
       return false;
     }
     return true;


### PR DESCRIPTION
### Description
isValidPath is not conform to BIP44.

path level should be 

`m / purpose' / coin_type' / account' / change / address_index`

please refer to : https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4818)
<!-- Reviewable:end -->
