### PR TITLE
[State Sync] Increase request timeouts and reduce max. message sizes.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -65,6 +65,7 @@ pub struct StateSyncDriverConfig {
     pub progress_check_interval_ms: u64, // The interval (ms) at which to check state sync progress
     pub max_connection_deadline_secs: u64, // The max time (secs) to wait for connections from peers
     pub max_consecutive_stream_notifications: u64, // The max number of notifications to process per driver loop
+    pub max_num_stream_timeouts: u64, // The max number of stream timeouts allowed before termination
     pub max_pending_data_chunks: u64, // The max number of data chunks pending execution or commit
     pub max_stream_wait_time_ms: u64, // The max time (ms) to wait for a data stream notification
     pub num_versions_to_skip_snapshot_sync: u64, // The version lag we'll tolerate before snapshot syncing
@@ -81,6 +82,7 @@ impl Default for StateSyncDriverConfig {
             progress_check_interval_ms: 100,
             max_connection_deadline_secs: 10,
             max_consecutive_stream_notifications: 10,
+            max_num_stream_timeouts: 6,
             max_pending_data_chunks: 100,
             max_stream_wait_time_ms: 5000,
             num_versions_to_skip_snapshot_sync: 100_000_000, // At 5k TPS, this allows a node to fail for about 6 hours.

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 // The maximum message size per state sync message
-pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024; /* 16 MiB */
+pub const MAX_MESSAGE_SIZE: usize = 4 * 1024 * 1024; /* 4 MiB */
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -180,7 +180,7 @@ impl Default for AptosDataClientConfig {
         Self {
             max_num_in_flight_priority_polls: 10,
             max_num_in_flight_regular_polls: 10,
-            response_timeout_ms: 10000,
+            response_timeout_ms: 20000, // 20 seconds
             summary_poll_interval_ms: 200,
             use_compression: true,
         }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -535,9 +535,13 @@ impl<
     /// Attempts to fetch a data notification from the active stream
     async fn fetch_next_data_notification(&mut self) -> Result<DataNotification, Error> {
         let max_stream_wait_time_ms = self.driver_configuration.config.max_stream_wait_time_ms;
-        let result =
-            utils::get_data_notification(max_stream_wait_time_ms, self.active_data_stream.as_mut())
-                .await;
+        let max_num_stream_timeouts = self.driver_configuration.config.max_num_stream_timeouts;
+        let result = utils::get_data_notification(
+            max_stream_wait_time_ms,
+            max_num_stream_timeouts,
+            self.active_data_stream.as_mut(),
+        )
+        .await;
         if matches!(result, Err(Error::CriticalDataStreamTimeout(_))) {
             // If the stream has timed out too many times, we need to reset it
             warn!("Resetting the currently active data stream due to too many timeouts!");

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -146,9 +146,13 @@ impl<
     /// Attempts to fetch a data notification from the active stream
     async fn fetch_next_data_notification(&mut self) -> Result<DataNotification, Error> {
         let max_stream_wait_time_ms = self.driver_configuration.config.max_stream_wait_time_ms;
-        let result =
-            utils::get_data_notification(max_stream_wait_time_ms, self.active_data_stream.as_mut())
-                .await;
+        let max_num_stream_timeouts = self.driver_configuration.config.max_num_stream_timeouts;
+        let result = utils::get_data_notification(
+            max_stream_wait_time_ms,
+            max_num_stream_timeouts,
+            self.active_data_stream.as_mut(),
+        )
+        .await;
         if matches!(result, Err(Error::CriticalDataStreamTimeout(_))) {
             // If the stream has timed out too many times, we need to reset it
             warn!("Resetting the currently active data stream due to too many timeouts!");

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/bootstrapper.rs
@@ -169,8 +169,8 @@ async fn test_critical_timeout() {
         .await
         .unwrap();
 
-    // Drive progress twice and verify we get non-critical timeouts
-    for _ in 0..2 {
+    // Drive progress and verify we get non-critical timeouts
+    for _ in 0..5 {
         let error = drive_progress(&mut bootstrapper, &global_data_summary, false)
             .await
             .unwrap_err();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/continuous_syncer.rs
@@ -42,6 +42,7 @@ async fn test_critical_timeout() {
     driver_configuration.config.continuous_syncing_mode =
         ContinuousSyncingMode::ApplyTransactionOutputs;
     driver_configuration.config.max_stream_wait_time_ms = 1000;
+    driver_configuration.config.max_num_stream_timeouts = 4;
 
     // Create the mock streaming client
     let mut mock_streaming_client = create_mock_streaming_client();
@@ -82,8 +83,8 @@ async fn test_critical_timeout() {
         .await
         .unwrap();
 
-    // Drive progress twice and verify we get non-critical timeouts
-    for _ in 0..2 {
+    // Drive progress and verify we get non-critical timeouts
+    for _ in 0..3 {
         let error = continuous_syncer
             .drive_progress(no_sync_request.clone())
             .await

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -1116,7 +1116,11 @@ impl StorageReaderInterface for StorageReader {
                     include_events,
                 )
                 .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            if num_transactions_to_fetch == 1 {
+                return Ok(transaction_list_with_proof); // We cannot return less than a single item
+            }
 
+            // Attempt to divide up the request if it overflows the message size
             let (overflow_frame, num_bytes) = check_overflow_network_frame(
                 &transaction_list_with_proof,
                 self.config.max_network_chunk_bytes,
@@ -1134,12 +1138,12 @@ impl StorageReaderInterface for StorageReader {
             }
         }
 
-        panic!(
+        Err(Error::UnexpectedErrorEncountered(format!(
             "Unable to serve the get_transactions_with_proof request! Proof version: {:?}, \
             start version: {:?}, end version: {:?}, include events: {:?}. The data cannot fit into \
             a single network frame!",
-            proof_version, start_version, end_version, include_events
-        )
+            proof_version, start_version, end_version, include_events,
+        )))
     }
 
     fn get_epoch_ending_ledger_infos(
@@ -1165,7 +1169,11 @@ impl StorageReaderInterface for StorageReader {
                 .storage
                 .get_epoch_ending_ledger_infos(start_epoch, end_epoch)
                 .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            if num_ledger_infos_to_fetch == 1 {
+                return Ok(epoch_change_proof); // We cannot return less than a single item
+            }
 
+            // Attempt to divide up the request if it overflows the message size
             let (overflow_frame, num_bytes) = check_overflow_network_frame(
                 &epoch_change_proof,
                 self.config.max_network_chunk_bytes,
@@ -1183,11 +1191,11 @@ impl StorageReaderInterface for StorageReader {
             }
         }
 
-        panic!(
+        Err(Error::UnexpectedErrorEncountered(format!(
             "Unable to serve the get_epoch_ending_ledger_infos request! Start epoch: {:?}, \
             expected end epoch: {:?}. The data cannot fit into a single network frame!",
             start_epoch, expected_end_epoch
-        )
+        )))
     }
 
     fn get_transaction_outputs_with_proof(
@@ -1207,7 +1215,11 @@ impl StorageReaderInterface for StorageReader {
                 .storage
                 .get_transaction_outputs(start_version, num_outputs_to_fetch, proof_version)
                 .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            if num_outputs_to_fetch == 1 {
+                return Ok(output_list_with_proof); // We cannot return less than a single item
+            }
 
+            // Attempt to divide up the request if it overflows the message size
             let (overflow_frame, num_bytes) = check_overflow_network_frame(
                 &output_list_with_proof,
                 self.config.max_network_chunk_bytes,
@@ -1225,11 +1237,11 @@ impl StorageReaderInterface for StorageReader {
             }
         }
 
-        panic!(
+        Err(Error::UnexpectedErrorEncountered(format!(
             "Unable to serve the get_transaction_outputs_with_proof request! Proof version: {:?}, \
             start version: {:?}, end version: {:?}. The data cannot fit into a single network frame!",
             proof_version, start_version, end_version
-        )
+        )))
     }
 
     fn get_number_of_states(&self, version: u64) -> Result<u64, Error> {
@@ -1261,7 +1273,11 @@ impl StorageReaderInterface for StorageReader {
                     num_state_values_to_fetch as usize,
                 )
                 .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            if num_state_values_to_fetch == 1 {
+                return Ok(state_value_chunk_with_proof); // We cannot return less than a single item
+            }
 
+            // Attempt to divide up the request if it overflows the message size
             let (overflow_frame, num_bytes) = check_overflow_network_frame(
                 &state_value_chunk_with_proof,
                 self.config.max_network_chunk_bytes,
@@ -1280,11 +1296,11 @@ impl StorageReaderInterface for StorageReader {
             }
         }
 
-        panic!(
+        Err(Error::UnexpectedErrorEncountered(format!(
             "Unable to serve the get_state_value_chunk_with_proof request! Version: {:?}, \
             start index: {:?}, end index: {:?}. The data cannot fit into a single network frame!",
             version, start_index, end_index
-        )
+        )))
     }
 }
 

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -275,6 +275,27 @@ async fn test_validator_bootstrap_outputs_network_limit() {
     test_validator_sync(&mut swarm, 1).await;
 }
 
+#[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
+#[tokio::test]
+async fn test_validator_bootstrap_outputs_network_limit_tiny() {
+    // Create a swarm of 4 validators using output syncing and an unrealistic network limit.
+    // This forces all chunks to be of size 1.
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::ApplyTransactionOutputsFromGenesis;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ApplyTransactionOutputs;
+            config.state_sync.storage_service.max_network_chunk_bytes = 1;
+        }))
+        .build()
+        .await;
+
+    // Test the ability of the validators to sync
+    test_validator_sync(&mut swarm, 1).await;
+}
+
 #[tokio::test]
 async fn test_validator_bootstrap_state_snapshot_no_compression() {
     // Create a swarm of 4 validators using state snapshot syncing
@@ -314,6 +335,27 @@ async fn test_validator_bootstrap_state_snapshot_network_limit() {
     test_validator_sync(&mut swarm, 1).await;
 }
 
+#[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
+#[tokio::test]
+async fn test_validator_bootstrap_state_snapshot_network_limit_tiny() {
+    // Create a swarm of 4 validators using state snapshot syncing and an unrealistic network limit.
+    // This forces all chunks to be of size 1.
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::DownloadLatestStates;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ExecuteTransactions;
+            config.state_sync.storage_service.max_network_chunk_bytes = 1;
+        }))
+        .build()
+        .await;
+
+    // Test the ability of the validators to sync
+    test_validator_sync(&mut swarm, 1).await;
+}
+
 #[tokio::test]
 async fn test_validator_bootstrap_transactions() {
     // Create a swarm of 4 validators using transaction syncing
@@ -344,6 +386,27 @@ async fn test_validator_bootstrap_transactions_network_limit() {
             config.state_sync.state_sync_driver.continuous_syncing_mode =
                 ContinuousSyncingMode::ExecuteTransactions;
             config.state_sync.storage_service.max_network_chunk_bytes = 100 * 1024;
+        }))
+        .build()
+        .await;
+
+    // Test the ability of the validators to sync
+    test_validator_sync(&mut swarm, 1).await;
+}
+
+#[ignore] // We ignore this test because it takes a long time. But, it works, so it shouldn't be removed.
+#[tokio::test]
+async fn test_validator_bootstrap_transactions_network_limit_tiny() {
+    // Create a swarm of 4 validators using transaction syncing and an unrealistic network limit.
+    // This forces all chunks to be of size 1.
+    let mut swarm = SwarmBuilder::new_local(4)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, config, _| {
+            config.state_sync.state_sync_driver.bootstrapping_mode =
+                BootstrappingMode::ExecuteTransactionsFromGenesis;
+            config.state_sync.state_sync_driver.continuous_syncing_mode =
+                ContinuousSyncingMode::ExecuteTransactions;
+            config.state_sync.storage_service.max_network_chunk_bytes = 1;
         }))
         .build()
         .await;


### PR DESCRIPTION
### Description
This PR updates the state sync code with the following tweaks to improve the experience of fullnodes. Each of these is in their own commits:
1. Make the max number of data stream timeouts configurable and increase the value from 3 to 6 to reduce stream termination rates when waiting for data. Each wait is up to 5 seconds, so this change goes from (3x5) 15 seconds to (6x5) 30 seconds before a stream will be terminated.
2. Increase the max RPC response timeout from 10 seconds to 20 seconds to allow nodes with limited network bandwidth to receive larger messages. In addition, reduce the max message size from 16MB to 4MB and update the logic such that if a single item cannot fit inside 4MB, it is still sent.
4. Add simple smoke tests to verify at least 1 item is sent per chunk on overflow.

### Test Plan
Existing test infrastructure (unit tests, smoke tests + forge).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5250)
<!-- Reviewable:end -->
