### PR TITLE
Update node requirements doc and generalize validator docs.

### DIFF
--- a/developer-docs-site/docs/nodes/aptos-deployments.md
+++ b/developer-docs-site/docs/nodes/aptos-deployments.md
@@ -3,7 +3,6 @@ title: "Aptos Blockchain Deployments"
 slug: "aptos-deployments"
 hide_table_of_contents: true
 ---
-import imageUrl from '/static/img/docs/1x1.png';
 
 # Aptos Blockchain Deployments
 

--- a/developer-docs-site/docs/nodes/aptos-deployments.md
+++ b/developer-docs-site/docs/nodes/aptos-deployments.md
@@ -3,6 +3,7 @@ title: "Aptos Blockchain Deployments"
 slug: "aptos-deployments"
 hide_table_of_contents: true
 ---
+import imageUrl from '/static/img/docs/1x1.png';
 
 # Aptos Blockchain Deployments
 
@@ -16,10 +17,11 @@ Make sure to see the row describing [**What not to do**](#what-not-to-do).
 
 |Description | Mainnet | Devnet | Long-lived Testnet | Aptos Incentivized Testnet (AIT)|
 |---|---|---|---|---|
-|**REST API URL**| https://fullnode.mainnet.aptoslabs.com/v1 |https://fullnode.devnet.aptoslabs.com/v1 | https://fullnode.testnet.aptoslabs.com/v1 | Available during AIT program. |
 |**Chain ID**| 1 |[Click here and **select Devnet from top right**](https://explorer.aptoslabs.com/?network=Devnet).| 2| Available during AIT program.|
+|**REST API URL**| https://fullnode.mainnet.aptoslabs.com/v1 |https://fullnode.devnet.aptoslabs.com/v1 | https://fullnode.testnet.aptoslabs.com/v1 | Available during AIT program. |
 |**Genesis blob and Waypoint**| In the `mainnet` directory on https://github.com/aptos-labs/aptos-genesis-waypoint |In the `devnet` directory on https://github.com/aptos-labs/aptos-genesis-waypoint  | In the `testnet` directory on https://github.com/aptos-labs/aptos-genesis-waypoint | Available during AIT program. |
 |**Faucet**| No Faucet |https://faucet.devnet.aptoslabs.com/ | https://faucet.testnet.aptoslabs.com/ |Available during AIT program.|
+|**Epoch**| 3600 seconds (set by governance) |--- | --- |Available during AIT program.|
 |**Network runs where**| Validators, validator fullnodes and public fullnodes are run by you (i.e., the Aptos community) and Aptos Labs. |Validators run on Aptos Labs servers. Fullnodes are run by both Aptos Labs and you (i.e., the Aptos community).|Validators run on Aptos Labs servers. Fullnodes are run by both Aptos Labs and you (i.e., the Aptos community). | Some Validators run on Aptos servers, others are run by the Aptos community. Fullnodes are run by Aptos Labs and the community.|
 |**Who is responsible for the network**| Fully decentralized. |Managed by Aptos Team. | Managed by Aptos Team. | Managed by Aptos Labs and the community.|
 |**Update release cadence**| Every month. |Every week. |Every 2 weeks. | Managed by Aptos Labs and the community.|

--- a/developer-docs-site/docs/nodes/leaderboard-metrics.md
+++ b/developer-docs-site/docs/nodes/leaderboard-metrics.md
@@ -7,15 +7,14 @@ slug: "leaderboard-metrics"
 
 This document explains how the rewards for validator are evaluated and displayed on the [Aptos Validator Status](https://aptoslabs.com/leaderboard/it3) page. 
 
-## How are rewards calculated
+## How rewards are calculated
 
 :::tip Staking documentation
 For a backgrounder on staking with explanations of epoch, rewards and how to join and leave validator set, see the [Staking](/concepts/staking.md). 
 :::
 
-- For the Aptos network deployments, the various epoch durations are as follows:
-  - <TBD: ADD VALUES or LINK to the table>.
 - An epoch starts with a finalized validator set. During the epoch, only validators in this validator set will vote. 
+- Epoch value on the mainnet is set by the governance. See [Aptos Blockchain Deployments](/nodes/aptos-deployments.md) for epoch values for other Aptos networks.
 - During the epoch, following the process described in [Validation on the Aptos blockchain](/concepts/staking#validation-on-the-aptos-blockchain), a validator is selected as a leader to make a proposal. Because the validator set is unchanged during the course of an epoch, this will result in a validator being selected multiple times as a leader in an epoch.
 -  On successful proposals, i.e., proposals achieving the quorum consensus, the leaders earn rewards based on their stake and on the reward rate that is configured on-chain. The reward rate is the same for every validator.
 -  If all the proposals in an epoch achieve quorum consensus, a validator earns the maximum reward for the epoch. **Rewards are given only to the leader validators, and not to the voters.**

--- a/developer-docs-site/docs/nodes/validator-node/operator/node-requirements.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/node-requirements.md
@@ -9,17 +9,15 @@ To make your validator node and validator fullnode deployment hassle-free, make 
 
 ## Validator and validator fullnode
 
-- For the Aptos mainnet, we require that you run a validator node and a validator fullnode. We strongly recommend that you run the validator node and the validator fullnode on two separate and independent machines. Make sure that these machines are well-provisioned and isolated from each other. Guaranteeing the resource isolation between the validator and the validator fullnode will help ensure smooth deployment of these nodes.
-- We recommend that optionally you run a public fullnode also. However, a public fullnode is not required. If you run public fullnode also, then we strongly recommend that you run the public fullnode on a third machine that is separate and independent from either the validator or the validator fullnode machines. 
-- For best availability and stability, **we recommend that you deploy your nodes on the cloud**. For deploying the nodes in cloud we have provided Terraform support on two cloud providers: GCP and AWS. See [**Running Validator Node**](running-validator-node/index.md).
-- Make sure that you open the network ports prior to connecting to the network. See [Ports](#ports).
-- Make sure that you close these ports after either being accepted or rejected for the network.
+- **Both a validator node and a validator fullnode required:** For the Aptos mainnet, we require that you run a validator node and a validator fullnode. We strongly recommend that you run the validator node and the validator fullnode on two separate and independent machines. Make sure that these machines are well-provisioned and isolated from each other. Guaranteeing the resource isolation between the validator and the validator fullnode will help ensure smooth deployment of these nodes.
+- **Public fullnode is optional:** We recommend that optionally you run a public fullnode also. However, a public fullnode is not required. If you run public fullnode also, then we strongly recommend that you run the public fullnode on a third machine that is separate and independent from either the validator or the validator fullnode machines. 
+- **Cloud is preferred:** For best availability and stability, **we recommend that you deploy your nodes on the cloud**. 
+:::tip Terraform support
+For deploying the nodes in cloud we have provided Terraform support on two cloud providers: **GCP** and **AWS**. See [**Running Validator Node**](running-validator-node/index.md).
+:::
 
-## Nodes in test mode
-
-You must run the validator node and the validator fullnode in the test mode to be eligible for mainnet or testnet. This is a method Aptos Labs uses to verify that a node operator can successfully start a validator node and validator fullnode and configure them properly with the Aptos network identity. 
-
-In test mode, you will be running a local network with one single validator node and one single validator fullnode, and they both should be functioning like a normal blockchain.
+- **Open the network ports:** Make sure that you open the network ports prior to connecting to the network. See [Ports](#ports).
+- **Close the network ports:** Make sure that you close these ports after either being accepted or rejected for the network.
 
 ## Hardware requirements
 
@@ -35,24 +33,24 @@ For running an Aptos **validator node and validator fullnode** we recommend the 
 
 ### Example machine types on various clouds
 
-- AWS
+- **AWS**
     - c6id.8xlarge (if use local SSD)
     - c6i.8xlarge + io1/io2 EBS volume with 40K IOPS.
-- GCP
+- **GCP**
     - n2-standard-16 (if use local SSD)
     - n2-standard-30 + pd-ssd with 40K IOPS.
 
-### Implications on hardware requirements
+### Motivations for hardware requirements
 
-The amount of data stored by the Aptos blockchain depends on the ledger history (the number of transactions) of the blockchain and the number of on-chain states (e.g., accounts and resources). These values depend on several factors, including: the age of the blockchain, the average transaction rate, and the configuration of the ledger pruner.
+Hardware requirements depend on the transaction rate and storage demands. The amount of data stored by the Aptos blockchain depends on the ledger history (the number of transactions) of the blockchain and the number of on-chain states (e.g., accounts and resources). Ledger history and the number of on-chain states depend on several factors: the age of the blockchain, the average transaction rate, and the configuration of the ledger pruner.
 
-Hardware requirements depend on the transaction rate and storage demands. Over time, hardware requirements will need to scale with these demands. The current hardware requirements are set with the consideration of estimated growth over the next 6 months.
+The current hardware requirements are set considering the estimated growth over the period ending in Q1-2023.
 
 **Local SSD vs. network storage**
 
-Cloud deployments typically must make a decision between using local or network storage (for example, AWS EBS, GCP PD). Local SSD typically provides lower latency and cost, especially relative to IOPS. 
+Cloud deployments require choosing between using local or network storage such as AWS EBS, GCP PD. Local SSD provides lower latency and cost, especially relative to IOPS. 
 
-Network storage usually requires additional CPU support to scale IOPS. However, network storage provides better support for backup snapshots and provide resilience for then nodes in scenarios where the instance is stopped. Network storage makes it easier to support storage needs for high availability.
+On the one hand, network storage requires additional CPU support to scale IOPS, but on the other hand, the network storage provides better support for backup snapshots and provide resilience for the nodes in scenarios where the instance is stopped. Network storage makes it easier to support storage needs for high availability.
 
 ## Ports
 
@@ -70,12 +68,14 @@ You can configure the port settings on your node using the configuration YAML fi
 
 For the validator:
 
-- Open the TCP port 6180, for the Validators to talk to each other.
-- Open the TCP port 9101, for getting the Validator metrics to validate the health stats (only needed during registration stage).
+- Open the TCP port 6180, to enable the validators to talk to each other.
+- Open the TCP port 9101, to send the validator metrics to validate the health stats.
+- Make sure to keep the TCP port 6186 open for the local backup storage service. 
 
 For the public fullnode:
 
-- Open the TCP port 6182, for fullnodes to talk to each other.
-- Open the TCP port 9101, for getting the fullnode metrics to validate the health stats (only needed during registration stage).
+- Open the TCP port 6182, to enable the fullnodes to talk to each other.
+- Open the TCP port 9101, to send the fullnode metrics to validate the health stats (only needed during registration stage).
 - Open the TCP port 80/8080, for the REST API access.
+- Make sure to keep the TCP port 6186 open for the local backup storage service. 
 

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
@@ -26,40 +26,40 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
 
 1. Create a working directory for your node configuration.
 
-    * Choose a workspace name, for example, `mainnet` for mainnet or `testnet` for testnet, and so on. **Note**: This defines the Terraform workspace name, which, in turn, is used to form the resource names.
+    * Choose a workspace name, for example, `mainnet` for mainnet, or `testnet` for testnet, and so on. **Note**: This defines the Terraform workspace name, which, in turn, is used to form the resource names.
 
-      ```
+      ```bash
       export WORKSPACE=mainnet
       ```
 
     * Create a directory for the workspace.
 
-      ```
+      ```bash
       mkdir -p ~/$WORKSPACE
       ```
     
     * Choose a username for your node, for example `alice`.
 
-      ```
+      ```bash
       export USERNAME=alice
       ```
 
 2. Create an S3 storage bucket for storing the Terraform state on AWS. You can do this on the AWS UI or by the below command: 
 
-      ```
+      ```bash
       aws s3 mb s3://<bucket name> --region <region name>
       ```
 
 3. Create a Terraform file called `main.tf` in your working directory:
 
-    ```
+    ```bash
     cd ~/$WORKSPACE
     vi main.tf
     ```
 
 4. Modify the `main.tf` file to configure Terraform and to create Aptos fullnode from the Terraform module. See below example content for `main.tf`:
 
-    ```
+    ```json
     terraform {
       required_version = "~> 1.2.0"
       backend "s3" {
@@ -91,14 +91,14 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
 
 5. Initialize Terraform in the `$WORKSPACE` directory where you created the `main.tf` file.
 
-  ```
+  ```bash
   terraform init
   ```
 This will download all the Terraform dependencies into the `.terraform` folder in your current working directory.
 
 6. Create a new Terraform workspace to isolate your environments:
 
-  ```
+  ```bash
   terraform workspace new $WORKSPACE
   # This command will list all workspaces
   terraform workspace list
@@ -106,7 +106,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 
 7. Apply the configuration.
 
-  ```
+  ```bash
   terraform apply
   ```
 
@@ -120,7 +120,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 
 9. Get your node IP information into your environment:
 
-    ```
+    ```bash
     export VALIDATOR_ADDRESS="$(kubectl get svc ${WORKSPACE}-aptos-node-0-validator-lb --output jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
 
     export FULLNODE_ADDRESS="$(kubectl get svc ${WORKSPACE}-aptos-node-0-fullnode-lb --output jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
@@ -128,7 +128,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 
 10. Generate the key pairs (node owner, voter, operator key, consensus key and networking key) in your working directory.
 
-    ```
+    ```bash
     aptos genesis generate-keys --output-dir ~/$WORKSPACE/keys
     ```
 
@@ -145,7 +145,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 
 11. Configure the validator information. 
 
-    ```
+    ```bash
     aptos genesis set-validator-configuration \
       --local-repository-dir ~/$WORKSPACE \
       --username $USERNAME \
@@ -176,7 +176,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 
 14. Insert `genesis.blob`, `waypoint.txt` and the identity files as secret into k8s cluster.
 
-    ```
+    ```bash
     kubectl create secret generic ${WORKSPACE}-aptos-node-0-genesis-e1 \
         --from-file=genesis.blob=genesis.blob \
         --from-file=waypoint.txt=waypoint.txt \
@@ -193,7 +193,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 
 15. Check that all the pods are running.
 
-    ```
+    ```bash
     kubectl get pods
 
     NAME                                        READY   STATUS    RESTARTS   AGE
@@ -202,4 +202,4 @@ This will download all the Terraform dependencies into the `.terraform` folder i
     node1-aptos-node-0-validator-0                1/1     Running   0          4h30m
     ```
 
-Now you have successfully completed setting up your node.
+Now you have successfully completed setting up your node. Make sure that you have set up one machine to run a validator node and a second machine to run a validator fullnode.

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
@@ -59,7 +59,7 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
 
 4. Modify the `main.tf` file to configure Terraform and to create Aptos fullnode from the Terraform module. See below example content for `main.tf`:
 
-    ```json
+    ```
     terraform {
       required_version = "~> 1.2.0"
       backend "s3" {

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-aws.md
@@ -5,7 +5,7 @@ slug: "run-validator-node-using-aws"
 
 # On AWS
 
-This is a step-by-step guide to install an Aptos node on AWS. These steps will configure a validator node and a fullnode on separate machines. 
+This is a step-by-step guide to install an Aptos node on AWS. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
 ## Before you proceed
 
@@ -13,24 +13,23 @@ Make sure you complete these prerequisite steps before you proceed:
 
 1. Set up your AWS account. 
 2. Make sure the following are installed on your local computer:
-
-   * **Aptos CLI 0.3.1**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
-   * **Terraform 1.2.4**: https://www.terraform.io/downloads.html
-   * **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/
-   * **AWS CLI**: https://aws.amazon.com/cli/
+   - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
+   - **Terraform 1.2.4**: https://www.terraform.io/downloads.html
+   - **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/
+   - **AWS CLI**: https://aws.amazon.com/cli/
 
 ## Install
 
 :::tip One validator node + one validator fullnode
-When you follow all the below instructions, you will run one validator node and one validator fullnode in the cluster. 
+Follow the below instructions **twice**, i.e., first on one machine to run a validator node and the second time on another machine to run a validator fullnode. 
 :::
 
 1. Create a working directory for your node configuration.
 
-    * Choose a workspace name, for example, `testnet`. **Note**: This defines the Terraform workspace name, which, in turn, is used to form the resource names.
+    * Choose a workspace name, for example, `mainnet` for mainnet or `testnet` for testnet, and so on. **Note**: This defines the Terraform workspace name, which, in turn, is used to form the resource names.
 
       ```
-      export WORKSPACE=testnet
+      export WORKSPACE=mainnet
       ```
 
     * Create a directory for the workspace.
@@ -76,13 +75,13 @@ When you follow all the below instructions, you will run one validator node and 
 
     module "aptos-node" {
       # Download Terraform module from aptos-labs/aptos-core repo
-      source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/aws?ref=testnet"
+      source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/aws?ref=mainnet"
       region        = <aws region>  # Specify the region
       # zone_id     = "<Route53 zone id>"  # zone id for Route53 if you want to use DNS
       era           = 1              # bump era number to wipe the chain
       chain_id      = 43
-      image_tag     = "testnet" # Specify the image tag to use
-      validator_name = "<Name of your Validator>"
+      image_tag     = "mainnet" # Specify the image tag to use
+      validator_name = "<Name of your validator>"
     }
     ```
 
@@ -139,12 +138,12 @@ This will download all the Terraform dependencies into the `.terraform` folder i
       - `validator-identity.yaml`, and
       - `validator-full-node-identity.yaml`.
       
-      :::caution IMPORTANT
+      :::danger IMPORTANT
 
-       Backup your private key files somewhere safe. These key files are important for you to establish ownership of your node. **Never share private keys with anyone.**
+       Backup your `private-keys.yaml` somewhere safe. These keys are important for you to establish ownership of your node. **Never share private keys with anyone.**
       :::
 
-11. Configure the Validator information. This is all the information you need to register on Aptos community website later.
+11. Configure the validator information. 
 
     ```
     aptos genesis set-validator-configuration \
@@ -159,28 +158,21 @@ This will download all the Terraform dependencies into the `.terraform` folder i
 
     This will create two YAML files in the `~/$WORKSPACE/$USERNAME` directory: `owner.yaml` and `operator.yaml`. 
 
-12. Download the genesis blob and waypoint for the network you want to connect to, you can find a full list of networks [here](https://github.com/aptos-labs/aptos-genesis-waypoint)
-
-  For example, to download testnet genesis and waypoint:
-
-  ```
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/waypoint.txt -o waypoint.txt
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/genesis.blob -o genesis.blob
-  ```
+12. Download the genesis blob and waypoint for the network you want to connect to. See [Node Files](/nodes/node-files.md) for a full list of files you should download and the download commands. 
 
 
-13. To summarize, in your working directory you should have a list of files:
+13. **Summary:** To summarize, in your working directory you should have a list of files:
     - `main.tf`: The Terraform files to install the `aptos-node` module (from steps 3 and 4).
-    - `keys` folder, which includes:
+    - `keys` folder containing:
       - `public-keys.yaml`: Public keys for the owner account, consensus, networking (from step 10).
       - `private-keys.yaml`: Private keys for the owner account, consensus, networking (from step 10).
       - `validator-identity.yaml`: Private keys for setting the Validator identity (from step 10).
       - `validator-full-node-identity.yaml`: Private keys for setting validator full node identity (from step 10).
-    - `username` folder, which includes: 
-      - `owner.yaml`: define owner, operator, and voter mapping. They are all the same account in test mode (from step 11).
-      - `operator.yaml`: Node information that will be used for both the Validator and the fullnode (from step 11). 
+    - `username` folder containing: 
+      - `owner.yaml`: Defines owner, operator, and voter mapping. 
+      - `operator.yaml`: Node information that will be used for both the validator and the validator fullnode (from step 11). 
     - `waypoint.txt`: The waypoint for the genesis transaction (from step 12).
-    - `genesis.blob` The genesis binary that contains all the information about the framework, validatorSet and more (from step 12).
+    - `genesis.blob` The genesis binary that contains all the information about the framework, validator set, and more (from step 12).
 
 14. Insert `genesis.blob`, `waypoint.txt` and the identity files as secret into k8s cluster.
 
@@ -192,7 +184,7 @@ This will download all the Terraform dependencies into the `.terraform` folder i
         --from-file=validator-full-node-identity.yaml=keys/validator-full-node-identity.yaml
     ```
 
-    :::note
+    :::tip
     
     The `-e1` suffix refers to the era number. If you changed the era number, make sure it matches when creating the secret.
 

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
@@ -3,58 +3,66 @@ title: "On Azure"
 slug: "run-validator-node-using-azure"
 ---
 
-## Run on Azure
+# On Azure
 
-This guide assumes you already have Azure account setup.
+This is a step-by-step guide to install an Aptos node on AWS. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
-Install prerequisites if needed:
+:::danger Did you set up your Azure account?
+This guide assumes that you already have Azure account setup.
+:::
 
-   * Aptos CLI 0.3.1: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
-   * Terraform 1.2.4: https://www.terraform.io/downloads.html
-   * Kubernetes CLI: https://kubernetes.io/docs/tasks/tools/
-   * Azure CLI: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+## Before you proceed
+
+Make sure you complete these prerequisite steps before you proceed:
+
+- **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
+- **Terraform 1.2.4**: https://www.terraform.io/downloads.html
+- **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/
+- **Azure CLI**: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli
+
+## Install
 
 :::tip One validator node + one validator fullnode
-When you follow all the below instructions, you will run one validator node and one validator fullnode in the cluster. 
+Follow the below instructions **twice**, i.e., first on one machine to run a validator node and the second time on another machine to run a validator fullnode. 
 :::
 
 1. Create a working directory for your configuration.
 
-    * Choose a workspace name e.g. `testnet`. Note: This defines Terraform workspace name, which in turn is used to form resource names.
+    * Choose a workspace name, for example, `mainnet` for mainnet, or `testnet` for testnet, and so on. **Note**: This defines the Terraform workspace name, which, in turn, is used to form the resource names.
 
-      ```
-      export WORKSPACE=testnet
+      ```bash
+      export WORKSPACE=mainnet
       ```
 
     * Create a directory for the workspace.
       
-      ```
+      ```bash
       mkdir -p ~/$WORKSPACE
       ```
     
     * Choose a username for your node, for example `alice`.
 
-      ```
+      ```bash
       export USERNAME=alice
       ```
 
 2. Create a blob storage container for storing the Terraform state on Azure, you can do this on Azure UI or by the command: 
 
-    ```
+    ```bash
     az group create -l <azure region> -n aptos-$WORKSPACE
     az storage account create -n <storage account name> -g aptos-$WORKSPACE -l <azure region> --sku Standard_LRS
     az storage container create -n <container name> --account-name <storage account name> --resource-group aptos-$WORKSPACE
     ```
 
 3. Create Terraform file called `main.tf` in your working directory:
-  ```
+  ```bash
   cd ~/$WORKSPACE
   vi main.tf
   ```
 
 4. Modify `main.tf` file to configure Terraform, and create fullnode from Terraform module. Example content for `main.tf`:
 
-  ```
+  ```json
   terraform {
     required_version = "~> 1.2.0"
     backend "azurerm" {
@@ -66,32 +74,32 @@ When you follow all the below instructions, you will run one validator node and 
   }
   module "aptos-node" {
     # download Terraform module from aptos-labs/aptos-core repo
-    source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/azure?ref=testnet"
+    source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/azure?ref=mainnet"
     region        = <azure region>  # Specify the region
     era           = 1              # bump era number to wipe the chain
     chain_id      = 43
-    image_tag     = "testnet" # Specify the docker image tag to use
-    validator_name = "<Name of Your Validator>"
+    image_tag     = "mainnet" # Specify the docker image tag to use
+    validator_name = "<Name of your validator>"
   }
   ```
 
     For the full customization options, see the variables file [here](https://github.com/aptos-labs/aptos-core/blob/main/terraform/aptos-node/azure/variables.tf), and the [Helm values](https://github.com/aptos-labs/aptos-core/blob/main/terraform/helm/aptos-node/values.yaml).
 
 5. Initialize Terraform in the same directory of your `main.tf` file.
-  ```
+  ```bash
   terraform init
   ```
-This will download all the terraform dependencies for you, in the `.terraform` folder in your current working directory.
+This will download all the Terraform dependencies for you, in the `.terraform` folder in your current working directory.
 
 6. Create a new Terraform workspace to isolate your environments:
-  ```
+  ```bash
   terraform workspace new $WORKSPACE
   # This command will list all workspaces
   terraform workspace list
   ```
 
 7. Apply the configuration.
-  ```
+  ```bash
   terraform apply
   ```
   This might take a while to finish (~20 minutes), Terraform will create all the resources on your cloud account.
@@ -104,7 +112,7 @@ This will download all the terraform dependencies for you, in the `.terraform` f
 
 9. Get your node IP info:
 
-    ```
+    ```bash
     export VALIDATOR_ADDRESS="$(kubectl get svc ${WORKSPACE}-aptos-node-0-validator-lb --output jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
 
     export FULLNODE_ADDRESS="$(kubectl get svc ${WORKSPACE}-aptos-node-0-fullnode-lb --output jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
@@ -112,7 +120,7 @@ This will download all the terraform dependencies for you, in the `.terraform` f
 
 10. Generate the key pairs (node owner, voter, operator key, consensus key and networking key) in your working directory.
 
-    ```
+    ```bash
     aptos genesis generate-keys --output-dir ~/$WORKSPACE/keys
     ```
 
@@ -122,14 +130,14 @@ This will download all the terraform dependencies for you, in the `.terraform` f
       - `validator-identity.yaml`, and
       - `validator-full-node-identity.yaml`.
       
-      :::caution IMPORTANT
+      :::danger IMPORTANT
 
-       Backup your private key files somewhere safe. These key files are important for you to establish ownership of your node. **Never share private keys with anyone.**
+       Backup your `private-keys.yaml` somewhere safe. These keys are important for you to establish ownership of your node. **Never share private keys with anyone.**
       :::
 
-11. Configure the Validator information. This is all the information you need to register on Aptos community website later.
+11. Configure the validator information.
 
-    ```
+    ```bash
     aptos genesis set-validator-configuration \
       --local-repository-dir ~/$WORKSPACE \
       --username $USERNAME \
@@ -142,31 +150,24 @@ This will download all the terraform dependencies for you, in the `.terraform` f
 
     This will create two YAML files in the `~/$WORKSPACE/$USERNAME` directory: `owner.yaml` and `operator.yaml`. 
 
-12. Download the genesis blob and waypoint for the network you want to connect to, you can find a full list of networks [here](https://github.com/aptos-labs/aptos-genesis-waypoint)
+12. Download the genesis blob and waypoint for the network you want to connect to. See [Node Files](/nodes/node-files.md) for a full list of files you should download and the download commands. 
 
-  For example, to download testnet genesis and waypoint:
-
-  ```
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/waypoint.txt -o waypoint.txt
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/genesis.blob -o genesis.blob
-  ```
-
-13. To summarize, in your working directory you should have a list of files:
+13. **Summary:** To summarize, in your working directory you should have a list of files:
     - `main.tf`: The Terraform files to install the `aptos-node` module (from steps 3 and 4).
-    - `keys` folder, which includes:
+    - `keys` folder containing:
       - `public-keys.yaml`: Public keys for the owner account, consensus, networking (from step 10).
       - `private-keys.yaml`: Private keys for the owner account, consensus, networking (from step 10).
       - `validator-identity.yaml`: Private keys for setting the Validator identity (from step 10).
       - `validator-full-node-identity.yaml`: Private keys for setting validator full node identity (from step 10).
-    - `username` folder, which includes: 
-      - `owner.yaml`: define owner, operator, and voter mapping. They are all the same account in test mode (from step 11).
+    - `username` folder containing: 
+      - `owner.yaml`: Defines owner, operator, and voter mapping. They are all the same account in test mode (from step 11).
       - `operator.yaml`: Node information that will be used for both the Validator and the fullnode (from step 11). 
     - `waypoint.txt`: The waypoint for the genesis transaction (from step 12).
     - `genesis.blob` The genesis binary that contains all the information about the framework, validatorSet and more (from step 12).
 
 14. Insert `genesis.blob`, `waypoint.txt` and the identity files as secret into k8s cluster.
 
-    ```
+    ```bash
     kubectl create secret generic ${WORKSPACE}-aptos-node-0-genesis-e1 \
         --from-file=genesis.blob=genesis.blob \
         --from-file=waypoint.txt=waypoint.txt \
@@ -174,15 +175,15 @@ This will download all the terraform dependencies for you, in the `.terraform` f
         --from-file=validator-full-node-identity.yaml=keys/validator-full-node-identity.yaml
     ```
   
-    :::note
+    :::tip
     
     The `-e1` suffix refers to the era number. If you changed the era number, make sure it matches when creating the secret.
 
     :::
 
-15. Check all pods running.
+15. Check that all pods are running.
 
-    ```
+    ```bash
     kubectl get pods
 
     NAME                                        READY   STATUS    RESTARTS   AGE
@@ -191,4 +192,4 @@ This will download all the terraform dependencies for you, in the `.terraform` f
     node1-aptos-node-0-validator-0                1/1     Running   0          4h30m
     ```
 
-Now you have successfully completed setting up your node.
+Now you have successfully completed setting up your node. Make sure that you have set up one machine to run a validator node and a second machine to run a validator fullnode.

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-azure.md
@@ -62,7 +62,7 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
 
 4. Modify `main.tf` file to configure Terraform, and create fullnode from Terraform module. Example content for `main.tf`:
 
-  ```json
+  ```
   terraform {
     required_version = "~> 1.2.0"
     backend "azurerm" {

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-docker.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-docker.md
@@ -5,37 +5,33 @@ slug: "run-validator-node-using-docker"
 
 # Using Docker
 
-:::tip For validator fullnode
-Use the `fullnode.yaml` to run a validator fullnode. See [Step 11](#docker-vfn).
-:::
+This is a step-by-step guide to install an Aptos node using Docker. Follow these steps to configure a validator node and a validator fullnode on separate machines. Use the `fullnode.yaml` to run a validator fullnode. See [Step 11](#docker-vfn).
 
-1. Install Docker and Docker-Compose, [Aptos CLI 0.3.1](https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli).
+## Before you proceed
+
+Make sure the following are installed on your local computer:
+   - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
+   - **Docker and Docker-compose:** https://docs.docker.com/engine/install/
 
 :::caution Note on Apple M1
 
-Docker has only been tested on Linux, Windows, and Intel macOS. If you are on M1 macOS, use the Aptos-core source approach.
+Docker method has only been tested on Linux, Windows, and Intel macOS. If you are on M1 macOS, use the [Aptos-core source approach](/nodes/validator-node/operator/running-validator-node/run-validator-node-using-source).
 
 :::
 
-2. Create a directory for your Aptos node composition, and pick a username for your node. e.g.
-    ```
-    export WORKSPACE=testnet
+1. Create a directory for your Aptos node composition, and pick a username for your node. e.g.
+    ```bash
+    export WORKSPACE=mainnet
     export USERNAME=alice
     mkdir ~/$WORKSPACE
     cd ~/$WORKSPACE
     ```
 
-3. Download the validator.yaml, docker-compose.yaml, haproxy.cfg, and blocked.ips configuration files into this directory.
-    ```
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/docker-compose.yaml
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/validator.yaml
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/haproxy.cfg
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/blocked.ips
-    ```
+2. Download the validator.yaml, docker-compose.yaml and blocked.ips configuration files into this directory. See [Node Files](/nodes/node-files.md) for a full list of files you should download and the download commands.  
 
-4. Generate the key pairs (node owner, voter, operator key, consensus key and networking key) in your working directory.
+3. Generate the key pairs (node owner, voter, operator key, consensus key and networking key) in your working directory.
 
-    ```
+    ```bash
     aptos genesis generate-keys --output-dir ~/$WORKSPACE/keys
     ```
 
@@ -45,22 +41,14 @@ Docker has only been tested on Linux, Windows, and Intel macOS. If you are on M1
       - `validator-identity.yaml`, and
       - `validator-full-node-identity.yaml`.
       
-      :::caution IMPORTANT
+      :::danger IMPORTANT
 
-       Backup your private key files somewhere safe. These key files are important for you to establish ownership of your node. **Never share private keys with anyone.**
+       Backup your `private-keys.yaml` somewhere safe. These keys are important for you to establish ownership of your node. **Never share private keys with anyone.**
       :::
 
-5. Configure validator information. You need to setup a static IP / DNS address (DNS is much preferred) which can be used by the node, and make sure the network / firewalls are properly configured to accept external connections. See [Network Identity For Fullnode](/docs/nodes/full-node/network-identity-fullnode.md) for how to do this. 
+4. Configure validator information. You need to setup a static IP / DNS address (DNS is much preferred) which can be used by the node, and make sure the network / firewalls are properly configured to accept external connections. See [Network Identity For Fullnode](/docs/nodes/full-node/network-identity-fullnode.md) for how to do this. 
 
-    You will need this information to register on Aptos community website later.
-
-    :::tip
-
-    The `--full-node-host` flag is optional.
-
-    :::
-
-    ```
+    ```bash
     cd ~/$WORKSPACE
     aptos genesis set-validator-configuration \
         --local-repository-dir ~/$WORKSPACE \
@@ -93,47 +81,34 @@ Docker has only been tested on Linux, Windows, and Intel macOS. If you are on M1
 
     This will create two YAML files in the `~/$WORKSPACE/$USERNAME` directory: `owner.yaml` and `operator.yaml`. 
 
-6. Download the genesis blob and waypoint for the network you want to connect to, you can find a full list of networks [here](https://github.com/aptos-labs/aptos-genesis-waypoint)
+5. Download the genesis blob and waypoint for the network you want to connect to. See [Node Files](/nodes/node-files.md) for a full list of files you should download and the download commands. 
 
-  For example, to download testnet genesis and waypoint:
-
-  ```
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/waypoint.txt -o waypoint.txt
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/genesis.blob -o genesis.blob
-  ```
-
-7. <span id="docker-files">To recap, in your working directory, you should have a list of files:</span>
+6. <span id="docker-files">To recap, in your working directory, you should have a list of files:</span>
 
     - `docker-compose.yaml` docker compose file to run validator and fullnode
-    - `keys` folder, which includes:
+    - `keys` folder containing:
       - `public-keys.yaml`: Public keys for the owner account, consensus, networking (from step 4).
       - `private-keys.yaml`: Private keys for the owner account, consensus, networking (from step 4).
       - `validator-identity.yaml`: Private keys for setting the Validator identity (from step 4).
       - `validator-full-node-identity.yaml`: Private keys for setting validator full node identity (from step 4).
-    - `username` folder, which includes: 
+    - `username` folder containing: 
       - `owner.yaml`: define owner, operator, and voter mapping. They are all the same account in test mode (from step 5).
       - `operator.yaml`: Node information that will be used for both the Validator and the fullnode (from step 5). 
     - `waypoint.txt`: The waypoint for the genesis transaction (from step 6).
     - `genesis.blob` The genesis binary that contains all the information about the framework, validatorSet and more (from step 6).
 
-8. Run docker-compose: `docker-compose up`. (or `docker compose up` depends on your version)
+7. Run docker-compose: `docker-compose up`. (or `docker compose up` depends on your version)
 
-Now you have completed setting up your validator node. Additionally, you can also setup a validator fullnode following the instructions below.
+**Now you have completed setting up your validator node. Next, setup a validator fullnode following the instructions below.**
 
-9. <span id="docker-vfn">Now let's setup fullnode on a different machine. Download the `fullnode.yaml` and `docker-compose-fullnode.yaml` configuration files into the working directory of fullnode machine.</span>
-
-    ```
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/docker-compose-fullnode.yaml
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/fullnode.yaml
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/haproxy.cfg
-    wget https://raw.githubusercontent.com/aptos-labs/aptos-core/main/docker/compose/aptos-node/blocked.ips
-    ```
+9. <span id="docker-vfn">Set up a validator fullnode on a different machine. Download the `fullnode.yaml` and `docker-compose-fullnode.yaml` configuration files into the working directory of fullnode machine.</span> See [Node Files](/nodes/node-files.md) for a full list of files you should download and the download commands. 
 
 10.  Edit `fullnode.yaml` file to update the IP address for validator node.
 
 11.  Copy the `validator-full-node-identity.yaml`, download `genesis.blob` and `waypoint.txt` files into the same working directory on fullnode machine.
 
 12.  Run docker-compose: `docker-compose -f docker-compose-fullnode.yaml up`.
+
 Now you have successfully completed setting up your node.
 
-13. Optional: if you need to block an ip address simply add it to the bottom of blocked.ips and reload haproxy
+<!-- 1.  Optional: if you need to block an ip address simply add it to the bottom of blocked.ips and reload haproxy -->

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
@@ -3,62 +3,62 @@ title: "On GCP"
 slug: "run-validator-node-using-gcp"
 ---
 
-# Run on GCP
+# On GCP
 
-:::tip Set up GCP account and create a project
+This is a step-by-step guide to install an Aptos node on Google GCP. Follow these steps to configure a validator node and a validator fullnode on separate machines. 
 
+:::danger Did you set up your GCP account and created a project?
 This guide assumes you already have GCP account setup, and have created a new project for deploying Aptos node. If you are not familiar with GCP (Google Cloud Platform), checkout this [Prerequisites section](https://aptos.dev/tutorials/run-a-fullnode-on-gcp#prerequisites) for GCP account setup.
 :::
 
-:::tip IMPORTANT: Before you proceed
+## Before you proceed
 
-Install the below pre-requisites if have not done so:
+Make sure the following are installed on your local computer:
+  - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
+  - **Terraform 1.2.4**: https://www.terraform.io/downloads.html
+  - **Kubernetes CLI**: https://kubernetes.io/docs/tasks/tools/
+  - **Google Cloud CLI**: https://cloud.google.com/sdk/docs/install-sdk
 
-   * Aptos CLI 0.3.1: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
-   * Terraform 1.2.4: https://www.terraform.io/downloads.html
-   * Kubernetes CLI: https://kubernetes.io/docs/tasks/tools/
-   * Google Cloud CLI: https://cloud.google.com/sdk/docs/install-sdk
-
-:::
+## Install
 
 :::tip One validator node + one validator fullnode
-When you follow all the below instructions, you will run one validator node and one validator fullnode in the cluster. 
+Follow the below instructions **twice**, i.e., first on one machine to run a validator node and the second time on another machine to run a validator fullnode. 
 :::
 
 1. Create a working directory for your configuration.
 
-    * Choose a workspace name e.g. `testnet`. Note: this defines Terraform workspace name, which in turn is used to form resource names.
-    ```
-    export WORKSPACE=testnet
-    ```
+    * Choose a workspace name, for example, `mainnet` for mainnet, or `testnet` for testnet, and so on. **Note**: This defines the Terraform workspace name, which, in turn, is used to form the resource names.
+      ```bash
+      export WORKSPACE=mainnet
+      ```
 
     * Create a directory for the workspace
-    ```
-    mkdir -p ~/$WORKSPACE
-    ```
+      ```bash
+      mkdir -p ~/$WORKSPACE
+      ```
 
     * Choose a username for your node, for example `alice`.
 
-      ```
+      ```bash
       export USERNAME=alice
       ```
 
-2. Create a storage bucket for storing the Terraform state on Google Cloud Storage.  Use the GCP UI or Google Cloud Storage command to create the bucket.  The name of the bucket must be unique.  See the Google Cloud Storage documentation here: https://cloud.google.com/storage/docs/creating-buckets#prereq-cli
+2. Create a storage bucket for storing the Terraform state on Google Cloud Storage.  Use the GCP UI or Google Cloud Storage command to create the bucket.  The name of the bucket must be unique. See the Google Cloud Storage documentation here: https://cloud.google.com/storage/docs/creating-buckets#prereq-cli.
 
-  ```
+  ```bash
   gsutil mb gs://BUCKET_NAME
   # for example
   gsutil mb gs://<project-name>-aptos-terraform-dev
   ```
 
 3. Create Terraform file called `main.tf` in your working directory:
-  ```
+  ```bash
   cd ~/$WORKSPACE
   touch main.tf
   ```
 
 4. Modify `main.tf` file to configure Terraform, and create fullnode from Terraform module. Example content for `main.tf`:
-  ```
+  ```json
   terraform {
     required_version = "~> 1.2.0"
     backend "gcs" {
@@ -69,27 +69,27 @@ When you follow all the below instructions, you will run one validator node and 
 
   module "aptos-node" {
     # download Terraform module from aptos-labs/aptos-core repo
-    source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/gcp?ref=testnet"
+    source        = "github.com/aptos-labs/aptos-core.git//terraform/aptos-node/gcp?ref=mainnet"
     region        = "us-central1"  # Specify the region
     zone          = "c"            # Specify the zone suffix
     project       = "<GCP Project ID>" # Specify your GCP project ID
     era           = 1              # bump era number to wipe the chain
     chain_id      = 43
-    image_tag     = "testnet" # Specify the docker image tag to use
-    validator_name = "<Name of Your Validator, no space, e.g. aptosbot>"
+    image_tag     = "mainnet" # Specify the docker image tag to use
+    validator_name = "<Name of your validator, no space, e.g. aptosbot>"
   }
   ```
 
   For the full customization options, see the variables file [here](https://github.com/aptos-labs/aptos-core/blob/main/terraform/aptos-node/gcp/variables.tf), and the [helm values](https://github.com/aptos-labs/aptos-core/blob/main/terraform/helm/aptos-node/values.yaml).
 
 5. Initialize Terraform in the same directory of your `main.tf` file
-  ```
+  ```bash
   terraform init
   ```
 This will download all the Terraform dependencies for you, in the `.terraform` folder in your current working directory.
 
 6. Create a new Terraform workspace to isolate your environments:
-  ```
+  ```bash
   terraform workspace new $WORKSPACE
   # This command will list all workspaces
   terraform workspace list
@@ -97,7 +97,7 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
 
 7. Apply the configuration.
 
-  ```
+  ```bash
   terraform apply
   ```
 
@@ -111,7 +111,7 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
 
 9. Get your node IP info:
 
-    ```
+    ```bash
     export VALIDATOR_ADDRESS="$(kubectl get svc ${WORKSPACE}-aptos-node-0-validator-lb --output jsonpath='{.status.loadBalancer.ingress[0].ip}')"
 
     export FULLNODE_ADDRESS="$(kubectl get svc ${WORKSPACE}-aptos-node-0-fullnode-lb --output jsonpath='{.status.loadBalancer.ingress[0].ip}')"
@@ -119,7 +119,7 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
 
 10. Generate the key pairs (node owner, voter, operator key, consensus key and networking key) in your working directory.
 
-    ```
+    ```bash
     aptos genesis generate-keys --output-dir ~/$WORKSPACE/keys
     ```
 
@@ -129,14 +129,14 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
       - `validator-identity.yaml`, and
       - `validator-full-node-identity.yaml`.
       
-      :::caution IMPORTANT
+      :::danger IMPORTANT
 
-       Backup your private key files somewhere safe. These key files are important for you to establish ownership of your node. **Never share private keys with anyone.**
+       Backup your `private-keys.yaml` somewhere safe. These keys are important for you to establish ownership of your node. **Never share private keys with anyone.**
       :::
 
-11. Configure the Validator information. This is all the information you need to register on Aptos community website later.
+11. Configure the validator information. 
 
-    ```
+    ```bash
     aptos genesis set-validator-configuration \
       --local-repository-dir ~/$WORKSPACE \
       --username $USERNAME \
@@ -149,14 +149,7 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
 
     This will create two YAML files in the `~/$WORKSPACE/$USERNAME` directory: `owner.yaml` and `operator.yaml`. 
 
-12. Download the genesis blob and waypoint for the network you want to connect to, you can find a full list of networks [here](https://github.com/aptos-labs/aptos-genesis-waypoint)
-
-  For example, to download testnet genesis and waypoint:
-
-  ```
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/waypoint.txt -o waypoint.txt
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/genesis.blob -o genesis.blob
-  ```
+12. Download the genesis blob and waypoint for the network you want to connect to. See [Node Files](/nodes/node-files.md) for a full list of files you should download and the download commands. 
 
 13. To summarize, in your working directory you should have a list of files:
     - `main.tf`: The Terraform files to install the `aptos-node` module (from steps 3 and 4).
@@ -173,7 +166,7 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
 
 14. Insert `genesis.blob`, `waypoint.txt` and the identity files as secret into k8s cluster.
 
-    ```
+    ```bash
     kubectl create secret generic ${WORKSPACE}-aptos-node-0-genesis-e1 \
         --from-file=genesis.blob=genesis.blob \
         --from-file=waypoint.txt=waypoint.txt \
@@ -181,15 +174,15 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
         --from-file=validator-full-node-identity.yaml=keys/validator-full-node-identity.yaml
     ```
 
-    :::note
+    :::tip
     
     The `-e1` suffix refers to the era number. If you changed the era number, make sure it matches when creating the secret.
 
     :::
 
-15. Check all pods running.
+15. Check that all pods are running.
 
-    ```
+    ```bash
     kubectl get pods
 
     NAME                                        READY   STATUS    RESTARTS   AGE
@@ -198,4 +191,4 @@ This will download all the Terraform dependencies for you, in the `.terraform` f
     node1-aptos-node-0-validator-0                1/1     Running   0          4h30m
     ```
 
-Now you have successfully completed setting up your node.
+Now you have successfully completed setting up your node. Make sure that you have set up one machine to run a validator node and a second machine to run a validator fullnode.

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-gcp.md
@@ -58,7 +58,7 @@ Follow the below instructions **twice**, i.e., first on one machine to run a val
   ```
 
 4. Modify `main.tf` file to configure Terraform, and create fullnode from Terraform module. Example content for `main.tf`:
-  ```json
+  ```
   terraform {
     required_version = "~> 1.2.0"
     backend "gcs" {

--- a/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-source-code.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/running-validator-node/using-source-code.md
@@ -5,54 +5,57 @@ slug: "run-validator-node-using-source"
 
 # Using Aptos-core source code
 
-:::tip For validator fullnode
-Use the `fullnode.yaml` to run a validator fullnode. See [Step 13](#source-code-vfn).
+This is a step-by-step guide to install an Aptos node using source code. Follow these steps to configure a validator node and a validator fullnode on separate machines. Use the `fullnode.yaml` to run a validator fullnode&mdash;see Step 12.
+
+## Before you proceed
+
+Make sure the following are installed on your local computer:
+   - **Aptos CLI**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
+
+## Install
+
+:::tip One validator node + one validator fullnode
+Follow the below instructions **twice**, i.e., first on one machine to run a validator node and the second time on another machine to run a validator fullnode. 
 :::
 
 1. Clone the Aptos repo.
 
-      ```
+      ```bash
       git clone https://github.com/aptos-labs/aptos-core.git
       ```
 
 2. `cd` into `aptos-core` directory.
 
-    ```
+    ```bash
     cd aptos-core
     ```
 
 3. Run the `scripts/dev_setup.sh` Bash script as shown below. This will prepare your developer environment.
 
-    ```
+    ```bash
     ./scripts/dev_setup.sh
     ```
 
 4. Update your current shell environment.
 
-    ```
+    ```bash
     source ~/.cargo/env
     ```
 
 With your development environment ready, now you can start to setup your validator node.
 
-5. Checkout the `testnet` branch using `git checkout --track origin/testnet`.
+5. Checkout the `mainnet` branch using `git checkout --track origin/mainnet`.
 
 6. Create a directory for your Aptos node composition, and pick a username for your node. e.g.
-    ```
-    export WORKSPACE=testnet
+    ```bash
+    export WORKSPACE=mainnet
     export USERNAME=alice
     mkdir ~/$WORKSPACE
     ```
 
-:::tip Install Aptos CLI
-
-Before proceeding further, install **Aptos CLI 0.3.1**: https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli 
-
-:::
-
 7. Generate the key pairs (node owner, voter, operator key, consensus key and networking key) in your working directory.
 
-    ```
+    ```bash
     aptos genesis generate-keys --output-dir ~/$WORKSPACE/keys
     ```
 
@@ -62,22 +65,14 @@ Before proceeding further, install **Aptos CLI 0.3.1**: https://aptos.dev/cli-to
       - `validator-identity.yaml`, and
       - `validator-full-node-identity.yaml`.
       
-      :::caution IMPORTANT
+      :::danger IMPORTANT
 
-       Backup your private key files somewhere safe. These key files are important for you to establish ownership of your node. **Never share private keys with anyone.**
+       Backup your `private-keys.yaml` somewhere safe. These keys are important for you to establish ownership of your node. **Never share private keys with anyone.**
       :::
 
 8. Configure validator information. You need to setup a static IP / DNS address (DNS is much preferred) which can be used by the node, and make sure the network / firewalls are properly configured to accept external connections.
 
-    You will need this information to register on Aptos community website later.
-
-    :::tip
-
-    The `--full-node-host` flag is optional.
-
-    :::
-
-    ```
+    ```bash
     cd ~/$WORKSPACE
     aptos genesis set-validator-configuration \
         --local-repository-dir ~/$WORKSPACE \
@@ -110,50 +105,42 @@ Before proceeding further, install **Aptos CLI 0.3.1**: https://aptos.dev/cli-to
 
     This will create two YAML files in the `~/$WORKSPACE/$USERNAME` directory: `owner.yaml` and `operator.yaml`. 
 
-9. Download the genesis blob and waypoint for the network you want to connect to, you can find a full list of networks [here](https://github.com/aptos-labs/aptos-genesis-waypoint)
-
-  For example, to download testnet genesis and waypoint:
-
-  ```
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/waypoint.txt -o waypoint.txt
-  curl https://raw.githubusercontent.com/aptos-labs/aptos-genesis-waypoint/main/testnet/genesis.blob -o genesis.blob
-  ```
+9. Download the genesis blob and waypoint for the network you want to connect to. See [Node Files](/nodes/node-files.md) for a full list of files you should download and the download commands. 
 
 10. Copy the `validator.yaml`, `fullnode.yaml` files into this directory.
-    ```
+    ```bash
     mkdir ~/$WORKSPACE/config
     cp docker/compose/aptos-node/validator.yaml ~/$WORKSPACE/config/validator.yaml
     cp docker/compose/aptos-node/fullnode.yaml ~/$WORKSPACE/config/fullnode.yaml
     ```
 
-    Modify the config files to update the data directory, key path, genesis file path, waypoint path.
-    User must have write access to data directory.
+    Modify the config files to update the data directory, key path, genesis file path, waypoint path. User must have write access to data directory.
 
 11. <span id="source-code-vfn">To recap, in your working directory (`~/$WORKSPACE`), you should have a list of files:</span>
 
-    - `config` folder, which includes:
+    - `config` folder containing:
       - `validator.yaml` validator config file
       - `fullnode.yaml` fullnode config file
-    - `keys` folder, which includes:
+    - `keys` folder containing:
       - `public-keys.yaml`: Public keys for the owner account, consensus, networking (from step 7).
       - `private-keys.yaml`: Private keys for the owner account, consensus, networking (from step 7).
       - `validator-identity.yaml`: Private keys for setting the Validator identity (from step 7).
       - `validator-full-node-identity.yaml`: Private keys for setting validator full node identity (from step 7).
-    - `username` folder, which includes: 
-      - `owner.yaml`: define owner, operator, and voter mapping. They are all the same account in test mode (from step 8).
+    - `username` folder containing: 
+      - `owner.yaml`: Define owner, operator, and voter mapping. They are all the same account in test mode (from step 8).
       - `operator.yaml`: Node information that will be used for both the Validator and the fullnode (from step 8). 
     - `waypoint.txt`: The waypoint for the genesis transaction (from step 9).
     - `genesis.blob` The genesis binary that contains all the information about the framework, validatorSet and more (from step 9).
 
-12. Start your local Validator by running the below command:
+12. Start your validator by running the below command:
 
-    ```
+    ```bash
     cargo run -p aptos-node --release -- -f ~/$WORKSPACE/config/validator.yaml
     ```
 
-    Run fullnode in **another machine**:
+    Run validator fullnode on **another machine**:
 
-    ```
+    ```bash
     cargo run -p aptos-node --release -- -f ~/$WORKSPACE/config/fullnode.yaml
     ```
 


### PR DESCRIPTION
This PR makes the following changes:
@sherry-x: 
- Removes test mode section from node requirements doc.
- Generalizes all validator deploy instructions to mainnet.
- Makes explicit that the use should run the validator deploy instructions twice, one for validator node on one machine and second time on another machine for the validator fullnode.
- Removes version number for CLI mentions.
- Links to the new Nodes List doc in steps to download files.
-  Added epoch row to the deployments table.
- General clean up.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4905)
<!-- Reviewable:end -->
