### PR TITLE
[docs] Fix node docker docs

### DIFF
--- a/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
+++ b/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
@@ -134,6 +134,8 @@ You have now successfully configured and started running a fullnode connected to
 
 :::tip Debugging?
 This will build a release binary: `aptos-core/target/release/aptos-node`. The release binaries tend to be substantially faster than debug binaries but lack debugging information useful for development. To build a debug binary, omit the `--release` flag.
+
+You can also run this directly as `./aptos-core/target/release/aptos-node -f ./fullnode.yaml` after running `cargo build -p aptos-node --release`
 :::
 
 ---

--- a/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
+++ b/developer-docs-site/docs/nodes/full-node/fullnode-source-code-or-docker.md
@@ -184,13 +184,15 @@ api:
 
 ```bash
 docker run --pull=always \
-    --rm -p 8080:8080 
+    --rm -p 8080:8080 \
     -p 9101:9101 -p 6180:6180 \
     -v $(pwd):/opt/aptos/etc -v $(pwd)/data:/opt/aptos/data \
     --workdir /opt/aptos/etc \
     --name=aptos-fullnode aptoslabs/validator:mainnet_506f94721ca0fd0d339472fffe149a1fda469cad aptos-node \
     -f /opt/aptos/etc/fullnode.yaml
 ```
+
+**NOTE**: You may need to prefix the command with `sudo` depending on your configuration
 
 **NOTE**: Ensure you have opened the relevant ports: 8080, 9101 and 6180. You may also need to update the 127.0.0.1 with 0.0.0.0 in the `fullnode.yaml` for the fields `listen_address` and `address` field in the `api` list.
 


### PR DESCRIPTION
### Description
Command was missing a `\` at the end of the line, plus sometimes need `sudo`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5114)
<!-- Reviewable:end -->
