### PR TITLE
[github actions] add lsof to rust setup

### DIFF
--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -1,7 +1,7 @@
 runs:
   using: composite
   steps:
-    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config --no-install-recommends --assume-yes
+    - run: sudo apt-get update && sudo apt-get install build-essential ca-certificates clang curl git libpq-dev libssl-dev pkg-config lsof --no-install-recommends --assume-yes
       shell: bash
     - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
       with:


### PR DESCRIPTION
### Description

Install lsof on rust machines, which is needed for smoke tests for #5347 

### Test Plan

Look at checks, confirm that apt-get lsof was successful as part of rust setup.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aptos-labs/aptos-core/5381)
<!-- Reviewable:end -->
