### PR TITLE
Move Typescript SDK to top of SDKs list

### DIFF
--- a/developer-docs-site/sidebars.js
+++ b/developer-docs-site/sidebars.js
@@ -311,15 +311,15 @@ const sidebars = {
       collapsed: true,
       link: { type: "doc", id: "sdks/index" },
       items: [
-        "sdks/python-sdk",
         {
           type: "category",
-          label: "Typescript SDK",
+          label: "TypeScript SDK",
           link: { type: "doc", id: "sdks/ts-sdk/index" },
           collapsible: true,
           collapsed: true,
           items: ["sdks/ts-sdk/typescript-sdk", "sdks/ts-sdk/typescript-sdk-overview"],
         },
+        "sdks/python-sdk",
         "sdks/rust-sdk",
       ],
     },


### PR DESCRIPTION
### Description

Move Typescript SDK to top of SDKs list in left nav since it's the most complete

### Test Plan

Manual link check in local build and deploy preview

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5047)
<!-- Reviewable:end -->
