### PR TITLE
fix: Typo in snippet

### DIFF
--- a/developer-docs-site/docs/guides/sign-a-transaction.md
+++ b/developer-docs-site/docs/guides/sign-a-transaction.md
@@ -85,7 +85,7 @@ An example of how BCS serializes a string is shown below:
 
 ```typescript
 // A string is serialized as: byte length + byte representation of the string. The byte length is required for deserialization. Without it, no way the deserializer knows how many bytes to deserialize.
-const bytes: Unint8Array = bcs_serialize_string("aptos");
+const bytes: Uint8Array = bcs_serialize_string("aptos");
 assert(bytes == [5, 0x61, 0x70, 0x74, 0x6f, 0x73]);
 ```
 


### PR DESCRIPTION
Fixed a typo in a code snippet from `Unint8Array` to `Uint8Array`.

### Description
Fixed a typo in the code snippet.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4909)
<!-- Reviewable:end -->
