### PR TITLE
feat: allow txn simulation without private key

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_types/ed25519.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/ed25519.ts
@@ -15,6 +15,10 @@ export class Ed25519PublicKey {
     this.value = value;
   }
 
+  toBytes(): Bytes {
+    return this.value;
+  }
+
   serialize(serializer: Serializer): void {
     serializer.serializeBytes(this.value);
   }

--- a/ecosystem/typescript/sdk/src/faucet_client.test.ts
+++ b/ecosystem/typescript/sdk/src/faucet_client.test.ts
@@ -7,7 +7,7 @@ import { AptosAccount } from "./aptos_account";
 import { HexString } from "./hex_string";
 import * as Gen from "./generated/index";
 
-import { NODE_URL, FAUCET_URL, getFaucetClient } from "./utils/test_helper.test";
+import { NODE_URL, getFaucetClient } from "./utils/test_helper.test";
 
 const aptosCoin = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
 

--- a/ecosystem/typescript/sdk/src/utils/test_helper.test.ts
+++ b/ecosystem/typescript/sdk/src/utils/test_helper.test.ts
@@ -10,7 +10,7 @@ export const FAUCET_URL = process.env.APTOS_FAUCET_URL!;
  * pass that along in the header in the format the faucet expects.
  */
 export function getFaucetClient(): FaucetClient {
-  let config: Partial<OpenAPIConfig> = {};
+  const config: Partial<OpenAPIConfig> = {};
   if (process.env.FAUCET_AUTH_TOKEN) {
     config.HEADERS = { Authorization: `Bearer ${process.env.FAUCET_AUTH_TOKEN}` };
   }


### PR DESCRIPTION
### Description
The current simulation interface requires an `AptosAccount` as an arg. This means SDK users need to possess the private key. This PR relaxes the rule by allowing users to pass in a public key. It would be nice if the argument can be an `address`. However, this is not possible since an address itself cannot be used to create a valid authenticator.

### Test Plan
yarn test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4842)
<!-- Reviewable:end -->
