### PR TITLE
[mempool] smoke test to confirm failover on default_failovers=0

### DIFF
--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -118,6 +118,7 @@ impl LocalFactory {
         version: &Version,
         genesis_framework: Option<ReleaseBundle>,
         init_config: Option<InitConfigFn>,
+        vfn_config: Option<NodeConfig>,
         init_genesis_config: Option<InitGenesisConfigFn>,
         guard: ActiveNodesGuard,
     ) -> Result<LocalSwarm>
@@ -149,7 +150,9 @@ impl LocalFactory {
             let _ = swarm
                 .add_validator_fullnode(
                     version,
-                    NodeConfig::default_for_validator_full_node(),
+                    vfn_config
+                        .clone()
+                        .unwrap_or_else(NodeConfig::default_for_validator_full_node),
                     *validator_peer_id,
                 )
                 .unwrap();
@@ -198,6 +201,7 @@ impl Factory for LocalFactory {
                 num_fullnodes,
                 version,
                 framework,
+                None,
                 None,
                 None,
                 guard,

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -107,7 +107,15 @@ async fn test_full_node_basic_flow() {
 
 #[tokio::test]
 async fn test_vfn_failover() {
-    let mut swarm = local_swarm_with_fullnodes(4, 4).await;
+    // VFN failover happens when validator is down even for default_failovers = 0
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.mempool.default_failovers = 0;
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_num_fullnodes(4)
+        .with_aptos()
+        .with_vfn_config(vfn_config)
+        .build()
+        .await;
     let transaction_factory = swarm.chain_info().transaction_factory();
 
     for fullnode in swarm.full_nodes_mut() {

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos::test::CliTestFramework;
+use aptos_config::config::NodeConfig;
 use aptos_config::{keys::ConfigKey, utils::get_available_port};
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_faucet::FaucetArgs;
@@ -26,6 +27,7 @@ pub struct SwarmBuilder {
     num_fullnodes: usize,
     genesis_framework: Option<ReleaseBundle>,
     init_config: Option<InitConfigFn>,
+    vfn_config: Option<NodeConfig>,
     init_genesis_config: Option<InitGenesisConfigFn>,
 }
 
@@ -37,6 +39,7 @@ impl SwarmBuilder {
             num_fullnodes: 0,
             genesis_framework: None,
             init_config: None,
+            vfn_config: None,
             init_genesis_config: None,
         }
     }
@@ -52,6 +55,11 @@ impl SwarmBuilder {
 
     pub fn with_init_config(mut self, init_config: InitConfigFn) -> Self {
         self.init_config = Some(init_config);
+        self
+    }
+
+    pub fn with_vfn_config(mut self, config: NodeConfig) -> Self {
+        self.vfn_config = Some(config);
         self
     }
 
@@ -91,6 +99,7 @@ impl SwarmBuilder {
                 &version,
                 builder.genesis_framework,
                 builder.init_config,
+                builder.vfn_config,
                 Some(Arc::new(move |genesis_config| {
                     if let Some(init_genesis_config) = &init_genesis_config {
                         (init_genesis_config)(genesis_config);


### PR DESCRIPTION
### Description

Change test_vfn_failover smoke test to explicitly have default_failovers=0. This matches what we run in the VFNs in prod.

### Test Plan

Run the test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4953)
<!-- Reviewable:end -->
