### PR TITLE
[move] export aptos_framework::chain_id::get() via NativeTransactionContext

### DIFF
--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -81,6 +81,7 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     [.type_info.type_name.base, "type_info.type_name.base", 300 * MUL],
     // TODO(Gas): the on-chain name is wrong...
     [.type_info.type_name.per_byte_in_str, "type_info.type_name.per_abstract_memory_unit", 5 * MUL],
+    [.type_info.chain_id.base, "type_info.chain_id.base", 150 * MUL],
 
     [.util.from_bytes.base, "util.from_bytes.base", 300 * MUL],
     [.util.from_bytes.per_byte, "util.from_bytes.per_byte", 5 * MUL],

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -72,7 +72,7 @@ pub fn configure_for_unit_test() {
 #[cfg(feature = "testing")]
 fn unit_test_extensions_hook(exts: &mut NativeContextExtensions) {
     exts.add(NativeCodeContext::default());
-    exts.add(NativeTransactionContext::new(vec![1]));
+    exts.add(NativeTransactionContext::new(vec![1], None)); // we do not set a chain ID here, because it is unclear what to set it to
     exts.add(NativeAggregatorContext::new([0; 32], &*DUMMY_RESOLVER));
     exts.add(NativeRistrettoPointContext::new());
 }

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "chain_id_test"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
@@ -1,0 +1,40 @@
+module 0x1::chain_id_test {
+    //use aptos_std::type_info;
+    use aptos_framework::chain_id;
+    use std::option;
+    use aptos_std::aptos_hash;
+
+    /// Since tests in e2e-move-tests/ can only call entry functions which don't have return values, we must store
+    /// the results we are interested in (i.e., the chain ID) inside this (rather-artificial) resource, which we can
+    /// read back in our e2e-move-tests/ test.
+    struct ChainIdStore has key {
+        id: u8,
+    }
+
+    fun init_module(sender: &signer) {
+        move_to(sender,
+            ChainIdStore {
+                id: 0u8
+            }
+        )
+    }
+
+    /// Fetches the chain ID (via aptos_framework::chain_id::get()) and stores it in the ChainIdStore resource.
+    public entry fun store_chain_id_from_aptos_framework(_s: &signer) acquires ChainIdStore {
+        let store = borrow_global_mut<ChainIdStore>(@0x1);
+        store.id = chain_id::get();
+    }
+
+    /// Fetches the chain ID (via the NativeTransactionContext) and stores it in the ChainIdStore resource.
+    public entry fun store_chain_id_from_native_txn_context(_s: &signer) acquires ChainIdStore {
+        let store = borrow_global_mut<ChainIdStore>(@0x1);
+
+        aptos_hash::testing_smth();
+
+        let opt = option::none<u8>(); // type_info::chain_id();
+
+        assert!(option::is_some(&opt), 1);
+
+        store.id = option::extract(&mut opt);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.rs
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.rs
@@ -1,0 +1,97 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tests::common;
+use crate::{assert_success, MoveHarness};
+use language_e2e_tests::account::Account;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::parser::parse_struct_tag;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct ChainIdStore {
+    id: u8,
+}
+
+fn call_get_chain_id_from_aptos_framework(harness: &mut MoveHarness, account: &Account) -> u8 {
+    let status = harness.run_entry_function(
+        account,
+        str::parse("0x1::chain_id_test::store_chain_id_from_aptos_framework").unwrap(),
+        vec![],
+        vec![],
+    );
+
+    assert!(status.status().unwrap().is_success());
+
+    let chain_id_store = harness
+        .read_resource::<ChainIdStore>(
+            account.address(),
+            parse_struct_tag("0x1::chain_id_test::ChainIdStore").unwrap(),
+        )
+        .unwrap();
+
+    chain_id_store.id
+}
+
+#[allow(unused)]
+fn call_get_chain_id_from_native_txn_context(harness: &mut MoveHarness, account: &Account) -> u8 {
+    let status = harness.run_entry_function(
+        account,
+        str::parse("0x1::chain_id_test::store_chain_id_from_native_txn_context").unwrap(),
+        vec![],
+        vec![],
+    );
+
+    assert!(status.status().unwrap().is_success());
+
+    let chain_id_store = harness
+        .read_resource::<ChainIdStore>(
+            account.address(),
+            parse_struct_tag("0x1::chain_id_test::ChainIdStore").unwrap(),
+        )
+        .unwrap();
+
+    chain_id_store.id
+}
+
+fn setup(harness: &mut MoveHarness) -> Account {
+    let path = common::test_dir_path("chain_id.data/pack");
+
+    let account = harness.new_account_at(AccountAddress::ONE);
+
+    assert_success!(harness.publish_package(&account, &path));
+
+    account
+}
+
+#[test]
+fn test_chain_id_set() {
+    let mut harness = MoveHarness::new_mainnet();
+    let account = setup(&mut harness);
+
+    assert_eq!(
+        call_get_chain_id_from_aptos_framework(&mut harness, &account),
+        4u8
+    );
+}
+
+// #[test]
+// fn test_chain_id_set() {
+//     let mut harness = MoveHarness::new_mainnet();
+//     let account = setup(&mut harness);
+//
+//     // Initializes the chain ID
+//     let chain_id = 128u8;
+//     let aptos_framework_acc = harness.aptos_framework_account();
+//     let status = harness.run_entry_function(
+//         &aptos_framework_acc,
+//         str::parse("0x1::chain_id::initialize_for_test").unwrap(),
+//         vec![],
+//         vec![bcs::to_bytes(&chain_id).unwrap()],
+//     );
+//
+//     assert!(status.status().unwrap().is_success());
+//
+//     // Tries to fetch it back
+//     assert_eq!(call_get_chain_id(&mut harness, &account), chain_id);
+// }

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod aggregator;
+mod chain_id;
 mod code_publishing;
 mod common;
 mod error_map;

--- a/aptos-move/framework/aptos-stdlib/doc/hash.md
+++ b/aptos-move/framework/aptos-stdlib/doc/hash.md
@@ -13,6 +13,7 @@ Non-cryptograhic hashes:
 - SipHash: an add-rotate-xor (ARX) based family of pseudorandom functions created by Jean-Philippe Aumasson and Daniel J. Bernstein in 2012
 
 
+-  [Function `testing_smth`](#0x1_aptos_hash_testing_smth)
 -  [Function `sip_hash`](#0x1_aptos_hash_sip_hash)
 -  [Function `sip_hash_from_value`](#0x1_aptos_hash_sip_hash_from_value)
 -  [Function `keccak256`](#0x1_aptos_hash_keccak256)
@@ -25,6 +26,28 @@ Non-cryptograhic hashes:
 </code></pre>
 
 
+
+<a name="0x1_aptos_hash_testing_smth"></a>
+
+## Function `testing_smth`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_testing_smth">testing_smth</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="hash.md#0x1_aptos_hash_testing_smth">testing_smth</a>() {}
+</code></pre>
+
+
+
+</details>
 
 <a name="0x1_aptos_hash_sip_hash"></a>
 

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -9,14 +9,18 @@
 -  [Function `account_address`](#0x1_type_info_account_address)
 -  [Function `module_name`](#0x1_type_info_module_name)
 -  [Function `struct_name`](#0x1_type_info_struct_name)
+-  [Function `chain_id`](#0x1_type_info_chain_id)
+-  [Function `chain_id_internal`](#0x1_type_info_chain_id_internal)
 -  [Function `type_of`](#0x1_type_info_type_of)
 -  [Function `type_name`](#0x1_type_info_type_name)
 -  [Specification](#@Specification_0)
+    -  [Function `chain_id_internal`](#@Specification_0_chain_id_internal)
     -  [Function `type_of`](#@Specification_0_type_of)
     -  [Function `type_name`](#@Specification_0_type_name)
 
 
-<pre><code><b>use</b> <a href="../../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<pre><code><b>use</b> <a href="../../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
 </code></pre>
 
 
@@ -132,6 +136,58 @@
 
 </details>
 
+<a name="0x1_type_info_chain_id"></a>
+
+## Function `chain_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id">chain_id</a>(): <a href="../../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id">chain_id</a>(): Option&lt;u8&gt; {
+    <b>let</b> (id, is_set) = <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>();
+
+    <b>if</b> (is_set) {
+        <a href="../../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(id)
+    } <b>else</b> {
+        <a href="../../move-stdlib/doc/option.md#0x1_option_none">option::none</a>&lt;u8&gt;()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_type_info_chain_id_internal"></a>
+
+## Function `chain_id_internal`
+
+
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>(): (u8, bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>(): (u8, bool);
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_type_info_type_of"></a>
 
 ## Function `type_of`
@@ -179,6 +235,22 @@
 <a name="@Specification_0"></a>
 
 ## Specification
+
+
+<a name="@Specification_0_chain_id_internal"></a>
+
+### Function `chain_id_internal`
+
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>(): (u8, bool)
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
 
 
 <a name="@Specification_0_type_of"></a>

--- a/aptos-move/framework/aptos-stdlib/sources/hash.move
+++ b/aptos-move/framework/aptos-stdlib/sources/hash.move
@@ -9,6 +9,8 @@
 module aptos_std::aptos_hash {
     use std::bcs;
 
+    public fun testing_smth() {}
+
     native public fun sip_hash(bytes: vector<u8>): u64;
 
     public fun sip_hash_from_value<MoveValue>(v: &MoveValue): u64 {

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -1,5 +1,6 @@
 module aptos_std::type_info {
     use std::string;
+    use std::option::{Self, Option};
 
     struct TypeInfo has copy, drop, store {
         account_address: address,
@@ -19,6 +20,18 @@ module aptos_std::type_info {
         type_info.struct_name
     }
 
+    public fun chain_id(): Option<u8> {
+        let (id, is_set) = chain_id_internal();
+
+        if (is_set) {
+            option::some(id)
+        } else {
+            option::none<u8>()
+        }
+    }
+
+    native fun chain_id_internal(): (u8, bool);
+
     public native fun type_of<T>(): TypeInfo;
 
     public native fun type_name<T>(): string::String;
@@ -29,6 +42,10 @@ module aptos_std::type_info {
         assert!(account_address(&type_info) == @aptos_std, 0);
         assert!(module_name(&type_info) == b"type_info", 1);
         assert!(struct_name(&type_info) == b"TypeInfo", 2);
+
+        // Because the testing environment doesn't set it.
+        let opt = chain_id();
+        assert!(option::is_none(&opt), 1);
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
@@ -8,4 +8,9 @@ spec aptos_std::type_info {
         // TODO: temporary mockup.
         pragma opaque;
     }
+
+    spec chain_id_internal {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
 }

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -128,6 +128,7 @@ impl GasParameters {
                     base: 0.into(),
                     per_byte_in_str: 0.into(),
                 },
+                chain_id: type_info::ChainIdGasParameters { base: 0.into() },
             },
             util: util::GasParameters {
                 from_bytes: util::FromBytesGasParameters {

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -10,6 +10,7 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 /// The native transaction context extension. This needs to be attached to the
@@ -18,13 +19,21 @@ use std::sync::Arc;
 #[derive(Tid)]
 pub struct NativeTransactionContext {
     script_hash: Vec<u8>,
+    chain_id: Option<u8>,
 }
 
 impl NativeTransactionContext {
     /// Create a new instance of a native transaction context. This must be passed in via an
     /// extension into VM session functions.
-    pub fn new(script_hash: Vec<u8>) -> Self {
-        Self { script_hash }
+    pub fn new(script_hash: Vec<u8>, chain_id: Option<u8>) -> Self {
+        Self {
+            script_hash,
+            chain_id,
+        }
+    }
+
+    pub fn chain_id(&self) -> Option<u8> {
+        self.chain_id
     }
 }
 

--- a/aptos-move/framework/src/natives/type_info.rs
+++ b/aptos-move/framework/src/natives/type_info.rs
@@ -13,6 +13,7 @@ use move_vm_types::{
     values::{Struct, Value},
 };
 
+use crate::natives::transaction_context::NativeTransactionContext;
 use smallvec::{smallvec, SmallVec};
 use std::{collections::VecDeque, fmt::Write, sync::Arc};
 
@@ -123,6 +124,48 @@ pub fn make_native_type_name(gas_params: TypeNameGasParameters) -> NativeFunctio
 }
 
 /***************************************************************************************************
+ * native fun chain_id
+ *
+ *   Returns the chain ID
+ *
+ *   gas cost: base_cost
+ *
+ **************************************************************************************************/
+#[derive(Debug, Clone)]
+pub struct ChainIdGasParameters {
+    pub base: InternalGas,
+}
+
+fn native_chain_id(
+    gas_params: &ChainIdGasParameters,
+    context: &mut NativeContext,
+    _ty_args: Vec<Type>,
+    arguments: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(arguments.is_empty());
+
+    let cost = gas_params.base;
+
+    let chain_id = context
+        .extensions()
+        .get::<NativeTransactionContext>()
+        .chain_id();
+
+    Ok(NativeResult::ok(
+        cost,
+        match chain_id {
+            Some(id) => smallvec![Value::u8(id), Value::bool(true)],
+            None => smallvec![Value::u8(0), Value::bool(false)],
+        },
+    ))
+}
+
+fn make_native_chain_id(gas_params: ChainIdGasParameters) -> NativeFunction {
+    Arc::new(move |context, ty_args, args| native_chain_id(&gas_params, context, ty_args, args))
+}
+
+/***************************************************************************************************
  * module
  *
  **************************************************************************************************/
@@ -130,12 +173,17 @@ pub fn make_native_type_name(gas_params: TypeNameGasParameters) -> NativeFunctio
 pub struct GasParameters {
     pub type_of: TypeOfGasParameters,
     pub type_name: TypeNameGasParameters,
+    pub chain_id: ChainIdGasParameters,
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
     let natives = [
         ("type_of", make_native_type_of(gas_params.type_of)),
         ("type_name", make_native_type_name(gas_params.type_name)),
+        (
+            "chain_id_internal",
+            make_native_chain_id(gas_params.chain_id),
+        ),
     ];
 
     crate::natives::helpers::make_module_natives(natives)

--- a/types/src/on_chain_config/chain_id.rs
+++ b/types/src/on_chain_config/chain_id.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::on_chain_config::OnChainConfig;
+use serde::{Deserialize, Serialize};
+
+/// Defines the version of Aptos Validator software.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct ChainId {
+    pub id: u8,
+}
+
+impl OnChainConfig for ChainId {
+    const MODULE_IDENTIFIER: &'static str = "chain_id";
+    const TYPE_IDENTIFIER: &'static str = "ChainId";
+}

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -19,6 +19,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 mod approved_execution_hashes;
 mod aptos_features;
 mod aptos_version;
+mod chain_id;
 mod consensus_config;
 mod gas_schedule;
 mod validator_set;
@@ -29,6 +30,7 @@ pub use self::{
     aptos_version::{
         Version, APTOS_MAX_KNOWN_VERSION, APTOS_VERSION_2, APTOS_VERSION_3, APTOS_VERSION_4,
     },
+    chain_id::ChainId,
     consensus_config::{
         ConsensusConfigV1, LeaderReputationType, OnChainConsensusConfig, ProposerElectionType,
     },
@@ -65,6 +67,7 @@ pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[
     ValidatorSet::CONFIG_ID,
     Version::CONFIG_ID,
     OnChainConsensusConfig::CONFIG_ID,
+    ChainId::CONFIG_ID,
 ];
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
### Description

The idea of this PR was to read the chain ID from storage upon every new `new_session` call in the VM and store it in the `NativeTransactionContext` extension so that Rust natives may read it.

The motivation for this was that we cannot call `aptos_framework::chain_id::get` from the `aptos_std` package due to a circular dependency issue.

However, this is problematic for a few reasons:

 1. The testing environment via `cargo test` in `aptos-move/framework` will have no chain ID set because it does not run genesis. This will be very weird for developers testing.
 2. Gold only knows whether the testing environment in `aptos move` command or in `move` command will run genesis. This will be very weird for developers testing.
 3. Fetching the chain ID behind a Move developer's back inside a native rather than via `aptos_framework::chain_id` will surprise developers trying to figure out with what chain ID value they should test the native.
     + For example, I wanted to have a `struct_to_json` native that included the chain ID behind the developer's back.
     + But now developers will have to be aware of this when using the native, such as when signing a struct's whose JSON is supposed to match what `struct_to_json` returns.

Furthermore, I currently cannot get my test in `e2e-move-tests/ ` to pass for reasons I do not understand:

```
alinush@Aptos-MacBook [~/repos/aptos-core/aptos-move/e2e-move-tests/src] (alin/native-chain-id *) $ cargo test -- chain_id
    Finished test [unoptimized + debuginfo] target(s) in 0.48s
     Running unittests src/lib.rs (/Users/alinush/repos/aptos-core/target/debug/deps/e2e_move_tests-6a6eb101e724ba59)

running 1 test
INCLUDING DEPENDENCY AptosFramework
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING chain_id_test
test tests::chain_id::test_chain_id_set ... FAILED

failures:

---- tests::chain_id::test_chain_id_set stdout ----
Compiling, may take a little while to download git dependencies...
thread 'tests::chain_id::test_chain_id_set' panicked at 'assertion failed: `(left == right)`
  left: `Keep(MiscellaneousError(Some(LOOKUP_FAILED)))`,
 right: `Keep(Success)`', aptos-move/e2e-move-tests/src/tests/chain_id.rs:62:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::chain_id::test_chain_id_set

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 54 filtered out; finished in 6.65s

error: test failed, to rerun pass '--lib'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5211)
<!-- Reviewable:end -->
