### PR TITLE
[API] Clarify which endpoints return committed / pending transactions

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -6070,7 +6070,7 @@
           "Transactions"
         ],
         "summary": "Get transactions",
-        "description": "Retrieve on-chain committed transactions. The page size and start can be provided to\nget a specific sequence of transactions.\n\nIf the version has been pruned, then a 410 will be returned",
+        "description": "Retrieve on-chain committed transactions. The page size and start ledger version\ncan provided to get a specific sequence of transactions.\n\nIf the version has been pruned, then a 410 will be returned.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
         "parameters": [
           {
             "name": "start",
@@ -7640,7 +7640,7 @@
           "Transactions"
         ],
         "summary": "Get transaction by version",
-        "description": "Retrieves a transaction by a given version.  If the version has been pruned, a 410 will\nbe returned.",
+        "description": "Retrieves a transaction by a given version. If the version has been\npruned, a 410 will be returned.",
         "parameters": [
           {
             "name": "txn_version",
@@ -8157,7 +8157,7 @@
           "Transactions"
         ],
         "summary": "Get account transactions",
-        "description": "Retrieves transactions from an account.  If the start version is too far in the past\na 410 will be returned.\n\nIf no start version is given, it will start at 0",
+        "description": "Retrieve on-chain committed transactions from an account. If the start\nversion is too far in the past a 410 will be returned.\n\nIf no start version is given, it will start at version 0.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
         "parameters": [
           {
             "name": "address",

--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -6070,7 +6070,7 @@
           "Transactions"
         ],
         "summary": "Get transactions",
-        "description": "Retrieve on-chain committed transactions. The page size and start ledger version\ncan provided to get a specific sequence of transactions.\n\nIf the version has been pruned, then a 410 will be returned.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
+        "description": "Retrieve on-chain committed transactions. The page size and start ledger version\ncan be provided to get a specific sequence of transactions.\n\nIf the version has been pruned, a 410 error will be returned.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
         "parameters": [
           {
             "name": "start",
@@ -7640,7 +7640,7 @@
           "Transactions"
         ],
         "summary": "Get transaction by version",
-        "description": "Retrieves a transaction by a given version. If the version has been\npruned, a 410 will be returned.",
+        "description": "Retrieves a transaction by a given version. If the version has been\npruned, a 410 error will be returned.",
         "parameters": [
           {
             "name": "txn_version",
@@ -8157,7 +8157,7 @@
           "Transactions"
         ],
         "summary": "Get account transactions",
-        "description": "Retrieve on-chain committed transactions from an account. If the start\nversion is too far in the past a 410 will be returned.\n\nIf no start version is given, it will start at version 0.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
+        "description": "Retrieve on-chain committed transactions from an account. If the start\nversion is too far in the past, a 410 error will be returned.\n\nIf no start version is given, retrieval will start at version 0.\n\nTo retrieve a pending transaction, use /transactions/by_hash.",
         "parameters": [
           {
             "name": "address",

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -4491,10 +4491,12 @@ paths:
       - Transactions
       summary: Get transactions
       description: |-
-        Retrieve on-chain committed transactions. The page size and start can be provided to
-        get a specific sequence of transactions.
+        Retrieve on-chain committed transactions. The page size and start ledger version
+        can provided to get a specific sequence of transactions.
 
-        If the version has been pruned, then a 410 will be returned
+        If the version has been pruned, then a 410 will be returned.
+
+        To retrieve a pending transaction, use /transactions/by_hash.
       parameters:
       - name: start
         schema:
@@ -5660,8 +5662,8 @@ paths:
       - Transactions
       summary: Get transaction by version
       description: |-
-        Retrieves a transaction by a given version.  If the version has been pruned, a 410 will
-        be returned.
+        Retrieves a transaction by a given version. If the version has been
+        pruned, a 410 will be returned.
       parameters:
       - name: txn_version
         schema:
@@ -6035,10 +6037,12 @@ paths:
       - Transactions
       summary: Get account transactions
       description: |-
-        Retrieves transactions from an account.  If the start version is too far in the past
-        a 410 will be returned.
+        Retrieve on-chain committed transactions from an account. If the start
+        version is too far in the past a 410 will be returned.
 
-        If no start version is given, it will start at 0
+        If no start version is given, it will start at version 0.
+
+        To retrieve a pending transaction, use /transactions/by_hash.
       parameters:
       - name: address
         schema:

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -137,10 +137,12 @@ pub struct TransactionsApi {
 impl TransactionsApi {
     /// Get transactions
     ///
-    /// Retrieve on-chain committed transactions. The page size and start can be provided to
-    /// get a specific sequence of transactions.
+    /// Retrieve on-chain committed transactions. The page size and start ledger version
+    /// can provided to get a specific sequence of transactions.
     ///
-    /// If the version has been pruned, then a 410 will be returned
+    /// If the version has been pruned, then a 410 will be returned.
+    ///
+    /// To retrieve a pending transaction, use /transactions/by_hash.
     #[oai(
         path = "/transactions",
         method = "get",
@@ -206,8 +208,8 @@ impl TransactionsApi {
 
     /// Get transaction by version
     ///
-    /// Retrieves a transaction by a given version.  If the version has been pruned, a 410 will
-    /// be returned.
+    /// Retrieves a transaction by a given version. If the version has been
+    /// pruned, a 410 will be returned.
     #[oai(
         path = "/transactions/by_version/:txn_version",
         method = "get",
@@ -229,10 +231,12 @@ impl TransactionsApi {
 
     /// Get account transactions
     ///
-    /// Retrieves transactions from an account.  If the start version is too far in the past
-    /// a 410 will be returned.
+    /// Retrieve on-chain committed transactions from an account. If the start
+    /// version is too far in the past a 410 will be returned.
     ///
-    /// If no start version is given, it will start at 0
+    /// If no start version is given, it will start at version 0.
+    ///
+    /// To retrieve a pending transaction, use /transactions/by_hash.
     #[oai(
         path = "/accounts/:address/transactions",
         method = "get",
@@ -540,8 +544,6 @@ impl TransactionsApi {
     /// - Decode the hex encoded string in the response to bytes.
     /// - Sign the bytes to create the signature.
     /// - Use that as the signature field in something like Ed25519Signature, which you then use to build a TransactionSignature.
-    //
-    // TODO: Link an example of how to do this. Use externalDoc.
     #[oai(
         path = "/transactions/encode_submission",
         method = "post",

--- a/ecosystem/typescript/sdk/src/aptos_client.ts
+++ b/ecosystem/typescript/sdk/src/aptos_client.ts
@@ -450,7 +450,9 @@ export class AptosClient {
   }
 
   /**
-   * Queries on-chain transactions
+   * Queries on-chain transactions. This function will not return pending
+   * transactions. For that, use `getTransactionsByHash`.
+   *
    * @param query Optional pagination object
    * @param query.start The start transaction version of the page. Default is the latest ledger version
    * @param query.limit The max number of transactions should be returned for the page. Default is 25
@@ -463,7 +465,7 @@ export class AptosClient {
 
   /**
    * @param txnHash - Transaction hash should be hex-encoded bytes string with 0x prefix.
-   * @returns Transaction from mempool or on-chain transaction
+   * @returns Transaction from mempool (pending) or on-chain (committed) transaction
    */
   @parseApiError
   async getTransactionByHash(txnHash: string): Promise<Gen.Transaction> {
@@ -472,7 +474,8 @@ export class AptosClient {
 
   /**
    * @param txnVersion - Transaction version is an uint64 number.
-   * @returns Transaction from mempool or on-chain transaction
+   * @returns On-chain transaction. Only on-chain transactions have versions, so this
+   * function cannot be used to query pending transactions.
    */
   @parseApiError
   async getTransactionByVersion(txnVersion: AnyNumber): Promise<Gen.Transaction> {

--- a/ecosystem/typescript/sdk/src/generated/services/TransactionsService.ts
+++ b/ecosystem/typescript/sdk/src/generated/services/TransactionsService.ts
@@ -22,10 +22,12 @@ export class TransactionsService {
 
     /**
      * Get transactions
-     * Retrieve on-chain committed transactions. The page size and start can be provided to
-     * get a specific sequence of transactions.
+     * Retrieve on-chain committed transactions. The page size and start ledger version
+     * can provided to get a specific sequence of transactions.
      *
-     * If the version has been pruned, then a 410 will be returned
+     * If the version has been pruned, then a 410 will be returned.
+     *
+     * To retrieve a pending transaction, use /transactions/by_hash.
      * @param start Ledger version to start list of transactions
      *
      * If not provided, defaults to showing the latest transactions
@@ -113,8 +115,8 @@ export class TransactionsService {
 
     /**
      * Get transaction by version
-     * Retrieves a transaction by a given version.  If the version has been pruned, a 410 will
-     * be returned.
+     * Retrieves a transaction by a given version. If the version has been
+     * pruned, a 410 will be returned.
      * @param txnVersion Version of transaction to retrieve
      * @returns Transaction
      * @throws ApiError
@@ -133,10 +135,12 @@ export class TransactionsService {
 
     /**
      * Get account transactions
-     * Retrieves transactions from an account.  If the start version is too far in the past
-     * a 410 will be returned.
+     * Retrieve on-chain committed transactions from an account. If the start
+     * version is too far in the past a 410 will be returned.
      *
-     * If no start version is given, it will start at 0
+     * If no start version is given, it will start at version 0.
+     *
+     * To retrieve a pending transaction, use /transactions/by_hash.
      * @param address Address of account with or without a `0x` prefix
      * @param start Ledger version to start list of transactions
      *


### PR DESCRIPTION
### Description
In this PR I make it clearer which endpoints return transactions in which states.

I also remove a todo about `/encode_submission`. We shouldn't be encouraging people to use this endpoint, it is insecure.

### Test Plan
👀

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5343)
<!-- Reviewable:end -->
