### PR TITLE
[cli] Add updates to make CLI default to devnet, cleanup messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "aptos-bitvec",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "0.4.0"
+version = "1.0.0"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1225,16 +1225,6 @@ pub struct GasOptions {
 /// Common options for interacting with an account for a validator
 #[derive(Debug, Default, Parser)]
 pub struct TransactionOptions {
-    /// [Deprecated] Estimate maximum gas via simulation
-    ///
-    /// Deprecated parameter, the default behavior is now to estimate max gas automatically, and ask for
-    /// confirmation
-    ///
-    /// This will simulate the transaction, and use the simulated actual amount of gas
-    /// to be used as the max gas.
-    #[clap(long)]
-    pub(crate) estimate_max_gas: bool,
-
     /// Sender account address
     ///
     /// This allows you to override the account address from the derived account address

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -4,14 +4,10 @@
 use crate::common::init::Network;
 use crate::common::utils::prompt_yes_with_override;
 use crate::{
-    common::{
-        init::{DEFAULT_FAUCET_URL, DEFAULT_REST_URL},
-        utils::{
-            chain_id, check_if_file_exists, create_dir_if_not_exist, dir_default_to_current,
-            get_auth_key, get_sequence_number, read_from_file, start_logger, to_common_result,
-            to_common_success_result, write_to_file, write_to_file_with_opts,
-            write_to_user_only_file,
-        },
+    common::utils::{
+        chain_id, check_if_file_exists, create_dir_if_not_exist, dir_default_to_current,
+        get_auth_key, get_sequence_number, read_from_file, start_logger, to_common_result,
+        to_common_success_result, write_to_file, write_to_file_with_opts, write_to_user_only_file,
     },
     config::GlobalConfig,
     genesis::git::from_yaml,
@@ -886,9 +882,7 @@ impl RestOptions {
             reqwest::Url::parse(&url)
                 .map_err(|err| CliError::UnableToParse("Rest URL", err.to_string()))
         } else {
-            reqwest::Url::parse(DEFAULT_REST_URL).map_err(|err| {
-                CliError::UnexpectedError(format!("Failed to parse default rest URL {}", err))
-            })
+            Err(CliError::CommandArgumentError("No rest url given.  Please add --url or add a rest_url to the .aptos/config.yaml for the current profile".to_string()))
         }
     }
 
@@ -1194,9 +1188,7 @@ impl FaucetOptions {
             reqwest::Url::parse(&url)
                 .map_err(|err| CliError::UnableToParse("config faucet_url", err.to_string()))
         } else {
-            reqwest::Url::parse(DEFAULT_FAUCET_URL).map_err(|err| {
-                CliError::UnexpectedError(format!("Failed to parse default faucet URL {}", err))
-            })
+            Err(CliError::CommandArgumentError("No faucet given.  Please add --faucet-url or add a faucet URL to the .aptos/config.yaml for the current profile".to_string()))
         }
     }
 }

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -227,7 +227,6 @@ impl CliTestFramework {
                 rest_options: self.rest_options(),
                 gas_options: gas_options.unwrap_or_default(),
                 prompt_options: PromptOptions::yes(),
-                estimate_max_gas: true,
                 ..Default::default()
             },
             new_private_key: Some(new_private_key),
@@ -943,7 +942,6 @@ impl CliTestFramework {
             rest_options: self.rest_options(),
             gas_options: gas_options.unwrap_or_default(),
             prompt_options: PromptOptions::yes(),
-            estimate_max_gas: true,
             ..Default::default()
         }
     }


### PR DESCRIPTION
### Description
Adds devnet as the default network, and cleans up some error messages with the custom
endpoint flow.

### Test Plan
Doing nothing, is much easier now, it'll default to devnet and not have you type in all the URLs:
```
apt init --profile awesome-test
Configuring for profile awesome-test
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]

No network given, using devnet...
Enter your private key as a hex literal (0x...) [Current: None | No input: Generate new key (or keep one if present)]

No key given, generating key...
Account 24ff19d58561b7ff4430f68798565c99c9fa1d8fa7b1ee194d1bf3f135b4ea57 doesn't exist, creating it and funding it with 100000000 Octas
Account 24ff19d58561b7ff4430f68798565c99c9fa1d8fa7b1ee194d1bf3f135b4ea57 funded successfully

---
Aptos CLI is now set up for account 24ff19d58561b7ff4430f68798565c99c9fa1d8fa7b1ee194d1bf3f135b4ea57 as profile awesome-test!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}
```

No input on custom if exists, defaults to existing settings:
```
apt init --profile awesome-test
Aptos already initialized for profile awesome-test, do you want to overwrite the existing config? [yes/no] >
y
Configuring for profile awesome-test
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]
custom
Enter your rest endpoint [Current: https://fullnode.devnet.aptoslabs.com | No input: Exit (or keep the existing if present)]

No rest url given, keeping the existing url...
Enter your faucet endpoint [Current: https://faucet.devnet.aptoslabs.com | No input: Skip (or keep the existing one if present) | 'skip' to not use a faucet]

No faucet url given, keeping the existing url...
Enter your private key as a hex literal (0x...) [Current: Redacted | No input: Generate new key (or keep one if present)]

No key given, keeping existing key...
Account 24ff19d58561b7ff4430f68798565c99c9fa1d8fa7b1ee194d1bf3f135b4ea57 has been already found onchain

---
Aptos CLI is now set up for account 24ff19d58561b7ff4430f68798565c99c9fa1d8fa7b1ee194d1bf3f135b4ea57 as profile awesome-test!  Run `aptos --help` for more information about commands
{
  "Result": "Success"
}

```

No input exits for rest endpoint, rather than default to devnet:
```
apt init --profile awesome-test2
Configuring for profile awesome-test2
Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]
custom
Enter your rest endpoint [Current: None | No input: Exit (or keep the existing if present)]

No rest url given, exiting...
{
  "Error": "Aborted command"
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5077)
<!-- Reviewable:end -->
