### PR TITLE
[Docs] Improvements to pruning and state sync docs.

### DIFF
--- a/developer-docs-site/docs/guides/data-pruning.md
+++ b/developer-docs-site/docs/guides/data-pruning.md
@@ -5,16 +5,26 @@ slug: "data-pruning"
 
 # Data Pruning
 
-When a validator node is running, it participates in the consensus to generate new data to the ledger, or sync the new data from the other nodes via [State Sync](/guides/state-sync). With the ledger growing fast, storage disk space can be managed by pruning the old ledger data. By default pruning is enabled on the node, with a default pruning window. This document describes how you can change these settings. 
+When a validator node is running, it participates in consensus to execute
+transactions and commit new data to the blockchain. Similarly, when fullnodes
+are running, they sync the new blockchain data through [state synchronization](/guides/state-sync).
+As the blockchain grows, storage disk space can be managed by pruning old
+blockchain data. Specifically, by pruning the **ledger history**: which
+contains old transactions. By default, ledger pruning is enabled on all
+nodes with a pruning window that can be configured. This document describes
+how you can configure the pruning behavior.
 
-To manage these settings, edit the node configuration YAML files, for example, `fullnode.yaml` for fullnode (validator or public) or `validator.yaml` for validator node, as shown below.
+To manage these settings, edit the node configuration YAML files,
+for example, `fullnode.yaml` for fullnodes (validator or public) or
+`validator.yaml` for validator nodes, as shown below.
 
 ## Disabling the ledger pruner
 
-Add the below settings to the node configuration YAML file:
+Add the following to the node configuration YAML file to disable the
+ledger pruner:
 
 :::caution Proceed with caution
-Disabling the pruning can result in the storage disk filling up quickly.
+Disabling the ledger pruner can result in the storage disk filling up very quickly.
 :::
 
 ```yaml
@@ -24,12 +34,14 @@ storage:
    enable: false
 ```
 
-## Changing the ledger prune window
+## Configuring the ledger pruning window
 
-Add the below settings to the node configuration YAML file to make the node retain, for example, 1 billion transactions and their outputs, including events and write sets.
+Add the following to the node configuration YAML file to make the node
+retain, for example, 1 billion transactions and their outputs, including events
+and write sets.
 
 :::caution Proceed with caution
-Setting the prune window smaller than 100 million can lead to runtime errors and can damage the health of the network.
+Setting the pruning window smaller than 100 million can lead to runtime errors and damage the health of the node.
 :::
 
 ```yaml

--- a/developer-docs-site/docs/guides/state-sync.md
+++ b/developer-docs-site/docs/guides/state-sync.md
@@ -94,8 +94,8 @@ However, `aptos_state_sync_version{type="synced"}` will only increase once
 the node has bootstrapped. This may take several hours depending on the 
 amount of data, network bandwidth and node resources available.
 
-**Note:** If `aptos_state_sync_version{type="synced"}` increases but
-`aptos_state_sync_version{type="synced_states"}` does not, then do the following:
+**Note:** If `aptos_state_sync_version{type="synced_states"}` does not 
+increase then do the following:
 1. Double-check the node configuration file has correctly been updated.
 2. Make sure that the node is starting up with an empty storage database
 (i.e., that it has not synced any state previously).
@@ -108,6 +108,32 @@ network delays that may occur when initializing slow network connections:
      ...
      max_connection_deadline_secs: 1000000 # Tolerate slow peer discovery & connections
 ```
+
+## Security implications and data integrity
+Each of the different syncing modes perform data integrity verifications to
+ensure that the data being synced to the node has been correctly produced
+and signed by the validators. This occurs slightly differently for
+each syncing mode:
+1. Executing transactions from genesis is the most secure syncing mode. It will
+verify that all transactions since the beginning of time were correctly agreed
+upon by consensus and that all transactions were correctly executed by the
+validators. All resulting blockchain state will thus be re-verified by the
+syncing node.
+2. Applying transaction outputs from genesis is faster than executing all
+transactions, but it requires that the syncing node trusts the validators to
+have executed the transactions correctly. However, all other
+blockchain state is still manually re-verified, e.g., consensus messages,
+the transaction history and the state hashes are still verified.
+3. Fast syncing skips the transaction history and downloads the latest
+blockchain state before continuously syncing. To do this, it requires that the
+syncing node trust the validators to have correctly agreed upon all
+transactions in the transaction history as well as trust that all transactions
+were correctly executed by the validators. However, all other blockchain state
+is still manually re-verified, e.g., epoch changes and the resulting blockchain states.
+
+All of the syncing modes get their root of trust from the validator set
+and cryptographic signatures from those validators over the blockchain data.
+For more information about how this works, see the [state synchronization blogpost](https://medium.com/aptoslabs/the-evolution-of-state-sync-the-path-to-100k-transactions-per-second-with-sub-second-latency-at-52e25a2c6f10).
 
 ## State sync architecture
 

--- a/state-sync/README.md
+++ b/state-sync/README.md
@@ -100,8 +100,8 @@ However, `aptos_state_sync_version{type="synced"}` will only increase once
 the node has boostrapped. This may take several hours depending on the 
 amount of data, network bandwidth and node resources available.
 
-Note: if `aptos_state_sync_version{type="synced"}` increases but
-`aptos_state_sync_version{type="synced_states"}` does not, do the following:
+**Note:** If `aptos_state_sync_version{type="synced_states"}` does not
+increase then do the following:
 1. Double-check the node configuration file has correctly been updated.
 2. Make sure that the node is starting up with an empty storage database
    (i.e., that it has not synced any state previously).
@@ -114,6 +114,33 @@ Note: if `aptos_state_sync_version{type="synced"}` increases but
      ...
      max_connection_deadline_secs: 1000000 # Tolerate slow peer discovery & connections
 ```
+
+## Security implications and data integrity
+Each of the different syncing modes perform data integrity verifications to
+ensure that the data being synced to the node has been correctly produced
+and signed by the validators. This occurs slightly differently for
+each syncing mode:
+1. Executing transactions from genesis is the most secure syncing mode. It will
+   verify that all transactions since the beginning of time were correctly agreed
+   upon by consensus and that all transactions were correctly executed by the
+   validators. All resulting blockchain state will thus be re-verified by the
+   syncing node.
+2. Applying transaction outputs from genesis is faster than executing all
+   transactions, but it requires that the syncing node trusts the validators to
+   have executed the transactions correctly. However, all other
+   blockchain state is still manually re-verified, e.g., consensus messages,
+   the transaction history and the state hashes are still verified.
+3. Fast syncing skips the transaction history and downloads the latest
+   blockchain state before continuously syncing. To do this, it requires that the
+   syncing node trust the validators to have correctly agreed upon all
+   transactions in the transaction history as well as trust that all transactions
+   were correctly executed by the validators. However, all other blockchain state
+   is still manually re-verified, e.g., epoch changes and the resulting blockchain states.
+
+All of the syncing modes get their root of trust from the validator set
+and cryptographic signatures from those validators over the blockchain data.
+For more information about how this works, see the [state synchronization blogpost](https://medium.com/aptoslabs/the-evolution-of-state-sync-the-path-to-100k-transactions-per-second-with-sub-second-latency-at-52e25a2c6f10).
+
 
 ## State sync architecture
 


### PR DESCRIPTION
### Description
This PR offers two improvements to the data pruning and state sync docs. Each of these is in their own commit:
1. A quick pass over the pruning document to make some of the wording more consistent with the rest of the docs.
2. Added a small section about security implications for state syncing modes.

### Test Plan
Manual verification.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4976)
<!-- Reviewable:end -->
