### PR TITLE
Return error if provided config was missing or invalid

### DIFF
--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -5,7 +5,7 @@
 
 mod log_build_information;
 
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use aptos_api::bootstrap as bootstrap_api;
 use aptos_build_info::build_information;
 use aptos_config::{
@@ -301,9 +301,8 @@ where
         fnn.runtime_threads = Some(1);
         // If a config path was provided, use that as the template
         if let Some(config_path) = config_path {
-            if let Ok(config) = NodeConfig::load_config(config_path) {
-                template = config;
-            }
+            template = NodeConfig::load_config(&config_path)
+                .with_context(|| format!("Failed to load config at path: {:?}", config_path))?;
         }
 
         template.logger.level = Level::Debug;


### PR DESCRIPTION
### Description
Currently if you pass in an explicit config path but there is no file at the path, or the config is missing, it just silently continues without even a warning. This PR makes it return an error in this case.

### Test Plan
```
cargo run --release -p aptos -- node run-local-testnet --force-restart --config-path /tmp/does_not_exist.yaml --assume-yes
```
Output (when this PR is on top of https://github.com/aptos-labs/aptos-core/pull/5261):
```
Node stopped unexpectedly Err(
    Error {
        context: "Failed to load config at path: \"/tmp/does_not_exist.yaml\"",
        source: Unexpected(
            "Failed to open config file: \"/tmp/does_not_exist.yaml\". Error: Os { code: 2, kind: NotFound, message: \"No such file or directory\" }",
        ),
    },
)
{
  "Error": "Unexpected error: One of the components stopped unexpectedly"
}
```

I checked and didn't see any location where we depend on the bad current behavior in our deployment code, and the CI will let us know if forge does.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5258)
<!-- Reviewable:end -->
