### PR TITLE
added a function to return resource address from source and seeds

### DIFF
--- a/ecosystem/typescript/sdk/src/aptos_account.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.test.ts
@@ -72,5 +72,5 @@ test("Gets the resource account address", () => {
   const seedInHex = "3031" // hexadecimal form of "01" which is 3031
   const seed = new HexString(seedInHex).toUint8Array();
 
-  expect(AptosAccount.getResourceAccountAddress(sourceAddress, seed).hex()).toBe("0x915e47f986471a5faba9cb2f726611cd554344419ddd6d5b3e9f00bcafd30169");
+  expect(AptosAccount.getResourceAccountAddress(sourceAddress, seed).hex()).toBe("0x5b4901c8b6ba76078f6f0b6fbae3dd9ce200e400e9f90b10d284c46fc460f24f");
 })

--- a/ecosystem/typescript/sdk/src/aptos_account.test.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.test.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosAccount, AptosAccountObject } from "./aptos_account";
+import { HexString } from "./hex_string";
 
 const aptosAccountObject: AptosAccountObject = {
   address: "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",
@@ -65,3 +66,11 @@ test("Signs Strings", () => {
     "0xc5de9e40ac00b371cd83b1c197fa5b665b7449b33cd3cdd305bb78222e06a671a49625ab9aea8a039d4bb70e275768084d62b094bc1b31964f2357b7c1af7e0d",
   );
 });
+
+test("Gets the resource account address", () => {
+  const sourceAddress = "9db1d65a321e4a86f8098cb04e76fce098890b84211fa06d65f24dc644bf0fec";
+  const seedInHex = "3031" // hexadecimal form of "01" which is 3031
+  const seed = new HexString(seedInHex).toUint8Array();
+
+  expect(AptosAccount.getResourceAccountAddress(sourceAddress, seed).hex()).toBe("0x915e47f986471a5faba9cb2f726611cd554344419ddd6d5b3e9f00bcafd30169");
+})

--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -9,6 +9,8 @@ import { derivePath } from "./utils/hd-key";
 import { HexString, MaybeHexString } from "./hex_string";
 import * as Gen from "./generated/index";
 import { Memoize } from "./utils";
+import { bcsToBytes } from "./bcs/helper";
+import { AccountAddress } from "./aptos_types/account_address";
 
 export interface AptosAccountObject {
   address?: Gen.HexEncodedBytes;
@@ -137,6 +139,27 @@ export class AptosAccount {
     return this.signBuffer(toSign);
   }
 
+    /**
+   * Takes source address and seeds and returns the resource account address
+   * @param sourceAddress Address used to derive the resource account
+   * @param seed The seeds need to be in hexadecimal format
+   * @returns The resource account address
+   */
+
+     static getResourceAccountAddress(sourceAddress: MaybeHexString, seed: Uint8Array): HexString {
+      const source = bcsToBytes(AccountAddress.fromHex(sourceAddress));
+  
+      const originBytes = new Uint8Array(source.length + seed.length);
+  
+      originBytes.set(source);
+      originBytes.set(seed, source.length);
+  
+      const hash = sha3Hash.create();
+      hash.update(originBytes);
+  
+      return HexString.fromUint8Array(hash.digest());
+    }
+
   /**
    * Derives account address, public key and private key
    * @returns AptosAccountObject instance.
@@ -157,4 +180,6 @@ export class AptosAccount {
       privateKeyHex: HexString.fromUint8Array(this.signingKey.secretKey.slice(0, 32)).hex(),
     };
   }
+
+
 }

--- a/ecosystem/typescript/sdk/src/aptos_account.ts
+++ b/ecosystem/typescript/sdk/src/aptos_account.ts
@@ -149,10 +149,11 @@ export class AptosAccount {
      static getResourceAccountAddress(sourceAddress: MaybeHexString, seed: Uint8Array): HexString {
       const source = bcsToBytes(AccountAddress.fromHex(sourceAddress));
   
-      const originBytes = new Uint8Array(source.length + seed.length);
+      const originBytes = new Uint8Array(source.length + seed.length + 1);
   
       originBytes.set(source);
       originBytes.set(seed, source.length);
+      originBytes.set([255], source.length + seed.length);
   
       const hash = sha3Hash.create();
       hash.update(originBytes);


### PR DESCRIPTION
### Description
This PR is related to the issue [#3739](https://github.com/aptos-labs/aptos-core/issues/3739) created to add a function in TS SDK to fetch the resource account given that the source address and seeds are provided.
### Test Plan
I have added a function getResourceAccountAddress with 2 parameters sourceAddress and seeds which are used to derive the resource account. Since the resource account derivation is expensive on chain, we can use this method to derive if off chain and send it to the smart contract.
This is second PR i am opening, the last PR had some issues with package.json and yarn.lock. The old PR [#3822](https://github.com/aptos-labs/aptos-core/pull/3822) was closed. A test is also added to check the functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4918)
<!-- Reviewable:end -->
