### PR TITLE
[api] Fix estimation error for too little funds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,7 +2215,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -5524,7 +5524,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5541,7 +5541,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -5556,12 +5556,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5576,7 +5576,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5588,7 +5588,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5600,7 +5600,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5617,7 +5617,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5663,7 +5663,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "difference",
@@ -5680,7 +5680,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5709,7 +5709,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5726,7 +5726,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5780,7 +5780,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5798,7 +5798,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5816,7 +5816,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5842,7 +5842,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5880,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "hex",
@@ -5893,7 +5893,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "hex",
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5933,7 +5933,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5969,7 +5969,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6006,7 +6006,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6034,7 +6034,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -6045,7 +6045,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6071,7 +6071,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6098,7 +6098,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6116,7 +6116,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "log",
@@ -6138,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6147,7 +6147,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6164,7 +6164,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6195,7 +6195,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6226,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6243,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6257,7 +6257,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -7801,7 +7801,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=2ceedb15751f586fc657b7e94325cacf9ed9629f#2ceedb15751f586fc657b7e94325cacf9ed9629f"
+source = "git+https://github.com/move-language/move?rev=e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4#e61c8d7c5e9c8085ce2602ef9a5ae9b2500dbfa4"
 dependencies = [
  "anyhow",
  "move-binary-format",


### PR DESCRIPTION
### Description
Right now simulation with too little gas will put your max gas amount below the min gas units, which will cause it to error with MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS.  Now this fixes, it to INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE which makes more sense if you don't have enough money

### Test Plan
Before
```
$ aptos account transfer --account 0x22 --amount 100 --profile local
{
  "Error": "Simulation failed with status: Transaction Executed and Committed with Error MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS"
}
```

After
```
$ aptos account transfer --account 0x22 --amount 100 --profile local  
{
  "Error": "Simulation failed with status: Transaction Executed and Committed with Error INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE"
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4870)
<!-- Reviewable:end -->
