### PR TITLE
[smoke tests] test_genesis_transaction_flow: add wait checks on validator restarts

### DIFF
--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -19,7 +19,7 @@ use regex::Regex;
 use std::time::Instant;
 use std::{fs, process::Command, str::FromStr, time::Duration};
 
-async fn update_node_config_restart(validator: &mut LocalNode, mut config: NodeConfig) {
+fn update_node_config_restart(validator: &mut LocalNode, mut config: NodeConfig) {
     validator.stop();
     let node_path = validator.config_path();
     config.save(node_path).unwrap();
@@ -64,7 +64,7 @@ async fn test_genesis_transaction_flow() {
     let node = env.validators_mut().nth(4).unwrap();
     let mut new_config = node.config().clone();
     new_config.consensus.sync_only = true;
-    update_node_config_restart(node, new_config.clone()).await;
+    update_node_config_restart(node, new_config.clone());
     wait_for_node(node, num_nodes - 1).await;
     // wait for some versions
     env.wait_for_all_nodes_to_catchup_to_version(10, Duration::from_secs(10))
@@ -75,7 +75,7 @@ async fn test_genesis_transaction_flow() {
     for node in env.validators_mut() {
         let mut node_config = node.config().clone();
         node_config.consensus.sync_only = true;
-        update_node_config_restart(node, node_config).await;
+        update_node_config_restart(node, node_config);
         wait_for_node(node, num_nodes - 1).await;
     }
 
@@ -174,7 +174,7 @@ async fn test_genesis_transaction_flow() {
         node_config.execution.genesis = Some(genesis_transaction.clone());
         // reset the sync_only flag to false
         node_config.consensus.sync_only = false;
-        update_node_config_restart(node, node_config).await;
+        update_node_config_restart(node, node_config);
         wait_for_node(node, expected_to_connect).await;
     }
 

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -10,18 +10,31 @@ use crate::{
 };
 use anyhow::anyhow;
 use aptos_config::config::NodeConfig;
+use aptos_logger::prelude::*;
 use aptos_temppath::TempPath;
 use aptos_types::{transaction::Transaction, waypoint::Waypoint};
-use forge::{get_highest_synced_version, LocalNode, Node, NodeExt, SwarmExt};
+use forge::{get_highest_synced_version, LocalNode, Node, NodeExt, SwarmExt, Validator};
 use move_core_types::language_storage::CORE_CODE_ADDRESS;
 use regex::Regex;
+use std::time::Instant;
 use std::{fs, process::Command, str::FromStr, time::Duration};
 
-fn update_node_config_restart(validator: &mut LocalNode, mut config: NodeConfig) {
+async fn update_node_config_restart(validator: &mut LocalNode, mut config: NodeConfig) {
     validator.stop();
     let node_path = validator.config_path();
     config.save(node_path).unwrap();
     validator.start().unwrap();
+}
+
+async fn wait_for_node(validator: &mut dyn Validator, expected_to_connect: usize) {
+    let deadline = Instant::now().checked_add(Duration::from_secs(60)).unwrap();
+    validator.wait_until_healthy(deadline).await.unwrap();
+    info!("Validator restart health check passed");
+    validator
+        .wait_for_connectivity(expected_to_connect, deadline)
+        .await
+        .unwrap();
+    info!("Validator restart connectivity check passed");
 }
 
 #[tokio::test]
@@ -51,7 +64,8 @@ async fn test_genesis_transaction_flow() {
     let node = env.validators_mut().nth(4).unwrap();
     let mut new_config = node.config().clone();
     new_config.consensus.sync_only = true;
-    update_node_config_restart(node, new_config.clone());
+    update_node_config_restart(node, new_config.clone()).await;
+    wait_for_node(node, num_nodes - 1).await;
     // wait for some versions
     env.wait_for_all_nodes_to_catchup_to_version(10, Duration::from_secs(10))
         .await
@@ -61,7 +75,8 @@ async fn test_genesis_transaction_flow() {
     for node in env.validators_mut() {
         let mut node_config = node.config().clone();
         node_config.consensus.sync_only = true;
-        update_node_config_restart(node, node_config)
+        update_node_config_restart(node, node_config).await;
+        wait_for_node(node, num_nodes - 1).await;
     }
 
     println!("3. delete one node's db and test they can still sync when sync_only is true for every nodes");
@@ -153,13 +168,14 @@ async fn test_genesis_transaction_flow() {
     let waypoint = parse_waypoint(output);
 
     println!("7. apply genesis transaction for nodes 0, 1, 2");
-    for node in env.validators_mut().take(3) {
+    for (expected_to_connect, node) in env.validators_mut().take(3).enumerate() {
         let mut node_config = node.config().clone();
         insert_waypoint(&mut node_config, waypoint);
         node_config.execution.genesis = Some(genesis_transaction.clone());
         // reset the sync_only flag to false
         node_config.consensus.sync_only = false;
-        update_node_config_restart(node, node_config);
+        update_node_config_restart(node, node_config).await;
+        wait_for_node(node, expected_to_connect).await;
     }
 
     println!("8. verify it's able to mint after the waypoint");
@@ -215,6 +231,7 @@ async fn test_genesis_transaction_flow() {
     db_restore(backup_path.path(), db_dir.as_path(), &[waypoint]);
 
     node.start().unwrap();
+    wait_for_node(node, num_nodes - 2).await;
     let client = node.rest_client();
     // wait for it to catch up
     {


### PR DESCRIPTION
### Description

This is one of the top flaky tests.

Observed flaky runs fail with `Waiting for nodes to catch up to version 10 timed out after 10s`. While this is probably enough time for state sync, there may be variation in node restart times, so adding the waits.

If things still fail, at least it will be clearer which is at fault.

### Test Plan

Will have to observe if the flakes go away.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5262)
<!-- Reviewable:end -->
