### PR TITLE
[Rust SDK] Fix Rust coin transfer example

### DIFF
--- a/crates/aptos-rest-client/src/faucet.rs
+++ b/crates/aptos-rest-client/src/faucet.rs
@@ -51,6 +51,7 @@ impl FaucetClient {
         let response = self
             .inner
             .post(url)
+            .header("content-length", 0)
             .send()
             .await
             .map_err(FaucetClientError::request)?;
@@ -84,6 +85,7 @@ impl FaucetClient {
         let response = self
             .inner
             .post(url)
+            .header("content-length", 0)
             .send()
             .await
             .map_err(FaucetClientError::request)?;

--- a/sdk/examples/transfer-coin.rs
+++ b/sdk/examples/transfer-coin.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<()> {
     // Create the accounts on chain, but only fund Alice.
     // :!:>section_3
     faucet_client
-        .fund(alice.address(), 600_000)
+        .fund(alice.address(), 100_000_000)
         .await
         .context("Failed to fund Alice's account")?;
     faucet_client


### PR DESCRIPTION
### Description
Faucet API now requires `content-length`, however, the Rust faucet client is not passing one in. This fixes it.

### Test Plan
cargo run --example transfer-coin

=== Addresses ===
Alice: 0x6e10921aa60ac688ee842fbb3ec9bd7dd46225ec1cc35b2d8f5d300bd911e31c
Bob: 0x65ede8aa5acbb9c1bb59bd6427c142cf61897d327c608cb5e5ec78dce15b6b99

=== Initial Balances ===
Alice: 100000000
Bob: 0

=== Intermediate Balances ===
Alice: 99944900
Bob: 1000

=== Final Balances ===
Alice: 99889800
Bob: 2000

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5052)
<!-- Reviewable:end -->
