### PR TITLE
[cli-build] Rename 22.04 build to Ubuntu22.04

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh
+        run: scripts/cli/build_cli_release.sh "Ubuntu"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
         with:
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh
+        run: scripts/cli/build_cli_release.sh "Ubuntu-22.04"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
         with:
@@ -58,7 +58,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh
+        run: scripts/cli/build_cli_release.sh "MacOSX"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
         with:

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -13,27 +13,20 @@ set -e
 NAME='aptos-cli'
 CRATE_NAME='aptos'
 CARGO_PATH="crates/$CRATE_NAME/Cargo.toml"
+NAME="$1"
 
 # Grab system information
 ARCH=`uname -m`
 OS=`uname -s`
 VERSION=`cat "$CARGO_PATH" | grep "^\w*version =" | sed 's/^.*=[ ]*"//g' | sed 's/".*$//g'`
 
-if [ "$OS" == "Darwin" ]; then
-  # Rename Darwin to MacOSX so it's less confusing
-  OS="MacOSX"
-elif [ "$OS" == "Linux" ]; then
-  # Get linux flavor
-  OS=`cat /etc/os-release | grep '^NAME=' | sed 's/^.*=//g' | sed 's/"//g'`
-fi
-
-echo "Building release $VERSION of $NAME for $OS-$ARCH"
+echo "Building release $VERSION of $NAME for $OS-$NAME"
 cargo build -p $CRATE_NAME --profile cli
 
 cd target/cli/
 
 # Compress the CLI
-ZIP_NAME="$NAME-$VERSION-$OS-$ARCH.zip"
+ZIP_NAME="$NAME-$VERSION-$NAME-$ARCH.zip"
 
 echo "Zipping release: $ZIP_NAME"
 zip $ZIP_NAME $CRATE_NAME


### PR DESCRIPTION

### Description
Right now the builds conflict, which causes the 22.04 one to overwrite the 20.04 build

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4888)
<!-- Reviewable:end -->
