### PR TITLE
[tf/gcp][fullnode] customize autoscaler and NAT

### DIFF
--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -97,7 +97,7 @@ resource "helm_release" "fullnode" {
       service = {
         type = "LoadBalancer"
         annotations = {
-          "external-dns.alpha.kubernetes.io/hostname" = "pfn${count.index}.${local.domain}"
+          "external-dns.alpha.kubernetes.io/hostname" = var.zone_name != "" ? "pfn${count.index}.${local.domain}" : ""
         }
       }
       backup = {
@@ -155,7 +155,7 @@ resource "helm_release" "monitoring" {
         name = var.fullnode_name
       }
       service = {
-        domain = trimsuffix(local.domain, ".")
+        domain = var.zone_name != "" ? trimsuffix(local.domain, ".") : ""
       }
       kube-state-metrics = {
         enabled = var.enable_kube_state_metrics

--- a/terraform/fullnode/gcp/network.tf
+++ b/terraform/fullnode/gcp/network.tf
@@ -22,13 +22,15 @@ resource "google_compute_router" "nat" {
 }
 
 resource "google_compute_address" "nat" {
-  name = "aptos-${terraform.workspace}-nat"
+  count = var.gke_enable_private_nodes ? 1 : 0
+  name  = "aptos-${terraform.workspace}-nat"
 }
 
 resource "google_compute_router_nat" "nat" {
+  count                              = var.gke_enable_private_nodes ? 1 : 0
   name                               = "aptos-${terraform.workspace}-nat"
   router                             = google_compute_router.nat.name
   nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = [google_compute_address.nat.self_link]
+  nat_ips                            = [google_compute_address.nat[0].self_link]
   source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES"
 }

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -148,3 +148,33 @@ variable "enable_kube_state_metrics" {
   description = "Enable kube-state-metrics within monitoring helm chart"
   default     = false
 }
+
+variable "gke_enable_private_nodes" {
+  description = "Enable private nodes for GKE cluster"
+  default     = true
+}
+
+variable "gke_enable_node_autoprovisioning" {
+  description = "Enable node autoprovisioning for GKE cluster. See https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning"
+  default     = false
+}
+
+variable "gke_node_autoprovisioning_max_cpu" {
+  description = "Maximum CPU utilization for GKE node_autoprovisioning"
+  default     = 10
+}
+
+variable "gke_node_autoprovisioning_max_memory" {
+  description = "Maximum memory utilization for GKE node_autoprovisioning"
+  default     = 100
+}
+
+variable "gke_enable_autoscaling" {
+  description = "Enable autoscaling for the nodepools in the GKE cluster. See https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler"
+  default     = true
+}
+
+variable "gke_autoscaling_max_node_count" {
+  description = "Maximum number of nodes for GKE nodepool autoscaling"
+  default     = 10
+}


### PR DESCRIPTION
### Description

Option to make the cluster have public nodes + remove the NAT, such that all GKE worker nodes have a different outbound IP address, and also add the option to enable and configure the autoscaler

### Test Plan

Apply

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5043)
<!-- Reviewable:end -->
