### PR TITLE
Fix typo move upgrade guide

### DIFF
--- a/developer-docs-site/docs/guides/move-guides/upgrading-move-code.md
+++ b/developer-docs-site/docs/guides/move-guides/upgrading-move-code.md
@@ -47,7 +47,7 @@ Aptos checks compatibility at the time a [Move package](https://move-language.gi
 
 ## Upgrade Policies
 
-Currently, three different upgrade policies are supported:
+Currently, two different upgrade policies are supported:
 
 - `compatible`: upgrades must be backwards compatible, specifically:
   - For storage, all old struct declarations must be the same in


### PR DESCRIPTION
### Description
Typo 3 instead of 2, since arbitrary was removed earlier.
https://github.com/aptos-labs/aptos-core/issues/4994

### Test Plan
None

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5083)
<!-- Reviewable:end -->
