### PR TITLE
[cli] Fix network argument in aptos init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "aptos-bitvec",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aptos"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Aptos Labs <opensource@aptoslabs.com>"]
 description = "Aptos tool for management of nodes and interacting with the blockchain"
 repository = "https://github.com/aptos-labs/aptos-core"

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -87,16 +87,21 @@ impl CliCommand<()> for InitTool {
         eprintln!("Configuring for profile {}", profile_name);
 
         // Choose a network
-        eprintln!(
-            "Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]"
-        );
-        let input = read_line("network")?;
-        let input = input.trim();
-        let network = if input.is_empty() {
-            eprintln!("No network given, using devnet...");
-            Network::Devnet
+        let network = if let Some(network) = self.network {
+            eprintln!("Configuring for network {:?}", network);
+            network
         } else {
-            Network::from_str(input)?
+            eprintln!(
+                "Choose network from [devnet, testnet, mainnet, local, custom | defaults to devnet]"
+            );
+            let input = read_line("network")?;
+            let input = input.trim();
+            if input.is_empty() {
+                eprintln!("No network given, using devnet...");
+                Network::Devnet
+            } else {
+                Network::from_str(input)?
+            }
         };
 
         match network {
@@ -309,7 +314,7 @@ impl InitTool {
 /// A simplified list of all networks supported by the CLI
 ///
 /// Any command using this, will be simpler to setup as profiles
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum Network {
     Mainnet,
     Testnet,


### PR DESCRIPTION
### Description
Fix network argument in `aptos init`

### Test Plan
```
aptos init --profile testing --network custom
Configuring for profile testing
Configuring for network Custom
Enter your rest endpoint [Current: None | No input: Exit (or keep the existing if present)]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5137)
<!-- Reviewable:end -->
