### PR TITLE
[cli] Add BLS key generation

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -345,6 +345,8 @@ pub enum KeyType {
     Ed25519,
     /// X25519 key used for network handshakes and identity
     X25519,
+    /// A BLS12381 key for consensus
+    Bls12381,
 }
 
 impl Display for KeyType {
@@ -352,6 +354,7 @@ impl Display for KeyType {
         let str = match self {
             KeyType::Ed25519 => "ed25519",
             KeyType::X25519 => "x25519",
+            KeyType::Bls12381 => "bls12381",
         };
         write!(f, "{}", str)
     }
@@ -364,6 +367,7 @@ impl FromStr for KeyType {
         match s.to_lowercase().as_str() {
             "ed25519" => Ok(KeyType::Ed25519),
             "x25519" => Ok(KeyType::X25519),
+            "bls12381" => Ok(KeyType::Bls12381),
             _ => Err("Invalid key type: Must be one of [ed25519, x25519]"),
         }
     }

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -11,7 +11,7 @@ use crate::{
     CliCommand, CliResult,
 };
 use aptos_config::config::{Peer, PeerRole};
-use aptos_crypto::{ed25519, x25519, PrivateKey, ValidCryptoMaterial};
+use aptos_crypto::{bls12381, ed25519, x25519, PrivateKey, ValidCryptoMaterial};
 use aptos_genesis::config::HostAndPort;
 use aptos_types::account_address::{from_identity_public_key, AccountAddress};
 use async_trait::async_trait;
@@ -163,7 +163,7 @@ impl NetworkKeyInputOptions {
 /// key encoded with the `encoding`.
 #[derive(Debug, Parser)]
 pub struct GenerateKey {
-    /// Key type to generate. Must be one of [x25519, ed25519]
+    /// Key type to generate. Must be one of [x25519, ed25519, bls12381]
     #[clap(long, default_value_t = KeyType::Ed25519)]
     pub(crate) key_type: KeyType,
 
@@ -196,6 +196,10 @@ impl CliCommand<HashMap<&'static str, PathBuf>> for GenerateKey {
             KeyType::Ed25519 => {
                 let private_key = keygen.generate_ed25519_private_key();
                 self.save_params.save_key(&private_key, "ed25519")
+            }
+            KeyType::Bls12381 => {
+                let private_key = keygen.generate_bls12381_private_key();
+                self.save_params.save_bls_key(&private_key, "bls12381")
             }
         }
     }
@@ -264,6 +268,11 @@ impl SaveKey {
         )
     }
 
+    /// Public key file name
+    fn proof_of_possession_file(&self) -> CliTypedResult<PathBuf> {
+        append_file_extension(self.file_options.output_file.as_path(), "pop")
+    }
+
     /// Check if the key file exists already
     pub fn check_key_file(&self) -> CliTypedResult<()> {
         // Check if file already exists
@@ -292,6 +301,41 @@ impl SaveKey {
         let mut map = HashMap::new();
         map.insert("PrivateKey Path", self.file_options.output_file);
         map.insert("PublicKey Path", public_key_file);
+        Ok(map)
+    }
+
+    /// Saves a key to a file encoded in a string
+    pub fn save_bls_key(
+        self,
+        key: &bls12381::PrivateKey,
+        key_name: &'static str,
+    ) -> CliTypedResult<HashMap<&'static str, PathBuf>> {
+        let encoded_private_key = self.encoding_options.encoding.encode_key(key_name, key)?;
+        let encoded_public_key = self
+            .encoding_options
+            .encoding
+            .encode_key(key_name, &key.public_key())?;
+        let encoded_proof_of_posession = self
+            .encoding_options
+            .encoding
+            .encode_key(key_name, &bls12381::ProofOfPossession::create(key))?;
+
+        // Write private and public keys to files
+        let public_key_file = self.public_key_file()?;
+        let proof_of_possession_file = self.proof_of_possession_file()?;
+        self.file_options
+            .save_to_file_confidential(key_name, &encoded_private_key)?;
+        write_to_file(&public_key_file, key_name, &encoded_public_key)?;
+        write_to_file(
+            &proof_of_possession_file,
+            key_name,
+            &encoded_proof_of_posession,
+        )?;
+
+        let mut map = HashMap::new();
+        map.insert("PrivateKey Path", self.file_options.output_file);
+        map.insert("PublicKey Path", public_key_file);
+        map.insert("Proof of possession Path", proof_of_possession_file);
         Ok(map)
     }
 }


### PR DESCRIPTION
### Description
Add bls key generation to the CLI


### Test Plan
```
$ aptos key generate --key-type bls12381 --output-file bls-key
"bls-key" already exists, are you sure you want to overwrite it? [yes/no] >
yes
"bls-key.pub" already exists, are you sure you want to overwrite it? [yes/no] >
yes
{
  "Result": {
    "PrivateKey Path": "bls-key",
    "PublicKey Path": "bls-key.pub",
    "Proof of possession Path": "bls-key.pop"
  }
}

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4873)
<!-- Reviewable:end -->
