### PR TITLE
Pin third party GH workflows

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,8 @@
+## Workflow versions
+Workflow versions are pinned using this tool: https://github.com/mheap/pin-github-action. We can use this same tool to (carefully) update the pinned versions if the need arises.
+```
+find . -type f -name "*.yaml" | xargs -I@ pin-github-action @
+find . -type f -name "*.yaml" | xargs -I@ prettier -w @
+```
+After this you have to go fix some formatting and remove some erroneous `null`s that the tool added: https://github.com/mheap/pin-github-action/issues/111.
+

--- a/.github/actions/docker-buildx-setup/action.yaml
+++ b/.github/actions/docker-buildx-setup/action.yaml
@@ -8,7 +8,7 @@ runs:
       shell: bash
       run: docker context create builders
     - name: setup docker buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # pin@v2
       with:
         endpoint: builders
         version: v0.8.2

--- a/.github/actions/gar-auth/action.yaml
+++ b/.github/actions/gar-auth/action.yaml
@@ -11,7 +11,7 @@ runs:
   steps:
     - id: auth
       name: "Authenticate to Google Cloud"
-      uses: "google-github-actions/auth@v0"
+      uses: "google-github-actions/auth@dac4e13deb3640f22e3ffe758fd3f95e6e89f712" # pin@v0
       with:
         create_credentials_file: false
         token_format: "access_token"
@@ -19,7 +19,7 @@ runs:
         service_account: ${{ inputs.GCP_SERVICE_ACCOUNT_EMAIL }}
 
     - name: Login to Google Artifact Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
       with:
         registry: us-west1-docker.pkg.dev
         username: oauth2accesstoken

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -3,11 +3,11 @@ runs:
   steps:
     - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config --no-install-recommends --assume-yes
       shell: bash
-    - uses: actions-rs/toolchain@v1
+    - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
       with:
         override: true
         components: rustfmt, clippy
-    - uses: bmwill/rust-cache@v1
+    - uses: bmwill/rust-cache@fb63fcd7a959767755b88b5af2f5cbf65fb8a127 # pin@v1
       with:
         path: ~/.cargo/registry/src/**/librocksdb-sys-*
     - name: install protoc and related tools

--- a/.github/workflows/check-minimum-revision.yaml
+++ b/.github/workflows/check-minimum-revision.yaml
@@ -20,7 +20,7 @@ jobs:
   check-minimum-revision:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ env.GIT_SHA }}
           fetch-depth: 1000

--- a/.github/workflows/check-sdk-examples.yaml
+++ b/.github/workflows/check-sdk-examples.yaml
@@ -21,11 +21,11 @@ jobs:
       APTOS_FAUCET_URL: https://faucet.devnet.aptoslabs.com
       FAUCET_AUTH_TOKEN: ${{ secrets.DEVNET_TAP_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
         with:
           node-version-file: .node-version
           registry-url: 'https://registry.npmjs.org'
@@ -33,7 +33,7 @@ jobs:
       - run: npm install -g yarn@1.22.19
 
       # Run example code in typescript.
-      - uses: nick-fields/retry@v2
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
         name: ts-example-test
         with:
           max_attempts: 5
@@ -41,7 +41,7 @@ jobs:
           command: cd ./ecosystem/typescript/sdk/examples/typescript && yarn install && yarn test
 
       # Run example code in javascript.
-      - uses: nick-fields/retry@v2
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
         name: js-example-test
         with:
           max_attempts: 5

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -17,20 +17,20 @@ on:
       release_title:
         type: string
         required: false
-        description: "Name of the release, e.g. \"Aptos CLI devnet release 2022-06-09\":"
+        description: 'Name of the release, e.g. "Aptos CLI devnet release 2022-06-09":'
 
 jobs:
   build-ubuntu20-binary:
     name: "Build Ubuntu 20.04 binary"
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu"
       - name: Upload Binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip
@@ -39,13 +39,13 @@ jobs:
     name: "Build Ubuntu 22.04 binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "Ubuntu-22.04"
       - name: Upload Binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip
@@ -54,13 +54,13 @@ jobs:
     name: "Build OS X binary"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
         run: scripts/cli/build_cli_release.sh "MacOSX"
       - name: Upload Binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip
@@ -69,13 +69,13 @@ jobs:
     name: "Build Windows binary"
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - name: Build CLI
         run: scripts\cli\build_cli_release.ps1
       - name: Upload Binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: cli-builds
           path: aptos-cli-*.zip
@@ -93,11 +93,11 @@ jobs:
       pull-requests: "read"
     steps:
       - name: Download prebuilt binaries
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
         with:
           name: cli-builds
       - name: Create GitHub Release
-        uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        uses: marvinpinto/action-automatic-releases@919008cf3f741b179569b7a6fb4d8860689ab7f0 # pin@v1.2.1
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "${{ github.event.inputs.release_tag }}"

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -3,7 +3,7 @@ name: "CodeQL"
 on:
   schedule:
     # Every day at 10:15am UTC aka 3:15am PT
-    - cron: '15 10 * * *'
+    - cron: "15 10 * * *"
 
 jobs:
   analyze:
@@ -17,39 +17,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'javascript', 'python', 'ruby' ]
+        language: [ "javascript", "python", "ruby" ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@807578363a7869ca324a79039e6db9c843e0e100 # pin@v2
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
-        
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@807578363a7869ca324a79039e6db9c843e0e100 # pin@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
-
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@807578363a7869ca324a79039e6db9c843e0e100 # pin@v2

--- a/.github/workflows/continuous-e2e-network-latency-test.yaml
+++ b/.github/workflows/continuous-e2e-network-latency-test.yaml
@@ -12,7 +12,6 @@ on:
 jobs:
   # Test under sub optimal circumstances (network delay)
   run-forge-three-region:
-
     uses: ./.github/workflows/run-forge.yaml
     secrets: inherit
     with:

--- a/.github/workflows/continuous-e2e-release-test.yaml
+++ b/.github/workflows/continuous-e2e-release-test.yaml
@@ -1,4 +1,3 @@
-
 name: Continuous E2E Release Test
 
 permissions:

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Wait for images to have been built
         timeout-minutes: 30
-        uses: lewagon/wait-on-check-action@v1.0.0
+        uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea # pin@v1.0.0
         with:
           ref: ${{ github.ref }}
           check-name: "rust-images / rust-all" # only copy the release images to dockerhub
@@ -34,7 +34,7 @@ jobs:
     needs: wait-for-images-to-have-been-built
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
 
       - uses: ./.github/actions/gar-auth
         with:
@@ -42,14 +42,14 @@ jobs:
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Login to ECR
-        uses: docker/login-action@v2
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
         with:
           registry: ${{ secrets.AWS_ECR_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
         with:
           username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
           password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -6,7 +6,7 @@ on:
     # every day at 9am PST
     - cron: "0 16 * * *"
   pull_request:
-    types: [labeled, opened, synchronize, reopened]
+    types: [ labeled, opened, synchronize, reopened ]
 
 env:
   CARGO_INCREMENTAL: "0"
@@ -24,19 +24,19 @@ jobs:
     timeout-minutes: 120
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/rust-setup
       - run: rustup component add llvm-tools-preview
-      - uses: taiki-e/install-action@v1.5.6
+      - uses: taiki-e/install-action@6f1ebcd9e21315fc37d7f7bc851dfcc8356d7da3 # pin@v1.5.6
         with:
           tool: nextest,cargo-llvm-cov
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
       - run: cargo llvm-cov --ignore-run-fail --workspace --exclude smoke-test --exclude testcases --lcov --jobs 32 --output-path lcov_unit.info
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: lcov_unit
           path: lcov_unit.info
@@ -46,37 +46,37 @@ jobs:
     timeout-minutes: 120
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/rust-setup
       - run: rustup component add llvm-tools-preview
-      - uses: taiki-e/install-action@v1.5.6
+      - uses: taiki-e/install-action@6f1ebcd9e21315fc37d7f7bc851dfcc8356d7da3 # pin@v1.5.6
         with:
           tool: nextest,cargo-llvm-cov
       - run: docker run --detach -p 5432:5432 cimg/postgres:14.2
       - run: cargo llvm-cov --ignore-run-fail --package smoke-test --lcov --output-path lcov_smoke.info
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v3
         with:
           name: lcov_smoke
           path: lcov_smoke.info
 
   upload-to-codecov:
     if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage')) && !cancelled()
-    needs: [rust-unit-coverage, rust-smoke-coverage]
+    needs: [ rust-unit-coverage, rust-smoke-coverage ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
         with:
           name: lcov_unit
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v3
         with:
           name: lcov_smoke
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
         with:
           files: lcov_unit.info,lcov_smoke.info
           fail_ci_if_error: true

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -27,18 +27,18 @@ on: # build on main branch OR when a PR is labeled with `CICD:build-images`
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
     # For most PRs run workflows from main, not the PR commit for security
     paths-ignore:
-      - 'documentation/**'
-      - 'developer-docs-site/**'
-      - '.github/**'
+      - "documentation/**"
+      - "developer-docs-site/**"
+      - ".github/**"
   # For PR that modify .github, run from that PR
   # This will fail to get secrets if you are not from aptos
   pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
     paths:
-      - '.github/workflows/docker-build-test.yaml'
-      - '.github/workflows/run-forge.yaml'
-      - '.github/workflows/docker-rust-build.yaml'
-      - '.github/workflows/sdk-release.yaml'
+      - ".github/workflows/docker-build-test.yaml"
+      - ".github/workflows/run-forge.yaml"
+      - ".github/workflows/docker-rust-build.yaml"
+      - ".github/workflows/sdk-release.yaml"
   push:
     branches:
       - main
@@ -102,7 +102,7 @@ jobs:
   # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
   determine-docker-build-metadata:
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: collect metadata
         run: |
           echo "GIT_SHA: ${{ env.GIT_SHA }}"

--- a/.github/workflows/docker-rust-build.yaml
+++ b/.github/workflows/docker-rust-build.yaml
@@ -34,7 +34,7 @@ jobs:
   rust-all:
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ env.GIT_SHA }}
 
@@ -44,7 +44,7 @@ jobs:
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
       - name: Login to ECR
-        uses: docker/login-action@v2
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # pin@v2
         with:
           registry: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}.dkr.ecr.us-west-2.amazonaws.com
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -52,7 +52,7 @@ jobs:
 
       - uses: ./.github/actions/docker-buildx-setup
 
-      - uses: imjasonh/setup-crane@v0.1
+      - uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # pin@v0.1
 
       - name: Build and Push Rust images
         run: docker/docker-bake-rust-all.sh

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -9,6 +9,6 @@ jobs:
   find-packages-with-undeclared-feature-dependencies:
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - uses: ./.github/actions/rust-setup
       - run: scripts/find-packages-with-undeclared-feature-dependencies.sh

--- a/.github/workflows/forge-continuous.yaml
+++ b/.github/workflows/forge-continuous.yaml
@@ -5,8 +5,8 @@ on:
     - cron: "0 * * * *"
   pull_request:
     paths:
-      - '.github/workflows/forge-continuous.yaml'
-      - '.github/workflows/run-forge.yaml'
+      - ".github/workflows/forge-continuous.yaml"
+      - ".github/workflows/run-forge.yaml"
 
 # cancel redundant builds
 concurrency:

--- a/.github/workflows/grafana-sync.yaml
+++ b/.github/workflows/grafana-sync.yaml
@@ -17,11 +17,11 @@ jobs:
   grafana-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
       - name: Pull and sync Grafana dashboards
         run: ./scripts/sync_grafana_dashboards.sh
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@671dc9c9e0c2d73f07fa45a3eb0220e1622f0c5f # pin@v4
         with:
           add-paths: dashboards
           title: "[dashboards] sync grafana dashboards"

--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -11,7 +11,7 @@ jobs:
   helm-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
           # Get enough commits to compare to
@@ -19,21 +19,19 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v29.0.3
+        uses: tj-actions/changed-files@60f4aabced9b4718c75acef86d42ffb631c4403a # pin@v29.0.3
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
 
       - name: Install Python Dependencies
         run: pip install -r testsuite/requirements.txt
 
       - name: Should run lint
         run: >
-          python testsuite/determinator.py
-          changed-files
-          --github-output-key SHOULD_RUN
-          --pattern 'terraform/helm/.*'
-          ${{ steps.changed-files.outputs.all_changed_files }}
+          python testsuite/determinator.py changed-files --github-output-key
+          SHOULD_RUN --pattern 'terraform/helm/.*' ${{
+          steps.changed-files.outputs.all_changed_files }}
         id: should-run-tests
 
       - name: Run Helm Lint

--- a/.github/workflows/nightly-replay-verify.yaml
+++ b/.github/workflows/nightly-replay-verify.yaml
@@ -11,7 +11,7 @@ on:
     - cron: "0 * * * */1"
   pull_request:
     paths:
-      - '.github/workflows/nightly-replay-verify.yaml'
+      - ".github/workflows/nightly-replay-verify.yaml"
 
 env:
   BUCKET: ${{ secrets.LLT_BACKUP_BUCKET }}
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 720
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.

--- a/.github/workflows/prover-test.yaml
+++ b/.github/workflows/prover-test.yaml
@@ -38,7 +38,7 @@ jobs:
   prover-test:
     runs-on: high-perf-docker
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/rust-setup

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -16,8 +16,8 @@ jobs:
     if: github.repository == 'aptos-labs/aptos-core'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
+      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
         with:
           node-version-file: .node-version
       - run: yarn pruneGithubWorkflowRuns

--- a/.github/workflows/python-unit-test.yaml
+++ b/.github/workflows/python-unit-test.yaml
@@ -11,7 +11,7 @@ jobs:
   python-unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
           # Get enough commits to compare to
@@ -19,21 +19,17 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v29.0.3
+        uses: tj-actions/changed-files@60f4aabced9b4718c75acef86d42ffb631c4403a # pin@v29.0.3
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
 
       - name: Install Python Dependencies
         run: pip install -r testsuite/requirements.txt
 
       - name: Should run tests
         run: >
-          python testsuite/determinator.py
-          changed-files
-          --github-output-key SHOULD_RUN
-          --pattern 'testsuite/.*py'
-          ${{ steps.changed-files.outputs.all_changed_files }}
+          python testsuite/determinator.py changed-files --github-output-key SHOULD_RUN --pattern 'testsuite/.*py' ${{steps.changed-files.outputs.all_changed_files }}
         id: should-run-tests
 
       - name: Run python unit tests

--- a/.github/workflows/run-forge.yaml
+++ b/.github/workflows/run-forge.yaml
@@ -56,7 +56,8 @@ on:
         required: false
         type: string
         default: forge
-        description: A unique ID for Forge sticky comment on your PR. See https://github.com/marocchino/sticky-pull-request-comment#keep-more-than-one-comment
+        description: A unique ID for Forge sticky comment on your PR. See
+          https://github.com/marocchino/sticky-pull-request-comment#keep-more-than-one-comment
 
 env:
   AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
@@ -88,12 +89,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
           # get the last 10 commits if GIT_SHA is not specified
           fetch-depth: inputs.GIT_SHA != null && 0 || 10
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # pin@v4
       - name: Install python deps
         run: pip3 install click==8.1.3 psutil==5.9.1
       - name: Run pre-Forge checks
@@ -103,7 +104,7 @@ jobs:
         run: testsuite/run_forge.sh
       - name: Post pre-Forge comment
         if: github.event.number != null
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@39c5b5dc7717447d0cba270cd115037d32d2844
         with:
           header: ${{ env.COMMENT_HEADER }}
           hide_and_recreate: true # Hide the previous comment and add a comment at the end
@@ -116,7 +117,7 @@ jobs:
       - name: Post forge result comment
         # Post a Github comment if the run has not been cancelled and if we're running on a PR
         if: github.event.number != null && !cancelled()
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # pin@39c5b5dc7717447d0cba270cd115037d32d2844
         with:
           header: ${{ env.COMMENT_HEADER }}
           hide_and_recreate: true
@@ -126,7 +127,7 @@ jobs:
         # Post a Slack comment if the run has not been cancelled and the envs are set
         if: env.POST_TO_SLACK == 'true' && failure()
         id: slack
-        uses: slackapi/slack-github-action@v1.21.0
+        uses: slackapi/slack-github-action@936158bbe252e9a6062e793ea4609642c966e302 # pin@v1.21.0
         with:
           # For posting a rich message using Block Kit
           payload: |

--- a/.github/workflows/sdk-release.yaml
+++ b/.github/workflows/sdk-release.yaml
@@ -23,7 +23,7 @@ on:
       GIT_SHA:
         required: true
         type: string
-        description:
+        description: Use this to override the git SHA1, branch name (e.g. devnet) or tag to release the SDK from
 
 jobs:
   # Confirm that the generated client within the TS SDK has been re-generated
@@ -39,7 +39,7 @@ jobs:
       APTOS_FAUCET_URL: http://127.0.0.1:8081
       FAUCET_AUTH_TOKEN: ${{ secrets.DEVNET_TAP_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:
           ref: ${{ inputs.GIT_SHA }}
 
@@ -48,10 +48,10 @@ jobs:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@969bd2663942d722d85b6a8626225850c2f7be4b # pin@v3
         with:
           node-version-file: .node-version
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       # Self hosted runners don't have yarn preinstalled.
       # https://github.com/actions/setup-node/issues/182
@@ -65,13 +65,13 @@ jobs:
       - run: mkdir -p ${{ runner.temp }}/specs
 
       # Build the API specs.
-      - uses: nick-fields/retry@v2
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
         name: generate-yaml-spec
         with:
           max_attempts: 3
           timeout_minutes: 20
           command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ secrets.GCP_DOCKER_ARTIFACT_REPO }}/tools:${{ inputs.GIT_SHA }} aptos-openapi-spec-generator -f yaml -o /specs/spec.yaml
-      - uses: nick-fields/retry@v2
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
         name: generate-json-spec
         with:
           max_attempts: 3
@@ -111,7 +111,7 @@ jobs:
       - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8081/health
 
       # Test and build.
-      - uses: nick-fields/retry@v2
+      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
         name: sdk-yarn-test
         with:
           max_attempts: 3


### PR DESCRIPTION
### Description
This PR pins GH workflows we depend on to specific commits (which in itself cannot be spoofed to have different content with the same hash). We consider nothing to be first party, even stuff from `actions/`, though we could revise that pending discussion.

At first I wrote my own script for this (https://gist.github.com/banool/2f19d6a9b8ab2faec77aae4e596704a9) but then I found something that already exists in the wild, though it does mess with the formatting in ways that I undid manually for now.

### Test Plan
CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4936)
<!-- Reviewable:end -->
