### PR TITLE
[CLI] Exit if the node / faucet stops when running a local testnet

### DIFF
--- a/crates/aptos-faucet/src/lib.rs
+++ b/crates/aptos-faucet/src/lib.rs
@@ -138,7 +138,7 @@ impl FaucetArgs {
                 .await
         };
 
-        println!("Faucet is running.  Faucet endpoint: {}", address);
+        println!("Faucet is running. Faucet endpoint: {}", address);
 
         info!(
             "[faucet]: running on: {}. Minting from {}",


### PR DESCRIPTION
### Description
As it is now, if you run this command and the node thread panics, it just prints the panic without exiting. Worse than that, if it returns an error, it prints nothing at all and just silently sits there, broken.
```
cargo run -p aptos -- node run-local-testnet --force-restart --assume-yes
```

This PR fixes that, making sure that the CLI exists if the local testnet / faucet exit.

This is a very imperfect fix. Really what we want is something like what we do in the tap: https://github.com/aptos-labs/aptos-tap/blob/main/src/server/run.rs#L170. In this setup, all never-ending tasks are represented as futures (whereas this is a blend of future and blocking thread) and all tasks return errors, so instead of printing the error and then bubbling up a `()`, it actually returns the error, which can then get propagated all the way up to main.

### Test Plan
Command:
```
cargo run -p aptos -- node run-local-testnet --force-restart --config-path /tmp/yes_api.yaml --assume-yes
```

No error introduced:
```
Completed generating configuration:
        Log file: "/Users/dport/a/core/.aptos/testnet/validator.log"
        Test dir: "/Users/dport/a/core/.aptos/testnet"
        Aptos root key path: "/Users/dport/a/core/.aptos/testnet/mint.key"
        Waypoint: 0:0d22c659f2a6e918612c9be311a0efdfa1fc9cf9751a4968f866924faf73bb9b
        ChainId: testing
        REST API endpoint: http://0.0.0.0:8080
        Metrics endpoint: http://0.0.0.0:9102/metrics
        Aptosnet Fullnode network endpoint: /ip4/0.0.0.0/tcp/6184

Aptos is running, press ctrl-c to exit
```

Error introduced in the node thread:
```
Node stopped unexpectedly Err(
    "manual error",
)
{
  "Error": "Unexpected error: One of the components stopped unexpectedly"
}
```

Panic introduced in the faucet future. Output: https://gist.github.com/banool/c6b4392aa1f41e9fb4f22c6a6b839a8c.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5261)
<!-- Reviewable:end -->
