### PR TITLE
[smoke tests] test_genesis_transaction_flow: some more debugging output

### DIFF
--- a/network/src/peer_manager/transport.rs
+++ b/network/src/peer_manager/transport.rs
@@ -66,7 +66,7 @@ where
         let addr_string = format!("{}", listen_addr);
         let (listener, listen_addr) = transport
             .listen_on(listen_addr)
-            .unwrap_or_else(|_| panic!("Transport listen on fails: {}", addr_string));
+            .unwrap_or_else(|err| panic!("Transport listen on fails: {}: {}", addr_string, err));
         debug!(
             NetworkSchema::new(&network_context),
             listen_address = listen_addr,

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -145,6 +145,11 @@ impl LocalNode {
             "Node {}: Inspection service is listening at http://127.0.0.1:{}",
             self.name, self.config.inspection_service.port
         );
+        info!(
+            "Node {}: Backup service is listening at http://127.0.0.1:{}",
+            self.name,
+            self.config.storage.backup_service_address.port()
+        );
 
         self.process = Some(Process(process));
 


### PR DESCRIPTION
### Description

Add more debug logging to understand why ports are not released. Smoke test logs all ports (that have been observed with conflicts) and PIDs, which can be compared to lsof output.

### Test Plan

Verified lsof output (on MacOS)

<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5347)
<!-- Reviewable:end -->
