### PR TITLE
[Indexer] Improve indexer restart

### DIFF
--- a/crates/indexer/README.md
+++ b/crates/indexer/README.md
@@ -35,7 +35,7 @@ Please follow standard fullnode installation guide on aptos.dev (https://aptos.d
 
 ### Running indexer
 ```bash
-cargo run --bin aptos-node --features "indexer"  -- --config <some_path>/fullnode.yaml
+cargo run -p aptos-node --features "indexer" --release -- -f <some_path>/fullnode.yaml
 ```
    * Example fullnode.yaml modification
       ```

--- a/crates/indexer/migrations/2022-10-30-053525_add_vote_data/down.sql
+++ b/crates/indexer/migrations/2022-10-30-053525_add_vote_data/down.sql
@@ -1,0 +1,8 @@
+-- This file should undo anything in `up.sql`
+DROP INDEX IF EXISTS ans_tn_index;
+ALTER TABLE current_ans_lookup DROP COLUMN IF EXISTS token_name;
+DROP INDEX IF EXISTS pv_pi_va_index;
+DROP INDEX IF EXISTS pv_va_index;
+DROP INDEX IF EXISTS pv_spa_index;
+DROP INDEX IF EXISTS pv_ia_index;
+DROP TABLE IF EXISTS proposal_votes;

--- a/crates/indexer/migrations/2022-10-30-053525_add_vote_data/up.sql
+++ b/crates/indexer/migrations/2022-10-30-053525_add_vote_data/up.sql
@@ -1,0 +1,22 @@
+-- Your SQL goes here
+-- Add token_name to join with token tables, {subdomain}.{domain}.apt
+ALTER TABLE current_ans_lookup
+ADD COLUMN token_name VARCHAR(140) NOT NULL DEFAULT '';
+CREATE INDEX ans_tn_index ON current_ans_lookup (token_name);
+-- Add voting table
+CREATE TABLE proposal_votes (
+  transaction_version BIGINT NOT NULL,
+  proposal_id BIGINT NOT NULL,
+  voter_address VARCHAR(66) NOT NULL,
+  staking_pool_address VARCHAR(66) NOT NULL,
+  num_votes NUMERIC NOT NULL,
+  should_pass BOOLEAN NOT NULL,
+  transaction_timestamp TIMESTAMP NOT NULL,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  -- Constraints
+  PRIMARY KEY (transaction_version, proposal_id, voter_address)
+);
+CREATE INDEX pv_pi_va_index ON proposal_votes (proposal_id, voter_address);
+CREATE INDEX pv_va_index ON proposal_votes (voter_address);
+CREATE INDEX pv_spa_index ON proposal_votes (staking_pool_address);
+CREATE INDEX pv_ia_index ON proposal_votes (inserted_at);

--- a/crates/indexer/src/indexer/fetcher.rs
+++ b/crates/indexer/src/indexer/fetcher.rs
@@ -7,7 +7,7 @@ use aptos_api_types::{AsConverter, LedgerInfo, Transaction, TransactionOnChainDa
 use aptos_logger::prelude::*;
 use aptos_vm::data_cache::StorageAdapterOwned;
 use futures::channel::mpsc;
-use futures::{SinkExt, StreamExt};
+use futures::SinkExt;
 use std::sync::Arc;
 use std::time::Duration;
 use storage_interface::state_view::DbStateView;
@@ -432,10 +432,16 @@ impl TransactionFetcher {
 impl TransactionFetcherTrait for TransactionFetcher {
     /// Fetches the next batch based on its internal version counter
     async fn fetch_next_batch(&mut self) -> Vec<Transaction> {
-        self.transaction_receiver
-            .next()
-            .await
-            .expect("No transactions, producer of batches died")
+        // try_next is nonblocking unlike next. It'll try to fetch the next one and return immediately.
+        match self.transaction_receiver.try_next() {
+            Ok(Some(transactions)) => transactions,
+            Ok(None) => {
+                // We never close the channel, so this should never happen
+                panic!("Transaction fetcher channel closed");
+            }
+            // The error here is when the channel is empty which we definitely expect.
+            Err(_) => vec![],
+        }
     }
 
     fn fetch_ledger_info(&mut self) -> LedgerInfo {

--- a/crates/indexer/src/models/stake_models/mod.rs
+++ b/crates/indexer/src/models/stake_models/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Aptos
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod proposal_votes;
 pub mod stake_utils;
 pub mod staking_pool_voter;

--- a/crates/indexer/src/models/stake_models/proposal_votes.rs
+++ b/crates/indexer/src/models/stake_models/proposal_votes.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Aptos
+// SPDX-License-Identifier: Apache-2.0
+
+// This is required because a diesel macro makes clippy sad
+#![allow(clippy::extra_unused_lifetimes)]
+
+use super::stake_utils::StakeEvent;
+use crate::{
+    schema::proposal_votes,
+    util::{parse_timestamp, standardize_address},
+};
+use aptos_api_types::Transaction as APITransaction;
+use bigdecimal::BigDecimal;
+use field_count::FieldCount;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, FieldCount, Identifiable, Insertable, Serialize)]
+#[diesel(primary_key(transaction_version, proposal_id, voter_address))]
+#[diesel(table_name = proposal_votes)]
+pub struct ProposalVote {
+    pub transaction_version: i64,
+    pub proposal_id: i64,
+    pub voter_address: String,
+    pub staking_pool_address: String,
+    pub num_votes: BigDecimal,
+    pub should_pass: bool,
+    pub transaction_timestamp: chrono::NaiveDateTime,
+}
+
+impl ProposalVote {
+    pub fn from_transaction(transaction: &APITransaction) -> anyhow::Result<Vec<Self>> {
+        let mut proposal_votes = vec![];
+        if let APITransaction::UserTransaction(user_txn) = transaction {
+            for event in &user_txn.events {
+                let txn_version = user_txn.info.version.0 as i64;
+                let event_type = event.typ.to_string();
+                match StakeEvent::from_event(event_type.as_str(), &event.data, txn_version)? {
+                    Some(StakeEvent::GovernanceVoteEvent(ev)) => proposal_votes.push(Self {
+                        transaction_version: txn_version,
+                        proposal_id: ev.proposal_id as i64,
+                        voter_address: standardize_address(&ev.voter),
+                        staking_pool_address: standardize_address(&ev.stake_pool),
+                        num_votes: ev.num_votes.clone(),
+                        should_pass: ev.should_pass,
+                        transaction_timestamp: parse_timestamp(user_txn.timestamp.0, txn_version),
+                    }),
+                    None => {}
+                };
+            }
+        }
+        Ok(proposal_votes)
+    }
+}

--- a/crates/indexer/src/models/stake_models/stake_utils.rs
+++ b/crates/indexer/src/models/stake_models/stake_utils.rs
@@ -4,12 +4,23 @@
 use crate::models::move_resources::MoveResource;
 use anyhow::{Context, Result};
 use aptos_api_types::{deserialize_from_string, WriteResource};
+use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct StakePoolResource {
-    #[serde(deserialize_with = "deserialize_from_string")]
     pub delegated_voter: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GovernanceVoteEvent {
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub proposal_id: u64,
+    pub voter: String,
+    pub stake_pool: String,
+    #[serde(deserialize_with = "deserialize_from_string")]
+    pub num_votes: BigDecimal,
+    pub should_pass: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -62,5 +73,28 @@ impl StakeResource {
             resource.data.as_ref().unwrap(),
             txn_version,
         )?))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum StakeEvent {
+    GovernanceVoteEvent(GovernanceVoteEvent),
+}
+
+impl StakeEvent {
+    pub fn from_event(
+        data_type: &str,
+        data: &serde_json::Value,
+        txn_version: i64,
+    ) -> Result<Option<Self>> {
+        match data_type {
+            "0x1::aptos_governance::VoteEvent" => serde_json::from_value(data.clone())
+                .map(|inner| Some(StakeEvent::GovernanceVoteEvent(inner))),
+            _ => Ok(None),
+        }
+        .context(format!(
+            "version {} failed! failed to parse type {}, data {:?}",
+            txn_version, data_type, data
+        ))
     }
 }

--- a/crates/indexer/src/models/token_models/ans_lookup.rs
+++ b/crates/indexer/src/models/token_models/ans_lookup.rs
@@ -31,6 +31,7 @@ pub struct CurrentAnsLookup {
     pub registered_address: Option<String>,
     pub last_transaction_version: i64,
     pub expiration_timestamp: chrono::NaiveDateTime,
+    pub token_name: String,
 }
 
 pub enum ANSEvent {
@@ -115,18 +116,22 @@ impl CurrentAnsLookup {
                                     bigdecimal_to_u64(&inner.expiration_time_secs),
                                     txn_version,
                                 );
+                                let subdomain =
+                                    inner.subdomain_name.get_string().unwrap_or_default();
+                                let mut token_name = format!("{}.apt", &inner.domain_name);
+                                if !subdomain.is_empty() {
+                                    token_name = format!("{}.{}", &subdomain, token_name);
+                                }
                                 Self {
                                     domain: inner.domain_name,
-                                    subdomain: inner
-                                        .subdomain_name
-                                        .get_string()
-                                        .unwrap_or_default(),
+                                    subdomain,
                                     registered_address: inner
                                         .new_address
                                         .get_string()
                                         .map(|s| standardize_address(&s)),
                                     last_transaction_version: txn_version,
                                     expiration_timestamp,
+                                    token_name,
                                 }
                             }
                             ANSEvent::RegisterNameEventV1(inner) => {
@@ -134,15 +139,19 @@ impl CurrentAnsLookup {
                                     bigdecimal_to_u64(&inner.expiration_time_secs),
                                     txn_version,
                                 );
+                                let subdomain =
+                                    inner.subdomain_name.get_string().unwrap_or_default();
+                                let mut token_name = format!("{}.apt", &inner.domain_name);
+                                if !subdomain.is_empty() {
+                                    token_name = format!("{}.{}", &subdomain, token_name);
+                                }
                                 Self {
                                     domain: inner.domain_name,
-                                    subdomain: inner
-                                        .subdomain_name
-                                        .get_string()
-                                        .unwrap_or_default(),
+                                    subdomain,
                                     registered_address: None,
                                     last_transaction_version: txn_version,
                                     expiration_timestamp,
+                                    token_name,
                                 }
                             }
                         };

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -463,6 +463,7 @@ fn insert_current_ans_lookups(
                     expiration_timestamp.eq(excluded(expiration_timestamp)),
                     last_transaction_version.eq(excluded(last_transaction_version)),
                     inserted_at.eq(excluded(inserted_at)),
+                    token_name.eq(excluded(token_name)),
                 )),
                 Some(" WHERE current_ans_lookup.last_transaction_version <= excluded.last_transaction_version "),
             )?;

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -224,8 +224,9 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
 
         for (num_txn, res) in batches {
             let processed_result: ProcessingResult = match res {
-                Ok(res) => res,
-                Err(tpe) => {
+                None => continue,
+                Some(Ok(res)) => res,
+                Some(Err(tpe)) => {
                     let (err, start_version, end_version, _) = tpe.inner();
                     error!(
                         processor_name = processor_name,

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -4,7 +4,7 @@
 use crate::{
     database::new_db_pool,
     indexer::{
-        fetcher::TransactionFetcherOptions, tailer::Tailer,
+        fetcher::TransactionFetcherOptions, processing_result::ProcessingResult, tailer::Tailer,
         transaction_processor::TransactionProcessor,
     },
     processors::{
@@ -171,15 +171,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
             0
         }) as u64;
     let start_version = match config.starting_version {
-        None => tailer
-            .get_start_version_long(&processor_name, lookback_versions)
-            .unwrap_or_else(|| {
-                info!(
-                    processor_name = processor_name,
-                    "Could not fetch version from db so starting from version 0"
-                );
-                0
-            }) as u64,
+        None => starting_version_from_db_short,
         Some(version) => version,
     };
 
@@ -187,7 +179,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
         processor_name = processor_name,
         final_start_version = start_version,
         start_version_from_config = config.starting_version,
-        starting_version_from_db_short = starting_version_from_db_short,
+        starting_version_from_db = starting_version_from_db_short,
         "Setting starting version..."
     );
     tailer.set_fetcher_version(start_version as u64).await;
@@ -212,52 +204,54 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
             .expect("Failed to get chain ID");
     }
 
-    let (tx, mut receiver) = tokio::sync::mpsc::channel(100);
-    let mut tasks = vec![];
-    for _ in 0..processor_tasks {
-        let other_tx = tx.clone();
-        let other_tailer = tailer.clone();
-        let task = tokio::task::spawn(async move {
-            loop {
-                let (num_res, res) = other_tailer.process_next_batch().await;
-                other_tx.send((num_res, res)).await.unwrap();
-            }
-        });
-        tasks.push(task);
-    }
-
     let mut ma = MovingAverage::new(10_000);
 
     loop {
-        let (num_res, result) = receiver
-            .recv()
-            .await
-            .expect("Failed to receive batch results: got None!");
-
-        let processing_result = match result {
+        let mut tasks = vec![];
+        for _ in 0..processor_tasks {
+            let other_tailer = tailer.clone();
+            let task = tokio::spawn(async move { other_tailer.process_next_batch().await });
+            tasks.push(task);
+        }
+        let batches = match futures::future::try_join_all(tasks).await {
             Ok(res) => res,
-            Err(tpe) => {
-                let (err, start_version, end_version, _) = tpe.inner();
-                error!(
-                    processor_name = processor_name,
-                    start_version = start_version,
-                    end_version = end_version,
-                    error =? err,
-                    "Error processing batch!"
-                );
-                panic!(
-                    "Error in '{}' while processing batch: {:?}",
-                    processor_name, err
-                );
-            }
+            Err(err) => panic!("Error processing transaction batches: {:?}", err),
         };
 
+        let mut batch_start_version = u64::MAX;
+        let mut batch_end_version = 0;
+        let mut num_res = 0;
+
+        for (num_txn, res) in batches {
+            let processed_result: ProcessingResult = match res {
+                Ok(res) => res,
+                Err(tpe) => {
+                    let (err, start_version, end_version, _) = tpe.inner();
+                    error!(
+                        processor_name = processor_name,
+                        start_version = start_version,
+                        end_version = end_version,
+                        error =? err,
+                        "Error processing batch!"
+                    );
+                    panic!(
+                        "Error in '{}' while processing batch: {:?}",
+                        processor_name, err
+                    );
+                }
+            };
+            batch_start_version =
+                std::cmp::min(batch_start_version, processed_result.start_version);
+            batch_end_version = std::cmp::max(batch_end_version, processed_result.end_version);
+            num_res += num_txn;
+        }
+
         tailer
-            .update_last_processed_version(&processor_name, processing_result.end_version)
+            .update_last_processed_version(&processor_name, batch_end_version)
             .unwrap_or_else(|e| {
                 error!(
                     processor_name = processor_name,
-                    end_version = processing_result.end_version,
+                    end_version = batch_end_version,
                     error = format!("{:?}", e),
                     "Failed to update last processed version!"
                 );
@@ -273,8 +267,8 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
                 base = new_base;
                 info!(
                     processor_name = processor_name,
-                    batch_start_version = processing_result.start_version,
-                    batch_end_version = processing_result.end_version,
+                    batch_start_version = batch_start_version,
+                    batch_end_version = batch_end_version,
                     versions_processed = versions_processed,
                     tps = (ma.avg() * 1000.0) as u64,
                     "Processed batch version"

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -224,6 +224,7 @@ pub async fn run_forever(config: IndexerConfig, context: Arc<Context>) {
 
         for (num_txn, res) in batches {
             let processed_result: ProcessingResult = match res {
+                // When the batch is empty b/c we're caught up, continue to next batch
                 None => continue,
                 Some(Ok(res)) => res,
                 Some(Err(tpe)) => {

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -104,6 +104,7 @@ diesel::table! {
         expiration_timestamp -> Timestamp,
         last_transaction_version -> Int8,
         inserted_at -> Timestamp,
+        token_name -> Varchar,
     }
 }
 
@@ -286,6 +287,19 @@ diesel::table! {
         success -> Bool,
         details -> Nullable<Text>,
         last_updated -> Timestamp,
+    }
+}
+
+diesel::table! {
+    proposal_votes (transaction_version, proposal_id, voter_address) {
+        transaction_version -> Int8,
+        proposal_id -> Int8,
+        voter_address -> Varchar,
+        staking_pool_address -> Varchar,
+        num_votes -> Numeric,
+        should_pass -> Bool,
+        transaction_timestamp -> Timestamp,
+        inserted_at -> Timestamp,
     }
 }
 
@@ -486,6 +500,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     move_resources,
     processor_status,
     processor_statuses,
+    proposal_votes,
     signatures,
     table_items,
     table_metadatas,


### PR DESCRIPTION
### Description
#### Context
Recording every version and restarting from gap is inefficient (takes about 30 minutes to restart in testnet). We tried to explore an easy solution where we only record the latest version processed, but the existing way skips ahead even though a batch may fail. 

#### This PR
We now wait for the full X batch to finish processing before logging. The tradeoff is that we may see a performance hit when processing large batches (before, we'd just go ahead, but now, we're stopping). Realistically though this is a non issue because we're wayyyy above our actual TPS. 

### Test Plan
#### Before
I tested by crashing the node, `processor_status` returned `latest_version_processed = 14999` 
```        
        if start_version == Some(1000) {
            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
            panic!("test panic");
        }
```

#### After
Same crash testing, `processor_status` returned blank as intended. 

**TPS**
About the same as before. I tested a few times and it was ~14K tps vs ~15K tps before.

**Restart**
Restart drops from 30 min to 1 sec.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5338)
<!-- Reviewable:end -->
