### PR TITLE
fix replay-verify

### DIFF
--- a/storage/backup/backup-cli/src/coordinators/replay_verify.rs
+++ b/storage/backup/backup-cli/src/coordinators/replay_verify.rs
@@ -88,12 +88,14 @@ impl ReplayVerifyCoordinator {
         } else {
             metadata_view.select_state_snapshot(self.start_version.wrapping_sub(1))?
         };
-        let replay_transactions_from_version = state_snapshot
-            .as_ref()
-            .map(|b| b.version.wrapping_add(1))
-            .unwrap_or(0);
-        let transactions = metadata_view
-            .select_transaction_backups(replay_transactions_from_version, self.end_version)?;
+        let replay_transactions_from_version =
+            state_snapshot.as_ref().map(|b| b.version).unwrap_or(0);
+        let transactions = metadata_view.select_transaction_backups(
+            // transaction info at the snapshot must be restored otherwise the db will be confused
+            // about the latest version after snapshot is restored.
+            replay_transactions_from_version.saturating_sub(1),
+            self.end_version,
+        )?;
 
         let global_opt = GlobalRestoreOptions {
             target_version: self.end_version,


### PR DESCRIPTION
calling with start-version 1 resulted in the genesis snapshot being recovered and then the txn backup starting at ver 1 directly being applied on top, which is bad because the DB thought its empty due to lack of TxnInfo at ver 0. This fixes that.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->


```bash
$ rm -rf db && ./replay-verify  --concurrent-downloads 16  --metadata-cache-dir ./mc --target-db-dir db --start-version 1 command-adapter --config s3-pfn.yaml

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4854)
<!-- Reviewable:end -->
