### PR TITLE
ed25519 test-only natives implementation tweak

### DIFF
--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -58,10 +58,12 @@ pub fn assert_no_test_natives() {
         LATEST_GAS_FEATURE_VERSION
     )
     .into_iter()
-    .all(
-        |(_, module_name, func_name, _)| module_name.as_str() != "unit_test"
-            && func_name.as_str() != "create_signers_for_testing"
-    ))
+    .all(|(_, module_name, func_name, _)| {
+        !(module_name.as_str() == "unit_test" && func_name.as_str() == "create_signers_for_testing")
+            && !(module_name.as_str() == "ed25519"
+                && func_name.as_str() == "generate_keys_internal")
+            && !(module_name.as_str() == "ed25519" && func_name.as_str() == "sign_internal")
+    }))
 }
 
 #[cfg(feature = "testing")]

--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -59,10 +59,9 @@ pub fn assert_no_test_natives() {
     )
     .into_iter()
     .all(|(_, module_name, func_name, _)| {
-        !(module_name.as_str() == "unit_test" && func_name.as_str() == "create_signers_for_testing")
-            && !(module_name.as_str() == "ed25519"
-                && func_name.as_str() == "generate_keys_internal")
-            && !(module_name.as_str() == "ed25519" && func_name.as_str() == "sign_internal")
+        !(module_name.as_str() == "unit_test" && func_name.as_str() == "create_signers_for_testing"
+            || module_name.as_str() == "ed25519" && func_name.as_str() == "generate_keys_internal"
+            || module_name.as_str() == "ed25519" && func_name.as_str() == "sign_internal")
     }))
 }
 

--- a/aptos-move/framework/src/natives/cryptography/ed25519.rs
+++ b/aptos-move/framework/src/natives/cryptography/ed25519.rs
@@ -144,7 +144,10 @@ pub struct GasParameters {
 }
 
 pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
-    let mut natives = vec![
+    let mut natives = vec![];
+
+    // Always-on natives.
+    natives.append(&mut vec![
         (
             "public_key_validate_internal",
             make_native_from_func(gas_params.clone(), native_public_key_validate),
@@ -153,21 +156,20 @@ pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, Nati
             "signature_verify_strict_internal",
             make_native_from_func(gas_params, native_signature_verify_strict),
         ),
-    ];
+    ]);
+
+    // Test-only natives.
     #[cfg(feature = "testing")]
-    {
-        let mut test_only_natives = vec![
-            (
-                "generate_keys_internal",
-                make_test_only_native_from_func(native_test_only_generate_keys_internal),
-            ),
-            (
-                "sign_internal",
-                make_test_only_native_from_func(native_test_only_sign_internal),
-            ),
-        ];
-        natives.append(&mut test_only_natives);
-    }
+    natives.append(&mut vec![
+        (
+            "generate_keys_internal",
+            make_test_only_native_from_func(native_test_only_generate_keys_internal),
+        ),
+        (
+            "sign_internal",
+            make_test_only_native_from_func(native_test_only_sign_internal),
+        ),
+    ]);
 
     crate::natives::helpers::make_module_natives(natives)
 }


### PR DESCRIPTION
When feature testing is disabled, the `natives` vector declared as `mut` is never mutated...

Also, we forgot to update `assert_no_test_natives`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5289)
<!-- Reviewable:end -->
