### PR TITLE
[consensus][e2e] Add e2e smoke test for changing onchain config and voting history fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8813,6 +8813,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos",
+ "aptos-bitvec",
  "aptos-config",
  "aptos-crypto",
  "aptos-debugger",

--- a/crates/aptos/src/node/analyze/fetch_metadata.rs
+++ b/crates/aptos/src/node/analyze/fetch_metadata.rs
@@ -15,7 +15,7 @@ const MAX_FETCH_BATCH_SIZE: u16 = 1000;
 pub struct ValidatorInfo {
     pub address: AccountAddress,
     pub voting_power: u64,
-    pub validator_index: u64,
+    pub validator_index: u16,
 }
 
 pub struct EpochInfo {

--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -12,7 +12,10 @@ use aptos_sdk::{
     types::{
         account_address::AccountAddress,
         chain_id::ChainId,
-        transaction::authenticator::{AuthenticationKey, AuthenticationKeyPreimage},
+        transaction::{
+            authenticator::{AuthenticationKey, AuthenticationKeyPreimage},
+            SignedTransaction,
+        },
         LocalAccount,
     },
 };
@@ -245,17 +248,22 @@ pub async fn reconfig(
     root_account: &mut LocalAccount,
 ) -> State {
     let aptos_version = client.get_aptos_version().await.unwrap();
-    let (current, state) = aptos_version.into_parts();
+    let current = aptos_version.into_inner();
     let current_version = *current.major.inner();
     let txn = root_account.sign_with_transaction_builder(
         transaction_factory
             .clone()
             .payload(aptos_stdlib::version_set_version(current_version + 1)),
     );
+    submit_and_wait_reconfig(client, txn).await
+}
+
+pub async fn submit_and_wait_reconfig(client: &RestClient, txn: SignedTransaction) -> State {
+    let state = client.get_ledger_information().await.unwrap().into_inner();
     let result = client.submit_and_wait(&txn).await;
     if let Err(e) = result {
         let last_transactions = client
-            .get_account_transactions(root_account.address(), None, None)
+            .get_account_transactions(txn.sender(), None, None)
             .await
             .map(|result| {
                 result
@@ -277,7 +285,7 @@ pub async fn reconfig(
         panic!(
             "Couldn't execute {:?}, for account {:?}, error {:?}, last account transactions: {:?}",
             txn,
-            root_account,
+            txn.sender(),
             e,
             last_transactions.unwrap_or_default()
         )
@@ -291,13 +299,8 @@ pub async fn reconfig(
         .unwrap();
 
     info!(
-        "Changed aptos version from {} (epoch={}, ledger_v={}), to {}, (epoch={}, ledger_v={})",
-        current_version,
-        state.epoch,
-        state.version,
-        current_version + 1,
-        new_state.epoch,
-        new_state.version
+        "Applied reconfig from (epoch={}, ledger_v={}), to (epoch={}, ledger_v={})",
+        state.epoch, state.version, new_state.epoch, new_state.version
     );
     assert_ne!(state.epoch, new_state.epoch);
 

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0.81"
 tokio = { version = "1.21.0", features = ["full"] }
 
 aptos = { path = "../../crates/aptos", features = ["fuzzing"] }
+aptos-bitvec = { path = "../../crates/aptos-bitvec" }
 aptos-config = { path = "../../config" }
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-debugger = { path = "../../aptos-move/aptos-debugger" }

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -7,6 +7,7 @@ use aptos::node::analyze::analyze_validators::{AnalyzeValidators, EpochStats};
 use aptos::node::analyze::fetch_metadata::FetchMetadata;
 use aptos::test::ValidatorPerformance;
 use aptos::{account::create::DEFAULT_FUNDED_COINS, test::CliTestFramework};
+use aptos_bitvec::BitVec;
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_crypto::{bls12381, x25519, ValidCryptoMaterialStringExt};
 use aptos_genesis::config::HostAndPort;
@@ -14,11 +15,15 @@ use aptos_keygen::KeyGen;
 use aptos_rest_client::{Client, State};
 use aptos_types::account_config::CORE_CODE_ADDRESS;
 use aptos_types::network_address::DnsName;
-use aptos_types::on_chain_config::ValidatorSet;
+use aptos_types::on_chain_config::{
+    ConsensusConfigV1, LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig,
+    ProposerElectionType, ValidatorSet,
+};
 use aptos_types::PeerId;
-use forge::{reconfig, NodeExt, Swarm, SwarmExt};
+use forge::{reconfig, LocalSwarm, NodeExt, Swarm, SwarmExt};
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt::Write;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -74,6 +79,269 @@ async fn test_show_validator_set() {
             .account_address(),
         &swarm.validators().next().unwrap().peer_id()
     );
+}
+
+async fn check_vote_to_elected(swarm: &mut LocalSwarm) -> (Option<u64>, Option<u64>) {
+    let transaction_factory = swarm.chain_info().transaction_factory();
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+
+    let (address_off, rest_client_off) = swarm
+        .validators()
+        .nth(1)
+        .map(|v| (v.peer_id(), v.rest_client()))
+        .unwrap();
+
+    let (_address_after_off, rest_client_after_off) = swarm
+        .validators()
+        .nth(2)
+        .map(|v| (v.peer_id(), v.rest_client()))
+        .unwrap();
+
+    rest_client_off
+        .set_failpoint("consensus::send::any".to_string(), "100%return".to_string())
+        .await
+        .unwrap();
+
+    // tokio::time::sleep(Duration::from_secs(20)).await;
+
+    // clear leader reputation history
+    for _ in 0..5 {
+        reconfig(
+            &rest_client,
+            &transaction_factory,
+            swarm.chain_info().root_account(),
+        )
+        .await;
+    }
+
+    tokio::time::sleep(Duration::from_secs(10)).await;
+    rest_client_off
+        .set_failpoint("consensus::send::any".to_string(), "off".to_string())
+        .await
+        .unwrap();
+
+    let epoch = reconfig(
+        &rest_client,
+        &transaction_factory,
+        swarm.chain_info().root_account(),
+    )
+    .await
+    .epoch;
+
+    rest_client_after_off
+        .set_failpoint("consensus::send::any".to_string(), "100%return".to_string())
+        .await
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_secs(60)).await;
+
+    rest_client_after_off
+        .set_failpoint("consensus::send::any".to_string(), "off".to_string())
+        .await
+        .unwrap();
+
+    let events = FetchMetadata::fetch_new_block_events(&rest_client, Some(epoch as i64), None)
+        .await
+        .unwrap();
+    assert_eq!(events.len(), 1);
+
+    let info = events.first().unwrap();
+    let off_index = info
+        .validators
+        .iter()
+        .find(|v| v.address == address_off)
+        .unwrap()
+        .validator_index;
+    let mut first_vote = None;
+    let mut first_elected = None;
+    for (_i, event) in info.blocks.iter().enumerate() {
+        let previous_block_votes_bitvec: BitVec =
+            event.event.previous_block_votes_bitvec().clone().into();
+        if first_vote.is_none() && previous_block_votes_bitvec.is_set(off_index as u16) {
+            first_vote = Some(event.event.round());
+        }
+
+        if first_elected.is_none() && event.event.proposer() == address_off {
+            first_elected = Some(event.event.round());
+        }
+    }
+    (first_vote, first_elected)
+}
+
+#[ignore]
+#[tokio::test]
+async fn test_onchain_config_change() {
+    let (mut swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
+        .with_init_config(Arc::new(|_, conf, _| {
+            // reduce timeout, as we will have dead node during rounds
+            conf.consensus.round_initial_timeout_ms = 400;
+            conf.consensus.quorum_store_poll_count = 4;
+            conf.api.failpoints_enabled = true;
+        }))
+        .with_init_genesis_config(Arc::new(|genesis_config| {
+            let OnChainConsensusConfig::V1(inner) = genesis_config.consensus_config.clone();
+
+            let leader_reputation_type =
+                if let ProposerElectionType::LeaderReputation(leader_reputation_type) =
+                    inner.proposer_election_type
+                {
+                    leader_reputation_type
+                } else {
+                    panic!()
+                };
+            let proposer_and_voter_config = match &leader_reputation_type {
+                LeaderReputationType::ProposerAndVoter(_) => panic!(),
+                LeaderReputationType::ProposerAndVoterV2(proposer_and_voter_config) => {
+                    proposer_and_voter_config
+                }
+            };
+            let new_consensus_config = OnChainConsensusConfig::V1(ConsensusConfigV1 {
+                proposer_election_type: ProposerElectionType::LeaderReputation(
+                    LeaderReputationType::ProposerAndVoter(ProposerAndVoterConfig {
+                        proposer_window_num_validators_multiplier: 20,
+                        // reduce max epoch history to speed up the test.
+                        use_history_from_previous_epoch_max_count: 2,
+                        // make test not flaky, by making unlikely selections extremely unlikely:
+                        active_weight: 1000000,
+                        ..*proposer_and_voter_config
+                    }),
+                ),
+                ..inner
+            });
+            genesis_config.consensus_config = new_consensus_config;
+        }))
+        .with_aptos()
+        .build_with_cli(0)
+        .await;
+
+    let root_cli_index = cli.add_account_with_address_to_cli(
+        swarm.root_key(),
+        swarm.chain_info().root_account().address(),
+    );
+
+    let rest_client = swarm.validators().next().unwrap().rest_client();
+
+    let current_consensus_config: OnChainConsensusConfig = bcs::from_bytes(
+        &rest_client
+            .get_account_resource_bcs::<Vec<u8>>(
+                CORE_CODE_ADDRESS,
+                "0x1::consensus_config::ConsensusConfig",
+            )
+            .await
+            .unwrap()
+            .into_inner(),
+    )
+    .unwrap();
+
+    let OnChainConsensusConfig::V1(inner) = current_consensus_config;
+    let leader_reputation_type =
+        if let ProposerElectionType::LeaderReputation(leader_reputation_type) =
+            inner.proposer_election_type
+        {
+            leader_reputation_type
+        } else {
+            panic!()
+        };
+    let proposer_and_voter_config = match &leader_reputation_type {
+        LeaderReputationType::ProposerAndVoterV2(_) => panic!(),
+        LeaderReputationType::ProposerAndVoter(proposer_and_voter_config) => {
+            proposer_and_voter_config
+        }
+    };
+    let new_consensus_config = OnChainConsensusConfig::V1(ConsensusConfigV1 {
+        proposer_election_type: ProposerElectionType::LeaderReputation(
+            LeaderReputationType::ProposerAndVoterV2(*proposer_and_voter_config),
+        ),
+        ..inner
+    });
+
+    let update_consensus_config_script = format!(
+        r#"
+    script {{
+        use aptos_framework::aptos_governance;
+        use aptos_framework::consensus_config;
+        fun main(core_resources: &signer) {{
+            let framework_signer = aptos_governance::get_signer_testnet_only(core_resources, @0000000000000000000000000000000000000000000000000000000000000001);
+            let config_bytes = {};
+            consensus_config::set(&framework_signer, config_bytes);
+        }}
+    }}
+    "#,
+        generate_blob(&bcs::to_bytes(&new_consensus_config).unwrap())
+    );
+
+    // confirm with old configs, validator will need to wait quite a bit from voting to being elected
+    let (first_vote_old, first_elected_old) = check_vote_to_elected(&mut swarm).await;
+    println!(
+        "With old config: {:?} to {:?}",
+        first_vote_old, first_elected_old
+    );
+
+    println!(
+        "Epoch before : {}",
+        rest_client
+            .get_ledger_information()
+            .await
+            .unwrap()
+            .into_inner()
+            .epoch
+    );
+    cli.run_script(root_cli_index, &update_consensus_config_script)
+        .await
+        .unwrap();
+    // faucet can make our root LocalAccount sequence number get out of sync.
+    swarm
+        .chain_info()
+        .resync_root_account_seq_num(&rest_client)
+        .await
+        .unwrap();
+    swarm
+        .wait_for_all_nodes_to_catchup_to_next(Duration::from_secs(30))
+        .await
+        .unwrap();
+    println!(
+        "Epoch after : {}",
+        rest_client
+            .get_ledger_information()
+            .await
+            .unwrap()
+            .into_inner()
+            .epoch
+    );
+
+    // confirm with new configs, validator doesn't wait much from voting to being elected
+    let (first_vote_new, first_elected_new) = check_vote_to_elected(&mut swarm).await;
+    println!(
+        "With new config: {:?} to {:?}",
+        first_vote_new, first_elected_new
+    );
+
+    cli.analyze_validator_performance(Some(0), None)
+        .await
+        .unwrap();
+
+    assert!(first_vote_old.unwrap() < 20);
+    assert!(first_vote_new.unwrap() < 20);
+    assert!(first_elected_old.unwrap() > 80);
+    assert!(first_elected_new.unwrap() < 40);
+}
+
+fn generate_blob(data: &[u8]) -> String {
+    let mut buf = String::new();
+
+    write!(buf, "vector[").unwrap();
+    for (i, b) in data.iter().enumerate() {
+        if i % 20 == 0 {
+            if i > 0 {
+                writeln!(buf).unwrap();
+            }
+        } else {
+            write!(buf, " ").unwrap();
+        }
+        write!(buf, "{}u8,", b).unwrap();
+    }
+    write!(buf, "]").unwrap();
+    buf
 }
 
 #[tokio::test]


### PR DESCRIPTION
running locally with:
LOCAL_SWARM_NODE_RELEASE=1 cargo test --release --package smoke-test --lib -- aptos_cli::validator::test_onchain_config_change --exact --nocapture

we get:
With new config: 23 rounds from vote to elected: Some(20) to Some(43)
With old config: 61 rounds from vote to elected: Some(12) to Some(73)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4986)
<!-- Reviewable:end -->
