### PR TITLE
Revised staking operations doc

### DIFF
--- a/developer-docs-site/docs/concepts/staking.md
+++ b/developer-docs-site/docs/concepts/staking.md
@@ -83,7 +83,7 @@ The following is a high-level description of how validation works on the Aptos b
 - Throughout the duration of an epoch, the following flow of events occurs several times (thousands of times):
   - A validator leader is selected by a deterministic formula based on the validator reputation determined by validator's performance (including whether the validator has voted in the past or not) and stake. **This leader selection is not done by voting.**
   - The selected leader sends a proposal containing the collected quorum votes of the previous proposal and the leader's proposed order of transactions for the new block. 
-  - All the validators from the validator set will vote on the leader's proposal for the new block. Once a quorum consensus is reached the block can be finalized. Hence the actual list of votes to achieve the quorum consensus is a subset of all the validators in the validator set. This leader validator is rewarded. **Rewards are given only to the leader validators, and not to the voters.**
+  - All the validators from the validator set will vote on the leader's proposal for the new block. Once a quorum consensus is reached the block can be finalized. Hence the actual list of votes to achieve the quorum consensus is a subset of all the validators in the validator set. This leader validator is rewarded. **Rewards are given only to the leader validators, not to the voter validators.**
   - The above flow repeats with the selection of another validator leader and repeating the steps for the next new block. Rewards are given at the end of the epoch. 
 
 ## Joining the validator set

--- a/developer-docs-site/docs/concepts/staking.md
+++ b/developer-docs-site/docs/concepts/staking.md
@@ -83,7 +83,7 @@ The following is a high-level description of how validation works on the Aptos b
 - Throughout the duration of an epoch, the following flow of events occurs several times (thousands of times):
   - A validator leader is selected by a deterministic formula based on the validator reputation determined by validator's performance (including whether the validator has voted in the past or not) and stake. **This leader selection is not done by voting.**
   - The selected leader sends a proposal containing the collected quorum votes of the previous proposal and the leader's proposed order of transactions for the new block. 
-  - All the validators from the validator set will vote on the leader's proposal for the new block. Once a quorum consensus is reached the block can be finalized. Hence the actual list of votes to achieve the quorum consensus is a subset of all the validators in the validator set. This leader validator is rewarded. **Rewards are given only to the leader validators, not to the voter validators.**
+  - All the validators from the validator set will vote on the leader's proposal for the new block. Once consensus is reached the block can be finalized. Hence the actual list of votes to achieve consensus is a subset of all the validators in the validator set. This leader validator is rewarded. **Rewards are given only to the leader validators, not to the voter validators.**
   - The above flow repeats with the selection of another validator leader and repeating the steps for the next new block. Rewards are given at the end of the epoch. 
 
 ## Joining the validator set

--- a/developer-docs-site/docs/issues-and-workarounds.md
+++ b/developer-docs-site/docs/issues-and-workarounds.md
@@ -35,7 +35,7 @@ The Aptos current epoch duration is 1 hour.
 
 To track epoch changes, follow these steps:
 
-1. Go to account `0x1` page on the Aptos Explorer by [clicking here](https://explorer.aptoslabs.com/account/0x1). Make sure **Premainnet** is selected at the top right.
+1. Go to account `0x1` page on the Aptos Explorer by [clicking here](https://explorer.aptoslabs.com/account/0x1). Make sure the correct network (mainnet or testnet or devnet) is selected at the top right.
 1. Switch to **RESOURCES** tab.
 1. Using the browser search (Ctrl-f, do not use the **Search transactions** field), search for `last_reconfiguration_time`. You will find the last epoch transition timestamp in microseconds. The text display looks like this:
   ```json
@@ -56,11 +56,11 @@ To track epoch changes, follow these steps:
 
 4. Go to https://www.epochconverter.com/ and include the epoch timestamp to convert it to a human-readable date. 
 
-### How to check if a validator address is in validator set
+### How to check if a validator address is in the validator set
 
-You can check if a validator address is in the Aptos validator set at the command line or by using the Aptos Explorer.
+You can check if a validator address is in the Aptos validator set either on the command line or by using the Aptos Explorer.
 
-#### CLI 
+**CLI** 
 
 Run the below command:
 ```bash
@@ -69,23 +69,23 @@ aptos node show-validator-set --profile operator | jq -r '.Result.active_validat
 
 And ensure you see the validator in the output.
 
-#### Aptos Explorer
+**Aptos Explorer**
 
 Follow these steps on the Aptos Explorer:
 
 1. Go to account [`0x1`](https://explorer.aptoslabs.com/account/0x1) page on the Aptos Explorer.
-1. Select **Premainnet** in the top-right drop-down menu.
-2. Switch to the **RESOURCES** tab below.
-2. Using the browser search (Ctrl-f, do not use the **Search transactions** field), search for the validator address. 
+1. Make sure the correct network (mainnet or testnet or devnet) is selected at the top right.
+2. Switch to the **RESOURCES** tab.
+3. Using the browser search (Ctrl-f, do not use the **Search transactions** field), search for the validator address. 
 
 ### How to find stake pool address
 
-To find out which stake pool address to use (for example, to bootstrap your node), run the below command. This example is for Premainnet. For other networks, use the appropriate REST URL for the `--url` field. See [Bootstrapping validator node](nodes/validator-node/operator/connect-to-aptos-network.md#bootstrapping-validator-node):
+To find out which stake pool address to use (for example, to bootstrap your node), run the below command. This example is for mainnet. See the `--url` value for testnet or devnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md). Also see [Bootstrapping validator node](nodes/validator-node/operator/connect-to-aptos-network.md#bootstrapping-validator-node):
 
 ```bash
 aptos node get-stake-pool \
   --owner-address 0x0756c80f0597fc221fe043d5388949b34151a4efe5753965bbfb0ed7d0be08ea \
-  --url https://premainnet.aptosdev.com
+  --url https://fullnode.mainnet.aptoslabs.com/v1
 ```
 
 ### How to check if an address is the correct stake pool address or a correct validator address
@@ -93,17 +93,17 @@ aptos node get-stake-pool \
 Follow these steps on the Aptos Explorer:
 
 1. Go to account [`0x1`](https://explorer.aptoslabs.com/account/0x1) page on the Aptos Explorer.
-1. Select **Premainnet** in the top-right drop-down menu.
-1. Switch to **RESOURCES** tab below.
-1. Using the browser search (Ctrl-f, do not use the **Search transactions** field), search for `StakePool`. The address with the `StakePool` resource is the correct stake pool address.
-1. You can double-check by searching for the operator and seeing if that’s your operator address. 
+1.  Make sure the correct network (mainnet or testnet or devnet) is selected at the top right.
+2. Switch to **RESOURCES** tab.
+3. Using the browser search (Ctrl-f, do not use the **Search transactions** field), search for `StakePool`. The address with the `StakePool` resource is the correct stake pool address.
+4. You can double-check by searching for the operator and seeing if that’s your operator address. 
 
 ### How to see previous epoch rewards
 
 To see the previous epoch rewards for a given pool address, click on a URL of the below format. This example is for Premainnet and for the pool address `0x2b32ede8ef4805487eff7b283571789e0f4d10766d5cb5691fe880b76f21e7e4`. Use the network and pool address of your choice in this place:
 
 ```html
-https://premainnet.aptosdev.com/v1/accounts/0x2b32ede8ef4805487eff7b283571789e0f4d10766d5cb5691fe880b76f21e7e4/events/10
+https://fullnode.mainnet.aptoslabs.com/v1/accounts/0x2b32ede8ef4805487eff7b283571789e0f4d10766d5cb5691fe880b76f21e7e4/events/10
 ```
 
 ### Terraform "Connection Refused" error
@@ -202,9 +202,6 @@ If your validator node is facing persistent issues, for example, it is unable to
    level: DEBUG
 ```
 - Make sure to also include any other information you think might be useful and whether or not restarting your validator helps.
-
-
-
 
 
 [rest_spec]: https://github.com/aptos-labs/aptos-core/tree/main/api

--- a/developer-docs-site/docs/issues-and-workarounds.md
+++ b/developer-docs-site/docs/issues-and-workarounds.md
@@ -25,7 +25,7 @@ Receive this error from a validator node:
 
 #### Workaround
 
-Delete the `secure-data.json` file because very likely you are using an older version of it. See [Bootstrapping validator node](nodes/validator-node/operator/connect-to-aptos-network.md#bootstrapping-validator-node) for the location of this file. 
+Delete the `secure-data.json` file because very likely you are using an older version of it.  Check your `validator.yaml` file and you will see something like `path: /opt/aptos/data/secure-data.json`. Or see [Bootstrapping validator node](nodes/validator-node/operator/connect-to-aptos-network.md#bootstrapping-validator-node) for the location of this file. For Docker, you can delete this file by `docker` commands such as: `docker-compose down --volumes` (check the `docker-compose` help). Finally, **remember to restart the node. **
 
 ### How to find out when the next epoch starts
 

--- a/developer-docs-site/docs/issues-and-workarounds.md
+++ b/developer-docs-site/docs/issues-and-workarounds.md
@@ -126,6 +126,14 @@ This likely means that the state of the install is out of sync with the saved te
   terraform state rm <state>
   ```
 
+### How to find chain ID of my node
+
+On your node, run this command to find out the chain ID of your node:
+
+```bash
+curl http://127.0.0.1:8080/v1
+```
+
 ### Fullnode "NoAvailablePeers" error
 
 #### Description

--- a/developer-docs-site/docs/nodes/validator-node/operator/connect-to-aptos-network.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/connect-to-aptos-network.md
@@ -101,84 +101,6 @@ aptos node get-stake-pool --owner-address <owner_address> --url <REST API URL>
       --from-file=validator-full-node-identity.yaml=keys/validator-full-node-identity.yaml
   ```
 
-## Joining validator set
-
-Follow these steps to setup the validator node using the operator account and join the validator set.
-
-1. Initialize Aptos CLI.
-
-    ```bash
-    aptos init --profile testnet-operator \
-    --private-key <operator_account_private_key> \
-    --rest-url https://testnet.aptoslabs.com \
-    --skip-faucet
-    ```
-    
-    :::tip
-    The `account_private_key` for the operator can be found in the `private-keys.yaml` file under `~/$WORKSPACE/keys` folder.
-    :::
-
-2. Check your validator account balance. Make sure you have some coins to pay gas. You can do this step either by checking on the Aptos Explorer or using the CLI:
-
-    On the Aptos Explorer `https://explorer.aptoslabs.com/account/<account-address>?network=testnet` or use the CLI:
-
-    ```bash
-    aptos account list --profile testnet-operator
-    ```
-    
-    This will show you the coin balance you have in the validator account. You will see something like:
-    
-    ```json
-    "coin": {
-        "value": "5000"
-      }
-    ```
-
-3. Update validator network addresses on chain.
-
-    ```bash
-    aptos node update-validator-network-addresses  \
-      --pool-address <pool-address> \
-      --operator-config-file ~/$WORKSPACE/$USERNAME/operator.yaml \
-      --profile testnet-operator
-    ```
-
-4. Update the validator consensus key on chain.
-
-    ```bash
-    aptos node update-consensus-key  \
-      --pool-address <pool-address> \
-      --operator-config-file ~/$WORKSPACE/$USERNAME/operator.yaml \
-      --profile testnet-operator
-    ```
-
-5. Join the validator set.
-
-    ```bash
-    aptos node join-validator-set \
-      --pool-address <pool-address> \
-      --profile testnet-operator \
-      --max-gas 10000 
-    ```
-
-    :::tip Max gas
-    You can adjust the above `max-gas` number. Ensure that you sent your operator enough tokens to pay for the gas fee.
-    :::
-
-    The `ValidatorSet` will be updated at every epoch change, which is **once every 2 hours**. You will only see your node joining the validator set in the next epoch. Both validator and fullnode will start syncing once your validator is in the validator set.
-
-6. Check the validator set.
-
-    ```bash
-    aptos node show-validator-set --profile testnet-operator | jq -r '.Result.pending_active' | grep <pool_address>
-    ```
-    
-    You will see your validator node in "pending_active" list. When the next epoch change happens, the node will be moved into "active_validators" list. This will happen within one hour from the completion of previous step. **During this time you might see errors like "No connected AptosNet peers". This is normal.**
-    
-    ```bash
-    aptos node show-validator-set --profile testnet-operator | jq -r '.Result.active_validators' | grep <pool_address>
-    ```
-
 
 ## Verify node connections
 
@@ -238,14 +160,3 @@ After your validator node joined the validator set, you can verify the correctne
     ```
     
     You should expect the active value for your `StakePool` to keep increasing. It is updated at every epoch.
-
-
-## Leaving validator set
-
-A node can choose to leave validator set at anytime, or it would happen automatically when there is insufficient stake in the validator account. To leave the validator set, you can perform the following steps:
-
-Leave validator set (will take effect in next epoch):
-
-```bash
-aptos node leave-validator-set --profile testnet-operator --pool-address <owner-address>
-```

--- a/developer-docs-site/docs/nodes/validator-node/operator/connect-to-aptos-network.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/connect-to-aptos-network.md
@@ -5,7 +5,7 @@ slug: "connect-to-aptos-network"
 
 # Connecting to Aptos Network
 
-This document describes how to connect your running validator node and public fullnode to an Aptos network. Follow these instructions only if your validator has met the minimal staking requirement. 
+This document describes how to connect your running validator node and validator fullnode to an Aptos network. Follow these instructions only if your validator has met the minimal staking requirement. 
 
 :::tip Minimum staking requirement
 The current required minimum for staking is 1M APT tokens.
@@ -13,18 +13,26 @@ The current required minimum for staking is 1M APT tokens.
 
 ## Bootstrapping validator node
 
-Before joining the network, you need to make sure the validator node is bootstrapped with the correct genesis blob and waypoint for corresponding network. To bootstrap your node, first you need to know the pool address to use:
+Before joining the network, make sure the validator node is bootstrapped with the correct genesis blob and waypoint for corresponding network. To bootstrap your node, first you need to know the pool address to use:
 
-```
-aptos node get-stake-pool --owner-address <owner_address> --url <REST API URL>
+:::tip 
+See the `--rest-url` value for testnet or devnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
+:::
+
+```bash
+aptos node get-stake-pool \
+  --owner-address <owner_address> 
+  --url https://fullnode.mainnet.aptoslabs.com/v1
 ```
 
 ### Using source code
 
-1. Stop your node and remove the data directory. **Make sure you remove the `secure-data.json` file too**. [Click here to see the location of the `secure-data.json` file](https://github.com/aptos-labs/aptos-core/blob/e358a61018bb056812b5c3dbd197b0311a071baf/docker/compose/aptos-node/validator.yaml#L13). 
-2. Download the `genesis.blob` and `waypoint.txt` files published by Aptos Labs team.
+1. Stop your node and remove the data directory. 
+   - **Make sure you remove the `secure-data.json` file also**. [Click here to see the location of the `secure-data.json` file](https://github.com/aptos-labs/aptos-core/blob/e358a61018bb056812b5c3dbd197b0311a071baf/docker/compose/aptos-node/validator.yaml#L13). 
+2. Download the `genesis.blob` and `waypoint.txt` files published by Aptos Labs team. 
+   - See [Node Files](/nodes/node-files) for locations and commands to download these files.
 3. Update your `account_address` in the `validator-identity.yaml` and `validator-fullnode-identity.yaml` files to your **pool address**. Do not change anything else. Keep the keys as they are. 
-4. Pull the latest changes from the `mainnet` branch. It should be commit: `843b204dce971d98449b82624f4f684c7a18b991`.
+4. Pull the latest changes from the `mainnet` branch. 
 5. [Optional] You can use fast sync to bootstrap your node if the network has been running for a long time (e.g. testnet). Add the below configuration to your `validator.yaml` and `fullnode.yaml` files. Also see [Fast syncing](/concepts/state-sync#fast-syncing).
     ```yaml
     state_sync:
@@ -37,10 +45,12 @@ aptos node get-stake-pool --owner-address <owner_address> --url <REST API URL>
 
 ### Using Docker
 
-1. Stop your node and remove the data volumes, `docker compose down --volumes`. **Make sure you remove the `secure-data.json` file too.** [Click here to see the location of the `secure-data.json` file](https://github.com/aptos-labs/aptos-core/blob/e358a61018bb056812b5c3dbd197b0311a071baf/docker/compose/aptos-node/validator.yaml#L13). 
-2. Download the `genesis.blob` and `waypoint.txt` files published by Aptos Labs team.
-3. Update your `account_address` in the `validator-identity.yaml` and `validator-fullnode-identity.yaml` files to your  **pool address**.
-4. Update your Docker image to use the tag `testnet_843b204dce971d98449b82624f4f684c7a18b991`.
+1. Stop your node and remove the data volumes: `docker compose down --volumes`. 
+   - **Make sure you remove the `secure-data.json` file too.** [Click here to see the location of the `secure-data.json` file](https://github.com/aptos-labs/aptos-core/blob/e358a61018bb056812b5c3dbd197b0311a071baf/docker/compose/aptos-node/validator.yaml#L13). 
+2. Download the `genesis.blob` and `waypoint.txt` files published by Aptos Labs team. 
+   - See [Node Files](/nodes/node-files) for locations and commands to download these files.
+3. Update your `account_address` in the `validator-identity.yaml` and `validator-fullnode-identity.yaml` files to your **pool address**.
+4. Update your Docker image.
 5. [Optional] You can use fast sync to bootstrap your node if the network has been running for a long time (e.g. testnet). Add this configuration to your `validator.yaml` and `fullnode.yaml` files. Also see [Fast syncing](/concepts/state-sync#fast-syncing).
     ```yaml
     state_sync:
@@ -54,9 +64,10 @@ aptos node get-stake-pool --owner-address <owner_address> --url <REST API URL>
 ### Using Terraform
 
 1. Increase `era` number in your Terraform configuration. When this configuration is applied, it will wipe the data.
-2. Update `chain_id` to 2.
+2. Update `chain_id` to 1 (for mainnet). The chain IDs for other Aptos networks are in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
 3. Update your Docker image to use the tag `testnet_843b204dce971d98449b82624f4f684c7a18b991`.
-4. Close the metrics port and the REST API port for validator. [Optional] You can use fast sync to bootstrap your node if the network has been running for a long time (e.g. testnet). by adding the following Helm values in your `main.tf ` file:
+4. Close the metrics port and the REST API port for validator. 
+5. [Optional] You can use fast sync to bootstrap your node if the network has been running for a long time (e.g. testnet). by adding the following Helm values in your `main.tf ` file:
 
     ```json
     module "aptos-node" {
@@ -81,12 +92,12 @@ aptos node get-stake-pool --owner-address <owner_address> --url <REST API URL>
             }
         }
     }
-
     ```
-5. Pull latest of the terraform module `terraform get -update`, and then apply Terraform: `terraform apply`.
-6. Download the `genesis.blob` and `waypoint.txt` files published by Aptos Labs team.
-7. Update your `account_address` in the `validator-identity.yaml` and `validator-fullnode-identity.yaml` files to your  **pool address**. Do not change anything else. Keep the keys as they are.
-8. Recreate the secrets. Make sure the secret name matches your `era` number, e.g. if you have `era = 3`, then you should replace the secret name to be:
+6. Pull latest of the terraform module `terraform get -update`, and then apply Terraform: `terraform apply`.
+7. Download the `genesis.blob` and `waypoint.txt` files published by Aptos Labs team. 
+   - See [Node Files](/nodes/node-files) for locations and commands to download these files.
+8. Update your `account_address` in the `validator-identity.yaml` and `validator-fullnode-identity.yaml` files to your  **pool address**. Do not change anything else. Keep the keys as they are.
+9. Recreate the secrets. Make sure the secret name matches your `era` number, e.g. if you have `era = 3`, then you should replace the secret name to be:
   ```bash
   ${WORKSPACE}-aptos-node-0-genesis-e3
   ```
@@ -110,7 +121,7 @@ See [node liveness defined here](https://aptos.dev/reference/node-liveness-crite
 
 After your validator node joined the validator set, you can verify the correctness following those steps:
 
-1. Verify that your node is connecting to other peers on testnet. **Replace `127.0.0.1` with your validator IP/DNS if deployed on the cloud**.
+1. Verify that your node is connecting to other peers on the network. **Replace `127.0.0.1` with your validator IP/DNS if deployed on the cloud**.
 
     ```bash
     curl 127.0.0.1:9101/metrics 2> /dev/null | grep "aptos_connections{.*\"Validator\".*}"
@@ -149,7 +160,7 @@ After your validator node joined the validator set, you can verify the correctne
 
     You should expect to see this number keep increasing.
     
-5. Finally, the most straight forward way to see if your node is functioning properly is to check if it is making staking reward. You can check it on the Aptos Explorer: `https://explorer.aptoslabs.com/account/<owner-account-address>?network=testnet`:
+5. Finally, the most straight forward way to see if your node is functioning properly is to check if it is making staking reward. You can check it on the Aptos Explorer: `https://explorer.aptoslabs.com/account/<owner-account-address>?network=Mainnet`:
 
     ```json
     0x1::stake::StakePool

--- a/developer-docs-site/docs/nodes/validator-node/operator/shutting-down-nodes.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/shutting-down-nodes.md
@@ -15,6 +15,11 @@ Before you shutdown the node, make sure to first leave validator set first. This
 aptos node leave-validator-set --profile testnet-operator --pool-address <owner-address>
 ```
 
+:::danger Important
+If you leave and then rejoin in the same epoch, the rejoin would fail. This is because  when you leave, your validator state changes from "active" to "pending_inactive" but not actually "inactive". Hence the rejoin would fail.
+::: 
+
+
 After leaving the validator set, follow any one of the below sections to shut down your nodes. 
 
 ## Using source code

--- a/developer-docs-site/docs/nodes/validator-node/operator/shutting-down-nodes.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/shutting-down-nodes.md
@@ -7,18 +7,17 @@ slug: "shutting-down-nodes"
 
 Follow these instructions to shut down the validator node and validator fullnode, and cleanup the resources used by the nodes.
 
-## Leaving validator set
+## Leaving the validator set
 
-Before you shutdown the node, make sure to first leave validator set first. This will be become effective in the next epoch. Also note that a node can choose to leave validator set at anytime, or it would happen automatically when there is insufficient stake in the validator account. To leave the validator set, run the below command, shown using the example profile of `testnet-operator`:
+Before you shutdown the node, make sure to leave the validator set first. This will be become effective in the next epoch. Also note that a node can choose to leave the validator set at anytime, or it would happen automatically when there is insufficient stake in the validator account. To leave the validator set, run the below command, shown using the example profile of `mainnet-operator`:
 
 ```bash
-aptos node leave-validator-set --profile testnet-operator --pool-address <owner-address>
+aptos node leave-validator-set --profile mainnet-operator --pool-address <owner-address>
 ```
 
 :::danger Important
-If you leave and then rejoin in the same epoch, the rejoin would fail. This is because  when you leave, your validator state changes from "active" to "pending_inactive" but not actually "inactive". Hence the rejoin would fail.
+If you leave and then rejoin in the same epoch, the rejoin would fail. This is because  when you leave, your validator state changes from "active" to "pending_inactive" but not yet "inactive". Hence the rejoin would fail.
 ::: 
-
 
 After leaving the validator set, follow any one of the below sections to shut down your nodes. 
 

--- a/developer-docs-site/docs/nodes/validator-node/operator/shutting-down-nodes.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/shutting-down-nodes.md
@@ -5,15 +5,17 @@ slug: "shutting-down-nodes"
 
 # Shutting Down Nodes
 
-Follow these instructions to shut down the validator node and cleanup the resources used by the node.
+Follow these instructions to shut down the validator node and validator fullnode, and cleanup the resources used by the nodes.
 
-:::tip Leave validator set first
-Before you shutdown the node, make sure to first leave validator set first. This will be become effective in the next epoch.
+## Leaving validator set
+
+Before you shutdown the node, make sure to first leave validator set first. This will be become effective in the next epoch. Also note that a node can choose to leave validator set at anytime, or it would happen automatically when there is insufficient stake in the validator account. To leave the validator set, run the below command, shown using the example profile of `testnet-operator`:
 
 ```bash
 aptos node leave-validator-set --profile testnet-operator --pool-address <owner-address>
 ```
-:::
+
+After leaving the validator set, follow any one of the below sections to shut down your nodes. 
 
 ## Using source code
 

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -127,9 +127,6 @@ aptos node get-stake-pool \
 Example output:
 
 ```json
- Compiling aptos ...
-    Finished dev [unoptimized + debuginfo] target(s) in 32.89s
-     Running `target/debug/aptos node get-stake-pool --owner-address e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb`
 {
   "Result": [
     {

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -27,80 +27,82 @@ Follow these steps to setup the validator node using the operator account and jo
 The below CLI command examples use mainnet. See the `--rest-url` value for testnet or devnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
 :::
 
-1. Initialize Aptos CLI.
+### 1. Initialize Aptos CLI
 
-    ```bash
-    aptos init --profile mainnet-operator \
-    --private-key <operator_account_private_key> \
-    --rest-url https://fullnode.mainnet.aptoslabs.com/v1 \
-    --skip-faucet
-    ```
+  ```bash
+  aptos init --profile mainnet-operator \
+  --private-key <operator_account_private_key> \
+  --rest-url https://fullnode.mainnet.aptoslabs.com/v1 \
+  --skip-faucet
+  ```
+  
+:::tip
+The `account_private_key` for the operator can be found in the `private-keys.yaml` file under `~/$WORKSPACE/keys` folder.
+:::
+
+### 2. Check your validator account balance 
+
+Make sure you have some coins to pay gas. You can do this step either by checking on the Aptos Explorer or using the CLI:
+
+On the Aptos Explorer `https://explorer.aptoslabs.com/account/<account-address>?network=testnet` or use the CLI:
+
+```bash
+aptos account list --profile mainnet-operator
+```
     
-    :::tip
-    The `account_private_key` for the operator can be found in the `private-keys.yaml` file under `~/$WORKSPACE/keys` folder.
-    :::
-
-2. Check your validator account balance. Make sure you have some coins to pay gas. You can do this step either by checking on the Aptos Explorer or using the CLI:
-
-    On the Aptos Explorer `https://explorer.aptoslabs.com/account/<account-address>?network=testnet` or use the CLI:
-
-    ```bash
-    aptos account list --profile mainnet-operator
-    ```
+This will show you the coin balance you have in the validator account. You will see an output like below:
     
-    This will show you the coin balance you have in the validator account. You will see something like:
-    
-    ```json
-    "coin": {
-        "value": "5000"
-      }
-    ```
+```json
+"coin": {
+    "value": "5000"
+  }
+```
 
-3. Update validator network addresses on chain.
+### 3. Update validator network addresses on-chain
 
-    ```bash
-    aptos node update-validator-network-addresses  \
-      --pool-address <pool-address> \
-      --operator-config-file ~/$WORKSPACE/$USERNAME/operator.yaml \
-      --profile mainnet-operator
-    ```
+```bash
+aptos node update-validator-network-addresses  \
+  --pool-address <pool-address> \
+  --operator-config-file ~/$WORKSPACE/$USERNAME/operator.yaml \
+  --profile mainnet-operator
+```
 
-4. Rotate the validator consensus key on chain.
+### 4. Rotate the validator consensus key on-chain
 
-    ```bash
-    aptos node update-consensus-key  \
-      --pool-address <pool-address> \
-      --operator-config-file ~/$WORKSPACE/$USERNAME/operator.yaml \
-      --profile mainnet-operator
-    ```
+```bash
+aptos node update-consensus-key  \
+  --pool-address <pool-address> \
+  --operator-config-file ~/$WORKSPACE/$USERNAME/operator.yaml \
+  --profile mainnet-operator
+```
 
-5. **Join the validator set.**
+### 5. Join the validator set
 
-    ```bash
-    aptos node join-validator-set \
-      --pool-address <pool-address> \
-      --profile mainnet-operator
-    ```
+```bash
+aptos node join-validator-set \
+  --pool-address <pool-address> \
+  --profile mainnet-operator
+```
 
-    The `ValidatorSet` will be updated at every epoch change. You will see your node joining the validator set only in the next epoch. Both validator and validator fullnode will start syncing once your validator is in the validator set.
+The `ValidatorSet` will be updated at every epoch change. You will see your node joining the validator set only in the next epoch. Both validator and validator fullnode will start syncing once your validator is in the validator set.
 
-    :::tip When is next epoch?
-    Click to find out [when the next epoch starts](/issues-and-workarounds#how-to-find-out-when-the-next-epoch-starts).
-    :::
+:::tip When is next epoch?
+Click to find out [when the next epoch starts](/issues-and-workarounds#how-to-find-out-when-the-next-epoch-starts).
+:::
 
-6. Check the validator set. 
+### 6. Check the validator set
    
-    Run the below command to look for your validator in the "pending_active" list.
+Run the below command to look for your validator in the "pending_active" list.
 
-    ```bash
-    aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.pending_active' | grep <pool_address>
-    ```
-    
-    When the next epoch change happens, the node will be moved into "active_validators" list. **During this time you might see errors like "No connected AptosNet peers". This is normal.** Run the below command to see your validator in the "active_validators" list:
-    
-    ```bash
-    aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.active_validators' | grep <pool_address>
-    ```
+```bash
+aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.pending_active' | grep <pool_address>
+```
+
+When the next epoch change happens, the node will be moved into "active_validators" list. **During this time you might see errors like "No connected AptosNet peers". This is normal.** Run the below command to see your validator in the "active_validators" list:
+
+```bash
+aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.active_validators' | grep <pool_address>
+```
 
 
 ## Checking your stake pool information

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -5,7 +5,7 @@ slug: "staking-pool-operations"
 
 # Staking Pool Operations
 
-This document describes how to perform staking pool operations. Note that you can stake only when you met the minimal staking requirement. 
+This document describes how to perform staking pool operations. Note that you can stake only when you meet the minimal staking requirement. 
 
 :::tip Minimum staking requirement
 The current required minimum for staking is 1M APT tokens.
@@ -21,7 +21,7 @@ Make sure that this initializing the stake pool step was performed by the owner.
 If you run into any errors, see the [Issues and Workarounds](/docs/issues-and-workarounds.md).
 :::
 
-Follow these steps to setup the validator node using the operator account and join the validator set.
+Follow the below steps to set up the validator node using the operator account and join the validator set.
 
 :::tip Mainnet vs Testnet
 The below CLI command examples use mainnet. See the `--rest-url` value for testnet or devnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
@@ -42,13 +42,14 @@ The `account_private_key` for the operator can be found in the `private-keys.yam
 
 ### 2. Check your validator account balance 
 
-Make sure you have some coins to pay gas. You can do this step either by checking on the Aptos Explorer or using the CLI:
+Make sure you have enough APT coins to pay for gas. You can check for this either on the Aptos Explorer or using the CLI:
 
-On the Aptos Explorer `https://explorer.aptoslabs.com/account/<account-address>?network=testnet` or use the CLI:
+- On the Aptos Explorer `https://explorer.aptoslabs.com/account/<account-address>?network=Mainnet`, or 
+- Use the CLI:
 
-```bash
-aptos account list --profile mainnet-operator
-```
+  ```bash
+  aptos account list --profile mainnet-operator
+  ```
     
 This will show you the coin balance you have in the validator account. You will see an output like below:
     

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -11,24 +11,28 @@ This document describes how to perform staking pool operations. Note that you ca
 The current required minimum for staking is 1M APT tokens.
 :::
 
-## Initialize the stake pool
+## Initializing the stake pool
 
-Make sure that this step was performed by the owner. See [Initialize staking pool](/nodes/validator-node/owner/index#initialize-staking-pool) in the owner documentation section.
+Make sure that this initializing the stake pool step was performed by the owner. See [Initialize staking pool](/nodes/validator-node/owner/index#initialize-staking-pool) in the owner documentation section.
 
 ## Joining validator set
 
-:::tip Errors? 
+:::danger Errors? 
 If you run into any errors, see the [Issues and Workarounds](/docs/issues-and-workarounds.md).
 :::
 
 Follow these steps to setup the validator node using the operator account and join the validator set.
+
+:::tip Mainnet vs Testnet
+The below CLI command examples use mainnet. See the `--rest-url` value for testnet or devnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
+:::
 
 1. Initialize Aptos CLI.
 
     ```bash
     aptos init --profile mainnet-operator \
     --private-key <operator_account_private_key> \
-    --rest-url https://testnet.aptoslabs.com \
+    --rest-url https://fullnode.mainnet.aptoslabs.com/v1 \
     --skip-faucet
     ```
     
@@ -78,15 +82,21 @@ Follow these steps to setup the validator node using the operator account and jo
       --profile mainnet-operator
     ```
 
-    The `ValidatorSet` will be updated at every epoch change, which is **once every 2 hours**. You will only see your node joining the validator set in the next epoch. Both validator and fullnode will start syncing once your validator is in the validator set.
+    The `ValidatorSet` will be updated at every epoch change. You will see your node joining the validator set only in the next epoch. Both validator and validator fullnode will start syncing once your validator is in the validator set.
 
-6. Check the validator set.
+    :::tip When is next epoch?
+    Click to find out [when the next epoch starts](/issues-and-workarounds#how-to-find-out-when-the-next-epoch-starts).
+    :::
+
+6. Check the validator set. 
+   
+    Run the below command to look for your validator in the "pending_active" list.
 
     ```bash
     aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.pending_active' | grep <pool_address>
     ```
     
-    You will see your validator node in "pending_active" list. When the next epoch change happens, the node will be moved into "active_validators" list. This will happen within one hour from the completion of previous step. **During this time you might see errors like "No connected AptosNet peers". This is normal.**
+    When the next epoch change happens, the node will be moved into "active_validators" list. **During this time you might see errors like "No connected AptosNet peers". This is normal.** Run the below command to see your validator in the "active_validators" list:
     
     ```bash
     aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.active_validators' | grep <pool_address>
@@ -97,13 +107,7 @@ Follow these steps to setup the validator node using the operator account and jo
 
 To check the details of your stake pool, run the below CLI command with the `get-stake-pool` option by providing the `--owner-address` and `--url` fields. 
 
-:::tip Use CLI 0.3.8 or higher
-Make sure you use the CLI version 0.3.8 or higher. See [Installing Aptos CLI](/cli-tools/aptos-cli-tool/install-aptos-cli.md).
-- Type `aptos --help` to see the CLI version.
-- Type `aptos node get-stake-pool --help` for more on the command option for the below example.
-:::
-
-The below command is an example for Premainnet and an example owner address `e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb`. For other networks, use the appropriate REST URL for the `--url` field. See [Aptos Blockchain Deployments](/nodes/aptos-deployments) for `--url` field values. 
+The below command is an example for Premainnet and an example owner address `e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb`. For mainnet or testnet or devnet, see [Aptos Blockchain Deployments](/nodes/aptos-deployments) for `--url` field values. 
 
 ```bash
 aptos node get-stake-pool \
@@ -114,13 +118,13 @@ aptos node get-stake-pool \
 Example output:
 
 ```json
- Compiling aptos v0.3.8 (/Users/kevin/aptos-core/crates/aptos)
+ Compiling aptos ...
     Finished dev [unoptimized + debuginfo] target(s) in 32.89s
      Running `target/debug/aptos node get-stake-pool --owner-address e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb`
 {
   "Result": [
     {
-      "state": "Active",
+      "state": "Active", 
       "pool_address": "25c3482850a188d8aa6edc5751846e1226a27863643f5ebc52be4f7d822264e3",
       "operator_address": "3bec5a529b023449dfc86e9a6b5b51bf75cec4a62bf21c15bbbef08a75f7038f",
       "voter_address": "3bec5a529b023449dfc86e9a6b5b51bf75cec4a62bf21c15bbbef08a75f7038f",
@@ -151,10 +155,38 @@ Example output:
 }
 ```
 
+### Description of key fields
 
-## Request commission
+**state**
+- "Active": Already in the validator set and proposing.
+- "Pending_active": Validator will be added to the validator set in the next epoch. Do not try to join the validator set again before the arrival of next epoch, or else you will receive an error. 
 
-As an operator, you can request commission once a month, i.e., at the end of a lockup period, by running the following command. Make sure to provide the operator and the owner addresses.
+**pool_address**
+- Use the "pool_address" (not the operator address) in the validator.yaml file. If you mistakenly used the operator address, you will receive the message: "Validator not in validator set". 
+
+**commission_percentage**
+- This can be set only by the stake pool owner. Operator receives the "commission_percentage" of the generated staking rewards. If you request the commission (you can do so by running the command `aptos stake request-commission`), after unlock (i.e., at the end of the `lockup_expiration_utc_time`) then the commission part of the rewards will go to the operator address while the rest will stay in the stake pool and belong to the owner. 
+
+  Here "the commission part of the rewards" means the unlocked commission amount at the time when unlock time expired, i.e., the value of **commission_not_yet_unlocked**. For example, for a lock up of one month, you call `aptos stake request-commission` every month, and this will pay out the commission that was accrued during the previous month but only when unlocked at the end of the previous month. Regardless of how often you run `aptos stake request-commission` during the month, the commission is only paid out upon the completion of `lockup_expiration_utc_time`.
+
+  :::tip Compounding
+  Note that if you do not request commission for multiple months, your commission will accrue more due to compounding of the **commission_percentage** during these months.
+  :::
+
+
+**commission_not_yet_unlocked**
+- The amount of commission that is not yet unlocked. It will be unlocked at the `lockup_expiration_utc_time`. This is the total commission amount available to the operator, i.e., the staking rewards only to the operator. This does not include the staking rewards to the owner.
+
+**lockup_expiration_utc_time**
+- The date when the commission that was locked up will unlock. However, this unlocked commission will not be auto-disbursed. It will only disburse when this command is called again.
+
+**epoch_info**
+- Use the [Epoch Converter](https://www.epochconverter.com/) to convert the `unix_time` into human readable time. Also see 
+
+
+## Requesting commission
+
+Either an owner or an operator can request commission. You can request commission once a month, i.e., at the end of a lockup period, by running the below command. Make sure to provide the operator and the owner addresses.
 
 ```bash
 aptos stake request-commission \
@@ -162,14 +194,14 @@ aptos stake request-commission \
   --owner-address 0xe7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb
 ```
 
-## Misc
+## Frequently used staking operations commands
 
 ### Checking your validator performance
 
 To see your validator performance in the current and past epochs and rewards earned, run the below command. The output will show the validator's performance in block proposals and in governance voting and governance proposals. Default values are used in the below command. Type `aptos node analyze-validator-performance --help` to see default values used.
 
 ```bash
-aptos node analyze-validator-performance --analyze-mode All \
+aptos node analyze-validator-performance --analyze-mode all \
   --url https://premainnet.aptosdev.com
 ```
 
@@ -221,7 +253,7 @@ aptos node update-consensus-key \
   --profile <profile>
   ```
 
-### Update addresses for validator and validator fullnode 
+### Updating addresses for validator and validator fullnode 
 
 You can update the address for the validator node and the validator fullnode by running the following command. Make sure to provide the pool address, the path to the `operator.yaml` file and the profile:
 
@@ -232,7 +264,7 @@ aptos node update-validator-network-addresses \
   --profile <profile>
   ```
 
-### Check performance for all epochs
+### Checking the performance for all epochs
 
 how can we receive performance for all epochs since Genesis? The command that you have provided early, only displays info for the latest period
 

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -69,7 +69,7 @@ aptos node update-validator-network-addresses  \
 ```
 
 :::tip Important notes
-The address updates and the consensus key rotation will be applied only at the end of the current epoch. However, the validator need not leave the validator set to make these updates. You can run the commands for address and key changes. For the rest of the current epoch your validator will still use the old key and addresses but when the epoch ends it will switch to the new key and addresses.
+The network address updates and the consensus key rotation will be applied only at the end of the current epoch. Note that the validator need not leave the validator set to make these updates. You can run the commands for address and key changes. For the remaining duration of the current epoch your validator will still use the old key and addresses but when the epoch ends it will switch to the new key and addresses.
 :::
 
 ### 4. Rotate the validator consensus key on-chain
@@ -89,21 +89,21 @@ aptos node join-validator-set \
   --profile mainnet-operator
 ```
 
-The `ValidatorSet` will be updated at every epoch change. You will see your node joining the validator set only in the next epoch. Both validator and validator fullnode will start syncing once your validator is in the validator set.
+The validator set is updated at every epoch change. You will see your validator node joining the validator set only in the next epoch. Both validator and validator fullnode will start syncing once your validator is in the validator set.
 
 :::tip When is next epoch?
-Click to find out [when the next epoch starts](/issues-and-workarounds#how-to-find-out-when-the-next-epoch-starts).
+Run the command `aptos node get-stake-pool` as shown in [Checking your stake pool information](#checking-your-stake-pool-information). You can also follow these steps: [How to find out when the next epoch starts](/issues-and-workarounds#how-to-find-out-when-the-next-epoch-starts).
 :::
 
 ### 6. Check the validator set
    
-Run the below command to look for your validator in the "pending_active" list.
+When you join the validator set, your validator node will be in "Pending Active" state until the next epoch occurs. **During this time you might see errors like "No connected AptosNet peers". This is normal.** Run the below command to look for your validator in the "pending_active" list.
 
 ```bash
 aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.pending_active' | grep <pool_address>
 ```
 
-When the next epoch change happens, the node will be moved into "active_validators" list. **During this time you might see errors like "No connected AptosNet peers". This is normal.** Run the below command to see your validator in the "active_validators" list:
+When the next epoch happens, the node will be moved into "active_validators" list.  Run the below command to see your validator in the "active_validators" list:
 
 ```bash
 aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.active_validators' | grep <pool_address>
@@ -112,17 +112,21 @@ aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.active
 ## Checking your stake pool information
 
 :::tip How validation works
-See [Validation on the Aptos blockchain](/concepts/staking#validation-on-the-aptos-blockchain).
+Before you proceed, see [Validation on the Aptos blockchain](/concepts/staking#validation-on-the-aptos-blockchain) for a brief overview.
 :::
 
 To check the details of your stake pool, run the below CLI command with the `get-stake-pool` option by providing the `--owner-address` and `--url` fields. 
 
-The below command is an example for Premainnet and an example owner address `e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb`. For mainnet or testnet or devnet, see [Aptos Blockchain Deployments](/nodes/aptos-deployments) for `--url` field values. 
+The below command is for an example owner address `e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb`. 
+
+:::tip
+For testnet or devnet `--url` field values, see [Aptos Blockchain Deployments](/nodes/aptos-deployments).
+:::
 
 ```bash
 aptos node get-stake-pool \
   --owner-address e7be097a90c18f6bdd53efe0e74bf34393cac2f0ae941523ea196a47b6859edb \
-  --url https://premainnet.aptosdev.com
+  --url https://fullnode.mainnet.aptoslabs.com/v1
 ```
 
 Example output:
@@ -162,19 +166,19 @@ Example output:
 }
 ```
 
-### Description of key fields
+### Description of output fields
 
 **state**
-- "Active": Already in the validator set and proposing.
-- "Pending_active": Validator will be added to the validator set in the next epoch. Do not try to join the validator set again before the arrival of next epoch, or else you will receive an error. 
+- "Active": Validator is already in the validator set and proposing.
+- "Pending_active": Validator will be added to the validator set in the next epoch. **Do not try to join the validator set again before the arrival of next epoch, or else you will receive an error. **
 
 **pool_address**
-- Use the "pool_address" (not the operator address) in the validator.yaml file. If you mistakenly used the operator address, you will receive the message: "Validator not in validator set". 
+- Use this "pool_address" (not the operator address) in you `validator.yaml` file. If you mistakenly used the operator address, you will receive the message: "Validator not in validator set". 
 
 **commission_percentage**
-- This can be set only by the stake pool owner. Operator receives the "commission_percentage" of the generated staking rewards. If you request the commission (you can do so by running the command `aptos stake request-commission`), after unlock (i.e., at the end of the `lockup_expiration_utc_time`) then the commission part of the rewards will go to the operator address while the rest will stay in the stake pool and belong to the owner. 
+- This can be set only by the stake pool owner. Operator receives the "commission_percentage" of the generated staking rewards. If you request the commission (you can do so by running the command `aptos stake request-commission`), then at the end of the `lockup_expiration_utc_time` the commission part of the rewards will go to the operator address while the rest will stay in the stake pool and belong to the owner. Here "the commission part of the rewards" means the value of **commission_not_yet_unlocked**. 
 
-  Here "the commission part of the rewards" means the unlocked commission amount at the time when unlock time expired, i.e., the value of **commission_not_yet_unlocked**. For example, for a lock up of one month, you call `aptos stake request-commission` every month, and this will pay out the commission that was accrued during the previous month but only when unlocked at the end of the previous month. Regardless of how often you run `aptos stake request-commission` during the month, the commission is only paid out upon the completion of `lockup_expiration_utc_time`.
+  For example, in a scenario with a lock up of one month, you call `aptos stake request-commission` every month. This will pay out the commission that was accrued during the previous month but only when unlocked at the end of the previous month. Regardless of how often you run `aptos stake request-commission` during the month, the commission is only paid out upon the completion of `lockup_expiration_utc_time`.
 
   :::tip Compounding
   Note that if you do not request commission for multiple months, your commission will accrue more due to compounding of the **commission_percentage** during these months.
@@ -182,17 +186,17 @@ Example output:
 
 
 **commission_not_yet_unlocked**
-- The amount of commission (amount of APT) that is not yet unlocked. It will be unlocked at the `lockup_expiration_utc_time`. This is the total commission amount available to the operator, i.e., the staking rewards only to the operator. This does not include the staking rewards to the owner.
+- The amount of commission (amount of APT) that is not yet unlocked. It will be unlocked at the `lockup_expiration_utc_time`. This is the total commission amount available to the operator, i.e., the staking rewards **only** to the operator. This does not include the staking rewards to the owner.
 
 **lockup_expiration_utc_time**
-- The date when the commission that was locked up will unlock. However, this unlocked commission will not be auto-disbursed. It will only disburse when this command is called again.
+- The date when the commission will unlock. However, this unlocked commission will not be auto-disbursed. It will only disburse when the command `aptos stake request-commission` is called again.
 
 **epoch_info**
 - Use the [Epoch Converter](https://www.epochconverter.com/) to convert the `unix_time` into human readable time. 
 
 ## Requesting commission
 
-Either an owner or an operator can request commission. You can request commission at the end of a lockup period, i.e., at the end of **lockup_expiration_utc_time**, by running the below command. Make sure to provide the operator and the owner addresses.
+Either an owner or an operator can request commission. You can request commission at the end of a lockup period, i.e., at the end of **lockup_expiration_utc_time**, by running the `aptos stake request-commission` command. Make sure to provide the operator and the owner addresses. See an example command below:
 
 ```bash
 aptos stake request-commission \
@@ -204,12 +208,12 @@ aptos stake request-commission \
 
 ### Checking your validator performance
 
-To see your validator performance in the current and past epochs and rewards earned, run the below command. The output will show the validator's performance in block proposals and in governance voting and governance proposals. Default values are used in the below command. Type `aptos node get-performance --help` to see default values used.
+To see your validator performance in the current and past epochs and the rewards earned, run the below command. The output will show the validator's performance in block proposals, and in governance voting and governance proposals. Default values are used in the below command. Type `aptos node get-performance --help` to see default values used.
 
 ```bash
 aptos node get-performance \ 
   --pool-address <pool address> \
-  --url https://premainnet.aptosdev.com
+  --url https://fullnode.mainnet.aptoslabs.com/v1
 ```
 
 Example output:
@@ -249,7 +253,7 @@ Example output:
 }
 ```
 
-#### Description of key fields
+#### Description of fields
 
 **current_epoch_successful_proposals**
 - Successful leader-validator proposals during the current epoch. Also see [Validation on the Aptos blockchain](/concepts/staking#validation-on-the-aptos-blockchain) for the distinction between leader-validator and the voter-validator.
@@ -261,11 +265,11 @@ Example output:
 
 ### Checking the performance for all epochs
 
-To check the performance of all the epochs since the genesis, run the below command:
+To check the performance of all the epochs since the genesis, run the below command. You can filter the results for your pool address with `grep`, as shown below:
 
 ```bash
 aptos node analyze-validator-performance \
-  --analyze-mode=detailed-epoch-table \
-  --url=https://premainnet.aptosdev.com \
-  --start-epoch=0 | grep <pool address>
+  --analyze-mode detailed-epoch-table \
+  --url https://fullnode.mainnet.aptoslabs.com/v1 \
+  --start-epoch 0 | grep <pool address>
 ```

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -67,6 +67,10 @@ aptos node update-validator-network-addresses  \
   --profile mainnet-operator
 ```
 
+:::tip Important notes
+The address updates and the consensus key rotation will be applied only at the end of the current epoch. However, the validator need not leave the validator set to make these updates. You can run the commands for address and key changes. For the rest of the current epoch your validator will still use the old key and addresses but when the epoch ends it will switch to the new key and addresses.
+:::
+
 ### 4. Rotate the validator consensus key on-chain
 
 ```bash
@@ -247,7 +251,7 @@ Example output:
 }
 ```
 
-where:
+#### Description of key fields
 
 **current_epoch_successful_proposals**
 - Successful leader-validator proposals during the current epoch. Also see [Validation on the Aptos blockchain](/concepts/staking#validation-on-the-aptos-blockchain) for the distinction between leader-validator and the voter-validator.
@@ -257,32 +261,13 @@ where:
   - Either the validator was not part of the validator set in that epoch (could have been in either inactive or pending_active validator state), or
   - The validator missed all the leader proposals.
 
-### Rotating the consensus key
-
-You can rotate the operator consensus key by running the following command. Make sure to provide the pool address, the path to the `config.yaml` file and the profile:
-
-```bash
-aptos node update-consensus-key \
-  --pool-address <pool address> \
-  --validator-config-file </path/to/config.yaml> \
-  --profile <profile>
-  ```
-
-### Updating addresses for validator and validator fullnode 
-
-You can update the address for the validator node and the validator fullnode by running the following command. Make sure to provide the pool address, the path to the `operator.yaml` file and the profile:
-
-```bash
-aptos node update-validator-network-addresses \
-  --pool-address <pool-address> \
-  --operator-config-file </path/to/operator.yaml> \
-  --profile <profile>
-  ```
-
 ### Checking the performance for all epochs
 
-how can we receive performance for all epochs since Genesis? The command that you have provided early, only displays info for the latest period
+To check the performance of all the epochs since the genesis, run the below command:
 
 ```bash
-aptos node analyze-validator-performance --analyze-mode=detailed-epoch-table '--url=https://premainnet.aptosdev.com' --start-epoch=0 | grep <pool address>
+aptos node analyze-validator-performance \
+  --analyze-mode=detailed-epoch-table \
+  --url=https://premainnet.aptosdev.com \
+  --start-epoch=0 | grep <pool address>
 ```

--- a/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/staking-pool-operations.md
@@ -104,8 +104,11 @@ When the next epoch change happens, the node will be moved into "active_validato
 aptos node show-validator-set --profile mainnet-operator | jq -r '.Result.active_validators' | grep <pool_address>
 ```
 
-
 ## Checking your stake pool information
+
+:::tip How validation works
+See [Validation on the Aptos blockchain](/concepts/staking#validation-on-the-aptos-blockchain).
+:::
 
 To check the details of your stake pool, run the below CLI command with the `get-stake-pool` option by providing the `--owner-address` and `--url` fields. 
 
@@ -177,18 +180,17 @@ Example output:
 
 
 **commission_not_yet_unlocked**
-- The amount of commission that is not yet unlocked. It will be unlocked at the `lockup_expiration_utc_time`. This is the total commission amount available to the operator, i.e., the staking rewards only to the operator. This does not include the staking rewards to the owner.
+- The amount of commission (amount of APT) that is not yet unlocked. It will be unlocked at the `lockup_expiration_utc_time`. This is the total commission amount available to the operator, i.e., the staking rewards only to the operator. This does not include the staking rewards to the owner.
 
 **lockup_expiration_utc_time**
 - The date when the commission that was locked up will unlock. However, this unlocked commission will not be auto-disbursed. It will only disburse when this command is called again.
 
 **epoch_info**
-- Use the [Epoch Converter](https://www.epochconverter.com/) to convert the `unix_time` into human readable time. Also see 
-
+- Use the [Epoch Converter](https://www.epochconverter.com/) to convert the `unix_time` into human readable time. 
 
 ## Requesting commission
 
-Either an owner or an operator can request commission. You can request commission once a month, i.e., at the end of a lockup period, by running the below command. Make sure to provide the operator and the owner addresses.
+Either an owner or an operator can request commission. You can request commission at the end of a lockup period, i.e., at the end of **lockup_expiration_utc_time**, by running the below command. Make sure to provide the operator and the owner addresses.
 
 ```bash
 aptos stake request-commission \
@@ -200,10 +202,11 @@ aptos stake request-commission \
 
 ### Checking your validator performance
 
-To see your validator performance in the current and past epochs and rewards earned, run the below command. The output will show the validator's performance in block proposals and in governance voting and governance proposals. Default values are used in the below command. Type `aptos node analyze-validator-performance --help` to see default values used.
+To see your validator performance in the current and past epochs and rewards earned, run the below command. The output will show the validator's performance in block proposals and in governance voting and governance proposals. Default values are used in the below command. Type `aptos node get-performance --help` to see default values used.
 
 ```bash
-aptos node analyze-validator-performance --analyze-mode all \
+aptos node get-performance \ 
+  --pool-address <pool address> \
   --url https://premainnet.aptosdev.com
 ```
 
@@ -243,6 +246,16 @@ Example output:
   }
 }
 ```
+
+where:
+
+**current_epoch_successful_proposals**
+- Successful leader-validator proposals during the current epoch. Also see [Validation on the Aptos blockchain](/concepts/staking#validation-on-the-aptos-blockchain) for the distinction between leader-validator and the voter-validator.
+
+**previous_epoch_rewards**
+- An ordered list of rewards earned (APT amounts) for the previous 10 epochs, starting with the 10 epoch in the past. In the above example, a reward of 12312716242 APT was earned 10 epochs past and a reward of 12313600288 APT was earned in the most recent epoch. If a reward is 0 for any epoch, then:
+  - Either the validator was not part of the validator set in that epoch (could have been in either inactive or pending_active validator state), or
+  - The validator missed all the leader proposals.
 
 ### Rotating the consensus key
 

--- a/developer-docs-site/docs/nodes/validator-node/owner/index.md
+++ b/developer-docs-site/docs/nodes/validator-node/owner/index.md
@@ -17,7 +17,7 @@ The [Petra wallet extension](/docs/guides/install-petra-wallet.md) is supported 
 ## Owner operations with CLI
 
 :::tip Testnet vs Mainnet
-The below examples use testnet. See the `--rest-url` value for mainnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
+The below CLI command examples use mainnet. See the `--rest-url` value for testnet and devnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
 :::
 
 ### Initialize CLI
@@ -25,8 +25,8 @@ The below examples use testnet. See the `--rest-url` value for mainnet in [Aptos
 Initialize CLI with your Petra wallet private key or create new wallet. 
 
 ```bash
-aptos init --profile testnet-owner \
-  --rest-url https://fullnode.testnet.aptoslabs.com/v1
+aptos init --profile mainnet-owner \
+  --rest-url https://fullnode.mainnet.aptoslabs.com/v1
 ```
 
 You can either enter the private key from an existing wallet, or create new wallet address.
@@ -38,7 +38,7 @@ aptos stake initialize-stake-owner \
   --initial-stake-amount 100000000000000 \
   --operator-address <operator-address> \
   --voter-address <voter-address> \
-  --profile testnet-owner
+  --profile mainnet-owner
 ```
 
 ### Transfer coin between accounts
@@ -47,7 +47,7 @@ aptos stake initialize-stake-owner \
 aptos account transfer \
   --account <operator-address> \
   --amount <amount> \
-  --profile testnet-owner
+  --profile mainnet-owner
 ```
 
 ### Switch operator
@@ -55,7 +55,7 @@ aptos account transfer \
 ```bash
 aptos stake set-operator \
   --operator-address <new-operator-address> \ 
-  --profile testnet-owner
+  --profile mainnet-owner
 ```
 
 ### Switch voter
@@ -63,7 +63,7 @@ aptos stake set-operator \
 ```bash
 aptos stake set-delegated-voter \
   --voter-address <new-voter-address> \ 
-  --profile testnet-owner
+  --profile mainnet-owner
 ```
 
 ### Add stake
@@ -71,13 +71,13 @@ aptos stake set-delegated-voter \
 ```bash
 aptos stake add-stake \
   --amount <amount> \
-  --profile testnet-owner
+  --profile mainnet-owner
 ```
 
 ### Increase stake lockup
 
 ```bash
-aptos stake increase-lockup --profile testnet-owner
+aptos stake increase-lockup --profile mainnet-owner
 ```
 
 ### Unlock stake
@@ -85,7 +85,7 @@ aptos stake increase-lockup --profile testnet-owner
 ```bash
 aptos stake unlock-stake \
   --amount <amount> \
-  --profile testnet-owner
+  --profile mainnet-owner
 ```
 
 ### Withdraw stake
@@ -93,5 +93,5 @@ aptos stake unlock-stake \
 ```bash
 aptos stake withdraw-stake \
   --amount <amount> \
-  --profile testnet-owner
+  --profile mainnet-owner
 ```

--- a/developer-docs-site/docs/nodes/validator-node/owner/index.md
+++ b/developer-docs-site/docs/nodes/validator-node/owner/index.md
@@ -71,13 +71,8 @@ aptos stake set-delegated-voter \
 ```bash
 aptos stake add-stake \
   --amount <amount> \
-  --profile testnet-owner \
-  --max-gas 10000
+  --profile testnet-owner
 ```
-
-:::tip Max gas
-You can adjust the above `max-gas` number. Ensure that you sent your operator enough tokens to pay for the gas fee.
-:::
 
 ### Increase stake lockup
 

--- a/developer-docs-site/docs/nodes/validator-node/owner/index.md
+++ b/developer-docs-site/docs/nodes/validator-node/owner/index.md
@@ -10,23 +10,23 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 This document describes how to use [Aptos CLI](/docs/cli-tools/aptos-cli-tool/index.md) to perform owner operations during validation.
 
-:::tip Using Petra wallet
-This document assumes that you are using [Petra wallet](/docs/guides/install-petra-wallet.md). The [Petra wallet](/docs/guides/install-petra-wallet.md) is supported only on the Chrome browser. You can also use Petra extension on [Brave browser](https://brave.com/) and [Kiwi browser](https://kiwibrowser.com/) and [Microsoft Edge browser](https://www.microsoft.com/en-us/edge).
+:::tip Petra on Chrome browser only
+The [Petra wallet extension](/docs/guides/install-petra-wallet.md) is supported only on the Chrome browser. However, the extensions for [Brave browser](https://brave.com/) and [Kiwi browser](https://kiwibrowser.com/) and [Microsoft Edge browser](https://www.microsoft.com/en-us/edge) will also work.
 :::
 
 ## Owner operations with CLI
 
-:::tip Examples using testnet
-The CLI command examples used in this section use testnet. You can use the same command for mainnet by passing the mainnet URL for the `--rest-url` parameter.
-::: 
+:::tip Testnet vs Mainnet
+The below examples use testnet. See the `--rest-url` value for mainnet in [Aptos Blockchain Deployments](/docs/nodes/aptos-deployments.md).
+:::
 
 ### Initialize CLI
 
-Initialize CLI with your Petra wallet private key or create new wallet. The below example uses testnet:
+Initialize CLI with your Petra wallet private key or create new wallet. 
 
 ```bash
 aptos init --profile testnet-owner \
-  --rest-url http://testnet.aptoslabs.com
+  --rest-url https://fullnode.testnet.aptoslabs.com/v1
 ```
 
 You can either enter the private key from an existing wallet, or create new wallet address.

--- a/developer-docs-site/docs/nodes/validator-node/voter/index.md
+++ b/developer-docs-site/docs/nodes/validator-node/voter/index.md
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 # Voter 
 
 :::tip Petra on Chrome browser only
-The [Petra wallet extension](/docs/guides/install-petra-wallet.md) is supported only on the Chrome browser. However, the extensions for [Brave browser](https://brave.com/) and [Kiwi browser](https://kiwibrowser.com/) and [Microsoft Edge browser](https://www.microsoft.com/en-us/edge) also work.
+The [Petra wallet extension](/docs/guides/install-petra-wallet.md) is supported only on the Chrome browser. However, the extensions for [Brave browser](https://brave.com/) and [Kiwi browser](https://kiwibrowser.com/) and [Microsoft Edge browser](https://www.microsoft.com/en-us/edge) will also work.
 :::
 
 If you are a voter, then we recommend strongly that you do not store your Aptos voter keys with a custodian before the custodian supports this function. Until then, we suggest you store your voter keys in an Aptos wallet like [Petra](/docs/guides/install-petra-wallet.md) or [Martian](https://martianwallet.xyz/).


### PR DESCRIPTION
A bunch of updates to the staking operations doc, including Slack thread discussion extracts, insights and gotchas. Updated the related docs also. 

@sherry-x this below especially needs your attention:
- I generalized the Connecting to the network section with "mainnet" as default. Hence I removed steps that ask the user to pull the main branch at specific commit hash, and specific Docker image ID. Wouldn't these be default default on the main branch for mainnet? I did retain the instruction to change the chain ID and set it to 1. 
- Other changes are not invasive like the above. If these changes are okay, then we should land this asap.
- **Question**: I need to move the **Add monitoring components** from Shutting Down section. I think this belongs in the validator installation section. Can you suggest a place? 
`+` @movekevin 
- I have not explained anything on "pool_type". Should we add the explanation for StakingContract, Vesting and Direct options?
- Other than the above, after I make fixes based on review comments, can we make the staking pool operations doc final? I will submit a separate PR for staking concept doc updates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4896)
<!-- Reviewable:end -->
