### PR TITLE
[cached packages] remove non-existant aptos-names

### DIFF
--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -15,14 +15,6 @@ fn main() {
         prev_dir.pop();
         println!(
             "cargo:rerun-if-changed={}",
-            prev_dir.join("aptos-names").join("sources").display()
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            prev_dir.join("aptos-names").join("Move.toml").display()
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
             prev_dir.join("aptos-token").join("sources").display()
         );
         println!(


### PR DESCRIPTION
### Description

Was missed in #4943.
It was slowing down builds and in particular smoke tests.

### Test Plan

CICD, also verified locally that a rebuild is much faster.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5025)
<!-- Reviewable:end -->
