### PR TITLE
[Indexer] Add aptos coin supply

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -148,6 +148,7 @@ impl<'a, R: MoveResolverExt + ?Sized> MoveConverter<'a, R> {
                 .filter_map(|(sk, wo)| self.try_into_write_set_change(sk, wo).ok())
                 .collect(),
             block_height: None,
+            epoch: None,
         }
     }
 

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -330,6 +330,10 @@ pub struct TransactionInfo {
     #[oai(skip)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub block_height: Option<U64>,
+    /// Epoch of the transaction belongs in, this field will not be present through the API
+    #[oai(skip)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub epoch: Option<U64>,
 }
 
 /// A transaction waiting in mempool

--- a/crates/aptos-faucet/src/main.rs
+++ b/crates/aptos-faucet/src/main.rs
@@ -164,6 +164,7 @@ mod tests {
                     accumulator_root_hash: HashValue::zero().into(),
                     changes: vec![],
                     block_height: None,
+                    epoch: None,
                 };
                 let serializable_txn: aptos_rest_client::aptos_api_types::Transaction = (
                     txn.as_signed_user_txn().unwrap(),

--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -26,7 +26,7 @@ When developing your own, ensure each `TransactionProcessor` is idempotent, and 
 4. `/opt/homebrew/bin/createuser -s postgres`
 5. Ensure you're able to do: `psql postgres`
 6. `cargo install diesel_cli --no-default-features --features postgres`
-7. In this folder, run `diesel migration run --database-url postgresql://localhost/postgres`
+7. Make sure that you're in the indexer folder (run `cd crates/indexer` from base directory), run `diesel migration run --database-url postgresql://localhost/postgres`
    a. If for some reason this database is already being used, try a different db. e.g.
       `DATABASE_URL=postgres://postgres@localhost:5432/indexer_v2 diesel database reset`
 
@@ -40,7 +40,11 @@ cargo run --bin aptos-node --features "indexer"  -- --config <some_path>/fullnod
    * Example fullnode.yaml modification
       ```
       storage:
-         enable_indexer: true
+      enable_indexer: true
+      # This is to avoid the node being pruned
+      storage_pruner_config:
+         ledger_pruner_config:
+            enable: false
 
       indexer:
          enabled: true

--- a/crates/indexer/migrations/2022-10-07-231825_add_coin_supply/down.sql
+++ b/crates/indexer/migrations/2022-10-07-231825_add_coin_supply/down.sql
@@ -1,0 +1,12 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS coin_supply;
+DROP INDEX IF EXISTS cs_ct_tv_index;
+DROP INDEX IF EXISTS cs_epoch_index;
+ALTER TABLE coin_infos DROP COLUMN IF EXISTS supply_aggregator_table_handle,
+  DROP COLUMN IF EXISTS supply_aggregator_table_key;
+ALTER TABLE token_datas DROP COLUMN IF EXISTS description;
+ALTER TABLE current_token_datas DROP COLUMN IF EXISTS description;
+ALTER TABLE user_transactions DROP COLUMN IF EXISTS epoch;
+ALTER TABLE transactions DROP COLUMN IF EXISTS epoch;
+DROP INDEX IF EXISTS ut_epoch_index;
+DROP INDEX IF EXISTS txn_epoch_index;

--- a/crates/indexer/migrations/2022-10-07-231825_add_coin_supply/up.sql
+++ b/crates/indexer/migrations/2022-10-07-231825_add_coin_supply/up.sql
@@ -1,0 +1,33 @@
+-- Your SQL goes here
+-- coin supply, currently aptos coin only
+CREATE TABLE coin_supply (
+  transaction_version BIGINT NOT NULL,
+  -- Hash of the non-truncated coin type
+  coin_type_hash VARCHAR(64) NOT NULL,
+  coin_type VARCHAR(5000) NOT NULL,
+  supply NUMERIC NOT NULL,
+  transaction_timestamp TIMESTAMP NOT NULL,
+  transaction_epoch BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (transaction_version, coin_type_hash)
+);
+CREATE INDEX cs_ct_tv_index on coin_supply (coin_type, transaction_version desc);
+CREATE INDEX cs_epoch_index on coin_supply (transaction_epoch);
+-- Add coin supply aggregator handle to coin infos to be able to access total supply data
+ALTER TABLE coin_infos
+ADD COLUMN supply_aggregator_table_handle VARCHAR(66),
+  ADD COLUMN supply_aggregator_table_key TEXT;
+-- Add description to token_datas and current_token_datas
+ALTER TABLE token_datas
+ADD COLUMN description TEXT NOT NULL;
+ALTER TABLE current_token_datas
+ADD COLUMN description TEXT NOT NULL;
+-- Add epoch to user transactions and transactions
+ALTER TABLE user_transactions
+ADD COLUMN epoch BIGINT NOT NULL;
+ALTER TABLE transactions
+ADD COLUMN epoch BIGINT NOT NULL;
+-- Create index on epoch for easy queries
+CREATE INDEX ut_epoch_index ON user_transactions (epoch);
+CREATE INDEX txn_epoch_index ON transactions (epoch);

--- a/crates/indexer/src/indexer/fetcher.rs
+++ b/crates/indexer/src/indexer/fetcher.rs
@@ -243,6 +243,8 @@ async fn fetch_nexts(
             )
         });
     let mut timestamp = block_event.proposed_time();
+    let mut epoch = block_event.epoch();
+    let mut epoch_bcs = aptos_api_types::U64::from(epoch);
     let mut block_height = block_event.height();
     let mut block_height_bcs = aptos_api_types::U64::from(block_height);
 
@@ -259,6 +261,8 @@ async fn fetch_nexts(
                 if let aptos_types::transaction::Transaction::BlockMetadata(ref txn) = t.transaction
                 {
                     timestamp = txn.timestamp_usecs();
+                    epoch = txn.epoch();
+                    epoch_bcs = aptos_api_types::U64::from(epoch);
                     block_height += 1;
                     block_height_bcs = aptos_api_types::U64::from(block_height);
                 }
@@ -271,16 +275,20 @@ async fn fetch_nexts(
                             unreachable!("Indexer should never see pending transactions")
                         }
                         Transaction::UserTransaction(ref mut ut) => {
-                            ut.info.block_height = Some(block_height_bcs)
+                            ut.info.block_height = Some(block_height_bcs);
+                            ut.info.epoch = Some(epoch_bcs);
                         }
                         Transaction::GenesisTransaction(ref mut gt) => {
-                            gt.info.block_height = Some(block_height_bcs)
+                            gt.info.block_height = Some(block_height_bcs);
+                            gt.info.epoch = Some(epoch_bcs);
                         }
                         Transaction::BlockMetadataTransaction(ref mut bmt) => {
-                            bmt.info.block_height = Some(block_height_bcs)
+                            bmt.info.block_height = Some(block_height_bcs);
+                            bmt.info.epoch = Some(epoch_bcs);
                         }
                         Transaction::StateCheckpointTransaction(ref mut sct) => {
-                            sct.info.block_height = Some(block_height_bcs)
+                            sct.info.block_height = Some(block_height_bcs);
+                            sct.info.epoch = Some(epoch_bcs);
                         }
                     };
                     txn

--- a/crates/indexer/src/indexer/tailer.rs
+++ b/crates/indexer/src/indexer/tailer.rs
@@ -368,6 +368,7 @@ mod test {
                "event_root_hash":"0xcbdbb1b830d1016d45a828bb3171ea81826e8315f14140acfbd7886f49fbcb40",
                "gas_used":"0",
                "block_height":"0",
+               "epoch":"0",
                "success":true,
                "vm_status":"Executed successfully",
                "accumulator_root_hash":"0x6a527d06063dfd42c6b3a862574d5f3ec1660afb8058135edda5072712bfdb51",
@@ -567,7 +568,7 @@ mod test {
             .unwrap();
 
         // A block_metadata_transaction
-        let block_metadata_transaction: Transaction = serde_json::from_value(json!(
+        let mut block_metadata_transaction: Transaction = serde_json::from_value(json!(
             {
               "type": "block_metadata_transaction",
               "version": "69158",
@@ -643,6 +644,10 @@ mod test {
               ]
             }
         )).unwrap();
+        // This is needed because deserializer only parses epoch once so info.epoch is always None
+        if let Transaction::BlockMetadataTransaction(ref mut bmt) = block_metadata_transaction {
+            bmt.info.epoch = Some(aptos_api_types::U64::from(1));
+        }
 
         tailer
             .processor
@@ -674,6 +679,7 @@ mod test {
               "type": "user_transaction",
               "version": "691595",
               "block_height": "100",
+              "epoch":"1",
               "hash": "0xefd4c865e00c240da0c426a37ceeda10d9b030d0e8a4fb4fb7ff452ad63401fb",
               "state_change_hash": "0xebfe1eb7aa5321e7a7d741d927487163c34c821eaab60646ae0efd02b286c97c",
               "event_root_hash": "0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",
@@ -799,6 +805,7 @@ mod test {
               "type": "user_transaction",
               "version": "260885",
               "block_height": "100",
+              "epoch":"3",
               "hash": "0xb8bbd3936b05e3643f4b4f910bb00c9b6fa817c1935c74b9a16b5b7a2c8a69a3",
               "state_change_hash": "0xde91b595abbeef217fb0be956df0909c1459ba8d82ed12b983e226ecbf0a4ec5",
               "event_root_hash": "0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",

--- a/crates/indexer/src/models/coin_models/coin_supply.rs
+++ b/crates/indexer/src/models/coin_models/coin_supply.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+#![allow(clippy::unused_unit)]
+
+use super::coin_infos::CoinInfoQuery;
+use crate::schema::coin_supply;
+use anyhow::Context;
+use aptos_api_types::WriteTableItem as APIWriteTableItem;
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, coin_type_hash))]
+#[diesel(table_name = coin_supply)]
+pub struct CoinSupply {
+    pub transaction_version: i64,
+    pub coin_type_hash: String,
+    pub coin_type: String,
+    pub supply: BigDecimal,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+    pub transaction_epoch: i64,
+}
+
+impl CoinSupply {
+    /// Currently only supports aptos_coin. Aggregator table detail is in CoinInfo which for aptos coin appears during genesis.
+    /// We query for the aggregator table details (handle and key) once upon indexer initiation and use it to fetch supply.
+    pub fn from_write_table_item(
+        write_table_item: &APIWriteTableItem,
+        maybe_aptos_coin_info: &Option<CoinInfoQuery>,
+        txn_version: i64,
+        txn_timestamp: chrono::NaiveDateTime,
+        txn_epoch: i64,
+    ) -> anyhow::Result<Option<Self>> {
+        if let Some(aptos_coin_info) = maybe_aptos_coin_info {
+            // Return early if we don't have the aptos aggregator table info
+            if aptos_coin_info.supply_aggregator_table_key.is_none()
+                || aptos_coin_info.supply_aggregator_table_handle.is_none()
+            {
+                return Ok(None);
+            }
+            if let Some(data) = &write_table_item.data {
+                // Return early if not aggregator table type
+                if !(data.key_type == "address" && data.value_type == "u128") {
+                    return Ok(None);
+                }
+                // Return early if not aggregator table handle
+                if &write_table_item.handle.to_string()
+                    != aptos_coin_info
+                        .supply_aggregator_table_handle
+                        .as_ref()
+                        .unwrap()
+                {
+                    return Ok(None);
+                }
+                // Return early if not aptos coin aggregator key
+                let table_key = data
+                    .key
+                    .as_str()
+                    .context(format!("key is not a string: {:?}", data.key))?;
+                if table_key
+                    != aptos_coin_info
+                        .supply_aggregator_table_key
+                        .as_ref()
+                        .unwrap()
+                {
+                    return Ok(None);
+                }
+                // Everything matches. Get the coin supply
+                let supply = data
+                    .value
+                    .as_str()
+                    .map(|s| s.parse::<BigDecimal>())
+                    .context(format!(
+                        "value is not a string: {:?}, table_item {:?}, version {}",
+                        data.value, write_table_item, txn_version
+                    ))?
+                    .context(format!(
+                        "cannot parse string as u128: {:?}, version {}",
+                        data.value, txn_version
+                    ))?;
+                return Ok(Some(Self {
+                    transaction_version: txn_version,
+                    coin_type_hash: aptos_coin_info.coin_type_hash.clone(),
+                    coin_type: aptos_coin_info.coin_type.clone(),
+                    supply,
+                    transaction_timestamp: txn_timestamp,
+                    transaction_epoch: txn_epoch,
+                }));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/crates/indexer/src/models/coin_models/coin_utils.rs
+++ b/crates/indexer/src/models/coin_models/coin_utils.rs
@@ -4,7 +4,6 @@
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]
 
-use super::coin_infos::CoinSupplyLookup;
 use crate::{
     models::move_resources::MoveResource,
     util::{hash_str, truncate_str},
@@ -36,14 +35,10 @@ impl CoinInfoResource {
         truncate_str(&self.symbol, 10)
     }
 
-    /// In case we do want to track supply
-    pub fn _get_supply(&self, supply_lookup: &CoinSupplyLookup) -> Option<BigDecimal> {
+    /// Getting the table item location of the supply aggregator
+    pub fn get_aggregator_metadata(&self) -> Option<AggregatorResource> {
         if let Some(inner) = self.supply.vec.get(0) {
-            let mut maybe_supply = inner.integer._get_supply();
-            if maybe_supply.is_none() {
-                maybe_supply = inner.aggregator._get_supply(supply_lookup);
-            }
-            maybe_supply
+            inner.aggregator.get_aggregator_metadata()
         } else {
             None
         }
@@ -68,14 +63,8 @@ pub struct AggregatorWrapperResource {
 
 impl AggregatorWrapperResource {
     /// In case we do want to track supply
-    pub fn _get_supply(&self, supply_lookup: &CoinSupplyLookup) -> Option<BigDecimal> {
-        if let Some(aggregator) = self.vec.get(0) {
-            let table_handle = aggregator.handle.clone();
-            let table_key = aggregator.key.clone();
-            supply_lookup.get(&(table_handle, table_key)).cloned()
-        } else {
-            None
-        }
+    pub fn get_aggregator_metadata(&self) -> Option<AggregatorResource> {
+        self.vec.get(0).cloned()
     }
 }
 

--- a/crates/indexer/src/models/coin_models/mod.rs
+++ b/crates/indexer/src/models/coin_models/mod.rs
@@ -4,4 +4,5 @@
 pub mod coin_activities;
 pub mod coin_balances;
 pub mod coin_infos;
+pub mod coin_supply;
 mod coin_utils;

--- a/crates/indexer/src/models/token_models/token_datas.rs
+++ b/crates/indexer/src/models/token_models/token_datas.rs
@@ -36,6 +36,7 @@ pub struct TokenData {
     pub default_properties: serde_json::Value,
     pub collection_data_id_hash: String,
     pub transaction_timestamp: chrono::NaiveDateTime,
+    pub description: String,
 }
 
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
@@ -62,6 +63,7 @@ pub struct CurrentTokenData {
     pub last_transaction_version: i64,
     pub collection_data_id_hash: String,
     pub last_transaction_timestamp: chrono::NaiveDateTime,
+    pub description: String,
 }
 
 impl TokenData {
@@ -125,6 +127,7 @@ impl TokenData {
                         royalty_mutable: token_data.mutability_config.royalty,
                         default_properties: token_data.default_properties.clone(),
                         transaction_timestamp: txn_timestamp,
+                        description: token_data.description.clone(),
                     },
                     CurrentTokenData {
                         collection_data_id_hash,
@@ -147,6 +150,7 @@ impl TokenData {
                         default_properties: token_data.default_properties,
                         last_transaction_version: txn_version,
                         last_transaction_timestamp: txn_timestamp,
+                        description: token_data.description,
                     },
                 )));
             } else {

--- a/crates/indexer/src/models/user_transactions.rs
+++ b/crates/indexer/src/models/user_transactions.rs
@@ -35,6 +35,7 @@ pub struct UserTransaction {
     pub gas_unit_price: BigDecimal,
     pub timestamp: chrono::NaiveDateTime,
     pub entry_function_id_str: String,
+    pub epoch: i64,
 }
 
 /// Need a separate struct for queryable because we don't want to define the inserted_at column (letting DB fill)
@@ -54,10 +55,15 @@ pub struct UserTransactionQuery {
     pub timestamp: chrono::NaiveDateTime,
     pub entry_function_id_str: String,
     pub inserted_at: chrono::NaiveDateTime,
+    pub epoch: i64,
 }
 
 impl UserTransaction {
-    pub fn from_transaction(txn: &APIUserTransaction, block_height: i64) -> (Self, Vec<Signature>) {
+    pub fn from_transaction(
+        txn: &APIUserTransaction,
+        block_height: i64,
+        epoch: i64,
+    ) -> (Self, Vec<Signature>) {
         let version = txn.info.version.0 as i64;
         (
             Self {
@@ -84,6 +90,7 @@ impl UserTransaction {
                     }
                     _ => String::default(),
                 },
+                epoch,
             },
             txn.request
                 .signature

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -117,7 +117,8 @@ fn insert_transactions(
             diesel::insert_into(schema::transactions::table)
                 .values(&txns[start_ind..end_ind])
                 .on_conflict(version)
-                .do_nothing(),
+                .do_update()
+                .set((epoch.eq(excluded(epoch)),)),
             None,
         )?;
     }
@@ -148,18 +149,7 @@ fn insert_user_transactions_w_sigs(
                 .values(&all_user_transactions[start_ind..end_ind])
                 .on_conflict(ut_schema::version)
                 .do_update()
-                .set((
-                    ut_schema::block_height.eq(excluded(ut_schema::block_height)),
-                    ut_schema::parent_signature_type.eq(excluded(ut_schema::parent_signature_type)),
-                    ut_schema::sender.eq(excluded(ut_schema::sender)),
-                    ut_schema::sequence_number.eq(excluded(ut_schema::sequence_number)),
-                    ut_schema::max_gas_amount.eq(excluded(ut_schema::max_gas_amount)),
-                    ut_schema::expiration_timestamp_secs
-                        .eq(excluded(ut_schema::expiration_timestamp_secs)),
-                    ut_schema::gas_unit_price.eq(excluded(ut_schema::gas_unit_price)),
-                    ut_schema::timestamp.eq(excluded(ut_schema::timestamp)),
-                    ut_schema::entry_function_id_str.eq(excluded(ut_schema::entry_function_id_str)),
-                )),
+                .set((ut_schema::epoch.eq(excluded(ut_schema::epoch)),)),
             None,
         )?;
     }

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -175,8 +175,7 @@ fn insert_tokens(
             diesel::insert_into(schema::tokens::table)
                 .values(&tokens_to_insert[start_ind..end_ind])
                 .on_conflict((token_data_id_hash, property_version, transaction_version))
-                .do_update()
-                .set((collection_data_id_hash.eq(excluded(collection_data_id_hash)),)),
+                .do_nothing(),
             None,
         )?;
     }
@@ -204,11 +203,7 @@ fn insert_token_ownerships(
                     transaction_version,
                     table_handle,
                 ))
-                .do_update()
-                .set((
-                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
-                    table_type.eq(excluded(table_type)),
-                )),
+                .do_nothing(),
             None,
         )?;
     }
@@ -229,7 +224,7 @@ fn insert_token_datas(
                 .values(&token_datas_to_insert[start_ind..end_ind])
                 .on_conflict((token_data_id_hash, transaction_version))
                 .do_update()
-                .set((collection_data_id_hash.eq(excluded(collection_data_id_hash)),)),
+                .set((description.eq(excluded(description)),)),
             None,
         )?;
     }
@@ -252,8 +247,7 @@ fn insert_collection_datas(
             diesel::insert_into(schema::collection_datas::table)
                 .values(&collection_datas_to_insert[start_ind..end_ind])
                 .on_conflict((collection_data_id_hash, transaction_version))
-                .do_update()
-                .set((table_handle.eq(excluded(table_handle)),)),
+                .do_nothing(),
             None,
         )?;
     }
@@ -325,6 +319,7 @@ fn insert_current_token_datas(
                     default_properties.eq(excluded(default_properties)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
                     collection_data_id_hash.eq(excluded(collection_data_id_hash)),
+                    description.eq(excluded(description)),
                 )),
             Some(" WHERE current_token_datas.last_transaction_version <= excluded.last_transaction_version "),
         )?;

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -157,24 +157,22 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
         lookback_versions = lookback_versions,
         "Fetching starting version from db..."
     );
-    let starting_version_from_db = tailer
-        .get_start_version(&processor_name, lookback_versions)
-        .unwrap_or_else(|| {
-            info!(
-                processor_name = processor_name,
-                "Could not fetch version from db so starting from version 0"
-            );
-            0
-        }) as u64;
     let start_version = match config.starting_version {
-        None => starting_version_from_db,
+        None => tailer
+            .get_start_version(&processor_name, lookback_versions)
+            .unwrap_or_else(|| {
+                info!(
+                    processor_name = processor_name,
+                    "Could not fetch version from db so starting from version 0"
+                );
+                0
+            }) as u64,
         Some(version) => version,
     };
 
     info!(
         processor_name = processor_name,
-        final_start_version = start_version,
-        start_version_from_db = starting_version_from_db,
+        start_version = start_version,
         start_version_from_config = config.starting_version,
         "Setting starting version..."
     );

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -60,6 +60,20 @@ diesel::table! {
         decimals -> Int4,
         transaction_created_timestamp -> Timestamp,
         inserted_at -> Timestamp,
+        supply_aggregator_table_handle -> Nullable<Varchar>,
+        supply_aggregator_table_key -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    coin_supply (transaction_version, coin_type_hash) {
+        transaction_version -> Int8,
+        coin_type_hash -> Varchar,
+        coin_type -> Varchar,
+        supply -> Numeric,
+        transaction_timestamp -> Timestamp,
+        transaction_epoch -> Int8,
+        inserted_at -> Timestamp,
     }
 }
 
@@ -147,6 +161,7 @@ diesel::table! {
         inserted_at -> Timestamp,
         collection_data_id_hash -> Varchar,
         last_transaction_timestamp -> Timestamp,
+        description -> Text,
     }
 }
 
@@ -344,6 +359,7 @@ diesel::table! {
         inserted_at -> Timestamp,
         collection_data_id_hash -> Varchar,
         transaction_timestamp -> Timestamp,
+        description -> Text,
     }
 }
 
@@ -398,6 +414,7 @@ diesel::table! {
         num_events -> Int8,
         num_write_set_changes -> Int8,
         inserted_at -> Timestamp,
+        epoch -> Int8,
     }
 }
 
@@ -414,6 +431,7 @@ diesel::table! {
         timestamp -> Timestamp,
         entry_function_id_str -> Text,
         inserted_at -> Timestamp,
+        epoch -> Int8,
     }
 }
 
@@ -435,6 +453,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     coin_activities,
     coin_balances,
     coin_infos,
+    coin_supply,
     collection_datas,
     current_ans_lookup,
     current_coin_balances,


### PR DESCRIPTION
### Description
Track coin supply in indexer. To enable, we need to first process CoinInfo which contains the aggregator key and handle. 

### Test Plan
Ran locally against devnet.

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/11738325/194743427-5c785aab-b4f6-4369-930b-753709414d12.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4907)
<!-- Reviewable:end -->
