### PR TITLE
[helm][aptos-node] remove haproxy probes

### DIFF
--- a/terraform/helm/aptos-node/templates/haproxy.yaml
+++ b/terraform/helm/aptos-node/templates/haproxy.yaml
@@ -154,10 +154,6 @@ spec:
         - containerPort: 9101
         - containerPort: 9102
         - containerPort: 9103
-        livenessProbe: # restart haproxy if the underlying VFN is not reachable
-          httpGet:
-            path: /v1/-/healthy
-            port: 8080
         volumeMounts:
         - name: haproxy-config
           mountPath: /usr/local/etc/haproxy


### PR DESCRIPTION
### Description

For now, in the `aptos-node` helm chart, we only support:
* single validator
* 0 or multiple VFN "groups", each with their own k8s service, but potentially multiple replicas. In practice, this is only up to 1 VFN per group per validator

Since there's usually only up to 1 instance behind each k8s service, k8s probes don't make much sense. Instead, we should rely on the application itself to handle failed connections.

### Test Plan

Forge. This unblocks HAProxy forge tests, as previously HAProxy instances without corresponding VFNs would fail livenessProbe.

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5306)
<!-- Reviewable:end -->
