### PR TITLE
[haproxy] Add runtime socket and simple transaction caching for fn

### DIFF
--- a/docker/compose/aptos-node/docker-compose-fullnode.yaml
+++ b/docker/compose/aptos-node/docker-compose-fullnode.yaml
@@ -12,6 +12,10 @@ services:
       - type: bind
         source: ./blocked.ips
         target: /usr/local/etc/haproxy/blocked.ips
+      # Bind /var/run to PWD to allow access to haproxy runtime socket
+      - type: bind
+        source: .
+        target: /var/run
     networks:
       - shared
     expose:

--- a/docker/compose/aptos-node/docker-compose-src.yaml
+++ b/docker/compose/aptos-node/docker-compose-src.yaml
@@ -12,6 +12,10 @@ services:
       - type: bind
         source: ./blocked.ips
         target: /usr/local/etc/haproxy/blocked.ips
+      # Bind /var/run to PWD to allow access to haproxy runtime socket
+      - type: bind
+        source: .
+        target: /var/run
     networks:
       - shared
     expose:

--- a/docker/compose/aptos-node/docker-compose.yaml
+++ b/docker/compose/aptos-node/docker-compose.yaml
@@ -12,6 +12,10 @@ services:
       - type: bind
         source: ./blocked.ips
         target: /usr/local/etc/haproxy/blocked.ips
+      # Bind /var/run to PWD to allow access to haproxy runtime socket
+      - type: bind
+        source: .
+        target: /var/run
     networks:
       - shared
     expose:

--- a/docker/compose/aptos-node/haproxy-fullnode.cfg
+++ b/docker/compose/aptos-node/haproxy-fullnode.cfg
@@ -15,6 +15,9 @@ global
 
     user nobody
 
+    # Enable the stats socket
+    stats socket /var/run/haproxy.sock mode 666 level admin expose-fd listeners
+
 ## TCP port defaults
 defaults
     log global
@@ -119,10 +122,22 @@ frontend fullnode-api
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
     http-request add-header Forwarded "for=%ci"
 
+cache apicache
+    # 128MB of cache
+    total-max-size 128
+    # Max object size 10MB
+    max-object-size 10000000
+    # Max age 5 minutes
+    max-age 300
+
 backend fullnode-api
     mode http
     default-server maxconn 16
     server fullnode fullnode:8080
+
+    # Only cache transactions at this level because they are immutable and thus safe to cache
+    http-request cache-use apicache if { path_beg /v1/transactions/ }
+    http-response cache-store apicache
 
 frontend stats
     mode http

--- a/docker/compose/aptos-node/haproxy.cfg
+++ b/docker/compose/aptos-node/haproxy.cfg
@@ -16,6 +16,9 @@ global
 
     user nobody
 
+    # Enable the stats socket
+    stats socket /var/run/haproxy.sock mode 666 level admin expose-fd listeners
+
 ## TCP port defaults
 defaults
     log global
@@ -159,10 +162,22 @@ frontend validator-api
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
     http-request add-header Forwarded "for=%ci"
 
+cache apicache
+    # 128MB of cache
+    total-max-size 128
+    # Max object size 10MB
+    max-object-size 10000000
+    # Max age 5 minutes
+    max-age 300
+
 backend validator-api
     mode http
     default-server maxconn 128
     server validator validator:8080
+
+    # Only cache transactions at this level because they are immutable and thus safe to cache
+    http-request cache-use apicache if { path_beg /v1/transactions/ }
+    http-response cache-store apicache
 
 frontend stats
     mode http

--- a/terraform/helm/aptos-node/files/haproxy.cfg
+++ b/terraform/helm/aptos-node/files/haproxy.cfg
@@ -15,6 +15,9 @@ global
 
     user nobody
 
+    # Enable the stats socket
+    stats socket /var/run/haproxy.sock mode 666 level admin expose-fd listeners
+
 ## TCP port defaults
 defaults
     log global
@@ -215,10 +218,22 @@ frontend {{ $config.name }}-api
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
     http-request add-header Forwarded "for=%ci"
 
+cache fullnode-apicache
+    # 128MB of cache
+    total-max-size 128
+    # Max object size 10MB
+    max-object-size 10000000
+    # Max age 5 minutes
+    max-age 300
+
 backend {{ $config.name }}-api
     mode http
     default-server maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }} {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }}:8080
+
+    # Only cache transactions at this level because they are immutable and thus safe to cache
+    http-request cache-use fullnode-apicache if { path_beg /v1/transactions/ }
+    http-response cache-store fullnode-apicache
 
 frontend {{ $config.name }}-metrics
     mode http


### PR DESCRIPTION
Add runtime socket to do all kinds of fun things like inspect / modify process
state and advanced debugging.

More info here: https://www.haproxy.com/blog/dynamic-configuration-haproxy-runtime-api/

Enable caching of transactions, this is especially useful for loading things
like the genesis blob which we can easily store and serve from memory.

This is intended to try and take just a little load off our fullnodes and it is
safely cacheable since transactions are immutable.

Test Plan: running docker compose locally of a fullnode connected to devnet

https://aptos.dev/nodes/full-node/fullnode-source-code-or-docker/#approach-2-using-docker

Add config, curl, time and check cache contents to make sure caching only
happen on endpoint we expect

```
mkdir ~/fullnode

cp all files over from src dir
mkdir keys
echo > keys/validator-full-node-identity.yaml

docker compose up -d

curl localhost:8080/v1/
{"chain_id":34,"epoch":"42","ledger_version":"5925004","oldest_ledger_version":"0","ledger_timestamp":"1665991966714301","node_role":"full_node","oldest_block_height":"0","block_height":"2339367"}%

echo "show cache" | docker run -i -v /Users/perry/fullnode/haproxy.sock:/var/run/haproxy.sock alpine/socat stdio /var/run/haproxy.sock
0xffff8b9ff03a: apicache (shctx:0xffff8b9ff000, available blocks:131072)

time (for i in {1..100}; do (curl localhost:8080/v1/transactions/by_version/0 &>/dev/null) || echo failed; done)
( for i in {1..100}; do; ( curl localhost:8080/v1/transactions/by_version/0 &)  0.33s user 0.63s system 15% cpu 6.123 total

echo "show cache" | docker run -i -v /Users/perry/fullnode/haproxy.sock:/var/run/haproxy.sock alpine/socat stdio /var/run/haproxy.sock

0xffff8b9ff03a: apicache (shctx:0xffff8b9ff000, available blocks:131072)
0xffff8b9ff0c0 hash:3974537210 size:2126450 (2077 blocks), refcount:0, expire:290
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5091)
<!-- Reviewable:end -->
