### PR TITLE
error fixed in first-dapp in tutorials

### DIFF
--- a/developer-docs-site/docs/tutorials/first-dapp.md
+++ b/developer-docs-site/docs/tutorials/first-dapp.md
@@ -160,7 +160,7 @@ First, add the SDK to the project's dependencies:
 npm install --save aptos
 ```
 
-You will now see `"aptos": "^0.0.20"` (or similar) in your `package.json`.
+You will now see `"aptos": "^1.3.15"` (or similar) in your `package.json`.
 
 ### Create an `AptosClient`
 
@@ -320,7 +320,7 @@ function App() {
   // ...
 
   // Check for the module; show publish instructions if not present.
-  const [modules, setModules] = React.useState<Types.MoveModule[]>([]);
+  const [modules, setModules] = React.useState<Types.MoveModuleBytecode[]>([]);
   React.useEffect(() => {
     if (!address) return;
     client.getAccountModules(address).then(setModules);


### PR DESCRIPTION
### Description
first-dapp was not working for aptos^1.3.15
I managed to get it running by changing `Types.MoveModule` into `Types.MoveModuleBytecode`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4825)
<!-- Reviewable:end -->
