### PR TITLE
[cli] Mulitple transfer example

### DIFF
--- a/aptos-move/move-examples/multiple_transfer/Move.toml
+++ b/aptos-move/move-examples/multiple_transfer/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "MultipleTransfer"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../framework/aptos-framework" }
+
+[addresses]
+transfer_account = "_"

--- a/aptos-move/move-examples/multiple_transfer/sources/multiple_transfer.move
+++ b/aptos-move/move-examples/multiple_transfer/sources/multiple_transfer.move
@@ -1,0 +1,32 @@
+module transfer_account::multiple_transfer {
+    use std::signer;
+    use std::vector;
+    use aptos_framework::coin;
+    use aptos_framework::aptos_account;
+    use aptos_framework::aptos_coin;
+
+    /// No addresses were provided
+    const ENO_ADDRESSES: u64 = 1;
+
+    /// Not enough funds to pay to all recipients
+    const ENOT_ENOUGH_FUNDS: u64 = 2;
+
+    /// Transfer to the list of addresses, using account transfer, and create the accounts
+    /// if they don't exist.  This gives an example of how to handle errors, as well as
+    /// handle iterating through a list of addresses.
+    public entry fun transfer(sender: &signer, addresses: vector<address>, amount: u64) {
+        let num_addresses = vector::length(&addresses);
+        assert!(num_addresses > 0, ENO_ADDRESSES);
+
+        let sender_address = signer::address_of(sender);
+        let total_balance = coin::balance<aptos_coin::AptosCoin>(sender_address);
+        assert!(total_balance > (num_addresses * amount), ENOT_ENOUGH_FUNDS);
+
+        let i = 0;
+        while (i < num_addresses) {
+            let receiver = vector::borrow(&addresses, i);
+            aptos_account::transfer(sender, *receiver, amount);
+            i = i + 1;
+        };
+    }
+}

--- a/aptos-move/move-examples/multiple_transfer/sources/multiple_transfer.move
+++ b/aptos-move/move-examples/multiple_transfer/sources/multiple_transfer.move
@@ -11,10 +11,13 @@ module transfer_account::multiple_transfer {
     /// Not enough funds to pay to all recipients
     const ENOT_ENOUGH_FUNDS: u64 = 2;
 
+    /// Address vector length and amount vector length are not the same
+    const ENO_ADDRESS_AMOUNT_MISMATCH: u64 = 3;
+
     /// Transfer to the list of addresses, using account transfer, and create the accounts
     /// if they don't exist.  This gives an example of how to handle errors, as well as
     /// handle iterating through a list of addresses.
-    public entry fun transfer(sender: &signer, addresses: vector<address>, amount: u64) {
+    public entry fun transfer_same_amount(sender: &signer, addresses: vector<address>, amount: u64) {
         let num_addresses = vector::length(&addresses);
         assert!(num_addresses > 0, ENO_ADDRESSES);
 
@@ -26,6 +29,24 @@ module transfer_account::multiple_transfer {
         while (i < num_addresses) {
             let receiver = vector::borrow(&addresses, i);
             aptos_account::transfer(sender, *receiver, amount);
+            i = i + 1;
+        };
+    }
+
+    /// Transfer to the list of addresses, using account transfer, and create the accounts
+    /// if they don't exist.  This gives an example of how to handle errors, as well as
+    /// handle iterating through a list of addresses and amounts
+    public entry fun transfer_different_amounts(sender: &signer, addresses: vector<address>, amounts: vector<u64>) {
+        let num_addresses = vector::length(&addresses);
+        let num_amounts = vector::length(&amounts);
+        assert!(num_addresses > 0, ENO_ADDRESSES);
+        assert!(num_amounts == num_addresses, ENO_ADDRESS_AMOUNT_MISMATCH);
+
+        let i = 0;
+        while (i < num_addresses) {
+            let receiver = vector::borrow(&addresses, i);
+            let amount = vector::borrow(&amounts, i);
+            aptos_account::transfer(sender, *receiver, *amount);
             i = i + 1;
         };
     }


### PR DESCRIPTION
### Description
An example to transfer the same amount to multiple accounts. Additionally, makes vector of address an input to the CLI

### Test Plan
https://explorer.aptoslabs.com/txn/0xd8101de3bd1db6c088cf856bd41d2d6ef078e38e635ce96f93fd7949490a8187
```
$ aptos move publish --package-dir /opt/git/aptos-core/aptos-move/move-examples/multiple_transfer --named-addresses transfer_account=default

package size 1556 bytes
Do you want to submit a transaction for a range of [138200 - 207300] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0xaa40840723189de37d5689b06a15af868c2748bccb39d930b0d6622e01a35405",
    "gas_used": 1382,
    "gas_unit_price": 100,
    "sender": "e42895bdea9ffef448368a95f51b4c883a8e025be3f8e7d08df39f46861a0dc5",
    "sequence_number": 0,
    "success": true,
    "timestamp_us": 1665386109175236,
    "version": 15908899,
    "vm_status": "Executed successfully"
  }
}
$ aptos move run --function-id default::multiple_transfer::transfer --args 'vector<address>:default,devnet,superuser' 'u64:50'
Do you want to submit a transaction for a range of [44200 - 66300] Octas at a gas unit price of 100 Octas? [yes/no] >
yes
{
  "Result": {
    "transaction_hash": "0xd8101de3bd1db6c088cf856bd41d2d6ef078e38e635ce96f93fd7949490a8187",
    "gas_used": 459,
    "gas_unit_price": 100,
    "sender": "e42895bdea9ffef448368a95f51b4c883a8e025be3f8e7d08df39f46861a0dc5",
    "sequence_number": 1,
    "success": true,
    "timestamp_us": 1665386119507198,
    "version": 15909133,
    "vm_status": "Executed successfully"
  }
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4916)
<!-- Reviewable:end -->
