### PR TITLE
markuze/haproxy api port hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,6 +4511,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
+name = "http_loader"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "tokio",
+]
+
+[[package]]
 name = "httparse"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7865,9 +7873,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64 0.13.0",
  "bytes 1.2.1",
@@ -7884,11 +7892,11 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static 1.4.0",
  "log",
  "mime",
  "mime_guess",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "proc-macro-hack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ members = [
     "testsuite/aptos-fuzzer",
     "testsuite/aptos-fuzzer/fuzz",
     "testsuite/dos/http_test",
+    "testsuite/dos/http_loader",
     "testsuite/dos/listener",
     "testsuite/dos/sender",
     "testsuite/forge",

--- a/docker/compose/aptos-node/haproxy-fullnode.cfg
+++ b/docker/compose/aptos-node/haproxy-fullnode.cfg
@@ -71,7 +71,7 @@ frontend fullnode-fn
 
 
 backend fullnode
-    default-server maxconn 128
+    default-server maxqueue 128, maxconn 128
     server fullnode fullnode:6182
 
 #CONNRATE holds only entry with key 1: used for determening global conn rate
@@ -106,7 +106,7 @@ frontend fullnode-metrics
 
 backend fullnode-metrics
     mode http
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server fullnode fullnode:9101
 
 frontend fullnode-api
@@ -117,11 +117,17 @@ frontend fullnode-api
 
     # Deny requests from blocked IPs
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+
+    stick-table type ip size 32K expire 10m store http_req_rate(1m)
+    http-request track-sc0 src
+
+    # allow no more than 1 request/sec
+    http-request silent-drop if { sc_http_req_rate(0) gt 60 }
     http-request add-header Forwarded "for=%ci"
 
 backend fullnode-api
     mode http
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server fullnode fullnode:8080
 
 frontend stats

--- a/docker/compose/aptos-node/haproxy.cfg
+++ b/docker/compose/aptos-node/haproxy.cfg
@@ -71,7 +71,7 @@ frontend fe-validator
 
 
 backend validator
-    default-server maxconn 8192
+    default-server maxqueue 128, maxconn 8192
     server validator validator:6180
 
 frontend fe-fullnode
@@ -110,7 +110,7 @@ frontend fe-fullnode
 
 
 backend validator-fn
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server validator validator:6181
 
 #CONNRATE holds only entry with key 1: used for determening global conn rate
@@ -146,7 +146,7 @@ frontend validator-metrics
 
 backend validator-metrics
     mode http
-    default-server maxconn 8
+    default-server maxqueue 128, maxconn 8
     server validator validator:9101
 
 frontend validator-api
@@ -157,11 +157,19 @@ frontend validator-api
 
     # Deny requests from blocked IPs
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+
+    stick-table type ip size 32K expire 10m store http_req_rate(1m)
+    http-request track-sc0 src
+
+    # allow no more than 1 request/sec
+    http-request silent-drop if { sc_http_req_rate(0) gt 60 }
+
     http-request add-header Forwarded "for=%ci"
 
 backend validator-api
     mode http
-    default-server maxconn 128
+    default-server maxqueue 128, maxconn 128
+
     server validator validator:8080
 
 frontend stats

--- a/terraform/helm/aptos-node/files/haproxy.cfg
+++ b/terraform/helm/aptos-node/files/haproxy.cfg
@@ -68,7 +68,7 @@ frontend fe-{{ include "aptos-validator.fullname" $ }}-validator
     tcp-request session sc-inc-gpc1(0) if { sc0_kbytes_out gt 4 }
 
 backend {{ include "aptos-validator.fullname" $ }}-validator
-    default-server maxconn 8192
+    default-server maxqueue 128, maxconn 8192
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:6180
 
 frontend fe-{{ include "aptos-validator.fullname" $ }}-validator-fn
@@ -106,7 +106,7 @@ frontend fe-{{ include "aptos-validator.fullname" $ }}-validator-fn
     tcp-request session sc-inc-gpc1(0) if { sc0_kbytes_out gt 4 }
 
 backend {{ include "aptos-validator.fullname" $ }}-validator-fn
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:6181
 
 #CONNRATE holds only entry with key 1: used for determening global conn rate
@@ -141,7 +141,7 @@ frontend validator-metrics
 
 backend validator-metrics
     mode http
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:9101
 
 # Exposes the validator's own REST API
@@ -154,11 +154,17 @@ frontend validator-api
 
     # Deny requests from blocked IPs
     tcp-request connection reject if { src -n -f /usr/local/etc/haproxy/blocked.ips }
+
+    stick-table type ip size 32K expire 10m store http_req_rate(1m)
+    http-request track-sc0 src
+
+    # allow no more than 1 request/sec
+    http-request silent-drop if { sc_http_req_rate(0) gt 60 }
     http-request add-header Forwarded "for=%ci"
 
 backend validator-api
     mode http
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-validator:8080
 {{- end }}
 
@@ -200,7 +206,7 @@ frontend {{ $config.name }}-aptosnet
     tcp-request session sc-inc-gpc1(0) if { sc0_kbytes_out gt 4 }
 
 backend {{ $config.name }}-aptosnet
-    default-server maxconn {{ $.Values.fullnode.config.max_inbound_connections }} {{ if $.Values.haproxy.config.send_proxy_protocol }}send-proxy-v2{{ end }}
+    default-server maxqueue 128, maxconn {{ $.Values.fullnode.config.max_inbound_connections }} {{ if $.Values.haproxy.config.send_proxy_protocol }}send-proxy-v2{{ end }}
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }} {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }}:6182
 
 frontend {{ $config.name }}-api
@@ -217,7 +223,7 @@ frontend {{ $config.name }}-api
 
 backend {{ $config.name }}-api
     mode http
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }} {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }}:8080
 
 frontend {{ $config.name }}-metrics
@@ -232,7 +238,7 @@ frontend {{ $config.name }}-metrics
 
 backend {{ $config.name }}-metrics
     mode http
-    default-server maxconn 16
+    default-server maxqueue 128, maxconn 16
     server {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }} {{ include "aptos-validator.fullname" $ }}-{{ $.Values.i }}-{{ $config.name }}:9101
 
 {{- end }}

--- a/testsuite/dos/http_loader/Cargo.toml
+++ b/testsuite/dos/http_loader/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "http_loader"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1.21.2", features = ["full"] }
+reqwest = "0.11.12"

--- a/testsuite/dos/http_loader/src/main.rs
+++ b/testsuite/dos/http_loader/src/main.rs
@@ -1,0 +1,23 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use core::time::Duration;
+use reqwest;
+use tokio::io;
+
+#[tokio::main]
+async fn main() -> tokio::io::Result<()> {
+    for _ in 0..10 {
+        tokio::spawn(async {
+            let rep = reqwest::get("http://localhost:8080")
+                .await
+                .expect("This should work: is the server up?")
+                .text()
+                .await
+                .expect("Well now...");
+            println!("{rep}");
+        });
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    Ok::<_, io::Error>(())
+}

--- a/testsuite/dos/http_test/src/main.rs
+++ b/testsuite/dos/http_test/src/main.rs
@@ -8,12 +8,13 @@ use tokio::net::TcpListener;
 #[tokio::main]
 async fn main() {
     // build our application with a single route
+
     let app = Router::new().route("/", get(|| async { "Hello, World!\n" }));
 
     let stats = Router::new().route("/", get(|| async { "Hello, World!\n" }));
 
     let h1 = tokio::spawn(async {
-        axum::Server::bind(&"0.0.0.0:80".parse().unwrap())
+        axum::Server::bind(&"0.0.0.0:8080".parse().unwrap())
             .serve(app.into_make_service())
             .await
             .unwrap();


### PR DESCRIPTION
- [haproxy] set maxqueue to 128 default is unlim
- [haproxy] limit http request to API port to 1/sec

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5196)
<!-- Reviewable:end -->
