### PR TITLE
[API] Remove erroneous log message about reverse proxy on startup

### DIFF
--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -201,10 +201,7 @@ pub fn attach_poem_to_runtime(
             .map_err(anyhow::Error::msg)
     });
 
-    info!(
-        "Poem is running at {}, behind the reverse proxy at the API port",
-        actual_address
-    );
+    info!("API server is running at {}", actual_address);
 
     Ok(actual_address)
 }


### PR DESCRIPTION
### Description
This was left over from when the Poem API was running behind a warp reverse proxy. This is no longer the case.

### Test Plan
👀 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5185)
<!-- Reviewable:end -->
