### PR TITLE
[move] add `chain_id()` call in `aptos_stdlib::type_info`

### DIFF
--- a/aptos-move/aptos-gas/src/aptos_framework.rs
+++ b/aptos-move/aptos-gas/src/aptos_framework.rs
@@ -81,6 +81,7 @@ crate::natives::define_gas_parameters_for_natives!(GasParameters, "aptos_framewo
     [.type_info.type_name.base, "type_info.type_name.base", 300 * MUL],
     // TODO(Gas): the on-chain name is wrong...
     [.type_info.type_name.per_byte_in_str, "type_info.type_name.per_abstract_memory_unit", 5 * MUL],
+    [.type_info.chain_id.base, optional "type_info.chain_id.base", 150 * MUL],
 
     // Reusing SHA2-512's cost from Ristretto
     [.hash.sha2_512.base, optional "hash.sha2_512.base", 3_240],

--- a/aptos-move/aptos-vm/src/aptos_vm_impl.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm_impl.rs
@@ -17,6 +17,7 @@ use aptos_gas::{
 };
 use aptos_logger::prelude::*;
 use aptos_state_view::StateView;
+use aptos_types::chain_id::ChainId;
 use aptos_types::on_chain_config::{FeatureFlag, Features};
 use aptos_types::transaction::AbortInfo;
 use aptos_types::{
@@ -112,11 +113,16 @@ impl AptosVMImpl {
         };
 
         let features = Features::fetch_config(&storage).unwrap_or_default();
+
+        // If no chain ID is in storage, we assume we are in a testing environment and use ChainId::TESTING
+        let chain_id = ChainId::fetch_config(&storage).unwrap_or_else(ChainId::test);
+
         let inner = MoveVmExt::new(
             native_gas_params,
             abs_val_size_gas_params,
             gas_feature_version,
             features.is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+            chain_id.id(),
         )
         .expect("should be able to create Move VM; check if there are duplicated natives");
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -19,6 +19,7 @@ use std::ops::Deref;
 
 pub struct MoveVmExt {
     inner: MoveVM,
+    chain_id: u8,
 }
 
 impl MoveVmExt {
@@ -27,6 +28,7 @@ impl MoveVmExt {
         abs_val_size_gas_params: AbstractValueSizeGasParameters,
         gas_feature_version: u64,
         treat_friend_as_private: bool,
+        chain_id: u8,
     ) -> VMResult<Self> {
         Ok(Self {
             inner: MoveVM::new_with_configs(
@@ -41,6 +43,7 @@ impl MoveVmExt {
                 },
                 crate::AptosVM::get_runtime_config(),
             )?,
+            chain_id,
         })
     }
 
@@ -55,6 +58,7 @@ impl MoveVmExt {
             .to_vec()
             .try_into()
             .expect("HashValue should convert to [u8; 32]");
+
         extensions.add(NativeTableContext::new(txn_hash, remote));
         extensions.add(NativeRistrettoPointContext::new());
         extensions.add(NativeAggregatorContext::new(txn_hash, remote));
@@ -67,7 +71,8 @@ impl MoveVmExt {
             } => script_hash,
             _ => vec![],
         };
-        extensions.add(NativeTransactionContext::new(script_hash));
+
+        extensions.add(NativeTransactionContext::new(script_hash, self.chain_id));
         extensions.add(NativeCodeContext::default());
         extensions.add(NativeStateStorageContext::new(remote));
 

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -5,6 +5,7 @@ use aptos_gas::{AbstractValueSizeGasParameters, NativeGasParameters, LATEST_GAS_
 use aptos_types::account_config::CORE_CODE_ADDRESS;
 use move_vm_runtime::native_functions::NativeFunctionTable;
 
+use aptos_types::chain_id::ChainId;
 #[cfg(feature = "testing")]
 use {
     framework::natives::{
@@ -79,7 +80,7 @@ pub fn configure_for_unit_test() {
 #[cfg(feature = "testing")]
 fn unit_test_extensions_hook(exts: &mut NativeContextExtensions) {
     exts.add(NativeCodeContext::default());
-    exts.add(NativeTransactionContext::new(vec![1]));
+    exts.add(NativeTransactionContext::new(vec![1], ChainId::test().id())); // We use the testing environment chain ID here
     exts.add(NativeAggregatorContext::new([0; 32], &*DUMMY_RESOLVER));
     exts.add(NativeRistrettoPointContext::new());
 }

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "chain_id_test"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
@@ -1,0 +1,32 @@
+module 0x1::chain_id_test {
+    use aptos_std::type_info;
+    use aptos_framework::chain_id;
+
+    /// Since tests in e2e-move-tests/ can only call entry functions which don't have return values, we must store
+    /// the results we are interested in (i.e., the chain ID) inside this (rather-artificial) resource, which we can
+    /// read back in our e2e-move-tests/ test.
+    struct ChainIdStore has key {
+        id: u8,
+    }
+
+    fun init_module(sender: &signer) {
+        move_to(sender,
+            ChainIdStore {
+                id: 0u8
+            }
+        )
+    }
+
+    /// Fetches the chain ID (via aptos_framework::chain_id::get()) and stores it in the ChainIdStore resource.
+    public entry fun store_chain_id_from_aptos_framework(_s: &signer) acquires ChainIdStore {
+        let store = borrow_global_mut<ChainIdStore>(@0x1);
+        store.id = chain_id::get();
+    }
+
+    /// Fetches the chain ID (via the NativeTransactionContext) and stores it in the ChainIdStore resource.
+    public entry fun store_chain_id_from_native_txn_context(_s: &signer) acquires ChainIdStore {
+        let store = borrow_global_mut<ChainIdStore>(@0x1);
+
+        store.id =  type_info::chain_id();
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.data/pack/sources/chain_id_test.move
@@ -1,6 +1,7 @@
 module 0x1::chain_id_test {
     use aptos_std::type_info;
     use aptos_framework::chain_id;
+    use std::features;
 
     /// Since tests in e2e-move-tests/ can only call entry functions which don't have return values, we must store
     /// the results we are interested in (i.e., the chain ID) inside this (rather-artificial) resource, which we can
@@ -9,12 +10,15 @@ module 0x1::chain_id_test {
         id: u8,
     }
 
+    /// Called when the module is first deployed at address `signer`, which is set to 0x1 (according to the `module 0x1::chain_id_test` line above).
     fun init_module(sender: &signer) {
         move_to(sender,
             ChainIdStore {
                 id: 0u8
             }
-        )
+        );
+
+        features::change_feature_flags(sender, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]);
     }
 
     /// Fetches the chain ID (via aptos_framework::chain_id::get()) and stores it in the ChainIdStore resource.

--- a/aptos-move/e2e-move-tests/src/tests/chain_id.rs
+++ b/aptos-move/e2e-move-tests/src/tests/chain_id.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tests::common;
+use crate::{assert_success, MoveHarness};
+use language_e2e_tests::account::Account;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::parser::parse_struct_tag;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize)]
+struct ChainIdStore {
+    id: u8,
+}
+
+fn call_get_chain_id_from_aptos_framework(harness: &mut MoveHarness, account: &Account) -> u8 {
+    let status = harness.run_entry_function(
+        account,
+        str::parse("0x1::chain_id_test::store_chain_id_from_aptos_framework").unwrap(),
+        vec![],
+        vec![],
+    );
+
+    assert!(status.status().unwrap().is_success());
+
+    let chain_id_store = harness
+        .read_resource::<ChainIdStore>(
+            account.address(),
+            parse_struct_tag("0x1::chain_id_test::ChainIdStore").unwrap(),
+        )
+        .unwrap();
+
+    chain_id_store.id
+}
+
+fn call_get_chain_id_from_native_txn_context(harness: &mut MoveHarness, account: &Account) -> u8 {
+    let status = harness.run_entry_function(
+        account,
+        str::parse("0x1::chain_id_test::store_chain_id_from_native_txn_context").unwrap(),
+        vec![],
+        vec![],
+    );
+
+    assert!(status.status().unwrap().is_success());
+
+    let chain_id_store = harness
+        .read_resource::<ChainIdStore>(
+            account.address(),
+            parse_struct_tag("0x1::chain_id_test::ChainIdStore").unwrap(),
+        )
+        .unwrap();
+
+    chain_id_store.id
+}
+
+fn setup(harness: &mut MoveHarness) -> Account {
+    let path = common::test_dir_path("chain_id.data/pack");
+
+    let account = harness.new_account_at(AccountAddress::ONE);
+
+    assert_success!(harness.publish_package(&account, &path));
+
+    account
+}
+
+#[test]
+fn test_chain_id_from_aptos_framework() {
+    let mut harness = MoveHarness::new();
+    let account = setup(&mut harness);
+
+    assert_eq!(
+        call_get_chain_id_from_aptos_framework(&mut harness, &account),
+        4u8
+    );
+}
+
+#[test]
+fn test_chain_id_from_type_info() {
+    let mut harness = MoveHarness::new();
+    let account = setup(&mut harness);
+
+    assert_eq!(
+        call_get_chain_id_from_native_txn_context(&mut harness, &account),
+        4u8
+    );
+}

--- a/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
+++ b/aptos-move/e2e-move-tests/src/tests/code_publishing.data/pack_stdlib/sources/configs/features.move
@@ -58,6 +58,17 @@ module std::features {
         is_enabled(SHA_512_AND_RIPEMD_160_NATIVES)
     }
 
+    /// Whether the new `aptos_stdlib::type_info::chain_id()` native for fetching the chain ID is enabled.
+    /// This is needed because of the introduction of a new native function.
+    /// Lifetime: transient
+    const APTOS_STD_CHAIN_ID_NATIVES: u64 = 4;
+
+    public fun get_aptos_stdlib_chain_id_feature(): u64 { APTOS_STD_CHAIN_ID_NATIVES }
+
+    public fun aptos_stdlib_chain_id_enabled(): bool acquires Features {
+        is_enabled(APTOS_STD_CHAIN_ID_NATIVES)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod aggregator;
+mod chain_id;
 mod code_publishing;
 mod common;
 mod error_map;

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -24,6 +24,7 @@ use aptos_crypto::HashValue;
 use aptos_gas::{AbstractValueSizeGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
 use aptos_keygen::KeyGen;
 use aptos_state_view::StateView;
+use aptos_types::chain_id::ChainId;
 use aptos_types::on_chain_config::{FeatureFlag, Features};
 use aptos_types::{
     access_path::AccessPath,
@@ -85,11 +86,12 @@ pub struct FakeExecutor {
     rng: KeyGen,
     no_parallel_exec: bool,
     features: Features,
+    chain_id: u8,
 }
 
 impl FakeExecutor {
     /// Creates an executor from a genesis [`WriteSet`].
-    pub fn from_genesis(write_set: &WriteSet) -> Self {
+    pub fn from_genesis(write_set: &WriteSet, chain_id: ChainId) -> Self {
         let mut executor = FakeExecutor {
             data_store: FakeDataStore::default(),
             block_time: 0,
@@ -98,6 +100,7 @@ impl FakeExecutor {
             rng: KeyGen::from_seed(RNG_SEED),
             no_parallel_exec: false,
             features: Features::default(),
+            chain_id: chain_id.id(),
         };
         executor.apply_write_set(write_set);
         // As a set effect, also allow module bundle txns. TODO: Remove
@@ -113,7 +116,7 @@ impl FakeExecutor {
 
     /// Creates an executor from the genesis file GENESIS_FILE_LOCATION
     pub fn from_head_genesis() -> Self {
-        Self::from_genesis(GENESIS_CHANGE_SET_HEAD.clone().write_set())
+        Self::from_genesis(GENESIS_CHANGE_SET_HEAD.clone().write_set(), ChainId::test())
     }
 
     /// Creates an executor from the genesis file GENESIS_FILE_LOCATION
@@ -121,17 +124,24 @@ impl FakeExecutor {
         Self::from_genesis(
             generate_genesis_change_set_for_testing_with_count(GenesisOptions::Head, count)
                 .write_set(),
+            ChainId::test(),
         )
     }
 
     /// Creates an executor using the standard genesis.
     pub fn from_testnet_genesis() -> Self {
-        Self::from_genesis(GENESIS_CHANGE_SET_TESTNET.clone().write_set())
+        Self::from_genesis(
+            GENESIS_CHANGE_SET_TESTNET.clone().write_set(),
+            ChainId::testnet(),
+        )
     }
 
     /// Creates an executor using the mainnet genesis.
     pub fn from_mainnet_genesis() -> Self {
-        Self::from_genesis(GENESIS_CHANGE_SET_MAINNET.clone().write_set())
+        Self::from_genesis(
+            GENESIS_CHANGE_SET_MAINNET.clone().write_set(),
+            ChainId::mainnet(),
+        )
     }
 
     /// Creates an executor in which no genesis state has been applied yet.
@@ -144,6 +154,7 @@ impl FakeExecutor {
             rng: KeyGen::from_seed(RNG_SEED),
             no_parallel_exec: false,
             features: Features::default(),
+            chain_id: ChainId::test().id(),
         }
     }
 
@@ -210,7 +221,7 @@ impl FakeExecutor {
     /// Creates fresh genesis from the framework passed in.
     pub fn custom_genesis(framework: &ReleaseBundle, validator_accounts: Option<usize>) -> Self {
         let genesis = vm_genesis::generate_test_genesis(framework, validator_accounts);
-        Self::from_genesis(genesis.0.write_set())
+        Self::from_genesis(genesis.0.write_set(), ChainId::test())
     }
 
     /// Create one instance of [`AccountData`] without saving it to data store.
@@ -567,6 +578,7 @@ impl FakeExecutor {
                 LATEST_GAS_FEATURE_VERSION,
                 self.features
                     .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+                self.chain_id,
             )
             .unwrap();
             let remote_view = StorageAdapter::new(&self.data_store);
@@ -613,6 +625,7 @@ impl FakeExecutor {
             LATEST_GAS_FEATURE_VERSION,
             self.features
                 .is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+            self.chain_id,
         )
         .unwrap();
         let remote_view = StorageAdapter::new(&self.data_store);

--- a/aptos-move/framework/aptos-framework/doc/chain_id.md
+++ b/aptos-move/framework/aptos-framework/doc/chain_id.md
@@ -76,7 +76,7 @@ Publish the chain ID <code>id</code> of this instance under the SystemAddresses 
 
 ## Function `get`
 
-Return the chain ID of this instance
+Return the chain ID of this instance.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="chain_id.md#0x1_chain_id_get">get</a>(): u8

--- a/aptos-move/framework/aptos-framework/doc/resource_account.md
+++ b/aptos-move/framework/aptos-framework/doc/resource_account.md
@@ -148,12 +148,12 @@ Container resource not found in account
 
 
 
-<a name="0x1_resource_account_ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST"></a>
+<a name="0x1_resource_account_EUNAUTHORIZED_NOT_OWNER"></a>
 
-Resource account address does not exist
+The resource account was not created by the specified source account
 
 
-<pre><code><b>const</b> <a href="resource_account.md#0x1_resource_account_ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST">ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST</a>: u64 = 2;
+<pre><code><b>const</b> <a href="resource_account.md#0x1_resource_account_EUNAUTHORIZED_NOT_OWNER">EUNAUTHORIZED_NOT_OWNER</a>: u64 = 2;
 </code></pre>
 
 
@@ -345,7 +345,7 @@ the SignerCapability.
     <b>let</b> resource_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(resource);
     <b>let</b> (resource_signer_cap, empty_container) = {
         <b>let</b> container = <b>borrow_global_mut</b>&lt;<a href="resource_account.md#0x1_resource_account_Container">Container</a>&gt;(source_addr);
-        <b>assert</b>!(<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&container.store, &resource_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="resource_account.md#0x1_resource_account_ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST">ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST</a>));
+        <b>assert</b>!(<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&container.store, &resource_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="resource_account.md#0x1_resource_account_EUNAUTHORIZED_NOT_OWNER">EUNAUTHORIZED_NOT_OWNER</a>));
         <b>let</b> (_resource_addr, signer_cap) = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_remove">simple_map::remove</a>(&<b>mut</b> container.store, &resource_addr);
         (signer_cap, <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_length">simple_map::length</a>(&container.store) == 0)
     };

--- a/aptos-move/framework/aptos-framework/sources/chain_id.move
+++ b/aptos-move/framework/aptos-framework/sources/chain_id.move
@@ -17,7 +17,7 @@ module aptos_framework::chain_id {
         move_to(aptos_framework, ChainId { id })
     }
 
-    /// Return the chain ID of this instance
+    /// Return the chain ID of this instance.
     public fun get(): u8 acquires ChainId {
         borrow_global<ChainId>(@aptos_framework).id
     }

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -15,7 +15,6 @@ module aptos_framework::reconfiguration {
     friend aptos_framework::aptos_governance;
     friend aptos_framework::block;
     friend aptos_framework::consensus_config;
-    friend aptos_framework::features;
     friend aptos_framework::gas_schedule;
     friend aptos_framework::genesis;
     friend aptos_framework::version;

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -9,10 +9,14 @@
 -  [Function `account_address`](#0x1_type_info_account_address)
 -  [Function `module_name`](#0x1_type_info_module_name)
 -  [Function `struct_name`](#0x1_type_info_struct_name)
+-  [Function `chain_id`](#0x1_type_info_chain_id)
 -  [Function `type_of`](#0x1_type_info_type_of)
 -  [Function `type_name`](#0x1_type_info_type_name)
+-  [Function `chain_id_internal`](#0x1_type_info_chain_id_internal)
 -  [Function `verify_type_of`](#0x1_type_info_verify_type_of)
 -  [Function `verify_type_of_generic`](#0x1_type_info_verify_type_of_generic)
+-  [Specification](#@Specification_0)
+    -  [Function `chain_id_internal`](#@Specification_0_chain_id_internal)
 
 
 <pre><code><b>use</b> <a href="../../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
@@ -131,6 +135,33 @@
 
 </details>
 
+<a name="0x1_type_info_chain_id"></a>
+
+## Function `chain_id`
+
+Returns the current chain ID, mirroring what <code>aptos_framework::chain_id::get()</code> would return, except in <code>#[test]</code>
+functions, where this will always return <code>4u8</code> as the chain ID, whereas <code>aptos_framework::chain_id::get()</code> will
+return whichever ID was passed to <code>aptos_framework::chain_id::initialize_for_test()</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id">chain_id</a>(): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id">chain_id</a>(): u8 {
+    <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>()
+}
+</code></pre>
+
+
+
+</details>
+
 <a name="0x1_type_info_type_of"></a>
 
 ## Function `type_of`
@@ -169,6 +200,28 @@
 
 
 <pre><code><b>public</b> <b>native</b> <b>fun</b> <a href="type_info.md#0x1_type_info_type_name">type_name</a>&lt;T&gt;(): <a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>;
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_type_info_chain_id_internal"></a>
+
+## Function `chain_id_internal`
+
+
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>(): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>(): u8;
 </code></pre>
 
 
@@ -238,6 +291,25 @@
 
 
 </details>
+
+<a name="@Specification_0"></a>
+
+## Specification
+
+
+<a name="@Specification_0_chain_id_internal"></a>
+
+### Function `chain_id_internal`
+
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>(): u8
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
 
 
 [move-book]: https://move-language.github.io/move/introduction.html

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -6,6 +6,7 @@
 
 
 -  [Struct `TypeInfo`](#0x1_type_info_TypeInfo)
+-  [Constants](#@Constants_0)
 -  [Function `account_address`](#0x1_type_info_account_address)
 -  [Function `module_name`](#0x1_type_info_module_name)
 -  [Function `struct_name`](#0x1_type_info_struct_name)
@@ -15,11 +16,13 @@
 -  [Function `chain_id_internal`](#0x1_type_info_chain_id_internal)
 -  [Function `verify_type_of`](#0x1_type_info_verify_type_of)
 -  [Function `verify_type_of_generic`](#0x1_type_info_verify_type_of_generic)
--  [Specification](#@Specification_0)
-    -  [Function `chain_id_internal`](#@Specification_0_chain_id_internal)
+-  [Specification](#@Specification_1)
+    -  [Function `chain_id_internal`](#@Specification_1_chain_id_internal)
 
 
-<pre><code><b>use</b> <a href="../../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<pre><code><b>use</b> <a href="../../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="../../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
 </code></pre>
 
 
@@ -62,6 +65,20 @@
 
 
 </details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_type_info_E_NATIVE_FUN_NOT_AVAILABLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="type_info.md#0x1_type_info_E_NATIVE_FUN_NOT_AVAILABLE">E_NATIVE_FUN_NOT_AVAILABLE</a>: u64 = 1;
+</code></pre>
+
+
 
 <a name="0x1_type_info_account_address"></a>
 
@@ -154,6 +171,10 @@ return whichever ID was passed to <code>aptos_framework::chain_id::initialize_fo
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_chain_id">chain_id</a>(): u8 {
+    <b>if</b> (!<a href="../../move-stdlib/doc/features.md#0x1_features_aptos_stdlib_chain_id_enabled">features::aptos_stdlib_chain_id_enabled</a>()) {
+        <b>abort</b>(std::error::invalid_state(<a href="type_info.md#0x1_type_info_E_NATIVE_FUN_NOT_AVAILABLE">E_NATIVE_FUN_NOT_AVAILABLE</a>))
+    };
+
     <a href="type_info.md#0x1_type_info_chain_id_internal">chain_id_internal</a>()
 }
 </code></pre>
@@ -292,12 +313,12 @@ return whichever ID was passed to <code>aptos_framework::chain_id::initialize_fo
 
 </details>
 
-<a name="@Specification_0"></a>
+<a name="@Specification_1"></a>
 
 ## Specification
 
 
-<a name="@Specification_0_chain_id_internal"></a>
+<a name="@Specification_1_chain_id_internal"></a>
 
 ### Function `chain_id_internal`
 

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -1,11 +1,26 @@
 module aptos_std::type_info {
     use std::string;
+    use std::features;
+
+    //
+    // Error codes
+    //
+
+    const E_NATIVE_FUN_NOT_AVAILABLE: u64 = 1;
+
+    //
+    // Structs
+    //
 
     struct TypeInfo has copy, drop, store {
         account_address: address,
         module_name: vector<u8>,
         struct_name: vector<u8>,
     }
+
+    //
+    // Public functions
+    //
 
     public fun account_address(type_info: &TypeInfo): address {
         type_info.account_address
@@ -23,6 +38,10 @@ module aptos_std::type_info {
     /// functions, where this will always return `4u8` as the chain ID, whereas `aptos_framework::chain_id::get()` will
     /// return whichever ID was passed to `aptos_framework::chain_id::initialize_for_test()`.
     public fun chain_id(): u8 {
+        if (!features::aptos_stdlib_chain_id_enabled()) {
+            abort(std::error::invalid_state(E_NATIVE_FUN_NOT_AVAILABLE))
+        };
+
         chain_id_internal()
     }
 
@@ -40,8 +59,11 @@ module aptos_std::type_info {
         assert!(struct_name(&type_info) == b"TypeInfo", 2);
     }
 
-    #[test]
-    fun test_chain_id() {
+    #[test(fx = @std)]
+    fun test_chain_id(fx: signer) {
+        // We need to enable the feature in order for the native call to be allowed.
+        features::change_feature_flags(&fx, vector[features::get_aptos_stdlib_chain_id_feature()], vector[]);
+
         // The testing environment chain ID is 4u8.
         assert!(chain_id() == 4u8, 1);
     }

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -19,9 +19,18 @@ module aptos_std::type_info {
         type_info.struct_name
     }
 
+    /// Returns the current chain ID, mirroring what `aptos_framework::chain_id::get()` would return, except in `#[test]`
+    /// functions, where this will always return `4u8` as the chain ID, whereas `aptos_framework::chain_id::get()` will
+    /// return whichever ID was passed to `aptos_framework::chain_id::initialize_for_test()`.
+    public fun chain_id(): u8 {
+        chain_id_internal()
+    }
+
     public native fun type_of<T>(): TypeInfo;
 
     public native fun type_name<T>(): string::String;
+
+    native fun chain_id_internal(): u8;
 
     #[test]
     fun test() {
@@ -29,6 +38,12 @@ module aptos_std::type_info {
         assert!(account_address(&type_info) == @aptos_std, 0);
         assert!(module_name(&type_info) == b"type_info", 1);
         assert!(struct_name(&type_info) == b"TypeInfo", 2);
+    }
+
+    #[test]
+    fun test_chain_id() {
+        // The testing environment chain ID is 4u8.
+        assert!(chain_id() == 4u8, 1);
     }
 
     #[test]

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
@@ -1,3 +1,8 @@
 spec aptos_std::type_info {
     // Move Prover natively supports `type_of` and `type_name`.
+
+    spec chain_id_internal {
+        // TODO: temporary mockup.
+        pragma opaque;
+    }
 }

--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -1812,10 +1812,12 @@ The token is owned at address owner
                 &<b>mut</b> collections.collection_data,
                 token_id.token_data_id.collection
             );
-            collection_data.supply = collection_data.supply - 1;
-            // delete the collection data <b>if</b> the collection supply equals 0
-            <b>if</b> (collection_data.supply == 0) {
-                <a href="token.md#0x3_token_destroy_collection_data">destroy_collection_data</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> collections.collection_data, collection_data.name));
+            <b>if</b> (collection_data.maximum &gt; 0) {
+                collection_data.supply = collection_data.supply - 1;
+                // delete the collection data <b>if</b> the collection supply equals 0
+                <b>if</b> (collection_data.supply == 0) {
+                    <a href="token.md#0x3_token_destroy_collection_data">destroy_collection_data</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> collections.collection_data, collection_data.name));
+                };
             };
         };
     };
@@ -1904,10 +1906,14 @@ Burn a token by the token owner
                 &<b>mut</b> collections.collection_data,
                 token_id.token_data_id.collection
             );
-            collection_data.supply = collection_data.supply - 1;
-            // delete the collection data <b>if</b> the collection supply equals 0
-            <b>if</b> (collection_data.supply == 0) {
-                <a href="token.md#0x3_token_destroy_collection_data">destroy_collection_data</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> collections.collection_data, collection_data.name));
+
+            // only <b>update</b> and check the supply for unlimited collection
+            <b>if</b> (collection_data.maximum &gt; 0){
+                collection_data.supply = collection_data.supply - 1;
+                // delete the collection data <b>if</b> the collection supply equals 0
+                <b>if</b> (collection_data.supply == 0) {
+                    <a href="token.md#0x3_token_destroy_collection_data">destroy_collection_data</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_remove">table::remove</a>(&<b>mut</b> collections.collection_data, collection_data.name));
+                };
             };
         };
     };
@@ -1942,9 +1948,9 @@ Burn a token by the token owner
     types: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;String&gt;,
 ): <a href="token.md#0x3_token_TokenId">TokenId</a> <b>acquires</b> <a href="token.md#0x3_token_Collections">Collections</a>, <a href="token.md#0x3_token_TokenStore">TokenStore</a> {
     <b>let</b> creator = token_id.token_data_id.creator;
-    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>) == creator, <a href="token.md#0x3_token_ENO_MUTATE_CAPABILITY">ENO_MUTATE_CAPABILITY</a>);
+    <b>assert</b>!(<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>) == creator, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_ENO_MUTATE_CAPABILITY">ENO_MUTATE_CAPABILITY</a>));
     // validate <b>if</b> the properties is mutable
-    <b>assert</b>!(<b>exists</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(creator), <a href="token.md#0x3_token_ECOLLECTIONS_NOT_PUBLISHED">ECOLLECTIONS_NOT_PUBLISHED</a>);
+    <b>assert</b>!(<b>exists</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(creator), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="token.md#0x3_token_ECOLLECTIONS_NOT_PUBLISHED">ECOLLECTIONS_NOT_PUBLISHED</a>));
     <b>let</b> all_token_data = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(
         creator
     ).token_data;

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -13,6 +13,8 @@ the Move stdlib, the Aptos stdlib, and the Aptos framework.
 -  [Function `treat_friend_as_private`](#0x1_features_treat_friend_as_private)
 -  [Function `get_sha_512_and_ripemd_160_feature`](#0x1_features_get_sha_512_and_ripemd_160_feature)
 -  [Function `sha_512_and_ripemd_160_enabled`](#0x1_features_sha_512_and_ripemd_160_enabled)
+-  [Function `get_aptos_stdlib_chain_id_feature`](#0x1_features_get_aptos_stdlib_chain_id_feature)
+-  [Function `aptos_stdlib_chain_id_enabled`](#0x1_features_aptos_stdlib_chain_id_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `is_enabled`](#0x1_features_is_enabled)
 -  [Function `set`](#0x1_features_set)
@@ -59,6 +61,18 @@ The enabled features, represented by a bitset stored on chain.
 <a name="@Constants_0"></a>
 
 ## Constants
+
+
+<a name="0x1_features_APTOS_STD_CHAIN_ID_NATIVES"></a>
+
+Whether the new <code>aptos_stdlib::type_info::chain_id()</code> native for fetching the chain ID is enabled.
+This is needed because of the introduction of a new native function.
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_APTOS_STD_CHAIN_ID_NATIVES">APTOS_STD_CHAIN_ID_NATIVES</a>: u64 = 4;
+</code></pre>
+
 
 
 <a name="0x1_features_CODE_DEPENDENCY_CHECK"></a>
@@ -194,6 +208,52 @@ Lifetime: ephemeral
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_sha_512_and_ripemd_160_enabled">sha_512_and_ripemd_160_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_SHA_512_AND_RIPEMD_160_NATIVES">SHA_512_AND_RIPEMD_160_NATIVES</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_get_aptos_stdlib_chain_id_feature"></a>
+
+## Function `get_aptos_stdlib_chain_id_feature`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_aptos_stdlib_chain_id_feature">get_aptos_stdlib_chain_id_feature</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_get_aptos_stdlib_chain_id_feature">get_aptos_stdlib_chain_id_feature</a>(): u64 { <a href="features.md#0x1_features_APTOS_STD_CHAIN_ID_NATIVES">APTOS_STD_CHAIN_ID_NATIVES</a> }
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_features_aptos_stdlib_chain_id_enabled"></a>
+
+## Function `aptos_stdlib_chain_id_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aptos_stdlib_chain_id_enabled">aptos_stdlib_chain_id_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_aptos_stdlib_chain_id_enabled">aptos_stdlib_chain_id_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_APTOS_STD_CHAIN_ID_NATIVES">APTOS_STD_CHAIN_ID_NATIVES</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -58,6 +58,16 @@ module std::features {
         is_enabled(SHA_512_AND_RIPEMD_160_NATIVES)
     }
 
+    /// Whether the new `aptos_stdlib::type_info::chain_id()` native for fetching the chain ID is enabled.
+    /// This is needed because of the introduction of a new native function.
+    /// Lifetime: transient
+    const APTOS_STD_CHAIN_ID_NATIVES: u64 = 4;
+
+    public fun get_aptos_stdlib_chain_id_feature(): u64 { APTOS_STD_CHAIN_ID_NATIVES }
+
+    public fun aptos_stdlib_chain_id_enabled(): bool acquires Features {
+        is_enabled(APTOS_STD_CHAIN_ID_NATIVES)
+    }
 
     // ============================================================================================
     // Feature Flag Implementation

--- a/aptos-move/framework/src/natives/mod.rs
+++ b/aptos-move/framework/src/natives/mod.rs
@@ -140,6 +140,7 @@ impl GasParameters {
                     base: 0.into(),
                     per_byte_in_str: 0.into(),
                 },
+                chain_id: type_info::ChainIdGasParameters { base: 0.into() },
             },
             util: util::GasParameters {
                 from_bytes: util::FromBytesGasParameters {

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -10,6 +10,7 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
+use std::fmt::Debug;
 use std::sync::Arc;
 
 /// The native transaction context extension. This needs to be attached to the
@@ -18,13 +19,21 @@ use std::sync::Arc;
 #[derive(Tid)]
 pub struct NativeTransactionContext {
     script_hash: Vec<u8>,
+    chain_id: u8,
 }
 
 impl NativeTransactionContext {
     /// Create a new instance of a native transaction context. This must be passed in via an
     /// extension into VM session functions.
-    pub fn new(script_hash: Vec<u8>) -> Self {
-        Self { script_hash }
+    pub fn new(script_hash: Vec<u8>, chain_id: u8) -> Self {
+        Self {
+            script_hash,
+            chain_id,
+        }
+    }
+
+    pub fn chain_id(&self) -> u8 {
+        self.chain_id
     }
 }
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -101,6 +101,7 @@ pub fn encode_aptos_mainnet_genesis_transaction(
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
         Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+        ChainId::test().id(),
     )
     .unwrap();
     let id1 = HashValue::zero();
@@ -196,6 +197,7 @@ pub fn encode_genesis_change_set(
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
         Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+        ChainId::test().id(),
     )
     .unwrap();
     let id1 = HashValue::zero();
@@ -839,6 +841,7 @@ pub fn test_genesis_module_publishing() {
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
         false,
+        ChainId::test().id(),
     )
     .unwrap();
     let id1 = HashValue::zero();

--- a/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
+++ b/aptos-move/writeset-transaction-generator/src/writeset_builder.rs
@@ -102,7 +102,7 @@ impl<'r, 'l, S: MoveResolverExt> GenesisSession<'r, 'l, S> {
     }
 }
 
-pub fn build_changeset<S: StateView, F>(state_view: &S, procedure: F) -> ChangeSet
+pub fn build_changeset<S: StateView, F>(state_view: &S, procedure: F, chain_id: u8) -> ChangeSet
 where
     F: FnOnce(&mut GenesisSession<StorageAdapter<S>>),
 {
@@ -111,6 +111,7 @@ where
         AbstractValueSizeGasParameters::zeros(),
         LATEST_GAS_FEATURE_VERSION,
         Features::default().is_enabled(FeatureFlag::TREAT_FRIEND_AS_PRIVATE),
+        chain_id,
     )
     .unwrap();
     let state_view_storage = StorageAdapter::new(state_view);

--- a/types/src/chain_id.rs
+++ b/types/src/chain_id.rs
@@ -167,6 +167,10 @@ impl ChainId {
         ChainId::new(NamedChain::TESTING.id())
     }
 
+    pub fn testnet() -> Self {
+        ChainId::new(NamedChain::TESTNET.id())
+    }
+
     pub fn mainnet() -> Self {
         ChainId::new(NamedChain::MAINNET.id())
     }

--- a/types/src/on_chain_config/chain_id.rs
+++ b/types/src/on_chain_config/chain_id.rs
@@ -1,0 +1,11 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::on_chain_config::OnChainConfig;
+
+use crate::chain_id::ChainId;
+
+impl OnChainConfig for ChainId {
+    const MODULE_IDENTIFIER: &'static str = "chain_id";
+    const TYPE_IDENTIFIER: &'static str = "ChainId";
+}

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::chain_id::ChainId;
 use crate::{
     access_path::AccessPath,
     account_config::CORE_CODE_ADDRESS,
@@ -19,6 +20,7 @@ use std::{collections::HashMap, fmt, sync::Arc};
 mod approved_execution_hashes;
 mod aptos_features;
 mod aptos_version;
+mod chain_id;
 mod consensus_config;
 mod gas_schedule;
 mod validator_set;
@@ -65,6 +67,7 @@ pub const ON_CHAIN_CONFIG_REGISTRY: &[ConfigID] = &[
     ValidatorSet::CONFIG_ID,
     Version::CONFIG_ID,
     OnChainConsensusConfig::CONFIG_ID,
+    ChainId::CONFIG_ID,
 ];
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
### Description

This PR exposes the chain ID inside the `aptos_stdlib` package by adding a public `chain_id()` function in the `type_info` module, which calls a native `chain_id_internal()` Rust function (Happy to move it somewhere better too.)

Everything is feature-gated too.

The chain ID is now fetched inside `AptosVMImpl::new` via an `OnChainConfig` implementation for `ChainId`. As a result, most of this PR deals with making sure all calling code correctly passes the chain ID into `AptosVMImpl`.

@davidiw, @movekevin, @wrwg and @vgao1996 your feedback is much appreciated.

#### Warning: A potential source of confusion

One problem of this approach is that `aptos_stdlib::type_info::chain_id()` will return `4u8` inside a testing environment (like a `#[test]` Move function), whereas `aptos_framework::chain_id::get()` will return whatever chain ID was given to `aptos_framework::chain_id::initialize_for_test()`, which could be confusing.

I've updated the docs to reflect this.

Perhaps this is not too problematic, since tests in  `aptos-move/e2e-move-tests/` initialized with `MoveHarness::new()` that call `aptos_framework::chain_id::get()` seem to return chain ID `4u8` too.

### Test Plan

Added an end-to-end Move test in `aptos-move/e2e-move-tests/src/tests/chain_id.rs` that fetches the chain ID via this new API (as well as via the old one in `aptos_framework::chain_id`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5288)
<!-- Reviewable:end -->
