### PR TITLE
make use of high perf local ssd runner for nightly replay verify LLT job

### DIFF
--- a/.github/workflows/nightly-replay-verify.yaml
+++ b/.github/workflows/nightly-replay-verify.yaml
@@ -20,7 +20,7 @@ env:
 jobs:
   replay-LTT-transactions:
     timeout-minutes: 720
-    runs-on: high-perf-docker
+    runs-on: high-perf-docker-with-local-ssd
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3
         with:


### PR DESCRIPTION
### Description

This makes use of CI runners with local-ssd for the replay verify LLT job and make it significantly faster. The local SSD gets 360-680k IOPS and has a size of 3TB (8 partitions): https://cloud.google.com/compute/docs/disks/local-ssd .
Corresponding change to the CI runner config: https://github.com/aptos-labs/internal-ops/commit/dcd6bc27519a2f4dfdbbf92fd5aef9cd07a052f0

### Test Plan
Run CI job on this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5198)
<!-- Reviewable:end -->
