### PR TITLE
[aptos-node] better error message for the feature flag check

### DIFF
--- a/aptos-move/aptos-vm/src/natives.rs
+++ b/aptos-move/aptos-vm/src/natives.rs
@@ -51,18 +51,24 @@ pub fn aptos_natives(
         .collect()
 }
 
-pub fn assert_no_test_natives() {
-    assert!(aptos_natives(
-        NativeGasParameters::zeros(),
-        AbstractValueSizeGasParameters::zeros(),
-        LATEST_GAS_FEATURE_VERSION
+pub fn assert_no_test_natives(err_msg: &str) {
+    assert!(
+        aptos_natives(
+            NativeGasParameters::zeros(),
+            AbstractValueSizeGasParameters::zeros(),
+            LATEST_GAS_FEATURE_VERSION
+        )
+        .into_iter()
+        .all(|(_, module_name, func_name, _)| {
+            !(module_name.as_str() == "unit_test"
+                && func_name.as_str() == "create_signers_for_testing"
+                || module_name.as_str() == "ed25519"
+                    && func_name.as_str() == "generate_keys_internal"
+                || module_name.as_str() == "ed25519" && func_name.as_str() == "sign_internal")
+        }),
+        "{}",
+        err_msg
     )
-    .into_iter()
-    .all(|(_, module_name, func_name, _)| {
-        !(module_name.as_str() == "unit_test" && func_name.as_str() == "create_signers_for_testing"
-            || module_name.as_str() == "ed25519" && func_name.as_str() == "generate_keys_internal"
-            || module_name.as_str() == "ed25519" && func_name.as_str() == "sign_internal")
-    }))
 }
 
 #[cfg(feature = "testing")]

--- a/aptos-node/src/lib.rs
+++ b/aptos-node/src/lib.rs
@@ -889,6 +889,17 @@ pub fn setup_environment(
     })
 }
 
+pub const ERROR_MSG_BAD_FEATURE_FLAGS: &str = r#"
+aptos-node was compiled with feature flags that shouldn't be enabled.
+
+This is caused by cargo's feature unification.
+When you compile two crates with a shared dependency, if one enables a feature flag for the dependency, then it is also enabled for the other crate.
+
+PLEASE RECOMPILE APTOS-NODE SEPARATELY using the following command:
+    cargo build --package aptos-node
+
+"#;
+
 #[cfg(test)]
 mod tests {
     use crate::setup_environment;
@@ -916,6 +927,6 @@ mod tests {
     #[cfg(feature = "check-vm-features")]
     #[test]
     fn test_aptos_vm_does_not_have_test_natives() {
-        aptos_vm::natives::assert_no_test_natives()
+        aptos_vm::natives::assert_no_test_natives(crate::ERROR_MSG_BAD_FEATURE_FLAGS)
     }
 }

--- a/aptos-node/src/main.rs
+++ b/aptos-node/src/main.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use aptos_node::AptosNodeArgs;
+use aptos_node::{AptosNodeArgs, ERROR_MSG_BAD_FEATURE_FLAGS};
 use clap::Parser;
 
 #[cfg(unix)]
@@ -12,6 +12,6 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn main() {
     // Check that we are not including any Move test natives
-    aptos_vm::natives::assert_no_test_natives();
+    aptos_vm::natives::assert_no_test_natives(ERROR_MSG_BAD_FEATURE_FLAGS);
     AptosNodeArgs::parse().run()
 }


### PR DESCRIPTION
This adds a meaningful error message to the feature flag check so users know what to do when they bump into it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5330)
<!-- Reviewable:end -->
