### PR TITLE
[framework] improve readability of compat check

### DIFF
--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -137,7 +137,7 @@ impl fmt::Display for UpgradePolicy {
 /// Abort code when code publishing is requested twice (0x03 == INVALID_STATE)
 const EALREADY_REQUESTED: u64 = 0x03_0000;
 
-const CHECK_COMPAT_POLICY: u8 = 1;
+const ARBITRARY_POLICY: u8 = 0;
 
 /// The native code context.
 #[derive(Tid, Default)]
@@ -280,7 +280,7 @@ fn native_request_publish(
         bundle: ModuleBundle::new(code),
         expected_modules,
         allowed_deps,
-        check_compat: policy == CHECK_COMPAT_POLICY,
+        check_compat: policy != ARBITRARY_POLICY,
     });
     // TODO(Gas): charge gas for requesting code load (charge for actual code loading done elsewhere)
     Ok(NativeResult::ok(cost, smallvec![]))


### PR DESCRIPTION
A reader could be led to believe that we do not enable compatibility check for stricter than arbitrary upgrades...

note, this is a no-op, but if we enable compatibility checking again in the future, it could be dangerous.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5078)
<!-- Reviewable:end -->
