### PR TITLE
[Indexer] Improve processor tracking and error handling

### DIFF
--- a/crates/indexer/migrations/2022-08-08-043603_core_tables/up.sql
+++ b/crates/indexer/migrations/2022-08-08-043603_core_tables/up.sql
@@ -302,7 +302,7 @@ CREATE TABLE table_metadatas (
   inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 CREATE INDEX tm_insat_index ON table_metadatas (inserted_at);
--- table metadatas in write set changes
+-- Tracks processor version status
 CREATE TABLE processor_statuses (
   name VARCHAR(50) NOT NULL,
   version BIGINT NOT NULL,

--- a/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/down.sql
+++ b/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS processor_status;

--- a/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/up.sql
+++ b/crates/indexer/migrations/2022-10-15-185912_improve_processor_recovery/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+-- Tracks latest processed version per processor
+CREATE TABLE processor_status (
+  processor VARCHAR(50) UNIQUE PRIMARY KEY NOT NULL,
+  last_success_version BIGINT NOT NULL,
+  last_updated TIMESTAMP NOT NULL DEFAULT NOW()
+);

--- a/crates/indexer/src/models/ledger_info.rs
+++ b/crates/indexer/src/models/ledger_info.rs
@@ -1,11 +1,21 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::extra_unused_lifetimes)]
-use crate::schema::ledger_infos;
+use crate::{database::PgPoolConnection, schema::ledger_infos};
+use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
 
 #[derive(Debug, Identifiable, Insertable, Queryable)]
 #[diesel(table_name = ledger_infos)]
 #[diesel(primary_key(chain_id))]
 pub struct LedgerInfo {
     pub chain_id: i64,
+}
+
+impl LedgerInfo {
+    pub fn get(conn: &mut PgPoolConnection) -> diesel::QueryResult<Option<Self>> {
+        ledger_infos::table
+            .select(ledger_infos::all_columns)
+            .first::<Self>(conn)
+            .optional()
+    }
 }

--- a/crates/indexer/src/models/mod.rs
+++ b/crates/indexer/src/models/mod.rs
@@ -8,6 +8,7 @@ pub mod ledger_info;
 pub mod move_modules;
 pub mod move_resources;
 pub mod move_tables;
+pub mod processor_status;
 pub mod processor_statuses;
 pub mod signatures;
 pub mod token_models;

--- a/crates/indexer/src/models/processor_status.rs
+++ b/crates/indexer/src/models/processor_status.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+#![allow(clippy::extra_unused_lifetimes)]
+use crate::{database::PgPoolConnection, schema::processor_status};
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
+
+#[derive(AsChangeset, Debug, Insertable)]
+#[diesel(table_name = processor_status)]
+/// Only tracking the latest version successfully processed
+pub struct ProcessorStatusV2 {
+    pub processor: String,
+    pub last_success_version: i64,
+}
+
+#[derive(AsChangeset, Debug, Queryable)]
+#[diesel(table_name = processor_status)]
+/// Only tracking the latest version successfully processed
+pub struct ProcessorStatusV2Query {
+    pub processor: String,
+    pub last_success_version: i64,
+    pub last_updated: chrono::NaiveDateTime,
+}
+
+impl ProcessorStatusV2Query {
+    pub fn get_by_processor(
+        processor_name: &String,
+        conn: &mut PgPoolConnection,
+    ) -> diesel::QueryResult<Option<Self>> {
+        processor_status::table
+            .filter(processor_status::processor.eq(processor_name))
+            .first::<Self>(conn)
+            .optional()
+    }
+}

--- a/crates/indexer/src/models/processor_statuses.rs
+++ b/crates/indexer/src/models/processor_statuses.rs
@@ -7,6 +7,7 @@ use field_count::FieldCount;
 #[derive(AsChangeset, Debug, FieldCount, Insertable, Queryable)]
 #[diesel(treat_none_as_null = true)]
 #[diesel(table_name = processor_statuses)]
+/// We are deprecating this in favor of ProcessorStatusV2
 pub struct ProcessorStatus {
     pub name: &'static str,
     pub version: i64,

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -112,7 +112,6 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
     let processor_tasks = config.processor_tasks.unwrap();
     let emit_every = config.emit_every.unwrap();
     let batch_size = config.batch_size.unwrap();
-    let lookback_versions = config.gap_lookback_versions.unwrap() as i64;
 
     info!(processor_name = processor_name, "Starting indexer...");
 
@@ -154,26 +153,28 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
 
     info!(
         processor_name = processor_name,
-        lookback_versions = lookback_versions,
         "Fetching starting version from db..."
     );
+    let starting_version_from_db = tailer
+        .get_start_version(&processor_name)
+        .unwrap_or_else(|e| panic!("Failed to get starting version: {:?}", e))
+        .unwrap_or_else(|| {
+            info!(
+                processor_name = processor_name,
+                "No starting version from db so starting from version 0"
+            );
+            0
+        }) as u64;
     let start_version = match config.starting_version {
-        None => tailer
-            .get_start_version(&processor_name, lookback_versions)
-            .unwrap_or_else(|| {
-                info!(
-                    processor_name = processor_name,
-                    "Could not fetch version from db so starting from version 0"
-                );
-                0
-            }) as u64,
+        None => starting_version_from_db,
         Some(version) => version,
     };
 
     info!(
         processor_name = processor_name,
-        start_version = start_version,
+        final_start_version = start_version,
         start_version_from_config = config.starting_version,
+        starting_version_from_db = starting_version_from_db,
         "Setting starting version..."
     );
     tailer.set_fetcher_version(start_version as u64).await;
@@ -228,7 +229,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
                     processor_name = processor_name,
                     start_version = start_version,
                     end_version = end_version,
-                    error = format!("{:?}", err),
+                    error =? err,
                     "Error processing batch!"
                 );
                 panic!(
@@ -237,6 +238,18 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
                 );
             }
         };
+
+        tailer
+            .update_last_processed_version(&processor_name, processing_result.end_version)
+            .unwrap_or_else(|e| {
+                error!(
+                    processor_name = processor_name,
+                    end_version = processing_result.end_version,
+                    error = format!("{:?}", e),
+                    "Failed to update last processed version!"
+                );
+                panic!("Failed to update last processed version: {:?}", e);
+            });
 
         ma.tick_now(num_res);
 

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -263,6 +263,14 @@ diesel::table! {
 }
 
 diesel::table! {
+    processor_status (processor) {
+        processor -> Varchar,
+        last_success_version -> Int8,
+        last_updated -> Timestamp,
+    }
+}
+
+diesel::table! {
     processor_statuses (name, version) {
         name -> Varchar,
         version -> Int8,
@@ -466,6 +474,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     ledger_infos,
     move_modules,
     move_resources,
+    processor_status,
     processor_statuses,
     signatures,
     table_items,


### PR DESCRIPTION
### Description
The old processor_statuses table is way too large (since we're saving every version) and restarting takes 10+ minutes. Tracking every version and finding the first gap is overkill anyway since we panic at the first error, so it's sufficient to just save fully completed batches. The other benefit of only saving the latest completed version is that we can use it to inform products (i.e. if it's behind). 

I also improved error handling here and there by removing expects and unwraps. 

### Test Plan
Tested locally and in staging environments. 
I'm also running the old processor_statuses table in parallel to make sure that the results are the same. E.g.
**old gap query**
<img width="138" alt="image" src="https://user-images.githubusercontent.com/11738325/196012282-43f1994a-579a-487e-95d5-3553ce5af563.png">

**new query**
<img width="516" alt="image" src="https://user-images.githubusercontent.com/11738325/196012260-2e12cbea-cb4f-487e-9347-f5c0f886fbea.png">

There's a 1 version difference b/c the gap formula gets the "next" version. So we just need to add +1 to the new table to get the next starting version. 

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5071)
<!-- Reviewable:end -->
