### PR TITLE
[tf/gcp] update default instance to recommended n2

### DIFF
--- a/developer-docs-site/docs/nodes/validator-node/operator/node-requirements.md
+++ b/developer-docs-site/docs/nodes/validator-node/operator/node-requirements.md
@@ -38,7 +38,7 @@ For running an Aptos **validator node and validator fullnode** we recommend the 
     - c6i.8xlarge + io1/io2 EBS volume with 40K IOPS.
 - **GCP**
     - n2-standard-16 (if use local SSD)
-    - n2-standard-30 + pd-ssd with 40K IOPS.
+    - n2-standard-32 + pd-ssd with 40K IOPS.
 
 ### Motivations for hardware requirements
 

--- a/terraform/aptos-node/gcp/variables.tf
+++ b/terraform/aptos-node/gcp/variables.tf
@@ -97,7 +97,7 @@ variable "utility_instance_enable_taint" {
 
 variable "validator_instance_type" {
   description = "Instance type used for validator and fullnodes"
-  default     = "c2-standard-30"
+  default     = "n2-standard-32"
 }
 
 variable "validator_instance_num" {

--- a/terraform/fullnode/gcp/variables.tf
+++ b/terraform/fullnode/gcp/variables.tf
@@ -120,7 +120,7 @@ variable "fullnode_name" {
 
 variable "machine_type" {
   description = "Machine type for running fullnode"
-  default     = "c2-standard-16"
+  default     = "n2-standard-32"
 }
 
 variable "enable_backup" {

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -76,7 +76,7 @@ variable "utility_instance_type" {
 
 variable "fullnode_instance_type" {
   description = "Instance type used for validator and fullnodes"
-  default     = "c5.xlarge"
+  default     = "c6i.8xlarge"
 }
 
 variable "num_fullnodes" {


### PR DESCRIPTION
### Description

Make it consistent with https://aptos.dev/nodes/validator-node/operator/node-requirements/
All VFN, PFN, Validators in the following clouds will run by default:
* GCP: `n2-standard-32` (it's not 30)
* AWS: `c6i.8xlarge` (subject to change)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5312)
<!-- Reviewable:end -->
