### PR TITLE
[Docs] Fix the command to get the validator performance

### DIFF
--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -74,7 +74,8 @@ Example output:
 To see your validator performance in the current and past epochs and rewards earned, run the below command. The output will show the validator's performance in block proposals and in governance voting and governance proposals. Default values are used in the below command. Type `aptos node analyze-validator-performance --help` to see default values used.
 
 ```bash
-aptos node analyze-validator-performance --analyze-mode All \
+aptos node get-performance \ 
+  --pool-address <pool address> \
   --url https://premainnet.aptosdev.com
 ```
 


### PR DESCRIPTION
### Description
The wrong command was specified - `aptos node analyze-validator-performance` instead of `aptos node get-performance`
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4865)
<!-- Reviewable:end -->
