### PR TITLE
[crypto] sha3 overflow unit tests

### DIFF
--- a/crates/aptos-crypto/benches/hash.rs
+++ b/crates/aptos-crypto/benches/hash.rs
@@ -37,6 +37,9 @@ fn bench_group(c: &mut Criterion) {
         sizes.push(size);
     }
 
+    // This gives around 510 MiB / s hashing throughput on an Apple M1
+    sha3_256(&mut group, 1024*1024*1);
+
     for n in sizes {
         sha2_256(&mut group, n);
         sha2_512(&mut group, n);

--- a/crates/aptos-crypto/src/unit_tests/hash_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/hash_test.rs
@@ -3,10 +3,12 @@
 
 use crate::hash::*;
 use bitvec::prelude::*;
+use digest::Digest;
 use proptest::{collection::vec, prelude::*};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use serde::Serialize;
 use std::str::FromStr;
+use tiny_keccak::{Hasher, Sha3};
 
 #[derive(Serialize)]
 struct Foo(u32);
@@ -245,4 +247,49 @@ proptest! {
         let bits2 = vec![false; HashValue::LENGTH_IN_BITS + 10];
         prop_assert!(HashValue::from_bit_iter(bits2.into_iter()).is_err());
     }
+}
+
+/// Sha3 Buffer overflow tests: https://mouha.be/sha-3-buffer-overflow/
+#[test]
+fn test_sha3_overflow_v256_keccack() {
+    let buffer = b"\x00".repeat(4294967295);
+    let mut sha3 = Sha3::v256();
+    sha3.update(&buffer);
+
+    let buffer = b"\x00".repeat(4294967296);
+    let mut sha3 = Sha3::v256();
+    sha3.update(&buffer);
+}
+
+#[test]
+fn test_sha3_overflow_v224_keccack() {
+    let buffer = b"\x00".repeat(4294967295);
+    let mut sha3 = Sha3::v224();
+    sha3.update(&buffer);
+
+    let buffer = b"\x00".repeat(4294967296);
+    let mut sha3 = Sha3::v224();
+    sha3.update(&buffer);
+}
+
+#[test]
+fn test_sha3_overflow_v256_sha3() {
+    let buffer = b"\x00".repeat(4294967295);
+    let mut sha3 = sha3::Sha3_256::new();
+    sha3.update(&buffer);
+
+    let buffer = b"\x00".repeat(4294967296);
+    let mut sha3 = sha3::Sha3_256::new();
+    sha3.update(&buffer);
+}
+
+#[test]
+fn test_sha3_overflow_v224_sha3() {
+    let buffer = b"\x00".repeat(4294967295);
+    let mut sha3 = sha3::Sha3_224::new();
+    sha3.update(&buffer);
+
+    let buffer = b"\x00".repeat(4294967296);
+    let mut sha3 = sha3::Sha3_224::new();
+    sha3.update(&buffer);
 }

--- a/crates/aptos-crypto/src/unit_tests/hash_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/hash_test.rs
@@ -251,45 +251,83 @@ proptest! {
 
 /// Sha3 Buffer overflow tests: https://mouha.be/sha-3-buffer-overflow/
 #[test]
-fn test_sha3_overflow_v256_keccack() {
-    let buffer = b"\x00".repeat(4294967295);
-    let mut sha3 = Sha3::v256();
-    sha3.update(&buffer);
+fn test_sha3_overflow_v256_keccak() {
+    let mut out = [0u8; 256/8];
+    let one = b"\x00".repeat(1);
+    let mut buffer = b"\x00".repeat(4294967295);
 
-    let buffer = b"\x00".repeat(4294967296);
+    let mut sha3 = Sha3::v256();
+    sha3.update(&one);
+    sha3.update(&buffer);
+    sha3.finalize(&mut out);
+
+
     let mut sha3 = Sha3::v256();
     sha3.update(&buffer);
+    sha3.finalize(&mut out);
+
+    buffer.push(0u8);   // of size 4294967295 + 1 now
+    let mut sha3 = Sha3::v256();
+    sha3.update(&buffer);
+    sha3.finalize(&mut out);
 }
 
 #[test]
-fn test_sha3_overflow_v224_keccack() {
-    let buffer = b"\x00".repeat(4294967295);
-    let mut sha3 = Sha3::v224();
-    sha3.update(&buffer);
+fn test_sha3_overflow_v224_keccak() {
+    let mut out = [0u8; 224/8];
+    let one = b"\x00".repeat(1);
+    let mut buffer = b"\x00".repeat(4294967295);
 
-    let buffer = b"\x00".repeat(4294967296);
+    let mut sha3 = Sha3::v224();
+    sha3.update(&one);
+    sha3.update(&buffer);
+    sha3.finalize(&mut out);
+
+
     let mut sha3 = Sha3::v224();
     sha3.update(&buffer);
+    sha3.finalize(&mut out);
+
+    buffer.push(0u8);   // of size 4294967295 + 1 now
+    let mut sha3 = Sha3::v224();
+    sha3.update(&buffer);
+    sha3.finalize(&mut out);
 }
 
 #[test]
 fn test_sha3_overflow_v256_sha3() {
-    let buffer = b"\x00".repeat(4294967295);
+    let one = b"\x00".repeat(1);
+    let mut buffer = b"\x00".repeat(4294967295);
+
+    let mut sha3 = sha3::Sha3_256::new();
+    sha3.update(&one);
+    sha3.update(&buffer);
+    sha3.finalize();
+
     let mut sha3 = sha3::Sha3_256::new();
     sha3.update(&buffer);
+    sha3.finalize();
 
-    let buffer = b"\x00".repeat(4294967296);
+    buffer.push(0u8);   // of size 4294967295 + 1 now
     let mut sha3 = sha3::Sha3_256::new();
     sha3.update(&buffer);
 }
 
 #[test]
 fn test_sha3_overflow_v224_sha3() {
-    let buffer = b"\x00".repeat(4294967295);
+    let one = b"\x00".repeat(1);
+    let mut buffer = b"\x00".repeat(4294967295);
+
+    let mut sha3 = sha3::Sha3_224::new();
+    sha3.update(&one);
+    sha3.update(&buffer);
+    sha3.finalize();
+
     let mut sha3 = sha3::Sha3_224::new();
     sha3.update(&buffer);
+    sha3.finalize();
 
-    let buffer = b"\x00".repeat(4294967296);
+    buffer.push(0u8);   // of size 4294967295 + 1 now
     let mut sha3 = sha3::Sha3_224::new();
     sha3.update(&buffer);
 }

--- a/crates/aptos-crypto/src/unit_tests/hash_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/hash_test.rs
@@ -254,80 +254,78 @@ proptest! {
 fn test_sha3_overflow_v256_keccak() {
     let mut out = [0u8; 256/8];
     let one = b"\x00".repeat(1);
-    let mut buffer = b"\x00".repeat(4294967295);
+    let buffer = b"\x00".repeat(4294967295);
 
     let mut sha3 = Sha3::v256();
     sha3.update(&one);
     sha3.update(&buffer);
     sha3.finalize(&mut out);
 
-
-    let mut sha3 = Sha3::v256();
-    sha3.update(&buffer);
-    sha3.finalize(&mut out);
-
-    buffer.push(0u8);   // of size 4294967295 + 1 now
-    let mut sha3 = Sha3::v256();
-    sha3.update(&buffer);
-    sha3.finalize(&mut out);
+    // let mut sha3 = Sha3::v256();
+    // sha3.update(&buffer);
+    // sha3.finalize(&mut out);
+    //
+    // buffer.push(0u8);   // of size 4294967295 + 1 now
+    // let mut sha3 = Sha3::v256();
+    // sha3.update(&buffer);
+    // sha3.finalize(&mut out);
 }
 
 #[test]
 fn test_sha3_overflow_v224_keccak() {
     let mut out = [0u8; 224/8];
     let one = b"\x00".repeat(1);
-    let mut buffer = b"\x00".repeat(4294967295);
+    let buffer = b"\x00".repeat(4294967295);
 
     let mut sha3 = Sha3::v224();
     sha3.update(&one);
     sha3.update(&buffer);
     sha3.finalize(&mut out);
 
-
-    let mut sha3 = Sha3::v224();
-    sha3.update(&buffer);
-    sha3.finalize(&mut out);
-
-    buffer.push(0u8);   // of size 4294967295 + 1 now
-    let mut sha3 = Sha3::v224();
-    sha3.update(&buffer);
-    sha3.finalize(&mut out);
+    // let mut sha3 = Sha3::v224();
+    // sha3.update(&buffer);
+    // sha3.finalize(&mut out);
+    //
+    // buffer.push(0u8);   // of size 4294967295 + 1 now
+    // let mut sha3 = Sha3::v224();
+    // sha3.update(&buffer);
+    // sha3.finalize(&mut out);
 }
 
 #[test]
 fn test_sha3_overflow_v256_sha3() {
     let one = b"\x00".repeat(1);
-    let mut buffer = b"\x00".repeat(4294967295);
+    let buffer = b"\x00".repeat(4294967295);
 
     let mut sha3 = sha3::Sha3_256::new();
     sha3.update(&one);
     sha3.update(&buffer);
     sha3.finalize();
 
-    let mut sha3 = sha3::Sha3_256::new();
-    sha3.update(&buffer);
-    sha3.finalize();
-
-    buffer.push(0u8);   // of size 4294967295 + 1 now
-    let mut sha3 = sha3::Sha3_256::new();
-    sha3.update(&buffer);
+    // let mut sha3 = sha3::Sha3_256::new();
+    // sha3.update(&buffer);
+    // sha3.finalize();
+    //
+    // buffer.push(0u8);   // of size 4294967295 + 1 now
+    // let mut sha3 = sha3::Sha3_256::new();
+    // sha3.update(&buffer);
 }
 
 #[test]
 fn test_sha3_overflow_v224_sha3() {
     let one = b"\x00".repeat(1);
-    let mut buffer = b"\x00".repeat(4294967295);
+    let buffer = b"\x00".repeat(4294967295);
 
     let mut sha3 = sha3::Sha3_224::new();
     sha3.update(&one);
     sha3.update(&buffer);
     sha3.finalize();
 
-    let mut sha3 = sha3::Sha3_224::new();
-    sha3.update(&buffer);
-    sha3.finalize();
-
-    buffer.push(0u8);   // of size 4294967295 + 1 now
-    let mut sha3 = sha3::Sha3_224::new();
-    sha3.update(&buffer);
+    // let mut sha3 = sha3::Sha3_224::new();
+    // sha3.update(&buffer);
+    // sha3.finalize();
+    //
+    // buffer.push(0u8);   // of size 4294967295 + 1 now
+    // let mut sha3 = sha3::Sha3_224::new();
+    // sha3.update(&buffer);
 }

--- a/crates/aptos-crypto/src/unit_tests/hash_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/hash_test.rs
@@ -249,34 +249,66 @@ proptest! {
     }
 }
 
+#[test]
+fn test_sha3_non_overflow_v256_keccak() {
+    let mut out = [0u8; 256 / 8];
+    let one = b"\x00".repeat(1);
+    let buffer = b"\x00".repeat(4294967295 - 1);
+    println!("Allocated {} bytes.", buffer.len());
+
+    let mut sha3 = Sha3::v256();
+    sha3.update(&one);
+    println!("Update(1) done.");
+    sha3.update(&buffer);
+    println!("Update({}) done.", buffer.len());
+    sha3.finalize(&mut out);
+    println!("Finalize done.");
+}
+
 /// Sha3 Buffer overflow tests: https://mouha.be/sha-3-buffer-overflow/
+///
+/// Execute in release mode with:
+/// `cargo test --release -- test_sha3_overflow_v256_keccak  --nocapture`
 #[test]
 fn test_sha3_overflow_v256_keccak() {
     let mut out = [0u8; 256/8];
     let one = b"\x00".repeat(1);
-    let buffer = b"\x00".repeat(4294967295);
+    let mut buffer = b"\x00".repeat(4294967295);
+    println!("Allocated {} bytes.", buffer.len());
 
+    // Will segfault, if vulnerable
+    println!("Testing Update(1) + Update({}) + Finalize()", buffer.len());
     let mut sha3 = Sha3::v256();
     sha3.update(&one);
+    println!("Update(1) done.");
     sha3.update(&buffer);
+    println!("Update({}) done.", buffer.len());
     sha3.finalize(&mut out);
+    println!("Finalize done: {:x?}", out);
 
     // let mut sha3 = Sha3::v256();
     // sha3.update(&buffer);
     // sha3.finalize(&mut out);
-    //
-    // buffer.push(0u8);   // of size 4294967295 + 1 now
-    // let mut sha3 = Sha3::v256();
-    // sha3.update(&buffer);
-    // sha3.finalize(&mut out);
+
+    // Will inifinite loop, if vulnerable
+    buffer.push(0u8);   // of size 4294967295 + 1 now
+    println!("Testing Update(1) + Update({}) + Finalize()", buffer.len());
+    let mut sha3 = Sha3::v256();
+    sha3.update(&one);
+    println!("Update(1) done.");
+    sha3.update(&buffer);
+    println!("Update({}) done.", buffer.len());
+    sha3.finalize(&mut out);
+    println!("Finalize done: {:x?}", out);
 }
 
 #[test]
 fn test_sha3_overflow_v224_keccak() {
     let mut out = [0u8; 224/8];
     let one = b"\x00".repeat(1);
-    let buffer = b"\x00".repeat(4294967295);
+    let mut buffer = b"\x00".repeat(4294967295);
 
+    // Will segfault, if vulnerable
     let mut sha3 = Sha3::v224();
     sha3.update(&one);
     sha3.update(&buffer);
@@ -285,18 +317,21 @@ fn test_sha3_overflow_v224_keccak() {
     // let mut sha3 = Sha3::v224();
     // sha3.update(&buffer);
     // sha3.finalize(&mut out);
-    //
-    // buffer.push(0u8);   // of size 4294967295 + 1 now
-    // let mut sha3 = Sha3::v224();
-    // sha3.update(&buffer);
-    // sha3.finalize(&mut out);
+
+    // Will inifinite loop, if vulnerable
+    buffer.push(0u8);   // of size 4294967295 + 1 now
+    let mut sha3 = Sha3::v224();
+    sha3.update(&one);
+    sha3.update(&buffer);
+    sha3.finalize(&mut out);
 }
 
 #[test]
 fn test_sha3_overflow_v256_sha3() {
     let one = b"\x00".repeat(1);
-    let buffer = b"\x00".repeat(4294967295);
+    let mut buffer = b"\x00".repeat(4294967295);
 
+    // Will segfault, if vulnerable
     let mut sha3 = sha3::Sha3_256::new();
     sha3.update(&one);
     sha3.update(&buffer);
@@ -305,17 +340,20 @@ fn test_sha3_overflow_v256_sha3() {
     // let mut sha3 = sha3::Sha3_256::new();
     // sha3.update(&buffer);
     // sha3.finalize();
-    //
-    // buffer.push(0u8);   // of size 4294967295 + 1 now
-    // let mut sha3 = sha3::Sha3_256::new();
-    // sha3.update(&buffer);
+
+    // Will inifinite loop, if vulnerable
+    buffer.push(0u8);   // of size 4294967295 + 1 now
+    let mut sha3 = sha3::Sha3_256::new();
+    sha3.update(&one);
+    sha3.update(&buffer);
 }
 
 #[test]
 fn test_sha3_overflow_v224_sha3() {
     let one = b"\x00".repeat(1);
-    let buffer = b"\x00".repeat(4294967295);
+    let mut buffer = b"\x00".repeat(4294967295);
 
+    // Will segfault, if vulnerable
     let mut sha3 = sha3::Sha3_224::new();
     sha3.update(&one);
     sha3.update(&buffer);
@@ -324,8 +362,10 @@ fn test_sha3_overflow_v224_sha3() {
     // let mut sha3 = sha3::Sha3_224::new();
     // sha3.update(&buffer);
     // sha3.finalize();
-    //
-    // buffer.push(0u8);   // of size 4294967295 + 1 now
-    // let mut sha3 = sha3::Sha3_224::new();
-    // sha3.update(&buffer);
+
+    // Will inifinite loop, if vulnerable
+    buffer.push(0u8);   // of size 4294967295 + 1 now
+    let mut sha3 = sha3::Sha3_224::new();
+    sha3.update(&one);
+    sha3.update(&buffer);
 }


### PR DESCRIPTION
### Description

Tests for [CVE-2022-37454](https://nvd.nist.gov/vuln/detail/CVE-2022-37454) explained in https://mouha.be/sha-3-buffer-overflow/ and in https://eprint.iacr.org/2023/331.pdf.

You have to run the tests in `release` mode; otherwise they are too slow.
 1. The following test will pass: `cargo test --release -- test_sha3_non_overflow_v256_keccak --nocapture`
 2. The following will also pass `cargo test --release -- test_sha3_overflow_v256_keccak  --nocapture`
 
 So `sha3` crate does not appear to be vulnerable to the test vectors from the links above.