### PR TITLE
[e2e tests] limit concurrency level for faster execution

### DIFF
--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -386,8 +386,11 @@ impl FakeExecutor {
         &self,
         txn_block: Vec<Transaction>,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
-        let (result, _) =
-            ParallelAptosVM::execute_block(txn_block, &self.data_store, num_cpus::get())?;
+        let (result, _) = ParallelAptosVM::execute_block(
+            txn_block,
+            &self.data_store,
+            usize::min(4, num_cpus::get()),
+        )?;
 
         Ok(result)
     }


### PR DESCRIPTION
The parallel executor uses busy loops for its workers, so we need to limit the concurrency level in tests or otherwise they would run for a really long time.

Update: it looks like we're saving about 7 minutes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4920)
<!-- Reviewable:end -->
