### PR TITLE
[State Sync] Small tweaks to configs.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 // The maximum message size per state sync message
-pub const MAX_MESSAGE_SIZE: usize = 12 * 1024 * 1024; /* 12 MiB */
+pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; /* 16 MiB */
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -75,9 +75,9 @@ pub struct StateSyncDriverConfig {
 impl Default for StateSyncDriverConfig {
     fn default() -> Self {
         Self {
-            bootstrapping_mode: BootstrappingMode::ExecuteTransactionsFromGenesis,
+            bootstrapping_mode: BootstrappingMode::ApplyTransactionOutputsFromGenesis,
             commit_notification_timeout_ms: 5000,
-            continuous_syncing_mode: ContinuousSyncingMode::ExecuteTransactions,
+            continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,
             max_consecutive_stream_notifications: 10,
@@ -156,7 +156,7 @@ impl Default for DataStreamingServiceConfig {
             max_concurrent_requests: 3,
             max_concurrent_state_requests: 6,
             max_data_stream_channel_sizes: 300,
-            max_request_retry: 3,
+            max_request_retry: 5,
             max_notification_id_mappings: 300,
             progress_check_interval_ms: 100,
         }


### PR DESCRIPTION
### Description
This PR makes several small tweaks to the default state sync configs:
1. Update the max message size from 12MB to 16MB. This should cover the worst possible cases.
2. Default to transaction output syncing instead of re-execution.
3. Increase the number of retries for failed requests. This will simply give more breathing room for slow peers before we fetch a new data stream.

### Test Plan
Existing test infra.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5182)
<!-- Reviewable:end -->
