### PR TITLE
standardize address and table handle

### DIFF
--- a/crates/indexer/src/models/block_metadata_transactions.rs
+++ b/crates/indexer/src/models/block_metadata_transactions.rs
@@ -6,7 +6,10 @@
 #![allow(clippy::unused_unit)]
 
 use super::transactions::{Transaction, TransactionQuery};
-use crate::{schema::block_metadata_transactions, util::parse_timestamp};
+use crate::{
+    schema::block_metadata_transactions,
+    util::{parse_timestamp, standardize_address},
+};
 use aptos_api_types::BlockMetadataTransaction as APIBlockMetadataTransaction;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
@@ -58,7 +61,7 @@ impl BlockMetadataTransaction {
             id: txn.id.to_string(),
             epoch: txn.epoch.0 as i64,
             round: txn.round.0 as i64,
-            proposer: txn.proposer.inner().to_hex_literal(),
+            proposer: standardize_address(&txn.proposer.inner().to_hex_literal()),
             failed_proposer_indices: serde_json::to_value(&txn.failed_proposer_indices).unwrap(),
             previous_block_votes_bitvec: serde_json::to_value(&txn.previous_block_votes_bitvec)
                 .unwrap(),

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     schema::coin_activities,
-    util::{parse_timestamp, truncate_str},
+    util::{parse_timestamp, standardize_address, truncate_str},
 };
 use aptos_api_types::{
     Event as APIEvent, Transaction as APITransaction, TransactionInfo as APITransactionInfo,
@@ -228,10 +228,10 @@ impl CoinActivity {
 
         Self {
             transaction_version: txn_version,
-            event_account_address: event.guid.account_address.to_string(),
+            event_account_address: standardize_address(&event.guid.account_address.to_string()),
             event_creation_number: event.guid.creation_number.0 as i64,
             event_sequence_number: event.sequence_number.0 as i64,
-            owner_address: event.guid.account_address.to_string(),
+            owner_address: standardize_address(&event.guid.account_address.to_string()),
             coin_type,
             amount,
             activity_type: event_type.to_string(),
@@ -255,10 +255,12 @@ impl CoinActivity {
 
         Self {
             transaction_version: txn_info.version.0 as i64,
-            event_account_address: user_transaction_request.sender.to_string(),
+            event_account_address: standardize_address(
+                &user_transaction_request.sender.to_string(),
+            ),
             event_creation_number: BURN_GAS_EVENT_CREATION_NUM,
             event_sequence_number: user_transaction_request.sequence_number.0 as i64,
-            owner_address: user_transaction_request.sender.to_string(),
+            owner_address: standardize_address(&user_transaction_request.sender.to_string()),
             coin_type: APTOS_COIN_TYPE.to_string(),
             amount: aptos_coin_burned,
             activity_type: GAS_FEE_EVENT.to_string(),

--- a/crates/indexer/src/models/coin_models/coin_balances.rs
+++ b/crates/indexer/src/models/coin_models/coin_balances.rs
@@ -9,7 +9,7 @@ use super::{
     coin_activities::EventToCoinType,
     coin_utils::{CoinInfoType, CoinResource},
 };
-use crate::{schema::coin_balances, schema::current_coin_balances};
+use crate::{schema::coin_balances, schema::current_coin_balances, util::standardize_address};
 use aptos_api_types::WriteResource as APIWriteResource;
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
@@ -53,7 +53,7 @@ impl CoinBalance {
                     &write_resource.data.typ.generic_type_params[0],
                     txn_version,
                 )?;
-                let owner_address = write_resource.address.to_string();
+                let owner_address = standardize_address(&write_resource.address.to_string());
                 let coin_balance = Self {
                     transaction_version: txn_version,
                     owner_address: owner_address.clone(),

--- a/crates/indexer/src/models/events.rs
+++ b/crates/indexer/src/models/events.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::extra_unused_lifetimes)]
-use crate::{models::transactions::Transaction, schema::events};
+use crate::{models::transactions::Transaction, schema::events, util::standardize_address};
 use aptos_api_types::Event as APIEvent;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
@@ -45,7 +45,7 @@ impl Event {
         transaction_block_height: i64,
     ) -> Self {
         Event {
-            account_address: event.guid.account_address.to_string(),
+            account_address: standardize_address(&event.guid.account_address.to_string()),
             creation_number: event.guid.creation_number.0 as i64,
             sequence_number: event.sequence_number.0 as i64,
             transaction_version,

--- a/crates/indexer/src/models/move_modules.rs
+++ b/crates/indexer/src/models/move_modules.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::extra_unused_lifetimes)]
-use crate::{models::transactions::Transaction, schema::move_modules};
+use crate::{models::transactions::Transaction, schema::move_modules, util::standardize_address};
 use aptos_api_types::{DeleteModule, MoveModule as APIMoveModule, MoveModuleBytecode, WriteModule};
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
@@ -50,7 +50,7 @@ impl MoveModule {
                 .as_ref()
                 .map(|d| d.name.clone())
                 .unwrap_or_default(),
-            address: write_module.address.to_string(),
+            address: standardize_address(&write_module.address.to_string()),
             bytecode: parsed_data.as_ref().map(|d| d.bytecode.clone()),
             exposed_functions: parsed_data.as_ref().map(|d| d.exposed_functions.clone()),
             friends: parsed_data.as_ref().map(|d| d.friends.clone()),
@@ -70,7 +70,7 @@ impl MoveModule {
             transaction_block_height,
             write_set_change_index,
             name: delete_module.module.name.to_string(),
-            address: delete_module.address.to_string(),
+            address: standardize_address(&delete_module.address.to_string()),
             bytecode: None,
             exposed_functions: None,
             friends: None,
@@ -97,7 +97,7 @@ impl MoveModule {
         bytecode: Vec<u8>,
     ) -> MoveModuleByteCodeParsed {
         MoveModuleByteCodeParsed {
-            address: move_module.address.to_string(),
+            address: standardize_address(&move_module.address.to_string()),
             name: move_module.name.0.to_string(),
             bytecode,
             exposed_functions: move_module

--- a/crates/indexer/src/models/move_resources.rs
+++ b/crates/indexer/src/models/move_resources.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 #![allow(clippy::extra_unused_lifetimes)]
-use crate::{models::transactions::Transaction, schema::move_resources};
+use crate::{models::transactions::Transaction, schema::move_resources, util::standardize_address};
 use anyhow::{Context, Result};
 use aptos_api_types::{DeleteResource, MoveStructTag as APIMoveStructTag, WriteResource};
 use field_count::FieldCount;
@@ -45,7 +45,7 @@ impl MoveResource {
             write_set_change_index,
             type_: write_resource.data.typ.to_string(),
             name: parsed_data.name.clone(),
-            address: write_resource.address.to_string(),
+            address: standardize_address(&write_resource.address.to_string()),
             module: parsed_data.module.clone(),
             generic_type_params: parsed_data.generic_type_params,
             data: Some(serde_json::to_value(&write_resource.data.data).unwrap()),
@@ -66,7 +66,7 @@ impl MoveResource {
             write_set_change_index,
             type_: delete_resource.resource.to_string(),
             name: parsed_data.name.clone(),
-            address: delete_resource.address.to_string(),
+            address: standardize_address(&delete_resource.address.to_string()),
             module: parsed_data.module.clone(),
             generic_type_params: parsed_data.generic_type_params,
             data: None,

--- a/crates/indexer/src/models/move_tables.rs
+++ b/crates/indexer/src/models/move_tables.rs
@@ -4,6 +4,7 @@
 use crate::{
     models::transactions::Transaction,
     schema::{table_items, table_metadatas},
+    util::standardize_address,
 };
 use aptos_api_types::{DeleteTableItem, WriteTableItem};
 use field_count::FieldCount;
@@ -47,7 +48,7 @@ impl TableItem {
             write_set_change_index,
             transaction_block_height,
             key: write_table_item.key.to_string(),
-            table_handle: write_table_item.handle.to_string(),
+            table_handle: standardize_address(&write_table_item.handle.to_string()),
             decoded_key: write_table_item.data.as_ref().unwrap().key.clone(),
             decoded_value: Some(write_table_item.data.as_ref().unwrap().value.clone()),
             is_deleted: false,
@@ -65,7 +66,7 @@ impl TableItem {
             write_set_change_index,
             transaction_block_height,
             key: delete_table_item.key.to_string(),
-            table_handle: delete_table_item.handle.to_string(),
+            table_handle: standardize_address(&delete_table_item.handle.to_string()),
             decoded_key: delete_table_item
                 .data
                 .as_ref()

--- a/crates/indexer/src/models/token_models/ans_lookup.rs
+++ b/crates/indexer/src/models/token_models/ans_lookup.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use crate::{
     schema::current_ans_lookup,
-    util::{bigdecimal_to_u64, parse_timestamp_secs},
+    util::{bigdecimal_to_u64, parse_timestamp_secs, standardize_address},
 };
 use aptos_api_types::{deserialize_from_string, MoveType, Transaction as APITransaction};
 use bigdecimal::BigDecimal;
@@ -121,7 +121,10 @@ impl CurrentAnsLookup {
                                         .subdomain_name
                                         .get_string()
                                         .unwrap_or_default(),
-                                    registered_address: inner.new_address.get_string(),
+                                    registered_address: inner
+                                        .new_address
+                                        .get_string()
+                                        .map(|s| standardize_address(&s)),
                                     last_transaction_version: txn_version,
                                     expiration_timestamp,
                                 }

--- a/crates/indexer/src/models/token_models/token_activities.rs
+++ b/crates/indexer/src/models/token_models/token_activities.rs
@@ -6,7 +6,10 @@
 #![allow(clippy::unused_unit)]
 
 use super::token_utils::{TokenDataIdType, TokenEvent};
-use crate::{schema::token_activities, util::parse_timestamp};
+use crate::{
+    schema::token_activities,
+    util::{parse_timestamp, standardize_address},
+};
 use aptos_api_types::{Event as APIEvent, Transaction as APITransaction};
 use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;
@@ -81,7 +84,7 @@ impl TokenActivity {
         txn_version: i64,
         txn_timestamp: chrono::NaiveDateTime,
     ) -> Self {
-        let event_account_address = event.guid.account_address.to_string();
+        let event_account_address = standardize_address(&event.guid.account_address.to_string());
         let event_creation_number = event.guid.creation_number.0 as i64;
         let event_sequence_number = event.sequence_number.0 as i64;
         let token_activity_helper = match token_event {
@@ -125,7 +128,7 @@ impl TokenActivity {
                 token_data_id: &inner.id.token_data_id,
                 property_version: inner.id.property_version.clone(),
                 from_address: None,
-                to_address: Some(event_account_address.clone()),
+                to_address: Some(standardize_address(&event_account_address)),
                 token_amount: inner.amount.clone(),
                 coin_type: None,
                 coin_amount: None,
@@ -134,7 +137,7 @@ impl TokenActivity {
                 token_data_id: &inner.token_id.token_data_id,
                 property_version: inner.token_id.property_version.clone(),
                 from_address: Some(event_account_address.clone()),
-                to_address: Some(inner.to_address.clone()),
+                to_address: Some(standardize_address(&inner.to_address)),
                 token_amount: inner.amount.clone(),
                 coin_type: None,
                 coin_amount: None,
@@ -143,7 +146,7 @@ impl TokenActivity {
                 token_data_id: &inner.token_id.token_data_id,
                 property_version: inner.token_id.property_version.clone(),
                 from_address: Some(event_account_address.clone()),
-                to_address: Some(inner.to_address.clone()),
+                to_address: Some(standardize_address(&inner.to_address)),
                 token_amount: inner.amount.clone(),
                 coin_type: None,
                 coin_amount: None,
@@ -152,7 +155,7 @@ impl TokenActivity {
                 token_data_id: &inner.token_id.token_data_id,
                 property_version: inner.token_id.property_version.clone(),
                 from_address: Some(event_account_address.clone()),
-                to_address: Some(inner.to_address.clone()),
+                to_address: Some(standardize_address(&inner.to_address)),
                 token_amount: inner.amount.clone(),
                 coin_type: None,
                 coin_amount: None,
@@ -166,7 +169,7 @@ impl TokenActivity {
             token_data_id_hash: token_data_id.to_hash(),
             property_version: token_activity_helper.property_version,
             collection_data_id_hash: token_data_id.get_collection_data_id_hash(),
-            creator_address: token_data_id.creator.clone(),
+            creator_address: standardize_address(&token_data_id.creator),
             collection_name: token_data_id.get_collection_trunc(),
             name: token_data_id.get_name_trunc(),
             transaction_version: txn_version,

--- a/crates/indexer/src/models/token_models/token_claims.rs
+++ b/crates/indexer/src/models/token_models/token_claims.rs
@@ -5,11 +5,8 @@
 #![allow(clippy::extra_unused_lifetimes)]
 #![allow(clippy::unused_unit)]
 
-use super::{
-    token_utils::TokenWriteSet,
-    tokens::{TableHandleToOwner, TableMetadataForToken},
-};
-use crate::schema::current_token_pending_claims;
+use super::{token_utils::TokenWriteSet, tokens::TableHandleToOwner};
+use crate::{schema::current_token_pending_claims, util::standardize_address};
 use aptos_api_types::{DeleteTableItem as APIDeleteTableItem, WriteTableItem as APIWriteTableItem};
 use bigdecimal::{BigDecimal, Zero};
 use field_count::FieldCount;
@@ -62,8 +59,7 @@ impl CurrentTokenPendingClaim {
                 _ => None,
             };
             if let Some(token) = maybe_token {
-                let table_handle =
-                    TableMetadataForToken::standardize_handle(&table_item.handle.to_string());
+                let table_handle = standardize_address(&table_item.handle.to_string());
 
                 let maybe_table_metadata = table_handle_to_owner.get(&table_handle);
 
@@ -78,10 +74,10 @@ impl CurrentTokenPendingClaim {
                     return Ok(Some(Self {
                         token_data_id_hash,
                         property_version: token_id.property_version,
-                        from_address: table_metadata.owner_address.clone(),
-                        to_address: offer.to_addr,
+                        from_address: standardize_address(&table_metadata.owner_address),
+                        to_address: standardize_address(&offer.to_addr),
                         collection_data_id_hash,
-                        creator_address: token_data_id.creator,
+                        creator_address: standardize_address(&token_data_id.creator),
                         collection_name,
                         name,
                         amount: token.amount,
@@ -126,8 +122,7 @@ impl CurrentTokenPendingClaim {
             _ => None,
         };
         if let Some(offer) = maybe_offer {
-            let table_handle =
-                TableMetadataForToken::standardize_handle(&table_item.handle.to_string());
+            let table_handle = standardize_address(&table_item.handle.to_string());
 
             let table_metadata = table_handle_to_owner.get(&table_handle).unwrap_or_else(|| {
                 panic!(
@@ -147,10 +142,10 @@ impl CurrentTokenPendingClaim {
             return Ok(Some(Self {
                 token_data_id_hash,
                 property_version: token_id.property_version,
-                from_address: table_metadata.owner_address.clone(),
-                to_address: offer.to_addr,
+                from_address: standardize_address(&table_metadata.owner_address),
+                to_address: standardize_address(&offer.to_addr),
                 collection_data_id_hash,
-                creator_address: token_data_id.creator,
+                creator_address: standardize_address(&token_data_id.creator),
                 collection_name,
                 name,
                 amount: BigDecimal::zero(),

--- a/crates/indexer/src/models/token_models/token_datas.rs
+++ b/crates/indexer/src/models/token_models/token_datas.rs
@@ -6,7 +6,10 @@
 #![allow(clippy::unused_unit)]
 
 use super::token_utils::TokenWriteSet;
-use crate::schema::{current_token_datas, token_datas};
+use crate::{
+    schema::{current_token_datas, token_datas},
+    util::standardize_address,
+};
 use aptos_api_types::WriteTableItem as APIWriteTableItem;
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
@@ -103,7 +106,7 @@ impl TokenData {
                     Self {
                         collection_data_id_hash: collection_data_id_hash.clone(),
                         token_data_id_hash: token_data_id_hash.clone(),
-                        creator_address: token_data_id.creator.clone(),
+                        creator_address: standardize_address(&token_data_id.creator),
                         collection_name: collection_name.clone(),
                         name: name.clone(),
                         transaction_version: txn_version,
@@ -111,7 +114,7 @@ impl TokenData {
                         supply: token_data.supply.clone(),
                         largest_property_version: token_data.largest_property_version.clone(),
                         metadata_uri: metadata_uri.clone(),
-                        payee_address: token_data.royalty.payee_address.clone(),
+                        payee_address: standardize_address(&token_data.royalty.payee_address),
                         royalty_points_numerator: token_data
                             .royalty
                             .royalty_points_numerator
@@ -132,14 +135,14 @@ impl TokenData {
                     CurrentTokenData {
                         collection_data_id_hash,
                         token_data_id_hash,
-                        creator_address: token_data_id.creator,
+                        creator_address: standardize_address(&token_data_id.creator),
                         collection_name,
                         name,
                         maximum: token_data.maximum,
                         supply: token_data.supply,
                         largest_property_version: token_data.largest_property_version,
                         metadata_uri,
-                        payee_address: token_data.royalty.payee_address,
+                        payee_address: standardize_address(&token_data.royalty.payee_address),
                         royalty_points_numerator: token_data.royalty.royalty_points_numerator,
                         royalty_points_denominator: token_data.royalty.royalty_points_denominator,
                         maximum_mutable: token_data.mutability_config.maximum,

--- a/crates/indexer/src/models/token_models/token_ownerships.rs
+++ b/crates/indexer/src/models/token_models/token_ownerships.rs
@@ -7,9 +7,12 @@
 
 use super::{
     token_utils::TokenWriteSet,
-    tokens::{TableHandleToOwner, TableMetadataForToken, Token},
+    tokens::{TableHandleToOwner, Token},
 };
-use crate::schema::{current_token_ownerships, token_ownerships};
+use crate::{
+    schema::{current_token_ownerships, token_ownerships},
+    util::standardize_address,
+};
 use bigdecimal::BigDecimal;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
@@ -81,7 +84,7 @@ impl TokenOwnership {
         if maybe_token_id.is_none() {
             return Ok(None);
         }
-        let table_handle = TableMetadataForToken::standardize_handle(&table_handle);
+        let table_handle = standardize_address(&table_handle);
         let maybe_table_metadata = table_handle_to_owner.get(&table_handle);
         // Return early if table type is not tokenstore
         if let Some(tm) = maybe_table_metadata {
@@ -95,8 +98,8 @@ impl TokenOwnership {
                     collection_data_id_hash: token.collection_data_id_hash.clone(),
                     token_data_id_hash: token.token_data_id_hash.clone(),
                     property_version: token.property_version.clone(),
-                    owner_address: tm.owner_address.clone(),
-                    creator_address: token.creator_address.clone(),
+                    owner_address: standardize_address(&tm.owner_address),
+                    creator_address: standardize_address(&token.creator_address.clone()),
                     collection_name: token.collection_name.clone(),
                     name: token.name.clone(),
                     amount: amount.clone(),
@@ -105,7 +108,7 @@ impl TokenOwnership {
                     table_type: tm.table_type.clone(),
                     last_transaction_timestamp: token.transaction_timestamp,
                 }),
-                Some(tm.owner_address.clone()),
+                Some(standardize_address(&tm.owner_address)),
                 Some(tm.table_type.clone()),
             ),
             None => {
@@ -124,8 +127,8 @@ impl TokenOwnership {
                 collection_data_id_hash: token.collection_data_id_hash.clone(),
                 token_data_id_hash: token.token_data_id_hash.clone(),
                 property_version: token.property_version.clone(),
-                owner_address,
-                creator_address: token.creator_address.clone(),
+                owner_address: owner_address.map(|s| standardize_address(&s)),
+                creator_address: standardize_address(&token.creator_address),
                 collection_name: token.collection_name.clone(),
                 name: token.name.clone(),
                 amount,

--- a/crates/indexer/src/models/token_models/tokens.rs
+++ b/crates/indexer/src/models/token_models/tokens.rs
@@ -16,7 +16,7 @@ use crate::{
     database::PgPoolConnection,
     models::move_resources::MoveResource,
     schema::tokens,
-    util::{ensure_not_negative, parse_timestamp},
+    util::{ensure_not_negative, parse_timestamp, standardize_address},
 };
 use aptos_api_types::{
     DeleteTableItem as APIDeleteTableItem, Transaction as APITransaction,
@@ -260,7 +260,7 @@ impl Token {
             let token_pg = Self {
                 collection_data_id_hash,
                 token_data_id_hash,
-                creator_address: token_data_id.creator,
+                creator_address: standardize_address(&token_data_id.creator),
                 collection_name,
                 name,
                 property_version: token_id.property_version,
@@ -317,7 +317,7 @@ impl Token {
             let token = Self {
                 collection_data_id_hash,
                 token_data_id_hash,
-                creator_address: token_data_id.creator,
+                creator_address: standardize_address(&token_data_id.creator),
                 collection_name,
                 name,
                 property_version: token_id.property_version,
@@ -393,7 +393,7 @@ impl TableMetadataForToken {
         );
 
         let value = TableMetadataForToken {
-            owner_address: resource.address,
+            owner_address: standardize_address(&resource.address),
             table_type: write_resource.data.typ.to_string(),
         };
         let table_handle: TableHandle = match TokenResource::from_resource(
@@ -408,13 +408,8 @@ impl TableMetadataForToken {
             TokenResource::PendingClaimsResource(inner) => inner.pending_claims.handle,
         };
         Ok(Some(HashMap::from([(
-            Self::standardize_handle(&table_handle),
+            standardize_address(&table_handle),
             value,
         )])))
-    }
-
-    /// Removes leading 0s after 0x in a table to standardize between resources and table items
-    pub fn standardize_handle(handle: &str) -> String {
-        format!("0x{}", &handle[2..].trim_start_matches('0'))
     }
 }

--- a/crates/indexer/src/models/user_transactions.rs
+++ b/crates/indexer/src/models/user_transactions.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     schema::user_transactions,
-    util::{parse_timestamp, parse_timestamp_secs, u64_to_bigdecimal},
+    util::{parse_timestamp, parse_timestamp_secs, standardize_address, u64_to_bigdecimal},
 };
 use aptos_api_types::{TransactionPayload, UserTransaction as APIUserTransaction};
 use bigdecimal::BigDecimal;
@@ -75,7 +75,7 @@ impl UserTransaction {
                     .as_ref()
                     .map(Signature::get_signature_type)
                     .unwrap_or_default(),
-                sender: txn.request.sender.inner().to_hex_literal(),
+                sender: standardize_address(&txn.request.sender.inner().to_hex_literal()),
                 sequence_number: txn.request.sequence_number.0 as i64,
                 max_gas_amount: u64_to_bigdecimal(txn.request.max_gas_amount.0),
                 expiration_timestamp_secs: parse_timestamp_secs(

--- a/crates/indexer/src/models/write_set_changes.rs
+++ b/crates/indexer/src/models/write_set_changes.rs
@@ -7,7 +7,9 @@ use super::{
     move_tables::{TableItem, TableMetadata},
     transactions::TransactionQuery,
 };
-use crate::{models::transactions::Transaction, schema::write_set_changes};
+use crate::{
+    models::transactions::Transaction, schema::write_set_changes, util::standardize_address,
+};
 use aptos_api_types::WriteSetChange as APIWriteSetChange;
 use field_count::FieldCount;
 use serde::{Deserialize, Serialize};
@@ -55,7 +57,7 @@ impl WriteSetChange {
                     hash: module.state_key_hash.clone(),
                     transaction_block_height,
                     type_,
-                    address: module.address.to_string(),
+                    address: standardize_address(&module.address.to_string()),
                     index,
                 },
                 WriteSetChangeDetail::Module(MoveModule::from_write_module(
@@ -71,7 +73,7 @@ impl WriteSetChange {
                     hash: module.state_key_hash.clone(),
                     transaction_block_height,
                     type_,
-                    address: module.address.to_string(),
+                    address: standardize_address(&module.address.to_string()),
                     index,
                 },
                 WriteSetChangeDetail::Module(MoveModule::from_delete_module(
@@ -87,7 +89,7 @@ impl WriteSetChange {
                     hash: resource.state_key_hash.clone(),
                     transaction_block_height,
                     type_,
-                    address: resource.address.to_string(),
+                    address: standardize_address(&resource.address.to_string()),
                     index,
                 },
                 WriteSetChangeDetail::Resource(MoveResource::from_write_resource(
@@ -103,7 +105,7 @@ impl WriteSetChange {
                     hash: resource.state_key_hash.clone(),
                     transaction_block_height,
                     type_,
-                    address: resource.address.to_string(),
+                    address: standardize_address(&resource.address.to_string()),
                     index,
                 },
                 WriteSetChangeDetail::Resource(MoveResource::from_delete_resource(

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -8,6 +8,11 @@ use sha2::Digest;
 // 9999-12-31 23:59:59, this is the max supported by Google BigQuery
 pub const MAX_TIMESTAMP_SECS: i64 = 253_402_300_799;
 
+/// Standardizes all addresses and table handles to be length 66 (0x-64 length hash)
+pub fn standardize_address(handle: &str) -> String {
+    format!("0x{:0>64}", &handle[2..])
+}
+
 pub fn hash_str(val: &str) -> String {
     hex::encode(sha2::Sha256::digest(val.as_bytes()))
 }


### PR DESCRIPTION
### Description
* If an address or table handle is less than 66 characters long (0x + 64 char hex), add 0 to fill to 64 chars. 

### Test Plan
Tested locally, made sure that new address added are 66 characters. Also 
```select * from current_token_ownerships cto where owner_address like '0x0%'```
returns something. 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5170)
<!-- Reviewable:end -->
