### PR TITLE
[Cargo] Add comment about performance profile.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,8 @@ read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = 
 debug = true
 overflow-checks = true
 
+# The performance build is not currently recommended
+# for production deployments. It has not been widely tested.
 [profile.performance]
 inherits = "release"
 opt-level = 3


### PR DESCRIPTION
### Description
This PR adds a small comment to the performance profile in Cargo.toml to warn the reader that performance builds are not stable yet.

### Test Plan
None.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5284)
<!-- Reviewable:end -->
