### PR TITLE
[CLI] Use jemalloc for the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools",
+ "jemallocator",
  "move-cli",
  "move-command-line-common",
  "move-core-types",

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -21,6 +21,7 @@ dirs = "4.0.0"
 futures = "0.3.21"
 hex = "0.4.3"
 itertools = "0.10.3"
+jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 rand = "0.7.3"
 regex = "1.1.5"
 reqwest = { version = "0.11.10", features = ["blocking", "json"] }

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -5,6 +5,10 @@
 
 #![forbid(unsafe_code)]
 
+#[cfg(unix)]
+#[global_allocator]
+static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use aptos::{move_tool, Tool};
 use clap::Parser;
 use std::process::exit;


### PR DESCRIPTION
### Description
We use jemalloc at main for the node, but not for the CLI. This could lead to inconsistencies between nodes run normally and nodes run through the CLI. This PR makes the CLI use jemalloc like the node does (unix only).

I'm not 100% sure why we didn't do this already. I'm assuming it was just an oversight, but perhaps there was some other reason, e.g. compatibility concerns. We can figure it out in this PR / through CI 😛 

### Test Plan
Running the TS SDK tests worked against a local testnet. Beyond that, CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5249)
<!-- Reviewable:end -->
