### PR TITLE
【Developer Tutorials】fix useEffect()

### DIFF
--- a/developer-docs-site/docs/tutorials/first-dapp.md
+++ b/developer-docs-site/docs/tutorials/first-dapp.md
@@ -154,10 +154,8 @@ function App() {
    */
   const init = async() => {
     // connect
-    await window.aptos.connect();
-    const data = await window.aptos.account(); 
-    // set address
-    setAddress(data.address);
+    const { address, publicKey } = await window.aptos.connect();
+    setAddress(address);
   }
   
   React.useEffect(() => {

--- a/developer-docs-site/docs/tutorials/first-dapp.md
+++ b/developer-docs-site/docs/tutorials/first-dapp.md
@@ -148,8 +148,20 @@ import './App.css';
 function App() {
   // Retrieve aptos.account on initial render and store it.
   const [address, setAddress] = React.useState<string | null>(null);
+  
+  /**
+   * init function
+   */
+  const init = async() => {
+    // connect
+    await window.aptos.connect();
+    const data = await window.aptos.account(); 
+    // set address
+    setAddress(data.address);
+  }
+  
   React.useEffect(() => {
-    window.aptos.account().then((data : {address: string}) => setAddress(data.address));
+     init();
   }, []);
 
   return (


### PR DESCRIPTION
add connect() function.

### Description

add connect() function before account() function.

### Test Plan
I tried aptos's tutorial  「Your First Dapp」and `window.aptos.account()` in the app didn't work well.
So I added `connect()` function before `account()` function.

Below is the link of my github repo.

[https://github.com/mashharuki/AptosRepo](https://github.com/mashharuki/AptosRepo)

 Pleae try the following to test.

1. `cd first-dapp`
2. `npm i`
3. `npm run start`
4.  please access to [http://localhost:3000](http://localhost:3000)

You can see a dapp like this.
<img width="1900" alt="スクリーンショット 2022-10-12 16 46 07" src="https://user-images.githubusercontent.com/44923695/195281889-0d952117-ed60-4f2e-a787-2acf79917b6f.png">

If you push "送信" button , a popup will appear.
<img width="1899" alt="スクリーンショット 2022-10-12 16 47 23" src="https://user-images.githubusercontent.com/44923695/195282148-c8efaa2f-3069-4fa7-b640-95f33a1fe2b9.png">

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4988)
<!-- Reviewable:end -->
