### PR TITLE
[helm] consensus alerts and mainnet urls

### DIFF
--- a/terraform/helm/fullnode/values.yaml
+++ b/terraform/helm/fullnode/values.yaml
@@ -19,6 +19,9 @@ aptos_chains:
   testnet:
     waypoint_txt_url: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/waypoint.txt
     genesis_blob_url: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/testnet/genesis.blob
+  mainnet:
+    waypoint_txt_url: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/mainnet/waypoint.txt
+    genesis_blob_url: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/mainnet/genesis.blob
 
 fullnode:
   # -- Fullnode configuration. See NodeConfig https://github.com/aptos-labs/aptos-core/blob/main/config/src/config/mod.rs
@@ -81,7 +84,6 @@ ingress:
   ingressClassName:
   annotations: {}
 
-
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true
@@ -131,7 +133,7 @@ backup:
 
 backup_verify:
   # -- The schedule for backup verification
-  schedule: '@daily'
+  schedule: "@daily"
   resources:
     limits:
       cpu: 0.5

--- a/terraform/helm/monitoring/files/alertmanager.yml
+++ b/terraform/helm/monitoring/files/alertmanager.yml
@@ -26,8 +26,8 @@ route:
 
   # The child route trees.
   # https://prometheus.io/docs/alerting/latest/configuration/#route
-  routes: { { .Values.monitoring.alertmanager.alertRouteTrees | toJson } }
+  routes: {{ .Values.monitoring.alertmanager.alertRouteTrees | toJson }}
 
 # A list of notification receivers
 # https://prometheus.io/docs/alerting/latest/configuration/#receiver
-receivers: { { .Values.monitoring.alertmanager.alertReceivers | toJson } }
+receivers: {{ .Values.monitoring.alertmanager.alertReceivers | toJson }}

--- a/terraform/helm/monitoring/files/alertmanager.yml
+++ b/terraform/helm/monitoring/files/alertmanager.yml
@@ -4,7 +4,7 @@
 global:
 
 route:
-  group_by: [...] # TBD
+  group_by: ["instance", "kubernetes_pod_name", "role"]
 
   # When a new group of alerts is created by an incoming alert, wait at
   # least 'group_wait' to send the initial notification.
@@ -22,12 +22,12 @@ route:
   repeat_interval: 10m
 
   # A default receiver
-  receiver: 'default'
+  receiver: "default"
 
   # The child route trees.
   # https://prometheus.io/docs/alerting/latest/configuration/#route
-  routes: {{ .Values.monitoring.alertmanager.alertRouteTrees | toJson }}
+  routes: { { .Values.monitoring.alertmanager.alertRouteTrees | toJson } }
 
 # A list of notification receivers
 # https://prometheus.io/docs/alerting/latest/configuration/#receiver
-receivers: {{ .Values.monitoring.alertmanager.alertReceivers | toJson }}
+receivers: { { .Values.monitoring.alertmanager.alertReceivers | toJson } }

--- a/terraform/helm/monitoring/files/rules/alerts.yml
+++ b/terraform/helm/monitoring/files/rules/alerts.yml
@@ -1,6 +1,7 @@
 groups:
 - name: "Aptos alerts"
   rules:
+{{- if .Values.validator.name }}
   # consensus
   - alert: Zero Block Commit Rate
     expr: rate(aptos_consensus_last_committed_round{role="validator"}[1m]) == 0 OR absent(aptos_consensus_last_committed_round{role="validator"})
@@ -23,7 +24,7 @@ groups:
       severity: warning
       summary: "Consensus error rate is high"
     annotations:
-
+{{- end }}
     # State sync alerts
   - alert: State sync is not making progress
     expr: rate(aptos_state_sync_version{type="synced"}[5m]) == 0 OR absent(aptos_state_sync_version{type="synced"})

--- a/terraform/helm/monitoring/values.yaml
+++ b/terraform/helm/monitoring/values.yaml
@@ -72,11 +72,11 @@ monitoring:
       pullPolicy: IfNotPresent
     resources:
       limits:
-        cpu: 0.2
-        memory: 128Mi
+        cpu: 1
+        memory: 256Mi
       requests:
-        cpu: 0.2
-        memory: 128Mi
+        cpu: 1
+        memory: 256Mi
     googleAuth:
     config:
     env:


### PR DESCRIPTION
### Description

update genesis info for mainnet

only alert on consensus alerts if we're a validator

also group by some labels (`instance`, `kubernetes_pod_name`, `role`) so we avoid alert spam -- now we'll get at most one alert per validator/fullnode

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5103)
<!-- Reviewable:end -->
