### PR TITLE
[scripts] override env vars for grafana-sync

### DIFF
--- a/scripts/grafana-sync.mts
+++ b/scripts/grafana-sync.mts
@@ -13,9 +13,9 @@ import "zx/globals";
 
 $.verbose = false;
 
-const GRAFANA_URL = "https://o11y.aptosdev.com";
-const GRAFANA_DASHBOARD_FOLDER_NAME_TO_SYNC = "aptos-core";
-const LOCAL_DASHBOARD_FOLDER_TO_SYNC = "dashboards";
+const GRAFANA_URL = process.env.GRAFANA_URL ?? "https://o11y.aptosdev.com";
+const GRAFANA_DASHBOARD_FOLDER_NAME_TO_SYNC = process.env.GRAFANA_DASHBOARD_FOLDER_NAME_TO_SYNC ?? "aptos-core";
+const LOCAL_DASHBOARD_FOLDER_TO_SYNC = process.env.LOCAL_DASHBOARD_FOLDER_TO_SYNC ?? "dashboards";
 
 enum Action {
   Download = "download",


### PR DESCRIPTION
### Description

Be able to override what was previously set constant:
* `GRAFANA_URL`
* `GRAFANA_DASHBOARD_FOLDER_NAME_TO_SYNC`
* `LOCAL_DASHBOARD_FOLDER_TO_SYNC`

### Test Plan

run grafana-sync

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5166)
<!-- Reviewable:end -->
