### PR TITLE
Make error cases clearer in Aptos API REST client

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -556,7 +556,7 @@ impl Client {
                 }
                 WaitForTransactionResult::Pending(state) => {
                     if expiration_timestamp_secs <= state.timestamp_usecs / 1_000_000 {
-                        return Err(anyhow!("Transaction expired, it is guaranteed it will not be committed on chain.").into());
+                        return Err(anyhow!("Transaction expired (pending), it is guaranteed it will not be committed on chain.").into());
                     }
                     chain_timestamp_usecs = Some(state.timestamp_usecs);
                 }
@@ -564,7 +564,7 @@ impl Client {
                     if let RestError::Api(aptos_error_response) = error {
                         if let Some(state) = aptos_error_response.state {
                             if expiration_timestamp_secs <= state.timestamp_usecs / 1_000_000 {
-                                return Err(anyhow!("Transaction expired, it is guaranteed it will not be committed on chain.").into());
+                                return Err(anyhow!("Transaction expired (not found), it is guaranteed it will not be committed on chain.").into());
                             }
                             chain_timestamp_usecs = Some(state.timestamp_usecs);
                         }
@@ -573,7 +573,7 @@ impl Client {
                     }
                     sample!(
                         SampleRate::Duration(Duration::from_secs(30)),
-                        debug!(
+                        warn!(
                             "Cannot yet find transaction in mempool on {:?}, continuing to wait.",
                             self.path_prefix_string(),
                         )


### PR DESCRIPTION
### Description
This way we can distinguish these error cases.

### Test Plan
👀 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5160)
<!-- Reviewable:end -->
