### PR TITLE
[framework] added explicit error code for resource account

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/resource_account.md
+++ b/aptos-move/framework/aptos-framework/doc/resource_account.md
@@ -148,6 +148,16 @@ Container resource not found in account
 
 
 
+<a name="0x1_resource_account_ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST"></a>
+
+Resource account address does not exist
+
+
+<pre><code><b>const</b> <a href="resource_account.md#0x1_resource_account_ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST">ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST</a>: u64 = 2;
+</code></pre>
+
+
+
 <a name="0x1_resource_account_create_resource_account"></a>
 
 ## Function `create_resource_account`
@@ -335,6 +345,7 @@ the SignerCapability.
     <b>let</b> resource_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(resource);
     <b>let</b> (resource_signer_cap, empty_container) = {
         <b>let</b> container = <b>borrow_global_mut</b>&lt;<a href="resource_account.md#0x1_resource_account_Container">Container</a>&gt;(source_addr);
+        <b>assert</b>!(<a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_contains_key">simple_map::contains_key</a>(&container.store, &resource_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="resource_account.md#0x1_resource_account_ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST">ERESOURCE_ACCOUNT_ADDRESS_DOES_NOT_EXIST</a>));
         <b>let</b> (_resource_addr, signer_cap) = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_remove">simple_map::remove</a>(&<b>mut</b> container.store, &resource_addr);
         (signer_cap, <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_length">simple_map::length</a>(&container.store) == 0)
     };


### PR DESCRIPTION
### Description
currently, if a user calls `resource_account::retrieve_resource_account_cap(resource: &signer, source_addr: address)` with a resource address that wasn't created by the `source_account`, it will abort with a `SimpleMap` error of `key_not_found`. It'd be easier for them to debug if we added a new error explicitly letting them know that the resource address does not exist in the source address' container. 

### Test Plan
added a unit test
<!-- Please provide us with clear details for verifying that your changes work. -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5378)
<!-- Reviewable:end -->
