### PR TITLE
[framework] enable all outstanding feature flags in genesis

### DIFF
--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -74,11 +74,12 @@ impl MoveHarness {
         }
     }
 
-    pub fn new_with_features(features: Vec<FeatureFlag>) -> Self {
+    pub fn new_with_features(
+        enabled_features: Vec<FeatureFlag>,
+        disabled_features: Vec<FeatureFlag>,
+    ) -> Self {
         let mut h = Self::new();
-        if !features.is_empty() {
-            h.enable_features(features);
-        }
+        h.enable_features(enabled_features, disabled_features);
         h
     }
 
@@ -335,9 +336,10 @@ impl MoveHarness {
     }
 
     /// Enables features
-    pub fn enable_features(&mut self, features: Vec<FeatureFlag>) {
+    pub fn enable_features(&mut self, enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {
         let acc = self.aptos_framework_account();
-        let enable = features.into_iter().map(|f| f as u64).collect::<Vec<_>>();
+        let enabled = enabled.into_iter().map(|f| f as u64).collect::<Vec<_>>();
+        let disabled = disabled.into_iter().map(|f| f as u64).collect::<Vec<_>>();
         self.executor.exec(
             "features",
             "change_feature_flags",
@@ -346,8 +348,8 @@ impl MoveHarness {
                 MoveValue::Signer(*acc.address())
                     .simple_serialize()
                     .unwrap(),
-                bcs::to_bytes(&enable).unwrap(),
-                bcs::to_bytes(&Vec::<u64>::new()).unwrap(),
+                bcs::to_bytes(&enabled).unwrap(),
+                bcs::to_bytes(&disabled).unwrap(),
             ],
         );
     }

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -109,6 +109,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
     // On-chain genesis process.
     let consensus_config = OnChainConsensusConfig::V1(ConsensusConfigV1::default());
     initialize(&mut session, consensus_config, chain_id, genesis_config);
+    initialize_features(&mut session);
     initialize_aptos_coin(&mut session);
     initialize_on_chain_governance(&mut session, genesis_config);
     create_accounts(&mut session, accounts);
@@ -202,6 +203,7 @@ pub fn encode_genesis_change_set(
 
     // On-chain genesis process.
     initialize(&mut session, consensus_config, chain_id, genesis_config);
+    initialize_features(&mut session);
     if genesis_config.is_test {
         initialize_core_resources_and_aptos_coin(&mut session, core_resources_key);
     } else {
@@ -365,6 +367,22 @@ fn initialize(
             MoveValue::U64(rewards_rate_denominator),
             MoveValue::U64(genesis_config.voting_power_increase_limit),
         ]),
+    );
+}
+
+fn initialize_features(session: &mut SessionExt<impl MoveResolver>) {
+    let features: Vec<u64> = vec![1, 2];
+
+    let mut serialized_values = serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]);
+    serialized_values.push(bcs::to_bytes(&features).unwrap());
+    serialized_values.push(bcs::to_bytes(&Vec::<u64>::new()).unwrap());
+
+    exec_function(
+        session,
+        "features",
+        "change_feature_flags",
+        vec![],
+        serialized_values,
     );
 }
 


### PR DESCRIPTION
moving forward, whenever someone adds a new feature, they should enable it in genesis much like this, otherwise we will never validate the features until we deploy on a live network .... :scared:

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4821)
<!-- Reviewable:end -->
