### PR TITLE
[move-prover] Refactor prover integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,6 +3963,8 @@ dependencies = [
  "move-model",
  "move-package",
  "move-prover",
+ "move-prover-boogie-backend",
+ "move-stackless-bytecode",
  "move-table-extension",
  "move-unit-test",
  "move-vm-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,6 +169,7 @@ move-model = { git = "https://github.com/move-language/move", rev = "b7f8071c836
 move-package = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
 move-prover = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
 move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
+move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
 move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
 move-resource-viewer = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }
 move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "b7f8071c8368a493becedfc5cd0e8e6bacbf3d56" }

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -50,6 +50,9 @@ move-core-types ={ workspace = true }
 move-docgen ={ workspace = true }
 move-model ={ workspace = true }
 move-package ={ workspace = true }
+move-prover ={ workspace = true }
+move-prover-boogie-backend ={ workspace = true }
+move-stackless-bytecode ={ workspace = true }
 move-table-extension ={ workspace = true }
 move-vm-runtime ={ workspace = true }
 move-vm-types ={ workspace = true }

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -80,11 +80,12 @@ pub struct BuiltPackage {
 
 pub(crate) fn build_model(
     package_path: &Path,
-    options: &BuildOptions,
+    additional_named_addresses: BTreeMap<String, AccountAddress>,
+    target_filter: Option<String>,
 ) -> anyhow::Result<GlobalEnv> {
     let build_config = BuildConfig {
         dev_mode: false,
-        additional_named_addresses: options.named_addresses.clone(),
+        additional_named_addresses,
         architecture: None,
         generate_abis: false,
         generate_docs: false,
@@ -97,7 +98,7 @@ pub(crate) fn build_model(
     build_config.move_model_for_package(
         package_path,
         ModelConfig {
-            target_filter: None,
+            target_filter,
             all_files_as_targets: false,
         },
     )
@@ -129,7 +130,11 @@ impl BuiltPackage {
         }
 
         let error_map = if options.with_error_map || options.with_docs {
-            let model = build_model(package_path.as_path(), &options)?;
+            let model = build_model(
+                package_path.as_path(),
+                options.named_addresses.clone(),
+                None,
+            )?;
             if options.with_docs {
                 let docgen = if let Some(opts) = options.docgen_options.clone() {
                     opts

--- a/aptos-move/framework/src/lib.rs
+++ b/aptos-move/framework/src/lib.rs
@@ -19,6 +19,7 @@ pub mod natives;
 mod release_builder;
 pub use release_builder::*;
 pub mod docgen;
+pub mod prover;
 mod release_bundle;
 mod released_framework;
 

--- a/aptos-move/framework/src/prover.rs
+++ b/aptos-move/framework/src/prover.rs
@@ -1,0 +1,190 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::build_model;
+use codespan_reporting::diagnostic::Severity;
+use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use log::LevelFilter;
+use move_core_types::account_address::AccountAddress;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Instant;
+use tempfile::TempDir;
+
+#[derive(Debug, Clone, clap::Parser, serde::Serialize, serde::Deserialize)]
+pub struct ProverOptions {
+    /// Verbosity level
+    #[clap(long, short)]
+    pub verbosity: Option<LevelFilter>,
+
+    /// Filters targets out from the package. Any module with a matching file name will
+    /// be a target, similar as with `cargo test`.
+    #[clap(long, short)]
+    pub filter: Option<String>,
+
+    /// Whether to display additional information in error reports. This may help
+    /// debugging but also can make verification slower.
+    #[clap(long, short)]
+    pub trace: bool,
+
+    /// Whether to use cvc5 as the smt solver backend. The environment variable
+    /// `CVC5_EXE` should point to the binary.
+    #[clap(long)]
+    pub cvc5: bool,
+
+    /// The depth until which stratified functions are expanded.
+    #[clap(long, default_value_t = 6)]
+    pub stratification_depth: usize,
+
+    /// A seed for the prover.
+    #[clap(long, default_value_t = 0)]
+    pub random_seed: usize,
+
+    /// The number of cores to use for parallel processing of verification conditions.
+    #[clap(long, default_value_t = 4)]
+    pub proc_cores: usize,
+
+    /// A (soft) timeout for the solver, per verification condition, in seconds.
+    #[clap(long, default_value_t = 40)]
+    pub vc_timeout: usize,
+
+    /// Whether to check consistency of specs by injecting impossible assertions.
+    #[clap(long)]
+    pub check_inconsistency: bool,
+
+    /// Whether to keep loops as they are and pass them on to the underlying solver.
+    #[clap(long)]
+    pub keep_loops: bool,
+
+    /// Number of iterations to unroll loops.
+    #[clap(long)]
+    pub loop_unroll: Option<u64>,
+
+    /// Whether output for e.g. diagnosis shall be stable/redacted so it can be used in test
+    /// output.
+    #[clap(long)]
+    pub stable_test_output: bool,
+
+    /// Whether to dump intermediate step results to files.
+    #[clap(long)]
+    pub dump: bool,
+
+    #[clap(skip)]
+    pub for_test: bool,
+}
+
+impl Default for ProverOptions {
+    fn default() -> Self {
+        Self {
+            verbosity: None,
+            filter: None,
+            trace: false,
+            cvc5: false,
+            stratification_depth: 6,
+            random_seed: 0,
+            proc_cores: 4,
+            vc_timeout: 40,
+            check_inconsistency: false,
+            keep_loops: false,
+            loop_unroll: None,
+            stable_test_output: false,
+            dump: false,
+            for_test: false,
+        }
+    }
+}
+
+impl ProverOptions {
+    /// Runs the move prover on the package.
+    pub fn prove(
+        self,
+        package_path: &Path,
+        named_addresses: BTreeMap<String, AccountAddress>,
+    ) -> anyhow::Result<()> {
+        let now = Instant::now();
+        let for_test = self.for_test;
+        let model = build_model(package_path, named_addresses, self.filter.clone())?;
+        let mut options = self.convert_options();
+        // Need to ensure a distinct output.bpl file for concurrent execution. In non-test
+        // mode, we actually want to use the static output.bpl for debugging purposes
+        let _temp_holder = if for_test {
+            let temp_dir = TempDir::new()?;
+            std::fs::create_dir_all(temp_dir.path())?;
+            options.output_path = temp_dir
+                .path()
+                .join("boogie.bpl")
+                .to_string_lossy()
+                .to_string();
+            Some(temp_dir)
+        } else {
+            options.output_path = std::env::current_dir()?
+                .join("boogie.bpl")
+                .display()
+                .to_string();
+            None
+        };
+        let mut writer = StandardStream::stderr(ColorChoice::Auto);
+        move_prover::run_move_prover_with_model(&model, &mut writer, options, Some(now))?;
+        Ok(())
+    }
+
+    fn convert_options(self) -> move_prover::cli::Options {
+        let verbosity_level = if let Some(level) = self.verbosity {
+            level
+        } else if self.for_test {
+            LevelFilter::Warn
+        } else {
+            LevelFilter::Info
+        };
+        let opts = move_prover::cli::Options {
+            output_path: "".to_string(),
+            verbosity_level,
+            prover: move_stackless_bytecode::options::ProverOptions {
+                stable_test_output: self.stable_test_output,
+                auto_trace_level: if self.trace {
+                    move_stackless_bytecode::options::AutoTraceLevel::VerifiedFunction
+                } else {
+                    move_stackless_bytecode::options::AutoTraceLevel::Off
+                },
+                report_severity: Severity::Warning,
+                dump_bytecode: self.dump,
+                dump_cfg: false,
+                check_inconsistency: self.check_inconsistency,
+                skip_loop_analysis: self.keep_loops,
+                ..Default::default()
+            },
+            backend: move_prover_boogie_backend::options::BoogieOptions {
+                use_cvc5: self.cvc5,
+                boogie_flags: vec![],
+                generate_smt: self.dump,
+                stratification_depth: self.stratification_depth,
+                proc_cores: self.proc_cores,
+                vc_timeout: self.vc_timeout,
+                keep_artifacts: self.dump,
+                stable_test_output: self.stable_test_output,
+                z3_trace_file: if self.dump {
+                    Some("z3.trace".to_string())
+                } else {
+                    None
+                },
+                custom_natives: None,
+                loop_unroll: self.loop_unroll,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        if self.for_test {
+            opts.setup_logging_for_test();
+        } else {
+            opts.setup_logging()
+        }
+        opts
+    }
+
+    pub fn default_for_test() -> Self {
+        Self {
+            for_test: true,
+            ..Self::default()
+        }
+    }
+}

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -1,9 +1,13 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
-use move_cli::base::prove::run_move_prover;
+use framework::prover::ProverOptions;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
-use tempfile::tempdir;
+
+// Note: to run these tests, use:
+//
+//   cargo test -- --include-ignored prover
 
 pub fn path_in_crate<S>(relative: S) -> PathBuf
 where
@@ -16,19 +20,10 @@ where
 
 pub fn run_prover_for_pkg(path_to_pkg: impl Into<String>) {
     let pkg_path = path_in_crate(path_to_pkg);
-    let config = move_package::BuildConfig {
-        test_mode: true,
-        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
-        ..Default::default()
-    };
-    run_move_prover(
-        config,
-        &pkg_path,
-        &None,
-        true,
-        move_prover::cli::Options::default(),
-    )
-    .unwrap();
+    let options = ProverOptions::default_for_test();
+    options
+        .prove(pkg_path.as_path(), BTreeMap::default())
+        .unwrap()
 }
 
 #[ignore]


### PR DESCRIPTION
This PR creates a new `prover` module (in framework) which lives side-by-side with the `docgen` module and serves as a single point of integration of the prover into the aptos stack. This comes with is own clap-ified set of options which are hand-selected from the many (some obsolete) options the core prover has in the move repo and which are now available via the CLI.

```
USAGE:
    aptos move prove [OPTIONS]

OPTIONS:
        --check-inconsistency
            Whether to check consistency of specs by injecting impossible assertions

        --cvc5
            Whether to use cvc5 as the smt solver backend. The environment variable `CVC5_EXE`
            should point to the binary

        --dump
            Whether to dump intermediate step results to files

        --keep-loops
            Whether to keep loops as they are and pass them on to the underlying solver

        --loop-unroll <LOOP_UNROLL>
            Number of iterations to unroll loops

        --named-addresses <NAMED_ADDRESSES>
            Named addresses for the move binary [default: ]

        --proc-cores <PROC_CORES>
            The number of cores to use for parallel processing of verification conditions [default:
            4]

        --random-seed <RANDOM_SEED>
            A seed for the prover [default: 0]

        --stable-test-output
            Whether output for e.g. diagnosis shall be stable/redacted so it can be used in test
            output

        --stratification-depth <STRATIFICATION_DEPTH>
            The depth until which stratified functions are expanded [default: 6]

    -t, --trace
            Whether to display additional information in error reports. This may help debugging but
            also can make verification slower

    -v, --verbosity <VERBOSITY>
            Verbosity level

        --vc-timeout <VC_TIMEOUT>
            A (soft) timeout for the solver, per verification condition, in seconds [default: 40]

	...

```

Moreover, the way how to call the prover from tests has been refactored and simplified. The prover integration is now 100% independent from the move-cli, brining us a step closer to decouple from that one.

### Description

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5208)
<!-- Reviewable:end -->
