### PR TITLE
[storage] disallow concurrent commit

### DIFF
--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -1490,7 +1490,10 @@ impl DbWriter for AptosDB {
             // Executing and committing from more than one threads not allowed -- consensus and
             // state sync must hand over to each other after all pending execution and committing
             // complete.
-            let _lock = self.ledger_commit_lock.lock();
+            let _lock = self
+                .ledger_commit_lock
+                .try_lock()
+                .expect("Concurrent committing detected.");
 
             let num_txns = txns_to_commit.len() as u64;
             // ledger_info_with_sigs could be None if we are doing state synchronization. In this case


### PR DESCRIPTION
### Description

It used to be paranoid like this, but https://github.com/aptos-labs/aptos-core/commit/8c16409042b102aad343aa873aaeef8c758c86bd started allowing two concurrent commits to be issued at the same time again (although they will be processed one after another because of the lock). Now that get_startup_info is removed by https://github.com/aptos-labs/aptos-core/pull/2606, we can be paranoid again.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5068)
<!-- Reviewable:end -->
