### PR TITLE
Support test only native

### DIFF
--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -471,7 +471,8 @@ impl<'a> AptosTestAdapter<'a> {
     /// Should error if the transaction ends up being discarded, or having a status other than
     /// EXECUTED.
     fn run_transaction(&mut self, txn: Transaction) -> Result<TransactionOutput> {
-        let mut outputs = AptosVM::execute_block_and_keep_vm_status(vec![txn], &self.storage)?;
+        let mut outputs =
+            AptosVM::execute_block_and_keep_vm_status(vec![txn], &self.storage, true)?;
 
         assert_eq!(outputs.len(), 1);
 

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -917,6 +917,7 @@ impl AptosVM {
     pub fn execute_block_and_keep_vm_status(
         transactions: Vec<Transaction>,
         state_view: &impl StateView,
+        include_test_natives: bool,
     ) -> Result<Vec<(VMStatus, TransactionOutput)>, VMStatus> {
         let mut state_view_cache = StateViewCache::new(state_view);
         let count = transactions.len();
@@ -993,7 +994,7 @@ impl VMExecutor for AptosVM {
             debug!("Parallel execution error {:?}", err);
             Ok(result)
         } else {
-            let output = Self::execute_block_and_keep_vm_status(transactions, state_view)?;
+            let output = Self::execute_block_and_keep_vm_status(transactions, state_view, false)?;
             Ok(output
                 .into_iter()
                 .map(|(_vm_status, txn_output)| txn_output)

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -58,7 +58,7 @@ pub struct AptosVMImpl {
 
 impl AptosVMImpl {
     #[allow(clippy::new_without_default)]
-    pub fn new<S: StateView>(state: &S) -> Self {
+    pub fn new<S: StateView>(state: &S, include_test_natives: bool) -> Self {
         let storage = StorageAdapter::new(state);
 
         // Get the gas parameters

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -117,6 +117,7 @@ impl AptosVMImpl {
             abs_val_size_gas_params,
             gas_feature_version,
             features.is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+            include_test_natives,
         )
         .expect("should be able to create Move VM; check if there are duplicated natives");
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -27,6 +27,7 @@ impl MoveVmExt {
         abs_val_size_gas_params: AbstractValueSizeGasParameters,
         gas_feature_version: u64,
         treat_friend_as_private: bool,
+        include_test_natives: bool,
     ) -> VMResult<Self> {
         Ok(Self {
             inner: MoveVM::new_with_configs(
@@ -34,6 +35,7 @@ impl MoveVmExt {
                     native_gas_params,
                     abs_val_size_gas_params,
                     gas_feature_version,
+                    include_test_natives,
                 ),
                 VerifierConfig {
                     max_loop_depth: Some(5),

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -49,6 +49,13 @@ pub fn aptos_natives(
                 !(*addr == CORE_CODE_ADDRESS && module_name.as_str() == "event")
             }),
         )
+        .chain({
+            if include_test_natives {
+                framework::natives::all_test_natives(CORE_CODE_ADDRESS)
+            } else {
+                vec![]
+            }
+        })
         .collect()
 }
 

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -24,6 +24,7 @@ pub fn aptos_natives(
     gas_params: NativeGasParameters,
     abs_val_size_gas_params: AbstractValueSizeGasParameters,
     feature_version: u64,
+    include_test_natives: bool,
 ) -> NativeFunctionTable {
     move_stdlib::natives::all_natives(CORE_CODE_ADDRESS, gas_params.move_stdlib)
         .into_iter()
@@ -55,7 +56,8 @@ pub fn assert_no_test_natives() {
     assert!(aptos_natives(
         NativeGasParameters::zeros(),
         AbstractValueSizeGasParameters::zeros(),
-        LATEST_GAS_FEATURE_VERSION
+        LATEST_GAS_FEATURE_VERSION,
+        false,
     )
     .into_iter()
     .all(

--- a/aptos-move/aptos-vm/src/parallel_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/parallel_executor/mod.rs
@@ -129,7 +129,8 @@ impl ParallelAptosVM {
                 ))
             }
             Err(err @ Error::ModulePathReadWrite) => {
-                let output = AptosVM::execute_block_and_keep_vm_status(transactions, state_view)?;
+                let output =
+                    AptosVM::execute_block_and_keep_vm_status(transactions, state_view, false)?;
                 Ok((
                     output
                         .into_iter()

--- a/aptos-move/aptos-vm/src/parallel_executor/vm_wrapper.rs
+++ b/aptos-move/aptos-vm/src/parallel_executor/vm_wrapper.rs
@@ -33,7 +33,7 @@ impl<'a, S: 'a + StateView> ExecutorTask for AptosVMWrapper<'a, S> {
     type Argument = &'a S;
 
     fn init(argument: &'a S) -> Self {
-        let vm = AptosVM::new(argument);
+        let vm = AptosVM::new(argument, false);
 
         // Loading `0x1::account` and its transitive dependency into the code cache.
         //

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -570,6 +570,7 @@ impl FakeExecutor {
                 LATEST_GAS_FEATURE_VERSION,
                 self.features
                     .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+                true,
             )
             .unwrap();
             let remote_view = StorageAdapter::new(&self.data_store);
@@ -616,6 +617,7 @@ impl FakeExecutor {
             LATEST_GAS_FEATURE_VERSION,
             self.features
                 .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+            true,
         )
         .unwrap();
         let remote_view = StorageAdapter::new(&self.data_store);

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -485,7 +485,7 @@ impl FakeExecutor {
 
     /// Verifies the given transaction by running it through the VM verifier.
     pub fn verify_transaction(&self, txn: SignedTransaction) -> VMValidatorResult {
-        let vm = AptosVM::new(self.get_state_view());
+        let vm = AptosVM::new(self.get_state_view(), true);
         vm.validate_transaction(txn, &self.data_store)
     }
 

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -357,6 +357,7 @@ impl FakeExecutor {
                 .map(Transaction::UserTransaction)
                 .collect(),
             &self.data_store,
+            true,
         )
     }
 

--- a/aptos-move/e2e-tests/src/on_chain_configs.rs
+++ b/aptos-move/e2e-tests/src/on_chain_configs.rs
@@ -16,6 +16,6 @@ pub fn set_aptos_version(executor: &mut FakeExecutor, version: Version) {
     executor.new_block();
     executor.execute_and_apply(txn);
 
-    let new_vm = AptosVM::new(executor.get_state_view());
+    let new_vm = AptosVM::new(executor.get_state_view(), false);
     assert_eq!(new_vm.internals().version().unwrap(), version);
 }

--- a/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
+++ b/aptos-move/e2e-testsuite/src/tests/failed_transaction_tests.rs
@@ -26,7 +26,7 @@ fn failed_transaction_cleanup_test() {
     executor.add_account_data(&sender);
 
     let log_context = AdapterLogSchema::new(executor.get_state_view().id(), 0);
-    let aptos_vm = AptosVM::new(executor.get_state_view());
+    let aptos_vm = AptosVM::new(executor.get_state_view(), false);
     let data_cache = StateViewCache::new(executor.get_state_view()).into_move_resolver();
 
     let txn_data = TransactionMetadata {

--- a/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
+++ b/aptos-move/e2e-testsuite/src/tests/on_chain_configs.rs
@@ -11,7 +11,7 @@ use language_e2e_tests::{common_transactions::peer_to_peer_txn, executor::FakeEx
 #[test]
 fn initial_aptos_version() {
     let mut executor = FakeExecutor::from_head_genesis();
-    let vm = AptosVM::new(executor.get_state_view());
+    let vm = AptosVM::new(executor.get_state_view(), false);
     let version = aptos_types::on_chain_config::APTOS_MAX_KNOWN_VERSION;
 
     assert_eq!(vm.internals().version().unwrap(), version,);
@@ -25,7 +25,7 @@ fn initial_aptos_version() {
     executor.new_block();
     executor.execute_and_apply(txn);
 
-    let new_vm = AptosVM::new(executor.get_state_view());
+    let new_vm = AptosVM::new(executor.get_state_view(), false);
     assert_eq!(
         new_vm.internals().version().unwrap(),
         Version {
@@ -37,7 +37,7 @@ fn initial_aptos_version() {
 #[test]
 fn drop_txn_after_reconfiguration() {
     let mut executor = FakeExecutor::from_head_genesis();
-    let vm = AptosVM::new(executor.get_state_view());
+    let vm = AptosVM::new(executor.get_state_view(), false);
     let version = aptos_types::on_chain_config::APTOS_MAX_KNOWN_VERSION;
 
     assert_eq!(vm.internals().version().unwrap(), version);

--- a/aptos-move/framework/src/natives/cryptography/ed25519.rs
+++ b/aptos-move/framework/src/natives/cryptography/ed25519.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::natives::make_test_only_native_from_func;
 use crate::natives::util::make_native_from_func;
 use aptos_crypto::ed25519::ED25519_PUBLIC_KEY_LENGTH;
 use aptos_crypto::{ed25519, traits::*};
@@ -149,4 +150,25 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
     ];
 
     crate::natives::helpers::make_module_natives(natives)
+}
+
+pub fn make_all_test() -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [(
+        "generate_keys",
+        make_test_only_native_from_func(native_test_only_generate_keys),
+    )];
+
+    crate::natives::helpers::make_module_natives(natives)
+}
+
+fn native_test_only_generate_keys(
+    _context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    //TODO
+    Ok(NativeResult::ok(
+        InternalGas::zero(),
+        smallvec![Value::vector_u8(vec![0_u8, 1_u8])],
+    ))
 }

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -38,6 +38,7 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
         NativeGasParameters::zeros(),
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
+        true,
     )
 }
 

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -49,6 +49,7 @@ pub fn aptos_test_natives() -> NativeFunctionTable {
         NativeGasParameters::zeros(),
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
+        true,
     )
 }
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -101,6 +101,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
         Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+        false,
     )
     .unwrap();
     let id1 = HashValue::zero();
@@ -196,6 +197,7 @@ pub fn encode_genesis_change_set(
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
         Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+        false,
     )
     .unwrap();
     let id1 = HashValue::zero();

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -113,6 +113,7 @@ where
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
         Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+        false,
     )
     .unwrap();
     let state_view_storage = StorageAdapter::new(state_view);

--- a/crates/aptos/src/move_tool/aptos_debug_natives.rs
+++ b/crates/aptos/src/move_tool/aptos_debug_natives.rs
@@ -18,5 +18,6 @@ pub fn aptos_debug_natives(
         gas_parameters,
         abs_val_size_gas_params,
         LATEST_GAS_FEATURE_VERSION,
+        true,
     )
 }


### PR DESCRIPTION
### Description

This will allow us to add `#[test_only]` native functions for generating signatures over arbitrary bytes and over Move structs in the `ed25519`, `multi_ed25519` and `bls12381` Move modules.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
