### PR TITLE
[tf/gcp][fullnode] ensure namespace and k8s serviceaccount name for b…

### DIFF
--- a/terraform/fullnode/aws/kubernetes.tf
+++ b/terraform/fullnode/aws/kubernetes.tf
@@ -77,7 +77,7 @@ resource "helm_release" "fullnode" {
         }
       }
       backup = {
-        enable = count.index == 0 ? var.enable_backup : false
+        enable = count.index == var.backup_fullnode_index ? var.enable_backup : false
         config = {
           location = "s3"
           s3 = {

--- a/terraform/fullnode/aws/variables.tf
+++ b/terraform/fullnode/aws/variables.tf
@@ -143,6 +143,11 @@ variable "enable_backup" {
   default     = false
 }
 
+variable "backup_fullnode_index" {
+  description = "index of fullnode to backup data from"
+  default     = 0
+}
+
 variable "fullnode_storage_class" {
   description = "Which storage class to use for the validator and fullnode"
   default     = "io1"

--- a/terraform/fullnode/gcp/backup.tf
+++ b/terraform/fullnode/gcp/backup.tf
@@ -21,5 +21,5 @@ resource "google_storage_bucket_iam_member" "backup" {
 resource "google_service_account_iam_binding" "backup" {
   service_account_id = google_service_account.backup.name
   role               = "roles/iam.workloadIdentityUser"
-  members            = ["serviceAccount:${google_container_cluster.aptos.workload_identity_config[0].workload_pool}[aptos/${terraform.workspace}0-aptos-fullnode]"]
+  members            = [for i in range(var.num_fullnodes) : "serviceAccount:${google_container_cluster.aptos.workload_identity_config[0].workload_pool}[${var.k8s_namespace}/pfn${i}-aptos-fullnode]"]
 }

--- a/terraform/fullnode/gcp/kubernetes.tf
+++ b/terraform/fullnode/gcp/kubernetes.tf
@@ -102,7 +102,7 @@ resource "helm_release" "fullnode" {
       }
       backup = {
         # only enable backup for fullnode 0
-        enable = count.index == 0 ? var.enable_backup : false
+        enable = count.index == var.backup_fullnode_index ? var.enable_backup : false
         config = {
           location = "gcs"
           gcs = {

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -128,6 +128,11 @@ variable "enable_backup" {
   default     = false
 }
 
+variable "backup_fullnode_index" {
+  description = "index of fullnode to backup data from"
+  default     = 0
+}
+
 variable "enable_monitoring" {
   description = "Enable monitoring helm chart"
   default     = false


### PR DESCRIPTION
…ackup

### Description

The namespace is variable, and the serviceaccount names are known based on the PFN index.

Also add the ability to run the backup against any PFN, not just PFN-0. Still just 1 PFN though

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5099)
<!-- Reviewable:end -->
