### PR TITLE
[move] Update commit hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,7 +2246,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -5560,7 +5560,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5577,7 +5577,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -5593,12 +5593,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5625,7 +5625,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5637,7 +5637,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5654,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5700,7 +5700,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "difference",
@@ -5717,7 +5717,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5746,7 +5746,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "arbitrary 1.1.7",
@@ -5764,7 +5764,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5784,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5802,7 +5802,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5850,7 +5850,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5869,7 +5869,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5888,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "hex",
@@ -5901,7 +5901,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "hex",
@@ -5915,7 +5915,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5941,7 +5941,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6014,7 +6014,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6042,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6053,7 +6053,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6068,7 +6068,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6095,7 +6095,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6113,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "log",
@@ -6135,7 +6135,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6144,7 +6144,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -6161,7 +6161,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6192,7 +6192,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6223,7 +6223,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6254,7 +6254,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "bcs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "move-binary-format",
@@ -7762,7 +7762,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7777,7 +7777,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e#6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e"
+source = "git+https://github.com/move-language/move?rev=b7f8071c8368a493becedfc5cd0e8e6bacbf3d56#b7f8071c8368a493becedfc5cd0e8e6bacbf3d56"
 dependencies = [
  "anyhow",
  "move-binary-format",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,33 +155,33 @@ rust-version = "1.64"
 
 [workspace.dependencies]
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-cli = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e", features = ["address32"] }
-move-docgen = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-model = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-package = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-prover = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "6a32284d6e04ea5bfa5919df9aac2ccb3ffa010e" }
+move-abigen = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-binary-format = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-cli = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-command-line-common = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-compiler ={ git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-core-types = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56", features = ["address32"] }
+move-docgen = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-ir-compiler = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-model = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-package = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-prover = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-resource-viewer = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-stdlib = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-symbol-pool = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-table-extension = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-unit-test = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+read-write-set = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
 # END MOVE DEPENDENCIES
 
 [profile.release]


### PR DESCRIPTION
This includes various fixes to the Move prover, to the `debug` print function, and a small change to expose the loader cache state publicly.


