### PR TITLE
[Indexer] Fix timestamp bug and restart from gap

### DIFF
--- a/crates/indexer/migrations/2022-10-21-055518_stake_to_voter/down.sql
+++ b/crates/indexer/migrations/2022-10-21-055518_stake_to_voter/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE IF EXISTS current_staking_pool_voter;

--- a/crates/indexer/migrations/2022-10-21-055518_stake_to_voter/up.sql
+++ b/crates/indexer/migrations/2022-10-21-055518_stake_to_voter/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+-- allows quick lookup of staking pool address to voter address and vice versa. Each staking pool 
+-- can only be mapped to one voter address at a time. 
+CREATE TABLE current_staking_pool_voter (
+  staking_pool_address VARCHAR(66) UNIQUE PRIMARY KEY NOT NULL,
+  voter_address VARCHAR(66) NOT NULL,
+  last_transaction_version BIGINT NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+CREATE INDEX ctpv_va_index ON current_staking_pool_voter (voter_address);
+CREATE INDEX ctpv_insat_index ON current_staking_pool_voter (inserted_at);

--- a/crates/indexer/src/indexer/tailer.rs
+++ b/crates/indexer/src/indexer/tailer.rs
@@ -18,6 +18,12 @@ use anyhow::{ensure, Context, Result};
 use aptos_api::context::Context as ApiContext;
 use aptos_logger::{debug, info};
 use chrono::ParseError;
+use diesel::{
+    pg::upsert::excluded,
+    sql_query,
+    sql_types::{BigInt, Text},
+    ExpressionMethods, RunQueryDsl,
+};
 use diesel_migrations::{EmbeddedMigrations, MigrationHarness};
 use std::{fmt::Debug, sync::Arc};
 use tokio::{sync::Mutex, task::JoinHandle};
@@ -168,11 +174,16 @@ impl Tailer {
                 .values(&status)
                 .on_conflict(processor_status::processor)
                 .do_update()
-                .set(&status),
+                .set((
+                    processor_status::last_success_version
+                        .eq(excluded(processor_status::last_success_version)),
+                    processor_status::last_updated.eq(excluded(processor_status::last_updated)),
+                )),
             Some(" WHERE processor_status.last_success_version <= EXCLUDED.last_success_version "),
         )?;
         Ok(())
     }
+
     /// Get last version processed successfully from databse
     pub fn get_start_version(&self, processor_name: &String) -> Result<Option<i64>> {
         let mut conn = self.connection_pool.get()?;
@@ -181,6 +192,93 @@ impl Tailer {
             Some(status) => Ok(Some(status.last_success_version + 1)),
             None => Ok(None),
         }
+    }
+
+    /// Get starting version from database. Starting version is defined as the first version that's either
+    /// not successful or missing from the DB.
+    pub fn get_start_version_long(
+        &self,
+        processor_name: &String,
+        lookback_versions: i64,
+    ) -> Option<i64> {
+        let mut conn = self
+            .connection_pool
+            .get()
+            .expect("DB connection should be available to get starting version");
+
+        // This query gets the first version that isn't equal to the next version (versions would be sorted of course).
+        // There's also special handling if the gap happens in the beginning.
+        let sql = "
+        WITH raw_boundaries AS
+        (
+            SELECT
+                MAX(version) AS MAX_V,
+                MIN(version) AS MIN_V
+            FROM
+                processor_statuses
+            WHERE
+                name = $1
+                AND success = TRUE
+        ),
+        boundaries AS
+        (
+            SELECT
+                MAX(version) AS MAX_V,
+                MIN(version) AS MIN_V
+            FROM
+                processor_statuses, raw_boundaries
+            WHERE
+                name = $1
+                AND success = true
+                and version >= GREATEST(MAX_V - $2, 0)
+        ),
+        gap AS
+        (
+            SELECT
+                MIN(version) + 1 AS maybe_gap
+            FROM
+                (
+                    SELECT
+                        version,
+                        LEAD(version) OVER (
+                    ORDER BY
+                        version ASC) AS next_version
+                    FROM
+                        processor_statuses,
+                        boundaries
+                    WHERE
+                        name = $1
+                        AND success = TRUE
+                        AND version >= GREATEST(MAX_V - $2, 0)
+                ) a
+            WHERE
+                version + 1 <> next_version
+        )
+        SELECT
+            CASE
+                WHEN
+                    MIN_V <> GREATEST(MAX_V - $2, 0)
+                THEN
+                    GREATEST(MAX_V - $2, 0)
+                ELSE
+                    COALESCE(maybe_gap, MAX_V + 1)
+            END
+            AS version
+        FROM
+            gap, boundaries
+        ";
+        #[derive(Debug, QueryableByName)]
+        pub struct Gap {
+            #[diesel(sql_type = BigInt)]
+            pub version: i64,
+        }
+        let mut res: Vec<Option<Gap>> = sql_query(sql)
+            .bind::<Text, _>(processor_name)
+            // This is the number used to determine how far we look back for gaps. Increasing it may result in slower startup
+            .bind::<BigInt, _>(lookback_versions)
+            .get_results(&mut conn)
+            .unwrap();
+        res.pop().unwrap().map(|g| g.version)
     }
 }
 

--- a/crates/indexer/src/models/mod.rs
+++ b/crates/indexer/src/models/mod.rs
@@ -11,6 +11,7 @@ pub mod move_tables;
 pub mod processor_status;
 pub mod processor_statuses;
 pub mod signatures;
+pub mod stake_models;
 pub mod token_models;
 pub mod transactions;
 pub mod user_transactions;

--- a/crates/indexer/src/models/stake_models/mod.rs
+++ b/crates/indexer/src/models/stake_models/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod stake_utils;
+pub mod staking_pool_voter;

--- a/crates/indexer/src/models/stake_models/stake_utils.rs
+++ b/crates/indexer/src/models/stake_models/stake_utils.rs
@@ -1,0 +1,66 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::models::move_resources::MoveResource;
+use anyhow::{Context, Result};
+use aptos_api_types::{deserialize_from_string, WriteResource};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct StakePoolResource {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub delegated_voter: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum StakeResource {
+    StakePool(StakePoolResource),
+}
+
+impl StakeResource {
+    fn is_resource_supported(data_type: &str) -> bool {
+        matches!(data_type, "0x1::stake::StakePool")
+    }
+
+    fn from_resource(data_type: &str, data: &serde_json::Value, txn_version: i64) -> Result<Self> {
+        match data_type {
+            "0x1::stake::StakePool" => serde_json::from_value(data.clone())
+                .map(|inner| Some(StakeResource::StakePool(inner))),
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {} failed! failed to parse type {}, data {:?}",
+            txn_version, data_type, data
+        ))?
+        .context(format!(
+            "Resource unsupported! Call is_resource_supported first. version {} type {}",
+            txn_version, data_type
+        ))
+    }
+
+    pub fn from_write_resource(
+        write_resource: &WriteResource,
+        txn_version: i64,
+    ) -> Result<Option<Self>> {
+        let type_str = format!(
+            "{}::{}::{}",
+            write_resource.data.typ.address,
+            write_resource.data.typ.module,
+            write_resource.data.typ.name
+        );
+        if !Self::is_resource_supported(type_str.as_str()) {
+            return Ok(None);
+        }
+        let resource = MoveResource::from_write_resource(
+            write_resource,
+            0, // Placeholder, this isn't used anyway
+            txn_version,
+            0, // Placeholder, this isn't used anyway
+        );
+        Ok(Some(Self::from_resource(
+            &type_str,
+            resource.data.as_ref().unwrap(),
+            txn_version,
+        )?))
+    }
+}

--- a/crates/indexer/src/models/stake_models/staking_pool_voter.rs
+++ b/crates/indexer/src/models/stake_models/staking_pool_voter.rs
@@ -1,0 +1,62 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+
+use super::stake_utils::StakeResource;
+use crate::{schema::current_staking_pool_voter, util::standardize_address};
+use aptos_api_types::{Transaction as APITransaction, WriteSetChange as APIWriteSetChange};
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+type StakingPoolAddress = String;
+pub type StakingPoolVoterMap = HashMap<StakingPoolAddress, CurrentStakingPoolVoter>;
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(staking_pool_address))]
+#[diesel(table_name = current_staking_pool_voter)]
+pub struct CurrentStakingPoolVoter {
+    pub staking_pool_address: String,
+    pub voter_address: String,
+    pub last_transaction_version: i64,
+}
+
+impl CurrentStakingPoolVoter {
+    pub fn from_transaction(transaction: &APITransaction) -> anyhow::Result<StakingPoolVoterMap> {
+        let mut staking_pool_voters = HashMap::new();
+        let empty_change = vec![];
+        let (txn_version, changes) = match transaction {
+            APITransaction::UserTransaction(txn) => (txn.info.version.0 as i64, &txn.info.changes),
+            APITransaction::GenesisTransaction(txn) => {
+                (txn.info.version.0 as i64, &txn.info.changes)
+            }
+            APITransaction::BlockMetadataTransaction(txn) => {
+                (txn.info.version.0 as i64, &txn.info.changes)
+            }
+            _ => (0, &empty_change),
+        };
+        for wsc in changes {
+            if let APIWriteSetChange::WriteResource(write_resource) = wsc {
+                if let Some(StakeResource::StakePool(inner)) =
+                    StakeResource::from_write_resource(write_resource, txn_version)?
+                {
+                    let staking_pool_address =
+                        standardize_address(&write_resource.address.to_string());
+                    let voter_address = standardize_address(&inner.delegated_voter);
+                    staking_pool_voters.insert(
+                        staking_pool_address.clone(),
+                        Self {
+                            staking_pool_address,
+                            voter_address,
+                            last_transaction_version: txn_version,
+                        },
+                    );
+                }
+            }
+        }
+
+        Ok(staking_pool_voters)
+    }
+}

--- a/crates/indexer/src/models/token_models/token_utils.rs
+++ b/crates/indexer/src/models/token_models/token_utils.rs
@@ -43,11 +43,7 @@ impl TokenDataIdType {
     }
 
     pub fn get_collection_data_id_hash(&self) -> String {
-        CollectionDataIdType {
-            creator: self.creator.clone(),
-            name: self.name.clone(),
-        }
-        .to_hash()
+        CollectionDataIdType::new(self.creator.clone(), self.collection.clone()).to_hash()
     }
 }
 

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -162,6 +162,7 @@ fn insert_coin_infos(
                     transaction_created_timestamp.eq(excluded(transaction_created_timestamp)),
                     supply_aggregator_table_handle.eq(excluded(supply_aggregator_table_handle)),
                     supply_aggregator_table_key.eq(excluded(supply_aggregator_table_key)),
+                    inserted_at.eq(excluded(inserted_at)),
                 )),
             Some(" WHERE coin_infos.transaction_version_created >= EXCLUDED.transaction_version_created "),
         )?;
@@ -207,6 +208,7 @@ fn insert_current_coin_balances(
                     amount.eq(excluded(amount)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
                     last_transaction_timestamp.eq(excluded(last_transaction_timestamp)),
+                    inserted_at.eq(excluded(inserted_at)),
                 )),
                 Some(" WHERE current_coin_balances.last_transaction_version <= excluded.last_transaction_version "),
             )?;
@@ -227,8 +229,7 @@ fn insert_coin_supply(
             diesel::insert_into(schema::coin_supply::table)
                 .values(&item_to_insert[start_ind..end_ind])
                 .on_conflict((transaction_version, coin_type_hash))
-                .do_update()
-                .set((transaction_epoch.eq(excluded(transaction_epoch)),)),
+                .do_nothing(),
             None,
         )?;
     }

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 use aptos_api_types::Transaction;
 use async_trait::async_trait;
-use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods, PgConnection};
+use diesel::{result::Error, PgConnection};
 use field_count::FieldCount;
 use std::fmt::Debug;
 
@@ -117,8 +117,7 @@ fn insert_transactions(
             diesel::insert_into(schema::transactions::table)
                 .values(&txns[start_ind..end_ind])
                 .on_conflict(version)
-                .do_update()
-                .set((epoch.eq(excluded(epoch)),)),
+                .do_nothing(),
             None,
         )?;
     }
@@ -148,8 +147,7 @@ fn insert_user_transactions_w_sigs(
             diesel::insert_into(schema::user_transactions::table)
                 .values(&all_user_transactions[start_ind..end_ind])
                 .on_conflict(ut_schema::version)
-                .do_update()
-                .set((ut_schema::epoch.eq(excluded(ut_schema::epoch)),)),
+                .do_nothing(),
             None,
         )?;
     }

--- a/crates/indexer/src/processors/mod.rs
+++ b/crates/indexer/src/processors/mod.rs
@@ -3,16 +3,19 @@
 
 pub mod coin_processor;
 pub mod default_processor;
+pub mod stake_processor;
 pub mod token_processor;
 
 use self::coin_processor::NAME as COIN_PROCESSOR_NAME;
 use self::default_processor::NAME as DEFAULT_PROCESSOR_NAME;
+use self::stake_processor::NAME as STAKE_PROCESSOR_NAME;
 use self::token_processor::NAME as TOKEN_PROCESSOR_NAME;
 
 pub enum Processor {
     CoinProcessor,
     DefaultProcessor,
     TokenProcessor,
+    StakeProcessor,
 }
 
 impl Processor {
@@ -21,6 +24,7 @@ impl Processor {
             DEFAULT_PROCESSOR_NAME => Self::DefaultProcessor,
             TOKEN_PROCESSOR_NAME => Self::TokenProcessor,
             COIN_PROCESSOR_NAME => Self::CoinProcessor,
+            STAKE_PROCESSOR_NAME => Self::StakeProcessor,
             _ => panic!("Processor unsupported {}", input_str),
         }
     }

--- a/crates/indexer/src/processors/stake_processor.rs
+++ b/crates/indexer/src/processors/stake_processor.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    database::{
+        clean_data_for_db, execute_with_better_error, get_chunks, PgDbPool, PgPoolConnection,
+    },
+    indexer::{
+        errors::TransactionProcessingError, processing_result::ProcessingResult,
+        transaction_processor::TransactionProcessor,
+    },
+    models::stake_models::staking_pool_voter::{CurrentStakingPoolVoter, StakingPoolVoterMap},
+    schema,
+};
+use aptos_api_types::Transaction as APITransaction;
+use async_trait::async_trait;
+use diesel::{pg::upsert::excluded, result::Error, ExpressionMethods, PgConnection};
+use field_count::FieldCount;
+use std::{collections::HashMap, fmt::Debug};
+
+pub const NAME: &str = "stake_processor";
+pub struct StakeTransactionProcessor {
+    connection_pool: PgDbPool,
+}
+
+impl StakeTransactionProcessor {
+    pub fn new(connection_pool: PgDbPool) -> Self {
+        Self { connection_pool }
+    }
+}
+
+impl Debug for StakeTransactionProcessor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = &self.connection_pool.state();
+        write!(
+            f,
+            "StakeTransactionProcessor {{ connections: {:?}  idle_connections: {:?} }}",
+            state.connections, state.idle_connections
+        )
+    }
+}
+
+fn insert_to_db_impl(
+    conn: &mut PgConnection,
+    current_stake_pool_voters: &[CurrentStakingPoolVoter],
+) -> Result<(), diesel::result::Error> {
+    insert_current_stake_pool_voter(conn, current_stake_pool_voters)?;
+    Ok(())
+}
+
+fn insert_to_db(
+    conn: &mut PgPoolConnection,
+    name: &'static str,
+    start_version: u64,
+    end_version: u64,
+    current_stake_pool_voters: Vec<CurrentStakingPoolVoter>,
+) -> Result<(), diesel::result::Error> {
+    aptos_logger::trace!(
+        name = name,
+        start_version = start_version,
+        end_version = end_version,
+        "Inserting to db",
+    );
+    match conn
+        .build_transaction()
+        .read_write()
+        .run::<_, Error, _>(|pg_conn| insert_to_db_impl(pg_conn, &current_stake_pool_voters))
+    {
+        Ok(_) => Ok(()),
+        Err(_) => conn
+            .build_transaction()
+            .read_write()
+            .run::<_, Error, _>(|pg_conn| {
+                let current_stake_pool_voters = clean_data_for_db(current_stake_pool_voters, true);
+
+                insert_to_db_impl(pg_conn, &current_stake_pool_voters)
+            }),
+    }
+}
+
+fn insert_current_stake_pool_voter(
+    conn: &mut PgConnection,
+    item_to_insert: &[CurrentStakingPoolVoter],
+) -> Result<(), diesel::result::Error> {
+    use schema::current_staking_pool_voter::dsl::*;
+
+    let chunks = get_chunks(item_to_insert.len(), CurrentStakingPoolVoter::field_count());
+    for (start_ind, end_ind) in chunks {
+        execute_with_better_error(
+            conn,
+            diesel::insert_into(schema::current_staking_pool_voter::table)
+                .values(&item_to_insert[start_ind..end_ind])
+                .on_conflict(staking_pool_address)
+                .do_update()
+                .set((
+                    staking_pool_address.eq(excluded(staking_pool_address)),
+                    voter_address.eq(excluded(voter_address)),
+                    last_transaction_version.eq(excluded(last_transaction_version)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
+            Some(
+                " WHERE current_staking_pool_voter.last_transaction_version <= EXCLUDED.last_transaction_version ",
+            ),
+        )?;
+    }
+    Ok(())
+}
+
+#[async_trait]
+impl TransactionProcessor for StakeTransactionProcessor {
+    fn name(&self) -> &'static str {
+        NAME
+    }
+
+    async fn process_transactions(
+        &self,
+        transactions: Vec<APITransaction>,
+        start_version: u64,
+        end_version: u64,
+    ) -> Result<ProcessingResult, TransactionProcessingError> {
+        let mut all_current_stake_pool_voters: StakingPoolVoterMap = HashMap::new();
+
+        for txn in &transactions {
+            let current_stake_pool_voter = CurrentStakingPoolVoter::from_transaction(txn).unwrap();
+            all_current_stake_pool_voters.extend(current_stake_pool_voter);
+        }
+        let mut all_current_stake_pool_voters = all_current_stake_pool_voters
+            .into_values()
+            .collect::<Vec<CurrentStakingPoolVoter>>();
+
+        // Sort by PK
+        all_current_stake_pool_voters
+            .sort_by(|a, b| a.staking_pool_address.cmp(&b.staking_pool_address));
+
+        let mut conn = self.get_conn();
+        let tx_result = insert_to_db(
+            &mut conn,
+            self.name(),
+            start_version,
+            end_version,
+            all_current_stake_pool_voters,
+        );
+        match tx_result {
+            Ok(_) => Ok(ProcessingResult::new(
+                self.name(),
+                start_version,
+                end_version,
+            )),
+            Err(err) => Err(TransactionProcessingError::TransactionCommitError((
+                anyhow::Error::from(err),
+                start_version,
+                end_version,
+                self.name(),
+            ))),
+        }
+    }
+
+    fn connection_pool(&self) -> &PgDbPool {
+        &self.connection_pool
+    }
+}

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -226,8 +226,7 @@ fn insert_token_datas(
             diesel::insert_into(schema::token_datas::table)
                 .values(&token_datas_to_insert[start_ind..end_ind])
                 .on_conflict((token_data_id_hash, transaction_version))
-                .do_update()
-                .set((description.eq(excluded(description)),)),
+                .do_nothing(),
             None,
         )?;
     }
@@ -281,6 +280,7 @@ fn insert_current_token_ownerships(
                     last_transaction_version.eq(excluded(last_transaction_version)),
                     collection_data_id_hash.eq(excluded(collection_data_id_hash)),
                     table_type.eq(excluded(table_type)),
+                    inserted_at.eq(excluded(inserted_at)),
                 )),
             Some(" WHERE current_token_ownerships.last_transaction_version <= excluded.last_transaction_version "),
         )?;
@@ -323,6 +323,7 @@ fn insert_current_token_datas(
                     last_transaction_version.eq(excluded(last_transaction_version)),
                     collection_data_id_hash.eq(excluded(collection_data_id_hash)),
                     description.eq(excluded(description)),
+                    inserted_at.eq(excluded(inserted_at)),
                 )),
             Some(" WHERE current_token_datas.last_transaction_version <= excluded.last_transaction_version "),
         )?;
@@ -357,6 +358,7 @@ fn insert_current_collection_datas(
                     description_mutable.eq(excluded(description_mutable)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
                     table_handle.eq(excluded(table_handle)),
+                    inserted_at.eq(excluded(inserted_at)),
                 )),
             Some(" WHERE current_collection_datas.last_transaction_version <= excluded.last_transaction_version "),
         )?;
@@ -417,6 +419,7 @@ fn insert_current_token_claims(
                     amount.eq(excluded(amount)),
                     table_handle.eq(excluded(table_handle)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
+                    inserted_at.eq(excluded(inserted_at)),
                 )),
             Some(" WHERE current_token_pending_claims.last_transaction_version <= excluded.last_transaction_version "),
         )?;
@@ -443,6 +446,7 @@ fn insert_current_ans_lookups(
                     registered_address.eq(excluded(registered_address)),
                     expiration_timestamp.eq(excluded(expiration_timestamp)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
+                    inserted_at.eq(excluded(inserted_at)),
                 )),
                 Some(" WHERE current_ans_lookup.last_transaction_version <= excluded.last_transaction_version "),
             )?;

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -178,7 +178,11 @@ fn insert_tokens(
             diesel::insert_into(schema::tokens::table)
                 .values(&tokens_to_insert[start_ind..end_ind])
                 .on_conflict((token_data_id_hash, property_version, transaction_version))
-                .do_nothing(),
+                .do_update()
+                .set((
+                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
             None,
         )?;
     }
@@ -206,7 +210,11 @@ fn insert_token_ownerships(
                     transaction_version,
                     table_handle,
                 ))
-                .do_nothing(),
+                .do_update()
+                .set((
+                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
             None,
         )?;
     }
@@ -226,7 +234,11 @@ fn insert_token_datas(
             diesel::insert_into(schema::token_datas::table)
                 .values(&token_datas_to_insert[start_ind..end_ind])
                 .on_conflict((token_data_id_hash, transaction_version))
-                .do_nothing(),
+                .do_update()
+                .set((
+                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
             None,
         )?;
     }
@@ -385,7 +397,11 @@ fn insert_token_activities(
                     event_creation_number,
                     event_sequence_number,
                 ))
-                .do_nothing(),
+                .do_update()
+                .set((
+                    collection_data_id_hash.eq(excluded(collection_data_id_hash)),
+                    inserted_at.eq(excluded(inserted_at)),
+                )),
             None,
         )?;
     }

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -9,7 +9,8 @@ use crate::{
     },
     processors::{
         coin_processor::CoinTransactionProcessor, default_processor::DefaultTransactionProcessor,
-        token_processor::TokenTransactionProcessor, Processor,
+        stake_processor::StakeTransactionProcessor, token_processor::TokenTransactionProcessor,
+        Processor,
     },
 };
 
@@ -139,6 +140,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
             config.ans_contract_address,
         )),
         Processor::CoinProcessor => Arc::new(CoinTransactionProcessor::new(conn_pool.clone())),
+        Processor::StakeProcessor => Arc::new(StakeTransactionProcessor::new(conn_pool.clone())),
     };
 
     let options =

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -112,6 +112,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
     let processor_tasks = config.processor_tasks.unwrap();
     let emit_every = config.emit_every.unwrap();
     let batch_size = config.batch_size.unwrap();
+    let lookback_versions = config.gap_lookback_versions.unwrap() as i64;
 
     info!(processor_name = processor_name, "Starting indexer...");
 
@@ -153,9 +154,11 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
 
     info!(
         processor_name = processor_name,
+        lookback_versions = lookback_versions,
         "Fetching starting version from db..."
     );
-    let starting_version_from_db = tailer
+    // For now this is not being used but we'd want to track it anyway
+    let starting_version_from_db_short = tailer
         .get_start_version(&processor_name)
         .unwrap_or_else(|e| panic!("Failed to get starting version: {:?}", e))
         .unwrap_or_else(|| {
@@ -166,7 +169,15 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
             0
         }) as u64;
     let start_version = match config.starting_version {
-        None => starting_version_from_db,
+        None => tailer
+            .get_start_version_long(&processor_name, lookback_versions)
+            .unwrap_or_else(|| {
+                info!(
+                    processor_name = processor_name,
+                    "Could not fetch version from db so starting from version 0"
+                );
+                0
+            }) as u64,
         Some(version) => version,
     };
 
@@ -174,7 +185,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
         processor_name = processor_name,
         final_start_version = start_version,
         start_version_from_config = config.starting_version,
-        starting_version_from_db = starting_version_from_db,
+        starting_version_from_db_short = starting_version_from_db_short,
         "Setting starting version..."
     );
     tailer.set_fetcher_version(start_version as u64).await;

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -139,6 +139,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    current_staking_pool_voter (staking_pool_address) {
+        staking_pool_address -> Varchar,
+        voter_address -> Varchar,
+        last_transaction_version -> Int8,
+        inserted_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     current_token_datas (token_data_id_hash) {
         token_data_id_hash -> Varchar,
         creator_address -> Varchar,
@@ -466,6 +475,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     current_ans_lookup,
     current_coin_balances,
     current_collection_datas,
+    current_staking_pool_voter,
     current_token_datas,
     current_token_ownerships,
     current_token_pending_claims,

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -45,8 +45,11 @@ pub fn parse_timestamp(ts: u64, version: i64) -> chrono::NaiveDateTime {
 }
 
 pub fn parse_timestamp_secs(ts: u64, version: i64) -> chrono::NaiveDateTime {
-    chrono::NaiveDateTime::from_timestamp_opt(std::cmp::min(ts as i64, MAX_TIMESTAMP_SECS), 0)
-        .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
+    chrono::NaiveDateTime::from_timestamp_opt(
+        std::cmp::min(ts, MAX_TIMESTAMP_SECS as u64) as i64,
+        0,
+    )
+    .unwrap_or_else(|| panic!("Could not parse timestamp {:?} for version {}", ts, version))
 }
 
 pub fn remove_null_bytes<T: serde::Serialize + for<'de> serde::Deserialize<'de>>(input: &T) -> T {


### PR DESCRIPTION
### Description
* Fix error where expiration timestamp could be > i64. 
* Revert to original way of restarting from gap (the issue is that other threads might cause indexer to skip over bad transactions completely which isn't good). 
* Also update inserted_at field in all the tables

Note, I would recommend backfilling from `7602762`. 

### Test Plan
Tested locally (`cargo run -p aptos-node --features "indexer" --release -- -f ./fullnode.yaml | grep -E _processor`)
Tested on devnet
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5214)
<!-- Reviewable:end -->
