### PR TITLE
[move] Print stack trace in unit tests

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -296,7 +296,7 @@ impl CliCommand<Vec<String>> for CompilePackage {
 #[derive(Parser)]
 pub struct TestPackage {
     /// A filter string to determine which unit tests to run
-    #[clap(long)]
+    #[clap(long, short)]
     pub filter: Option<String>,
 
     #[clap(flatten)]
@@ -334,6 +334,7 @@ impl CliCommand<&'static str> for TestPackage {
             UnitTestingConfig {
                 filter: self.filter,
                 instruction_execution_bound: Some(self.instruction_execution_bound),
+                report_stacktrace_on_abort: true,
                 ..UnitTestingConfig::default_with_bound(None)
             },
             // TODO(Gas): we may want to switch to non-zero costs in the future


### PR DESCRIPTION
It just needed to be turned on. However, the existing implementation in the Move repo isn't optimal. For example, it prints stacktrace only on Move abort, but not internal (like division by zero) error.

Tests locally with some of our unit tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5374)
<!-- Reviewable:end -->
