### PR TITLE
[vm] fix index shifting bug in bytecode verifier's instantiation loop checker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,7 +2226,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -5546,7 +5546,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5563,7 +5563,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -5579,12 +5579,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5599,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5611,7 +5611,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5623,7 +5623,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5640,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5686,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "difference",
@@ -5703,7 +5703,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5732,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -5750,7 +5750,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5804,7 +5804,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5822,7 +5822,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5840,7 +5840,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5866,7 +5866,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5885,7 +5885,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5904,7 +5904,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "hex",
@@ -5917,7 +5917,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "hex",
@@ -5931,7 +5931,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5957,7 +5957,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5993,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6030,7 +6030,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6058,7 +6058,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -6069,7 +6069,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6080,7 +6080,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6095,7 +6095,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6122,7 +6122,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6140,7 +6140,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "log",
@@ -6162,7 +6162,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6171,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6188,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6219,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6250,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6267,7 +6267,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6281,7 +6281,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -7814,7 +7814,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7829,7 +7829,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=c49400cff7851bf126de8105d0ea645d6b1cead2#c49400cff7851bf126de8105d0ea645d6b1cead2"
+source = "git+https://github.com/move-language/move?rev=b71fba7ba74656334db952bcb4031e787d3928bc#b71fba7ba74656334db952bcb4031e787d3928bc"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -43,7 +43,7 @@ aptos-vm = { path = "../aptos-move/aptos-vm" }
 
 storage-interface = { path = "../storage/storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
 
 [dev-dependencies]
 aptos-api-test-context = { path = "./test-context", package = "aptos-api-test-context" }
@@ -57,7 +57,7 @@ regex = "1.5.5"
 reqwest = { version = "0.11.10", features = ["blocking", "json"], default_features = false }
 warp = { version = "0.3.2", features = ["default"] }
 
-move-package = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-package = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [features]
 failpoints = ["fail/failpoints"]

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -28,6 +28,6 @@ aptos-vm = { path = "../../aptos-move/aptos-vm" }
 
 storage-interface = { path = "../../storage/storage-interface" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }

--- a/aptos-move/aptos-aggregator/Cargo.toml
+++ b/aptos-move/aptos-aggregator/Cargo.toml
@@ -19,10 +19,10 @@ smallvec = "1.8.0"
 aptos-crypto = { path = "../../crates/aptos-crypto" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [dev-dependencies]
 claims = "0.7"

--- a/aptos-move/aptos-gas/Cargo.toml
+++ b/aptos-move/aptos-gas/Cargo.toml
@@ -14,12 +14,12 @@ anyhow = "1.0.57"
 bcs = { git = "https://github.com/aptos-labs/bcs", rev = "2cde3e8446c460cb17b0c1d6bac7e27e964ac169" }
 clap = { version = "3.1.17", features = ["derive"] }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-model = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-model = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 aptos-global-constants = { path = "../../config/global-constants" }
 aptos-types = { path = "../../types" }

--- a/aptos-move/aptos-module-verifier/Cargo.toml
+++ b/aptos-move/aptos-module-verifier/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 edition = "2021"
 
 [dependencies]
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }

--- a/aptos-move/aptos-sdk-builder/Cargo.toml
+++ b/aptos-move/aptos-sdk-builder/Cargo.toml
@@ -23,7 +23,7 @@ textwrap = "0.15.0"
 
 aptos-types = { path = "../../types" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
 
 [dev-dependencies]
 cached-packages = { path = "../../aptos-move/framework/cached-packages" }

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -34,20 +34,20 @@ aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 
 framework =  { path = "../framework" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 mvhashmap = { path = "../mvhashmap" }
 
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
-move-unit-test = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["table-extension"], optional = true }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["table-extension"], optional = true }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -42,26 +42,26 @@ aptos-sdk-builder = { path = "../aptos-sdk-builder" }
 aptos-state-view = { path = "../../storage/state-view" }
 aptos-types = { path = "../../types" }
 gas-algebra-ext =  { path = "../gas-algebra-ext" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-core-types ={ git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-model ={ git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-package ={ git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-table-extension ={ git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-runtime ={ git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-types ={ git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-core-types ={ git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-model ={ git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-package ={ git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-table-extension ={ git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-runtime ={ git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-types ={ git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [dev-dependencies]
 claims = "0.7"
 
 aptos-gas = { path = "../../aptos-move/aptos-gas" }
 aptos-vm = { path = "../../aptos-move/aptos-vm", features = ["testing"] }
-move-cli = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-prover = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-cli = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-prover = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
-move-unit-test = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [features]
 default = []

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -19,7 +19,7 @@ proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 tempfile = "3.3.0"
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
 
 [build-dependencies]
 framework = { path = ".." }

--- a/aptos-move/gas-algebra-ext/Cargo.toml
+++ b/aptos-move/gas-algebra-ext/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }

--- a/aptos-move/move-deps/Cargo.toml
+++ b/aptos-move/move-deps/Cargo.toml
@@ -21,34 +21,34 @@ edition = "2021"
 #   actively looking for solutions.
 #
 ##########################################################################################
-move-abigen = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-cli = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-compiler = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-model = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-package = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-prover = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-cli = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-compiler = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-docgen = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-errmapgen = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-model = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-package = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-prover = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-runtime = { git = "https://github.com/move-language/move", features = ["lazy_natives"], rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [features]
 default = []

--- a/aptos-move/package-builder/Cargo.toml
+++ b/aptos-move/package-builder/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1.0.57"
 itertools = "0.10.0"
 tempfile = "3.3.0"
 
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-package = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-package = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 framework = { path = "../framework" }

--- a/aptos-move/vm-genesis/Cargo.toml
+++ b/aptos-move/vm-genesis/Cargo.toml
@@ -24,8 +24,8 @@ aptos-vm = { path = "../aptos-vm" }
 cached-packages =  { path = "../framework/cached-packages" }
 framework =  { path = "../framework" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -33,7 +33,7 @@ proptest-derive = "0.3.0"
 
 aptos-proptest-helpers = { path = "../../crates/aptos-proptest-helpers" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32", "fuzzing"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32", "fuzzing"] }
 
 [features]
 default = []

--- a/crates/aptos-rest-client/Cargo.toml
+++ b/crates/aptos-rest-client/Cargo.toml
@@ -33,5 +33,5 @@ aptos-infallible = { path = "../aptos-infallible" }
 aptos-logger = { path = "../aptos-logger" }
 aptos-types = { path = "../../types" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }

--- a/ecosystem/sf-indexer/firehose-stream/Cargo.toml
+++ b/ecosystem/sf-indexer/firehose-stream/Cargo.toml
@@ -36,9 +36,9 @@ aptos-types = { path = "../../../types" }
 aptos-vm = { path = "../../../aptos-move/aptos-vm" }
 storage-interface = { path = "../../../storage/storage-interface" }
 
-move-binary-format = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-package = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-package = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [dev-dependencies]
 goldenfile = "1.1.0"

--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -33,7 +33,7 @@ executor-types = { path = "../executor-types" }
 scratchpad = { path = "../../storage/scratchpad" }
 storage-interface = { path = "../../storage/storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/storage/aptosdb/Cargo.toml
+++ b/storage/aptosdb/Cargo.toml
@@ -45,8 +45,8 @@ schemadb = { path = "../schemadb" }
 scratchpad = { path = "../scratchpad" }
 storage-interface = { path = "../storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/storage/indexer/Cargo.toml
+++ b/storage/indexer/Cargo.toml
@@ -33,8 +33,8 @@ schemadb = { path = "../schemadb" }
 scratchpad = { path = "../scratchpad" }
 storage-interface = { path = "../storage-interface" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -29,7 +29,7 @@ aptos-vm = { path = "../../aptos-move/aptos-vm" }
 
 scratchpad = { path = "../scratchpad" }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
 
 [dev-dependencies]
 assert_unordered = "0.1.1"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -31,9 +31,9 @@ tiny-keccak = { version = "2.0.2", default-features = false, features = ["sha3"]
 aptos-bitvec = { path = "../crates/aptos-bitvec" }
 aptos-crypto = { path = "../crates/aptos-crypto" }
 aptos-crypto-derive = { path = "../crates/aptos-crypto-derive" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32"] }
 
-move-table-extension = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc" }
 
 [dev-dependencies]
 claims = "0.7"
@@ -44,7 +44,7 @@ serde_json = "1.0.81"
 
 aptos-crypto = { path = "../crates/aptos-crypto", features = ["fuzzing"] }
 
-move-core-types = { git = "https://github.com/move-language/move", rev = "c49400cff7851bf126de8105d0ea645d6b1cead2", features = ["address32", "fuzzing"] }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b71fba7ba74656334db952bcb4031e787d3928bc", features = ["address32", "fuzzing"] }
 
 [features]
 default = []


### PR DESCRIPTION
This fixes an index shifting bug in bytecode verifier's instantiation loop checker by updating the Move dependencies 

Original fix in the Move repo: https://github.com/move-language/move/pull/573

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5034)
<!-- Reviewable:end -->
