### PR TITLE
[Spec] Specs for math64, math128 and type_info

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/math128.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math128.md
@@ -10,6 +10,11 @@ Standard math utilities missing in the Move Language.
 -  [Function `min`](#0x1_math128_min)
 -  [Function `average`](#0x1_math128_average)
 -  [Function `pow`](#0x1_math128_pow)
+-  [Specification](#@Specification_0)
+    -  [Function `max`](#@Specification_0_max)
+    -  [Function `min`](#@Specification_0_min)
+    -  [Function `average`](#@Specification_0_average)
+    -  [Function `pow`](#@Specification_0_pow)
 
 
 <pre><code></code></pre>
@@ -131,6 +136,97 @@ Return the value of n raised to power e
 
 
 </details>
+
+<a name="@Specification_0"></a>
+
+## Specification
+
+
+<a name="@Specification_0_max"></a>
+
+### Function `max`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_max">max</a>(a: u128, b: u128): u128
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> a &gt;= b ==&gt; result == a;
+<b>ensures</b> a &lt; b ==&gt; result == b;
+</code></pre>
+
+
+
+<a name="@Specification_0_min"></a>
+
+### Function `min`
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(a: u128, b: u128): u128
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> a &lt; b ==&gt; result == a;
+<b>ensures</b> a &gt;= b ==&gt; result == b;
+</code></pre>
+
+
+
+<a name="@Specification_0_average"></a>
+
+### Function `average`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_average">average</a>(a: u128, b: u128): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <b>false</b>;
+<b>ensures</b> result == (a + b) / 2;
+</code></pre>
+
+
+
+<a name="@Specification_0_pow"></a>
+
+### Function `pow`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math128.md#0x1_math128_pow">pow</a>(n: u128, e: u128): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <a href="math128.md#0x1_math128_spec_pow">spec_pow</a>(n, e) &gt; MAX_U128;
+<b>ensures</b> [abstract] result == <a href="math128.md#0x1_math128_spec_pow">spec_pow</a>(n, e);
+</code></pre>
+
+
+
+
+<a name="0x1_math128_spec_pow"></a>
+
+
+<pre><code><b>fun</b> <a href="math128.md#0x1_math128_spec_pow">spec_pow</a>(e: u128, n: u128): u128 {
+   <b>if</b> (e == 0) {
+       1
+   }
+   <b>else</b> {
+       n * <a href="math128.md#0x1_math128_spec_pow">spec_pow</a>(n, e-1)
+   }
+}
+</code></pre>
 
 
 [move-book]: https://move-language.github.io/move/introduction.html

--- a/aptos-move/framework/aptos-stdlib/doc/math64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/math64.md
@@ -11,7 +11,10 @@ Standard math utilities missing in the Move Language.
 -  [Function `average`](#0x1_math64_average)
 -  [Function `pow`](#0x1_math64_pow)
 -  [Specification](#@Specification_0)
+    -  [Function `max`](#@Specification_0_max)
+    -  [Function `min`](#@Specification_0_min)
     -  [Function `average`](#@Specification_0_average)
+    -  [Function `pow`](#@Specification_0_pow)
 
 
 <pre><code></code></pre>
@@ -139,6 +142,42 @@ Return the value of n raised to power e
 ## Specification
 
 
+<a name="@Specification_0_max"></a>
+
+### Function `max`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math64.md#0x1_math64_max">max</a>(a: u64, b: u64): u64
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> a &gt;= b ==&gt; result == a;
+<b>ensures</b> a &lt; b ==&gt; result == b;
+</code></pre>
+
+
+
+<a name="@Specification_0_min"></a>
+
+### Function `min`
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(a: u64, b: u64): u64
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> a &lt; b ==&gt; result == a;
+<b>ensures</b> a &gt;= b ==&gt; result == b;
+</code></pre>
+
+
+
 <a name="@Specification_0_average"></a>
 
 ### Function `average`
@@ -153,6 +192,40 @@ Return the value of n raised to power e
 <pre><code><b>pragma</b> opaque;
 <b>aborts_if</b> <b>false</b>;
 <b>ensures</b> result == (a + b) / 2;
+</code></pre>
+
+
+
+<a name="@Specification_0_pow"></a>
+
+### Function `pow`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="math64.md#0x1_math64_pow">pow</a>(n: u64, e: u64): u64
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> [abstract] <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n, e) &gt; MAX_U64;
+<b>ensures</b> [abstract] result == <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n, e);
+</code></pre>
+
+
+
+
+<a name="0x1_math64_spec_pow"></a>
+
+
+<pre><code><b>fun</b> <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(e: u64, n: u64): u64 {
+   <b>if</b> (e == 0) {
+       1
+   }
+   <b>else</b> {
+       n * <a href="math64.md#0x1_math64_spec_pow">spec_pow</a>(n, e-1)
+   }
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -11,9 +11,8 @@
 -  [Function `struct_name`](#0x1_type_info_struct_name)
 -  [Function `type_of`](#0x1_type_info_type_of)
 -  [Function `type_name`](#0x1_type_info_type_name)
--  [Specification](#@Specification_0)
-    -  [Function `type_of`](#@Specification_0_type_of)
-    -  [Function `type_name`](#@Specification_0_type_name)
+-  [Function `verify_type_of`](#0x1_type_info_verify_type_of)
+-  [Function `verify_type_of_generic`](#0x1_type_info_verify_type_of_generic)
 
 
 <pre><code><b>use</b> <a href="../../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
@@ -176,40 +175,69 @@
 
 </details>
 
-<a name="@Specification_0"></a>
+<a name="0x1_type_info_verify_type_of"></a>
 
-## Specification
-
-
-<a name="@Specification_0_type_of"></a>
-
-### Function `type_of`
+## Function `verify_type_of`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;(): <a href="type_info.md#0x1_type_info_TypeInfo">type_info::TypeInfo</a>
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of">verify_type_of</a>()
 </code></pre>
 
 
 
+<details>
+<summary>Implementation</summary>
 
-<pre><code><b>pragma</b> opaque;
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of">verify_type_of</a>() {
+    <b>let</b> <a href="type_info.md#0x1_type_info">type_info</a> = <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>&gt;();
+    <b>let</b> account_address = <a href="type_info.md#0x1_type_info_account_address">account_address</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> module_name = <a href="type_info.md#0x1_type_info_module_name">module_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> struct_name = <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>spec</b> {
+        <b>assert</b> account_address == @aptos_std;
+        <b>assert</b> module_name == b"<a href="type_info.md#0x1_type_info">type_info</a>";
+        <b>assert</b> struct_name == b"<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>";
+    };
+}
 </code></pre>
 
 
 
-<a name="@Specification_0_type_name"></a>
+</details>
 
-### Function `type_name`
+<a name="0x1_type_info_verify_type_of_generic"></a>
+
+## Function `verify_type_of_generic`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="type_info.md#0x1_type_info_type_name">type_name</a>&lt;T&gt;(): <a href="../../move-stdlib/doc/string.md#0x1_string_String">string::String</a>
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of_generic">verify_type_of_generic</a>&lt;T&gt;()
 </code></pre>
 
 
 
+<details>
+<summary>Implementation</summary>
 
-<pre><code><b>pragma</b> opaque;
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of_generic">verify_type_of_generic</a>&lt;T&gt;() {
+    <b>let</b> <a href="type_info.md#0x1_type_info">type_info</a> = <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;();
+    <b>let</b> account_address = <a href="type_info.md#0x1_type_info_account_address">account_address</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> module_name = <a href="type_info.md#0x1_type_info_module_name">module_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> struct_name = <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>spec</b> {
+        <b>assert</b> account_address == <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;().account_address;
+        <b>assert</b> module_name == <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;().module_name;
+        <b>assert</b> struct_name == <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;().struct_name;
+    };
+}
 </code></pre>
+
+
+
+</details>
 
 
 [move-book]: https://move-language.github.io/move/introduction.html

--- a/aptos-move/framework/aptos-stdlib/sources/math128.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math128.spec.move
@@ -1,0 +1,36 @@
+spec aptos_std::math128 {
+
+    spec max(a: u128, b: u128): u128 {
+        aborts_if false;
+        ensures a >= b ==> result == a;
+        ensures a < b ==> result == b;
+    }
+
+    spec min(a: u128, b: u128): u128 {
+        aborts_if false;
+        ensures a < b ==> result == a;
+        ensures a >= b ==> result == b;
+    }
+
+    spec average(a: u128, b: u128): u128 {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (a + b) / 2;
+    }
+
+    spec pow(n: u128, e: u128): u128 {
+        pragma opaque;
+        // TODO: verify the spec.
+        aborts_if [abstract] spec_pow(n, e) > MAX_U128;
+        ensures [abstract] result == spec_pow(n, e);
+    }
+
+    spec fun spec_pow(e: u128, n: u128): u128 {
+        if (e == 0) {
+            1
+        }
+        else {
+            n * spec_pow(n, e-1)
+        }
+    }
+}

--- a/aptos-move/framework/aptos-stdlib/sources/math64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.move
@@ -20,12 +20,6 @@ module aptos_std::math64 {
         }
     }
 
-    spec average {
-        pragma opaque;
-        aborts_if false;
-        ensures result == (a + b) / 2;
-    }
-
     /// Return the value of n raised to power e
     public fun pow(n: u64, e: u64): u64 {
         if (e == 0) {

--- a/aptos-move/framework/aptos-stdlib/sources/math64.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/math64.spec.move
@@ -1,0 +1,36 @@
+spec aptos_std::math64 {
+
+    spec max(a: u64, b: u64): u64 {
+        aborts_if false;
+        ensures a >= b ==> result == a;
+        ensures a < b ==> result == b;
+    }
+
+    spec min(a: u64, b: u64): u64 {
+        aborts_if false;
+        ensures a < b ==> result == a;
+        ensures a >= b ==> result == b;
+    }
+
+    spec average(a: u64, b: u64): u64 {
+        pragma opaque;
+        aborts_if false;
+        ensures result == (a + b) / 2;
+    }
+
+    spec pow(n: u64, e: u64): u64 {
+        pragma opaque;
+        // TODO: verify the spec.
+        aborts_if [abstract] spec_pow(n, e) > MAX_U64;
+        ensures [abstract] result == spec_pow(n, e);
+    }
+
+    spec fun spec_pow(e: u64, n: u64): u64 {
+        if (e == 0) {
+            1
+        }
+        else {
+            n * spec_pow(n, e-1)
+        }
+    }
+}

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.move
@@ -57,4 +57,30 @@ module aptos_std::type_info {
             >
         >() == string::utf8(b"0x1::table::Table<0x1::type_info::TypeInfo, 0x1::table::Table<u8, vector<0x1::type_info::TypeInfo>>>"), 10);
     }
+
+    #[verify_only]
+    fun verify_type_of() {
+        let type_info = type_of<TypeInfo>();
+        let account_address = account_address(&type_info);
+        let module_name = module_name(&type_info);
+        let struct_name = struct_name(&type_info);
+        spec {
+            assert account_address == @aptos_std;
+            assert module_name == b"type_info";
+            assert struct_name == b"TypeInfo";
+        };
+    }
+
+    #[verify_only]
+    fun verify_type_of_generic<T>() {
+        let type_info = type_of<T>();
+        let account_address = account_address(&type_info);
+        let module_name = module_name(&type_info);
+        let struct_name = struct_name(&type_info);
+        spec {
+            assert account_address == type_of<T>().account_address;
+            assert module_name == type_of<T>().module_name;
+            assert struct_name == type_of<T>().struct_name;
+        };
+    }
 }

--- a/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
+++ b/aptos-move/framework/aptos-stdlib/sources/type_info.spec.move
@@ -1,11 +1,3 @@
 spec aptos_std::type_info {
-    spec type_of {
-        // TODO: temporary mockup.
-        pragma opaque;
-    }
-
-    spec type_name {
-        // TODO: temporary mockup.
-        pragma opaque;
-    }
+    // Move Prover natively supports `type_of` and `type_name`.
 }

--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -1791,6 +1791,7 @@ The token is owned at address owner
 
     <b>let</b> burn_by_creator_flag = <a href="property_map.md#0x3_property_map_read_bool">property_map::read_bool</a>(&token_data.default_properties, &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(<a href="token.md#0x3_token_BURNABLE_BY_CREATOR">BURNABLE_BY_CREATOR</a>));
     <b>assert</b>!(burn_by_creator_flag, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_ECREATOR_CANNOT_BURN_TOKEN">ECREATOR_CANNOT_BURN_TOKEN</a>));
+
     // Burn the tokens.
     <b>let</b> <a href="token.md#0x3_token_Token">Token</a> { id: _, amount: burned_amount, token_properties: _ } = <a href="token.md#0x3_token_withdraw_with_event_internal">withdraw_with_event_internal</a>(owner, token_id, amount);
     <b>let</b> token_store = <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_TokenStore">TokenStore</a>&gt;(owner);
@@ -2147,7 +2148,7 @@ Burn a token by the token owner
     <a href="token.md#0x3_token_assert_collection_exists">assert_collection_exists</a>(creator_address, collection_name);
     <b>let</b> collection_data = <a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(&<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(creator_address).collection_data, collection_name);
     // cannot change maximum from 0 and cannot change maximum <b>to</b> 0
-    <b>assert</b>!(collection_data.maximum != 0 && maximum !=0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
+    <b>assert</b>!(collection_data.maximum != 0 && maximum != 0, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(maximum &gt;= collection_data.supply, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(collection_data.mutability_config.maximum, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>));
     collection_data.maximum = maximum;
@@ -2205,7 +2206,7 @@ Burn a token by the token owner
     <a href="token.md#0x3_token_assert_tokendata_exists">assert_tokendata_exists</a>(creator, token_data_id);
     <b>let</b> all_token_data = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="token.md#0x3_token_Collections">Collections</a>&gt;(token_data_id.creator).token_data;
     <b>let</b> token_data = <a href="../../aptos-framework/../aptos-stdlib/doc/table.md#0x1_table_borrow_mut">table::borrow_mut</a>(all_token_data, token_data_id);
-    <b>assert</b>!(token_data.supply &lt;= maximum, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
+    <b>assert</b>!(maximum &gt;= token_data.supply, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EINVALID_MAXIMUM">EINVALID_MAXIMUM</a>));
     <b>assert</b>!(token_data.mutability_config.maximum, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="token.md#0x3_token_EFIELD_NOT_MUTABLE">EFIELD_NOT_MUTABLE</a>));
     token_data.maximum = maximum;
 }


### PR DESCRIPTION
### Description

- Specified the `math64` and `math128` modules
- Updated the spec of `type_info`
  - `type_of` and `type_name` are natively supported by Prover now.
  - added a `[verify_only]` function to test the feature

TODO:
- the `pow` functions have non trivial loops, which still need abort-conditions and loop invariants.


### Test Plan
aptos move prove

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5341)
<!-- Reviewable:end -->
