### PR TITLE
Fix link to TypeScript index from SDKs index

### DIFF
--- a/developer-docs-site/docs/sdks/index.md
+++ b/developer-docs-site/docs/sdks/index.md
@@ -10,6 +10,6 @@ Use these Aptos SDKs, in combination with the [Aptos CLI](/cli-tools/aptos-cli-t
 
 - ### [Python SDK](python-sdk.md)
 
-- ### [Typescript SDK](ts-sdk/index)
+- ### [Typescript SDK](ts-sdk/index.md)
 
 - ### [Rust SDK](rust-sdk.md)


### PR DESCRIPTION
### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4924)
<!-- Reviewable:end -->
