### PR TITLE
[move-release] Add ability to strip source from release bundle

### DIFF
--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -54,9 +54,13 @@ fn main() {
             prev_dir.join("move-stdlib").join("Move.toml").display()
         );
         ReleaseTarget::Head
-            .create_release(Some(
-                PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR defined")).join("head.mrb"),
-            ))
+            .create_release(
+                true,
+                Some(
+                    PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR defined"))
+                        .join("head.mrb"),
+                ),
+            )
             .expect("release build failed");
     }
 }

--- a/aptos-move/framework/src/aptos.rs
+++ b/aptos-move/framework/src/aptos.rs
@@ -90,7 +90,7 @@ impl ReleaseTarget {
         ReleaseBundle::read(path)
     }
 
-    pub fn create_release(self, out: Option<PathBuf>) -> anyhow::Result<()> {
+    pub fn create_release(self, with_srcs: bool, out: Option<PathBuf>) -> anyhow::Result<()> {
         let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         let packages = self
             .packages()
@@ -101,7 +101,7 @@ impl ReleaseTarget {
             .collect::<Vec<_>>();
         let options = ReleaseOptions {
             build_options: BuildOptions {
-                with_srcs: true,
+                with_srcs,
                 with_abis: true,
                 with_source_maps: false,
                 with_error_map: true,

--- a/aptos-move/framework/src/main.rs
+++ b/aptos-move/framework/src/main.rs
@@ -53,10 +53,14 @@ struct StandardRelease {
     /// some packages may be available in testnet, but aren't in mainnet.
     #[clap(long, default_value = "head")]
     target: ReleaseTarget,
+
+    /// Remove the source code from the release package to shrink its size.
+    #[clap(long)]
+    without_source_code: bool,
 }
 
 impl StandardRelease {
     fn execute(self) -> anyhow::Result<()> {
-        self.target.create_release(None)
+        self.target.create_release(!self.without_source_code, None)
     }
 }

--- a/aptos-move/framework/src/release_builder.rs
+++ b/aptos-move/framework/src/release_builder.rs
@@ -19,7 +19,7 @@ pub struct ReleaseOptions {
     #[clap(flatten)]
     pub build_options: BuildOptions,
     /// The path to the Move packages for which to create a release.
-    #[clap(long, parse(from_os_str))]
+    #[clap(long, parse(from_os_str), multiple_values = true)]
     pub packages: Vec<PathBuf>,
     /// The path where to place generated Rust bindings for this module, in order for
     /// each package. If the value is empty (`""`) for a particular package, no bindings are


### PR DESCRIPTION
### Description
Additionally, add the ability to put in the multiple paths for package paths in the custom release

### Test Plan
```
$ cargo run --release -- release; ls -lah head.mrb
Including package `MoveStdlib` size 21k
Including package `AptosStdlib` size 67k
Including package `AptosFramework` size 195k
Including package `AptosToken` size 34k
Including package `AptosNames` size 30k
-rw-r--r--  1 greg  wheel   341K Oct  6 12:23 head.mrb
$ cargo run --release -- release --without-source-code; ls -lah head.mrb
Including package `MoveStdlib` size 8k
Including package `AptosStdlib` size 22k
Including package `AptosFramework` size 83k
Including package `AptosToken` size 17k
Including package `AptosNames` size 15k
-rw-r--r--  1 greg  wheel   144K Oct  6 12:23 head.mrb
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4829)
<!-- Reviewable:end -->
