### PR TITLE
[terraform][testnet] disable logger

### DIFF
--- a/terraform/aptos-node-testnet/main.tf
+++ b/terraform/aptos-node-testnet/main.tf
@@ -68,7 +68,6 @@ module "validator" {
   enable_monitoring               = true
   enable_prometheus_node_exporter = true
   enable_kube_state_metrics       = true
-  enable_logger                   = true
   monitoring_helm_values          = var.monitoring_helm_values
   logger_helm_values              = var.logger_helm_values
 }


### PR DESCRIPTION
### Description

This PR disables the logger chart in testnet by default. We let nodes write logs to stdout and then export them to our desired logging platform using vector. 

This change should also stop nodes from trying to write logs via TCP, which has been failing because the logger replicaset was rolled back to 0 few weeks ago.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5132)
<!-- Reviewable:end -->
