### PR TITLE
[telemetry-service] Give common name to peers in metrics

### DIFF
--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -117,6 +117,7 @@ pub struct Context {
     chain_set: HashSet<ChainId>,
     jwt_service: JsonWebTokenService,
     log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
+    peer_identities: HashMap<ChainId, HashMap<PeerId, String>>,
 }
 
 impl Context {
@@ -127,6 +128,7 @@ impl Context {
         chain_set: HashSet<ChainId>,
         jwt_service: JsonWebTokenService,
         log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
+        peer_identities: HashMap<ChainId, HashMap<PeerId, String>>,
     ) -> Self {
         Self {
             noise_config: Arc::new(noise::NoiseConfig::new(private_key)),
@@ -135,6 +137,7 @@ impl Context {
             chain_set,
             jwt_service,
             log_env_map,
+            peer_identities,
         }
     }
 
@@ -169,6 +172,10 @@ impl Context {
 
     pub(crate) fn bigquery_client(&self) -> Option<&TableWriteClient> {
         self.clients.bigquery_client.as_ref()
+    }
+
+    pub(crate) fn peer_identities(&self) -> &HashMap<ChainId, HashMap<PeerId, String>> {
+        &self.peer_identities
     }
 
     pub fn chain_set(&self) -> &HashSet<ChainId> {

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -151,6 +151,7 @@ impl AptosTelemetryServiceArgs {
             chain_set,
             jwt_service,
             config.log_env_map.clone(),
+            config.peer_identities.clone(),
         );
 
         PeerSetCacheUpdater::new(
@@ -212,6 +213,7 @@ pub struct TelemetryServiceConfig {
     pub humio_url: String,
 
     pub log_env_map: HashMap<ChainId, HashMap<PeerId, String>>,
+    pub peer_identities: HashMap<ChainId, HashMap<PeerId, String>>,
 }
 
 impl TelemetryServiceConfig {

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -88,7 +88,12 @@ pub async fn handle_log_ingest(
     fields.insert(EPOCH_FIELD_NAME.into(), claims.epoch.to_string());
 
     let mut tags = HashMap::new();
-    tags.insert(CHAIN_ID_TAG_NAME.into(), claims.chain_id.to_string());
+    let chain_name = if claims.chain_id.id() == 3 {
+        format!("{}", claims.chain_id.id())
+    } else {
+        format!("{}", claims.chain_id)
+    };
+    tags.insert(CHAIN_ID_TAG_NAME.into(), chain_name);
     tags.insert(PEER_ROLE_TAG_NAME.into(), claims.node_type.to_string());
 
     let unstructured_log = UnstructuredLog {

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -61,7 +61,13 @@ pub async fn handle_metrics_ingest(
 ) -> anyhow::Result<impl Reply, Rejection> {
     debug!("handling prometheus metrics ingest");
 
-    let extra_labels = claims_to_extra_labels(&claims);
+    let extra_labels = claims_to_extra_labels(
+        &claims,
+        context
+            .peer_identities()
+            .get(&claims.chain_id)
+            .and_then(|peers| peers.get(&claims.peer_id)),
+    );
 
     let start_timer = Instant::now();
 
@@ -117,23 +123,32 @@ pub async fn handle_metrics_ingest(
     Ok(reply::with_status(reply::reply(), StatusCode::CREATED))
 }
 
-fn claims_to_extra_labels(claims: &Claims) -> Vec<String> {
+fn claims_to_extra_labels(claims: &Claims, common_name: Option<&String>) -> Vec<String> {
     let chain_name = if claims.chain_id.id() == 3 {
         format!("chain_name={}", claims.chain_id.id())
     } else {
         format!("chain_name={}", claims.chain_id)
     };
-    vec![
-        format!("role={}", claims.node_type),
-        chain_name,
-        format!("namespace={}", "telemetry-service"),
+    let pod_name = if let Some(common_name) = common_name {
+        format!(
+            "kubernetes_pod_name=peer_id:{}//{}",
+            common_name,
+            claims.peer_id.to_hex_literal()
+        )
+    } else {
         // for community nodes we cannot determine which pod name they run in (or whether they run in k8s at all),
         // so we use the peer id as an approximation/replacement for pod_name
         // This works well with our existing grafana dashboards
         format!(
             "kubernetes_pod_name=peer_id:{}",
             claims.peer_id.to_hex_literal()
-        ),
+        )
+    };
+    vec![
+        format!("role={}", claims.node_type),
+        chain_name,
+        format!("namespace={}", "telemetry-service"),
+        pod_name,
     ]
 }
 
@@ -151,14 +166,38 @@ mod test {
 
     #[test]
     fn verify_labels() {
-        let claims = claims_to_extra_labels(&super::Claims {
-            chain_id: ChainId::new(25),
-            peer_id: PeerId::from_str("0x1").unwrap(),
-            node_type: NodeType::Validator,
-            epoch: 3,
-            exp: 123,
-            iat: 123,
-        });
+        let claims = claims_to_extra_labels(
+            &super::Claims {
+                chain_id: ChainId::new(25),
+                peer_id: PeerId::from_str("0x1").unwrap(),
+                node_type: NodeType::Validator,
+                epoch: 3,
+                exp: 123,
+                iat: 123,
+            },
+            Some(&String::from("test_name")),
+        );
+        assert_eq!(
+            claims,
+            vec![
+                "role=validator",
+                "chain_name=25",
+                "namespace=telemetry-service",
+                "kubernetes_pod_name=peer_id:test_name/0x1",
+            ]
+        );
+
+        let claims = claims_to_extra_labels(
+            &super::Claims {
+                chain_id: ChainId::new(25),
+                peer_id: PeerId::from_str("0x1").unwrap(),
+                node_type: NodeType::Validator,
+                epoch: 3,
+                exp: 123,
+                iat: 123,
+            },
+            None,
+        );
         assert_eq!(
             claims,
             vec![

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -36,6 +36,7 @@ pub async fn new_test_context() -> TestContext {
         pfn_allowlist: HashMap::new(),
         log_env_map: HashMap::new(),
         metrics_exporter_base_url: "".into(),
+        peer_identities: HashMap::new(),
     };
 
     let peers = PeerStoreTuple::default();
@@ -49,6 +50,7 @@ pub async fn new_test_context() -> TestContext {
             ClientTuple::new(None, Some(BTreeMap::new()), None),
             HashSet::new(),
             jwt_service,
+            HashMap::new(),
             HashMap::new(),
         ),
     )


### PR DESCRIPTION
### Description

This PR introduces the ability to prepend common names of the peers to their peer IDs. The names can be defined in the config file ordered by chain ID and peer ID.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

Added unit test. Works locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4851)
<!-- Reviewable:end -->
