### PR TITLE
[tf/aws][fullnode] public-read acl for public backups

### DIFF
--- a/terraform/fullnode/aws/backup.tf
+++ b/terraform/fullnode/aws/backup.tf
@@ -14,6 +14,12 @@ resource "aws_s3_bucket_public_access_block" "backup" {
   restrict_public_buckets = !var.enable_public_backup
 }
 
+resource "aws_s3_bucket_acl" "public-backup" {
+  count  = var.enable_public_backup ? 1 : 0
+  bucket = aws_s3_bucket.backup.id
+  acl    = "public-read"
+}
+
 data "aws_iam_policy_document" "backup-assume-role" {
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]


### PR DESCRIPTION
### Description

if `var.enable_public_backup = true`, then add an additional ACL on the bucket to enable `public-read`

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5252)
<!-- Reviewable:end -->
