### PR TITLE
[aptos-node] assert no Move test natives

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -103,9 +103,10 @@ jobs:
       - uses: taiki-e/install-action@v1.5.6
         with:
           tool: nextest
-      # prebuild node binary, so that tests don't start before node is built.
+      # prebuild aptos-node binary, so that tests don't start before node is built.
+      # also prebuild aptos-node binary as a separate step to avoid feature unification issues
       # --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
-      - run: cargo build --locked --bin=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile ci --package smoke-test --test-threads 6 --retries 3
+      - run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile ci --package smoke-test --test-threads 6 --retries 3
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 

--- a/aptos-node/src/main.rs
+++ b/aptos-node/src/main.rs
@@ -11,5 +11,7 @@ use clap::Parser;
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
+    // Check that we are not including any Move test natives
+    aptos_vm::natives::assert_no_test_natives();
     AptosNodeArgs::parse().run()
 }

--- a/docker/build-rust-all.sh
+++ b/docker/build-rust-all.sh
@@ -14,7 +14,6 @@ echo "FEATURES: $FEATURES"
 cargo build --locked --profile=$PROFILE \
     -p aptos \
     -p aptos-faucet \
-    -p aptos-node \
     -p aptos-node-checker \
     -p aptos-openapi-spec-generator \
     -p aptos-telemetry-service \
@@ -23,6 +22,11 @@ cargo build --locked --profile=$PROFILE \
     -p db-bootstrapper \
     -p forge-cli \
     -p transaction-emitter \
+    "$@"
+
+# Build aptos-node separately
+cargo build --locked --profile=$PROFILE \
+    -p aptos-node \
     "$@"
 
 # Build and overwrite the aptos-node binary with features if specified

--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -162,7 +162,12 @@ where
     let target_directory = target_directory.as_ref();
     let directory = directory.as_ref();
 
-    let mut args = vec!["build", "--bin=aptos-node", "--features=failpoints,indexer"];
+    // build the aptos-node package directly to avoid feature unification issues
+    let mut args = vec![
+        "build",
+        "--package=aptos-node",
+        "--features=failpoints,indexer",
+    ];
     if use_release {
         args.push("--release");
     }


### PR DESCRIPTION
### Description

Ensure that the aptos-node binary is never run with these feature flags. Panic if it is.

### Test Plan

If the node has the feature, then it will fail to start. Run all tests

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4935)
<!-- Reviewable:end -->
