### PR TITLE
[networking] set_reuseaddr before bind, and a logging improvement

### DIFF
--- a/network/netcore/src/transport/tcp.rs
+++ b/network/netcore/src/transport/tcp.rs
@@ -120,6 +120,7 @@ impl Transport for TcpTransport {
         if let Some(tx_buf) = self.tcp_buff_cfg.inbound_tx_buffer_bytes {
             socket.set_send_buffer_size(tx_buf)?;
         }
+        socket.set_reuseaddr(true)?;
         socket.bind(addr)?;
 
         let listener = socket.listen(256)?;

--- a/network/src/peer_manager/transport.rs
+++ b/network/src/peer_manager/transport.rs
@@ -63,9 +63,10 @@ where
         transport_reqs_rx: channel::Receiver<TransportRequest>,
         transport_notifs_tx: channel::Sender<TransportNotification<TSocket>>,
     ) -> (Self, NetworkAddress) {
+        let addr_string = format!("{}", listen_addr);
         let (listener, listen_addr) = transport
             .listen_on(listen_addr)
-            .expect("Transport listen on fails");
+            .unwrap_or_else(|_| panic!("Transport listen on fails: {}", addr_string));
         debug!(
             NetworkSchema::new(&network_context),
             listen_address = listen_addr,


### PR DESCRIPTION
### Description

This was done within `TcpListener.bind()` before #4649.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/4999)
<!-- Reviewable:end -->
