### PR TITLE
[cli] Add compiler output and dependency warning

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -87,7 +87,9 @@ impl BuiltPackage {
             fetch_deps_only: false,
             fetch_latest_git_deps: false,
         };
-        let mut package = build_config.compile_package_no_exit(&package_path, &mut Vec::new())?;
+        eprintln!("Compiling, may take a little while to download git dependencies...");
+        let mut package =
+            build_config.compile_package_no_exit(&package_path, &mut std::io::stderr())?;
         for module in package.root_modules_map().iter_modules().iter() {
             verify_module_init_function(module)?;
         }


### PR DESCRIPTION
### Description
Fix the output to be the same as the Move CLI, and warn users about downloading dependencies.

https://github.com/aptos-labs/aptos-core/issues/4049

### Test Plan
Now it says all the same things as the move compiler does in the Move CLI, but it stderr, so stdout can be reserved for the output.
```
aptos move run-script --script-path aptos-move/move-examples/scripts/minter/sources/minter.move
Compiling, may take a little while to download git dependencies
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING RunScript
{
  "Error": "API error: API error Error(ResourceNotFound): Resource not found by Address(0xfdf0c99777dd2821101c0b1c26a140c8fcfd63f99a371c4103397ed27791e65d), Struct tag(0x1::account::Account) and Ledger version(5594617)"
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5084)
<!-- Reviewable:end -->
