### PR TITLE
refactor: consolidate the code of generating auth key for Aptos account

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import nacl from "tweetnacl";
-import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import * as bip39 from "@scure/bip39";
 import { bytesToHex } from "@noble/hashes/utils";
 import { derivePath } from "./utils/hd-key";
 import { HexString, MaybeHexString } from "./hex_string";
 import * as Gen from "./generated/index";
 import { Memoize } from "./utils";
+import { AuthenticationKey, Ed25519PublicKey } from "./aptos_types";
 
 export interface AptosAccountObject {
   address?: Gen.HexEncodedBytes;
@@ -102,10 +102,9 @@ export class AptosAccount {
    */
   @Memoize()
   authKey(): HexString {
-    const hash = sha3Hash.create();
-    hash.update(this.signingKey.publicKey);
-    hash.update("\x00");
-    return HexString.fromUint8Array(hash.digest());
+    const pubKey = new Ed25519PublicKey(this.signingKey.publicKey);
+    const authKey = AuthenticationKey.fromEd25519PublicKey(pubKey);
+    return authKey.derivedAddress();
   }
 
   /**

--- a/ecosystem/typescript/sdk/src/aptos_types/authentication_key.ts
+++ b/ecosystem/typescript/sdk/src/aptos_types/authentication_key.ts
@@ -5,6 +5,7 @@ import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { HexString } from "../hex_string";
 import { Bytes } from "../bcs";
 import { MultiEd25519PublicKey } from "./multi_ed25519";
+import { Ed25519PublicKey } from "./ed25519";
 
 /**
  * Each account stores an authentication key. Authentication key enables account owners to rotate
@@ -17,6 +18,8 @@ export class AuthenticationKey {
   static readonly LENGTH: number = 32;
 
   static readonly MULTI_ED25519_SCHEME: number = 1;
+
+  static readonly ED25519_SCHEME: number = 0;
 
   readonly bytes: Bytes;
 
@@ -38,6 +41,19 @@ export class AuthenticationKey {
     const bytes = new Uint8Array(pubKeyBytes.length + 1);
     bytes.set(pubKeyBytes);
     bytes.set([AuthenticationKey.MULTI_ED25519_SCHEME], pubKeyBytes.length);
+
+    const hash = sha3Hash.create();
+    hash.update(bytes);
+
+    return new AuthenticationKey(hash.digest());
+  }
+
+  static fromEd25519PublicKey(publicKey: Ed25519PublicKey): AuthenticationKey {
+    const pubKeyBytes = publicKey.value;
+
+    const bytes = new Uint8Array(pubKeyBytes.length + 1);
+    bytes.set(pubKeyBytes);
+    bytes.set([AuthenticationKey.ED25519_SCHEME], pubKeyBytes.length);
 
     const hash = sha3Hash.create();
     hash.update(bytes);


### PR DESCRIPTION
### Description
Delegate auth key generation logic to a single place -- `AuthenticationKey`

### Test Plan
yarn test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4843)
<!-- Reviewable:end -->
