### PR TITLE
fix md link bug for docs

### DIFF
--- a/developer-docs-site/docs/index.md
+++ b/developer-docs-site/docs/index.md
@@ -117,18 +117,18 @@ Welcome! At Aptos Labs we are building a Layer 1 for everyone. This documentatio
 Aptos offers running a local testnet, as well as using the shared devnet and testnet, with mainnet on the way. See the [System Integrators Guide](guides/system-integrators-guide.md#networks) for a summary of the available networks and the means to connect to them.
 
 :::tip Aptos Devnet Resets
-The Aptos devnet is reset every Thursday. See the latest updates in Aptos [Discord][discord].
+The Aptos devnet is reset every Thursday. See the latest updates in Aptos [Discord](https://discord.gg/aptoslabs).
 :::info
 
 ## Ask questions and offer answers
 
-Join [Discord][discord] to speak with developers and hop into the Aptos community. It's the best way to keep up to date with news and developments in the Aptos universe. Be sure to check pinned messages in the channels - this is where we like to keep topic-specific links, events, and more.
+Join [Discord](https://discord.gg/aptoslabs) to speak with developers and hop into the Aptos community. It's the best way to keep up to date with news and developments in the Aptos universe. Be sure to check pinned messages in the channels - this is where we like to keep topic-specific links, events, and more.
 
 Or even if you just want to stop by to say "Good Morning!". There's a little something for everyone!
 
 :::caution Be safe out there
 
-It's dangerous to go alone. Please remember, community managers will never message or DM you first, and they will never ask you to send them money or share any sensitive, private, or personal information. If this happens to you, please report it to us in [Discord][discord], or by sending an email to [security@aptoslabs.com](mailto:security@aptoslabs.com).
+It's dangerous to go alone. Please remember, community managers will never message or DM you first, and they will never ask you to send them money or share any sensitive, private, or personal information. If this happens to you, please report it to us in [Discord](https://discord.gg/aptoslabs), or by sending an email to [security@aptoslabs.com](mailto:security@aptoslabs.com).
 
 :::
 


### PR DESCRIPTION
### Description

Fixed the `broken link` of `discord` in docs.

### Test Plan
Nothing to test... Just head over to the `File changed` section in the pr and see the links being added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5149)
<!-- Reviewable:end -->
