### PR TITLE
[CLI] Handle empty consensus key and addresses

### DIFF
--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -423,7 +423,7 @@ pub struct SubmitVote {
 
     #[clap(flatten)]
     pub(crate) txn_options: TransactionOptions,
-    /// Comma separated list of pool addresses.
+    /// Space separated list of pool addresses.
     #[clap(long, multiple_values = true, parse(try_from_str=crate::common::types::load_account_arg))]
     pub(crate) pool_addresses: Vec<AccountAddress>,
 }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -28,7 +28,7 @@ use crate::node::{
     AnalyzeMode, AnalyzeValidatorPerformance, GetStakePool, InitializeValidator, JoinValidatorSet,
     LeaveValidatorSet, OperatorArgs, OperatorConfigFileArgs, ShowValidatorConfig, ShowValidatorSet,
     ShowValidatorStake, StakePoolResult, UpdateConsensusKey, UpdateValidatorNetworkAddresses,
-    ValidatorConsensusKeyArgs, ValidatorNetworkAddressesArgs,
+    ValidatorConfig, ValidatorConsensusKeyArgs, ValidatorNetworkAddressesArgs,
 };
 use crate::op::key::{ExtractPeer, GenerateKey, NetworkKeyInputOptions, SaveKey};
 use crate::stake::{
@@ -49,7 +49,6 @@ use aptos_sdk::move_types::identifier::Identifier;
 use aptos_sdk::move_types::language_storage::ModuleId;
 use aptos_temppath::TempPath;
 use aptos_types::on_chain_config::ValidatorSet;
-use aptos_types::validator_config::ValidatorConfig;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -8,7 +8,7 @@ use aptos::node::analyze::fetch_metadata::FetchMetadata;
 use aptos::test::ValidatorPerformance;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
-use aptos_crypto::{bls12381, x25519};
+use aptos_crypto::{bls12381, x25519, ValidCryptoMaterialStringExt};
 use aptos_genesis::config::HostAndPort;
 use aptos_keygen::KeyGen;
 use aptos_rest_client::{Client, State};
@@ -520,6 +520,10 @@ async fn test_register_and_update_validator() {
     assert_eq!(
         validator_config.consensus_public_key,
         keys.consensus_public_key()
+            .to_encoded_string()
+            .unwrap()
+            .as_bytes()
+            .to_vec()
     );
 
     let new_port = 5678;


### PR DESCRIPTION
### Description
Current aptos node get-stake-pool errors out if consensus key or network/fullnode addresses are empty,

### Test Plan
Manual tests

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4885)
<!-- Reviewable:end -->
