### PR TITLE
[Indexer] Limit token ownership to only tokenstore

### DIFF
--- a/crates/indexer/migrations/2022-08-08-043603_core_tables/up.sql
+++ b/crates/indexer/migrations/2022-08-08-043603_core_tables/up.sql
@@ -302,7 +302,7 @@ CREATE TABLE table_metadatas (
   inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX tm_insat_index ON table_metadatas (inserted_at);
--- table metadatas in write set changes
+-- Tracks processor version status
 CREATE TABLE processor_statuses (
   name VARCHAR(50) NOT NULL,
   version BIGINT NOT NULL,

--- a/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/down.sql
+++ b/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS processor_status;

--- a/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/up.sql
+++ b/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+-- Tracks latest processed version per processor
+CREATE TABLE processor_status (
+  processor VARCHAR(50) UNIQUE PRIMARY KEY NOT NULL,
+  last_success_version BIGINT NOT NULL,
+  last_updated TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/crates/indexer/src/models/ledger_info.rs
+++ b/crates/indexer/src/models/ledger_info.rs
@@ -1,11 +1,21 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::extra_unused_lifetimes)]
-use crate::schema::ledger_infos;
+use crate::{database::PgPoolConnection, schema::ledger_infos};
+use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
 
 #[derive(Debug, Identifiable, Insertable, Queryable)]
 #[diesel(table_name = ledger_infos)]
 #[diesel(primary_key(chain_id))]
 pub struct LedgerInfo {
     pub chain_id: i64,
+}
+
+impl LedgerInfo {
+    pub fn get(conn: &mut PgPoolConnection) -> diesel::QueryResult<Option<Self>> {
+        ledger_infos::table
+            .select(ledger_infos::all_columns)
+            .first::<Self>(conn)
+            .optional()
+    }
 }

--- a/crates/indexer/src/models/mod.rs
+++ b/crates/indexer/src/models/mod.rs
@@ -8,6 +8,7 @@ pub mod ledger_info;
 pub mod move_modules;
 pub mod move_resources;
 pub mod move_tables;
+pub mod processor_status;
 pub mod processor_statuses;
 pub mod signatures;
 pub mod token_models;

--- a/crates/indexer/src/models/processor_status.rs
+++ b/crates/indexer/src/models/processor_status.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::extra_unused_lifetimes)]
+use crate::{database::PgPoolConnection, schema::processor_status};
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
+
+#[derive(AsChangeset, Debug, Insertable)]
+#[diesel(table_name = processor_status)]
+/// Only tracking the latest version successfully processed
+pub struct ProcessorStatusV2 {
+    pub processor: String,
+    pub last_success_version: i64,
+}
+
+#[derive(AsChangeset, Debug, Queryable)]
+#[diesel(table_name = processor_status)]
+/// Only tracking the latest version successfully processed
+pub struct ProcessorStatusV2Query {
+    pub processor: String,
+    pub last_success_version: i64,
+    pub last_updated: chrono::NaiveDateTime,
+}
+
+impl ProcessorStatusV2Query {
+    pub fn get_by_processor(
+        processor_name: &String,
+        conn: &mut PgPoolConnection,
+    ) -> diesel::QueryResult<Option<Self>> {
+        processor_status::table
+            .filter(processor_status::processor.eq(processor_name))
+            .first::<Self>(conn)
+            .optional()
+    }
+}

--- a/crates/indexer/src/models/processor_statuses.rs
+++ b/crates/indexer/src/models/processor_statuses.rs
@@ -7,6 +7,7 @@ use field_count::FieldCount;
 #[derive(AsChangeset, Debug, FieldCount, Insertable, Queryable)]
 #[diesel(treat_none_as_null = true)]
 #[diesel(table_name = processor_statuses)]
+/// We are deprecating this in favor of ProcessorStatusV2
 pub struct ProcessorStatus {
     pub name: &'static str,
     pub version: i64,

--- a/crates/indexer/src/models/token_models/collection_datas.rs
+++ b/crates/indexer/src/models/token_models/collection_datas.rs
@@ -157,8 +157,6 @@ impl CollectionData {
     /// If collection data is not in resources of the same transaction, then try looking for it in the database. Since collection owner
     /// cannot change, we can just look in the current_collection_datas table.
     /// Retrying a few times since this collection could've been written in a separate thread.
-    /// Note, there's an edge case where this could still break. If the collection is written in the same thread in an earlier transaction, we won't be able to process.
-    /// TODO: Fast follow with a fix for above problem.
     pub fn get_collection_creator(
         conn: &mut PgPoolConnection,
         table_handle: &str,

--- a/crates/indexer/src/models/token_models/token_ownerships.rs
+++ b/crates/indexer/src/models/token_models/token_ownerships.rs
@@ -5,11 +5,15 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::tokens::{TableHandleToOwner, TableMetadataForToken, Token};
+use super::{
+    token_utils::TokenWriteSet,
+    tokens::{TableHandleToOwner, TableMetadataForToken, Token},
+};
 use crate::schema::{current_token_ownerships, token_ownerships};
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
 #[diesel(primary_key(
@@ -53,18 +57,39 @@ pub struct CurrentTokenOwnership {
 }
 
 impl TokenOwnership {
+    /// We only want to track tokens in 0x1::token::TokenStore for now. This is because the table
+    /// schema doesn't have table type (i.e. token container) as primary key. TokenStore has token_id
+    /// as key and token as value.
     pub fn from_token(
         token: &Token,
+        table_item_key_type: &str,
+        table_item_key: &Value,
         amount: BigDecimal,
         table_handle: String,
         table_handle_to_owner: &TableHandleToOwner,
-        // Escrow tables somehow don't appear in resources so this is just a temporary workaround to record that it's an escrow table
-        value_type: Option<&str>,
-    ) -> (Self, Option<CurrentTokenOwnership>) {
-        let table_handle = TableMetadataForToken::standardize_handle(&table_handle);
+    ) -> anyhow::Result<Option<(Self, Option<CurrentTokenOwnership>)>> {
         let txn_version = token.transaction_version;
+        let maybe_token_id = match TokenWriteSet::from_table_item_type(
+            table_item_key_type,
+            table_item_key,
+            txn_version,
+        )? {
+            Some(TokenWriteSet::TokenId(inner)) => Some(inner),
+            _ => None,
+        };
+        // Return early if table key is not token id
+        if maybe_token_id.is_none() {
+            return Ok(None);
+        }
+        let table_handle = TableMetadataForToken::standardize_handle(&table_handle);
         let maybe_table_metadata = table_handle_to_owner.get(&table_handle);
-        let (curr_token_ownership, owner_address, mut table_type) = match maybe_table_metadata {
+        // Return early if table type is not tokenstore
+        if let Some(tm) = maybe_table_metadata {
+            if tm.table_type != "0x3::token::TokenStore" {
+                return Ok(None);
+            }
+        }
+        let (curr_token_ownership, owner_address, table_type) = match maybe_table_metadata {
             Some(tm) => (
                 Some(CurrentTokenOwnership {
                     collection_data_id_hash: token.collection_data_id_hash.clone(),
@@ -94,17 +119,7 @@ impl TokenOwnership {
             }
         };
 
-        // Hacky handling of escrow tables that are generally present as a resource
-        if let Some(val) = value_type {
-            if val == "0x3::token_coin_swap::TokenEscrow" {
-                table_type = Some(
-                    table_type
-                        .unwrap_or_else(|| "0x3::token_coin_swap::TokenStoreEscrow".to_string()),
-                )
-            }
-        }
-
-        (
+        Ok(Some((
             Self {
                 collection_data_id_hash: token.collection_data_id_hash.clone(),
                 token_data_id_hash: token.token_data_id_hash.clone(),
@@ -120,6 +135,6 @@ impl TokenOwnership {
                 transaction_timestamp: token.transaction_timestamp,
             },
             curr_token_ownership,
-        )
+        )))
     }
 }

--- a/crates/indexer/src/models/token_models/tokens.rs
+++ b/crates/indexer/src/models/token_models/tokens.rs
@@ -69,6 +69,7 @@ impl Token {
     /// state at the last transaction will be tracked, hence using hashmap to dedupe)
     pub fn from_transaction(
         transaction: &APITransaction,
+        table_handle_to_owner: &TableHandleToOwner,
         conn: &mut PgPoolConnection,
     ) -> (
         Vec<Self>,
@@ -101,19 +102,6 @@ impl Token {
 
             let txn_version = user_txn.info.version.0 as i64;
             let txn_timestamp = parse_timestamp(user_txn.timestamp.0, txn_version);
-            let mut table_handle_to_owner: TableHandleToOwner = HashMap::new();
-            for wsc in &user_txn.info.changes {
-                if let APIWriteSetChange::WriteResource(write_resource) = wsc {
-                    let maybe_map = TableMetadataForToken::get_table_handle_to_owner(
-                        write_resource,
-                        txn_version,
-                    )
-                    .unwrap();
-                    if let Some(map) = maybe_map {
-                        table_handle_to_owner.extend(map);
-                    }
-                }
-            }
 
             for wsc in &user_txn.info.changes {
                 // Basic token and ownership data
@@ -123,7 +111,7 @@ impl Token {
                             write_table_item,
                             txn_version,
                             txn_timestamp,
-                            &table_handle_to_owner,
+                            table_handle_to_owner,
                         )
                         .unwrap(),
                         TokenData::from_write_table_item(
@@ -136,7 +124,7 @@ impl Token {
                             write_table_item,
                             txn_version,
                             txn_timestamp,
-                            &table_handle_to_owner,
+                            table_handle_to_owner,
                             conn,
                         )
                         .unwrap(),
@@ -146,7 +134,7 @@ impl Token {
                             delete_table_item,
                             txn_version,
                             txn_timestamp,
-                            &table_handle_to_owner,
+                            table_handle_to_owner,
                         )
                         .unwrap(),
                         None,
@@ -161,7 +149,7 @@ impl Token {
                             write_table_item,
                             txn_version,
                             txn_timestamp,
-                            &table_handle_to_owner,
+                            table_handle_to_owner,
                         )
                         .unwrap()
                     }
@@ -170,14 +158,14 @@ impl Token {
                             delete_table_item,
                             txn_version,
                             txn_timestamp,
-                            &table_handle_to_owner,
+                            table_handle_to_owner,
                         )
                         .unwrap()
                     }
                     _ => None,
                 };
 
-                if let Some((token, token_ownership, maybe_current_token_ownership)) =
+                if let Some((token, maybe_token_ownership, maybe_current_token_ownership)) =
                     maybe_token_w_ownership
                 {
                     tokens.insert(
@@ -187,7 +175,9 @@ impl Token {
                         ),
                         token,
                     );
-                    token_ownerships.push(token_ownership);
+                    if let Some(token_ownership) = maybe_token_ownership {
+                        token_ownerships.push(token_ownership);
+                    }
                     if let Some(current_token_ownership) = maybe_current_token_ownership {
                         current_token_ownerships.insert(
                             (
@@ -247,7 +237,7 @@ impl Token {
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
         table_handle_to_owner: &TableHandleToOwner,
-    ) -> anyhow::Result<Option<(Self, TokenOwnership, Option<CurrentTokenOwnership>)>> {
+    ) -> anyhow::Result<Option<(Self, Option<TokenOwnership>, Option<CurrentTokenOwnership>)>> {
         let table_item_data = table_item.data.as_ref().unwrap();
 
         let maybe_token = match TokenWriteSet::from_table_item_type(
@@ -281,11 +271,16 @@ impl Token {
 
             let (token_ownership, current_token_ownership) = TokenOwnership::from_token(
                 &token_pg,
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
                 ensure_not_negative(token.amount),
                 table_item.handle.to_string(),
                 table_handle_to_owner,
-                Some(table_item_data.value_type.as_str()),
-            );
+            )?
+            .map(|(token_ownership, current_token_ownership)| {
+                (Some(token_ownership), current_token_ownership)
+            })
+            .unwrap_or((None, None));
 
             Ok(Some((token_pg, token_ownership, current_token_ownership)))
         } else {
@@ -300,7 +295,7 @@ impl Token {
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
         table_handle_to_owner: &TableHandleToOwner,
-    ) -> anyhow::Result<Option<(Self, TokenOwnership, Option<CurrentTokenOwnership>)>> {
+    ) -> anyhow::Result<Option<(Self, Option<TokenOwnership>, Option<CurrentTokenOwnership>)>> {
         let table_item_data = table_item.data.as_ref().unwrap();
 
         let maybe_token_id = match TokenWriteSet::from_table_item_type(
@@ -332,11 +327,16 @@ impl Token {
             };
             let (token_ownership, current_token_ownership) = TokenOwnership::from_token(
                 &token,
+                table_item_data.key_type.as_str(),
+                &table_item_data.key,
                 BigDecimal::zero(),
                 table_item.handle.to_string(),
                 table_handle_to_owner,
-                None,
-            );
+            )?
+            .map(|(token_ownership, current_token_ownership)| {
+                (Some(token_ownership), current_token_ownership)
+            })
+            .unwrap_or((None, None));
             Ok(Some((token, token_ownership, current_token_ownership)))
         } else {
             Ok(None)
@@ -345,6 +345,32 @@ impl Token {
 }
 
 impl TableMetadataForToken {
+    /// Mapping from table handle to owner type, including type of the table (AKA resource type)
+    /// from user transactions in a batch of transactions
+    pub fn get_table_handle_to_owner_from_transactions(
+        transactions: &[APITransaction],
+    ) -> TableHandleToOwner {
+        let mut table_handle_to_owner: TableHandleToOwner = HashMap::new();
+        // Do a first pass to get all the table metadata in the batch.
+        for transaction in transactions {
+            if let APITransaction::UserTransaction(user_txn) = transaction {
+                let txn_version = user_txn.info.version.0 as i64;
+                for wsc in &user_txn.info.changes {
+                    if let APIWriteSetChange::WriteResource(write_resource) = wsc {
+                        let maybe_map = TableMetadataForToken::get_table_handle_to_owner(
+                            write_resource,
+                            txn_version,
+                        )
+                        .unwrap();
+                        if let Some(map) = maybe_map {
+                            table_handle_to_owner.extend(map);
+                        }
+                    }
+                }
+            }
+        }
+        table_handle_to_owner
+    }
     /// Mapping from table handle to owner type, including type of the table (AKA resource type)
     fn get_table_handle_to_owner(
         write_resource: &APIWriteResource,

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -465,7 +465,7 @@ impl TransactionProcessor for TokenTransactionProcessor {
         let mut conn = self.get_conn();
 
         // First get all token related table metadata from the batch of transactions. This is in case
-        // an earlier transaction has metadata (in resources) that's missing from a later transaction. 
+        // an earlier transaction has metadata (in resources) that's missing from a later transaction.
         let table_handle_to_owner =
             TableMetadataForToken::get_table_handle_to_owner_from_transactions(&transactions);
 

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -16,7 +16,10 @@ use crate::{
         token_claims::CurrentTokenPendingClaim,
         token_datas::{CurrentTokenData, TokenData},
         token_ownerships::{CurrentTokenOwnership, TokenOwnership},
-        tokens::{CurrentTokenOwnershipPK, CurrentTokenPendingClaimPK, Token, TokenDataIdHash},
+        tokens::{
+            CurrentTokenOwnershipPK, CurrentTokenPendingClaimPK, TableMetadataForToken, Token,
+            TokenDataIdHash,
+        },
     },
     schema,
 };
@@ -461,6 +464,11 @@ impl TransactionProcessor for TokenTransactionProcessor {
     ) -> Result<ProcessingResult, TransactionProcessingError> {
         let mut conn = self.get_conn();
 
+        // First get all token related table metadata from the batch of transactions. This is in case
+        // an earlier transaction has metadata (in resources) that's missing from a later transaction. 
+        let table_handle_to_owner =
+            TableMetadataForToken::get_table_handle_to_owner_from_transactions(&transactions);
+
         let mut all_tokens = vec![];
         let mut all_token_ownerships = vec![];
         let mut all_token_datas = vec![];
@@ -493,7 +501,7 @@ impl TransactionProcessor for TokenTransactionProcessor {
                 current_token_datas,
                 current_collection_datas,
                 current_token_claims,
-            ) = Token::from_transaction(&txn, &mut conn);
+            ) = Token::from_transaction(&txn, &table_handle_to_owner, &mut conn);
             all_tokens.append(&mut tokens);
             all_token_ownerships.append(&mut token_ownerships);
             all_token_datas.append(&mut token_datas);

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -112,7 +112,6 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
     let processor_tasks = config.processor_tasks.unwrap();
     let emit_every = config.emit_every.unwrap();
     let batch_size = config.batch_size.unwrap();
-    let lookback_versions = config.gap_lookback_versions.unwrap() as i64;
 
     info!(processor_name = processor_name, "Starting indexer...");
 
@@ -154,26 +153,28 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
 
     info!(
         processor_name = processor_name,
-        lookback_versions = lookback_versions,
         "Fetching starting version from db..."
     );
+    let starting_version_from_db = tailer
+        .get_start_version(&processor_name)
+        .unwrap_or_else(|e| panic!("Failed to get starting version: {:?}", e))
+        .unwrap_or_else(|| {
+            info!(
+                processor_name = processor_name,
+                "No starting version from db so starting from version 0"
+            );
+            0
+        }) as u64;
     let start_version = match config.starting_version {
-        None => tailer
-            .get_start_version(&processor_name, lookback_versions)
-            .unwrap_or_else(|| {
-                info!(
-                    processor_name = processor_name,
-                    "Could not fetch version from db so starting from version 0"
-                );
-                0
-            }) as u64,
+        None => starting_version_from_db,
         Some(version) => version,
     };
 
     info!(
         processor_name = processor_name,
-        start_version = start_version,
+        final_start_version = start_version,
         start_version_from_config = config.starting_version,
+        starting_version_from_db = starting_version_from_db,
         "Setting starting version..."
     );
     tailer.set_fetcher_version(start_version as u64).await;
@@ -228,7 +229,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
                     processor_name = processor_name,
                     start_version = start_version,
                     end_version = end_version,
-                    error = format!("{:?}", err),
+                    error =? err,
                     "Error processing batch!"
                 );
                 panic!(
@@ -237,6 +238,18 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
                 );
             }
         };
+
+        tailer
+            .update_last_processed_version(&processor_name, processing_result.end_version)
+            .unwrap_or_else(|e| {
+                error!(
+                    processor_name = processor_name,
+                    end_version = processing_result.end_version,
+                    error = format!("{:?}", e),
+                    "Failed to update last processed version!"
+                );
+                panic!("Failed to update last processed version: {:?}", e);
+            });
 
         ma.tick_now(num_res);
 

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -263,6 +263,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    processor_status (processor) {
+        processor -> Varchar,
+        last_success_version -> Int8,
+        last_updated -> Timestamp,
+    }
+}
+
+diesel::table! {
     processor_statuses (name, version) {
         name -> Varchar,
         version -> Int8,
@@ -466,6 +474,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     ledger_infos,
     move_modules,
     move_resources,
+    processor_status,
     processor_statuses,
     signatures,
     table_items,


### PR DESCRIPTION
### Description
Currently there's a bug where `token_ownerships` and `current_token_ownerships` are mishandling non 0x3::token::TokenStore objects. (e.g. missing delete event). This PR removes non 0x3 TokenStore tables from token ownership tables. This should be fine b/c products should be filtering on TokenStore anyway (e.g. to get user owned NFTs). 

This PR also fixes a previous issue with table handles. We now get all the table metadata per batch. 

```
    /// Note, there's an edge case where this could still break. If the collection is written in the same thread in an earlier transaction, we won't be able to process.
    /// TODO: Fast follow with a fix for above problem.
```

### Test Plan
Tested locally and deployed against devnet. 
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5062)
<!-- Reviewable:end -->
