### PR TITLE
[fix]: type hints for addresses

### DIFF
--- a/ecosystem/python/sdk/aptos_sdk/client.py
+++ b/ecosystem/python/sdk/aptos_sdk/client.py
@@ -50,7 +50,7 @@ class RestClient:
             raise ApiError(f"{response.text} - {account_address}", response.status_code)
         return response.json()
 
-    def account_balance(self, account_address: str) -> int:
+    def account_balance(self, account_address: str | AccountAddress) -> int:
         """Returns the test coin balance associated with the account"""
         return self.account_resource(
             account_address, "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>"
@@ -354,8 +354,8 @@ class RestClient:
     def offer_token(
         self,
         account: Account,
-        receiver: str,
-        creator: str,
+        receiver: str | AccountAddress,
+        creator: str | AccountAddress,
         collection_name: str,
         token_name: str,
         property_version: int,
@@ -384,8 +384,8 @@ class RestClient:
     def claim_token(
         self,
         account: Account,
-        sender: str,
-        creator: str,
+        sender: str | AccountAddress,
+        creator: str | AccountAddress,
         collection_name: str,
         token_name: str,
         property_version: int,
@@ -570,7 +570,7 @@ class FaucetClient:
     def close(self):
         self.rest_client.close()
 
-    def fund_account(self, address: str, amount: int):
+    def fund_account(self, address: str | AccountAddress, amount: int):
         """This creates an account if it does not exist and mints the specified amount of
         coins into that account."""
         response = self.rest_client.client.post(


### PR DESCRIPTION
In some case address (reciver/sender) hinted as str. Fixed it to str | AccountAddress

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5212)
<!-- Reviewable:end -->
