### PR TITLE
[draft][build] switch to lld on linux

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,3 +22,6 @@ xclippy = [
 
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld"]

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -642,6 +642,13 @@ function install_postgres {
   fi
 }
 
+function install_lld {
+  # Right now, only install lld for linux
+  if [[ "$(uname)" == "Linux" ]]; then
+    install_pkg lld "$PACKAGE_MANAGER"
+  fi
+}
+
 function welcome_message {
 cat <<EOF
 Welcome to Aptos!
@@ -664,6 +671,7 @@ Build tools (since -t or no option was provided):
   * libssl-dev
   * NodeJS / NPM
   * protoc (and related tools)
+  * lld (only for Linux)
 EOF
   fi
 
@@ -866,6 +874,8 @@ if [[ "$INSTALL_BUILD_TOOLS" == "true" ]]; then
 
   install_openssl_dev "$PACKAGE_MANAGER"
   install_pkg_config "$PACKAGE_MANAGER"
+
+  install_lld
 
   install_rustup "$BATCH_MODE"
   install_toolchain "$(cat ./rust-toolchain)"


### PR DESCRIPTION
`ld`, the default linker on Linux is slow and can consume a lot of memory (40-80 GB). This PR attempts to switch us over to `lld`, which runs faster and consumes much less memory.

Some benchmark results (from a VM running on my workstation):
- cargo build
  - ld: 2m 32s
  - lld: 1m 53s
  - mold: 1m 52s

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4908)
<!-- Reviewable:end -->
