### PR TITLE
[cli] Fix naming of zips on CLI release

### DIFF
--- a/scripts/cli/build_cli_release.ps1
+++ b/scripts/cli/build_cli_release.ps1
@@ -21,5 +21,6 @@ cargo build -p $CRATE_NAME --profile cli
 
 # Compress the CLI.
 $ZIP_NAME="$NAME-$VERSION-Windows-x86_64.zip"
+echo "Compressing CLI to $ZIP_NAME"
 Compress-Archive -Path target\cli\$CRATE_NAME.exe -DestinationPath $ZIP_NAME
 

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -13,23 +13,21 @@ set -e
 NAME='aptos-cli'
 CRATE_NAME='aptos'
 CARGO_PATH="crates/$CRATE_NAME/Cargo.toml"
-NAME="$1"
+PLATFORM_NAME="$1"
 
 # Grab system information
 ARCH=`uname -m`
 OS=`uname -s`
 VERSION=`cat "$CARGO_PATH" | grep "^\w*version =" | sed 's/^.*=[ ]*"//g' | sed 's/".*$//g'`
 
-echo "Building release $VERSION of $NAME for $OS-$NAME"
+echo "Building release $VERSION of $NAME for $OS-$PLATFORM_NAME"
 cargo build -p $CRATE_NAME --profile cli
 
 cd target/cli/
 
 # Compress the CLI
-ZIP_NAME="$NAME-$VERSION-$NAME-$ARCH.zip"
+ZIP_NAME="$NAME-$VERSION-$PLATFORM_NAME-$ARCH.zip"
 
 echo "Zipping release: $ZIP_NAME"
 zip $ZIP_NAME $CRATE_NAME
 mv $ZIP_NAME ../..
-
-# TODO: Add installation instructions?


### PR DESCRIPTION
### Description
The CLI release script was wrongly generating the file names so no releases were being added for non-windows builds.  Additional cleanup as well

### Test Plan
Works: See https://github.com/gregnazario/aptos-core/releases/tag/aptos-cli-v0.4.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5081)
<!-- Reviewable:end -->
