### PR TITLE
[smoke tests] fix flaky node panic due to rebuild in parallel tests

### DIFF
--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -152,25 +152,26 @@ pub fn git_merge_base<R: AsRef<str>>(rev: R) -> Result<String> {
     }
 }
 
+pub fn cargo_build_common_args() -> Vec<&'static str> {
+    let use_release = use_release();
+    let mut args = vec!["build", "--features=failpoints,indexer"];
+    if use_release {
+        args.push("--release");
+    };
+    args
+}
+
 fn cargo_build_aptos_node<D, T>(directory: D, target_directory: T) -> Result<PathBuf>
 where
     D: AsRef<Path>,
     T: AsRef<Path>,
 {
-    let use_release = use_release();
-
     let target_directory = target_directory.as_ref();
     let directory = directory.as_ref();
 
+    let mut args = cargo_build_common_args();
     // build the aptos-node package directly to avoid feature unification issues
-    let mut args = vec![
-        "build",
-        "--package=aptos-node",
-        "--features=failpoints,indexer",
-    ];
-    if use_release {
-        args.push("--release");
-    }
+    args.push("--package=aptos-node");
     info!("Compiling with cargo args: {:?}", args);
     let output = Command::new("cargo")
         .current_dir(directory)
@@ -182,7 +183,7 @@ where
     if output.status.success() {
         let bin_path = target_directory.join(format!(
             "{}/{}{}",
-            if use_release { "release" } else { "debug" },
+            if use_release() { "release" } else { "debug" },
             "aptos-node",
             env::consts::EXE_SUFFIX
         ));

--- a/testsuite/forge/src/backend/local/mod.rs
+++ b/testsuite/forge/src/backend/local/mod.rs
@@ -19,6 +19,7 @@ use std::{
 mod cargo;
 mod node;
 mod swarm;
+pub use cargo::cargo_build_common_args;
 pub use node::LocalNode;
 pub use swarm::{LocalSwarm, SwarmDirectory};
 

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -30,6 +30,8 @@ mod state_sync;
 #[cfg(test)]
 mod storage;
 #[cfg(test)]
+mod test_smoke_tests;
+#[cfg(test)]
 mod transaction;
 #[cfg(test)]
 mod txn_broadcast;

--- a/testsuite/smoke-test/src/test_smoke_tests.rs
+++ b/testsuite/smoke-test/src/test_smoke_tests.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::smoke_test_environment::SwarmBuilder;
-use crate::test_utils::{assert_balance, create_and_fund_account, transfer_coins};
 use aptos_config::config::NodeConfig;
-use forge::{NodeExt, Swarm, SwarmExt};
+use forge::{NodeExt, Swarm};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/testsuite/smoke-test/src/test_smoke_tests.rs
+++ b/testsuite/smoke-test/src/test_smoke_tests.rs
@@ -1,0 +1,51 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::smoke_test_environment::SwarmBuilder;
+use crate::test_utils::{assert_balance, create_and_fund_account, transfer_coins};
+use aptos_config::config::NodeConfig;
+use forge::{NodeExt, Swarm, SwarmExt};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+const MAX_WAIT_SECS: u64 = 60;
+
+/// Bring up a swarm normally, then run get_bin, and bring up a VFN.
+/// Previously get_bin triggered a rebuild of aptos-node, which caused issues that were only seen
+/// during parallel execution of tests.
+/// This test should make regressions obvious.
+#[tokio::test]
+async fn test_aptos_node_after_get_bin() {
+    let mut swarm = SwarmBuilder::new_local(1)
+        .with_aptos()
+        .with_init_config(Arc::new(|_, conf, _| {
+            conf.api.failpoints_enabled = true;
+        }))
+        .build()
+        .await;
+    let version = swarm.versions().max().unwrap();
+    let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+
+    // Before #5308 this re-compiled aptos-node and caused a panic on the vfn.
+    let _aptos_cli = crate::workspace_builder::get_bin("aptos");
+
+    let validator = validator_peer_ids[0];
+    let _vfn = swarm
+        .add_validator_fullnode(
+            &version,
+            NodeConfig::default_for_validator_full_node(),
+            validator,
+        )
+        .unwrap();
+
+    for fullnode in swarm.full_nodes_mut() {
+        fullnode
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .await
+            .unwrap();
+        fullnode
+            .wait_for_connectivity(Instant::now() + Duration::from_secs(MAX_WAIT_SECS))
+            .await
+            .unwrap();
+    }
+}

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -25,9 +25,6 @@ async fn test_txn_broadcast() {
     let version = swarm.versions().max().unwrap();
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
 
-    // Inject failure
-    let _aptos_cli = crate::workspace_builder::get_bin("aptos");
-
     let validator = validator_peer_ids[1];
     let vfn = swarm
         .add_validator_fullnode(

--- a/testsuite/smoke-test/src/txn_broadcast.rs
+++ b/testsuite/smoke-test/src/txn_broadcast.rs
@@ -25,6 +25,9 @@ async fn test_txn_broadcast() {
     let version = swarm.versions().max().unwrap();
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
 
+    // Inject failure
+    let _aptos_cli = crate::workspace_builder::get_bin("aptos");
+
     let validator = validator_peer_ids[1];
     let vfn = swarm
         .add_validator_fullnode(

--- a/testsuite/smoke-test/src/workspace_builder.rs
+++ b/testsuite/smoke-test/src/workspace_builder.rs
@@ -64,7 +64,8 @@ fn build_dir() -> PathBuf {
 // Path to a specified binary
 pub fn get_bin<S: AsRef<str>>(bin_name: S) -> PathBuf {
     assert_ne!(
-        "aptos-node", bin_name,
+        "aptos-node",
+        bin_name.as_ref(),
         "aptos-node must be built and used via local swarm cargo_build_aptos_node"
     );
 

--- a/testsuite/smoke-test/src/workspace_builder.rs
+++ b/testsuite/smoke-test/src/workspace_builder.rs
@@ -6,24 +6,21 @@
 //! This utility is to only be used inside of smoke test.
 
 use aptos_logger::prelude::*;
+use forge::cargo_build_common_args;
 use once_cell::sync::Lazy;
 use std::{env, path::PathBuf, process::Command};
 
 const WORKSPACE_BUILD_ERROR_MSG: &str = r#"
     Unable to build all workspace binaries. Cannot continue running tests.
 
-    Try running 'cargo build --all --bins --exclude aptos-node' yourself.
+    Try running 'cargo build --release --all --bins --exclude aptos-node' yourself.
 "#;
 
 // Global flag indicating if all binaries in the workspace have been built.
 static WORKSPACE_BUILT: Lazy<bool> = Lazy::new(|| {
     info!("Building project binaries");
-    let args = if cfg!(debug_assertions) {
-        // use get_aptos_node_with_failpoints to get aptos-node binary
-        vec!["build", "--all", "--bins", "--exclude", "aptos-node"]
-    } else {
-        vec!["build", "--all", "--bins", "--release"]
-    };
+    let mut args = cargo_build_common_args();
+    args.append(&mut vec!["--all", "--bins", "--exclude", "aptos-node"]);
 
     let cargo_build = Command::new("cargo")
         .current_dir(workspace_root())
@@ -66,6 +63,11 @@ fn build_dir() -> PathBuf {
 
 // Path to a specified binary
 pub fn get_bin<S: AsRef<str>>(bin_name: S) -> PathBuf {
+    assert_ne!(
+        "aptos-node", bin_name,
+        "aptos-node must be built and used via local swarm cargo_build_aptos_node"
+    );
+
     // We have to check to see if the workspace is built first to ensure that the binaries we're
     // testing are up to date.
     if !*WORKSPACE_BUILT {


### PR DESCRIPTION
### Description

With smoke tests running in parallel, some tests failed on node panic after asserting that feature "testing" from crate move-stdlib is set.

```
thread 'main' panicked at 'assertion failed: aptos_natives(NativeGasParameters::zeros(),\n            AbstractValueSizeGasParameters::zeros(),\n            LATEST_GAS_FEATURE_VERSION).into_iter().all(|(_, module_name,\n            func_name, _)|\n        module_name.as_str() != \"unit_test\" &&\n            func_name.as_str() != \"create_signers_for_testing\")', aptos-move/aptos-vm/src/natives.rs:55:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This is because other tests that call `get_bin` were recompiling aptos-node without release flags. So there is a race where a node is startup with the non-release aptos-node.

We don't actually need a non-release version for smoke tests. So removing that completely and adding some sharing to prevent the builds from diverging again.

### Test Plan

Add an explicit deterministic repro that failed before this fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5308)
<!-- Reviewable:end -->
