### PR TITLE
cicd: create release-images.sh script which can be run from local and use it in CICD

### DIFF
--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -32,10 +32,6 @@ jobs:
 
   copy-images:
     needs: wait-for-images-to-have-been-built
-    strategy:
-      fail-fast: false
-      matrix:
-        IMAGE_NAME: [validator, forge, tools, faucet, indexer, node-checker]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,7 +44,7 @@ jobs:
       - name: Login to ECR
         uses: docker/login-action@v2
         with:
-          registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
+          registry: ${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
@@ -58,16 +54,10 @@ jobs:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
 
-      - name: Push Images to Dockerhub
-        uses: akhilerm/tag-push-action@v2.0.0
-        with:
-          src: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ github.sha }}
-          dst: |
-            docker.io/aptoslab/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
-            docker.io/aptoslab/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
-            docker.io/aptoslabs/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
-            docker.io/aptoslabs/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
-            ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
-            ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
-            ${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com/aptos/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}
-            ${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com/aptos/${{ matrix.IMAGE_NAME }}:${{ inputs.image_tag_prefix }}_${{ github.sha }}
+      - name: Release Images
+        env:
+          GIT_SHA: ${{ github.sha }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_NUM }}
+          IMAGE_TAG_PREFIX: ${{ inputs.image_tag_prefix }}
+        run: ./docker/release_images.sh

--- a/docker/release-images.sh
+++ b/docker/release-images.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# This script releases our aptos main images to docker hub.
+# It does so by copying the images from the aptos GCP artifact registry to docker hub.
+# It also copies the release tags to GCP Artifact Registry and AWS ECR.
+# Usually it's run in CI, but you can also run it locally in emergency situations, assuming you have the right credentials
+# Prerequisites when running locally:
+# 1. `docker login` with authorization to push to the `aptoslabs` org
+# 2. gcloud auth login --update-adc
+# 3. aws-mfa
+# Run with: 
+# GIT_SHA=${{ github.sha }} GCP_DOCKER_ARTIFACT_REPO="${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}" AWS_ACCOUNT_ID="${{ secrets.AWS_ECR_ACCOUNT_NUM }}" IMAGE_TAG_PREFIX="${{ inputs.image_tag_prefix }}" ./docker/release_images.sh
+
+REQUIRED_VARS=(
+  GIT_SHA
+  GCP_DOCKER_ARTIFACT_REPO
+  AWS_ACCOUNT_ID
+  IMAGE_TAG_PREFIX
+)
+
+for VAR in "${REQUIRED_VARS[@]}"; do
+  if [ -z "${!VAR}" ]; then
+    echo "missing required env var: $VAR"
+    exit 1
+  fi
+done
+
+if [ "$CI" == "true" ]; then
+  echo "installing crane automatically in CI"
+  curl -sL https://github.com/google/go-containerregistry/releases/download/v0.11.0/go-containerregistry_Linux_x86_64.tar.gz > crane.tar.gz
+  tar -xf crane.tar.gz
+  sha=$(shasum -a 256 ./crane | awk '{ print $1 }')
+  [ "$sha" != "2af448965b5feb6c315f4c8e79b18bd15f8c916ead0396be3962baf2f0c815bf" ] && echo "shasum mismatch - got: $sha" && exit 1
+  crane="./crane"
+else
+  if ! [ -x "$(command -v crane)" ]; then
+  echo "could not find crane binary in PATH - follow https://github.com/google/go-containerregistry/tree/main/cmd/crane#installation to install"
+  exit 1
+  fi
+  crane=$(which crane)
+fi
+
+set -ex
+
+IMAGES=(
+  validator
+  forge
+  tools
+  faucet
+  indexer
+  node-checker
+)
+
+TARGET_REGISTRIES=(
+  "$GCP_DOCKER_ARTIFACT_REPO"
+  "docker.io/aptoslabs"
+  "$AWS_ACCOUNT_NUM.dkr.ecr.us-west-2.amazonaws.com/aptos"
+)
+
+for IMAGE in "${IMAGES[@]}"; do
+  for TARGET_REGISTRY in "${TARGET_REGISTRIES[@]}"; do
+    $crane copy "$GCP_DOCKER_ARTIFACT_REPO/$IMAGE:$GIT_SHA" "$TARGET_REGISTRY/$IMAGE:$IMAGE_TAG_PREFIX"
+    $crane copy "$GCP_DOCKER_ARTIFACT_REPO/$IMAGE:$GIT_SHA" "$TARGET_REGISTRY/$IMAGE:${IMAGE_TAG_PREFIX}_${GIT_SHA}"
+  done
+done


### PR DESCRIPTION
This moves some of the logic for releasing docker images into a seperate bash script instead of fully relying on github actions. This makes it easier to make emergency releases of images when github actions is broken.

Also removed publishing to `aptoslab` legacy docker hub organization.

### Test Plan

Executed script locally with `release_testing` as image tag. Observed images in docker hub: https://hub.docker.com/layers/aptoslabs/validator/release_testing_377b6697d44c3f2c9b3e23424c6840581506ff71/images/sha256-645cec292b649611211b77462a34d034872cbeb425f6554c47409f51d667c7cc?context=explore

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4855)
<!-- Reviewable:end -->
