### PR TITLE
[prometheus] external_labels owner for fullnode or vaildator name

### DIFF
--- a/terraform/helm/monitoring/files/prometheus.yml
+++ b/terraform/helm/monitoring/files/prometheus.yml
@@ -3,6 +3,13 @@ global:
   evaluation_interval: 15s
   external_labels:
     chain_name: {{ .Values.chain.name }}
+    {{- if .Values.validator.name }}
+    owner: {{ .Values.validator.name }}
+    {{- else if .Values.fullnode.name  }}
+    owner: {{ .Values.fullnode.name }}
+    {{- else }}
+    owner: release:{{ .Release.Name }}
+    {{- end }}
 
 # Alertmanager configuration
 alerting:


### PR DESCRIPTION
### Description

report `owner` label as the fullnode or validator name, so it's easier to differentiate 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5024)
<!-- Reviewable:end -->
