### PR TITLE
[storage] add pagination in get_state_values_by_key_prefix() signature

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -7,7 +7,7 @@ use crate::response::{
     block_pruned_by_height, json_api_disabled, version_not_found, version_pruned, ForbiddenError,
     InternalError, NotFoundError, ServiceUnavailableError, StdApiError,
 };
-use anyhow::{ensure, format_err, Context as AnyhowContext, Result};
+use anyhow::{bail, ensure, format_err, Context as AnyhowContext, Result};
 use aptos_api_types::{
     AptosErrorCode, AsConverter, BcsBlock, GasEstimation, LedgerInfo, TransactionOnChainData,
 };
@@ -37,7 +37,7 @@ use std::sync::RwLock;
 use std::{collections::HashMap, sync::Arc};
 use storage_interface::{
     state_view::{DbStateView, DbStateViewAtVersion, LatestDbStateCheckpointView},
-    DbReader, Order,
+    DbReader, Order, MAX_REQUEST_LIMIT,
 };
 
 // Context holds application scope context
@@ -236,10 +236,28 @@ impl Context {
         address: AccountAddress,
         version: u64,
     ) -> Result<HashMap<StateKey, StateValue>> {
-        self.db
-            .get_state_values_by_key_prefix(&StateKeyPrefix::from(address), version)
+        let (kvs, cursor) =
+            self.get_state_values_by_pagination(address, None, version, MAX_REQUEST_LIMIT)?;
+        if cursor.is_some() {
+            bail!("Too many state items under account {}.", address);
+        }
+        Ok(kvs)
     }
 
+    pub fn get_state_values_by_pagination(
+        &self,
+        address: AccountAddress,
+        prev_state_key: Option<&StateKey>,
+        version: u64,
+        limit: u64,
+    ) -> Result<(HashMap<StateKey, StateValue>, Option<StateKey>)> {
+        self.db.get_state_values_by_key_prefix(
+            &StateKeyPrefix::from(address),
+            prev_state_key,
+            version,
+            limit,
+        )
+    }
     pub fn get_account_state<E: InternalError>(
         &self,
         address: AccountAddress,

--- a/aptos-move/aptos-validator-interface/src/storage_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/storage_interface.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::AptosValidatorInterface;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use aptos_config::config::{
     RocksdbConfigs, BUFFERED_STATE_TARGET_ITEMS, DEFAULT_MAX_NUM_NODES_PER_LRU_CACHE_SHARD,
     NO_OP_STORAGE_PRUNER_CONFIG,
@@ -17,7 +17,7 @@ use aptos_types::{
 };
 use aptosdb::AptosDB;
 use std::{path::Path, sync::Arc};
-use storage_interface::{DbReader, Order};
+use storage_interface::{DbReader, Order, MAX_REQUEST_LIMIT};
 
 pub struct DBDebuggerInterface(Arc<dyn DbReader>);
 
@@ -41,12 +41,17 @@ impl AptosValidatorInterface for DBDebuggerInterface {
         account: AccountAddress,
         version: Version,
     ) -> Result<Option<AccountState>> {
-        AccountState::from_access_paths_and_values(
-            account,
-            &self
-                .0
-                .get_state_values_by_key_prefix(&StateKeyPrefix::from(account), version)?,
-        )
+        let (kvs, cursor) = self.0.get_state_values_by_key_prefix(
+            &StateKeyPrefix::from(account),
+            None,
+            version,
+            MAX_REQUEST_LIMIT,
+        )?;
+        if cursor.is_some() {
+            bail!("Too many state items under account {}.", account);
+        }
+
+        AccountState::from_access_paths_and_values(account, &kvs)
     }
 
     fn get_state_value_by_version(

--- a/storage/aptosdb/src/lib.rs
+++ b/storage/aptosdb/src/lib.rs
@@ -116,15 +116,11 @@ use crate::stale_node_index::StaleNodeIndexSchema;
 use crate::stale_node_index_cross_epoch::StaleNodeIndexCrossEpochSchema;
 use storage_interface::{
     state_delta::StateDelta, state_view::DbStateView, DbReader, DbWriter, ExecutedTrees, Order,
-    StateSnapshotReceiver,
+    StateSnapshotReceiver, MAX_REQUEST_LIMIT,
 };
 
 pub const LEDGER_DB_NAME: &str = "ledger_db";
 pub const STATE_MERKLE_DB_NAME: &str = "state_merkle_db";
-
-// This is last line of defense against large queries slipping through external facing interfaces,
-// like the API and State Sync, etc.
-const MAX_LIMIT: u64 = 10000;
 
 // TODO: Either implement an iteration API to allow a very old client to loop through a long history
 // or guarantee that there is always a recent enough waypoint and client knows to boot from there.
@@ -679,7 +675,7 @@ impl AptosDB {
         limit: u64,
         ledger_version: Version,
     ) -> Result<Vec<EventWithVersion>> {
-        error_if_too_many_requested(limit, MAX_LIMIT)?;
+        error_if_too_many_requested(limit, MAX_REQUEST_LIMIT)?;
         let get_latest = order == Order::Descending && start_seq_num == u64::max_value();
 
         let cursor = if get_latest {
@@ -875,12 +871,16 @@ impl DbReader for AptosDB {
     fn get_state_values_by_key_prefix(
         &self,
         key_prefix: &StateKeyPrefix,
+        cursor: Option<&StateKey>,
         version: Version,
-    ) -> Result<HashMap<StateKey, StateValue>> {
+        limit: u64,
+    ) -> Result<(HashMap<StateKey, StateValue>, Option<StateKey>)> {
         gauged_api("get_state_values_by_key_prefix", || {
             self.error_if_ledger_pruned("State", version)?;
+            error_if_too_many_requested(limit, MAX_REQUEST_LIMIT)?;
+
             self.state_store
-                .get_values_by_key_prefix(key_prefix, version)
+                .get_values_by_key_prefix(key_prefix, cursor, version, limit)
         })
     }
 
@@ -916,7 +916,7 @@ impl DbReader for AptosDB {
         ledger_version: Version,
     ) -> Result<AccountTransactionsWithProof> {
         gauged_api("get_account_transactions", || {
-            error_if_too_many_requested(limit, MAX_LIMIT)?;
+            error_if_too_many_requested(limit, MAX_REQUEST_LIMIT)?;
 
             let txns_with_proofs = self
                 .transaction_store
@@ -979,7 +979,7 @@ impl DbReader for AptosDB {
         fetch_events: bool,
     ) -> Result<TransactionListWithProof> {
         gauged_api("get_transactions", || {
-            error_if_too_many_requested(limit, MAX_LIMIT)?;
+            error_if_too_many_requested(limit, MAX_REQUEST_LIMIT)?;
 
             if start_version > ledger_version || limit == 0 {
                 return Ok(TransactionListWithProof::new_empty());
@@ -1088,7 +1088,7 @@ impl DbReader for AptosDB {
         ledger_version: Version,
     ) -> Result<TransactionOutputListWithProof> {
         gauged_api("get_transactions_outputs", || {
-            error_if_too_many_requested(limit, MAX_LIMIT)?;
+            error_if_too_many_requested(limit, MAX_REQUEST_LIMIT)?;
 
             if start_version > ledger_version || limit == 0 {
                 return Ok(TransactionOutputListWithProof::new_empty());

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -57,7 +57,7 @@ mod state_store_test;
 
 type StateValueBatch = crate::state_restore::StateValueBatch<StateKey, Option<StateValue>>;
 
-pub const MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX: usize = 10_000;
+pub const MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX: u64 = 10_000;
 // We assume TARGET_SNAPSHOT_INTERVAL_IN_VERSION > block size.
 const MAX_WRITE_SETS_AFTER_SNAPSHOT: LeafCount = buffered_state::TARGET_SNAPSHOT_INTERVAL_IN_VERSION
     * (buffered_state::ASYNC_COMMIT_CHANNEL_BUFFER_SIZE + 2 + 1/*  Rendezvous channel */)
@@ -421,13 +421,25 @@ impl StateStore {
     pub fn get_values_by_key_prefix(
         &self,
         key_prefix: &StateKeyPrefix,
+        next_key_opt: Option<&StateKey>,
         desired_version: Version,
-    ) -> Result<HashMap<StateKey, StateValue>> {
+        limit: u64,
+    ) -> Result<(HashMap<StateKey, StateValue>, Option<StateKey>)> {
+        // We don't allow fetching arbitrarily large number of values to be fetched as this can
+        // potentially slowdown the DB.
+        if limit > MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX {
+            return Err(anyhow!(
+                "Too many values requested for key_prefix {:?} - maximum allowed {}",
+                key_prefix,
+                MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX
+            ));
+        }
         let mut read_opts = ReadOptions::default();
         // Without this, iterators are not guaranteed a total order of all keys, but only keys for the same prefix.
         // For example,
-        // aptos/abc|0
+        // aptos/abc|2
         // aptos/abc|1
+        // aptos/abc|0
         // aptos/abd|1
         // if we seek('aptos/'), and call next, we may not reach `aptos/abd/1` because the prefix extractor we adopted
         // here will stick with prefix `aptos/abc` and return `None` or any arbitrary result after visited all the
@@ -435,8 +447,14 @@ impl StateStore {
         read_opts.set_total_order_seek(true);
         let mut iter = self.ledger_db.iter::<StateValueSchema>(read_opts)?;
         let mut result = HashMap::new();
+
         let mut prev_key = None;
-        iter.seek(&(key_prefix))?;
+        if let Some(next_key) = next_key_opt {
+            iter.seek(&(next_key.clone(), u64::MAX))?;
+        } else {
+            iter.seek(&key_prefix)?;
+        };
+        let mut count = 0;
         while let Some(((state_key, version), state_value_opt)) = iter.next().transpose()? {
             // In case the previous seek() ends on the same key with version 0.
             if Some(&state_key) == prev_key.as_ref() {
@@ -455,22 +473,19 @@ impl StateStore {
             }
 
             if let Some(state_value) = state_value_opt {
+                if count == limit {
+                    // Reach the `limit + 1`-th key, we can return the result with the potential
+                    // next key.
+                    return Ok((result, Some(state_key)));
+                }
                 result.insert(state_key.clone(), state_value);
-            }
-            // We don't allow fetching arbitrarily large number of values to be fetched as this can
-            // potentially slowdown the DB.
-            if result.len() > MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX {
-                return Err(anyhow!(
-                    "Too many values requested for key_prefix {:?} - maximum allowed {:?}",
-                    key_prefix,
-                    MAX_VALUES_TO_FETCH_FOR_KEY_PREFIX
-                ));
+                count += 1;
             }
             prev_key = Some(state_key.clone());
             // Seek to the next key - this can be done by seeking to the current key with version 0
             iter.seek(&(state_key, 0))?;
         }
-        Ok(result)
+        Ok((result, None))
     }
 
     /// Gets the proof that proves a range of accounts.

--- a/storage/aptosdb/src/state_store/state_store_test.rs
+++ b/storage/aptosdb/src/state_store/state_store_test.rs
@@ -135,6 +135,25 @@ fn test_state_store_reader_writer() {
     verify_value_and_proof(store, key3, Some(&value3), 1, root);
 }
 
+fn traverse_values(
+    store: &StateStore,
+    prefix: &StateKeyPrefix,
+    version: Version,
+) -> HashMap<StateKey, StateValue> {
+    let mut ret = HashMap::new();
+    let mut cursor = None;
+    loop {
+        let (page, new_cursor) = store
+            .get_values_by_key_prefix(prefix, cursor.as_ref(), version, 1 /* limit */)
+            .unwrap();
+        ret.extend(page.into_iter());
+        if new_cursor.is_none() {
+            return ret;
+        }
+        cursor = new_cursor;
+    }
+}
+
 #[test]
 fn test_get_values_by_key_prefix() {
     let tmp_dir = TempPath::new();
@@ -160,9 +179,7 @@ fn test_get_values_by_key_prefix() {
         None,
     );
 
-    let key_value_map = store
-        .get_values_by_key_prefix(&account_key_prefx, 0)
-        .unwrap();
+    let key_value_map = traverse_values(store, &account_key_prefx, 0);
     assert_eq!(key_value_map.len(), 2);
     assert_eq!(*key_value_map.get(&key1).unwrap(), value1_v0);
     assert_eq!(*key_value_map.get(&key2).unwrap(), value2_v0);
@@ -183,17 +200,13 @@ fn test_get_values_by_key_prefix() {
     );
 
     // Ensure that we still get only values for key1 and key2 for version 0 after the update
-    let key_value_map = store
-        .get_values_by_key_prefix(&account_key_prefx, 0)
-        .unwrap();
+    let key_value_map = traverse_values(store, &account_key_prefx, 0);
     assert_eq!(key_value_map.len(), 2);
     assert_eq!(*key_value_map.get(&key1).unwrap(), value1_v0);
     assert_eq!(*key_value_map.get(&key2).unwrap(), value2_v0);
 
     // Ensure that key value map for version 1 returns value for key1 at version 0.
-    let key_value_map = store
-        .get_values_by_key_prefix(&account_key_prefx, 1)
-        .unwrap();
+    let key_value_map = traverse_values(store, &account_key_prefx, 1);
     assert_eq!(key_value_map.len(), 3);
     assert_eq!(*key_value_map.get(&key1).unwrap(), value1_v0);
     assert_eq!(*key_value_map.get(&key2).unwrap(), value2_v1);
@@ -209,19 +222,13 @@ fn test_get_values_by_key_prefix() {
     put_value_set(store, vec![(key5.clone(), value5_v2.clone())], 2, Some(1));
 
     // address1 did not exist in version 0 and 1.
-    let key_value_map = store
-        .get_values_by_key_prefix(&account1_key_prefx, 0)
-        .unwrap();
+    let key_value_map = traverse_values(store, &account1_key_prefx, 0);
     assert_eq!(key_value_map.len(), 0);
 
-    let key_value_map = store
-        .get_values_by_key_prefix(&account1_key_prefx, 1)
-        .unwrap();
+    let key_value_map = traverse_values(store, &account1_key_prefx, 1);
     assert_eq!(key_value_map.len(), 0);
 
-    let key_value_map = store
-        .get_values_by_key_prefix(&account1_key_prefx, 2)
-        .unwrap();
+    let key_value_map = traverse_values(store, &account1_key_prefx, 2);
     assert_eq!(key_value_map.len(), 1);
     assert_eq!(*key_value_map.get(&key5).unwrap(), value5_v2);
 }

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -50,6 +50,10 @@ pub mod sync_proof_fetcher;
 use crate::state_delta::StateDelta;
 pub use executed_trees::ExecutedTrees;
 
+// This is last line of defense against large queries slipping through external facing interfaces,
+// like the API and State Sync, etc.
+pub const MAX_REQUEST_LIMIT: u64 = 10000;
+
 pub trait StateSnapshotReceiver<K, V>: Send {
     fn add_chunk(&mut self, chunk: Vec<(K, V)>, proof: SparseMerkleRangeProof) -> Result<()>;
 
@@ -251,8 +255,10 @@ pub trait DbReader: Send + Sync {
     fn get_state_values_by_key_prefix(
         &self,
         key_prefix: &StateKeyPrefix,
+        cursor: Option<&StateKey>,
         version: Version,
-    ) -> Result<HashMap<StateKey, StateValue>> {
+        limit: u64,
+    ) -> Result<(HashMap<StateKey, StateValue>, Option<StateKey>)> {
         unimplemented!()
     }
 


### PR DESCRIPTION
### Description
add  `prev_key` and `limit` as paramters to `get_state_values_by_key_prefix` to support pagination.
return `prev_key` as a second returning value.

When there is no more items to return, the returned `prev_key` would be `None`.
the passed-in `prev_key` is the last key visited previously. pass `None` in when call it the first time.

### Test Plan
ut

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5304)
<!-- Reviewable:end -->
