### PR TITLE
[account][minor fix] nits in key rotation

### DIFF
--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -55,12 +55,16 @@ pub enum EntryFunctionCall {
     },
 
     /// Generic authentication key rotation function that allows the user to rotate their authentication key from any scheme to any scheme.
-    /// To authorize the rotation, a signature by the current private key on a valid RotationProofChallenge (`cap_rotate_key`)
-    /// demonstrates that the user intends to and has the capability to rotate the authentication key. A signature by the new
-    /// private key on a valid RotationProofChallenge (`cap_update_table`) verifies that the user has the capability to update the
-    /// value at key `auth_key` on the `OriginatingAddress` table. `from_scheme` refers to the scheme of the `from_public_key` and
-    /// `to_scheme` refers to the scheme of the `to_public_key`. A scheme of 0 refers to an Ed25519 key and a scheme of 1 refers to
-    /// Multi-Ed25519 keys.
+    /// To authorize the rotation, we need two signatures:
+    /// - the first signature `cap_rotate_key` refers to the signature by the account owner's current key on a valid `RotationProofChallenge`,
+    /// demonstrating that the user intends to and has the capability to rotate the authentication key of this account;
+    /// - the second signature `cap_update_table` refers to the signature by the new key (that the account owner wants to rotate to) on a
+    /// valid `RotationProofChallenge`, demonstrating that the user owns the new private key, and has the authority to update the
+    /// `OriginatingAddress` map with the new address mapping <new_address, originating_address>.
+    /// To verify signatures, we need their corresponding public key and public key scheme: we use `from_scheme` and `from_public_key_bytes`
+    /// to verify `cap_rotate_key`, and `to_scheme` and `to_public_key_bytes` to verify `cap_update_table`.
+    /// A scheme of 0 refers to an Ed25519 key and a scheme of 1 refers to Multi-Ed25519 keys.
+    /// `originating address` refers to an account's original/first address.
     AccountRotateAuthenticationKey {
         from_scheme: u8,
         from_public_key_bytes: Vec<u8>,
@@ -787,12 +791,16 @@ pub fn account_revoke_signer_capability(
 }
 
 /// Generic authentication key rotation function that allows the user to rotate their authentication key from any scheme to any scheme.
-/// To authorize the rotation, a signature by the current private key on a valid RotationProofChallenge (`cap_rotate_key`)
-/// demonstrates that the user intends to and has the capability to rotate the authentication key. A signature by the new
-/// private key on a valid RotationProofChallenge (`cap_update_table`) verifies that the user has the capability to update the
-/// value at key `auth_key` on the `OriginatingAddress` table. `from_scheme` refers to the scheme of the `from_public_key` and
-/// `to_scheme` refers to the scheme of the `to_public_key`. A scheme of 0 refers to an Ed25519 key and a scheme of 1 refers to
-/// Multi-Ed25519 keys.
+/// To authorize the rotation, we need two signatures:
+/// - the first signature `cap_rotate_key` refers to the signature by the account owner's current key on a valid `RotationProofChallenge`,
+/// demonstrating that the user intends to and has the capability to rotate the authentication key of this account;
+/// - the second signature `cap_update_table` refers to the signature by the new key (that the account owner wants to rotate to) on a
+/// valid `RotationProofChallenge`, demonstrating that the user owns the new private key, and has the authority to update the
+/// `OriginatingAddress` map with the new address mapping <new_address, originating_address>.
+/// To verify signatures, we need their corresponding public key and public key scheme: we use `from_scheme` and `from_public_key_bytes`
+/// to verify `cap_rotate_key`, and `to_scheme` and `to_public_key_bytes` to verify `cap_update_table`.
+/// A scheme of 0 refers to an Ed25519 key and a scheme of 1 refers to Multi-Ed25519 keys.
+/// `originating address` refers to an account's original/first address.
 pub fn account_rotate_authentication_key(
     from_scheme: u8,
     from_public_key_bytes: Vec<u8>,


### PR DESCRIPTION
### Description
this PR has a lot of very minor changes (comments, capitalization, etc. ), but the slightly more noteworthy ones in `account.move` are:  
- red line 296 is redundant - we don't need to generate the current auth key by doing `bcs::to_address` again, since we already did that earlier in the function; 
- red line 308 in `account.move` we had a redundant line `let account_resource = borrow_global_mut<Account>(addr)` - we already have this at the beginning of the file; 
- red line 338 and 373 are redundant - we don't need to check if the signer's address exists; 

### Test Plan
existing unit tests & e2e tests
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4944)
<!-- Reviewable:end -->
