### PR TITLE
[mempool] add bucket to latency stats

### DIFF
--- a/mempool/src/core_mempool/mempool.rs
+++ b/mempool/src/core_mempool/mempool.rs
@@ -90,9 +90,9 @@ impl Mempool {
     }
 
     fn log_latency(&self, account: AccountAddress, sequence_number: u64, stage: &'static str) {
-        if let Some((&insertion_time, is_end_to_end)) = self
+        if let Some((&insertion_time, is_end_to_end, bucket)) = self
             .transactions
-            .get_insertion_time(&account, sequence_number)
+            .get_insertion_time_and_bucket(&account, sequence_number)
         {
             if let Ok(time_delta) = SystemTime::now().duration_since(insertion_time) {
                 let scope = if is_end_to_end {
@@ -100,7 +100,7 @@ impl Mempool {
                 } else {
                     LOCAL_LABEL
                 };
-                counters::core_mempool_txn_commit_latency(stage, scope, time_delta);
+                counters::core_mempool_txn_commit_latency(stage, scope, bucket, time_delta);
             }
         }
     }

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -170,10 +170,11 @@ pub static CORE_MEMPOOL_IDEMPOTENT_TXNS: Lazy<IntCounter> = Lazy::new(|| {
 pub fn core_mempool_txn_commit_latency(
     stage: &'static str,
     scope: &'static str,
+    bucket: &str,
     latency: Duration,
 ) {
     CORE_MEMPOOL_TXN_COMMIT_LATENCY
-        .with_label_values(&[stage, scope])
+        .with_label_values(&[stage, scope, bucket])
         .observe(latency.as_secs_f64());
 }
 
@@ -185,7 +186,7 @@ static CORE_MEMPOOL_TXN_COMMIT_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
         "Latency of txn reaching various stages in core mempool after insertion",
         LARGER_LATENCY_BUCKETS.to_vec()
     );
-    register_histogram_vec!(histogram_opts, &["stage", "scope"]).unwrap()
+    register_histogram_vec!(histogram_opts, &["stage", "scope", "bucket"]).unwrap()
 });
 
 pub fn core_mempool_txn_ranking_score(

--- a/mempool/src/tests/core_mempool_test.rs
+++ b/mempool/src/tests/core_mempool_test.rs
@@ -84,16 +84,16 @@ fn test_transaction_metrics() {
     );
 
     // Check timestamp returned as end-to-end for broadcast-able transaction
-    let (&_insertion_time, is_end_to_end) = mempool
+    let (&_insertion_time, is_end_to_end, _bucket) = mempool
         .get_transaction_store()
-        .get_insertion_time(&TestTransaction::get_address(0), 0)
+        .get_insertion_time_and_bucket(&TestTransaction::get_address(0), 0)
         .unwrap();
     assert!(is_end_to_end);
 
     // Check timestamp returned as not end-to-end for non-broadcast-able transaction
-    let (&_insertion_time, is_end_to_end) = mempool
+    let (&_insertion_time, is_end_to_end, _bucket) = mempool
         .get_transaction_store()
-        .get_insertion_time(&TestTransaction::get_address(1), 0)
+        .get_insertion_time_and_bucket(&TestTransaction::get_address(1), 0)
         .unwrap();
     assert!(!is_end_to_end);
 }


### PR DESCRIPTION
### Description

For use in mempool and general health (gas schedule) dashboards.

### Test Plan

Forge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5057)
<!-- Reviewable:end -->
