### PR TITLE
[aptos-move] renamed all `aptos_std::event` to `aptos_framework::event`

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/aptos_governance.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_governance.move
@@ -17,12 +17,12 @@ module aptos_framework::aptos_governance {
     use std::signer;
     use std::string::{Self, String, utf8};
 
-    use aptos_std::event::{Self, EventHandle};
     use aptos_std::simple_map::{Self, SimpleMap};
     use aptos_std::table::{Self, Table};
 
     use aptos_framework::account::{Self, SignerCapability, create_signer_with_capability};
     use aptos_framework::coin;
+    use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::governance_proposal::{Self, GovernanceProposal};
     use aptos_framework::reconfiguration;
     use aptos_framework::stake;

--- a/aptos-move/framework/aptos-framework/sources/block.move
+++ b/aptos-move/framework/aptos-framework/sources/block.move
@@ -3,9 +3,9 @@ module aptos_framework::block {
     use std::error;
     use std::vector;
     use std::option;
-    use aptos_std::event::{Self, EventHandle};
 
     use aptos_framework::account;
+    use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::reconfiguration;
     use aptos_framework::stake;
     use aptos_framework::state_storage;

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -6,9 +6,9 @@ module aptos_framework::coin {
     use std::signer;
 
     use aptos_framework::account;
+    use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::optional_aggregator::{Self, OptionalAggregator};
     use aptos_framework::system_addresses;
-    use aptos_std::event::{Self, EventHandle};
 
     use aptos_std::type_info;
 

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -2,10 +2,10 @@
 /// to synchronize configuration changes for the validators.
 module aptos_framework::reconfiguration {
     use std::error;
-    use aptos_std::event;
     use std::signer;
 
     use aptos_framework::account;
+    use aptos_framework::event;
     use aptos_framework::stake;
     use aptos_framework::system_addresses;
     use aptos_framework::timestamp;

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -24,11 +24,11 @@ module aptos_framework::stake {
     use std::signer;
     use std::vector;
     use aptos_std::bls12381;
-    use aptos_std::event::{Self, EventHandle};
     use aptos_std::math64::min;
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::account;
     use aptos_framework::coin::{Self, Coin, MintCapability};
+    use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::timestamp;
     use aptos_framework::system_addresses;
     use aptos_framework::staking_config::{Self, StakingConfig};

--- a/aptos-move/framework/aptos-framework/sources/staking_contract.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_contract.move
@@ -30,13 +30,13 @@ module aptos_framework::staking_contract {
     use std::signer;
     use std::vector;
 
-    use aptos_std::event::{EventHandle, emit_event};
     use aptos_std::pool_u64::{Self, Pool};
     use aptos_std::simple_map::{Self, SimpleMap};
 
     use aptos_framework::account::{Self, SignerCapability};
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::event::{EventHandle, emit_event};
     use aptos_framework::stake::{Self, OwnerCapability};
     use aptos_framework::staking_config;
 

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -42,7 +42,6 @@ module aptos_framework::vesting {
     use std::string::{utf8, String};
     use std::vector;
 
-    use aptos_std::event::{EventHandle, emit_event};
     use aptos_std::pool_u64::{Self, Pool};
     use aptos_std::simple_map::{Self, SimpleMap};
 
@@ -50,6 +49,7 @@ module aptos_framework::vesting {
     use aptos_framework::aptos_account::assert_account_is_registered_for_apt;
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::event::{EventHandle, emit_event};
     use aptos_framework::stake;
     use aptos_framework::staking_contract;
     use aptos_framework::system_addresses;

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -29,13 +29,13 @@ module aptos_framework::voting {
     use std::string::{String, utf8};
     use std::vector;
 
-    use aptos_std::event::{Self, EventHandle};
     use aptos_std::from_bcs::to_u64;
     use aptos_std::simple_map::{Self, SimpleMap};
     use aptos_std::table::{Self, Table};
     use aptos_std::type_info::{Self, TypeInfo};
 
     use aptos_framework::account;
+    use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::timestamp;
     use aptos_framework::transaction_context;
 

--- a/aptos-move/framework/aptos-names/sources/domains.move
+++ b/aptos-move/framework/aptos-names/sources/domains.move
@@ -2,13 +2,13 @@ module aptos_names::domains {
     use aptos_framework::account;
     use aptos_framework::aptos_coin::AptosCoin;
     use aptos_framework::coin;
+    use aptos_framework::event;
     use aptos_framework::timestamp;
     use aptos_names::config;
     use aptos_names::price_model;
     use aptos_names::time_helper;
     use aptos_names::token_helper;
     use aptos_names::utf8_utils;
-    use aptos_std::event;
     use aptos_std::table::{Self, Table};
     use aptos_token::property_map::Self;
     use aptos_token::token::{Self, TokenId};

--- a/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move
+++ b/aptos-move/move-examples/hello_blockchain/sources/hello_blockchain.move
@@ -3,7 +3,7 @@ module hello_blockchain::message {
     use std::signer;
     use std::string;
     use aptos_framework::account;
-    use aptos_std::event;
+    use aptos_framework::event;
 
 //:!:>resource
     struct MessageHolder has key {

--- a/aptos-move/move-examples/message_board/sources/acl_message_board.move
+++ b/aptos-move/move-examples/message_board/sources/acl_message_board.move
@@ -14,7 +14,7 @@ module message_board::acl_based_mb {
     use std::signer;
     use std::vector;
     use aptos_framework::account;
-    use aptos_std::event::{Self, EventHandle};
+    use aptos_framework::event::{Self, EventHandle};
 
     // Error map
     const EACCOUNT_NOT_IN_ACL: u64 = 1;

--- a/aptos-move/move-examples/message_board/sources/cap_message_board.move
+++ b/aptos-move/move-examples/message_board/sources/cap_message_board.move
@@ -16,7 +16,7 @@ module message_board::cap_based_mb {
     use std::signer;
     use std::vector;
     use aptos_framework::account;
-    use aptos_std::event::{Self, EventHandle};
+    use aptos_framework::event::{Self, EventHandle};
 
     // Error map
     const EACCOUNT_NO_NOTICE_CAP: u64 = 1;


### PR DESCRIPTION
### Description
@alinush proposed that bc we moved events from `aptos_std` to `aptos_framework`, it makes sense to rename all these imports

### Test Plan
existing unit tests, e2e tests
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4929)
<!-- Reviewable:end -->
