### PR TITLE
[publishing runbook] typo nit

### DIFF
--- a/sdk/publishing.md
+++ b/sdk/publishing.md
@@ -1,9 +1,8 @@
 # Publishing Runbook
 
 When preparing to make a release of the SDK follow these steps:
-1. Update version numbers of all crates to be published from `0.0.X` to `0.0.X
-   + 1` including updating the version requirement for any packages which have
-   workspace dependencies which are also being published.
+1. Update version numbers of all crates to be published from `0.0.X` to `0.0.X + 1` (e.g., from `0.0.2` to `0.0.3`) including updating the version requirement for any packages which have
+workspace dependencies which are also being published. 
 2. Perform a dry-run publish (use `cargo publish --dry-run`) in order to verify that publishing will be successful.
 3. Create a PR and get it merged into master.
 4. Once the PR has landed in master, check out the commit which does the versions bump.


### PR DESCRIPTION
### Description
just a small nit - the changed part of `publishing.md` will go from 

<img width="987" alt="Screen Shot 2022-10-13 at 4 05 51 PM" src="https://user-images.githubusercontent.com/79347459/195726855-882ccb3f-0779-419f-8810-4b4e68d6ce60.png">

to 

![Screen Shot 2022-10-13 at 4 05 34 PM](https://user-images.githubusercontent.com/79347459/195726887-51344220-65b2-4059-93ea-d41e6f504506.png)



### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5035)
<!-- Reviewable:end -->
