### PR TITLE
make fmt for examples and aptos_sdk folders

### DIFF
--- a/ecosystem/python/sdk/Makefile
+++ b/ecosystem/python/sdk/Makefile
@@ -5,9 +5,9 @@ test:
 	- poetry run python -m unittest discover -s aptos_sdk/ -p '*.py' -t ..
 
 fmt:
-	- find . -type f -name "*.py" | xargs poetry run autoflake -i -r --remove-all-unused-imports --remove-unused-variables --ignore-init-module-imports
-	- find . -type f -name "*.py" | xargs poetry run isort
-	- find . -type f -name "*.py" | xargs poetry run black
+	- find ./examples ./aptos_sdk -type f -name "*.py" | xargs poetry run autoflake -i -r --remove-all-unused-imports --remove-unused-variables --ignore-init-module-imports
+	- find ./examples ./aptos_sdk -type f -name "*.py" | xargs poetry run isort
+	- find ./examples ./aptos_sdk -type f -name "*.py" | xargs poetry run black
 
 examples:
 	- poetry run python -m examples.transfer-coin

--- a/ecosystem/python/sdk/aptos_sdk/transactions.py
+++ b/ecosystem/python/sdk/aptos_sdk/transactions.py
@@ -244,7 +244,7 @@ class ScriptArgument:
     U128: int = 2
     ADDRESS: int = 3
     U8_VECTOR: int = 4
-    BOOL: int = (5,)
+    BOOL: int = 5
 
     variant: int
     value: typing.Any

--- a/ecosystem/python/sdk/aptos_sdk/transactions.py
+++ b/ecosystem/python/sdk/aptos_sdk/transactions.py
@@ -229,10 +229,10 @@ class Script:
 
     def __eq__(self, other: ScriptArgument) -> bool:
         return (
-                self.code == other.code
-                and self.ty_args == other.ty_args
-                and self.args == other.args
-                )
+            self.code == other.code
+            and self.ty_args == other.ty_args
+            and self.args == other.args
+        )
 
     def __str__(self):
         return f"<{self.ty_args}>({self.args})"
@@ -244,7 +244,7 @@ class ScriptArgument:
     U128: int = 2
     ADDRESS: int = 3
     U8_VECTOR: int = 4
-    BOOL: int = 5,
+    BOOL: int = (5,)
 
     variant: int
     value: typing.Any

--- a/ecosystem/python/sdk/examples/common.py
+++ b/ecosystem/python/sdk/examples/common.py
@@ -6,5 +6,6 @@ import os
 #:!:>section_1
 NODE_URL = os.getenv("APTOS_NODE_URL", "https://fullnode.devnet.aptoslabs.com/v1")
 FAUCET_URL = os.getenv(
-        "APTOS_FAUCET_URL", "https://tap.devnet.prod.gcp.aptosdev.com" #"https://faucet.testnet.aptoslabs.com"
+    "APTOS_FAUCET_URL",
+    "https://tap.devnet.prod.gcp.aptosdev.com",  # "https://faucet.testnet.aptoslabs.com"
 )  # <:!:section_1

--- a/ecosystem/python/sdk/examples/transfer-two-by-two.py
+++ b/ecosystem/python/sdk/examples/transfer-two-by-two.py
@@ -1,10 +1,11 @@
 # Copyright (c) Aptos
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 from aptos_sdk.account import Account
 from aptos_sdk.client import FaucetClient, RestClient
 from aptos_sdk.transactions import Script, ScriptArgument, TransactionPayload
-import os
 
 from .common import FAUCET_URL, NODE_URL
 
@@ -30,7 +31,7 @@ if __name__ == "__main__":
 
     path = os.path.dirname(__file__)
     filepath = os.path.join(path, "two_by_two_transfer.mv")
-    with open(filepath, mode='rb') as file:
+    with open(filepath, mode="rb") as file:
         code = file.read()
 
     script_arguments = [

--- a/ecosystem/python/sdk/examples/your-coin.py
+++ b/ecosystem/python/sdk/examples/your-coin.py
@@ -35,8 +35,7 @@ class CoinClient(RestClient):
         payload = EntryFunction.natural(
             "0x1::managed_coin",
             "register",
-            [TypeTag(StructTag.from_str(
-                f"{coin_address}::moon_coin::MoonCoin"))],
+            [TypeTag(StructTag.from_str(f"{coin_address}::moon_coin::MoonCoin"))],
             [],
         )
         signed_transaction = self.create_single_signer_bcs_transaction(
@@ -52,8 +51,7 @@ class CoinClient(RestClient):
         payload = EntryFunction.natural(
             "0x1::managed_coin",
             "mint",
-            [TypeTag(StructTag.from_str(
-                f"{minter.address()}::moon_coin::MoonCoin"))],
+            [TypeTag(StructTag.from_str(f"{minter.address()}::moon_coin::MoonCoin"))],
             [
                 TransactionArgument(receiver_address, Serializer.struct),
                 TransactionArgument(amount, Serializer.u64),


### PR DESCRIPTION
This pr is for issue https://github.com/aptos-labs/aptos-core/issues/4859

`Make fmt` will scan .venv in default. We just need to specify `aptos_sdk/` and `examples/` folder.

And in this pr, some files are formated after running `make fmt`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4858)
<!-- Reviewable:end -->
