### PR TITLE
[smoke tests] keep logs even on flaky tests

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -118,8 +118,8 @@ jobs:
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 
-      # Even retain when the smoke tests succeed, because there may be flaky tests to investigate
-      - name: Upload smoke test logs (always)
+      # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.
+      - name: Upload smoke test logs for failed and flaky tests
         uses: actions/upload-artifact@v3
         with:
           name: failed-smoke-test-logs

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -118,9 +118,9 @@ jobs:
         env:
           INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 
-      - name: Upload smoke test logs for failures
+      # Even retain when the smoke tests succeed, because there may be flaky tests to investigate
+      - name: Upload smoke test logs (always)
         uses: actions/upload-artifact@v3
-        if: failure()
         with:
           name: failed-smoke-test-logs
           # Retain all smoke test data except for the db (which may be large).

--- a/testsuite/smoke-test/src/aptos/error_report.rs
+++ b/testsuite/smoke-test/src/aptos/error_report.rs
@@ -7,8 +7,6 @@ use aptos_types::{
 };
 use cached_packages::aptos_stdlib;
 use forge::{AptosPublicInfo, Swarm};
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
 
 use crate::smoke_test_environment::new_local_swarm_with_aptos;
 
@@ -37,11 +35,6 @@ async fn submit_and_check_err<F: Fn(TransactionBuilder) -> TransactionBuilder>(
 
 #[tokio::test]
 async fn test_error_report() {
-    let mut rng = StdRng::from_entropy();
-    if rng.gen_bool(0.5) {
-        panic!("Inject failure")
-    }
-
     let mut swarm = new_local_swarm_with_aptos(1).await;
     let mut info = swarm.aptos_public_info();
 

--- a/testsuite/smoke-test/src/aptos/error_report.rs
+++ b/testsuite/smoke-test/src/aptos/error_report.rs
@@ -7,6 +7,8 @@ use aptos_types::{
 };
 use cached_packages::aptos_stdlib;
 use forge::{AptosPublicInfo, Swarm};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 use crate::smoke_test_environment::new_local_swarm_with_aptos;
 
@@ -35,6 +37,11 @@ async fn submit_and_check_err<F: Fn(TransactionBuilder) -> TransactionBuilder>(
 
 #[tokio::test]
 async fn test_error_report() {
+    let mut rng = StdRng::from_entropy();
+    if rng.gen_bool(0.5) {
+        panic!("Inject failure")
+    }
+
     let mut swarm = new_local_swarm_with_aptos(1).await;
     let mut info = swarm.aptos_public_info();
 


### PR DESCRIPTION
### Description

Previously only kept logs on failure. Now, we will always try to create the artifact, but if there are no failures or flaky tests, the artifact doesn't get created anyway because there are no directories.

### Test Plan

Created a flaky test (using rng) on CICD and confirmed artifact created on flaky and not created on flawless runs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5167)
<!-- Reviewable:end -->
